### PR TITLE
Fixes two issues related to IoHelper::getItemType and the detection of links

### DIFF
--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -148,11 +148,12 @@ bool IoHelper::_isExpectedError(IoError ioError) noexcept {
 bool IoHelper::_setTargetType(ItemType &itemType) noexcept {
     std::error_code ec;
     const bool isDir = _isDirectory(itemType.targetPath, ec);
-    itemType.ioError = stdError2ioError(ec);
+    IoError ioError = stdError2ioError(ec);
 
-    if (itemType.ioError != IoErrorSuccess) {
-        const bool expected = _isExpectedError(itemType.ioError);
+    if (ioError != IoErrorSuccess) {
+        const bool expected = _isExpectedError(ioError);
         if (!expected) {
+            itemType.ioError = ioError;
             LOGW_WARN(Log::instance()->getLogger(), L"Failed to check if the item is a directory: "
                                                         << Utility::formatStdError(itemType.targetPath, ec).c_str());
         }

--- a/test/libcommonserver/io/testcheckifisdirectory.cpp
+++ b/test/libcommonserver/io/testcheckifisdirectory.cpp
@@ -124,7 +124,7 @@ void TestIo::testCheckIfIsDirectory() {
 
         CPPUNIT_ASSERT(_testObj->checkIfIsDirectory(path, isDirectory, ioError));
         CPPUNIT_ASSERT(!isDirectory);
-        CPPUNIT_ASSERT(ioError == IoErrorNoSuchFileOrDirectory);
+        CPPUNIT_ASSERT(ioError == IoErrorSuccess);  // Although the target path is invalid.
     }
 
     // A regular directory missing all permissions: no error expected

--- a/test/libcommonserver/io/testcreatesymlink.cpp
+++ b/test/libcommonserver/io/testcreatesymlink.cpp
@@ -76,7 +76,7 @@ void TestIo::testCreateSymlink() {
 
         ItemType itemType;
         CPPUNIT_ASSERT(IoHelper::getItemType(path, itemType));
-        CPPUNIT_ASSERT(itemType.ioError == IoErrorNoSuchFileOrDirectory);
+        CPPUNIT_ASSERT(itemType.ioError == IoErrorSuccess);  // Although the target path is invalid.
         CPPUNIT_ASSERT(itemType.nodeType == NodeTypeFile);
         CPPUNIT_ASSERT(itemType.linkType == LinkTypeSymlink);
         CPPUNIT_ASSERT(itemType.targetType == NodeTypeUnknown);

--- a/test/libcommonserver/io/testgetfilesize.cpp
+++ b/test/libcommonserver/io/testgetfilesize.cpp
@@ -17,7 +17,6 @@
  */
 
 #include "testio.h"
-#include "config.h"
 
 #include <filesystem>
 
@@ -117,7 +116,7 @@ void TestIo::testGetFileSizeSimpleCases() {
 
             CPPUNIT_ASSERT(_testObj->getFileSize(path, fileSize, ioError));
             CPPUNIT_ASSERT(fileSize == targetPath.native().size());
-            CPPUNIT_ASSERT(ioError == IoErrorNoSuchFileOrDirectory);
+            CPPUNIT_ASSERT(ioError == IoErrorSuccess);  // Although the target path is invalid.
         }
     }
 

--- a/test/libcommonserver/io/testgetitemtype.cpp
+++ b/test/libcommonserver/io/testgetitemtype.cpp
@@ -192,7 +192,7 @@ void TestIo::testGetItemTypeSimpleCases() {
         // Actual test
         ItemType itemType;
         CPPUNIT_ASSERT(_testObj->getItemType(path, itemType));
-        CPPUNIT_ASSERT(itemType.ioError == IoErrorNoSuchFileOrDirectory);
+        CPPUNIT_ASSERT(itemType.ioError == IoErrorSuccess);  // Although the target path is invalid.
         CPPUNIT_ASSERT(itemType.nodeType == NodeTypeFile);
         CPPUNIT_ASSERT(itemType.linkType == LinkTypeSymlink);
         CPPUNIT_ASSERT(itemType.targetType == NodeTypeUnknown);
@@ -556,7 +556,7 @@ void TestIo::testGetItemTypeAllBranches() {
 
         ItemType itemType;
         CPPUNIT_ASSERT(_testObj->getItemType(path, itemType));
-        CPPUNIT_ASSERT(itemType.ioError == IoErrorNoSuchFileOrDirectory);
+        CPPUNIT_ASSERT(itemType.ioError == IoErrorSuccess);  // Although the target path is invalid.
         CPPUNIT_ASSERT(itemType.nodeType == NodeTypeFile);
         CPPUNIT_ASSERT(itemType.linkType == LinkTypeSymlink);
         CPPUNIT_ASSERT(itemType.targetType == NodeTypeUnknown);

--- a/test/libcommonserver/io/testisfileaccessible.cpp
+++ b/test/libcommonserver/io/testisfileaccessible.cpp
@@ -31,34 +31,29 @@ namespace KDC {
 void TestIo::testIsFileAccessible() {
     const TemporaryDirectory temporaryDirectory;
     const SyncPath sourcePath = _localTestDirPath / "big_file_dir/test_big_file.mov";
-    ;
-
-    std::cout << std::endl;
-    std::cout << "Creating job" << std::endl;
 
     std::shared_ptr<LocalCopyJob> copyJob =
         std::make_shared<LocalCopyJob>(sourcePath, temporaryDirectory.path / "test_big_file.mov");
     JobManager::instance()->queueAsyncJob(copyJob);
-
-    std::cout << "Waiting for job to start" << std::endl;
 
     while (!copyJob->isRunning()) {
         // Just wait for the job to start
     }
     Utility::msleep(10);
 
-    std::cout << "Job started" << std::endl;
-
     IoError ioError = IoErrorUnknown;
     bool res = IoHelper::isFileAccessible(temporaryDirectory.path / "test_big_file.mov", ioError);
-    std::cout << "res: " << res << ", ioError: " << ioError << std::endl;
+    // IoHelper::isFileAccessible returns instantly `true` on MacOSX and Linux.
+#ifdef _WIN32
     CPPUNIT_ASSERT(!res);
-    std::cout << "File copy not finished" << std::endl;
+#endif
+
+    // File copy not finished yet.
     Utility::msleep(1000);
+
+    // File copy is now finished.
     res = IoHelper::isFileAccessible(temporaryDirectory.path / "test_big_file.mov", ioError);
-    std::cout << "res: " << res << ", ioError: " << ioError << std::endl;
     CPPUNIT_ASSERT(res);
-    std::cout << "File copy is finished!" << std::endl;
 }
 
 }  // namespace KDC


### PR DESCRIPTION
The first issue was reported by @ChristopheLarchier today: the value of `_linkType` is not set anymore in `uploadjob.cpp` due to an accidental change while introducing `IoHelper::getItemType` in this file.

The second issue is also visible in this file: the error returned by `IoHelper::getItemType` should be `IoErrorNoSuchFileOrDirectory` if and only if the item argument could not be found. Before these changes, the function would return `IoErrorNoSuchFileOrDirectory` if the item is an existing symlink with an invalid target path.

Unit tests have been adapted. 