### PR TITLE
[KDESKTOP-240] Delete user logs only after 7 days

### DIFF
--- a/src/gui/appclient.cpp
+++ b/src/gui/appclient.cpp
@@ -547,7 +547,7 @@ void AppClient::setupLogging() {
 
         logger->setupTemporaryFolderLogDir();
         if (ParametersCache::instance()->parametersInfo().purgeOldLogs()) {
-            logger->setLogExpire(std::chrono::hours(ClientGui::logsPurgeRate() * 24));  // TODO(Luc): C++20 can handle days.
+            logger->setLogExpire(std::chrono::hours(ClientGui::logsPurgeRate * 24));  // C++20 offers std::chrono::day.
         } else {
             logger->setLogExpire(std::chrono::hours(0));
         }

--- a/src/gui/appclient.cpp
+++ b/src/gui/appclient.cpp
@@ -547,7 +547,7 @@ void AppClient::setupLogging() {
 
         logger->setupTemporaryFolderLogDir();
         if (ParametersCache::instance()->parametersInfo().purgeOldLogs()) {
-            logger->setLogExpire(std::chrono::hours(ClientGui::logsPurgeRate() * 24));
+            logger->setLogExpire(std::chrono::hours(ClientGui::logsPurgeRate() * 24));  // TODO(Luc): C++20 can handle days.
         } else {
             logger->setLogExpire(std::chrono::hours(0));
         }

--- a/src/gui/appclient.cpp
+++ b/src/gui/appclient.cpp
@@ -547,7 +547,7 @@ void AppClient::setupLogging() {
 
         logger->setupTemporaryFolderLogDir();
         if (ParametersCache::instance()->parametersInfo().purgeOldLogs()) {
-            logger->setLogExpire(std::chrono::hours(24));
+            logger->setLogExpire(std::chrono::hours(ClientGui::logsPurgeRate() * 24));
         } else {
             logger->setLogExpire(std::chrono::hours(0));
         }

--- a/src/gui/clientgui.cpp
+++ b/src/gui/clientgui.cpp
@@ -50,6 +50,8 @@ namespace KDC {
 
 Q_LOGGING_CATEGORY(lcClientGui, "gui.clientgui", QtInfoMsg)
 
+const int ClientGui::logsPurgeRate = 7;  // days
+
 ClientGui::ClientGui(AppClient *parent)
     : QObject(),
       _tray(nullptr),
@@ -467,9 +469,9 @@ void ClientGui::setupSynthesisPopover() {
     _workaroundManualVisibility = true;
 #endif
 
-    qCInfo(lcClientGui) << "Tray menu workarounds:" << "noabouttoshow:" << _workaroundNoAboutToShowUpdate
-                        << "fakedoubleclick:" << _workaroundFakeDoubleClick << "showhide:" << _workaroundShowAndHideTray
-                        << "manualvisibility:" << _workaroundManualVisibility;
+    qCInfo(lcClientGui) << "Tray menu workarounds:"
+                        << "noabouttoshow:" << _workaroundNoAboutToShowUpdate << "fakedoubleclick:" << _workaroundFakeDoubleClick
+                        << "showhide:" << _workaroundShowAndHideTray << "manualvisibility:" << _workaroundManualVisibility;
 
     connect(&_delayedTrayUpdateTimer, &QTimer::timeout, this, &ClientGui::onUpdateSystray);
     _delayedTrayUpdateTimer.setInterval(2 * 1000);

--- a/src/gui/clientgui.h
+++ b/src/gui/clientgui.h
@@ -23,7 +23,6 @@
 #include "parametersdialog.h"
 #include "adddrivewizard.h"
 #include "logindialog.h"
-#include "common/utility.h"
 #include "info/userinfoclient.h"
 #include "info/accountinfo.h"
 #include "info/driveinfoclient.h"
@@ -81,6 +80,8 @@ class ClientGui : public QObject, public std::enable_shared_from_this<ClientGui>
         void errorInfoList(int driveDbId, QList<ErrorInfo> &errorInfoList);
         void resolveConflictErrors(int driveDbId, bool keepLocalVersion);
         void resolveUnsupportedCharErrors(int driveDbId);
+        // Delay after which the logs are purged, expressed in days.
+        static constexpr int logsPurgeRate() { return 7; };
 
     signals:
         void userListRefreshed();

--- a/src/gui/clientgui.h
+++ b/src/gui/clientgui.h
@@ -80,8 +80,9 @@ class ClientGui : public QObject, public std::enable_shared_from_this<ClientGui>
         void errorInfoList(int driveDbId, QList<ErrorInfo> &errorInfoList);
         void resolveConflictErrors(int driveDbId, bool keepLocalVersion);
         void resolveUnsupportedCharErrors(int driveDbId);
+
         // Delay after which the logs are purged, expressed in days.
-        static constexpr int logsPurgeRate() { return 7; };
+        static const int logsPurgeRate;
 
     signals:
         void userListRefreshed();

--- a/src/gui/debuggingdialog.cpp
+++ b/src/gui/debuggingdialog.cpp
@@ -137,7 +137,7 @@ void DebuggingDialog::initUI() {
 
     _deleteLogsCheckBox = new CustomCheckBox(this);
     _deleteLogsCheckBox->setObjectName("deleteLogsCheckBox");
-    _deleteLogsCheckBox->setText(tr("Delete logs older than %1 hours").arg(24));
+    _deleteLogsCheckBox->setText(tr("Delete logs older than %1 days").arg(ClientGui::logsPurgeRate()));
     deleteLogsHBox->addWidget(_deleteLogsCheckBox);
 
     mainLayout->addStretch();

--- a/src/gui/debuggingdialog.cpp
+++ b/src/gui/debuggingdialog.cpp
@@ -137,7 +137,7 @@ void DebuggingDialog::initUI() {
 
     _deleteLogsCheckBox = new CustomCheckBox(this);
     _deleteLogsCheckBox->setObjectName("deleteLogsCheckBox");
-    _deleteLogsCheckBox->setText(tr("Delete logs older than %1 days").arg(ClientGui::logsPurgeRate()));
+    _deleteLogsCheckBox->setText(tr("Delete logs older than %1 days").arg(ClientGui::logsPurgeRate));
     deleteLogsHBox->addWidget(_deleteLogsCheckBox);
 
     mainLayout->addStretch();


### PR DESCRIPTION
This pull request addresses [KDESKTOP-240](https://infomaniak.atlassian.net/browse/KDESKTOP-240): the delay to purge logs is raised from 24 hours to 7 days if the user checks the corresponding preference box.

[KDESKTOP-240]: https://infomaniak.atlassian.net/browse/KDESKTOP-240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ