### PR TITLE
KDESKTOP-804-Incorrect-resolution-of-the-MoveParentDelete-conflict-for-folders

### DIFF
--- a/src/libsyncengine/jobs/network/abstractnetworkjob.cpp
+++ b/src/libsyncengine/jobs/network/abstractnetworkjob.cpp
@@ -498,6 +498,7 @@ bool AbstractNetworkJob::followRedirect(std::istream &inputStream) {
     bool receiveOk = receiveResponse(session, uri);
     if (!receiveOk && _resHttp.getStatus() == Poco::Net::HTTPResponse::HTTP_NOT_FOUND) {
         // Special cases where the file exist in DB but not in storage
+        _downloadImpossible = true;
         return true;
     }
     return receiveOk;

--- a/src/libsyncengine/jobs/network/abstractnetworkjob.h
+++ b/src/libsyncengine/jobs/network/abstractnetworkjob.h
@@ -44,6 +44,8 @@ class AbstractNetworkJob : public AbstractJob {
         inline Poco::Net::HTTPResponse::HTTPStatus getStatusCode() const { return _resHttp.getStatus(); }
         virtual void abort() override;
 
+        inline bool isDownloadImpossible() const { return _downloadImpossible; }
+
     protected:
         virtual void runJob() noexcept override;
         virtual void addRawHeader(const std::string &key, const std::string &value) final;
@@ -116,6 +118,8 @@ class AbstractNetworkJob : public AbstractJob {
         static bool isManagedError(ExitCode exitCode, ExitCause exitCause) noexcept;
 
         std::unordered_map<std::string, std::string> _rawHeaders;
+
+        bool _downloadImpossible {false};
 };
 
 }  // namespace KDC

--- a/src/libsyncengine/propagation/executor/executorworker.h
+++ b/src/libsyncengine/propagation/executor/executorworker.h
@@ -70,7 +70,7 @@ class ExecutorWorker : public OperationProcessor {
 
         void waitForAllJobsToFinish(bool &hasError);
         bool deleteFinishedAsyncJobs();
-        bool handleManagedBackError(ExitCause jobExitCause, SyncOpPtr syncOp, bool isInconsistencyIssue);
+        bool handleManagedBackError(ExitCause jobExitCause, SyncOpPtr syncOp, bool isInconsistencyIssue, bool downloadImpossible);
         bool handleFinishedJob(std::shared_ptr<AbstractJob> job, SyncOpPtr syncOp, const SyncPath &relativeLocalPath);
         void handleForbiddenAction(SyncOpPtr syncOp, const SyncPath &relativeLocalPath);
         void sendProgress();


### PR DESCRIPTION
This issue was a side effect of a fix aiming to ignore errors 404 on dowload jobs because is not available anymore on storage.
However, the this case, a directory has been deleted while we were trying to propagate a move operation inside it. The reaction to the error 404 must be different in this case : simply rebuild the snapshot and restart the sync.