### PR TITLE
[KDESKTOP-866] Special handling on MacOSX of paths of length 1023 with special characters

### DIFF
--- a/src/libcommon/utility/types.h
+++ b/src/libcommon/utility/types.h
@@ -345,12 +345,13 @@ typedef enum {
     IoErrorFileExists,
     IoErrorFileNameTooLong,
     IoErrorInvalidArgument,
+    IoErrorInvalidDirectoryIterator,
+    IoErrorInvalidFileName,
     IoErrorIsADirectory,
     IoErrorIsAFile,
+    IoErrorMaxDepthExceeded,
     IoErrorNoSuchFileOrDirectory,
     IoErrorResultOutOfRange,
-    IoErrorInvalidDirectoryIterator,
-    IoErrorMaxDepthExceeded,
     IoErrorUnknown
 } IoError;
 
@@ -377,15 +378,7 @@ enum class AppStateKey {
     Unknown  //!\ keep in last position (For tests) /!\\ Only for initialization purpose
 };
 
-enum class LogUploadState {
-    None,
-    Archiving,
-    Uploading,
-    Success,
-    Failed,
-    CancelRequested,
-    Canceled
-};
+enum class LogUploadState { None, Archiving, Uploading, Success, Failed, CancelRequested, Canceled };
 
 // Adding a new types here requires to add it in stringToAppStateValue and appStateValueToString in libcommon/utility/utility.cpp
 using AppStateValue = std::variant<std::string, int, int64_t, LogUploadState>;

--- a/src/libcommonserver/io/iohelper.h
+++ b/src/libcommonserver/io/iohelper.h
@@ -407,7 +407,7 @@ struct IoHelper {
         static bool _setRightsStd(const SyncPath &path, bool read, bool write, bool exec, IoError &ioError) noexcept;
 
 #ifdef _WIN32
-        static bool _setRightsWindowsApiInheritance; // For windows tests only
+        static bool _setRightsWindowsApiInheritance;  // For windows tests only
 #endif
 };
 

--- a/src/libcommonserver/io/iohelper_mac.mm
+++ b/src/libcommonserver/io/iohelper_mac.mm
@@ -34,6 +34,8 @@ IoError nsError2ioError(NSError *nsError) noexcept {
     if ([nsError.domain isEqualToString:NSCocoaErrorDomain]) {
         switch (nsError.code) {
             case NSFileNoSuchFileError:
+            case NSFileReadInvalidFileNameError:
+                return IoErrorInvalidFileName;
             case NSFileReadNoSuchFileError:
                 return IoErrorNoSuchFileOrDirectory;
             case NSFileReadNoPermissionError:

--- a/src/libcommonserver/io/iohelper_mac.mm
+++ b/src/libcommonserver/io/iohelper_mac.mm
@@ -34,12 +34,12 @@ IoError nsError2ioError(NSError *nsError) noexcept {
     if ([nsError.domain isEqualToString:NSCocoaErrorDomain]) {
         switch (nsError.code) {
             case NSFileNoSuchFileError:
-            case NSFileReadInvalidFileNameError:
-                return IoErrorInvalidFileName;
             case NSFileReadNoSuchFileError:
                 return IoErrorNoSuchFileOrDirectory;
             case NSFileReadNoPermissionError:
                 return IoErrorAccessDenied;
+            case NSFileReadInvalidFileNameError:
+                return IoErrorInvalidFileName;
             default:
                 return IoErrorUnknown;
         }

--- a/test/libcommonserver/io/testcreatealias.cpp
+++ b/test/libcommonserver/io/testcreatealias.cpp
@@ -131,7 +131,7 @@ void TestIo::testCreateAlias() {
 
         IoError aliasError = IoErrorSuccess;
         CPPUNIT_ASSERT(!IoHelper::createAliasFromPath(targetPath, path, aliasError));
-        CPPUNIT_ASSERT_EQUAL(IoErrorInvalidFileName, aliasError);
+        CPPUNIT_ASSERT_EQUAL(IoErrorNoSuchFileOrDirectory, aliasError);
         // The test CPPUNIT_ASSERT(!std::filesystem::exists(path)) throws because a filesystem error.
     }
 
@@ -157,7 +157,7 @@ void TestIo::testCreateAlias() {
 
         IoError aliasError = IoErrorSuccess;
         CPPUNIT_ASSERT(!IoHelper::createAliasFromPath(targetPath, path, aliasError));
-        CPPUNIT_ASSERT_EQUAL(IoErrorInvalidFileName, aliasError);
+        CPPUNIT_ASSERT_EQUAL(IoErrorNoSuchFileOrDirectory, aliasError);
         // The test CPPUNIT_ASSERT(!std::filesystem::exists(path)) throws because a filesystem error.
     }
 

--- a/test/libcommonserver/io/testcreatealias.cpp
+++ b/test/libcommonserver/io/testcreatealias.cpp
@@ -131,7 +131,7 @@ void TestIo::testCreateAlias() {
 
         IoError aliasError = IoErrorSuccess;
         CPPUNIT_ASSERT(!IoHelper::createAliasFromPath(targetPath, path, aliasError));
-        CPPUNIT_ASSERT(aliasError == IoErrorNoSuchFileOrDirectory);
+        CPPUNIT_ASSERT_EQUAL(IoErrorInvalidFileName, aliasError);
         // The test CPPUNIT_ASSERT(!std::filesystem::exists(path)) throws because a filesystem error.
     }
 
@@ -157,7 +157,7 @@ void TestIo::testCreateAlias() {
 
         IoError aliasError = IoErrorSuccess;
         CPPUNIT_ASSERT(!IoHelper::createAliasFromPath(targetPath, path, aliasError));
-        CPPUNIT_ASSERT(aliasError == IoErrorNoSuchFileOrDirectory);
+        CPPUNIT_ASSERT_EQUAL(IoErrorInvalidFileName, aliasError);
         // The test CPPUNIT_ASSERT(!std::filesystem::exists(path)) throws because a filesystem error.
     }
 

--- a/test/libcommonserver/io/testgetitemtype.cpp
+++ b/test/libcommonserver/io/testgetitemtype.cpp
@@ -207,8 +207,9 @@ void TestIo::testGetItemTypeSimpleCases() {
 
 #ifdef _WIN32
         ItemType itemType;
-        CPPUNIT_ASSERT(_testObj->getItemType(path, itemType)); // Invalid name is considered as IoErrorNoSuchFileOrDirectory (expected error)
-        CPPUNIT_ASSERT(itemType.ioError == IoErrorNoSuchFileOrDirectory); 
+        CPPUNIT_ASSERT(_testObj->getItemType(
+            path, itemType));  // Invalid name is considered as IoErrorNoSuchFileOrDirectory (expected error)
+        CPPUNIT_ASSERT(itemType.ioError == IoErrorNoSuchFileOrDirectory);
         CPPUNIT_ASSERT(itemType.nodeType == NodeTypeUnknown);
         CPPUNIT_ASSERT(itemType.linkType == LinkTypeNone);
         CPPUNIT_ASSERT(itemType.targetType == NodeTypeUnknown);
@@ -308,17 +309,12 @@ void TestIo::testGetItemTypeSimpleCases() {
         IoHelper::createAliasFromPath(targetPath, path, aliasError);
         std::filesystem::remove_all(targetPath);
 
-#ifdef _WIN32
-        const auto result =
-            checker.checkSuccessfullRetrievalOfDanglingLink(path, SyncPath{}, LinkTypeFinderAlias, NodeTypeDirectory);
-#else
         const auto result =
             checker.checkSuccessfullRetrievalOfDanglingLink(path, SyncPath{}, LinkTypeFinderAlias, NodeTypeUnknown);
 #endif
         CPPUNIT_ASSERT_MESSAGE(result.message, result.success);
     }
 
-#endif
 #if defined(_WIN32)
     // A Windows junction on a regular folder.
     {
@@ -398,8 +394,8 @@ void TestIo::testGetItemTypeSimpleCases() {
         CPPUNIT_ASSERT(itemType.ioError == IoErrorSuccess);
         CPPUNIT_ASSERT(itemType.nodeType == NodeTypeFile);
 #else
-        CPPUNIT_ASSERT(itemType.ioError == IoErrorAccessDenied);
-        CPPUNIT_ASSERT(itemType.nodeType == NodeTypeUnknown);
+    CPPUNIT_ASSERT(itemType.ioError == IoErrorAccessDenied);
+    CPPUNIT_ASSERT(itemType.nodeType == NodeTypeUnknown);
 #endif
         CPPUNIT_ASSERT(itemType.linkType == LinkTypeNone);
         CPPUNIT_ASSERT(itemType.targetType == NodeTypeUnknown);
@@ -434,10 +430,10 @@ void TestIo::testGetItemTypeSimpleCases() {
         CPPUNIT_ASSERT(itemType.targetType == NodeTypeFile);
         CPPUNIT_ASSERT(itemType.targetPath == targetPath);
 #else
-        const auto result = checker.checkAccessIsDenied(path);
-        // Restore permission to allow subdir removal
-        std::filesystem::permissions(subdir, std::filesystem::perms::owner_exec, std::filesystem::perm_options::add);
-        CPPUNIT_ASSERT_MESSAGE(result.message, result.success);
+    const auto result = checker.checkAccessIsDenied(path);
+    // Restore permission to allow subdir removal
+    std::filesystem::permissions(subdir, std::filesystem::perms::owner_exec, std::filesystem::perm_options::add);
+    CPPUNIT_ASSERT_MESSAGE(result.message, result.success);
 #endif
     }
 }
@@ -617,9 +613,58 @@ void TestIo::testGetItemTypeAllBranches() {
 #endif
 }
 
+void TestIo::testGetItemTypeEdgeCases() {
+#ifdef __APPLE__
+    // A regular file with a file path of length 1023 which contains moreover a Japanese character.
+    // Such a path causes the function `getResourceValue` to issue an error with code 258 in the following excerpt:
+    //
+    // NSURL *pathURL = [NSURL fileURLWithPath:pathStr]
+    // NSError *error = nil;
+    // NSNumber *isAliasNumber = nil;
+    // BOOL ret = [pathURL getResourceValue:&isAliasNumber forKey:NSURLIsAliasFileKey error:&error];
+    //
+    // Above `ret` is FALSE and `error` has code 258 as in
+    // https://developer.apple.com/documentation/foundation/1448136-nserror_codes/nsfilereadinvalidfilenameerror?language=objc
+    // It is unclear which of `fileURLWithPath` or `getResourceValue` is the culprit.
+
+    const TemporaryDirectory temporaryDirectory;
+    const int bound = (1020 - temporaryDirectory.path.string().size()) / 4;
+    std::string segment(bound, 'a');
+
+    SyncPath path = temporaryDirectory.path / segment / segment / segment / u8"놔";
+
+    std::error_code ec;
+    CPPUNIT_ASSERT(std::filesystem::create_directories(path, ec));
+    CPPUNIT_ASSERT(!ec);
+    CPPUNIT_ASSERT(std::filesystem::exists(path));
+    CPPUNIT_ASSERT(!ec);
+    CPPUNIT_ASSERT(std::filesystem::is_directory(path, ec));
+    CPPUNIT_ASSERT(!ec);
+
+    path = path / std::string(1022 - path.string().size(), 'a');
+    // The length of a file path can be at most 1024 on MacOSX, including the terminating null character.
+    CPPUNIT_ASSERT_EQUAL(size_t(1023), path.string().size());
+    { std::ofstream{path}; }
+
+    ItemType itemType;
+    CPPUNIT_ASSERT(!_testObj->getItemType(path, itemType));
+    // The outcome depends on the value of `temporaryDirectory.path`.
+    if (std::filesystem::exists(path, ec)) {
+        CPPUNIT_ASSERT_EQUAL(
+            IoErrorInvalidFileName,  // Ooops! Because of NSFileReadInvalidNameError with code 258 issued within `checkIfAlias_`
+            itemType.ioError);
+    } else {
+        CPPUNIT_ASSERT_EQUAL(
+            IoErrorFileNameTooLong,  // Ooops! Because of NSFileReadInvalidNameError with code 258 issued within `checkIfAlias_`
+            itemType.ioError);
+    }
+#endif
+}
+
 void TestIo::testGetItemType() {
     testGetItemTypeSimpleCases();
     testGetItemTypeAllBranches();
+    testGetItemTypeEdgeCases();
 }
 
 }  // namespace KDC

--- a/test/libcommonserver/io/testio.h
+++ b/test/libcommonserver/io/testio.h
@@ -43,7 +43,7 @@ struct IoHelperTests : public IoHelper {
 
 class TestIo : public CppUnit::TestFixture {
         CPPUNIT_TEST_SUITE(TestIo);
-        CPPUNIT_TEST(testCheckSetAndGetRights); // Keep this test before any tests that may use set/get rights functions
+        CPPUNIT_TEST(testCheckSetAndGetRights);  // Keep this test before any tests that may use set/get rights functions
         CPPUNIT_TEST(testGetItemType);
         CPPUNIT_TEST(testGetFileSize);
         CPPUNIT_TEST(testTempDirectoryPath);
@@ -107,6 +107,7 @@ class TestIo : public CppUnit::TestFixture {
 
     private:
         void testGetItemTypeSimpleCases(void);
+        void testGetItemTypeEdgeCases(void);
         void testGetItemTypeAllBranches(void);
 
         void testGetFileSizeSimpleCases(void);


### PR DESCRIPTION
This pull requests addresses the Jira ticket [KDESKTOP-866] (https://infomaniak.atlassian.net/browse/KDESKTOP-866): a file of file path length 1023 containing a special character can cause a trouble to some of MacOSX file system API calls.

The issue is not entirely understood: we don't know which of `fileURLWithPath` or `getResourceValue` is actually causing the problem.  

The current proposition consists mostly in documenting the issue in unit tests and returning a more accurate error message when such an edge case occurs.