### PR TITLE
KDESKTOP-981 Unit tests failing to run on Windows and CI not catching errors.

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Build kDrive desktop
         run: |
           call "C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Auxiliary/Build/vcvars64.bat"
-          powershell ./infomaniak-build-tools/windows/build-drive.ps1 -ci
+          powershell ./infomaniak-build-tools/windows/build-drive.ps1 -ci -buildType Debug
         shell: cmd
 
       - name: Execute tests

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Build kDrive desktop
         run: |
           call "C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Auxiliary/Build/vcvars64.bat"
-          powershell ./infomaniak-build-tools/windows/build-drive.ps1 -ci -buildType Debug
+          powershell ./infomaniak-build-tools/windows/build-drive.ps1 -ci
         shell: cmd
 
       - name: Execute tests

--- a/infomaniak-build-tools/run-tests.ps1
+++ b/infomaniak-build-tools/run-tests.ps1
@@ -28,7 +28,7 @@ foreach ($file in $testers)
     $path="..\..\$file"
     & $path
     if ($LASTEXITCODE -ne 0) {
-        $errors += $LASTEXITCODE
+        $errors += 1
         $failures+=$file
         Write-Host "---------- Failure: $file ----------" -f Red
     }
@@ -43,7 +43,7 @@ if ($errors -eq 0) {
     Write-Host "Success: All Tests passed !" -f Green
 }
 else {
-    Write-Host "Failures: 
+    Write-Host "Failures ($errors): 
     " -f Red
     foreach ($failure in $failures)
     {


### PR DESCRIPTION
Unit tests are failing to run on Windows. The tests are not executing on the CI system. It appears that the paths are incorrect, leading to failures when attempting to execute the different test executables (text.exe). Additionally, the CI does not catch these errors and does not fail in such cases. This issue needs to be addressed within the scope of this PR.