### PR TITLE
Fix vfs socket bug.

### DIFF
--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -721,7 +721,7 @@ bool ExecutorWorker::generateCreateJob(SyncOpPtr syncOp, std::shared_ptr<Abstrac
                     _executorExitCode = ExitCodeDataError;
                     _executorExitCause = ExitCauseUnknown;
                     return false;
-                };
+                }
             } else {
                 try {
                     job = std::make_shared<UploadJob>(

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -3011,7 +3011,7 @@ void AppServer::handleCrashRecovery(bool &shouldQuit) {
         }
         return;
     }
-    
+
     std::string timestampStr;
     if (_crashRecovered) {
         LOG_WARN(_logger, "Server auto restart after a crash.");
@@ -3582,7 +3582,8 @@ ExitCode AppServer::createAndStartVfs(const Sync &sync, ExitCause &exitCause) no
 #endif
         vfsSetupParams._localPath = sync.localPath();
         vfsSetupParams._targetPath = sync.targetPath();
-        vfsSetupParams._executeCommand = std::bind(&SocketApi::executeCommandDirect, _socketApi.data(), std::placeholders::_1);
+        connect(this, &AppServer::socketApiExecuteCommandDirect, _socketApi.data(), &SocketApi::executeCommandDirect);
+        vfsSetupParams._executeCommand = [this](const char *command) { emit socketApiExecuteCommandDirect(QString(command)); };
         vfsSetupParams._logger = _logger;
         QString error;
         _vfsMap[sync.dbId()] = KDC::createVfsFromPlugin(sync.virtualFileMode(), vfsSetupParams, error);

--- a/src/server/appserver.h
+++ b/src/server/appserver.h
@@ -132,7 +132,8 @@ class AppServer : public SharedTools::QtSingleApplication {
         void parseOptions(const QStringList &);
         void initLogging() noexcept(false);
         void setupProxy();
-        void handleCrashRecovery(bool &shouldQuit);  // Sets `shouldQuit` with true if the crash recovery is successful, false if the application should exit.
+        void handleCrashRecovery(bool &shouldQuit);  // Sets `shouldQuit` with true if the crash recovery is successful, false if
+                                                     // the application should exit.
         bool serverCrashedRecently(int seconds = 60 /*Allow one server self restart per minute (default)*/);
         bool clientCrashedRecently(int second = 60 /*Allow one client self restart per minute (default)*/);
 
@@ -248,6 +249,9 @@ class AppServer : public SharedTools::QtSingleApplication {
         void onRequestReceived(int id, RequestNum num, const QByteArray &params);
         void onRestartClientReceived();
         void onMessageReceivedFromAnotherProcess(const QString &message, QObject *);
+
+    signals:
+        void socketApiExecuteCommandDirect(const QString commandLine);
 };
 
 

--- a/src/server/socketapi.cpp
+++ b/src/server/socketapi.cpp
@@ -149,8 +149,7 @@ SocketApi::~SocketApi() {
     _listeners.clear();
 }
 
-void SocketApi::executeCommandDirect(const char *commandLine) {
-    QString commandLineStr(commandLine);
+void SocketApi::executeCommandDirect(const QString commandLineStr) {
     LOGW_DEBUG(KDC::Log::instance()->getLogger(), L"Execute command - cmd=" << commandLineStr.toStdWString().c_str());
 
     QByteArray command = commandLineStr.split(MSG_CDE_SEPARATOR).value(0).toLatin1();

--- a/src/server/socketapi.h
+++ b/src/server/socketapi.h
@@ -86,11 +86,12 @@ class SocketApi : public QObject {
             _getPublicLinkUrl = getPublicLinkUrl;
         }
 
-        void executeCommandDirect(const char *commandLine);
         void unregisterSync(int syncDbId);
         void registerSync(int syncDbId);
 
         static bool syncForPath(const std::filesystem::path &path, KDC::Sync &sync);
+    public slots:
+        void executeCommandDirect(const QString commandLine);
 
     private slots:
         void slotNewConnection();

--- a/src/server/socketlistener.cpp
+++ b/src/server/socketlistener.cpp
@@ -34,9 +34,15 @@ bool BloomFilter::isHashMaybeStored(uint hash) const {
     return hashBits.testBit((hash & 0xFFFF) % NumBits) && hashBits.testBit((hash >> 16) % NumBits);
 }
 
-SocketListener::SocketListener(QIODevice *socket) : socket(socket) {}
+SocketListener::SocketListener(QIODevice *socket) : socket(socket) {
+    _threadId = std::this_thread::get_id();
+}
 
 void SocketListener::sendMessage(const QString &message, bool doWait) const {
+    if (_threadId != std::this_thread::get_id()) {
+        LOGW_ERROR(KDC::Log::instance()->getLogger(), L"SocketListener::sendMessage should only be called from the main thread");
+    }
+
     if (!socket) {
         LOGW_INFO(KDC::Log::instance()->getLogger(), L"Not sending message to dead socket: " << message.toStdWString().c_str());
         return;

--- a/src/server/socketlistener.h
+++ b/src/server/socketlistener.h
@@ -21,6 +21,7 @@
 #include <QBitArray>
 #include <QIODevice>
 #include <QPointer>
+#include <thread>
 
 namespace KDC {
 
@@ -54,6 +55,7 @@ class SocketListener {
 
     private:
         BloomFilter _monitoredDirectoriesBloomFilter;
+        std::thread::id _threadId;
 };
 
 }  // namespace KDC

--- a/test/libsyncengine/jobs/testjobmanager.cpp
+++ b/test/libsyncengine/jobs/testjobmanager.cpp
@@ -126,7 +126,7 @@ void KDC::TestJobManager::tearDown() {
 
 void TestJobManager::testWithoutCallback() {
     // Upload all files in testDir
-    ulong counter = 0;
+    size_t counter = 0;
     for (auto &dirEntry : std::filesystem::directory_iterator(localTestDirPath_manyFiles)) {
         if (dirEntry.path().filename() == ".DS_Store") {
             continue;
@@ -147,7 +147,7 @@ void TestJobManager::testWithoutCallback() {
     CPPUNIT_ASSERT(resObj);
     Poco::JSON::Array::Ptr data = resObj->getArray(dataKey);
     size_t total = data->size();
-    CPPUNIT_ASSERT(counter == total);
+    CPPUNIT_ASSERT_EQUAL(counter, total);
 }
 
 void TestJobManager::testWithCallback() {


### PR DESCRIPTION
Summary: Fix issue with random crashes during app download step related to QLocalSocket internal buffer management.

Description: We have identified an issue where the application crashes randomly during the download step, initially thought to be related to large sync operations.

Upon investigation, the error occurs within the vfsForceStatus call, specifically when the socket->write method is invoked within SocketListener::sendMessage. The root cause appears to be inconsistencies in the QLocalSocket's internal buffer, which occasionally becomes empty or changes size unpredictably.

During downloads, the write method is called in a dedicated thread, while some QLocalSocket private callback rely on connect and are  handled by the event loop (in the main thread). This asynchronous handling can lead to a situation where one download callback interferes with another, corrupting the download buffer.

Solution: To mitigate this issue, we propose emitting a signal from the download thread instead of directly invoking the function. This approach ensures that all operations are processed sequentially by the application's event loop in the main thread, preventing interference between multiple download instances and other file explorer events.