### PR TITLE
Kdesktop 849 add tests and documentation for get rights

### DIFF
--- a/src/libcommonserver/io/iohelper.h
+++ b/src/libcommonserver/io/iohelper.h
@@ -386,7 +386,7 @@ struct IoHelper {
         static bool _setRightsStd(const SyncPath &path, bool read, bool write, bool exec, IoError &ioError) noexcept;
 
 #ifdef _WIN32
-        static void _setRightsWindowsInheritance(bool inherit); // For windows tests only
+        static bool _setRightsWindowsApiInheritance; // For windows tests only
 #endif
 };
 

--- a/src/libcommonserver/io/iohelper.h
+++ b/src/libcommonserver/io/iohelper.h
@@ -356,6 +356,7 @@ struct IoHelper {
 
     protected:
         friend class DirectoryIterator;
+        friend class TestIo;
 
         // These functions default to the std::filesystem functions.
         // They can be modified in tests.
@@ -383,6 +384,10 @@ struct IoHelper {
         static bool _checkIfIsHiddenFile(const SyncPath &path, bool &isHidden, IoError &ioError) noexcept;
 
         static bool _setRightsStd(const SyncPath &path, bool read, bool write, bool exec, IoError &ioError) noexcept;
+
+#ifdef _WIN32
+        static void _setRightsWindowsInheritance(bool inherit); // For windows tests only
+#endif
 };
 
 }  // namespace KDC

--- a/src/libcommonserver/io/iohelper_win.cpp
+++ b/src/libcommonserver/io/iohelper_win.cpp
@@ -337,7 +337,6 @@ bool IoHelper::checkIfFileIsDehydrated(const SyncPath &itemPath, bool &isDehydra
 // Always return false if ioError != IoErrorSuccess, caller should call _isExpectedError
 static bool setRightsWindowsApi(const SyncPath &path, DWORD permission, ACCESS_MODE accessMode, IoError &ioError,
                                 log4cplus::Logger logger, bool inherite = false) noexcept {
-    
     PACL pACLold = nullptr;  // Current ACL
     PACL pACLnew = nullptr;  // New ACL
     PSECURITY_DESCRIPTOR pSecurityDescriptor = nullptr;

--- a/src/libcommonserver/io/iohelper_win.cpp
+++ b/src/libcommonserver/io/iohelper_win.cpp
@@ -421,8 +421,7 @@ static bool setRightsWindowsApi(const SyncPath &path, DWORD permission, ACCESS_M
 
 // Always return false if ioError != IoErrorSuccess, caller should call _isExpectedError.
 static bool getRightsWindowsApi(const SyncPath &path, bool &read, bool &write, bool &exec, IoError &ioError,
-                                log4cplus::Logger logger,
-                                bool retry = true) noexcept {  
+                                log4cplus::Logger logger, bool retry = true) noexcept {
     ioError = IoErrorSuccess;
     read = false;
     write = false;
@@ -557,14 +556,16 @@ bool IoHelper::setRights(const SyncPath &path, bool read, bool write, bool exec,
         } else {
             grantedPermission |= FILE_GENERIC_EXECUTE;
         }
+        // clang-format off
         bool res = setRightsWindowsApi(path, grantedPermission, ACCESS_MODE::SET_ACCESS, ioError, logger(),
-                                       _setRightsWindowsApiInheritance) ||
-                   _isExpectedError(ioError);
+                                       _setRightsWindowsApiInheritance) 
+            || _isExpectedError(ioError);
         if (res) {
             res &= setRightsWindowsApi(path, deniedPermission, ACCESS_MODE::DENY_ACCESS, ioError, logger(),
-                                       _setRightsWindowsApiInheritance) ||
-                   _isExpectedError(ioError);
+                                       _setRightsWindowsApiInheritance) 
+                || _isExpectedError(ioError);
         }
+        // clang-format on
 
         if (res) {
             return true;

--- a/src/libcommonserver/io/iohelper_win.cpp
+++ b/src/libcommonserver/io/iohelper_win.cpp
@@ -333,6 +333,12 @@ bool IoHelper::checkIfFileIsDehydrated(const SyncPath &itemPath, bool &isDehydra
     return IoHelper::getXAttrValue(itemPath.native(), FILE_ATTRIBUTE_OFFLINE, isDehydrated, ioError);
 }
 
+static bool setRightsWindowsApiInheritance = false;
+
+void IoHelper::_setRightsWindowsInheritance(bool inherit) {
+    setRightsWindowsApiInheritance = inherit;
+}
+
 static bool setRightsWindowsApi(const SyncPath &path, DWORD permission, ACCESS_MODE accessMode, IoError &ioError,
                                 log4cplus::Logger logger) noexcept {  // Always return false if ioError != IoErrorSuccess, caller
                                                                       // should call _isExpectedError
@@ -344,7 +350,11 @@ static bool setRightsWindowsApi(const SyncPath &path, DWORD permission, ACCESS_M
 
     explicitAccess.grfAccessPermissions = permission;
     explicitAccess.grfAccessMode = accessMode;
-    explicitAccess.grfInheritance = NO_INHERITANCE;
+    if (!setRightsWindowsApiInheritance) {
+        explicitAccess.grfInheritance = NO_INHERITANCE;
+    } else {
+        explicitAccess.grfInheritance = SUB_CONTAINERS_AND_OBJECTS_INHERIT;
+    }
     explicitAccess.Trustee.pMultipleTrustee = nullptr;
     explicitAccess.Trustee.MultipleTrusteeOperation = NO_MULTIPLE_TRUSTEE;
     explicitAccess.Trustee.TrusteeForm = Utility::_trustee.TrusteeForm;

--- a/test/libcommonserver/io/testchecksetgetrights.cpp
+++ b/test/libcommonserver/io/testchecksetgetrights.cpp
@@ -314,7 +314,7 @@ void TestIo::testCheckSetAndGetRights() {
          *  |  0   |   0   |    0    | v
          *  ...
          */
-        IoHelper::_setRightsWindowsInheritance(true);
+        IoHelper::_setRightsWindowsApiInheritance = true; 
         for (int baseRigths = 0; baseRigths < 7;
              baseRigths++) {  // Test all the possible rights and the all the possible order of rights modification
             for (int targetRigths = baseRigths + 1; targetRigths < 8; targetRigths++) {
@@ -323,7 +323,7 @@ void TestIo::testCheckSetAndGetRights() {
                 result &= ioError == IoErrorSuccess;
                 if (!result) {
                     IoHelper::setRights(path, true, true, true, ioError);
-                    IoHelper::_setRightsWindowsInheritance(false);
+                    IoHelper::_setRightsWindowsApiInheritance = false; 
                     CPPUNIT_ASSERT(false /* Failed to set base rights */);
                 }
 
@@ -331,13 +331,13 @@ void TestIo::testCheckSetAndGetRights() {
                 result &= ioError == IoErrorSuccess;
                 if (!result) {
                     IoHelper::setRights(path, true, true, true, ioError);
-                    IoHelper::_setRightsWindowsInheritance(false);
+                    IoHelper::_setRightsWindowsApiInheritance = false; 
                     CPPUNIT_ASSERT(false /* Failed to get base rights */);
                 }
 
                 if (!(isReadable == rightsSet.read && isWritable == rightsSet.write && isExecutable == rightsSet.execute)) {
                     IoHelper::setRights(path, true, true, true, ioError);
-                    IoHelper::_setRightsWindowsInheritance(false);
+                    IoHelper::_setRightsWindowsApiInheritance = false; 
                     CPPUNIT_ASSERT(false /* Set base rights mismatch  with get base rights */);
                 }
 
@@ -346,20 +346,20 @@ void TestIo::testCheckSetAndGetRights() {
                 result &= ioError == IoErrorSuccess;
                 if (!result) {
                     IoHelper::setRights(path, true, true, true, ioError);
-                    IoHelper::_setRightsWindowsInheritance(false);
+                    IoHelper::_setRightsWindowsApiInheritance = false; 
                     CPPUNIT_ASSERT(false /* Failed to set target rights */);
                 }
                 result = IoHelper::getRights(subFolderPath, isReadable, isWritable, isExecutable, ioError);
                 result &= ioError == IoErrorSuccess;
                 if (!result) {
                     IoHelper::setRights(path, true, true, true, ioError);
-                    IoHelper::_setRightsWindowsInheritance(false);
+                    IoHelper::_setRightsWindowsApiInheritance = false; 
                     CPPUNIT_ASSERT(false /* Failed to get target rights */);
                 }
 
                 if (!(isReadable == rightsSet.read && isWritable == rightsSet.write && isExecutable == rightsSet.execute)) {
                     IoHelper::setRights(path, true, true, true, ioError);
-                    IoHelper::_setRightsWindowsInheritance(false);
+                    IoHelper::_setRightsWindowsApiInheritance = false; 
                     CPPUNIT_ASSERT(false /* Set target rights mismatch with get target rights */);
                 }
             }
@@ -367,7 +367,7 @@ void TestIo::testCheckSetAndGetRights() {
 
         // Restore the rights
         IoHelper::setRights(path, true, true, true, ioError);
-        IoHelper::_setRightsWindowsInheritance(false);
+        IoHelper::_setRightsWindowsApiInheritance = false; 
         CPPUNIT_ASSERT_EQUAL(0, IoHelper::_getAndSetRightsMethod);  // Check that no error occurred with the windows API
 
 
@@ -413,7 +413,7 @@ void TestIo::testCheckSetAndGetRights() {
          *  |  0   |   0   |    0    | v
          *  ...
          */
-        IoHelper::_setRightsWindowsInheritance(true);
+        IoHelper::_setRightsWindowsApiInheritance = true; 
         for (int baseRigths = 0; baseRigths < 7;
              baseRigths++) {  // Test all the possible rights and the all the possible order of rights modification
             for (int targetRigths = baseRigths + 1; targetRigths < 8; targetRigths++) {
@@ -422,7 +422,7 @@ void TestIo::testCheckSetAndGetRights() {
                 result &= ioError == IoErrorSuccess;
                 if (!result) {
                     IoHelper::setRights(path, true, true, true, ioError);
-                    IoHelper::_setRightsWindowsInheritance(false);
+                    IoHelper::_setRightsWindowsApiInheritance = false; 
                     CPPUNIT_ASSERT(false /* Failed to set base rights */);
                 }
 
@@ -430,12 +430,12 @@ void TestIo::testCheckSetAndGetRights() {
                 result &= ioError == IoErrorSuccess;
                 if (!result) {
                     IoHelper::setRights(path, true, true, true, ioError);
-                    IoHelper::_setRightsWindowsInheritance(false);
+                    IoHelper::_setRightsWindowsApiInheritance = false; 
                     CPPUNIT_ASSERT(false /* Failed to get base rights */);
                 }
                 if (!(isReadable == rightsSet.read && isWritable == rightsSet.write && isExecutable == rightsSet.execute)) {
                     IoHelper::setRights(path, true, true, true, ioError);
-                    IoHelper::_setRightsWindowsInheritance(false);
+                    IoHelper::_setRightsWindowsApiInheritance = false; 
                     CPPUNIT_ASSERT(false /* Set base rights mismatch  with get base rights */);
                 }
 
@@ -444,20 +444,20 @@ void TestIo::testCheckSetAndGetRights() {
                 result &= ioError == IoErrorSuccess;
                 if (!result) {
                     IoHelper::setRights(path, true, true, true, ioError);
-                    IoHelper::_setRightsWindowsInheritance(false);
+                    IoHelper::_setRightsWindowsApiInheritance = false; 
                     CPPUNIT_ASSERT(false /* Failed to set target rights */);
                 }
                 result = IoHelper::getRights(filePath, isReadable, isWritable, isExecutable, ioError);
                 result &= ioError == IoErrorSuccess;
                 if (!result) {
                     IoHelper::setRights(path, true, true, true, ioError);
-                    IoHelper::_setRightsWindowsInheritance(false);
+                    IoHelper::_setRightsWindowsApiInheritance = false; 
                     CPPUNIT_ASSERT(false /* Failed to get target rights */);
                 }
 
                 if (!(isReadable == rightsSet.read && isWritable == rightsSet.write && isExecutable == rightsSet.execute)) {
                     IoHelper::setRights(path, true, true, true, ioError);
-                    IoHelper::_setRightsWindowsInheritance(false);
+                    IoHelper::_setRightsWindowsApiInheritance = false; 
                     CPPUNIT_ASSERT(false /* Set target rights mismatch with get target rights */);
                 }
             }
@@ -465,7 +465,7 @@ void TestIo::testCheckSetAndGetRights() {
 
         // Restore the rights
         IoHelper::setRights(path, true, true, true, ioError);
-        IoHelper::_setRightsWindowsInheritance(false);
+        IoHelper::_setRightsWindowsApiInheritance = false; 
         CPPUNIT_ASSERT_EQUAL(0, IoHelper::_getAndSetRightsMethod);  // Check that no error occurred with the wndows API
 #endif
     }

--- a/test/libcommonserver/io/testchecksetgetrights.cpp
+++ b/test/libcommonserver/io/testchecksetgetrights.cpp
@@ -51,9 +51,11 @@ void TestIo::testCheckSetAndGetRights() {
         bool isWritable = false;
         bool isExecutable = false;
 
-        // Test for a directory without any change on rights (ie: the default rights). Assumed that there is no inherited rights
+#ifdef _WIN32
+        // Test for a directory without any Explicit ACE (ie no inherited rights)
         CPPUNIT_ASSERT(IoHelper::getRights(path, isReadable, isWritable, isExecutable, ioError));
         CPPUNIT_ASSERT(ioError == IoErrorSuccess && isReadable && isWritable && isExecutable);
+#endif
 
         /* Test all the possible rights and all the possible order of rights modification. ie:
          *  | READ | WRITE | EXECUTE | |
@@ -140,9 +142,11 @@ void TestIo::testCheckSetAndGetRights() {
         bool isWritable = false;
         bool isExecutable = false;
 
-        // Test for a file without any change on rights (ie: the default rights). Assumed that there is no inherited rights
+#ifdef _WIN32
+        // Test for a file without any Explicit ACE (ie no inherited rights)
         CPPUNIT_ASSERT(IoHelper::getRights(filepath, isReadable, isWritable, isExecutable, ioError));
         CPPUNIT_ASSERT(ioError == IoErrorSuccess && isReadable && isWritable && isExecutable);
+#endif
 
 
         /* Test all the possible rights and all the possible order of rights modification. ie:
@@ -385,7 +389,7 @@ void TestIo::testCheckSetAndGetRights() {
         CPPUNIT_ASSERT(file.is_open());
         file << "testCheckSetAndGetRights";
         file.close();
-        
+
         bool isReadable = false;
         bool isWritable = false;
         bool isExecutable = false;


### PR DESCRIPTION
From Microsoft documentation:
> https://learn.microsoft.com/en-us/windows/win32/api/aclapi/nf-aclapi-geteffectiverightsfromacla
> 
> The GetEffectiveRightsFromAcl function fails and returns ERROR_INVALID_ACL if the specified ACL contains an inherited access-denied ACE.

From my personal test on Windows 11 Pro 23H2, the function does work as expected and returns the rights for the trustee even if the ACL contains an inherited access-denied ACE.

If we get ERROR_INVALID_ACL, we will consider to be in the case described in the documentation and consider the file as not existing (we can't get the rights).

This PR also add tests for inherited permission and for files/folders on without inherited permission. 

To test inheritance, I introduced `IoHelper::_setRightsWindowsApiInheritance`, which is false by default.

The `_setRightsWindowsApi` then uses this variable to determine whether it should set permissions on sub-objects. 
This is necessary to test the `getRights` method on files/folders that inherit permissions from the parent folder.
This method avoids the need to add a parameter to the `getRights` function, which is generic across Linux, MacOS, and Windows.