### PR TITLE
[HOTFIX] Fixes label string with incorrect formatting inside the AddDriveLiteSyncWidget

### DIFF
--- a/src/gui/adddriveslitesyncwidget.cpp
+++ b/src/gui/adddriveslitesyncwidget.cpp
@@ -120,9 +120,9 @@ void AddDriveLiteSyncWidget::initUI() {
     auto *textLabel = new QLabel(this);
     textLabel->setObjectName("largeMediumTextLabel");
     textLabel->setContentsMargins(0, 0, 0, 0);
-    textLabel->setText(tr(R"(Lite Sync syncs all your files without using your computer space."
+    textLabel->setText(tr("Lite Sync syncs all your files without using your computer space."
                           " You can browse the files in your kDrive and download them locally whenever you want."
-                          " <a style="%1" href="%2">Learn more</a>)")
+                          R"( <a style="%1" href="%2">Learn more</a>)")
                            .arg(CommonUtility::linkStyle, KDC::GuiUtility::learnMoreLink));
     textLabel->setWordWrap(true);
     mainLayout->addWidget(textLabel);


### PR DESCRIPTION
This pull-request restores the original format of an information label displayed when creating a drive:

![Capture d’écran 2024-06-20 à 16 27 05](https://github.com/Infomaniak/desktop-kDrive/assets/162997198/e4245dbb-8f30-41e6-aac0-259a7f6cc84b)

The string formatting was broken due to a misuse of the raw string `R` instruction. 
With the proposed changes, the offending string is displayed as above.