### PR TITLE
Add environment variable pointing to the local lib folder

### DIFF
--- a/infomaniak-build-tools/linux/Readme.md
+++ b/infomaniak-build-tools/linux/Readme.md
@@ -171,6 +171,10 @@ make install
 
 # Build in Debug
 
+## Linking dependencies
+
+In order for CMake to be able to find all dependencies, you might need to define `LD_LIBRARY_PATH=/usr/local/lib` in your environment variables.
+
 ## Using Qt Creator 
 
 ### Configuration
@@ -194,7 +198,6 @@ In the project build settings, paste the following lines in the Initial Configur
 
 ### Debugging
 
-In order that all libraries are found, you might need to define `LD_LIBRARY_PATH=/usr/local/lib`in your environment variables.
 The configuration and database files are stored in the `~/.config/kDrive` directory.  
 The log files will be generated in the `/tmp/kDrive-logdir` directory.
 

--- a/infomaniak-build-tools/macos/Readme.md
+++ b/infomaniak-build-tools/macos/Readme.md
@@ -238,6 +238,9 @@ xcrun notarytool store-credentials "notarytool" --apple-id <email address> --tea
 
 # Build in Debug
 
+In order that all libraries are found, you might need to define `DYLD_LIBRARY_PATH=/usr/local/lib` in your environment variables.
+Either add `export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:/usr/local/lib` in your personal `.zshrc` file or add the environment variable in your IDE.
+
 ## Using Qt Creator
 
 ### Qt Configuration

--- a/infomaniak-build-tools/macos/Readme.md
+++ b/infomaniak-build-tools/macos/Readme.md
@@ -238,7 +238,9 @@ xcrun notarytool store-credentials "notarytool" --apple-id <email address> --tea
 
 # Build in Debug
 
-In order that all libraries are found, you might need to define `DYLD_LIBRARY_PATH=/usr/local/lib` in your environment variables.
+## Linking dependencies
+
+In order for CMake to be able to find all dependencies, you might need to define `DYLD_LIBRARY_PATH=/usr/local/lib` in your environment variables.
 Either add `export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:/usr/local/lib` in your personal `.zshrc` file or add the environment variable in your IDE.
 
 ## Using Qt Creator

--- a/infomaniak-build-tools/windows/Readme.md
+++ b/infomaniak-build-tools/windows/Readme.md
@@ -265,7 +265,21 @@ Once installed, open `F:\Projects\desktop-kDrive\extensions\windows\cfapi\kDrive
 
 # Build in Debug
 
-To build in `Debug` mode, you will need to build and deploy the Windows extension first.  
+To build in `Debug` mode, you will need to build and deploy the Windows extension first.
+
+## Link dependencies
+
+In order for CMake to be able to find all dependencies. Add all libraries install folder in the `PATH` environment variable:
+```
+C:\Program Files (x86)\Poco\bin
+C:\Program Files (x86)\libzip\bin
+C:\Program Files (x86)\zlib-1.2.11\bin
+C:\Program Files (x86)\xxHash\bin
+C:\Program Files (x86)\Sentry-Native\bin
+C:\Program Files (x86)\log4cplus\bin
+C:\Program Files (x86)\cppunit\bin
+C:\Program Files\OpenSSL\bin
+```
 
 ## Using Qt Creator
 You can disable QML debugger from the settings to avoid some error pop-ups.

--- a/infomaniak-build-tools/windows/Readme.md
+++ b/infomaniak-build-tools/windows/Readme.md
@@ -267,9 +267,9 @@ Once installed, open `F:\Projects\desktop-kDrive\extensions\windows\cfapi\kDrive
 
 To build in `Debug` mode, you will need to build and deploy the Windows extension first.
 
-## Link dependencies
+## Linking dependencies
 
-In order for CMake to be able to find all dependencies. Add all libraries install folder in the `PATH` environment variable:
+In order for CMake to be able to find all dependencies, add all libraries installation folder in the `PATH` environment variable:
 ```
 C:\Program Files (x86)\Poco\bin
 C:\Program Files (x86)\libzip\bin
@@ -282,6 +282,7 @@ C:\Program Files\OpenSSL\bin
 ```
 
 ## Using Qt Creator
+
 You can disable QML debugger from the settings to avoid some error pop-ups.
 
 ### Additionnal Requirements


### PR DESCRIPTION
In order to avoid copying the lib by hand in debug mode, we need to add an environment variable pointing to the lib folder. For example on macOS : `/usr/local/lib`.
Doc updated