### PR TITLE
Adds a pre-commit git hook to automatically format staged files with clang-format

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,25 @@
+#!/bin/sh
+#
+# A hook script to format the source files about to be committed with clang-format.
+# Called by "git commit" with no arguments.  The hook should
+# exit with non-zero status after issuing an appropriate message if
+# it wants to stop the commit.
+#
+
+echo "The pre-commit hook for automated formatting is activated. Use '--no-verify' to by-pass it." 
+
+GIT_DIR=`git rev-parse --git-dir`
+staged_files=`git diff --name-only --cached`
+
+for file in ${staged_files}
+do
+	# Source file filtering is based on file extensions.
+	if [ -f "$file" ] && [[ "$file" =~ ^.*\.(ino|cpp|cc|c|h|hpp|hh|mm)$ ]]; then
+		clang-format -i ${file} --style="file:${GIT_DIR}/../.clang-format"
+		formatting_exit_code=$?
+		if [ ${formatting_exit_code} -ne 0 ]; then
+			echo "The program clang-format issued an error on file ${file}. Commit aborted."
+			exit $formatting_exit_code
+		fi
+	fi
+done


### PR DESCRIPTION
Dear `kDrive Desktop` developers, to activate the proposed pre-commit hook, please run this command in your local git repository: 

```
# change your 'core.hookspath' to the tracked 'hooks' directory
$ git config --lobal core.hookspath .githooks
```