### PR TITLE
[KDESKTOP-801]  Shortens translations of 'Remove all synchronizations' 

### DIFF
--- a/translations/client_de.ts
+++ b/translations/client_de.ts
@@ -624,7 +624,7 @@ Wählen Sie diejenigen aus, die Sie synchronisieren möchten:</translation>
     <message>
         <location filename="../src/gui/clientgui.cpp" line="1196"/>
         <source>REMOVE ALL SYNCHRONIZATIONS</source>
-        <translation>ALLE SYNCHRONISATIONEN ENTFERNEN</translation>
+        <translation>ALLE SYNC. ENTFERNEN</translation>
     </message>
     <message>
         <location filename="../src/gui/clientgui.cpp" line="1197"/>

--- a/translations/client_es.ts
+++ b/translations/client_es.ts
@@ -624,7 +624,7 @@ Selecciona los que quieras sincronizar:</translation>
     <message>
         <location filename="../src/gui/clientgui.cpp" line="1196"/>
         <source>REMOVE ALL SYNCHRONIZATIONS</source>
-        <translation>ELIMINAR TODAS LAS SINCRONIZACIONES</translation>
+        <translation>ELIMINAR TODAS LAS SINC.</translation>
     </message>
     <message>
         <location filename="../src/gui/clientgui.cpp" line="1197"/>

--- a/translations/client_fr.ts
+++ b/translations/client_fr.ts
@@ -629,7 +629,7 @@ Sélectionnez ceux que vous souhaitez synchroniser:</translation>
     <message>
         <location filename="../src/gui/clientgui.cpp" line="1196"/>
         <source>REMOVE ALL SYNCHRONIZATIONS</source>
-        <translation>SUPPRIMER TOUTES LES SYNCHRONISATIONS</translation>
+        <translation>SUPPRIMER TOUTES LES SYNC.</translation>
     </message>
     <message>
         <location filename="../src/gui/clientgui.cpp" line="1197"/>

--- a/translations/client_it.ts
+++ b/translations/client_it.ts
@@ -624,7 +624,7 @@ Seleziona quelli che desideri sincronizzare:</translation>
     <message>
         <location filename="../src/gui/clientgui.cpp" line="1196"/>
         <source>REMOVE ALL SYNCHRONIZATIONS</source>
-        <translation>RIMUOVERE TUTTE LE SINCRONIZZAZIONI</translation>
+        <translation>RIMUOVERE TUTTE LE SINC.</translation>
     </message>
     <message>
         <location filename="../src/gui/clientgui.cpp" line="1197"/>


### PR DESCRIPTION
The text for synchronizations removal is oversized and doesn't fit with the containing button size:

![supprimer_toutes_les_syncs](https://github.com/Infomaniak/desktop-kDrive/assets/162997198/61cc5146-3cc3-4692-8ac7-1a4e1a9717fd)

This pull-request suggests shorter texts for the three supported languages distinct from english.