### PR TITLE
KDESKTOP-757 - provide to logger as function parameter

### DIFF
--- a/src/libcommonserver/utility/utility.cpp
+++ b/src/libcommonserver/utility/utility.cpp
@@ -273,13 +273,13 @@ std::string Utility::formatGenericServerError(std::istream &inputStream, const P
     return errorStream.str();   // str() return a copy of the underlying string
 }
 
-void Utility::logGenericServerError(const std::string &errorTitle, std::istream &inputStream,
+void Utility::logGenericServerError(const log4cplus::Logger &logger, const std::string &errorTitle, std::istream &inputStream,
                                     const Poco::Net::HTTPResponse &httpResponse) {
     std::string errorMsg = formatGenericServerError(inputStream, httpResponse);
 #ifdef NDEBUG
     sentry_capture_event(sentry_value_new_message_event(SENTRY_LEVEL_WARNING, errorTitle.c_str(), errorMsg.c_str()));
 #endif
-    LOG_WARN(_logger, errorTitle.c_str() << ": " << errorMsg.c_str());
+    LOG_WARN(logger, errorTitle.c_str() << ": " << errorMsg.c_str());
 }
 
 #ifdef _WIN32

--- a/src/libcommonserver/utility/utility.h
+++ b/src/libcommonserver/utility/utility.h
@@ -72,7 +72,7 @@ struct COMMONSERVER_EXPORT Utility {
         static std::wstring formatSyncPath(const SyncPath &path);
 
         static std::string formatGenericServerError(std::istream &inputStream, const Poco::Net::HTTPResponse &httpResponse);
-        static void logGenericServerError(const std::string &errorTitle, std::istream &inputStream, const Poco::Net::HTTPResponse &httpResponse);
+        static void logGenericServerError(const log4cplus::Logger &logger, const std::string &errorTitle, std::istream &inputStream, const Poco::Net::HTTPResponse &httpResponse);
 
 #ifdef _WIN32
         static bool isNtfs(const SyncPath &dirPath);

--- a/src/libsyncengine/jobs/network/abstractnetworkjob.cpp
+++ b/src/libsyncengine/jobs/network/abstractnetworkjob.cpp
@@ -447,7 +447,7 @@ bool AbstractNetworkJob::followRedirect(std::istream &inputStream) {
         pDoc = parser.parse(&inputSrc);
     } catch (Poco::Exception &exc) {
         LOG_DEBUG(_logger, "Reply " << jobId() << " received doesn't contain a valid JSON error: " << exc.displayText().c_str());
-        Utility::logGenericServerError("Redirection error", inputStream, _resHttp);
+        Utility::logGenericServerError(_logger, "Redirection error", inputStream, _resHttp);
 
         _exitCode = ExitCodeBackError;
         _exitCause = ExitCauseApiErr;

--- a/src/libsyncengine/jobs/network/abstracttokennetworkjob.cpp
+++ b/src/libsyncengine/jobs/network/abstracttokennetworkjob.cpp
@@ -199,7 +199,7 @@ bool AbstractTokenNetworkJob::handleError(std::istream &is, const Poco::URI &uri
         } catch (Poco::Exception &exc) {
             LOGW_WARN(_logger, L"Reply " << jobId() << L" received doesn't contain a valid JSON error: "
                                          << Utility::s2ws(exc.displayText()).c_str());
-            Utility::logGenericServerError("Request error", ss, _resHttp);
+            Utility::logGenericServerError(_logger, "Request error", ss, _resHttp);
 
             _exitCode = ExitCodeBackError;
             _exitCause = ExitCauseApiErr;

--- a/src/libsyncengine/jobs/network/login/abstractloginjob.cpp
+++ b/src/libsyncengine/jobs/network/login/abstractloginjob.cpp
@@ -72,7 +72,7 @@ bool AbstractLoginJob::handleError(std::istream &inputStream, const Poco::URI &u
         jsonError = jsonParser.parse(inputStream).extract<Poco::JSON::Object::Ptr>();
     } catch (Poco::Exception &exc) {
         LOG_WARN(_logger, "Reply " << jobId() << " received doesn't contain a valid JSON error: " << exc.displayText().c_str());
-        Utility::logGenericServerError("Login error", inputStream, _resHttp);
+        Utility::logGenericServerError(_logger, "Login error", inputStream, _resHttp);
 
         _exitCode = ExitCodeBackError;
         _exitCause = ExitCauseApiErr;


### PR DESCRIPTION
The app crashed after deleteing the folder used as root for an advanced synchronisation.
This issue reveal a deeper problem: the logger instance used in `Utility::logGenericServerError` was not correctly defined