### PR TITLE
KDESKTOP-954-Error-in-updateNodeWithDb

### DIFF
--- a/.run/kDrive.run.xml
+++ b/.run/kDrive.run.xml
@@ -6,8 +6,6 @@
     </envs>
     <method v="2">
       <option name="com.jetbrains.cidr.execution.CidrBuildBeforeRunTaskProvider$BuildBeforeRunTask" enabled="true" />
-      <option name="ToolBeforeRunTask" enabled="true" actionId="Tool_External Tools_macdeploy kDrive" />
-      <option name="ToolBeforeRunTask" enabled="true" actionId="Tool_External Tools_Sign packages" />
     </method>
   </configuration>
 </component>

--- a/src/libsyncengine/update_detection/file_system_observer/snapshot/snapshot.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/snapshot/snapshot.cpp
@@ -148,7 +148,7 @@ bool Snapshot::removeItem(const NodeId &id) {
     _items.erase(id);
 
     if (ParametersCache::isExtendedLogEnabled()) {
-        LOG_DEBUG(Log::instance()->getLogger(), "Item " << id.c_str() << "removed from remote snapshot.");
+        LOG_DEBUG(Log::instance()->getLogger(), "Item " << id.c_str() << " removed from remote snapshot.");
     }
 
     return true;

--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
@@ -1164,7 +1164,9 @@ ExitCode UpdateTreeWorker::updateNodeWithDb(const std::shared_ptr<Node> parentNo
 
         // if node is temporary node
         if (node->isTmp()) {
-            updateTmpNode(node);
+            if (ExitCode exitCode = updateTmpNode(node); exitCode != ExitCodeOk) {
+                return exitCode;
+            }
         }
 
         // use previous nodeId if it's an Edit from Delete-Create

--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
@@ -179,7 +179,7 @@ ExitCode UpdateTreeWorker::step3DeleteDirectory() {
                     }
                 }
                 // get parentNode
-                parentNode = getOrCreateNodeFromPath(newPath.parent_path());
+                parentNode = getOrCreateNodeFromPath(newPath.parent_path(), true);
             }
 
             // Find dbNodeId
@@ -450,7 +450,7 @@ ExitCode UpdateTreeWorker::step4DeleteFile() {
 
             if (!ok) {
                 // find parentNode
-                parentNode = getOrCreateNodeFromPath(op->path().parent_path());
+                parentNode = getOrCreateNodeFromPath(op->path().parent_path(), true);
             }
 
             // find child node
@@ -520,7 +520,7 @@ ExitCode UpdateTreeWorker::step5CreateDirectory() {
         }
 
         // find node by path because it may have been created before
-        std::shared_ptr<Node> currentNode = getOrCreateNodeFromPath(createOp->path());
+        std::shared_ptr<Node> currentNode = getOrCreateNodeFromPath(createOp->path(), false);
         if (currentNode->hasChangeEvent(OperationTypeDelete)) {
             // A directory has been deleted and another one has been created with the same name
             currentNode->setPreviousId(currentNode->id());
@@ -562,7 +562,7 @@ ExitCode UpdateTreeWorker::step6CreateFile() {
         FSOpPtr operation = op.second;
 
         // find parentNode by path
-        std::shared_ptr<Node> parentNode = getOrCreateNodeFromPath(operation->path().parent_path());
+        std::shared_ptr<Node> parentNode = getOrCreateNodeFromPath(operation->path().parent_path(), false);
         std::shared_ptr<Node> newNode = parentNode->findChildrenById(operation->nodeId());
         if (newNode != nullptr) {
             // Node already exists, update it
@@ -640,7 +640,7 @@ ExitCode UpdateTreeWorker::step7EditFile() {
             continue;
         }
         // find parentNode by path because should have been created
-        std::shared_ptr<Node> parentNode = getOrCreateNodeFromPath(editOp->path().parent_path());
+        std::shared_ptr<Node> parentNode = getOrCreateNodeFromPath(editOp->path().parent_path(), false);
         std::shared_ptr<Node> newNode = parentNode->findChildrenById(editOp->nodeId());
         if (newNode != nullptr) {
             // Node already exists, update it
@@ -856,7 +856,7 @@ ExitCode UpdateTreeWorker::createMoveNodes(const NodeType &nodeType) {
             }
 
             // create node if not exist
-            std::shared_ptr<Node> parentNode = getOrCreateNodeFromPath(moveOp->destinationPath().parent_path());
+            std::shared_ptr<Node> parentNode = getOrCreateNodeFromPath(moveOp->destinationPath().parent_path(), false);
 
             currentNode->insertChangeEvent(OperationTypeMove);
             currentNode->setCreatedAt(moveOp->createdAt());
@@ -905,7 +905,7 @@ ExitCode UpdateTreeWorker::createMoveNodes(const NodeType &nodeType) {
             }
         } else {
             // get parentNode
-            std::shared_ptr<Node> parentNode = getOrCreateNodeFromPath(moveOp->destinationPath().parent_path());
+            std::shared_ptr<Node> parentNode = getOrCreateNodeFromPath(moveOp->destinationPath().parent_path(), false);
 
             // create node
             DbNodeId idb;
@@ -977,7 +977,7 @@ void UpdateTreeWorker::updateNodeId(std::shared_ptr<Node> node, const NodeId &ne
     }
 }
 
-std::shared_ptr<Node> UpdateTreeWorker::getOrCreateNodeFromPath(const SyncPath &path) {
+std::shared_ptr<Node> UpdateTreeWorker::getOrCreateNodeFromPath(const SyncPath &path, const bool isDeleted) {
     if (path.empty()) {
         return _updateTree->rootNode();
     }
@@ -997,6 +997,11 @@ std::shared_ptr<Node> UpdateTreeWorker::getOrCreateNodeFromPath(const SyncPath &
         std::shared_ptr<Node> tmpChildNode = nullptr;
         for (auto &childNode : tmpNode->children()) {
             if (childNode.second->type() == NodeTypeDirectory && *nameIt == childNode.second->name()) {
+                if (!isDeleted && childNode.second->hasChangeEvent(OperationTypeDelete)) {
+                    // An item on a deleted branch can only have a DELETE change event. If it has any other change event, it
+                    // means its parent is on a different branch.
+                    continue;
+                }
                 tmpChildNode = childNode.second;
                 break;
             }

--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.h
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.h
@@ -134,7 +134,7 @@ class UpdateTreeWorker : public ISyncWorker {
          */
         ExitCode handleCreateOperationsWithSamePath();
 
-        std::shared_ptr<Node> getOrCreateNodeFromPath(const SyncPath &path);
+        std::shared_ptr<Node> getOrCreateNodeFromPath(const SyncPath &path, const bool isDeleted);
         void mergingTempNodeToRealNode(std::shared_ptr<Node> tmpNode, std::shared_ptr<Node> realNode);
 
         /**


### PR DESCRIPTION
If a tree structure is deleted and recreated with the same names (ex: folder AAA containing the following structure A/AA/AAA/test.txt is deleted and the same structure is re-created with different IDs), then the UpdateTreeWorkers will merge to deleted folder nodes and the newly created folder nodes.
This PR aims to differanciate the node newly created from the ones deleted. Since a node on a deleted branch will have only a DELETE event, we do not insert a node with CREATE event (or any event other that DELETE) as a child of a node with a DELETE event.