### PR TITLE
[KDESKTOP-580] Removes reference to an explicit size limit for uploaded files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ install/
 *.user
 *.sln.docstates
 .drone-secrets.env
+*.vscode
 
 # Build results
 [Dd]ebug/

--- a/src/gui/parametersdialog.cpp
+++ b/src/gui/parametersdialog.cpp
@@ -820,8 +820,7 @@ QString ParametersDialog::getErrorMessage(ErrorInfo &errorInfo) {
                                   "The file/directory has been temporarily blacklisted.")
                             .arg(errorInfo.path());
                     } else if (errorInfo.exitCause() == ExitCauseFileTooBig) {
-                        return tr("Impossible to upload a file bigger than 100GB.<br>"
-                                  "The file \"%1\" has been temporarily blacklisted")
+                        return tr("The file \"%1\" is too large to be uploaded. It has been temporarily blacklisted.")
                             .arg(errorInfo.path());
                     } else if (errorInfo.exitCause() == ExitCauseNotFound) {
                         return tr("Impossible to download file \"%1\"").arg(errorInfo.path());


### PR DESCRIPTION
This change removes the hard-coded value of `100 GB` mentioned in an error message, as envisioned in the issue [KDESKTOP-580](https://infomaniak.atlassian.net/browse/KDESKTOP-580).
This limit may change with the back-end server characteristics and we have no actual means to retrieve the information at the moment.
 

[KDESKTOP-580]: https://infomaniak.atlassian.net/browse/KDESKTOP-580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ