### PR TITLE
[KDESKTOP-31] Change the logging level of verbose item lists in `LocalFileSystemObserverWorker::exploreDir`

### DIFF
--- a/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
@@ -637,7 +637,9 @@ ExitCode LocalFileSystemObserverWorker::exploreDir(const SyncPath &absoluteParen
                 continue;
             }
 
-            LOGW_SYNCPAL_INFO(_logger, L"Item \"" << Path2WStr(dirIt->path()).c_str() << L"\" found");
+            if (ParametersCache::instance()->parameters().extendedLog()) {
+                LOGW_SYNCPAL_DEBUG(_logger, L"Item \"" << Path2WStr(dirIt->path()).c_str() << L"\" found");
+            }
 
             if (stopAsked()) {
                 return ExitCodeOk;


### PR DESCRIPTION
This pull-request addresses the issue [DESKTOP-31](https://infomaniak.atlassian.net/browse/KDESKTOP-31) : 

- The log level when logging the found items in the full item list parsed within `LocalFileSystemObserverWorker::exploreDir`, is now set to `DEBUG`.
- These logs are only recorded in the extended log of the application (i.e., only if the user checked the extended log box in her preferences).