### PR TITLE
[HOTFIX] Revert the accidental merge of two if-statements

### DIFF
--- a/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
@@ -332,10 +332,12 @@ void LocalFileSystemObserverWorker::changesDetected(const std::list<std::pair<st
             SnapshotItem item(nodeId, parentNodeId, absolutePath.filename().native(), fileStat.creationTime, fileStat.modtime,
                               nodeType, fileStat.size, isLink);
 
-            if (_snapshot->updateItem(item) && ParametersCache::isExtendedLogEnabled()) {
-                LOGW_SYNCPAL_DEBUG(_logger, L"Item inserted in local snapshot: " << Utility::formatSyncPath(absolutePath).c_str()
-                                                                                 << L" (" << Utility::s2ws(nodeId).c_str()
-                                                                                 << L") at " << fileStat.modtime);
+            if (_snapshot->updateItem(item)) {
+                if (ParametersCache::isExtendedLogEnabled()) {
+                    LOGW_SYNCPAL_DEBUG(_logger, L"Item inserted in local snapshot: "
+                                                    << Utility::formatSyncPath(absolutePath).c_str() << L" ("
+                                                    << Utility::s2ws(nodeId).c_str() << L") at " << fileStat.modtime);
+                }
                 //                if (nodeType == NodeTypeFile) {
                 //                    if (canComputeChecksum(absolutePath)) {
                 //                        // Start asynchronous checkum generation

--- a/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
@@ -332,23 +332,24 @@ void LocalFileSystemObserverWorker::changesDetected(const std::list<std::pair<st
             SnapshotItem item(nodeId, parentNodeId, absolutePath.filename().native(), fileStat.creationTime, fileStat.modtime,
                               nodeType, fileStat.size, isLink);
 
-            if (_snapshot->updateItem(item)) {
-                if (ParametersCache::isExtendedLogEnabled()) {
-                    LOGW_SYNCPAL_DEBUG(_logger, L"Item inserted in local snapshot: "
-                                                    << Utility::formatSyncPath(absolutePath).c_str() << L" ("
-                                                    << Utility::s2ws(nodeId).c_str() << L") at " << fileStat.modtime);
-                }
+            if (!_snapshot->updateItem(item)) {
+                LOGW_SYNCPAL_WARN(_logger, L"Failed to insert item: " << Utility::formatSyncPath(absolutePath).c_str() << L" ("
+                                                                      << Utility::s2ws(nodeId).c_str() << L")");
+                invalidateSnapshot();
+                return;
+            }
+
+            if (ParametersCache::isExtendedLogEnabled()) {
+                LOGW_SYNCPAL_DEBUG(_logger, L"Item inserted in local snapshot: " << Utility::formatSyncPath(absolutePath).c_str()
+                                                                                 << L" (" << Utility::s2ws(nodeId).c_str()
+                                                                                 << L") at " << fileStat.modtime);
+
                 //                if (nodeType == NodeTypeFile) {
                 //                    if (canComputeChecksum(absolutePath)) {
                 //                        // Start asynchronous checkum generation
                 //                        _checksumWorker->computeChecksum(nodeId, absolutePath);
                 //                    }
                 //                }
-            } else {
-                LOGW_SYNCPAL_WARN(_logger, L"Failed to insert item: " << Utility::formatSyncPath(absolutePath).c_str() << L" ("
-                                                                      << Utility::s2ws(nodeId).c_str() << L")");
-                invalidateSnapshot();
-                return;
             }
 
             // Manage directories moved from outside the synchronized directory

--- a/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.cpp
+++ b/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.cpp
@@ -51,14 +51,14 @@ void TestLocalFileSystemObserverWorker::setUp() {
 
     _testRootFolderPath = _tempDir.path / "sync_folder";
 
-    Poco::File((_testRootFolderPath / "A" / "AA").c_str()).createDirectories();
-    Poco::File((_testRootFolderPath / "A" / "AB").c_str()).createDirectories();
-    Poco::File((_testRootFolderPath / "B" / "BA").c_str()).createDirectories();
-    Poco::File((_testRootFolderPath / "B" / "BB").c_str()).createDirectories();
+    Poco::File((_testRootFolderPath / "A" / "AA").string()).createDirectories();
+    Poco::File((_testRootFolderPath / "A" / "AB").string()).createDirectories();
+    Poco::File((_testRootFolderPath / "B" / "BA").string()).createDirectories();
+    Poco::File((_testRootFolderPath / "B" / "BB").string()).createDirectories();
 
-    Poco::File((_testFolderPath / "test_dir").c_str()).copyTo((_testRootFolderPath / _testPicturesFolderName).c_str());
-    Poco::File((_testFolderPath / "test_a").c_str()).copyTo((_testRootFolderPath / "test_a").c_str());
-    Poco::File((_testFolderPath / "test_b").c_str()).copyTo((_testRootFolderPath / "test_b").c_str());
+    Poco::File((_testFolderPath / "test_dir").string()).copyTo((_testRootFolderPath / _testPicturesFolderName).string());
+    Poco::File((_testFolderPath / "test_a").string()).copyTo((_testRootFolderPath / "test_a").string());
+    Poco::File((_testFolderPath / "test_b").string()).copyTo((_testRootFolderPath / "test_b").string());
 
     // Create parmsDb
     bool alreadyExists = false;
@@ -228,7 +228,7 @@ void TestLocalFileSystemObserverWorker::testFolderWatcher() {
         testRelativePath = "B/AC";
         testAbsolutePath = _testRootFolderPath / testRelativePath;
 #ifdef _WIN32
-        testCallStr = "move " + source.make_preferred().string() + " " + testAbsolutePath.make_preferred().string();
+        testCallStr = "move " + source.make_preferred().string() + " " + _testAbsolutePath.make_preferred().string();
 #else
         testCallStr = "mv " + source.make_preferred().string() + " " + testAbsolutePath.make_preferred().string();
 #endif
@@ -245,7 +245,7 @@ void TestLocalFileSystemObserverWorker::testFolderWatcher() {
         testRelativePath = "B/ACc";
         testAbsolutePath = _testRootFolderPath / testRelativePath;
 #ifdef _WIN32
-        testCallStr = "ren " + source.make_preferred().string() + " " + testAbsolutePath.filename().string();
+        testCallStr = "ren " + source.make_preferred().string() + " " + _testAbsolutePath.filename().string();
 #else
         testCallStr = "mv " + source.make_preferred().string() + " " + testAbsolutePath.make_preferred().string();
 #endif
@@ -300,7 +300,7 @@ void TestLocalFileSystemObserverWorker::testFolderWatcher() {
 
         source = _testFolderPath / "test_dir_copy";
 #ifdef _WIN32
-        testCallStr = "move " + source.make_preferred().string() + " " + SyncPath(testRootFolderPath).make_preferred().string();
+        testCallStr = "move " + source.make_preferred().string() + " " + _testRootFolderPath.make_preferred().string();
 #else
         testCallStr = "mv " + source.make_preferred().string() + " " + _testRootFolderPath.make_preferred().string();
 #endif
@@ -350,7 +350,8 @@ void TestLocalFileSystemObserverWorker::testFolderWatcher() {
         std::system(testCallStr.c_str());
         //// move
 #ifdef _WIN32
-        testCallStr = "move " + testAbsolutePath.make_preferred().string() + " " + testRootFolderPath + "aa.jpg";
+        testCallStr =
+            "move " + testAbsolutePath.make_preferred().string() + " " + _testRootFolderPath.make_preferred().string() + "aa.jpg";
 #else
         testCallStr =
             "mv " + testAbsolutePath.make_preferred().string() + " " + _testRootFolderPath.make_preferred().string() + "/aa.jpg";
@@ -373,8 +374,8 @@ void TestLocalFileSystemObserverWorker::testFolderWatcher() {
         IoHelper::getFileStat(testAbsolutePath.c_str(), &fileStat, exists);
         NodeId initItemId = std::to_string(fileStat.inode);
 #ifdef _WIN32
-        std::string testCallStr = "move " + _testRootFolderPath..make_preferred().string() + "/test_b/b.jpg" + " " +
-                                  testRootFolderPath..make_preferred().string() + "/bb.jpg";
+        std::string testCallStr = "move " + _testRootFolderPath.make_preferred().string() + "/test_b/b.jpg" + " " +
+                                  _testRootFolderPath.make_preferred().string() + "/bb.jpg";
 #else
         std::string testCallStr = "mv " + _testRootFolderPath.make_preferred().string() + "/test_b/b.jpg" + " " +
                                   _testRootFolderPath.make_preferred().string() + "/bb.jpg";
@@ -383,7 +384,7 @@ void TestLocalFileSystemObserverWorker::testFolderWatcher() {
         //// create
         SyncPath source = _testFolderPath / "test_b" / "b.jpg";
 #ifdef _WIN32
-        Poco::File(source.make_preferred().string()).copyTo(testAbsolutePath);
+        Poco::File(source.make_preferred().string()).copyTo(testAbsolutePath.make_preferred().string());
 #else
         testCallStr = Str("cp -R ") + source.make_preferred().native() + Str(" ") + testAbsolutePath.make_preferred().native();
         std::system(testCallStr.c_str());

--- a/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.cpp
+++ b/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.cpp
@@ -392,7 +392,7 @@ void TestLocalFileSystemObserverWorker::testFolderWatcher() {
         IoHelper::getFileStat(testAbsolutePath.c_str(), &fileStat, exists);
         NodeId newItemId = std::to_string(fileStat.inode);
         //// edit
-        testCallStr = Str("(echo \"This is an edit test\" >>  )") + testAbsolutePath.make_preferred().native();
+        testCallStr = R"(echo "This is an edit test" >>  )" + testAbsolutePath.make_preferred().string();
         std::system(testCallStr.c_str());
         //// delete
 #ifdef _WIN32

--- a/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.cpp
+++ b/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.cpp
@@ -228,7 +228,7 @@ void TestLocalFileSystemObserverWorker::testFolderWatcher() {
         testRelativePath = "B/AC";
         testAbsolutePath = _testRootFolderPath / testRelativePath;
 #ifdef _WIN32
-        testCallStr = "move " + source.make_preferred().string() + " " + _testAbsolutePath.make_preferred().string();
+        testCallStr = "move " + source.make_preferred().string() + " " + testAbsolutePath.make_preferred().string();
 #else
         testCallStr = "mv " + source.make_preferred().string() + " " + testAbsolutePath.make_preferred().string();
 #endif
@@ -245,7 +245,7 @@ void TestLocalFileSystemObserverWorker::testFolderWatcher() {
         testRelativePath = "B/ACc";
         testAbsolutePath = _testRootFolderPath / testRelativePath;
 #ifdef _WIN32
-        testCallStr = "ren " + source.make_preferred().string() + " " + _testAbsolutePath.filename().string();
+        testCallStr = "ren " + source.make_preferred().string() + " " + testAbsolutePath.filename().string();
 #else
         testCallStr = "mv " + source.make_preferred().string() + " " + testAbsolutePath.make_preferred().string();
 #endif
@@ -350,8 +350,8 @@ void TestLocalFileSystemObserverWorker::testFolderWatcher() {
         std::system(testCallStr.c_str());
         //// move
 #ifdef _WIN32
-        testCallStr =
-            "move " + testAbsolutePath.make_preferred().string() + " " + _testRootFolderPath.make_preferred().string() + "aa.jpg";
+        testCallStr = "move " + testAbsolutePath.make_preferred().string() + " " + _testRootFolderPath.make_preferred().string() +
+                      "\\aa.jpg";
 #else
         testCallStr =
             "mv " + testAbsolutePath.make_preferred().string() + " " + _testRootFolderPath.make_preferred().string() + "/aa.jpg";
@@ -374,8 +374,8 @@ void TestLocalFileSystemObserverWorker::testFolderWatcher() {
         IoHelper::getFileStat(testAbsolutePath.c_str(), &fileStat, exists);
         NodeId initItemId = std::to_string(fileStat.inode);
 #ifdef _WIN32
-        std::string testCallStr = "move " + _testRootFolderPath.make_preferred().string() + "/test_b/b.jpg" + " " +
-                                  _testRootFolderPath.make_preferred().string() + "/bb.jpg";
+        std::string testCallStr = "move " + _testRootFolderPath.make_preferred().string() + "\\test_b\\b.jpg" + " " +
+                                  _testRootFolderPath.make_preferred().string() + "\\bb.jpg";
 #else
         std::string testCallStr = "mv " + _testRootFolderPath.make_preferred().string() + "/test_b/b.jpg" + " " +
                                   _testRootFolderPath.make_preferred().string() + "/bb.jpg";
@@ -392,7 +392,7 @@ void TestLocalFileSystemObserverWorker::testFolderWatcher() {
         IoHelper::getFileStat(testAbsolutePath.c_str(), &fileStat, exists);
         NodeId newItemId = std::to_string(fileStat.inode);
         //// edit
-        testCallStr = R"(echo "This is an edit test" >>  )" + testAbsolutePath.make_preferred().native();
+        testCallStr = Str("(echo \"This is an edit test\" >>  )") + testAbsolutePath.make_preferred().native();
         std::system(testCallStr.c_str());
         //// delete
 #ifdef _WIN32

--- a/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.cpp
+++ b/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.cpp
@@ -41,7 +41,7 @@ using namespace CppUnit;
 namespace KDC {
 
 const SyncPath TestLocalFileSystemObserverWorker::_testFolderPath = SyncPath(TEST_DIR) / "test_ci" / "test_local_FSO";
-const SyncName TestLocalFileSystemObserverWorker::_testPicturesFolderName = "test_pictures";
+const SyncPath TestLocalFileSystemObserverWorker::_testPicturesFolderName = SyncPath("test_pictures");
 const uint64_t TestLocalFileSystemObserverWorker::_nbFileInTestDir = 5;  // Test directory contains 5 files
 
 void TestLocalFileSystemObserverWorker::setUp() {
@@ -51,14 +51,14 @@ void TestLocalFileSystemObserverWorker::setUp() {
 
     _testRootFolderPath = _tempDir.path / "sync_folder";
 
-    Poco::File(_testRootFolderPath / "A" / "AA").createDirectories();
-    Poco::File(_testRootFolderPath / "A" / "AB").createDirectories();
-    Poco::File(_testRootFolderPath / "B" / "BA").createDirectories();
-    Poco::File(_testRootFolderPath / "B" / "BB").createDirectories();
+    Poco::File((_testRootFolderPath / "A" / "AA").c_str()).createDirectories();
+    Poco::File((_testRootFolderPath / "A" / "AB").c_str()).createDirectories();
+    Poco::File((_testRootFolderPath / "B" / "BA").c_str()).createDirectories();
+    Poco::File((_testRootFolderPath / "B" / "BB").c_str()).createDirectories();
 
-    Poco::File(_testFolderPath / "test_dir").copyTo(_testRootFolderPath / _testPicturesFolderName);
-    Poco::File(_testFolderPath / "test_a").copyTo(_testRootFolderPath / "test_a");
-    Poco::File(_testFolderPath / "test_b").copyTo(_testRootFolderPath / "test_b");
+    Poco::File((_testFolderPath / "test_dir").c_str()).copyTo((_testRootFolderPath / _testPicturesFolderName).c_str());
+    Poco::File((_testFolderPath / "test_a").c_str()).copyTo((_testRootFolderPath / "test_a").c_str());
+    Poco::File((_testFolderPath / "test_b").c_str()).copyTo((_testRootFolderPath / "test_b").c_str());
 
     // Create parmsDb
     bool alreadyExists = false;
@@ -367,7 +367,7 @@ void TestLocalFileSystemObserverWorker::testFolderWatcher() {
     {
         LOGW_DEBUG(_logger, L"***** move(x,y) + create(x) + edit(x,<newcontent>) + delete(x) *****");
         //// move
-        std::string testAbsolutePath = _testRootFolderPath / "test_b" / "b.jpg";
+        SyncPath testAbsolutePath = _testRootFolderPath / "test_b" / "b.jpg";
         FileStat fileStat;
         bool exists = false;
         IoHelper::getFileStat(testAbsolutePath.c_str(), &fileStat, exists);
@@ -385,19 +385,19 @@ void TestLocalFileSystemObserverWorker::testFolderWatcher() {
 #ifdef _WIN32
         Poco::File(source.make_preferred().string()).copyTo(testAbsolutePath);
 #else
-        testCallStr = Str("cp -R ") + source.make_preferred().native() + Str(" ") + testAbsolutePath;
+        testCallStr = Str("cp -R ") + source.make_preferred().native() + Str(" ") + testAbsolutePath.make_preferred().native();
         std::system(testCallStr.c_str());
 #endif
         IoHelper::getFileStat(testAbsolutePath.c_str(), &fileStat, exists);
         NodeId newItemId = std::to_string(fileStat.inode);
         //// edit
-        testCallStr = R"(echo "This is an edit test" >>  )" + testAbsolutePath;
+        testCallStr = R"(echo "This is an edit test" >>  )" + testAbsolutePath.make_preferred().native();
         std::system(testCallStr.c_str());
         //// delete
 #ifdef _WIN32
         testCallStr = "del " + testAbsolutePath;
 #else
-        testCallStr = "rm -r " + testAbsolutePath;
+        testCallStr = "rm -r " + testAbsolutePath.make_preferred().native();
 #endif
         std::system(testCallStr.c_str());
 

--- a/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.cpp
+++ b/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.cpp
@@ -396,7 +396,7 @@ void TestLocalFileSystemObserverWorker::testFolderWatcher() {
         std::system(testCallStr.c_str());
         //// delete
 #ifdef _WIN32
-        testCallStr = "del " + testAbsolutePath;
+        testCallStr = "del " + testAbsolutePath.make_preferred().string();
 #else
         testCallStr = "rm -r " + testAbsolutePath.make_preferred().native();
 #endif

--- a/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.h
+++ b/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.h
@@ -49,7 +49,7 @@ class TestLocalFileSystemObserverWorker : public CppUnit::TestFixture {
         std::shared_ptr<SyncPal> _syncPal = nullptr;
 
         static const SyncPath _testFolderPath;
-        static const SyncName _testPicturesFolderName;
+        static const SyncPath _testPicturesFolderName;
         static const uint64_t _nbFileInTestDir;
 
         TemporaryDirectory _tempDir;

--- a/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.h
+++ b/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "testincludes.h"
+#include "test_utility/temporarydirectory.h"
 
 #include "db/parmsdb.h"
 #include "syncpal/syncpal.h"
@@ -46,6 +47,13 @@ class TestLocalFileSystemObserverWorker : public CppUnit::TestFixture {
     private:
         log4cplus::Logger _logger;
         std::shared_ptr<SyncPal> _syncPal = nullptr;
+
+        static const SyncPath _testFolderPath;
+        static const SyncName _testPicturesFolderName;
+        static const uint64_t _nbFileInTestDir;
+
+        TemporaryDirectory _tempDir;
+        SyncPath _testRootFolderPath;
 };
 
 }  // namespace KDC

--- a/test/test_utility/temporarydirectory.cpp
+++ b/test/test_utility/temporarydirectory.cpp
@@ -17,6 +17,7 @@
  */
 #include "temporarydirectory.h"
 
+#include <sstream>
 
 namespace KDC {
 

--- a/test/test_utility/temporarydirectory.h
+++ b/test/test_utility/temporarydirectory.h
@@ -18,7 +18,6 @@
 
 #include <string>
 #include <filesystem>
-#include <sstream> 
 
 namespace KDC {
 


### PR DESCRIPTION
The re-activation of the LFSO unit tests would have prevented a regression.

However, the latter task is more involved than expected: after a first refactoring proposed in this pull request, a number of assertions fail with no clear reason.

To be continued with https://infomaniak.atlassian.net/browse/KDESKTOP-990. 