### PR TITLE
KDESKTOP-751-Remove-sentry-message-just-keep-errors

### DIFF
--- a/src/gui/appclient.cpp
+++ b/src/gui/appclient.cpp
@@ -88,10 +88,6 @@ static void displayHelpText(const QString &t) {
 
 
 AppClient::AppClient(int &argc, char **argv) : SharedTools::QtSingleApplication(Theme::instance()->appClientName(), argc, argv) {
-#ifdef NDEBUG
-    sentry_capture_event(sentry_value_new_message_event(SENTRY_LEVEL_INFO, "AppClient", "Start"));
-#endif
-
     _startedAt.start();
 
     setOrganizationDomain(QLatin1String(APPLICATION_REV_DOMAIN));

--- a/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
@@ -840,7 +840,7 @@ ExitCode ComputeFSOperationWorker::checkIfOkToDelete(ReplicaSide side, const Syn
     LOGW_SYNCPAL_DEBUG(_logger, L"Item " << Path2WStr(absolutePath).c_str()
                                          << L" still exists on local replica. Snapshot not up to date, restarting sync.");
 #ifdef NDEBUG
-    sentry_capture_event(sentry_value_new_message_event(SENTRY_LEVEL_INFO, "ComputeFSOperationWorker::checkIfOkToDelete",
+    sentry_capture_event(sentry_value_new_message_event(SENTRY_LEVEL_WARNING, "ComputeFSOperationWorker::checkIfOkToDelete",
                                                         "Unwanted local delete operation averted"));
 #endif
 

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -126,10 +126,6 @@ AppServer::AppServer(int &argc, char **argv)
       _versionAsked(false),
       _clearSyncNodesAsked(false),
       _debugMode(false) {
-#ifdef NDEBUG
-    sentry_capture_event(sentry_value_new_message_event(SENTRY_LEVEL_INFO, "AppServer", "Start"));
-#endif
-
     _startedAt.start();
 
     setOrganizationDomain(QLatin1String(APPLICATION_REV_DOMAIN));
@@ -3697,7 +3693,7 @@ void AppServer::addError(const Error &error) {
         }
 
 #ifdef NDEBUG
-        sentry_capture_event(sentry_value_new_message_event(SENTRY_LEVEL_INFO, "AppServer::addError", "Sockets defuncted error"));
+        sentry_capture_event(sentry_value_new_message_event(SENTRY_LEVEL_WARNING, "AppServer::addError", "Sockets defuncted error"));
 #endif
     }
 
@@ -3714,8 +3710,7 @@ void AppServer::addError(const Error &error) {
         sentry_set_user(sentryUser);
 
         sentry_capture_event(
-            sentry_value_new_message_event(error.exitCode() != ExitCodeOk ? SENTRY_LEVEL_WARNING : SENTRY_LEVEL_INFO,
-                                           "AppServer::addError", error.errorString().c_str()));
+            sentry_value_new_message_event(SENTRY_LEVEL_WARNING, "AppServer::addError", error.errorString().c_str()));
 
         sentry_remove_user();
     }


### PR DESCRIPTION
Do not send information message to sentry anymore.