### PR TITLE
KDESKTOP-919 - Do not check file availability for syncing it for now

### DIFF
--- a/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
@@ -517,18 +517,23 @@ ExitCode ComputeFSOperationWorker::exploreSnapshotTree(ReplicaSide side, const s
                     continue;
                 }
 
-                const bool isLink = _syncPal->_localSnapshot->isLink(nodeId);
-
-                if (type == NodeTypeFile && !isLink) {
-                    // On Windows, we receive CREATE event while the file is still being copied
-                    // Do not start synchronizing the file while copying is in progress
-                    const SyncPath absolutePath = _syncPal->_localPath / snapPath;
-                    if (!IoHelper::isFileAccessible(absolutePath, ioError)) {
-                        LOG_SYNCPAL_INFO(_logger, L"Item \"" << Path2WStr(absolutePath).c_str()
-                                                             << L"\" is not ready. Synchronization postponed.");
-                        continue;
-                    }
-                }
+                // TODO : this portion of code aimed to wait for a file to be available locally before starting to synchronize it
+                // For example, on Windows, when copying a big file inside the sync folder, the creation event is received
+                // immediately but the copy will take some time. Therefor, the file will appear locked during the copy.
+                // However, this will also block the update of file locked by an application during its edition (Microsoft Office,
+                // Open Office, ...)
+//                const bool isLink = _syncPal->_localSnapshot->isLink(nodeId);
+//
+//                if (type == NodeTypeFile && !isLink) {
+//                    // On Windows, we receive CREATE event while the file is still being copied
+//                    // Do not start synchronizing the file while copying is in progress
+//                    const SyncPath absolutePath = _syncPal->_localPath / snapPath;
+//                    if (!IoHelper::isFileAccessible(absolutePath, ioError)) {
+//                        LOG_SYNCPAL_INFO(_logger, L"Item \"" << Path2WStr(absolutePath).c_str()
+//                                                             << L"\" is not ready. Synchronization postponed.");
+//                        continue;
+//                    }
+//                }
             }
 
             // Create operation


### PR DESCRIPTION
This PR remove a functionnality added in version 3.6.0.
The feature was waiting for a big file to be completly copied before starting to sync it.
However, we notice that this would make the sync of Office files (among others) impossible while the file is open in Word or similar apps.