### PR TITLE
KDESKTOP-966-Bump-Xcode-Clang

### DIFF
--- a/infomaniak-build-tools/linux/Readme.md
+++ b/infomaniak-build-tools/linux/Readme.md
@@ -35,18 +35,37 @@ cd desktop-kDrive && git submodule update --init --recursive
 These requirements will only apply if you want to build from a Linux device  
 Currently, the build for Linux release is created from a podman container
 
-You will need cmake and gcc-c++ to compile the libraries and the kDrive project  
+You will need cmake and clang to compile the libraries and the kDrive project  
 This documentation was made for Ubuntu 22.04 LTS
 
 ## Packages :
 
-If not already installed, you will need **git**, **cmake** and **clang** packages.
+If not already installed, you will need **git**, **cmake** and **clang** (clang-18 or higher) packages.
 
 ```bash
 sudo apt install -y git
 sudo apt install -y cmake
 sudo apt install -y clang
 ```
+
+Ensure that CLANG is installed with a version higher than 18 with the following command :
+
+```bash
+clang --version
+```
+
+If the version is lower than 18, you can install the latest version with the following commands :
+
+```bash
+wget https://apt.llvm.org/llvm.sh
+chmod u+x llvm.sh
+apt install lsb-release wget software-properties-common gnupg
+sudo ./llvm.sh 18
+sudo update-alternatives --install /usr/bin/clang clang /usr/lib/llvm-18/bin/clang 100
+sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/lib/llvm-18/bin/clang++ 100
+```
+
+Check the version again with `clang --version` to ensure that the version is now 18 or higher.
 
 ## Qt 6.2.3
 

--- a/infomaniak-build-tools/linux/Readme.md
+++ b/infomaniak-build-tools/linux/Readme.md
@@ -48,7 +48,7 @@ sudo apt install -y cmake
 sudo apt install -y clang
 ```
 
-Ensure that CLANG is installed with a version higher than 18 with the following command :
+Ensure that CLANG is installed with at least version 18 by running the following command :
 
 ```bash
 clang --version


### PR DESCRIPTION
# Summary

Some `std::` functions, such as `std::format`, are not available in the current version of libc++.

# Description

Certain standard functions from the C++ library (e.g., `std::format`) are missing in the current version of libc++ we are using. This issue is specific to MacOS and Ubuntu environments.

# Environment

## MacOS

The missing functions seem to be implemented starting from Xcode 15.3. More information can be found in the [C++ Language Support section on the Apple Developer site](https://developer.apple.com/documentation/xcode/c++-language-support).

## Ubuntu

These functions are supported starting from CLang 17. Reference: [Compiler support for C++20 on cppreference.com](https://en.cppreference.com/w/cpp/compiler_support).

## Windows

No changes are required.

# Proposed Solution

- Upgrade the development environment on MacOS to Xcode 15.3 or later.
- Upgrade CLang to version ~~17~~ 18 or later on Ubuntu.

# Additional Information

No changes are necessary for Windows environments.