### PR TITLE
KDESKTOP-408-Launch-at-startup-on-macOS

### DIFF
--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -253,6 +253,10 @@ AppServer::AppServer(int &argc, char **argv)
     // Setup proxy
     setupProxy();
 
+    // Setup auto start
+    if (ParametersCache::instance()->parameters().autoStart() && !OldUtility::hasLaunchOnStartup(_theme->appName(), _logger)) {
+        OldUtility::setLaunchOnStartup(_theme->appName(), _theme->appClientName(), true, _logger);
+    }
 
 #ifdef PLUGINDIR
     // Setup extra plugin search path


### PR DESCRIPTION
The auto start parameter should be activated by default