### PR TITLE
KDESKTOP-988-Crash-on-Windows-invalid-comparator

### DIFF
--- a/src/libsyncengine/update_detection/file_system_observer/remotefilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/remotefilesystemobserverworker.cpp
@@ -482,7 +482,7 @@ ExitCode RemoteFileSystemObserverWorker::sendLongPoll(bool &changes) {
 ExitCode RemoteFileSystemObserverWorker::processActions(Poco::JSON::Array::Ptr actionArray) {
     if (!actionArray) return ExitCodeOk;
 
-    std::set<NodeId, std::equal_to<>> movedItems;
+    std::set<NodeId, std::less<>> movedItems;
 
     for (auto it = actionArray->begin(); it != actionArray->end(); ++it) {
         if (stopAsked()) {
@@ -591,7 +591,7 @@ ExitCode RemoteFileSystemObserverWorker::extractActionInfo(const Poco::JSON::Obj
 }
 
 ExitCode RemoteFileSystemObserverWorker::processAction(const SyncName &usedName, const ActionInfo &actionInfo,
-                                                       std::set<NodeId, std::equal_to<>> &movedItems) {
+                                                       std::set<NodeId, std::less<>> &movedItems) {
     SnapshotItem item(actionInfo.nodeId, actionInfo.parentNodeId, usedName, actionInfo.createdAt, actionInfo.modtime,
                       actionInfo.type, actionInfo.size, actionInfo.canWrite);
 

--- a/src/libsyncengine/update_detection/file_system_observer/remotefilesystemobserverworker.h
+++ b/src/libsyncengine/update_detection/file_system_observer/remotefilesystemobserverworker.h
@@ -31,13 +31,13 @@ class CsvFullFileListWithCursorJob;
 class RemoteFileSystemObserverWorker : public FileSystemObserverWorker {
     public:
         RemoteFileSystemObserverWorker(std::shared_ptr<SyncPal> syncPal, const std::string &name, const std::string &shortName);
-        ~RemoteFileSystemObserverWorker();
+        ~RemoteFileSystemObserverWorker() override;
 
     private:
-        virtual void execute() override;
-        virtual ExitCode generateInitialSnapshot() override;
-        virtual ExitCode processEvents() override;
-        virtual ReplicaSide getSnapshotType() const override { return ReplicaSide::ReplicaSideRemote; }
+        void execute() override;
+        ExitCode generateInitialSnapshot() override;
+        ExitCode processEvents() override;
+        [[nodiscard]] ReplicaSide getSnapshotType() const override { return ReplicaSide::ReplicaSideRemote; }
 
         ExitCode initWithCursor();
         ExitCode exploreDirectory(const NodeId &nodeId);
@@ -46,21 +46,21 @@ class RemoteFileSystemObserverWorker : public FileSystemObserverWorker {
         ExitCode sendLongPoll(bool &changes);
 
         struct ActionInfo {
-            ActionCode actionCode {ActionCode::actionCodeUnknown};
-            NodeId nodeId;
-            NodeId parentNodeId;
-            SyncName name;
-            SyncName path;
-            SyncName destName;
-            SyncTime createdAt {0};
-            SyncTime modtime {0};
-            NodeType type {NodeTypeUnknown};
-            int64_t size {0};
-            bool canWrite {true};
+                ActionCode actionCode{ActionCode::actionCodeUnknown};
+                NodeId nodeId;
+                NodeId parentNodeId;
+                SyncName name;
+                SyncName path;
+                SyncName destName;
+                SyncTime createdAt{0};
+                SyncTime modtime{0};
+                NodeType type{NodeTypeUnknown};
+                int64_t size{0};
+                bool canWrite{true};
         };
         ExitCode processActions(Poco::JSON::Array::Ptr filesArray);
         ExitCode extractActionInfo(const Poco::JSON::Object::Ptr actionObj, ActionInfo &actionInfo);
-        ExitCode processAction(const SyncName &usedName, const ActionInfo &actionInfo, std::set<NodeId, std::equal_to<>> &movedItems);
+        ExitCode processAction(const SyncName &usedName, const ActionInfo &actionInfo, std::set<NodeId, std::less<>> &movedItems);
 
         ExitCode checkRightsAndUpdateItem(const NodeId &nodeId, bool &hasRights, SnapshotItem &snapshotItem);
 


### PR DESCRIPTION
The crash was introduced following a small refactoring suggested by SonarCloud.
It crashed while processing the event on files retrieved from the back through the '/listing/continue' request