### PR TITLE
Fix false positive sentry (require for 3.6.3)

### DIFF
--- a/src/gui/synthesispopover.cpp
+++ b/src/gui/synthesispopover.cpp
@@ -1064,7 +1064,7 @@ void SynthesisPopover::onUpdateSynchronizedListWidget() {
 
 void SynthesisPopover::onUpdateAvailabalityChange() {
     if (!_lockedAppUpdateButton || !_lockedAppUpdateOptionalLabel) return;
-
+    if(_lockedAppVersionWidget->isHidden()) return;
     QString statusString;
     UpdateState updateState = UpdateState::Error;
     try {


### PR DESCRIPTION
We receive a sentry when we do not find an update even if the app is not locked.