### PR TITLE
Fix log uploader on small logs.

### DIFF
--- a/src/gui/debuggingdialog.cpp
+++ b/src/gui/debuggingdialog.cpp
@@ -652,6 +652,7 @@ void DebuggingDialog::onExit() {
 
 void DebuggingDialog::onSendLogButtonTriggered() {
     _sendLogButton->setEnabled(false);
+    _sendArchivedLogs |= _heavyLogBox->isHidden();
     GuiRequests::sendLogToSupport(_sendArchivedLogs);
 }
 

--- a/src/gui/debuggingdialog.cpp
+++ b/src/gui/debuggingdialog.cpp
@@ -652,8 +652,7 @@ void DebuggingDialog::onExit() {
 
 void DebuggingDialog::onSendLogButtonTriggered() {
     _sendLogButton->setEnabled(false);
-    _sendArchivedLogs |= _heavyLogBox->isHidden();
-    GuiRequests::sendLogToSupport(_sendArchivedLogs);
+    GuiRequests::sendLogToSupport(_sendArchivedLogs || _heavyLogBox->isHidden());
 }
 
 void DebuggingDialog::onCancelLogUploadButtonTriggered() {

--- a/src/gui/debuggingdialog.cpp
+++ b/src/gui/debuggingdialog.cpp
@@ -599,7 +599,7 @@ QString DebuggingDialog::convertAppStateTimeToLocalHumanReadable(const QString &
     }
 
     //: Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second
-    return tr("%1/%2/%3 at %4h%5m and %6s").arg(timeParts[1], timeParts[0], timeParts[2], timeParts[3], timeParts[4], timeParts[5]);
+    return tr("%1/%2/%3 at %4h%5m and %6s").arg(timeParts[0], timeParts[1], timeParts[2], timeParts[3], timeParts[4], timeParts[5]);
 }
 
 void DebuggingDialog::onRecordDebuggingSwitchClicked(bool checked) {


### PR DESCRIPTION
The Log uploader don't send old logs when log folder is too small.