### PR TITLE
KDESKTOP-94-Sync-loop-because-of-case-issue

### DIFF
--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -609,6 +609,8 @@ bool ExecutorWorker::generateCreateJob(SyncOpPtr syncOp, std::shared_ptr<Abstrac
 
                 if (exists) {
                     // Normal in lite sync mode
+                    // or in case where a remote item and a local item have same name with different cases
+                    // (ex: 'test.txt' on local replica needs to be uploaded, 'Text.txt' on remote replica needs to be downloaded)
                     if (ParametersCache::instance()->parameters().extendedLog()) {
                         LOGW_SYNCPAL_DEBUG(
                             _logger, L"File " << Path2WStr(absoluteLocalFilePath).c_str() << L" already exists on local replica");


### PR DESCRIPTION
This case is already correctly handled:
`2024-04-12 10:42:05:125 [D] (0x700007ca2000) executorworker.cpp:614 - *1* File /Users/clementkunz/kDrive/Test.txt already exists on local replica`
But the description was incomplete, the PR just add more explanation in comment
