### PR TITLE
[HOTFIX] Open local folder of a new drive instead of its parent 

### DIFF
--- a/src/gui/abstractfileitemwidget.cpp
+++ b/src/gui/abstractfileitemwidget.cpp
@@ -177,7 +177,6 @@ void AbstractFileItemWidget::setFileTypeIcon(const QString &ressourcePath) {
 
 void AbstractFileItemWidget::setFileName(const QString &path, NodeType type) {
     setFileTypeIcon(CommonUtility::getFileIconPathFromFileName(path, type));
-    QString test = QFileInfo(path).fileName();
     _filenameLabel->setText(QFileInfo(path).fileName());
 }
 

--- a/src/gui/adddriveconfirmationwidget.cpp
+++ b/src/gui/adddriveconfirmationwidget.cpp
@@ -17,7 +17,6 @@
  */
 
 #include "adddriveconfirmationwidget.h"
-#include "customtoolbutton.h"
 #include "guiutility.h"
 
 #include <QBoxLayout>
@@ -44,8 +43,7 @@ static const int progressBarMax = 5;
 
 Q_LOGGING_CATEGORY(lcAddDriveConfirmationWidget, "gui.adddriveconfirmationwidget", QtInfoMsg)
 
-AddDriveConfirmationWidget::AddDriveConfirmationWidget(QWidget *parent)
-    : QWidget(parent), _logoTextIconLabel(nullptr), _descriptionLabel(nullptr), _logoColor(QColor()) {
+AddDriveConfirmationWidget::AddDriveConfirmationWidget(QWidget *parent) : QWidget(parent) {
     initUI();
 }
 

--- a/src/gui/adddriveconfirmationwidget.h
+++ b/src/gui/adddriveconfirmationwidget.h
@@ -43,8 +43,8 @@ class AddDriveConfirmationWidget : public QWidget {
         void terminated(bool next = true);
 
     private:
-        QLabel *_logoTextIconLabel;
-        QLabel *_descriptionLabel;
+        QLabel *_logoTextIconLabel{nullptr};
+        QLabel *_descriptionLabel{nullptr};
         QColor _logoColor;
         KDC::GuiUtility::WizardAction _action;
 

--- a/src/gui/genericerroritemwidget.cpp
+++ b/src/gui/genericerroritemwidget.cpp
@@ -95,7 +95,7 @@ void GenericErrorItemWidget::openFolder(const QString &path) {
     }
 
     // Open on local filesystem (open the parent folder for an item of file type).
-    const QString folderPath = GuiUtility::getFolderPath(syncInfoMapIt->second.localPath() + "/" + path, _errorInfo.nodeType());
+    const auto folderPath = GuiUtility::getFolderPath(syncInfoMapIt->second.localPath() + "/" + path, _errorInfo.nodeType());
     AbstractFileItemWidget::openFolder(folderPath);
 }
 

--- a/src/gui/genericerroritemwidget.cpp
+++ b/src/gui/genericerroritemwidget.cpp
@@ -29,8 +29,6 @@
 #include <QPainter>
 #include <QPainterPath>
 
-#include <iostream>
-
 namespace KDC {
 
 #define GENERICERRORITEMWIDGET_NEW_ERROR_MSG "Failed to create GenericErrorItemWidget instance!"
@@ -59,14 +57,13 @@ void GenericErrorItemWidget::init() {
         }
 
         // Path
-        QString pathStr;
         if (_errorInfo.level() == ErrorLevelSyncPal) {
             setDriveName(driveInfoMapIt->second.name(), syncInfoMapIt->second.localPath());
             setPathIconColor(driveInfoMapIt->second.color());
         } else if (_errorInfo.level() == ErrorLevelNode) {
-            bool useDestPath = _errorInfo.cancelType() == CancelTypeAlreadyExistRemote ||
-                               _errorInfo.cancelType() == CancelTypeMoveToBinFailed ||
-                               _errorInfo.conflictType() == ConflictTypeEditDelete;
+            const bool useDestPath = _errorInfo.cancelType() == CancelTypeAlreadyExistRemote ||
+                                     _errorInfo.cancelType() == CancelTypeMoveToBinFailed ||
+                                     _errorInfo.conflictType() == ConflictTypeEditDelete;
             const QString &filePath = useDestPath ? _errorInfo.destinationPath() : _errorInfo.path();
             setFilePath(filePath, _errorInfo.nodeType());
         }
@@ -76,7 +73,7 @@ void GenericErrorItemWidget::init() {
     QLabel *fileDateLabel = new QLabel(this);
     fileDateLabel->setObjectName("fileDateLabel");
     fileDateLabel->setText(QDateTime::fromSecsSinceEpoch(_errorInfo.getTime()).toString(dateFormat));
-    ;
+
     addCustomWidget(fileDateLabel);
 }
 
@@ -97,21 +94,21 @@ void GenericErrorItemWidget::openFolder(const QString &path) {
         }
     }
 
-    // Open on local filesystem
-    QString fullPath = syncInfoMapIt->second.localPath() + "/" + path;
-    AbstractFileItemWidget::openFolder(fullPath);
+    // Open on local filesystem (open the parent folder for an item of file type).
+    const QString folderPath = GuiUtility::getFolderPath(syncInfoMapIt->second.localPath() + "/" + path, _errorInfo.nodeType());
+    AbstractFileItemWidget::openFolder(folderPath);
 }
 
 bool GenericErrorItemWidget::openInWebview() const {
-    return _errorInfo.inconsistencyType() == InconsistencyTypePathLength
-        || _errorInfo.inconsistencyType() == InconsistencyTypeCase
-        || _errorInfo.inconsistencyType() == InconsistencyTypeForbiddenChar
-        || _errorInfo.inconsistencyType() == InconsistencyTypeReservedName
-        || _errorInfo.inconsistencyType() == InconsistencyTypeNameLength
-        || _errorInfo.inconsistencyType() == InconsistencyTypeNotYetSupportedChar
-        || _errorInfo.cancelType() == CancelTypeAlreadyExistLocal
-        || (_errorInfo.conflictType() == ConflictTypeEditDelete && !_errorInfo.remoteNodeId().isEmpty())
-        || (_errorInfo.exitCode() == ExitCodeBackError && _errorInfo.exitCause() == ExitCauseNotFound);
+    return _errorInfo.inconsistencyType() == InconsistencyTypePathLength ||
+           _errorInfo.inconsistencyType() == InconsistencyTypeCase ||
+           _errorInfo.inconsistencyType() == InconsistencyTypeForbiddenChar ||
+           _errorInfo.inconsistencyType() == InconsistencyTypeReservedName ||
+           _errorInfo.inconsistencyType() == InconsistencyTypeNameLength ||
+           _errorInfo.inconsistencyType() == InconsistencyTypeNotYetSupportedChar ||
+           _errorInfo.cancelType() == CancelTypeAlreadyExistLocal ||
+           (_errorInfo.conflictType() == ConflictTypeEditDelete && !_errorInfo.remoteNodeId().isEmpty()) ||
+           (_errorInfo.exitCode() == ExitCodeBackError && _errorInfo.exitCause() == ExitCauseNotFound);
 }
 
 }  // namespace KDC

--- a/src/gui/guiutility.cpp
+++ b/src/gui/guiutility.cpp
@@ -480,6 +480,10 @@ qint64 GuiUtility::folderDiskSize(const QString &dirPath) {
     return total;
 }
 
+QString GuiUtility::getFolderPath(const QString &path, NodeType nodeType) {
+    return nodeType == NodeTypeDirectory ? path : QFileInfo(path).path();
+}
+
 bool GuiUtility::openFolder(const QString &dirPath) {
     if (dirPath.isEmpty()) return true;
 

--- a/src/gui/guiutility.cpp
+++ b/src/gui/guiutility.cpp
@@ -483,8 +483,7 @@ qint64 GuiUtility::folderDiskSize(const QString &dirPath) {
 bool GuiUtility::openFolder(const QString &dirPath) {
     if (dirPath.isEmpty()) return true;
 
-    QFileInfo fileInfo(dirPath);
-    if (fileInfo.exists()) {
+    if (const auto fileInfo = QFileInfo(dirPath); fileInfo.exists()) {
         const QUrl url = getUrlFromLocalPath(QDir::cleanPath(fileInfo.filePath()));
         if (url.isValid() && !QDesktopServices::openUrl(url)) return false;
     } else if (fileInfo.dir().exists()) {

--- a/src/gui/guiutility.cpp
+++ b/src/gui/guiutility.cpp
@@ -481,28 +481,20 @@ qint64 GuiUtility::folderDiskSize(const QString &dirPath) {
 }
 
 bool GuiUtility::openFolder(const QString &dirPath) {
-    if (!dirPath.isEmpty()) {
-        QFileInfo fileInfo(dirPath);
-        if (fileInfo.exists()) {
-            const QUrl url = getUrlFromLocalPath(fileInfo.path());
-            if (url.isValid()) {
-                if (!QDesktopServices::openUrl(url)) {
-                    return false;
-                }
-            }
-        } else if (fileInfo.dir().exists()) {
-            const QUrl url = getUrlFromLocalPath(fileInfo.dir().path());
-            if (url.isValid()) {
-                if (!QDesktopServices::openUrl(url)) {
-                    return false;
-                }
-            } else {
-                return false;
-            }
-        } else {
-            return false;
-        }
+    if (dirPath.isEmpty()) return true;
+
+    QFileInfo fileInfo(dirPath);
+    if (fileInfo.exists()) {
+        const QUrl url = getUrlFromLocalPath(QDir::cleanPath(fileInfo.filePath()));
+        if (url.isValid() && !QDesktopServices::openUrl(url)) return false;
+    } else if (fileInfo.dir().exists()) {
+        const QUrl url = getUrlFromLocalPath(QDir::cleanPath(fileInfo.dir().path()));
+        if (!url.isValid()) return false;
+        if (!QDesktopServices::openUrl(url)) return false;
+    } else {
+        return false;
     }
+
     return true;
 }
 

--- a/src/gui/guiutility.h
+++ b/src/gui/guiutility.h
@@ -94,7 +94,15 @@ QUrl getUrlFromLocalPath(const QString &path);
 int getQFontWeightFromQSSFontWeight(int weight);
 qint64 folderSize(const QString &dirPath);
 qint64 folderDiskSize(const QString &dirPath);
+
+// Returns `path` if `nodeType` is `NodeTypeDirectory`, else the parent folder path.
+QString getFolderPath(const QString &path, NodeType nodeType);
+
+// Opens the folder indicated by `path`, if `path` is valid, otherwise tries to open the parent folder.
+// Returns true if `path` is empty, or if the folder indicated by `path` is successfully open,
+// or if the parent folder is successfully open. Returns false otherwise.
 bool openFolder(const QString &path);
+
 QWidget *getTopLevelWidget(QWidget *widget);
 void forceUpdate(QWidget *widget);
 void invalidateLayout(QLayout *layout);

--- a/src/libsyncengine/jobs/network/downloadjob.cpp
+++ b/src/libsyncengine/jobs/network/downloadjob.cpp
@@ -207,16 +207,15 @@ bool DownloadJob::handleResponse(std::istream &is) {
     } else {
         // Create/fetch normal file
 #ifdef _WIN32
-        std::string tmpFileName = tmpnam(nullptr);
+        const std::string tmpFileName = tmpnam(nullptr);
 #else
-        std::string tmpFileName = "kdrive_" + CommonUtility::generateRandomStringAlphaNum();
+        const std::string tmpFileName = "kdrive_" + CommonUtility::generateRandomStringAlphaNum();
 #endif
 
         SyncPath tmpPath;
         IoError ioError = IoErrorSuccess;
         if (!IoHelper::tempDirectoryPath(tmpPath, ioError)) {
-            const std::wstring message = Utility::s2ws(IoHelper::ioError2StdString(ioError));
-            LOGW_WARN(_logger, L"Failed to get temporary directory path" << L": " << message.c_str());
+            LOGW_WARN(_logger, L"Failed to get temporary directory path: " << Utility::formatIoError(tmpPath, ioError).c_str());
             _exitCode = ExitCodeSystemError;
             _exitCause = ExitCauseFileAccessError;
             return false;
@@ -425,14 +424,14 @@ bool DownloadJob::handleResponse(std::istream &is) {
 bool DownloadJob::createLink(const std::string &mimeType, const std::string &data) {
     if (mimeType == mimeTypeSymlink) {
         // Create symlink
-        SyncPath targetPath(Str2Path(data));
+        const auto targetPath = Str2Path(data);
         if (targetPath == _localpath) {
-            LOGW_DEBUG(_logger, L"Cannot create symlink on itself : " << Utility::formatSyncPath(_localpath).c_str());
+            LOGW_DEBUG(_logger, L"Cannot create symlink on itself: " << Utility::formatSyncPath(_localpath).c_str());
             return false;
         }
 
-        LOGW_DEBUG(_logger, L"Create symlink : " << Utility::formatSyncPath(targetPath).c_str() << L" "
-                                                 << Utility::formatSyncPath(_localpath).c_str());
+        LOGW_DEBUG(_logger, L"Create symlink: " << Utility::formatSyncPath(targetPath).c_str() << L", "
+                                                << Utility::formatSyncPath(_localpath).c_str());
 
         IoError ioError = IoErrorSuccess;
         if (!IoHelper::createSymlink(targetPath, _localpath, ioError)) {
@@ -441,22 +440,21 @@ bool DownloadJob::createLink(const std::string &mimeType, const std::string &dat
         }
     } else if (mimeType == mimeTypeHardlink) {
         // Unreachable code
-        SyncPath targetPath(Str2Path(data));
+        const auto targetPath = Str2Path(data);
         if (targetPath == _localpath) {
-            LOGW_DEBUG(_logger, L"Cannot create hardlink on itself : " << Utility::formatSyncPath(_localpath).c_str());
+            LOGW_DEBUG(_logger, L"Cannot create hardlink on itself: " << Utility::formatSyncPath(_localpath).c_str());
             return false;
         }
 
-        LOGW_DEBUG(_logger, L"Create hardlink : " << Utility::formatSyncPath(targetPath).c_str() << L" "
-                                                  << Utility::formatSyncPath(_localpath).c_str());
+        LOGW_DEBUG(_logger, L"Create hardlink: target " << Utility::formatSyncPath(targetPath).c_str() << L", "
+                                                        << Utility::formatSyncPath(_localpath).c_str());
 
         std::error_code ec;
         std::filesystem::create_hard_link(targetPath, _localpath, ec);
-        if (ec.value() != 0) {
-            LOGW_WARN(_logger, L"Failed to create hardlink : " << Utility::formatSyncPath(targetPath).c_str() << L" "
-                                                               << Utility::formatSyncPath(_localpath).c_str() << L" err="
-                                                               << Utility::s2ws(ec.message()).c_str() << L" (" << ec.value()
-                                                               << L")");
+        if (ec) {
+            LOGW_WARN(_logger, L"Failed to create hardlink: target " << Utility::formatSyncPath(targetPath).c_str() << L", "
+                                                                     << Utility::formatSyncPath(_localpath).c_str() << L", "
+                                                                     << Utility::formatStdError(ec).c_str());
             return false;
         }
     } else if (mimeType == mimeTypeJunction) {
@@ -471,13 +469,12 @@ bool DownloadJob::createLink(const std::string &mimeType, const std::string &dat
 #endif
     } else if (mimeType == mimeTypeFinderAlias) {
 #if defined(__APPLE__)
-        LOGW_DEBUG(_logger, L"Create alias : " << Utility::formatSyncPath(_localpath).c_str());
+        LOGW_DEBUG(_logger, L"Create alias: " << Utility::formatSyncPath(_localpath).c_str());
 
         IoError ioError = IoErrorSuccess;
         if (!IoHelper::createAlias(data, _localpath, ioError)) {
             const std::wstring message = Utility::s2ws(IoHelper::ioError2StdString(ioError));
-            LOGW_WARN(_logger,
-                      L"Failed to create alias : " << Utility::formatSyncPath(_localpath).c_str() << L" err=" << message.c_str());
+            LOGW_WARN(_logger, L"Failed to create alias: " << Utility::formatIoError(_localpath, ioError).c_str());
 
             return false;
         }
@@ -493,9 +490,9 @@ bool DownloadJob::createLink(const std::string &mimeType, const std::string &dat
 bool DownloadJob::removeTmpFile(const SyncPath &path) {
     std::error_code ec;
     if (!std::filesystem::remove_all(path, ec)) {
-        if (ec.value() != 0) {
-            LOGW_WARN(_logger, L"Failed to remove all : " << Utility::formatSyncPath(path).c_str() << L" err="
-                                                          << Utility::s2ws(ec.message()).c_str() << L" (" << ec.value() << L")");
+        if (ec) {
+            LOGW_WARN(_logger, L"Failed to remove all : " << Utility::formatSyncPath(path).c_str() << L", "
+                                                          << Utility::formatStdError(ec).c_str());
             return false;
         }
 
@@ -518,20 +515,19 @@ bool DownloadJob::moveTmpFile(const SyncPath &path, bool &restartSync) {
         retry = false;
 #endif
         std::filesystem::rename(path, _localpath, ec);
-        bool crossDeviceLink;
 #ifdef _WIN32
-        crossDeviceLink = ec.value() == ERROR_NOT_SAME_DEVICE;
+        const bool crossDeviceLink = ec.value() == ERROR_NOT_SAME_DEVICE;
 #else
-    crossDeviceLink = ec.value() == (int)std::errc::cross_device_link;
+    const bool crossDeviceLink = ec.value() == (int)std::errc::cross_device_link;
 #endif
         if (crossDeviceLink) {
-            // The sync might be on a different file system than tmp folder
-            // In that case, try to copy the file instead
+            // The sync might be on a different file system than tmp folder.
+            // In that case, try to copy the file instead.
             ec.clear();
             std::filesystem::copy(path, _localpath, std::filesystem::copy_options::overwrite_existing, ec);
-            if (ec.value() != 0) {
-                LOGW_WARN(_logger, L"Failed to copy : " << Utility::formatSyncPath(_localpath).c_str() << L" err="
-                                                        << Utility::s2ws(ec.message()).c_str() << L" (" << ec.value() << L")");
+            if (ec) {
+                LOGW_WARN(_logger, L"Failed to copy: " << Utility::formatSyncPath(_localpath).c_str() << L", "
+                                                       << Utility::formatStdError(ec).c_str());
                 return false;
             }
         }
@@ -544,13 +540,13 @@ bool DownloadJob::moveTmpFile(const SyncPath &path, bool &restartSync) {
                 LOGW_DEBUG(_logger, L"Retrying to move downloaded file : " << Utility::formatSyncPath(_localpath).c_str());
                 counter--;
             } else {
-                LOGW_WARN(_logger, L"Failed to rename : " << Utility::formatSyncPath(_localpath).c_str() << L" err="
-                                                          << Utility::s2ws(ec.message()).c_str() << L" (" << ec.value() << L")");
+                LOGW_WARN(_logger, L"Failed to rename : " << Utility::formatSyncPath(_localpath).c_str() << L", "
+                                                          << Utility::formatStdError(ec).c_str());
                 return false;
             }
         }
 #endif
-        else if (ec.value() != 0) {
+        else if (ec) {
             bool exists = false;
             IoError ioError = IoErrorSuccess;
             if (!IoHelper::checkIfPathExists(_localpath.parent_path(), exists, ioError)) {
@@ -563,14 +559,13 @@ bool DownloadJob::moveTmpFile(const SyncPath &path, bool &restartSync) {
 
             if (!exists) {
                 LOGW_INFO(_logger, L"Parent of item does not exist anymore : " << Utility::formatSyncPath(_localpath).c_str()
-                                                                               << L" err=" << Utility::s2ws(ec.message()).c_str()
-                                                                               << L" (" << ec.value() << L")");
+                                                                               << L", " << Utility::formatStdError(ec).c_str());
                 restartSync = true;
                 return true;
             }
 
-            LOGW_WARN(_logger, L"Failed to rename : " << Utility::formatSyncPath(_localpath).c_str() << L" err="
-                                                      << Utility::s2ws(ec.message()).c_str() << L" (" << ec.value() << L")");
+            LOGW_WARN(_logger, L"Failed to rename : " << Utility::formatSyncPath(_localpath).c_str() << L", "
+                                                      << Utility::formatStdError(ec).c_str());
             return false;
         }
 #ifdef _WIN32


### PR DESCRIPTION
This bug has been detected on MacOSX, but should be visible on every operaring system: the method `QFileInfo:path()` removes the name of the item from its output path, see https://doc.qt.io/qt-6/qfileinfo.html#path.