### PR TITLE
KDESKTOP-829-executor-abort-very-frequently

### DIFF
--- a/src/libsyncengine/syncpal/operationprocessor.cpp
+++ b/src/libsyncengine/syncpal/operationprocessor.cpp
@@ -81,6 +81,7 @@ std::shared_ptr<Node> OperationProcessor::correspondingNodeInOtherTree(std::shar
         }
         if (found) {
             dbNodeId = tmpDbNodeId;
+            node->setIdb(dbNodeId);
         }
     }
 


### PR DESCRIPTION
This bug is a side effect of commit ffb1bdfbb64e4aac349b7dcb6a08f9781f040471, whuich was a refactoring of class OperationProcessor.
The problem was that we looked in DB for a node DB ID but then did not use it in method `correspondingNodeDirect`.