### PR TITLE
KDESKTOP-684-Operation-generator-fail-if-an-item-with-DELETE-operation-is-blacklisted

### DIFF
--- a/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerworker.cpp
+++ b/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerworker.cpp
@@ -39,8 +39,8 @@ void PlatformInconsistencyCheckerWorker::execute() {
     ExitCode exitCode = checkTree(_syncPal->_remoteUpdateTree->rootNode(), _syncPal->_remoteUpdateTree->rootNode()->name());
 
     for (const auto &idItem : _idsToBeRemoved) {
-        _syncPal->_remoteUpdateTree->deleteNode(idItem.first);
-        _syncPal->_localUpdateTree->deleteNode(idItem.second);
+        _syncPal->_remoteUpdateTree->deleteNode(idItem.remoteId);
+        _syncPal->_localUpdateTree->deleteNode(idItem.localId);
     }
 
     std::chrono::duration<double> elapsed_seconds = std::chrono::steady_clock::now() - start;
@@ -103,7 +103,7 @@ void PlatformInconsistencyCheckerWorker::blacklistNode(const std::shared_ptr<Nod
                                                        const InconsistencyType inconsistencyType) {
     // Local node needs to be excluded before call to blacklistTemporarily because
     // we need the DB entry to retrieve the corresponding node
-    NodeId localNodeId;
+    NodeIdPair nodeIDs;
     const auto localNode = correspondingNodeDirect(remoteNode);
     if (localNode) {
         // Also exclude local node by adding "conflict" suffix
@@ -111,7 +111,7 @@ void PlatformInconsistencyCheckerWorker::blacklistNode(const std::shared_ptr<Nod
         LOGW_SYNCPAL_INFO(_logger, L"Excluding also local item with " << Utility::formatSyncPath(absoluteLocalPath).c_str() << L".");
         PlatformInconsistencyCheckerUtility::renameLocaLFile(absoluteLocalPath, PlatformInconsistencyCheckerUtility::SuffixTypeConflict);
 
-        if (localNode->id().has_value()) localNodeId = *localNode->id();
+        if (localNode->id().has_value()) nodeIDs.localId = *localNode->id();
     }
 
     _syncPal->blacklistTemporarily(remoteNode->id().value(), relativePath, remoteNode->side());
@@ -138,7 +138,8 @@ void PlatformInconsistencyCheckerWorker::blacklistNode(const std::shared_ptr<Nod
     }
     LOGW_SYNCPAL_INFO(_logger, L"Blacklisting remote item with " << Utility::formatSyncPath(relativePath).c_str() << L" because " << causeStr.c_str() << L".");
 
-    _idsToBeRemoved.push_back(std::make_pair(remoteNode->id().value(), localNodeId));
+    nodeIDs.remoteId = *remoteNode->id();
+    _idsToBeRemoved.emplace_back(nodeIDs);
 }
 
 bool PlatformInconsistencyCheckerWorker::checkPathAndName(std::shared_ptr<Node> remoteNode) {

--- a/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerworker.cpp
+++ b/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerworker.cpp
@@ -109,7 +109,7 @@ void PlatformInconsistencyCheckerWorker::blacklistNode(const std::shared_ptr<Nod
         // Also exclude local node by adding "conflict" suffix
         const SyncPath absoluteLocalPath = _syncPal->localPath() / localNode->getPath();
         LOGW_SYNCPAL_INFO(_logger, L"Excluding also local item with " << Utility::formatSyncPath(absoluteLocalPath).c_str() << L".");
-        PlatformInconsistencyCheckerUtility::renameLocaLFile(absoluteLocalPath, PlatformInconsistencyCheckerUtility::SuffixTypeConflict);
+        PlatformInconsistencyCheckerUtility::renameLocalFile(absoluteLocalPath, PlatformInconsistencyCheckerUtility::SuffixTypeConflict);
 
         if (localNode->id().has_value()) nodeIDs.localId = *localNode->id();
     }

--- a/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerworker.h
+++ b/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerworker.h
@@ -38,10 +38,9 @@ class PlatformInconsistencyCheckerWorker : public OperationProcessor {
         bool checkPathAndName(std::shared_ptr<Node> remoteNode);
         void checkNameClashAgainstSiblings(std::shared_ptr<Node> remoteParentNode);
 
-        //std::list<std::pair<NodeId, NodeId>> _idsToBeRemoved;   // first item = remote ID (mandatory), second item = local ID (optional)
         struct NodeIdPair {
                 NodeId remoteId;
-                NodeId localId; // optional.
+                NodeId localId; // Optional, only required if the file is already synchronized.
         };
         std::list<NodeIdPair> _idsToBeRemoved;
 

--- a/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerworker.h
+++ b/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerworker.h
@@ -38,7 +38,12 @@ class PlatformInconsistencyCheckerWorker : public OperationProcessor {
         bool checkPathAndName(std::shared_ptr<Node> remoteNode);
         void checkNameClashAgainstSiblings(std::shared_ptr<Node> remoteParentNode);
 
-        std::list<std::pair<NodeId, NodeId>> _idsToBeRemoved;   // first item = remote ID (mandatory), second item = local ID (optional)
+        //std::list<std::pair<NodeId, NodeId>> _idsToBeRemoved;   // first item = remote ID (mandatory), second item = local ID (optional)
+        struct NodeIdPair {
+                NodeId remoteId;
+                NodeId localId; // optional.
+        };
+        std::list<NodeIdPair> _idsToBeRemoved;
 
         friend class TestPlatformInconsistencyCheckerWorker;
 };

--- a/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerworker.h
+++ b/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerworker.h
@@ -38,7 +38,7 @@ class PlatformInconsistencyCheckerWorker : public OperationProcessor {
         bool checkPathAndName(std::shared_ptr<Node> remoteNode);
         void checkNameClashAgainstSiblings(std::shared_ptr<Node> remoteParentNode);
 
-        std::list<NodeId> _idsToBeRemoved;
+        std::list<std::pair<NodeId, NodeId>> _idsToBeRemoved;   // first item = remote ID (mandatory), second item = local ID (optional)
 
         friend class TestPlatformInconsistencyCheckerWorker;
 };


### PR DESCRIPTION
Following [issue](https://infomaniak.atlassian.net/browse/KDESKTOP-393) the local items that were blacklisted remains in the update tree. This should not be the case, no excluded items should appear in the update tree.