### PR TITLE
KDESKTOP-784 - Do not set pinstate to "Online" at each startup

### DIFF
--- a/src/server/vfs/win/vfs_win.cpp
+++ b/src/server/vfs/win/vfs_win.cpp
@@ -132,8 +132,6 @@ bool VfsWin::startImpl(bool &, bool &, bool &) {
 
     _vfsSetupParams._namespaceCLSID = Utility::ws2s(std::wstring(clsid));
 
-    setPinState(Path2QStr(_vfsSetupParams._localPath), PinStateOnlineOnly);
-
     return true;
 }
 


### PR DESCRIPTION
The pinstate of pinned folder on Windows was changed after each app startup. This behavior seems to be caused by the fact that the pinstate "ONLINE" was set recursively on the root folder at each startup.