### PR TITLE
[KDESKTOP-1045] Removes unused calls and variables from ConflictResolverWorker::generateOperations

### DIFF
--- a/src/libsyncengine/reconciliation/conflict_resolver/conflictresolverworker.cpp
+++ b/src/libsyncengine/reconciliation/conflict_resolver/conflictresolverworker.cpp
@@ -122,9 +122,6 @@ ExitCode ConflictResolverWorker::generateOperations(const Conflict &conflict, bo
 
                 // Generate a delete operation to remove entry from the DB only (not from the FS!)
                 // The deleted file will be restored on next sync iteration
-                std::unordered_set<std::shared_ptr<Node>> allDeletedNodes;
-                findAllChildNodes(deleteNode, allDeletedNodes);
-
                 auto deleteOp = std::make_shared<SyncOperation>();
                 deleteOp->setType(OperationTypeDelete);
                 deleteOp->setAffectedNode(deleteNode);
@@ -144,9 +141,6 @@ ExitCode ConflictResolverWorker::generateOperations(const Conflict &conflict, bo
             } else {
                 // Delete the edit node from DB
                 // This will cause the file to be detected as new in the next sync iteration, thus it will be restored
-                std::unordered_set<std::shared_ptr<Node>> allDeletedNodes;
-                findAllChildNodes(editNode, allDeletedNodes);
-
                 auto deleteOp = std::make_shared<SyncOperation>();
                 deleteOp->setType(OperationTypeDelete);
                 deleteOp->setAffectedNode(editNode);

--- a/src/libsyncengine/reconciliation/conflict_resolver/conflictresolverworker.h
+++ b/src/libsyncengine/reconciliation/conflict_resolver/conflictresolverworker.h
@@ -23,8 +23,6 @@
 #include "reconciliation/conflict_finder/conflict.h"
 #include "reconciliation/syncoperation.h"
 
-#include <list>
-
 namespace KDC {
 
 class ConflictResolverWorker : public OperationProcessor {
@@ -45,7 +43,9 @@ class ConflictResolverWorker : public OperationProcessor {
          * If return false, the file path is too long, the file needs to be moved to root directory
          */
         bool generateConflictedName(const std::shared_ptr<Node> node, SyncName &newName, bool isOrphanNode = false) const;
-        void findAllChildNodes(const std::shared_ptr<Node> parentNode, std::unordered_set<std::shared_ptr<Node>> &children);
+
+        static void findAllChildNodes(const std::shared_ptr<Node> parentNode,
+                                      std::unordered_set<std::shared_ptr<Node>> &children);
         ExitCode findAllChildNodeIdsFromDb(const std::shared_ptr<Node> parentNode, std::unordered_set<DbNodeId> &childrenDbIds);
         ExitCode undoMove(const std::shared_ptr<Node> moveNode, SyncOpPtr moveOp);
 

--- a/src/libsyncengine/update_detection/update_detector/node.h
+++ b/src/libsyncengine/update_detection/update_detector/node.h
@@ -24,7 +24,6 @@
 #include <algorithm>
 #include <vector>
 #include <optional>
-#include <unordered_set>
 #include <unordered_map>
 
 namespace KDC {


### PR DESCRIPTION
This pull request only removes some unused calls and variables.

These changes are likely to solve the infinite loop issue described in [KDESKTOP-1045](https://infomaniak.atlassian.net/browse/KDESKTOP-1045) in the narrow case reported by the user. 

A general fix will be proposed in a separate pull request.


[KDESKTOP-1045]: https://infomaniak.atlassian.net/browse/KDESKTOP-1045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ