### PR TITLE
KDESKTOP-1047-Fix-tests-clean-up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,7 +173,6 @@ FakesAssemblies/
 # reference to "build"
 !building.adoc
 extensions/MacOSX/kDriveFinderSync.xcworkspace/contents.xcworkspacedata
-test/libsyncengine/update_detection/file_system_observer/test_folder/sync_folder
 
 # CLion settings folder
 .idea

--- a/.run/kDrive.run.xml
+++ b/.run/kDrive.run.xml
@@ -6,6 +6,7 @@
     </envs>
     <method v="2">
       <option name="com.jetbrains.cidr.execution.CidrBuildBeforeRunTaskProvider$BuildBeforeRunTask" enabled="true" />
+      <option name="CMake.Install" enabled="true" />
     </method>
   </configuration>
 </component>

--- a/src/libsyncengine/jobs/abstractjob.h
+++ b/src/libsyncengine/jobs/abstractjob.h
@@ -83,7 +83,7 @@ class AbstractJob : public Poco::Runnable {
         virtual void abort();
         bool isAborted() const;
 
-        inline bool bypassCheck() const { return _bypassCheck; }
+        [[nodiscard]] inline bool bypassCheck() const { return _bypassCheck; }
         inline void setBypassCheck(bool newBypassCheck) { _bypassCheck = newBypassCheck; }
 
     protected:

--- a/src/libsyncengine/jobs/network/createdirjob.h
+++ b/src/libsyncengine/jobs/network/createdirjob.h
@@ -27,20 +27,22 @@ class CreateDirJob : public AbstractTokenNetworkJob {
     public:
         CreateDirJob(int driveDbId, const SyncPath &filepath, const NodeId &parentId, const SyncName &name,
                      const std::string &color = "");
-        ~CreateDirJob();
+        CreateDirJob(int driveDbId, const NodeId &parentId, const SyncName &name);
+        ~CreateDirJob() override;
 
-        inline const NodeId &parentDirId() const { return _parentDirId; }
+        [[nodiscard]] inline const NodeId &parentDirId() const { return _parentDirId; }
 
-        inline const NodeId &nodeId() const { return _nodeId; }
-        inline SyncTime modtime() const { return _modtime; }
+        [[nodiscard]] inline const NodeId &nodeId() const { return _nodeId; }
+        [[nodiscard]] inline SyncTime modtime() const { return _modtime; }
 
     protected:
-        virtual bool handleResponse(std::istream &is) override;
+        bool handleResponse(std::istream &is) override;
 
     private:
-        virtual std::string getSpecificUrl() override;
-        virtual void setQueryParameters(Poco::URI &, bool &) override {}
-        virtual void setData(bool &canceled) override;
+        std::string getSpecificUrl() override;
+        void setQueryParameters(Poco::URI &, bool &) override { /* Query parameters are not mandatory */
+        }
+        void setData(bool &canceled) override;
 
         SyncPath _filePath;
         NodeId _parentDirId;

--- a/test/libcommonserver/io/testcheckdirectoryiterator.cpp
+++ b/test/libcommonserver/io/testcheckdirectoryiterator.cpp
@@ -59,18 +59,18 @@ void TestIo::testCheckDirectoryIteratorExistingPath() {
     LocalTemporaryDirectory tempDir;
 
     // Create test empty directory
-    const SyncPath emptyDir = tempDir.path / "chekDirIt/empty_dir";
+    const SyncPath emptyDir = tempDir.path() / "chekDirIt/empty_dir";
     std::filesystem::create_directories(emptyDir);
 
     // Create test directory with one file
-    SyncPath oneFileDir = tempDir.path / "chekDirIt/oneFile_dir";
+    SyncPath oneFileDir = tempDir.path() / "chekDirIt/oneFile_dir";
     std::filesystem::create_directories(oneFileDir);
     std::ofstream file(oneFileDir / "oneFile.txt");
     file << "oneFile";
     file.close();
 
     // Create test directory with one directory
-    std::filesystem::create_directories(tempDir.path / "chekDirIt/oneDir_dir/testDir1");
+    std::filesystem::create_directories(tempDir.path() / "chekDirIt/oneDir_dir/testDir1");
 
     // Check that the directory iterator is valid when the path is an empty directory and return EOF
     {
@@ -87,7 +87,7 @@ void TestIo::testCheckDirectoryIteratorExistingPath() {
 
     // Check that the directory iterator is valid when the path is a directory with one file and return the file on first call
     {
-        const SyncPath directoryWithOneFile = tempDir.path / "chekDirIt/oneFile_dir";
+        const SyncPath directoryWithOneFile = tempDir.path() / "chekDirIt/oneFile_dir";
 
         IoError error;
         IoHelper::DirectoryIterator it(directoryWithOneFile, false, error);
@@ -106,7 +106,7 @@ void TestIo::testCheckDirectoryIteratorExistingPath() {
 
     // Check that the directory iterator is valid when the path is a directory with one child directory
     {
-        const SyncPath directoryWithOneChildDirectory = tempDir.path / "chekDirIt/oneDir_dir";
+        const SyncPath directoryWithOneChildDirectory = tempDir.path() / "chekDirIt/oneDir_dir";
 
         IoError error;
         IoHelper::DirectoryIterator it(directoryWithOneChildDirectory, false, error);
@@ -125,7 +125,7 @@ void TestIo::testCheckDirectoryRecursive(void) {
     LocalTemporaryDirectory tempDir;
 
     // Create test directory with 4 directories with 1 file each
-    SyncPath recursiveDir = tempDir.path / "chekDirIt/recursive_dir";
+    SyncPath recursiveDir = tempDir.path() / "chekDirIt/recursive_dir";
     for (int i = 0; i < 4; ++i) {
         SyncPath childDir = recursiveDir / ("childDir_" + std::to_string(i));
         std::filesystem::create_directories(childDir);
@@ -174,7 +174,7 @@ void TestIo::testCheckDirectoryRecursive(void) {
 void TestIo::testCheckDirectoryIteratotNextAfterEndOfDir() {
     // Create test directory with one file
     LocalTemporaryDirectory tempDir;
-    SyncPath oneFileDir = tempDir.path / "chekDirIt/oneFile_dir";
+    SyncPath oneFileDir = tempDir.path() / "chekDirIt/oneFile_dir";
     std::filesystem::create_directories(oneFileDir);
     std::ofstream file(oneFileDir / "oneFile.txt");
     file << "oneFile";
@@ -205,7 +205,7 @@ void TestIo::testCheckDirectoryIteratorPermission() {
     {
         // Check that the directory iterator skips each directory with no permission
         LocalTemporaryDirectory tempDir;
-        const SyncPath noPermissionDir = tempDir.path / "chekDirIt/noPermission";
+        const SyncPath noPermissionDir = tempDir.path() / "chekDirIt/noPermission";
         const SyncPath noPermissionFile = noPermissionDir / "file.txt";
 
         IoError ioError = IoErrorSuccess;
@@ -245,7 +245,7 @@ void TestIo::testCheckDirectoryIteratorUnexpectedDelete() {
     LocalTemporaryDirectory tempDir;
 
     // Create test directory with 5 subdirectories
-    const SyncPath path = tempDir.path.string() + "\\chekDirIt\\IteratorUnexpectedDelete";
+    const SyncPath path = tempDir.path().string() + "\\chekDirIt\\IteratorUnexpectedDelete";
     std::string subDir = path.string();
 
     for (int i = 0; i < 5; i++) {
@@ -275,9 +275,9 @@ void TestIo::testCheckDirectoryIteratorUnexpectedDelete() {
     }
 }
 
-void TestIo::testCheckDirectoryPermissionLost(void) {
+void TestIo::testCheckDirectoryPermissionLost() {
     const LocalTemporaryDirectory temporaryDirectory;
-    const SyncPath chekDirItDir = temporaryDirectory.path / "chekDirIt";
+    const SyncPath chekDirItDir = temporaryDirectory.path() / "chekDirIt";
     const SyncPath permLostRoot = chekDirItDir / "permissionLost";
     const SyncPath subDir = permLostRoot / "subDir1";
     const SyncPath filePath = subDir / "file.txt";

--- a/test/libcommonserver/io/testcheckifdehydrated.cpp
+++ b/test/libcommonserver/io/testcheckifdehydrated.cpp
@@ -46,7 +46,7 @@ void TestIo::testCheckIfFileIsDehydrated() {
     // A dehydrated file
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "dehydrated_file";
+        const SyncPath path = temporaryDirectory.path() / "dehydrated_file";
         {
             std::ofstream ofs(path);
             ofs << "Some content.\n";
@@ -62,7 +62,7 @@ void TestIo::testCheckIfFileIsDehydrated() {
     // A hydrated file
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "hydrated_file";
+        const SyncPath path = temporaryDirectory.path() / "hydrated_file";
         {
             std::ofstream ofs(path);
             ofs << "Some content.\n";
@@ -107,7 +107,7 @@ void TestIo::testCheckIfFileIsDehydrated() {
     // A non-existing file
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "non_existing_file.txt";
+        const SyncPath path = temporaryDirectory.path() / "non_existing_file.txt";
 
         IoError ioError = IoErrorSuccess;
         bool isDehydrated = true;
@@ -123,7 +123,7 @@ void TestIo::testCheckIfFileIsDehydrated() {
     // A file missing owner read permission
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "permission_less_file.txt";
+        const SyncPath path = temporaryDirectory.path() / "permission_less_file.txt";
         {
             std::ofstream ofs(path);
             ofs << "Some content.\n";

--- a/test/libcommonserver/io/testcheckifisdirectory.cpp
+++ b/test/libcommonserver/io/testcheckifisdirectory.cpp
@@ -51,7 +51,7 @@ void TestIo::testCheckIfIsDirectory() {
     {
         const SyncPath targetPath = _localTestDirPath / "test_pictures/picture-1.jpg";
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "regular_file_symbolic_link";
+        const SyncPath path = temporaryDirectory.path() / "regular_file_symbolic_link";
         std::filesystem::create_symlink(targetPath, path);
 
         IoError ioError = IoErrorUnknown;
@@ -66,9 +66,9 @@ void TestIo::testCheckIfIsDirectory() {
     {
         const SyncPath targetPath = _localTestDirPath / "test_pictures/picture-1.jpg";
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path_ = temporaryDirectory.path / "symbolic_link";
+        const SyncPath path_ = temporaryDirectory.path() / "symbolic_link";
         std::filesystem::create_symlink(targetPath, path_);
-        const SyncPath path = temporaryDirectory.path / "symbolic_link_link";
+        const SyncPath path = temporaryDirectory.path() / "symbolic_link_link";
         std::filesystem::create_symlink(path_, path);
 
         IoError ioError = IoErrorUnknown;
@@ -83,7 +83,7 @@ void TestIo::testCheckIfIsDirectory() {
     {
         const SyncPath targetPath = _localTestDirPath / "test_pictures";
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "regular_dir_symbolic_link";
+        const SyncPath path = temporaryDirectory.path() / "regular_dir_symbolic_link";
         std::filesystem::create_symlink(targetPath, path);
 
         IoError ioError = IoErrorUnknown;
@@ -115,8 +115,8 @@ void TestIo::testCheckIfIsDirectory() {
     // A dangling symbolic link
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath targetPath = temporaryDirectory.path / "non_existing_file.txt";  // This file does not exist.
-        const SyncPath path = temporaryDirectory.path / "dangling_symbolic_link";
+        const SyncPath targetPath = temporaryDirectory.path() / "non_existing_file.txt";  // This file does not exist.
+        const SyncPath path = temporaryDirectory.path() / "dangling_symbolic_link";
         std::filesystem::create_symlink(targetPath, path);
 
         IoError ioError = IoErrorSuccess;
@@ -130,7 +130,7 @@ void TestIo::testCheckIfIsDirectory() {
     // A regular directory missing all permissions: no error expected
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "permission_less_directory";
+        const SyncPath path = temporaryDirectory.path() / "permission_less_directory";
         std::filesystem::create_directory(path);
 
         std::filesystem::permissions(path, std::filesystem::perms::all, std::filesystem::perm_options::remove);
@@ -170,10 +170,10 @@ void TestIo::testCheckIfIsDirectory() {
     // - Access denied expected on MacOSX and Linux
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "subdir";
+        const SyncPath path = temporaryDirectory.path() / "subdir";
         std::filesystem::create_directory(path);
 
-        std::filesystem::permissions(temporaryDirectory.path, std::filesystem::perms::owner_exec,
+        std::filesystem::permissions(temporaryDirectory.path(), std::filesystem::perms::owner_exec,
                                      std::filesystem::perm_options::remove);
 
         IoError ioError = IoErrorSuccess;
@@ -188,7 +188,7 @@ void TestIo::testCheckIfIsDirectory() {
         CPPUNIT_ASSERT(!isDirectory);
 #endif
         // Restore permission to allow subdir removal
-        std::filesystem::permissions(temporaryDirectory.path, std::filesystem::perms::owner_exec,
+        std::filesystem::permissions(temporaryDirectory.path(), std::filesystem::perms::owner_exec,
                                      std::filesystem::perm_options::add);
     }
 
@@ -197,7 +197,7 @@ void TestIo::testCheckIfIsDirectory() {
     {
         const LocalTemporaryDirectory temporaryDirectory;
         const SyncPath targetPath = _localTestDirPath / "test_pictures/picture-1.jpg";
-        const SyncPath path = temporaryDirectory.path / "regular_file_alias";
+        const SyncPath path = temporaryDirectory.path() / "regular_file_alias";
 
         IoError aliasError;
         IoHelper::createAliasFromPath(targetPath, path, aliasError);
@@ -214,7 +214,7 @@ void TestIo::testCheckIfIsDirectory() {
     {
         const LocalTemporaryDirectory temporaryDirectory;
         const SyncPath targetPath = _localTestDirPath / "test_pictures";
-        const SyncPath path = temporaryDirectory.path / "regular_dir_alias";
+        const SyncPath path = temporaryDirectory.path() / "regular_dir_alias";
 
         IoError aliasError;
         CPPUNIT_ASSERT(IoHelper::createAliasFromPath(targetPath, path, aliasError));
@@ -230,10 +230,10 @@ void TestIo::testCheckIfIsDirectory() {
     // A dangling MacOSX Finder alias on a non-existing directory.
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath targetPath = temporaryDirectory.path / "directory_to_be_deleted";  // This directory will be deleted.
+        const SyncPath targetPath = temporaryDirectory.path() / "directory_to_be_deleted";  // This directory will be deleted.
         std::filesystem::create_directory(targetPath);
 
-        const SyncPath path = temporaryDirectory.path / "dangling_directory_alias";
+        const SyncPath path = temporaryDirectory.path() / "dangling_directory_alias";
 
         IoError aliasError;
         IoHelper::createAliasFromPath(targetPath, path, aliasError);
@@ -253,7 +253,7 @@ void TestIo::testCreateDirectory() {
     // Creates successfully a directory
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "regular_directory";
+        const SyncPath path = temporaryDirectory.path() / "regular_directory";
 
         IoError ioError = IoErrorUnknown;
         CPPUNIT_ASSERT(_testObj->createDirectory(path, ioError));
@@ -270,7 +270,7 @@ void TestIo::testCreateDirectory() {
     // Fails to create a directory because the dir path indicates an existing directory
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path;
+        const SyncPath path = temporaryDirectory.path();
 
         IoError ioError = IoErrorSuccess;
         CPPUNIT_ASSERT(!_testObj->createDirectory(path, ioError));
@@ -280,7 +280,7 @@ void TestIo::testCreateDirectory() {
     // Fails to create a directory because the dir path indicates an existing file
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "file.txt";
+        const SyncPath path = temporaryDirectory.path() / "file.txt";
         { std::ofstream ofs(path); }
 
         IoError ioError = IoErrorSuccess;
@@ -293,9 +293,9 @@ void TestIo::testCreateDirectory() {
     // - Access denied on MacOSX and Linux.
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "subdir";
+        const SyncPath path = temporaryDirectory.path() / "subdir";
 
-        std::filesystem::permissions(temporaryDirectory.path, std::filesystem::perms::owner_exec,
+        std::filesystem::permissions(temporaryDirectory.path(), std::filesystem::perms::owner_exec,
                                      std::filesystem::perm_options::remove);
 
         IoError ioError = IoErrorSuccess;
@@ -307,7 +307,7 @@ void TestIo::testCreateDirectory() {
         CPPUNIT_ASSERT(ioError == IoErrorAccessDenied);
 #endif
         // Restore permission to allow subdir removal
-        std::filesystem::permissions(temporaryDirectory.path, std::filesystem::perms::owner_exec,
+        std::filesystem::permissions(temporaryDirectory.path(), std::filesystem::perms::owner_exec,
                                      std::filesystem::perm_options::add);
     }
 

--- a/test/libcommonserver/io/testcheckifpathexists.cpp
+++ b/test/libcommonserver/io/testcheckifpathexists.cpp
@@ -49,7 +49,7 @@ void TestIo::testCheckIfPathExistsSimpleCases() {
     {
         const SyncPath targetPath = _localTestDirPath / "test_pictures/picture-1.jpg";
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "regular_file_symbolic_link";
+        const SyncPath path = temporaryDirectory.path() / "regular_file_symbolic_link";
         std::filesystem::create_symlink(targetPath, path);
 
         bool exists = false;
@@ -63,7 +63,7 @@ void TestIo::testCheckIfPathExistsSimpleCases() {
     {
         const SyncPath targetPath = _localTestDirPath / "test_pictures";
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "regular_dir_symbolic_link";
+        const SyncPath path = temporaryDirectory.path() / "regular_dir_symbolic_link";
         std::filesystem::create_symlink(targetPath, path);
 
         bool exists = false;
@@ -86,8 +86,8 @@ void TestIo::testCheckIfPathExistsSimpleCases() {
     // A dangling symbolic link
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath targetPath = temporaryDirectory.path / "non_existing_test_file.txt";  // This file does not exist.
-        const SyncPath path = temporaryDirectory.path / "dangling_symbolic_link";
+        const SyncPath targetPath = temporaryDirectory.path() / "non_existing_test_file.txt";  // This file does not exist.
+        const SyncPath path = temporaryDirectory.path() / "dangling_symbolic_link";
         std::filesystem::create_symlink(targetPath, path);
 
         bool exists = false;
@@ -101,7 +101,7 @@ void TestIo::testCheckIfPathExistsSimpleCases() {
     {
         const LocalTemporaryDirectory temporaryDirectory;
         const SyncPath targetPath = _localTestDirPath / "test_pictures/picture-1.jpg";
-        const SyncPath path = temporaryDirectory.path / "regular_file_alias";
+        const SyncPath path = temporaryDirectory.path() / "regular_file_alias";
 
         IoError aliasError;
         CPPUNIT_ASSERT(IoHelper::createAliasFromPath(targetPath, path, aliasError));
@@ -116,8 +116,8 @@ void TestIo::testCheckIfPathExistsSimpleCases() {
     // A dangling MacOSX Finder alias on a non-existing file.
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath targetPath = temporaryDirectory.path / "file_to_be_deleted.png";  // This file will be deleted.
-        const SyncPath path = temporaryDirectory.path / "dangling_file_alias";
+        const SyncPath targetPath = temporaryDirectory.path() / "file_to_be_deleted.png";  // This file will be deleted.
+        const SyncPath path = temporaryDirectory.path() / "dangling_file_alias";
         {
             std::ofstream ofs(targetPath);
             ofs << "Some content.\n";
@@ -143,7 +143,7 @@ void TestIo::testCheckIfPathExistsAllBranches() {
     {
         const SyncPath targetPath = _localTestDirPath / "test_pictures";
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "regular_dir_symbolic_link";
+        const SyncPath path = temporaryDirectory.path() / "regular_dir_symbolic_link";
         std::filesystem::create_symlink(targetPath, path);
 
         _testObj->setIsSymlinkFunction([](const SyncPath &, std::error_code &ec) -> bool {
@@ -164,7 +164,7 @@ void TestIo::testCheckIfPathExistsAllBranches() {
     {
         const SyncPath targetPath = _localTestDirPath / "test_pictures";
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "regular_dir_symbolic_link";
+        const SyncPath path = temporaryDirectory.path() / "regular_dir_symbolic_link";
         std::filesystem::create_symlink(targetPath, path);
 
         _testObj->setReadSymlinkFunction([](const SyncPath &path, std::error_code &ec) -> SyncPath {
@@ -186,7 +186,7 @@ void TestIo::testCheckIfPathExistsAllBranches() {
     // No error on Windows. Access denied on MacOSX and Linux.
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath subdir = temporaryDirectory.path / "permission_less_subdirectory";
+        const SyncPath subdir = temporaryDirectory.path() / "permission_less_subdirectory";
         std::filesystem::create_directory(subdir);
 
         const SyncPath targetPath = _localTestDirPath / "test_pictures/picture-1.jpg";
@@ -256,7 +256,7 @@ void TestIo::testCheckIfPathExistsWithSameNodeIdSimpleCases() {
     {
         const SyncPath targetPath = _localTestDirPath / "test_pictures/picture-1.jpg";
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "regular_file_symbolic_link";
+        const SyncPath path = temporaryDirectory.path() / "regular_file_symbolic_link";
         std::filesystem::create_symlink(targetPath, path);
 
         bool existsWithSameId = false;
@@ -274,7 +274,7 @@ void TestIo::testCheckIfPathExistsWithSameNodeIdSimpleCases() {
     {
         const SyncPath targetPath = _localTestDirPath / "test_pictures";
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "regular_dir_symbolic_link";
+        const SyncPath path = temporaryDirectory.path() / "regular_dir_symbolic_link";
         std::filesystem::create_symlink(targetPath, path);
 
         bool existsWithSameId = false;
@@ -305,8 +305,8 @@ void TestIo::testCheckIfPathExistsWithSameNodeIdSimpleCases() {
     // A dangling symbolic link
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath targetPath = temporaryDirectory.path / "non_existing_test_file.txt";  // This file does not exist.
-        const SyncPath path = temporaryDirectory.path / "dangling_symbolic_link";
+        const SyncPath targetPath = temporaryDirectory.path() / "non_existing_test_file.txt";  // This file does not exist.
+        const SyncPath path = temporaryDirectory.path() / "dangling_symbolic_link";
         std::filesystem::create_symlink(targetPath, path);
 
         bool existsWithSameId = false;
@@ -338,7 +338,7 @@ void TestIo::testCheckIfPathExistsWithSameNodeIdSimpleCases() {
     {
         const LocalTemporaryDirectory temporaryDirectory;
         const SyncPath targetPath = _localTestDirPath / "test_pictures/picture-1.jpg";
-        const SyncPath path = temporaryDirectory.path / "regular_file_alias";
+        const SyncPath path = temporaryDirectory.path() / "regular_file_alias";
 
         IoError aliasError;
         CPPUNIT_ASSERT(IoHelper::createAliasFromPath(targetPath, path, aliasError));
@@ -357,8 +357,8 @@ void TestIo::testCheckIfPathExistsWithSameNodeIdSimpleCases() {
     // A dangling MacOSX Finder alias on a non-existing file.
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath targetPath = temporaryDirectory.path / "file_to_be_deleted.png";  // This file will be deleted.
-        const SyncPath path = temporaryDirectory.path / "dangling_file_alias";
+        const SyncPath targetPath = temporaryDirectory.path() / "file_to_be_deleted.png";  // This file will be deleted.
+        const SyncPath path = temporaryDirectory.path() / "dangling_file_alias";
         { std::ofstream ofs(targetPath); }
 
         IoError aliasError;
@@ -385,7 +385,7 @@ void TestIo::testCheckIfPathExistsWithSameNodeIdAllBranches() {
     {
         const SyncPath targetPath = _localTestDirPath / "test_pictures";
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "regular_dir_symbolic_link";
+        const SyncPath path = temporaryDirectory.path() / "regular_dir_symbolic_link";
         std::filesystem::create_symlink(targetPath, path);
 
         _testObj->setIsSymlinkFunction([](const SyncPath &, std::error_code &ec) -> bool {
@@ -410,7 +410,7 @@ void TestIo::testCheckIfPathExistsWithSameNodeIdAllBranches() {
     // right before `std::filesystem::read_symlink` is called.
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath subdir = temporaryDirectory.path / "permission_less_subdirectory";
+        const SyncPath subdir = temporaryDirectory.path() / "permission_less_subdirectory";
         std::filesystem::create_directory(subdir);
 
         const SyncPath targetPath = _localTestDirPath / "test_pictures/picture-1.jpg";
@@ -446,7 +446,7 @@ void TestIo::testCheckIfPathExistsWithSameNodeIdAllBranches() {
     {
         const SyncPath targetPath = _localTestDirPath / "test_pictures";
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "regular_dir_symbolic_link";
+        const SyncPath path = temporaryDirectory.path() / "regular_dir_symbolic_link";
         std::filesystem::create_symlink(targetPath, path);
 
         _testObj->setReadSymlinkFunction([](const SyncPath &path, std::error_code &ec) -> SyncPath {

--- a/test/libcommonserver/io/testchecksetgetrights.cpp
+++ b/test/libcommonserver/io/testchecksetgetrights.cpp
@@ -37,7 +37,7 @@ void TestIo::testCheckSetAndGetRights() {
     // Test if the rights are correctly set and get on a directory
     {
         const LocalTemporaryDirectory temporaryDirectory("io_rights");
-        const SyncPath path = temporaryDirectory.path / "changePerm";
+        const SyncPath path = temporaryDirectory.path() / "changePerm";
 
         IoError ioError = IoErrorUnknown;
         CPPUNIT_ASSERT(IoHelper::createDirectory(path, ioError));
@@ -145,7 +145,7 @@ void TestIo::testCheckSetAndGetRights() {
     // Test if the rights are correctly set and if they can be successfully retrieved from a file
     {
         const LocalTemporaryDirectory temporaryDirectory("io_rights");
-        const SyncPath filepath = temporaryDirectory.path / "changePerm.txt";
+        const SyncPath filepath = temporaryDirectory.path() / "changePerm.txt";
 
         IoError ioError = IoErrorUnknown;
 
@@ -256,7 +256,7 @@ void TestIo::testCheckSetAndGetRights() {
     // Check permissions are not set recursively on a folder
     {
         const LocalTemporaryDirectory temporaryDirectory("io_rights");
-        const SyncPath path = temporaryDirectory.path / "testCheckSetAndGetRights";
+        const SyncPath path = temporaryDirectory.path() / "testCheckSetAndGetRights";
         const SyncPath subFolderPath = path / "subFolder";
         const SyncPath subFilePath = path / "subFile.txt";
 
@@ -505,7 +505,7 @@ void TestIo::testCheckSetAndGetRights() {
     // Test on a non existing file
     {
         const LocalTemporaryDirectory temporaryDirectory("io_rights");
-        const SyncPath path = temporaryDirectory.path / "testCheckSetAndGetRights/nonExistingFile.txt";
+        const SyncPath path = temporaryDirectory.path() / "testCheckSetAndGetRights/nonExistingFile.txt";
         bool isReadable = false;
         bool isWritable = false;
         bool isExecutable = false;

--- a/test/libcommonserver/io/testcreatealias.cpp
+++ b/test/libcommonserver/io/testcreatealias.cpp
@@ -32,7 +32,7 @@ void TestIo::testCreateAlias() {
     {
         const LocalTemporaryDirectory temporaryDirectory;
         const SyncPath targetPath = _localTestDirPath / "test_pictures/picture-1.jpg";
-        const SyncPath path = temporaryDirectory.path / "regular_file_alias";
+        const SyncPath path = temporaryDirectory.path() / "regular_file_alias";
 
         IoError aliasError = IoErrorUnknown;
         CPPUNIT_ASSERT(IoHelper::createAliasFromPath(targetPath, path, aliasError));
@@ -47,7 +47,7 @@ void TestIo::testCreateAlias() {
     {
         const LocalTemporaryDirectory temporaryDirectory;
         const SyncPath targetPath = _localTestDirPath / "test_pictures";
-        const SyncPath path = temporaryDirectory.path / "regular_dir_alias";
+        const SyncPath path = temporaryDirectory.path() / "regular_dir_alias";
 
         IoError aliasError = IoErrorUnknown;
         CPPUNIT_ASSERT(IoHelper::createAliasFromPath(targetPath, path, aliasError));
@@ -62,7 +62,7 @@ void TestIo::testCreateAlias() {
     {
         const LocalTemporaryDirectory temporaryDirectory;
         const SyncPath targetPath = _localTestDirPath / "non-existing.jpg";  // This file does not exist.
-        const SyncPath path = temporaryDirectory.path / "regular_dir_alias";
+        const SyncPath path = temporaryDirectory.path() / "regular_dir_alias";
 
         IoError aliasError = IoErrorSuccess;
         CPPUNIT_ASSERT(!IoHelper::createAliasFromPath(targetPath, path, aliasError));
@@ -74,7 +74,7 @@ void TestIo::testCreateAlias() {
     {
         const LocalTemporaryDirectory temporaryDirectory;
         const SyncPath targetPath = _localTestDirPath / "test_pictures/picture-1.jpg";
-        const SyncPath path = temporaryDirectory.path / "file.txt";
+        const SyncPath path = temporaryDirectory.path() / "file.txt";
         { std::ofstream ofs(path); }
 
         IoError aliasError = IoErrorUnknown;
@@ -90,7 +90,7 @@ void TestIo::testCreateAlias() {
     {
         const LocalTemporaryDirectory temporaryDirectory;
         const SyncPath targetPath = _localTestDirPath / "test_pictures/picture-1.jpg";
-        const SyncPath path = temporaryDirectory.path;
+        const SyncPath path = temporaryDirectory.path();
 
         IoError aliasError = IoErrorSuccess;
         CPPUNIT_ASSERT(!IoHelper::createAliasFromPath(targetPath, path, aliasError));
@@ -108,7 +108,7 @@ void TestIo::testCreateAlias() {
     // The alias path is the target path (of an existing file): no error!
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "file.txt";
+        const SyncPath path = temporaryDirectory.path() / "file.txt";
         { std::ofstream ofs(path); }
         const SyncPath targetPath = path;
 
@@ -139,7 +139,7 @@ void TestIo::testCreateAlias() {
     // The target file name is very long: failure
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "alias.txt";  // This file doesn't exist.
+        const SyncPath path = temporaryDirectory.path() / "alias.txt";  // This file doesn't exist.
 
         const std::string veryLongfileName(1000,
                                            'a');  // Exceeds the max allowed name length on every file system of interest.
@@ -169,7 +169,7 @@ void TestIo::testCreateAlias() {
         const SyncPath targetPath = makeVeryLonPath(_localTestDirPath);
 
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "alias.txt";  // This file doesn't exist.
+        const SyncPath path = temporaryDirectory.path() / "alias.txt";  // This file doesn't exist.
 
         IoError aliasError = IoErrorSuccess;
         CPPUNIT_ASSERT(!IoHelper::createAliasFromPath(targetPath, path, aliasError));
@@ -180,7 +180,7 @@ void TestIo::testCreateAlias() {
     // The alias file name contains emojis: success
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / makeFileNameWithEmojis();
+        const SyncPath path = temporaryDirectory.path() / makeFileNameWithEmojis();
         const SyncPath targetPath = _localTestDirPath / "test_pictures/picture-1.jpg";
 
         IoError aliasError = IoErrorUnknown;

--- a/test/libcommonserver/io/testcreatesymlink.cpp
+++ b/test/libcommonserver/io/testcreatesymlink.cpp
@@ -29,7 +29,7 @@ void TestIo::testCreateSymlink() {
     {
         const LocalTemporaryDirectory temporaryDirectory;
         const SyncPath targetPath = _localTestDirPath / "test_pictures" / "picture-1.jpg";
-        const SyncPath path = temporaryDirectory.path / "regular_file_alias";
+        const SyncPath path = temporaryDirectory.path() / "regular_file_alias";
 
         IoError ioError = IoErrorUnknown;
         CPPUNIT_ASSERT(IoHelper::createSymlink(targetPath, path, false, ioError));
@@ -48,7 +48,7 @@ void TestIo::testCreateSymlink() {
     {
         const LocalTemporaryDirectory temporaryDirectory;
         const SyncPath targetPath = _localTestDirPath / "test_pictures";
-        const SyncPath path = temporaryDirectory.path / "regular_dir_alias";
+        const SyncPath path = temporaryDirectory.path() / "regular_dir_alias";
 
         IoError ioError = IoErrorUnknown;
         CPPUNIT_ASSERT(IoHelper::createSymlink(targetPath, path, true, ioError));
@@ -67,7 +67,7 @@ void TestIo::testCreateSymlink() {
     {
         const LocalTemporaryDirectory temporaryDirectory;
         const SyncPath targetPath = _localTestDirPath / "non-existing.jpg";
-        const SyncPath path = temporaryDirectory.path / "file_symlink";
+        const SyncPath path = temporaryDirectory.path() / "file_symlink";
 
         IoError ioError = IoErrorUnknown;
         CPPUNIT_ASSERT(IoHelper::createSymlink(targetPath, path, false, ioError));
@@ -91,7 +91,7 @@ void TestIo::testCreateSymlink() {
     {
         const LocalTemporaryDirectory temporaryDirectory;
         const SyncPath targetPath = _localTestDirPath / "test_pictures/picture-1.jpg";
-        const SyncPath path = temporaryDirectory.path / "file.txt";
+        const SyncPath path = temporaryDirectory.path() / "file.txt";
         { std::ofstream ofs(path); }
 
         IoError ioError = IoErrorSuccess;
@@ -104,7 +104,7 @@ void TestIo::testCreateSymlink() {
     {
         const LocalTemporaryDirectory temporaryDirectory;
         const SyncPath targetPath = _localTestDirPath / "test_pictures/picture-1.jpg";
-        const SyncPath path = temporaryDirectory.path;
+        const SyncPath path = temporaryDirectory.path();
 
         IoError ioError = IoErrorSuccess;
         CPPUNIT_ASSERT(!IoHelper::createSymlink(targetPath, path, true, ioError));
@@ -122,7 +122,7 @@ void TestIo::testCreateSymlink() {
     // Fails to create a symlink whose path is the target path (of an existing file)
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "file.txt";
+        const SyncPath path = temporaryDirectory.path() / "file.txt";
         { std::ofstream ofs(path); }
         const SyncPath targetPath = path;
 
@@ -158,7 +158,7 @@ void TestIo::testCreateSymlink() {
     // Successfully creates a symlink whose file name contains emojis
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / makeFileNameWithEmojis();
+        const SyncPath path = temporaryDirectory.path() / makeFileNameWithEmojis();
         const SyncPath targetPath = _localTestDirPath / "test_pictures/picture-1.jpg";
 
         IoError aliasError;

--- a/test/libcommonserver/io/testfilechanged.cpp
+++ b/test/libcommonserver/io/testfilechanged.cpp
@@ -58,7 +58,7 @@ void TestIo::testFileChanged() {
     {
         const SyncPath targetPath = _localTestDirPath / "test_pictures/picture-1.jpg";
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "regular_file_symbolic_link";
+        const SyncPath path = temporaryDirectory.path() / "regular_file_symbolic_link";
         std::filesystem::create_symlink(targetPath, path);
 
         FileStat fileStat;
@@ -85,7 +85,7 @@ void TestIo::testFileChanged() {
     // A file whose content has been modified
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "file.txt";
+        const SyncPath path = temporaryDirectory.path() / "file.txt";
         {
             std::ofstream ofs(path);
             ofs << "Some content.\n";
@@ -110,7 +110,7 @@ void TestIo::testFileChanged() {
     // A file whose permissions have been modified: no change detected
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "file.txt";
+        const SyncPath path = temporaryDirectory.path() / "file.txt";
         {
             std::ofstream ofs(path);
             ofs << "Some content.\n";
@@ -136,7 +136,7 @@ void TestIo::testFileChanged() {
     // A file that is set to "hidden" on MacOSX or Windows: no change detected
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "visible_file.txt";
+        const SyncPath path = temporaryDirectory.path() / "visible_file.txt";
         { std::ofstream ofs(path); }
 
         FileStat fileStat;
@@ -180,7 +180,7 @@ void TestIo::testCheckIfIsHiddenFile() {
     // A hidden file on MacOSX and Windows
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "hidden_file.txt";
+        const SyncPath path = temporaryDirectory.path() / "hidden_file.txt";
         { std::ofstream ofs(path); }
 
         _testObj->setFileHidden(path, true);
@@ -206,7 +206,7 @@ void TestIo::testCheckIfIsHiddenFile() {
     // A hidden file on MacOSX and Linux
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / ".hidden_file.txt";
+        const SyncPath path = temporaryDirectory.path() / ".hidden_file.txt";
         { std::ofstream ofs(path); }
         bool isHidden = false;
         IoError ioError = IoErrorUnknown;
@@ -228,7 +228,7 @@ void TestIo::testCheckIfIsHiddenFile() {
     // A non-hidden file within a hidden directory
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath hiddenSubdir = temporaryDirectory.path / "hidden";
+        const SyncPath hiddenSubdir = temporaryDirectory.path() / "hidden";
         std::filesystem::create_directory(hiddenSubdir);
         const SyncPath path = hiddenSubdir / "visible_file.txt";
         {
@@ -277,7 +277,7 @@ void TestIo::testCheckIfIsHiddenFile() {
     // A non-hidden file within a hidden directory
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath hiddenSubdir = temporaryDirectory.path / ".hidden";
+        const SyncPath hiddenSubdir = temporaryDirectory.path() / ".hidden";
         std::filesystem::create_directory(hiddenSubdir);
         const SyncPath path = hiddenSubdir / "visible_file.txt";
         { std::ofstream ofs(path); }

--- a/test/libcommonserver/io/testgetfilesize.cpp
+++ b/test/libcommonserver/io/testgetfilesize.cpp
@@ -40,7 +40,7 @@ void TestIo::testGetFileSizeSimpleCases() {
     // Getting the size of a regular file missing all permissions: no error expected
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "permission_less_file.txt";
+        const SyncPath path = temporaryDirectory.path() / "permission_less_file.txt";
         {
             std::ofstream ofs(path);
             ofs << "Some content.\n";
@@ -75,7 +75,7 @@ void TestIo::testGetFileSizeSimpleCases() {
     {
         const SyncPath targetPath = _localTestDirPath / "test_pictures/picture-1.jpg";
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "regular_file_symbolic_link";
+        const SyncPath path = temporaryDirectory.path() / "regular_file_symbolic_link";
         std::filesystem::create_symlink(targetPath, path);
 
         uint64_t fileSize = 0u;
@@ -91,7 +91,7 @@ void TestIo::testGetFileSizeSimpleCases() {
     {
         const SyncPath targetPath = _localTestDirPath / "test_pictures";
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "regular_dir_symbolic_link";
+        const SyncPath path = temporaryDirectory.path() / "regular_dir_symbolic_link";
         std::filesystem::create_symlink(targetPath, path);
 
         uint64_t fileSize = 0u;
@@ -106,8 +106,8 @@ void TestIo::testGetFileSizeSimpleCases() {
         // is set with `IoErrorNoSuchFileOrDirectory`.
         {
             const LocalTemporaryDirectory temporaryDirectory;
-            const SyncPath targetPath = temporaryDirectory.path / "non_existing_test_file.txt";  // This file does not exist.
-            const SyncPath path = temporaryDirectory.path / "dangling_symbolic_link";
+            const SyncPath targetPath = temporaryDirectory.path() / "non_existing_test_file.txt";  // This file does not exist.
+            const SyncPath path = temporaryDirectory.path() / "dangling_symbolic_link";
             std::filesystem::create_symlink(targetPath, path);
 
             uint64_t fileSize = 0u;
@@ -124,7 +124,7 @@ void TestIo::testGetFileSizeSimpleCases() {
     {
         const LocalTemporaryDirectory temporaryDirectory;
         const SyncPath targetPath = _localTestDirPath / "test_pictures/picture-1.jpg";
-        const SyncPath path = temporaryDirectory.path / "regular_file_alias";
+        const SyncPath path = temporaryDirectory.path() / "regular_file_alias";
 
         IoError aliasError;
         CPPUNIT_ASSERT(_testObj->createAliasFromPath(targetPath, path, aliasError));
@@ -142,7 +142,7 @@ void TestIo::testGetFileSizeSimpleCases() {
     {
         const LocalTemporaryDirectory temporaryDirectory;
         const SyncPath targetPath = _localTestDirPath / "test_pictures";
-        const SyncPath path = temporaryDirectory.path / "regular_dir_alias";
+        const SyncPath path = temporaryDirectory.path() / "regular_dir_alias";
 
         IoError aliasError;
         CPPUNIT_ASSERT(_testObj->createAliasFromPath(targetPath, path, aliasError));
@@ -159,8 +159,8 @@ void TestIo::testGetFileSizeSimpleCases() {
     // Getting the size of a dangling MacOSX Finder alias on a non-existing file.
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath targetPath = temporaryDirectory.path / "file_to_be_deleted.png";  // This file will be deleted.
-        const SyncPath path = temporaryDirectory.path / "dangling_file_alias";
+        const SyncPath targetPath = temporaryDirectory.path() / "file_to_be_deleted.png";  // This file will be deleted.
+        const SyncPath path = temporaryDirectory.path() / "dangling_file_alias";
         {
             std::ofstream ofs(targetPath);
             ofs << "Some content.\n";
@@ -188,7 +188,7 @@ void TestIo::testGetFileSizeAllBranches() {
     // Access denied for a regular file after `getItemType` was called successfully.
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath subdir = temporaryDirectory.path / "permission_less_subdirectory";
+        const SyncPath subdir = temporaryDirectory.path() / "permission_less_subdirectory";
         std::filesystem::create_directory(subdir);
         const SyncPath path = subdir / "file.txt";
         { std::ofstream ofs(path); }

--- a/test/libcommonserver/io/testgetfilestat.cpp
+++ b/test/libcommonserver/io/testgetfilestat.cpp
@@ -65,7 +65,7 @@ void TestIo::testGetFileStat() {
     {
         const SyncPath targetPath = _localTestDirPath / "test_pictures/picture-1.jpg";
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "regular_file_symbolic_link";
+        const SyncPath path = temporaryDirectory.path() / "regular_file_symbolic_link";
         std::filesystem::create_symlink(targetPath, path);
 
         FileStat fileStat;
@@ -87,7 +87,7 @@ void TestIo::testGetFileStat() {
     {
         const SyncPath targetPath = _localTestDirPath / "test_pictures";
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "regular_dir_symbolic_link";
+        const SyncPath path = temporaryDirectory.path() / "regular_dir_symbolic_link";
         std::filesystem::create_directory_symlink(targetPath, path);
 
         FileStat fileStat;
@@ -158,7 +158,7 @@ void TestIo::testGetFileStat() {
     {
         const LocalTemporaryDirectory temporaryDirectory;
 #if defined(__APPLE__) || defined(WIN32)
-        const SyncPath path = temporaryDirectory.path / "hidden_file.txt";
+        const SyncPath path = temporaryDirectory.path() / "hidden_file.txt";
 #else
         const SyncPath path = temporaryDirectory.path / ".hidden_file.txt";
 #endif
@@ -187,9 +187,9 @@ void TestIo::testGetFileStat() {
     {
         const LocalTemporaryDirectory temporaryDirectory;
 #if defined(__APPLE__) || defined(WIN32)
-        const SyncPath path = temporaryDirectory.path;
+        const SyncPath path = temporaryDirectory.path();
 #else
-        const SyncPath path = temporaryDirectory.path / ".hidden_directory";
+        const SyncPath path = temporaryDirectory.path() / ".hidden_directory";
         std::filesystem::create_directory(path);
 #endif
 
@@ -208,7 +208,7 @@ void TestIo::testGetFileStat() {
     // An existing file with dots and colons in its name
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / ":.file.::.name.:";
+        const SyncPath path = temporaryDirectory.path() / ":.file.::.name.:";
         {
             std::ofstream ofs(path);
             ofs << "Some content.\n";
@@ -237,7 +237,7 @@ void TestIo::testGetFileStat() {
     // An existing file with emojis in its name
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / makeFileNameWithEmojis();
+        const SyncPath path = temporaryDirectory.path() / makeFileNameWithEmojis();
         {
             std::ofstream ofs(path);
             ofs << "Some content.\n";
@@ -258,8 +258,8 @@ void TestIo::testGetFileStat() {
     // A dangling symbolic link
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath targetPath = temporaryDirectory.path / "non_existing_test_file.txt";  // This file does not exist.
-        const SyncPath path = temporaryDirectory.path / "dangling_symbolic_link";
+        const SyncPath targetPath = temporaryDirectory.path() / "non_existing_test_file.txt";  // This file does not exist.
+        const SyncPath path = temporaryDirectory.path() / "dangling_symbolic_link";
         std::filesystem::create_symlink(targetPath, path);
 
         FileStat fileStat;
@@ -285,7 +285,7 @@ void TestIo::testGetFileStat() {
     {
         const LocalTemporaryDirectory temporaryDirectory;
         const SyncPath targetPath = _localTestDirPath / "test_pictures/picture-1.jpg";
-        const SyncPath path = temporaryDirectory.path / "regular_file_alias";
+        const SyncPath path = temporaryDirectory.path() / "regular_file_alias";
 
         IoError aliasError;
         IoHelper::createAliasFromPath(targetPath, path, aliasError);
@@ -305,7 +305,7 @@ void TestIo::testGetFileStat() {
     {
         const LocalTemporaryDirectory temporaryDirectory;
         const SyncPath targetPath = _localTestDirPath / "test_pictures";
-        const SyncPath path = temporaryDirectory.path / "regular_dir_alias";
+        const SyncPath path = temporaryDirectory.path() / "regular_dir_alias";
 
         IoError aliasError;
         IoHelper::createAliasFromPath(targetPath, path, aliasError);
@@ -324,8 +324,8 @@ void TestIo::testGetFileStat() {
     // A dangling MacOSX Finder alias on a non-existing file.
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath targetPath = temporaryDirectory.path / "file_to_be_deleted.png";  // This file will be deleted.
-        const SyncPath path = temporaryDirectory.path / "dangling_file_alias";
+        const SyncPath targetPath = temporaryDirectory.path() / "file_to_be_deleted.png";  // This file will be deleted.
+        const SyncPath path = temporaryDirectory.path() / "dangling_file_alias";
         {
             std::ofstream ofs(targetPath);
             ofs << "Some content.\n";
@@ -349,10 +349,10 @@ void TestIo::testGetFileStat() {
     // A dangling MacOSX Finder alias on a non-existing directory.
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath targetPath = temporaryDirectory.path / "directory_to_be_deleted";  // This directory will be deleted.
+        const SyncPath targetPath = temporaryDirectory.path() / "directory_to_be_deleted";  // This directory will be deleted.
         std::filesystem::create_directory(targetPath);
 
-        const SyncPath path = temporaryDirectory.path / "dangling_directory_alias";
+        const SyncPath path = temporaryDirectory.path() / "dangling_directory_alias";
 
         IoError aliasError;
         CPPUNIT_ASSERT(IoHelper::createAliasFromPath(targetPath, path, aliasError));
@@ -372,7 +372,7 @@ void TestIo::testGetFileStat() {
     // A regular file missing all permissions (no error expected)
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "permission_less_file.txt";
+        const SyncPath path = temporaryDirectory.path() / "permission_less_file.txt";
         {
             std::ofstream ofs(path);
             ofs << "Some content.\n";
@@ -397,7 +397,7 @@ void TestIo::testGetFileStat() {
     // A regular directory missing all permissions (no error expected)
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "permission_less_directory";
+        const SyncPath path = temporaryDirectory.path() / "permission_less_directory";
         std::filesystem::create_directory(path);
 
         std::filesystem::permissions(path, std::filesystem::perms::all, std::filesystem::perm_options::remove);
@@ -423,7 +423,7 @@ void TestIo::testGetFileStat() {
     // A regular file within a subdirectory that misses owner read permission (no error expected)
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath subdir = temporaryDirectory.path / "permission_less_subdirectory";
+        const SyncPath subdir = temporaryDirectory.path() / "permission_less_subdirectory";
         std::filesystem::create_directory(subdir);
         const SyncPath path = subdir / "file.txt";
         {
@@ -454,7 +454,7 @@ void TestIo::testGetFileStat() {
     // - no error expected on Windows
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath subdir = temporaryDirectory.path / "permission_less_subdirectory";
+        const SyncPath subdir = temporaryDirectory.path() / "permission_less_subdirectory";
         std::filesystem::create_directory(subdir);
         const SyncPath path = subdir / "file.txt";
         {

--- a/test/libcommonserver/io/testgetitemtype.cpp
+++ b/test/libcommonserver/io/testgetitemtype.cpp
@@ -134,7 +134,7 @@ void TestIo::testGetItemTypeSimpleCases() {
     {
         const SyncPath targetPath = _localTestDirPath / "test_pictures/picture-1.jpg";
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "regular_file_symbolic_link";
+        const SyncPath path = temporaryDirectory.path() / "regular_file_symbolic_link";
         std::filesystem::create_symlink(targetPath, path);
 
         const auto result = checker.checkSuccessfulLinkRetrieval(path, targetPath, LinkTypeSymlink, NodeTypeFile);
@@ -145,7 +145,7 @@ void TestIo::testGetItemTypeSimpleCases() {
     {
         const SyncPath targetPath = _localTestDirPath / "test_pictures";
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "regular_dir_symbolic_link";
+        const SyncPath path = temporaryDirectory.path() / "regular_dir_symbolic_link";
         std::filesystem::create_directory_symlink(targetPath, path);
 
         const auto result = checker.checkSuccessfulLinkRetrieval(path, targetPath, LinkTypeSymlink, NodeTypeDirectory);
@@ -202,7 +202,7 @@ void TestIo::testGetItemTypeSimpleCases() {
     // An existing file with dots and colons in its name
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / ":.file.::.name.:";
+        const SyncPath path = temporaryDirectory.path() / ":.file.::.name.:";
         { std::ofstream ofs(path); }
 
 #ifdef _WIN32
@@ -223,7 +223,7 @@ void TestIo::testGetItemTypeSimpleCases() {
     // An existing file with emojis in its name
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / makeFileNameWithEmojis();
+        const SyncPath path = temporaryDirectory.path() / makeFileNameWithEmojis();
         { std::ofstream ofs(path); }
 
         const auto result = checker.checkSuccessfulRetrieval(path, NodeTypeFile);
@@ -233,8 +233,8 @@ void TestIo::testGetItemTypeSimpleCases() {
     // A dangling symbolic link
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath targetPath = temporaryDirectory.path / "non_existing_test_file.txt";  // This file does not exist.
-        const SyncPath path = temporaryDirectory.path / "dangling_symbolic_link";
+        const SyncPath targetPath = temporaryDirectory.path() / "non_existing_test_file.txt";  // This file does not exist.
+        const SyncPath path = temporaryDirectory.path() / "dangling_symbolic_link";
         std::filesystem::create_symlink(targetPath, path);
 
         // Assumptions made to implement getItemType.
@@ -258,7 +258,7 @@ void TestIo::testGetItemTypeSimpleCases() {
     {
         const LocalTemporaryDirectory temporaryDirectory;
         const SyncPath targetPath = _localTestDirPath / "test_pictures/picture-1.jpg";
-        const SyncPath path = temporaryDirectory.path / "regular_file_alias";
+        const SyncPath path = temporaryDirectory.path() / "regular_file_alias";
 
         IoError aliasError = IoErrorSuccess;
         IoHelper::createAliasFromPath(targetPath, path, aliasError);
@@ -271,7 +271,7 @@ void TestIo::testGetItemTypeSimpleCases() {
     {
         const LocalTemporaryDirectory temporaryDirectory;
         const SyncPath targetPath = _localTestDirPath / "test_pictures";
-        const SyncPath path = temporaryDirectory.path / "regular_dir_alias";
+        const SyncPath path = temporaryDirectory.path() / "regular_dir_alias";
 
         IoError aliasError = IoErrorSuccess;
         IoHelper::createAliasFromPath(targetPath, path, aliasError);
@@ -283,8 +283,8 @@ void TestIo::testGetItemTypeSimpleCases() {
     // A dangling MacOSX Finder alias on a non-existing file.
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath targetPath = temporaryDirectory.path / "file_to_be_deleted.png";  // This file will be deleted.
-        const SyncPath path = temporaryDirectory.path / "dangling_file_alias";
+        const SyncPath targetPath = temporaryDirectory.path() / "file_to_be_deleted.png";  // This file will be deleted.
+        const SyncPath path = temporaryDirectory.path() / "dangling_file_alias";
         { std::ofstream ofs(targetPath); }
 
         IoError aliasError;
@@ -299,10 +299,10 @@ void TestIo::testGetItemTypeSimpleCases() {
     // A dangling MacOSX Finder alias on a non-existing directory.
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath targetPath = temporaryDirectory.path / "directory_to_be_deleted";  // This directory will be deleted.
+        const SyncPath targetPath = temporaryDirectory.path() / "directory_to_be_deleted";  // This directory will be deleted.
         std::filesystem::create_directory(targetPath);
 
-        const SyncPath path = temporaryDirectory.path / "dangling_directory_alias";
+        const SyncPath path = temporaryDirectory.path() / "dangling_directory_alias";
 
         IoError aliasError = IoErrorSuccess;
         IoHelper::createAliasFromPath(targetPath, path, aliasError);
@@ -336,7 +336,7 @@ void TestIo::testGetItemTypeSimpleCases() {
     // A regular file missing all permissions (no error expected)
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "permission_less_file.txt";
+        const SyncPath path = temporaryDirectory.path() / "permission_less_file.txt";
         { std::ofstream ofs(path); }
 
         std::filesystem::permissions(path, std::filesystem::perms::all, std::filesystem::perm_options::remove);
@@ -349,7 +349,7 @@ void TestIo::testGetItemTypeSimpleCases() {
     // A regular directory missing all permissions (no error expected)
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "permission_less_directory";
+        const SyncPath path = temporaryDirectory.path() / "permission_less_directory";
         std::filesystem::create_directory(path);
 
         const auto allPermissions =
@@ -364,7 +364,7 @@ void TestIo::testGetItemTypeSimpleCases() {
     // A regular file within a subdirectory that misses owner read permission (no error expected)
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath subdir = temporaryDirectory.path / "permission_less_subdirectory";
+        const SyncPath subdir = temporaryDirectory.path() / "permission_less_subdirectory";
         std::filesystem::create_directory(subdir);
         const SyncPath path = subdir / "file.txt";
         { std::ofstream ofs(path); }
@@ -381,7 +381,7 @@ void TestIo::testGetItemTypeSimpleCases() {
     // - no error on Windows
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath subdir = temporaryDirectory.path / "permission_less_subdirectory";
+        const SyncPath subdir = temporaryDirectory.path() / "permission_less_subdirectory";
         std::filesystem::create_directory(subdir);
         const SyncPath path = subdir / "file.txt";
         { std::ofstream ofs(path); }
@@ -409,7 +409,7 @@ void TestIo::testGetItemTypeSimpleCases() {
     // - no error expected on Windows
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath subdir = temporaryDirectory.path / "permission_less_subdirectory";
+        const SyncPath subdir = temporaryDirectory.path() / "permission_less_subdirectory";
         std::filesystem::create_directory(subdir);
 
         const SyncPath targetPath = _localTestDirPath / "test_pictures/picture-1.jpg";
@@ -444,7 +444,7 @@ void TestIo::testGetItemTypeAllBranches() {
     {
         const SyncPath targetPath = _localTestDirPath / "test_pictures";
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "regular_dir_symbolic_link";
+        const SyncPath path = temporaryDirectory.path() / "regular_dir_symbolic_link";
         std::filesystem::create_symlink(targetPath, path);
 
         _testObj->setIsSymlinkFunction([](const SyncPath &, std::error_code &ec) -> bool {
@@ -467,7 +467,7 @@ void TestIo::testGetItemTypeAllBranches() {
     {
         const SyncPath targetPath = _localTestDirPath / "test_pictures";
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "regular_dir_symbolic_link";
+        const SyncPath path = temporaryDirectory.path() / "regular_dir_symbolic_link";
         std::filesystem::create_symlink(targetPath, path);
 
         _testObj->setReadSymlinkFunction([](const SyncPath &path, std::error_code &ec) -> SyncPath {
@@ -485,7 +485,7 @@ void TestIo::testGetItemTypeAllBranches() {
     // after `filesystem::is_simlink` was called.
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath subdir = temporaryDirectory.path / "permission_less_subdirectory";
+        const SyncPath subdir = temporaryDirectory.path() / "permission_less_subdirectory";
         std::filesystem::create_directory(subdir);
 
         const SyncPath targetPath = _localTestDirPath / "test_pictures/picture-1.jpg";
@@ -519,7 +519,7 @@ void TestIo::testGetItemTypeAllBranches() {
     {
         const SyncPath targetPath = _localTestDirPath / "test_pictures";
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "regular_dir_symbolic_link";
+        const SyncPath path = temporaryDirectory.path() / "regular_dir_symbolic_link";
         std::filesystem::create_symlink(targetPath, path);
 
         _testObj->setReadSymlinkFunction([](const SyncPath &path, std::error_code &ec) -> SyncPath {
@@ -536,8 +536,8 @@ void TestIo::testGetItemTypeAllBranches() {
     // Checking the target type of a symlink after the target file has been removed
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath targetPath = temporaryDirectory.path / "file.txt";
-        const SyncPath path = temporaryDirectory.path / "symlink_to_file.txt";
+        const SyncPath targetPath = temporaryDirectory.path() / "file.txt";
+        const SyncPath path = temporaryDirectory.path() / "symlink_to_file.txt";
         { std::ofstream ofs(targetPath); }
         std::filesystem::create_symlink(targetPath, path);
 
@@ -557,7 +557,7 @@ void TestIo::testGetItemTypeAllBranches() {
     {
         const SyncPath targetPath = _localTestDirPath / "test_pictures";
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "test_pictures_alias";
+        const SyncPath path = temporaryDirectory.path() / "test_pictures_alias";
 
         IoError aliasError;
         CPPUNIT_ASSERT(_testObj->createAliasFromPath(targetPath, path, aliasError));
@@ -583,7 +583,7 @@ void TestIo::testGetItemTypeAllBranches() {
     // A regular MacOSX Finder alias in a directory that misses search permission.
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath subdir = temporaryDirectory.path / "directory_without_search_permission";
+        const SyncPath subdir = temporaryDirectory.path() / "directory_without_search_permission";
         std::filesystem::create_directory(subdir);
 
         const SyncPath targetPath = _localTestDirPath / "test_pictures" / "picture-1.jpg";
@@ -627,10 +627,10 @@ void TestIo::testGetItemTypeEdgeCases() {
     // It is unclear which of `fileURLWithPath` or `getResourceValue` is the culprit.
 
     const LocalTemporaryDirectory temporaryDirectory;
-    const int bound = (1020 - temporaryDirectory.path.string().size()) / 4;
+    const int bound = (1020 - temporaryDirectory.path().string().size()) / 4;
     std::string segment(bound, 'a');
 
-    SyncPath path = temporaryDirectory.path / segment / segment / segment / u8"놔";
+    SyncPath path = temporaryDirectory.path() / segment / segment / segment / u8"놔";
 
     std::error_code ec;
     CPPUNIT_ASSERT(std::filesystem::create_directories(path, ec));

--- a/test/libcommonserver/io/testgetnodeid.cpp
+++ b/test/libcommonserver/io/testgetnodeid.cpp
@@ -45,7 +45,7 @@ void TestIo::testGetNodeId() {
     {
         const SyncPath targetPath = _localTestDirPath / "test_pictures/picture-1.jpg";
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "regular_file_symbolic_link";
+        const SyncPath path = temporaryDirectory.path() / "regular_file_symbolic_link";
         std::filesystem::create_symlink(targetPath, path);
 
         NodeId nodeId;
@@ -57,7 +57,7 @@ void TestIo::testGetNodeId() {
     {
         const SyncPath targetPath = _localTestDirPath / "test_pictures";
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "regular_dir_symbolic_link";
+        const SyncPath path = temporaryDirectory.path() / "regular_dir_symbolic_link";
         std::filesystem::create_symlink(targetPath, path);
 
         NodeId nodeId;
@@ -99,7 +99,7 @@ void TestIo::testGetNodeId() {
     // An existing file with dots and colons in its name
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / ":.file.::.name.:";
+        const SyncPath path = temporaryDirectory.path() / ":.file.::.name.:";
         {
             std::ofstream ofs(path);
             ofs << "Some content.\n";
@@ -114,7 +114,7 @@ void TestIo::testGetNodeId() {
     // An existing file with emojis in its name
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / makeFileNameWithEmojis();
+        const SyncPath path = temporaryDirectory.path() / makeFileNameWithEmojis();
         {
             std::ofstream ofs(path);
             ofs << "Some content.\n";
@@ -129,8 +129,8 @@ void TestIo::testGetNodeId() {
     // A dangling symbolic link
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath targetPath = temporaryDirectory.path / "non_existing_test_file.txt";  // This file does not exist.
-        const SyncPath path = temporaryDirectory.path / "dangling_symbolic_link";
+        const SyncPath targetPath = temporaryDirectory.path() / "non_existing_test_file.txt";  // This file does not exist.
+        const SyncPath path = temporaryDirectory.path() / "dangling_symbolic_link";
         std::filesystem::create_symlink(targetPath, path);
 
         std::error_code ec;
@@ -147,7 +147,7 @@ void TestIo::testGetNodeId() {
     {
         const LocalTemporaryDirectory temporaryDirectory;
         const SyncPath targetPath = _localTestDirPath / "test_pictures/picture-1.jpg";
-        const SyncPath path = temporaryDirectory.path / "regular_file_alias";
+        const SyncPath path = temporaryDirectory.path() / "regular_file_alias";
 
         IoError aliasError;
         CPPUNIT_ASSERT(IoHelper::createAliasFromPath(targetPath, path, aliasError));
@@ -163,7 +163,7 @@ void TestIo::testGetNodeId() {
     {
         const LocalTemporaryDirectory temporaryDirectory;
         const SyncPath targetPath = _localTestDirPath / "test_pictures";
-        const SyncPath path = temporaryDirectory.path / "regular_dir_alias";
+        const SyncPath path = temporaryDirectory.path() / "regular_dir_alias";
 
         IoError aliasError;
         CPPUNIT_ASSERT(IoHelper::createAliasFromPath(targetPath, path, aliasError));
@@ -178,8 +178,8 @@ void TestIo::testGetNodeId() {
     // A dangling MacOSX Finder alias on a non-existing file.
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath targetPath = temporaryDirectory.path / "file_to_be_deleted.png";  // This file will be deleted.
-        const SyncPath path = temporaryDirectory.path / "dangling_file_alias";
+        const SyncPath targetPath = temporaryDirectory.path() / "file_to_be_deleted.png";  // This file will be deleted.
+        const SyncPath path = temporaryDirectory.path() / "dangling_file_alias";
         {
             std::ofstream ofs(targetPath);
             ofs << "Some content.\n";
@@ -202,10 +202,10 @@ void TestIo::testGetNodeId() {
     // A dangling MacOSX Finder alias on a non-existing directory.
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath targetPath = temporaryDirectory.path / "directory_to_be_deleted";  // This directory will be deleted.
+        const SyncPath targetPath = temporaryDirectory.path() / "directory_to_be_deleted";  // This directory will be deleted.
         std::filesystem::create_directory(targetPath);
 
-        const SyncPath path = temporaryDirectory.path / "dangling_directory_alias";
+        const SyncPath path = temporaryDirectory.path() / "dangling_directory_alias";
 
         IoError aliasError;
         CPPUNIT_ASSERT(IoHelper::createAliasFromPath(targetPath, path, aliasError));
@@ -224,7 +224,7 @@ void TestIo::testGetNodeId() {
     // A regular file missing all permissions (no error expected)
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "permission_less_file.txt";
+        const SyncPath path = temporaryDirectory.path() / "permission_less_file.txt";
         {
             std::ofstream ofs(path);
             ofs << "Some content.\n";
@@ -245,7 +245,7 @@ void TestIo::testGetNodeId() {
     // A regular directory missing all permissions (no error expected)
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "permission_less_directory";
+        const SyncPath path = temporaryDirectory.path() / "permission_less_directory";
         std::filesystem::create_directory(path);
 
         const auto allPermissions =
@@ -263,7 +263,7 @@ void TestIo::testGetNodeId() {
     // A regular file within a subdirectory that misses owner read permission (no error expected)
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath subdir = temporaryDirectory.path / "permission_less_subdirectory";
+        const SyncPath subdir = temporaryDirectory.path() / "permission_less_subdirectory";
         std::filesystem::create_directory(subdir);
         const SyncPath path = subdir / "file.txt";
         {
@@ -287,7 +287,7 @@ void TestIo::testGetNodeId() {
     // - no error on Windows
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath subdir = temporaryDirectory.path / "permission_less_subdirectory";
+        const SyncPath subdir = temporaryDirectory.path() / "permission_less_subdirectory";
         std::filesystem::create_directory(subdir);
         const SyncPath path = subdir / "file.txt";
         { std::ofstream ofs(path); }

--- a/test/libcommonserver/io/testgetxattrvalue.cpp
+++ b/test/libcommonserver/io/testgetxattrvalue.cpp
@@ -54,7 +54,7 @@ void TestIo::testGetXAttrValue() {
     {
         const SyncPath targetPath = _localTestDirPath / "test_pictures/picture-1.jpg";
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "regular_file_symbolic_link";
+        const SyncPath path = temporaryDirectory.path() / "regular_file_symbolic_link";
         std::filesystem::create_symlink(targetPath, path);
 
         IoError ioError = IoErrorSuccess;
@@ -88,7 +88,7 @@ void TestIo::testGetXAttrValue() {
     // A regular file missing owner read permission and without extended attribute: access denied expected
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "permission_less_file.txt";
+        const SyncPath path = temporaryDirectory.path() / "permission_less_file.txt";
         {
             std::ofstream ofs(path);
             ofs << "Some content.\n";
@@ -107,7 +107,7 @@ void TestIo::testGetXAttrValue() {
     // An existing file with an extended attribute
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "file.txt";
+        const SyncPath path = temporaryDirectory.path() / "file.txt";
         {
             std::ofstream ofs(path);
             ofs << "Some content.\n";
@@ -126,7 +126,7 @@ void TestIo::testGetXAttrValue() {
     // An existing directory with an extended attribute
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path;
+        const SyncPath path = temporaryDirectory.path();
 
         IoError ioError = IoErrorSuccess;
         CPPUNIT_ASSERT(_testObj->setXAttrValue(path, "status", "super-dry", ioError));
@@ -142,7 +142,7 @@ void TestIo::testGetXAttrValue() {
     {
         const SyncPath targetPath = _localTestDirPath / "test_pictures/picture-1.jpg";
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "regular_file_symbolic_link";
+        const SyncPath path = temporaryDirectory.path() / "regular_file_symbolic_link";
         std::filesystem::create_symlink(targetPath, path);
 
         IoError ioError = IoErrorSuccess;
@@ -163,7 +163,7 @@ void TestIo::testGetXAttrValue() {
     {
         const SyncPath targetPath = _localTestDirPath / "test_pictures";
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "regular_dir_symbolic_link";
+        const SyncPath path = temporaryDirectory.path() / "regular_dir_symbolic_link";
         std::filesystem::create_symlink(targetPath, path);
 
         IoError ioError = IoErrorSuccess;
@@ -183,8 +183,8 @@ void TestIo::testGetXAttrValue() {
     // A dangling symbolic link on a file, with an extended attribute set for the link
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath targetPath = temporaryDirectory.path / "non_existing_test_file.txt";  // This file does not exist.
-        const SyncPath path = temporaryDirectory.path / "dangling_symbolic_link";
+        const SyncPath targetPath = temporaryDirectory.path() / "non_existing_test_file.txt";  // This file does not exist.
+        const SyncPath path = temporaryDirectory.path() / "dangling_symbolic_link";
         std::filesystem::create_symlink(targetPath, path);
 
         IoError ioError = IoErrorSuccess;
@@ -201,7 +201,7 @@ void TestIo::testGetXAttrValue() {
     {
         const LocalTemporaryDirectory temporaryDirectory;
         const SyncPath targetPath = _localTestDirPath / "test_pictures/picture-1.jpg";
-        const SyncPath path = temporaryDirectory.path / "regular_file_alias";
+        const SyncPath path = temporaryDirectory.path() / "regular_file_alias";
 
         IoError aliasError;
         CPPUNIT_ASSERT(IoHelper::createAliasFromPath(targetPath, path, aliasError));
@@ -223,7 +223,7 @@ void TestIo::testGetXAttrValue() {
     // An existing file with an extended attribute
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "file.txt";
+        const SyncPath path = temporaryDirectory.path() / "file.txt";
         {
             std::ofstream ofs(path);
             ofs << "Some content.\n";
@@ -242,7 +242,7 @@ void TestIo::testGetXAttrValue() {
     // An existing directory with an extended attribute
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path;
+        const SyncPath path = temporaryDirectory.path();
 
         IoError ioError = IoErrorSuccess;
         CPPUNIT_ASSERT(_testObj->setXAttrValue(path, "status", "super-dry", ioError));
@@ -258,7 +258,7 @@ void TestIo::testGetXAttrValue() {
     {
         const SyncPath targetPath = _localTestDirPath / "test_pictures/picture-1.jpg";
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "regular_file_symbolic_link";
+        const SyncPath path = temporaryDirectory.path() / "regular_file_symbolic_link";
         std::filesystem::create_symlink(targetPath, path);
 
         IoError ioError = IoErrorSuccess;
@@ -279,7 +279,7 @@ void TestIo::testGetXAttrValue() {
     {
         const SyncPath targetPath = _localTestDirPath / "test_pictures";
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "regular_dir_symbolic_link";
+        const SyncPath path = temporaryDirectory.path() / "regular_dir_symbolic_link";
         std::filesystem::create_symlink(targetPath, path);
 
         IoError ioError = IoErrorSuccess;
@@ -299,8 +299,8 @@ void TestIo::testGetXAttrValue() {
     // A dangling symbolic link on a file, with an extended attribute set for the link
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath targetPath = temporaryDirectory.path / "non_existing_test_file.txt";  // This file does not exist.
-        const SyncPath path = temporaryDirectory.path / "dangling_symbolic_link";
+        const SyncPath targetPath = temporaryDirectory.path() / "non_existing_test_file.txt";  // This file does not exist.
+        const SyncPath path = temporaryDirectory.path() / "dangling_symbolic_link";
         std::filesystem::create_symlink(targetPath, path);
 
         IoError ioError = IoErrorSuccess;
@@ -317,7 +317,7 @@ void TestIo::testGetXAttrValue() {
     {
         const LocalTemporaryDirectory temporaryDirectory;
         const SyncPath targetPath = _localTestDirPath / "test_pictures/picture-1.jpg";
-        const SyncPath path = temporaryDirectory.path / "regular_file_alias";
+        const SyncPath path = temporaryDirectory.path() / "regular_file_alias";
 
         IoError aliasError;
         CPPUNIT_ASSERT(IoHelper::createAliasFromPath(targetPath, path, aliasError));

--- a/test/libcommonserver/io/testisfileaccessible.cpp
+++ b/test/libcommonserver/io/testisfileaccessible.cpp
@@ -30,8 +30,8 @@ namespace KDC {
 
 void TestIo::testIsFileAccessible() {
     const LocalTemporaryDirectory temporaryDirectory;
-    const SyncPath sourcePath = temporaryDirectory.path / "test_big_file.txt";
-    const SyncPath destPath = temporaryDirectory.path / "test_big_file_copy.txt";
+    const SyncPath sourcePath = temporaryDirectory.path() / "test_big_file.txt";
+    const SyncPath destPath = temporaryDirectory.path() / "test_big_file_copy.txt";
 
     // Create a 100 MB file
     {

--- a/test/libcommonserver/io/testsetxattrvalue.cpp
+++ b/test/libcommonserver/io/testsetxattrvalue.cpp
@@ -33,7 +33,7 @@ void TestIo::testSetXAttrValue() {
     // A regular file
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "file.txt";
+        const SyncPath path = temporaryDirectory.path() / "file.txt";
         {
             std::ofstream ofs(path);
             ofs << "Some content.\n";
@@ -76,7 +76,7 @@ void TestIo::testSetXAttrValue() {
     // A regular file missing owner write permission: access denied expected
     {
         const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path / "permission_less_file.txt";
+        const SyncPath path = temporaryDirectory.path() / "permission_less_file.txt";
         {
             std::ofstream ofs(path);
             ofs << "Some content.\n";

--- a/test/libcommonserver/utility/testutility.cpp
+++ b/test/libcommonserver/utility/testutility.cpp
@@ -178,7 +178,7 @@ void TestUtility::testIsEqualInsensitive(void) {
 
 void TestUtility::testMoveItemToTrash(void) {
     LocalTemporaryDirectory tempDir;
-    SyncPath path = tempDir.path / "test.txt";
+    SyncPath path = tempDir.path() / "test.txt";
     std::ofstream file(path);
     file << "test";
     file.close();
@@ -187,16 +187,16 @@ void TestUtility::testMoveItemToTrash(void) {
     CPPUNIT_ASSERT(!std::filesystem::exists(path));
 
     // Test with a non existing file
-    CPPUNIT_ASSERT(!_testObj->moveItemToTrash(tempDir.path / "test2.txt"));
+    CPPUNIT_ASSERT(!_testObj->moveItemToTrash(tempDir.path() / "test2.txt"));
 
     // Test with a directory
-    SyncPath dirPath = tempDir.path / "testDir";
+    SyncPath dirPath = tempDir.path() / "testDir";
     std::filesystem::create_directory(dirPath);
     CPPUNIT_ASSERT(_testObj->moveItemToTrash(dirPath));
     CPPUNIT_ASSERT(!std::filesystem::exists(dirPath));
 }
 
-void TestUtility::testGetLinuxDesktopType(void) {
+void TestUtility::testGetLinuxDesktopType() {
     std::string currentDesktop;
 
 #ifdef __unix__
@@ -236,7 +236,7 @@ void TestUtility::testJoinStr() {
     CPPUNIT_ASSERT(_testObj->joinStr(strList, '@') == "C'est@ @un @test!");
 }
 
-void TestUtility::testPathDepth(void) {
+void TestUtility::testPathDepth() {
     SyncPath path = "";
     CPPUNIT_ASSERT_EQUAL(0, _testObj->pathDepth(path));
 
@@ -246,7 +246,7 @@ void TestUtility::testPathDepth(void) {
     }
 }
 
-void TestUtility::testComputeMd5Hash(void) {
+void TestUtility::testComputeMd5Hash() {
     std::vector<std::pair<std::string, std::string>> testCases = {
         {"", "d41d8cd98f00b204e9800998ecf8427e"},
         {"a", "0cc175b9c0f1b6a831c399e269772661"},
@@ -274,7 +274,7 @@ void TestUtility::testXxHash() {
     CPPUNIT_ASSERT(contentHash == "5dcc477e35136516");
 }
 
-void TestUtility::testToUpper(void) {
+void TestUtility::testToUpper() {
     CPPUNIT_ASSERT_EQUAL(std::string("ABC"), _testObj->toUpper("abc"));
     CPPUNIT_ASSERT_EQUAL(std::string("ABC"), _testObj->toUpper("ABC"));
     CPPUNIT_ASSERT_EQUAL(std::string("ABC"), _testObj->toUpper("AbC"));
@@ -285,7 +285,7 @@ void TestUtility::testToUpper(void) {
                          _testObj->toUpper("²&é~\"#'{([-|`è_\\ç^à@)]}=+*ù%µ£¤§:;,!.?/"));
 }
 
-void TestUtility::testErrId(void) {
+void TestUtility::testErrId() {
     // The macro ERRID expands to Utility::errId(__FILE__, __LINE__) (see types.h)
     CPPUNIT_ASSERT_EQUAL(std::string("TES:") + std::to_string(__LINE__), ERRID);
     CPPUNIT_ASSERT_EQUAL(std::string("TES:") + std::to_string(__LINE__), _testObj->errId(__FILE__, __LINE__));
@@ -309,9 +309,9 @@ void TestUtility::isSubDir() {
     CPPUNIT_ASSERT(!CommonUtility::isSubDir(path2, path1));
 }
 
-void TestUtility::testcheckIfDirEntryIsManaged(void) {
+void TestUtility::testcheckIfDirEntryIsManaged() {
     LocalTemporaryDirectory tempDir;
-    SyncPath path = tempDir.path / "test.txt";
+    SyncPath path = tempDir.path() / "test.txt";
     std::ofstream file(path);
     file << "test";
     file.close();
@@ -319,7 +319,7 @@ void TestUtility::testcheckIfDirEntryIsManaged(void) {
     bool isManaged = false;
     bool isLink = false;
     IoError ioError = IoErrorSuccess;
-    std::filesystem::recursive_directory_iterator entry(tempDir.path);
+    std::filesystem::recursive_directory_iterator entry(tempDir.path());
 
     // Check with an existing file (managed)
     CPPUNIT_ASSERT(Utility::checkIfDirEntryIsManaged(entry, isManaged, isLink, ioError));
@@ -328,7 +328,7 @@ void TestUtility::testcheckIfDirEntryIsManaged(void) {
     CPPUNIT_ASSERT(ioError == IoErrorSuccess);
 
     // Check with a simlink (managed)
-    const SyncPath simLinkDir = tempDir.path / "simLinkDir";
+    const SyncPath simLinkDir = tempDir.path() / "simLinkDir";
     std::filesystem::create_directory(simLinkDir);
     std::filesystem::create_symlink(path, simLinkDir / "testLink.txt");
     entry = std::filesystem::recursive_directory_iterator(simLinkDir);
@@ -338,7 +338,7 @@ void TestUtility::testcheckIfDirEntryIsManaged(void) {
     CPPUNIT_ASSERT(ioError == IoErrorSuccess);
 
     // Check with a directory
-    entry = std::filesystem::recursive_directory_iterator(tempDir.path);
+    entry = std::filesystem::recursive_directory_iterator(tempDir.path());
     CPPUNIT_ASSERT(Utility::checkIfDirEntryIsManaged(entry, isManaged, isLink, ioError));
     CPPUNIT_ASSERT(isManaged);
     CPPUNIT_ASSERT(!isLink);
@@ -361,7 +361,7 @@ void TestUtility::testFormatStdError() {
                            result.find(Utility::s2ws(path.string())) != std::wstring::npos);
 }
 
-void TestUtility::testFormatIoError(void) {
+void TestUtility::testFormatIoError() {
     const IoError ioError = IoErrorSuccess;
     const SyncPath path = "A/AA";
     const std::wstring result = _testObj->formatIoError(path, ioError);
@@ -371,12 +371,12 @@ void TestUtility::testFormatIoError(void) {
                            result.find(Utility::s2ws(path.string())) != std::wstring::npos);
 }
 
-void TestUtility::testFormatSyncPath(void) {
+void TestUtility::testFormatSyncPath() {
     const SyncPath path = "A/AA";
     CPPUNIT_ASSERT(Utility::formatSyncPath(path).find(Utility::s2ws(path.string())) != std::wstring::npos);
 }
 
-void TestUtility::testFormatRequest(void) {
+void TestUtility::testFormatRequest() {
     const std::string uri("http://www.example.com");
     const std::string code = "404";
     const std::string description = "Not Found";

--- a/test/libsyncengine/CMakeLists.txt
+++ b/test/libsyncengine/CMakeLists.txt
@@ -10,6 +10,7 @@ set(testsyncengine_SRCS
         ../test.cpp
         test.cpp
         ../test_utility/localtemporarydirectory.h ../test_utility/localtemporarydirectory.cpp
+        ../test_utility/remotetemporarydirectory.h ../test_utility/remotetemporarydirectory.cpp
         ../test_classes/syncpaltest.h ../test_classes/syncpaltest.cpp
         # Database
         db/testsyncdb.h db/testsyncdb.cpp

--- a/test/libsyncengine/jobs/local/testlocaljobs.cpp
+++ b/test/libsyncengine/jobs/local/testlocaljobs.cpp
@@ -44,7 +44,7 @@ void KDC::TestLocalJobs::setUp() {
 
 void KDC::TestLocalJobs::testLocalJobs() {
     const LocalTemporaryDirectory temporaryDirectory("testLocalJobs");
-    const SyncPath localDirPath = temporaryDirectory.path / "tmp_dir";
+    const SyncPath localDirPath = temporaryDirectory.path() / "tmp_dir";
 
     // Create
     LocalCreateDirJob createJob(localDirPath);
@@ -57,7 +57,7 @@ void KDC::TestLocalJobs::testLocalJobs() {
     std::filesystem::copy(picturesPath / "picture-1.jpg", localDirPath / "tmp_picture.jpg");
 
     // Copy
-    const SyncPath copyDirPath = temporaryDirectory.path / "tmp_dir2";
+    const SyncPath copyDirPath = temporaryDirectory.path() / "tmp_dir2";
     LocalCopyJob copyJob(localDirPath, copyDirPath);
     copyJob.runSynchronously();
 

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -47,18 +47,19 @@
 #include "utility/jsonparserutility.h"
 #include "requests/parameterscache.h"
 #include "test_utility/localtemporarydirectory.h"
+#include "test_utility/remotetemporarydirectory.h"
 
 using namespace CppUnit;
 
 namespace KDC {
 
-static const NodeId pictureDirRemoteId = "56851";       // test_ci/test_pictures
-static const NodeId picture1RemoteId = "97373";         // test_ci/test_pictures/picture-1.jpg
-static const NodeId testFileRemoteId = "97370";         // test_ci/test_networkjobs/test_download.txt
-static const NodeId testFileRemoteRenameId = "97376";   // test_ci/test_networkjobs/test_rename*.txt
-static const NodeId testBigFileRemoteId = "97601";      // test_ci/big_file_dir/big_text_file.txt
-static const NodeId testDummyDirRemoteId = "98648";     // test_ci/dummy_dir
-static const NodeId testDummyFileRemoteId = "98649";    // test_ci/dummy_dir/picture.jpg
+static const NodeId pictureDirRemoteId = "56851";      // test_ci/test_pictures
+static const NodeId picture1RemoteId = "97373";        // test_ci/test_pictures/picture-1.jpg
+static const NodeId testFileRemoteId = "97370";        // test_ci/test_networkjobs/test_download.txt
+static const NodeId testFileRemoteRenameId = "97376";  // test_ci/test_networkjobs/test_rename*.txt
+static const NodeId testBigFileRemoteId = "97601";     // test_ci/big_file_dir/big_text_file.txt
+static const NodeId testDummyDirRemoteId = "98648";    // test_ci/dummy_dir
+static const NodeId testDummyFileRemoteId = "98649";   // test_ci/dummy_dir/picture.jpg
 
 static const std::string desktopTeamTestDriveName = "kDrive Desktop Team";
 static const std::string bigFileDirName = "big_file_dir";
@@ -119,42 +120,35 @@ void TestNetworkJobs::setUp() {
 void TestNetworkJobs::tearDown() {
     LOGW_DEBUG(Log::instance()->getLogger(), L"$$$$$ Tear Down");
 
-    if (_deleteDummyFile) {
-        DeleteJob job(_driveDbId, _dummyRemoteFileId, "1234", _dummyLocalFilePath);
-        ExitCode exitCode = job.runSynchronously();
-        CPPUNIT_ASSERT(exitCode == ExitCodeOk);
-    }
-
-    if (_deleteDummyDir) {
-        DeleteJob job(_driveDbId, _dummyRemoteDirId, "1234", _dummyLocalDirPath);
+    if (!_dummyRemoteFileId.empty()) {
+        DeleteJob job(_driveDbId, _dummyRemoteFileId, "", "");
         job.setBypassCheck(true);
-        ExitCode exitCode = job.runSynchronously();
-        CPPUNIT_ASSERT(exitCode == ExitCodeOk);
+        job.runSynchronously();
     }
+    if (!_dummyLocalFilePath.empty()) std::filesystem::remove_all(_dummyLocalFilePath);
 
     ParmsDb::instance()->close();
     ParmsDb::reset();
 }
 
 void TestNetworkJobs::testCreateDir() {
-    CPPUNIT_ASSERT(createTestDir());
+    const RemoteTemporaryDirectory remoteTmpDir(_driveDbId, _remoteDirId, "testCreateDir");
 
     GetFileListJob fileListJob(_driveDbId, _remoteDirId);
-    ExitCode exitCode = fileListJob.runSynchronously();
+    const ExitCode exitCode = fileListJob.runSynchronously();
     CPPUNIT_ASSERT(exitCode == ExitCodeOk);
 
     Poco::JSON::Object::Ptr resObj = fileListJob.jsonRes();
     CPPUNIT_ASSERT(resObj);
 
     bool newDirFound = false;
-    Poco::JSON::Array::Ptr dataArray = resObj->getArray(dataKey);
-    for (auto it = dataArray->begin(); it != dataArray->end(); ++it) {
-        Poco::JSON::Object::Ptr dirObj = it->extract<Poco::JSON::Object::Ptr>();
+    for (const auto dataArray = resObj->getArray(dataKey); const auto &item : *dataArray) {
+        const auto &dirObj = item.extract<Poco::JSON::Object::Ptr>();
 
         SyncName name;
         CPPUNIT_ASSERT(JsonParserUtility::extractValue(dirObj, nameKey, name));
 
-        if (_dummyDirName == name) {
+        if (remoteTmpDir.name() == name) {
             newDirFound = true;
             break;
         }
@@ -164,14 +158,14 @@ void TestNetworkJobs::testCreateDir() {
 
 void TestNetworkJobs::testCopyToDir() {
     // Create test dir
-    CPPUNIT_ASSERT(createTestDir());
+    const RemoteTemporaryDirectory remoteTmpDir(_driveDbId, _remoteDirId, "testCopyToDir");
 
-    SyncName filename = Str("testCopyToDir_") + Str2SyncName(CommonUtility::generateRandomStringAlphaNum()) + Str(".txt");
-    CopyToDirectoryJob job(_driveDbId, testFileRemoteId, _dummyRemoteDirId, filename);
+    const SyncName filename = Str("testCopyToDir_") + Str2SyncName(CommonUtility::generateRandomStringAlphaNum()) + Str(".txt");
+    CopyToDirectoryJob job(_driveDbId, testFileRemoteId, remoteTmpDir.id(), filename);
     ExitCode exitCode = job.runSynchronously();
     CPPUNIT_ASSERT(exitCode == ExitCodeOk);
 
-    GetFileListJob fileListJob(_driveDbId, _dummyRemoteDirId);
+    GetFileListJob fileListJob(_driveDbId, remoteTmpDir.id());
     exitCode = fileListJob.runSynchronously();
     CPPUNIT_ASSERT(exitCode == ExitCodeOk);
 
@@ -216,31 +210,29 @@ void TestNetworkJobs::testDelete() {
     CPPUNIT_ASSERT(resObj);
 
     bool newFileFound = false;
-    Poco::JSON::Array::Ptr dataArray = resObj->getArray(dataKey);
-    for (Poco::JSON::Array::ConstIterator it = dataArray->begin(); it != dataArray->end(); ++it) {
-        Poco::JSON::Object::Ptr dirObj = it->extract<Poco::JSON::Object::Ptr>();
-        SyncName currentName = dirObj->get(nameKey);
-        if (_dummyFileName == currentName) {
+
+    for (const auto dataArray = resObj->getArray(dataKey); const auto &item : *dataArray) {
+        const auto &dirObj = item.extract<Poco::JSON::Object::Ptr>();
+        if (_dummyFileName == dirObj->get(nameKey)) {
             newFileFound = true;
             break;
         }
     }
     CPPUNIT_ASSERT(!newFileFound);
 
-    _deleteDummyFile = false;
-
-    CPPUNIT_ASSERT(createTestDir());
+    const RemoteTemporaryDirectory remoteTmpDir(_driveDbId, _remoteDirId, "testDelete");
+    const LocalTemporaryDirectory localTmpDir("testDelete");
 
     // Delete directory - Empty local id & path provided => canRun == false
-    DeleteJob jobEmptyLocalDirId(_driveDbId, _dummyRemoteDirId, "", "");
+    DeleteJob jobEmptyLocalDirId(_driveDbId, remoteTmpDir.id(), "", "");
     CPPUNIT_ASSERT(!jobEmptyLocalDirId.canRun());
 
     // Delete directory - A local dir exists with the same path & id => canRun == false
-    DeleteJob jobLocalDirExists(_driveDbId, _dummyRemoteDirId, _dummyLocalDirId, _dummyLocalDirPath);
+    DeleteJob jobLocalDirExists(_driveDbId, remoteTmpDir.id(), localTmpDir.id(), localTmpDir.path());
     CPPUNIT_ASSERT(!jobLocalDirExists.canRun());
 
     // Delete directory - A local dir exists with the same path but not the same id => canRun == true
-    DeleteJob jobLocalDirSynonymExists(_driveDbId, _dummyRemoteDirId, "1234", _dummyLocalDirPath);
+    DeleteJob jobLocalDirSynonymExists(_driveDbId, remoteTmpDir.id(), "1234", localTmpDir.path());
     CPPUNIT_ASSERT(jobLocalDirSynonymExists.canRun());
     exitCode = jobLocalDirSynonymExists.runSynchronously();
     CPPUNIT_ASSERT(exitCode == ExitCodeOk);
@@ -254,23 +246,21 @@ void TestNetworkJobs::testDelete() {
     CPPUNIT_ASSERT(resObj);
 
     bool newDirFound = false;
-    dataArray = resObj->getArray(dataKey);
+    const auto dataArray = resObj->getArray(dataKey);
     for (Poco::JSON::Array::ConstIterator it = dataArray->begin(); it != dataArray->end(); ++it) {
         Poco::JSON::Object::Ptr dirObj = it->extract<Poco::JSON::Object::Ptr>();
         SyncName currentName = dirObj->get(nameKey);
-        if (_dummyDirName == currentName) {
+        if (remoteTmpDir.name() == currentName) {
             newDirFound = true;
             break;
         }
     }
     CPPUNIT_ASSERT(!newDirFound);
-
-    _deleteDummyDir = false;
 }
 
 void TestNetworkJobs::testDownload() {
     const LocalTemporaryDirectory temporaryDirectory("testDownload");
-    SyncPath localDestFilePath = temporaryDirectory.path / "test_file.txt";
+    SyncPath localDestFilePath = temporaryDirectory.path() / "test_file.txt";
     DownloadJob job(_driveDbId, testFileRemoteId, localDestFilePath, 0, 0, 0, false);
     ExitCode exitCode = job.runSynchronously();
     CPPUNIT_ASSERT(exitCode == ExitCodeOk);
@@ -285,7 +275,7 @@ void TestNetworkJobs::testDownload() {
 
 void TestNetworkJobs::testDownloadAborted() {
     const LocalTemporaryDirectory temporaryDirectory("testDownloadAborted");
-    SyncPath localDestFilePath = temporaryDirectory.path / bigFileName;
+    SyncPath localDestFilePath = temporaryDirectory.path() / bigFileName;
     std::shared_ptr<DownloadJob> job =
         std::make_shared<DownloadJob>(_driveDbId, testBigFileRemoteId, localDestFilePath, 0, 0, 0, false);
     JobManager::instance()->queueAsyncJob(job);
@@ -563,7 +553,7 @@ void TestNetworkJobs::testThumbnail() {
 }
 
 void TestNetworkJobs::testDuplicateRenameMove() {
-    CPPUNIT_ASSERT(createTestDir());
+    const RemoteTemporaryDirectory remoteTmpDir(_driveDbId, _remoteDirId, "testDuplicateRenameMove");
 
     // Duplicate
     DuplicateJob dupJob(_driveDbId, testFileRemoteId, Str("test_duplicate.txt"));
@@ -581,12 +571,12 @@ void TestNetworkJobs::testDuplicateRenameMove() {
     CPPUNIT_ASSERT(!dupFileId.empty());
 
     // Move
-    MoveJob moveJob(_driveDbId, "", dupFileId, _dummyRemoteDirId);
+    MoveJob moveJob(_driveDbId, "", dupFileId, remoteTmpDir.id());
     moveJob.setBypassCheck(true);
     exitCode = moveJob.runSynchronously();
     CPPUNIT_ASSERT(exitCode == ExitCodeOk);
 
-    GetFileListJob fileListJob(_driveDbId, _dummyRemoteDirId);
+    GetFileListJob fileListJob(_driveDbId, remoteTmpDir.id());
     exitCode = fileListJob.runSynchronously();
     CPPUNIT_ASSERT(exitCode == ExitCodeOk);
 
@@ -599,7 +589,7 @@ void TestNetworkJobs::testDuplicateRenameMove() {
 
 void TestNetworkJobs::testRename() {
     // Rename
-    SyncName filename = Str("test_rename_") + Str2SyncName(CommonUtility::generateRandomStringAlphaNum()) + Str(".txt");
+    const SyncName filename = Str("test_rename_") + Str2SyncName(CommonUtility::generateRandomStringAlphaNum()) + Str(".txt");
     RenameJob renamejob(_driveDbId, testFileRemoteRenameId, filename);
     renamejob.runSynchronously();
 
@@ -617,11 +607,11 @@ void TestNetworkJobs::testRename() {
 }
 
 void TestNetworkJobs::testUpload() {
-    CPPUNIT_ASSERT(createTestDir());
+    const RemoteTemporaryDirectory remoteTmpDir(_driveDbId, _remoteDirId, "testUpload");
 
     SyncPath localFilePath = localTestDirPath / bigFileDirName / bigFileName;
 
-    UploadJob job(_driveDbId, localFilePath, localFilePath.filename().native(), _dummyRemoteDirId, 0);
+    UploadJob job(_driveDbId, localFilePath, localFilePath.filename().native(), remoteTmpDir.id(), 0);
     ExitCode exitCode = job.runSynchronously();
     CPPUNIT_ASSERT(exitCode == ExitCodeOk);
 
@@ -640,12 +630,12 @@ void TestNetworkJobs::testUpload() {
 }
 
 void TestNetworkJobs::testUploadAborted() {
-    CPPUNIT_ASSERT(createTestDir());
+    const RemoteTemporaryDirectory remoteTmpDir(_driveDbId, _remoteDirId, "testUploadAborted");
 
     SyncPath localFilePath = localTestDirPath / bigFileDirName / bigFileName;
 
-    std::shared_ptr<UploadJob> job =
-        std::make_shared<UploadJob>(_driveDbId, localFilePath, localFilePath.filename().native(), _dummyRemoteDirId, 0);
+    const std::shared_ptr<UploadJob> job =
+        std::make_shared<UploadJob>(_driveDbId, localFilePath, localFilePath.filename().native(), remoteTmpDir.id(), 0);
     JobManager::instance()->queueAsyncJob(job);
 
     Utility::msleep(1000);  // Wait 1sec
@@ -659,32 +649,30 @@ void TestNetworkJobs::testUploadAborted() {
 }
 
 void TestNetworkJobs::testUploadSessionConstructorException() {
-    LOGW_DEBUG(Log::instance()->getLogger(), L"$$$$$ testUploadSessionConstructor");
-
-    CPPUNIT_ASSERT(createTestDir());
+    const RemoteTemporaryDirectory remoteTmpDir(_driveDbId, _remoteDirId, "testUploadSessionConstructorException");
 
     SyncPath localFilePath =
         localTestDirPath;  // The constructor of UploadSession will attempt to retrieve the file size of directory.
 
     CPPUNIT_ASSERT_THROW_MESSAGE(
         "UploadSession() didn't throw as expected",
-        UploadSession(_driveDbId, nullptr, localFilePath, localFilePath.filename().native(), _dummyRemoteDirId, 12345, false, 1),
+        UploadSession(_driveDbId, nullptr, localFilePath, localFilePath.filename().native(), remoteTmpDir.id(), 12345, false, 1),
         std::runtime_error);
 }
 
 void TestNetworkJobs::testUploadSessionSynchronous() {
     LOGW_DEBUG(Log::instance()->getLogger(), L"$$$$$ testUploadSessionSynchronous");
 
-    CPPUNIT_ASSERT(createTestDir());
+    const RemoteTemporaryDirectory remoteTmpDir(_driveDbId, _remoteDirId, "testUploadSessionSynchronous");
 
     SyncPath localFilePath = localTestDirPath / bigFileDirName / bigFileName;
 
-    UploadSession uploadSessionJob(_driveDbId, nullptr, localFilePath, localFilePath.filename().native(), _dummyRemoteDirId,
+    UploadSession uploadSessionJob(_driveDbId, nullptr, localFilePath, localFilePath.filename().native(), remoteTmpDir.id(),
                                    12345, false, 1);
     ExitCode exitCode = uploadSessionJob.runSynchronously();
     CPPUNIT_ASSERT(exitCode == ExitCodeOk);
 
-    GetFileListJob fileListJob(_driveDbId, _dummyRemoteDirId);
+    GetFileListJob fileListJob(_driveDbId, remoteTmpDir.id());
     exitCode = fileListJob.runSynchronously();
     CPPUNIT_ASSERT(exitCode == ExitCodeOk);
 
@@ -698,15 +686,15 @@ void TestNetworkJobs::testUploadSessionSynchronous() {
 void TestNetworkJobs::testUploadSessionAsynchronous() {
     LOGW_DEBUG(Log::instance()->getLogger(), L"$$$$$ testUploadSessionAsynchronous");
 
-    CPPUNIT_ASSERT(createTestDir());
+    const RemoteTemporaryDirectory remoteTmpDir(_driveDbId, _remoteDirId, "testUploadSessionAsynchronous");
 
-    SyncPath localFilePath = localTestDirPath / bigFileDirName / bigFileName;
+    const SyncPath localFilePath = localTestDirPath / bigFileDirName / bigFileName;
 
     ExitCode exitCode = ExitCodeUnknown;
     NodeId nodeId;
     while (_nbParalleleThreads > 0) {
         LOGW_DEBUG(Log::instance()->getLogger(), L"$$$$$ testUploadSessionAsynchronous - " << _nbParalleleThreads << " threads");
-        UploadSession uploadSessionJob(_driveDbId, nullptr, localFilePath, localFilePath.filename().native(), _dummyRemoteDirId,
+        UploadSession uploadSessionJob(_driveDbId, nullptr, localFilePath, localFilePath.filename().native(), remoteTmpDir.id(),
                                        12345, false, _nbParalleleThreads);
         exitCode = uploadSessionJob.runSynchronously();
         if (exitCode == ExitCodeOk) {
@@ -727,7 +715,7 @@ void TestNetworkJobs::testUploadSessionAsynchronous() {
 
     CPPUNIT_ASSERT(exitCode == ExitCodeOk);
 
-    GetFileListJob fileListJob(_driveDbId, _dummyRemoteDirId);
+    GetFileListJob fileListJob(_driveDbId, remoteTmpDir.id());
     exitCode = fileListJob.runSynchronously();
     CPPUNIT_ASSERT(exitCode == ExitCodeOk);
 
@@ -741,14 +729,14 @@ void TestNetworkJobs::testUploadSessionAsynchronous() {
 void TestNetworkJobs::testUploadSessionSynchronousAborted() {
     LOGW_DEBUG(Log::instance()->getLogger(), L"$$$$$ testUploadSessionSynchronousAborted");
 
-    CPPUNIT_ASSERT(createTestDir());
+    const RemoteTemporaryDirectory remoteTmpDir(_driveDbId, _remoteDirId, "testUploadSessionSynchronousAborted");
 
     SyncPath localFilePath = localTestDirPath / bigFileDirName / bigFileName;
 
     LOGW_DEBUG(Log::instance()->getLogger(),
                L"$$$$$ testUploadSessionSynchronousAborted - " << _nbParalleleThreads << " threads");
     std::shared_ptr<UploadSession> uploadSessionJob = std::make_shared<UploadSession>(
-        _driveDbId, nullptr, localFilePath, localFilePath.filename().native(), _dummyRemoteDirId, 12345, false, 1);
+        _driveDbId, nullptr, localFilePath, localFilePath.filename().native(), remoteTmpDir.id(), 12345, false, 1);
     JobManager::instance()->queueAsyncJob(uploadSessionJob);
 
     Utility::msleep(1000);  // Wait 1sec
@@ -764,12 +752,12 @@ void TestNetworkJobs::testUploadSessionSynchronousAborted() {
 void TestNetworkJobs::testUploadSessionAsynchronousAborted() {
     LOGW_DEBUG(Log::instance()->getLogger(), L"$$$$$ testUploadSessionAsynchronousAborted");
 
-    CPPUNIT_ASSERT(createTestDir());
+    const RemoteTemporaryDirectory remoteTmpDir(_driveDbId, _remoteDirId, "testUploadSessionAsynchronousAborted");
 
     SyncPath localFilePath = localTestDirPath / bigFileDirName / bigFileName;
 
     std::shared_ptr<UploadSession> uploadSessionJob =
-        std::make_shared<UploadSession>(_driveDbId, nullptr, localFilePath, localFilePath.filename().native(), _dummyRemoteDirId,
+        std::make_shared<UploadSession>(_driveDbId, nullptr, localFilePath, localFilePath.filename().native(), remoteTmpDir.id(),
                                         12345, false, _nbParalleleThreads);
     JobManager::instance()->queueAsyncJob(uploadSessionJob);
 
@@ -781,7 +769,7 @@ void TestNetworkJobs::testUploadSessionAsynchronousAborted() {
     Utility::msleep(1000);  // Wait 1sec
 
     LOGW_DEBUG(Log::instance()->getLogger(), L"$$$$$ testUploadSessionAsynchronousAborted - Check jobs");
-    GetFileListJob fileListJob(_driveDbId, _dummyRemoteDirId);
+    GetFileListJob fileListJob(_driveDbId, remoteTmpDir.id());
     ExitCode exitCode = fileListJob.runSynchronously();
     CPPUNIT_ASSERT(exitCode == ExitCodeOk);
 
@@ -790,41 +778,6 @@ void TestNetworkJobs::testUploadSessionAsynchronousAborted() {
     Poco::JSON::Array::Ptr dataArray = resObj->getArray(dataKey);
     CPPUNIT_ASSERT(dataArray);
     CPPUNIT_ASSERT(dataArray->empty());
-}
-
-bool TestNetworkJobs::createTestDir() {
-    _dummyDirName = Str("test_dir_") + Str2SyncName(CommonUtility::generateRandomStringAlphaNum(10));
-
-    // Create local test dir
-    _dummyLocalDirPath = localTestDirPath / _dummyDirName;
-    CPPUNIT_ASSERT(std::filesystem::create_directory(_dummyLocalDirPath));
-
-    // Extract local dir ID
-    FileStat fileStat;
-    IoError ioError = IoErrorSuccess;
-    IoHelper::getFileStat(_dummyLocalDirPath, &fileStat, ioError);
-    CPPUNIT_ASSERT(ioError == IoErrorSuccess);
-    _dummyLocalDirId = std::to_string(fileStat.inode);
-
-    // Create remote test dir
-    CreateDirJob job(_driveDbId, _dummyDirName, _remoteDirId, _dummyDirName);
-    ExitCode exitCode = job.runSynchronously();
-    CPPUNIT_ASSERT(exitCode == ExitCodeOk);
-
-    // Extract file ID
-    if (job.jsonRes()) {
-        Poco::JSON::Object::Ptr dataObj = job.jsonRes()->getObject(dataKey);
-        if (dataObj) {
-            _dummyRemoteDirId = dataObj->get(idKey).toString();
-        }
-    }
-
-    if (_dummyRemoteDirId.empty()) {
-        return false;
-    }
-
-    _deleteDummyDir = true;
-    return true;
 }
 
 bool TestNetworkJobs::createTestFiles() {
@@ -860,7 +813,6 @@ bool TestNetworkJobs::createTestFiles() {
         return false;
     }
 
-    _deleteDummyFile = true;
     return true;
 }
 

--- a/test/libsyncengine/jobs/network/testnetworkjobs.h
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.h
@@ -93,24 +93,17 @@ class TestNetworkJobs : public CppUnit::TestFixture {
         void testUploadSessionAsynchronousAborted();
 
     private:
-        bool createTestDir();
+        // bool createTestDir();
         bool createTestFiles();
 
         int _driveDbId = 0;
         int _userDbId = 0;
         NodeId _remoteDirId;
 
-        SyncName _dummyDirName;
-        SyncPath _dummyLocalDirPath;
-        NodeId _dummyLocalDirId;
-        NodeId _dummyRemoteDirId;
-        bool _deleteDummyDir = false;
-
         SyncName _dummyFileName;
         SyncPath _dummyLocalFilePath;
         NodeId _dummyLocalFileId;
         NodeId _dummyRemoteFileId;
-        bool _deleteDummyFile = false;
 
         static int _nbParalleleThreads;
 };

--- a/test/libsyncengine/jobs/testjobmanager.cpp
+++ b/test/libsyncengine/jobs/testjobmanager.cpp
@@ -196,12 +196,12 @@ void TestJobManager::testWithCallback() {
 
 void TestJobManager::testWithCallbackMediumFiles() {
     const LocalTemporaryDirectory temporaryDirectory("testJobManager");
-    testWithCallbackBigFiles(temporaryDirectory.path, 50, 15);  // 15 files of 50 MB
+    testWithCallbackBigFiles(temporaryDirectory.path(), 50, 15);  // 15 files of 50 MB
 }
 
 void TestJobManager::testWithCallbackBigFiles() {
     const LocalTemporaryDirectory temporaryDirectory("testJobManager");
-    testWithCallbackBigFiles(temporaryDirectory.path, 200, 10);  // 10 files of 200 MB
+    testWithCallbackBigFiles(temporaryDirectory.path(), 200, 10);  // 10 files of 200 MB
 }
 
 void TestJobManager::testCancelJobs() {

--- a/test/libsyncengine/test.cpp
+++ b/test/libsyncengine/test.cpp
@@ -39,27 +39,27 @@
 #include "requests/testexclusiontemplatecache.h"
 
 namespace KDC {
-CPPUNIT_TEST_SUITE_REGISTRATION(TestExclusionTemplateCache);
-CPPUNIT_TEST_SUITE_REGISTRATION(TestLocalJobs);
+// CPPUNIT_TEST_SUITE_REGISTRATION(TestExclusionTemplateCache);
+// CPPUNIT_TEST_SUITE_REGISTRATION(TestLocalJobs);
 CPPUNIT_TEST_SUITE_REGISTRATION(TestNetworkJobs);
-CPPUNIT_TEST_SUITE_REGISTRATION(TestSnapshotItemHandler);
-CPPUNIT_TEST_SUITE_REGISTRATION(TestJobManager);
-//  CPPUNIT_TEST_SUITE_REGISTRATION(TestSyncDb);
-// CPPUNIT_TEST_SUITE_REGISTRATION(TestSnapshot);
-// CPPUNIT_TEST_SUITE_REGISTRATION(TestLocalFileSystemObserverWorker);
-CPPUNIT_TEST_SUITE_REGISTRATION(TestRemoteFileSystemObserverWorker);
-// CPPUNIT_TEST_SUITE_REGISTRATION(TestComputeFSOperationWorker);
-CPPUNIT_TEST_SUITE_REGISTRATION(TestUpdateTree);
-CPPUNIT_TEST_SUITE_REGISTRATION(TestUpdateTreeWorker);
-CPPUNIT_TEST_SUITE_REGISTRATION(TestPlatformInconsistencyCheckerWorker);
-//  CPPUNIT_TEST_SUITE_REGISTRATION(TestConflictFinderWorker);
-CPPUNIT_TEST_SUITE_REGISTRATION(TestConflictResolverWorker);
-//  CPPUNIT_TEST_SUITE_REGISTRATION(TestOperationGeneratorWorker);
-//  CPPUNIT_TEST_SUITE_REGISTRATION(TestOperationSorterWorker);
-
-// CPPUNIT_TEST_SUITE_REGISTRATION(TestOldSyncDb); // Needs a pre 3.3.4 DB
-// CPPUNIT_TEST_SUITE_REGISTRATION(TestSyncPal);
-// CPPUNIT_TEST_SUITE_REGISTRATION(TestIntegration);
+// CPPUNIT_TEST_SUITE_REGISTRATION(TestSnapshotItemHandler);
+// CPPUNIT_TEST_SUITE_REGISTRATION(TestJobManager);
+// //  CPPUNIT_TEST_SUITE_REGISTRATION(TestSyncDb);
+// // CPPUNIT_TEST_SUITE_REGISTRATION(TestSnapshot);
+// // CPPUNIT_TEST_SUITE_REGISTRATION(TestLocalFileSystemObserverWorker);
+// CPPUNIT_TEST_SUITE_REGISTRATION(TestRemoteFileSystemObserverWorker);
+// // CPPUNIT_TEST_SUITE_REGISTRATION(TestComputeFSOperationWorker);
+// CPPUNIT_TEST_SUITE_REGISTRATION(TestUpdateTree);
+// CPPUNIT_TEST_SUITE_REGISTRATION(TestUpdateTreeWorker);
+// CPPUNIT_TEST_SUITE_REGISTRATION(TestPlatformInconsistencyCheckerWorker);
+// //  CPPUNIT_TEST_SUITE_REGISTRATION(TestConflictFinderWorker);
+// CPPUNIT_TEST_SUITE_REGISTRATION(TestConflictResolverWorker);
+// //  CPPUNIT_TEST_SUITE_REGISTRATION(TestOperationGeneratorWorker);
+// //  CPPUNIT_TEST_SUITE_REGISTRATION(TestOperationSorterWorker);
+//
+// // CPPUNIT_TEST_SUITE_REGISTRATION(TestOldSyncDb); // Needs a pre 3.3.4 DB
+// // CPPUNIT_TEST_SUITE_REGISTRATION(TestSyncPal);
+// // CPPUNIT_TEST_SUITE_REGISTRATION(TestIntegration);
 }  // namespace KDC
 
 int main(int, char **) {

--- a/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.cpp
+++ b/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.cpp
@@ -36,6 +36,8 @@
 #include <Poco/Path.h>
 #include <Poco/File.h>
 
+#include <memory>
+
 using namespace CppUnit;
 
 namespace KDC {
@@ -49,7 +51,7 @@ void TestLocalFileSystemObserverWorker::setUp() {
 
     LOGW_DEBUG(_logger, L"$$$$$ Set Up $$$$$");
 
-    _testRootFolderPath = _tempDir.path / "sync_folder";
+    _testRootFolderPath = _tempDir.path() / "sync_folder";
 
     Poco::File((_testRootFolderPath / "A" / "AA").string()).createDirectories();
     Poco::File((_testRootFolderPath / "A" / "AB").string()).createDirectories();
@@ -76,7 +78,7 @@ void TestLocalFileSystemObserverWorker::setUp() {
     // Create SyncPal
     SyncPath syncDbPath = Db::makeDbName(1, 1, 1, 1, alreadyExists);
     std::filesystem::remove(syncDbPath);
-    _syncPal = std::shared_ptr<SyncPal>(new SyncPal(syncDbPath, "3.4.0", true));
+    _syncPal = std::make_shared<SyncPal>(syncDbPath, "3.4.0", true);
     _syncPal->_syncDb->setAutoDelete(true);
 
     _syncPal->_localPath = _testRootFolderPath;

--- a/test/libsyncengine/update_detection/file_system_observer/testremotefilesystemobserverworker.cpp
+++ b/test/libsyncengine/update_detection/file_system_observer/testremotefilesystemobserverworker.cpp
@@ -129,7 +129,7 @@ void TestRemoteFileSystemObserverWorker::testUpdateSnapshot() {
     // Create test file locally
     const LocalTemporaryDirectory temporaryDirectory("testRFSO");
     const SyncName testFileName = Str("test_file_") + Str2SyncName(CommonUtility::generateRandomStringAlphaNum()) + Str(".txt");
-    SyncPath testFilePath = temporaryDirectory.path / testFileName;
+    SyncPath testFilePath = temporaryDirectory.path() / testFileName;
     std::string testCallStr = R"(echo "File creation" > )" + testFilePath.make_preferred().string();
     std::system(testCallStr.c_str());
 

--- a/test/test_utility/localtemporarydirectory.h
+++ b/test/test_utility/localtemporarydirectory.h
@@ -16,15 +16,24 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "utility/types.h"
+
 #include <string>
 #include <filesystem>
 
 namespace KDC {
 
-struct LocalTemporaryDirectory {
-        std::filesystem::path path;
-        LocalTemporaryDirectory(const std::string& testType = "undef");
+class LocalTemporaryDirectory {
+    public:
+        explicit LocalTemporaryDirectory(const std::string& testType = "undef");
         ~LocalTemporaryDirectory();
+
+        [[nodiscard]] const std::filesystem::path& path() const { return _path; }
+        [[nodiscard]] const NodeId& id() const { return _id; }
+
+    private:
+        std::filesystem::path _path;
+        NodeId _id;
 };
 
 }  // namespace KDC

--- a/test/test_utility/remotetemporarydirectory.cpp
+++ b/test/test_utility/remotetemporarydirectory.cpp
@@ -1,0 +1,54 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2024 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "remotetemporarydirectory.h"
+
+#include "libsyncengine/jobs/network/createdirjob.h"
+#include "libsyncengine/jobs/network/deletejob.h"
+#include "libsyncengine/jobs/network/networkjobsparams.h"
+
+namespace KDC {
+RemoteTemporaryDirectory::RemoteTemporaryDirectory(int driveDbId, const NodeId& parentId,
+                                                   const std::string& testType /*= "undef"*/)
+    : _driveDbId(driveDbId) {
+    // Generate directory name
+    const std::time_t now = std::time(nullptr);
+    const std::tm tm = *std::localtime(&now);
+    std::ostringstream woss;
+    woss << std::put_time(&tm, "%Y%m%d_%H%M");
+
+    _dirName = "kdrive_" + testType + "_unit_tests_" + woss.str();
+
+    // Create remote test dir
+    CreateDirJob job(_driveDbId, parentId, _dirName);
+    job.runSynchronously();
+
+    // Extract file ID
+    if (job.jsonRes()) {
+        Poco::JSON::Object::Ptr dataObj = job.jsonRes()->getObject(dataKey);
+        if (dataObj) {
+            _dirId = dataObj->get(idKey).toString();
+        }
+    }
+}
+RemoteTemporaryDirectory::~RemoteTemporaryDirectory() {
+    DeleteJob job(_driveDbId, _dirId, "", "");
+    job.setBypassCheck(true);
+    job.runSynchronously();
+}
+}  // namespace KDC

--- a/test/test_utility/remotetemporarydirectory.h
+++ b/test/test_utility/remotetemporarydirectory.h
@@ -15,33 +15,26 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include "localtemporarydirectory.h"
 
-#include "io/filestat.h"
-#include "io/iohelper.h"
+#pragma once
 
-#include <sstream>
+#include "utility/types.h"
 
 namespace KDC {
 
-LocalTemporaryDirectory::LocalTemporaryDirectory(const std::string &testType) {
-    const std::time_t now = std::time(nullptr);
-    const std::tm tm = *std::localtime(&now);
-    std::ostringstream woss;
-    woss << std::put_time(&tm, "%Y%m%d_%H%M");
+class RemoteTemporaryDirectory {
+    public:
+        RemoteTemporaryDirectory(int driveDbId, const NodeId& parentId, const std::string& testType = "undef");
+        ~RemoteTemporaryDirectory();
 
-    _path = std::filesystem::temp_directory_path() / ("kdrive_" + testType + "_unit_tests_" + woss.str());
-    std::filesystem::create_directory(_path);
+        [[nodiscard]] const NodeId& id() const { return _dirId; }
+        [[nodiscard]] const SyncName& name() const { return _dirName; }
 
-    FileStat fileStat;
-    IoError ioError = IoErrorSuccess;
-    IoHelper::getFileStat(_path, &fileStat, ioError);
-    _id = std::to_string(fileStat.inode);
-}
+    private:
+        int _driveDbId{0};
 
-LocalTemporaryDirectory::~LocalTemporaryDirectory() {
-    std::filesystem::remove_all(_path);
-}
-
+        NodeId _dirId;
+        SyncName _dirName;
+};
 
 }  // namespace KDC


### PR DESCRIPTION
Some files and empty folders were remaining on local side after running network jobs