### PR TITLE
KDESKTOP-863-Do-not-setup-auto-start-in-debug-mode

### DIFF
--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -254,9 +254,11 @@ AppServer::AppServer(int &argc, char **argv)
     setupProxy();
 
     // Setup auto start
+#ifdef NDEBUG
     if (ParametersCache::instance()->parameters().autoStart() && !OldUtility::hasLaunchOnStartup(_theme->appName(), _logger)) {
         OldUtility::setLaunchOnStartup(_theme->appName(), _theme->appClientName(), true, _logger);
     }
+#endif
 
 #ifdef PLUGINDIR
     // Setup extra plugin search path


### PR DESCRIPTION
Multiple entries of kDrive.app appeared in the "Open at login" preference panel of macOS