### PR TITLE
Fix infinit loop sync.

### DIFF
--- a/src/libsyncengine/syncpal/syncpal.cpp
+++ b/src/libsyncengine/syncpal/syncpal.cpp
@@ -1403,6 +1403,8 @@ void SyncPal::removeItemFromTmpBlacklist(const NodeId &nodeId, ReplicaSide side)
 void SyncPal::copySnapshots() {
     *_localSnapshotCopy = *_localSnapshot;
     *_remoteSnapshotCopy = *_remoteSnapshot;
+    _localSnapshot->startRead();
+    _remoteSnapshot->startRead();
 }
 
 }  // namespace KDC

--- a/src/libsyncengine/syncpal/syncpalworker.cpp
+++ b/src/libsyncengine/syncpal/syncpalworker.cpp
@@ -391,7 +391,8 @@ SyncStep SyncPalWorker::nextStep() const {
         case SyncStepIdle:
             return (_syncPal->isSnapshotValid(ReplicaSideLocal) && _syncPal->isSnapshotValid(ReplicaSideRemote) &&
                     !_syncPal->_localFSObserverWorker->updating() && !_syncPal->_remoteFSObserverWorker->updating() &&
-                    (_syncPal->_localSnapshot->updated() || _syncPal->_remoteSnapshot->updated() || _syncPal->_restart))
+                    (_syncPal->snapshot(ReplicaSideLocal)->updated() || _syncPal->snapshot(ReplicaSideRemote)->updated() ||
+                     _syncPal->_restart))
                        ? SyncStepUpdateDetection1
                        : SyncStepIdle;
             break;


### PR DESCRIPTION
This issue addresses a bug implemented by the use of a copy of the snapshot. The copy operation is not calling the liveSnapshot 'startRead' method, causing it to keep its 'updated' member as true.