### PR TITLE
[KDESKTOP-965] Fixes use of wrong operation type in UpdateTreeWorker::updateTmpNode

### DIFF
--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
@@ -338,17 +338,17 @@ void UpdateTreeWorker::logUpdate(const std::shared_ptr<Node> node, const Operati
                                     << opTypeStr.c_str() << L" inserted in change events.");
 }
 
-void UpdateTreeWorker::updateTmpNode(std::shared_ptr<Node> newNode, const FSOpPtr op, const FSOpPtr deleteOp) {
+void UpdateTreeWorker::updateTmpNode(std::shared_ptr<Node> newNode, const FSOpPtr op, const FSOpPtr deleteOp,
+                                     OperationType opType) {
     assert(newNode != nullptr && newNode->isTmp());
 
     updateNodeId(newNode, op->nodeId());
     newNode->setCreatedAt(op->createdAt());
     newNode->setLastModified(op->lastModified());
     newNode->setSize(op->size());
-    newNode->insertChangeEvent(op->operationType());
+    newNode->insertChangeEvent(opType);
     newNode->setIsTmp(false);
 
-    const auto opType = op->operationType();
     if (opType == OperationTypeEdit) {
         newNode->setPreviousId(deleteOp->nodeId());
         _updateTree->previousIdSet()[deleteOp->nodeId()] = op->nodeId();
@@ -457,7 +457,7 @@ ExitCode UpdateTreeWorker::step4DeleteFile() {
             std::shared_ptr<Node> newNode = parentNode->findChildrenById(deleteOp->nodeId());
             if (newNode != nullptr && newNode->isTmp()) {
                 // Tmp node already exists, update it
-                updateTmpNode(newNode, op, deleteOp);
+                updateTmpNode(newNode, op, deleteOp, opType);
             } else {
                 // create node
                 DbNodeId idb;

--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.h
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.h
@@ -119,7 +119,7 @@ class UpdateTreeWorker : public ISyncWorker {
         // Log update information if extended logging is on.
         void logUpdate(const std::shared_ptr<Node> node, const OperationType opType,
                        const std::shared_ptr<Node> parentNode = nullptr);
-        void updateTmpNode(const std::shared_ptr<Node> node, FSOpPtr op, FSOpPtr deleteOp);
+        void updateTmpNode(const std::shared_ptr<Node> node, FSOpPtr op, FSOpPtr deleteOp, OperationType opType);
 
 
         /**


### PR DESCRIPTION
This pull-request fixes a regression that I introduced while re-factoring `UpdateTreeWorker` (Sonar's suggested improvements).

To do: 
- [ ] Unit test to prevent regression.