### PR TITLE
Kdesktop 1033 file size mismatch detected for logic pro files

### DIFF
--- a/src/libcommon/utility/utility.cpp
+++ b/src/libcommon/utility/utility.cpp
@@ -641,7 +641,7 @@ QString CommonUtility::getRelativePathFromHome(const QString &dirPath) {
 }
 
 bool CommonUtility::isFileSizeMismatchDetectionEnabled() {
-    static bool enableFileSizeMismatchDetection = !envVarValue("KDRIVE_ENABLE_FILE_SIZE_MISMATCH_DETECTION").empty();
+    static const bool enableFileSizeMismatchDetection = !envVarValue("KDRIVE_ENABLE_FILE_SIZE_MISMATCH_DETECTION").empty();
     return enableFileSizeMismatchDetection;
 }
 

--- a/src/libcommon/utility/utility.cpp
+++ b/src/libcommon/utility/utility.cpp
@@ -640,6 +640,11 @@ QString CommonUtility::getRelativePathFromHome(const QString &dirPath) {
     return QDir::toNativeSeparators(name);
 }
 
+bool CommonUtility::isFileSizeMismatchDetectionEnabled() {
+    static bool _enableFileSizeMismatchDetection = envVarValue("KDRIVE_ENABLE_FILE_SIZE_MISMATCH_DETECTION").empty() ? false : true;
+    return _enableFileSizeMismatchDetection;
+}
+
 size_t CommonUtility::maxPathLength() {
 #if defined(_WIN32)
     static size_t _maxPathWin = 0;

--- a/src/libcommon/utility/utility.cpp
+++ b/src/libcommon/utility/utility.cpp
@@ -641,8 +641,8 @@ QString CommonUtility::getRelativePathFromHome(const QString &dirPath) {
 }
 
 bool CommonUtility::isFileSizeMismatchDetectionEnabled() {
-    static bool _enableFileSizeMismatchDetection = envVarValue("KDRIVE_ENABLE_FILE_SIZE_MISMATCH_DETECTION").empty() ? false : true;
-    return _enableFileSizeMismatchDetection;
+    static bool enableFileSizeMismatchDetection = !envVarValue("KDRIVE_ENABLE_FILE_SIZE_MISMATCH_DETECTION").empty();
+    return enableFileSizeMismatchDetection;
 }
 
 size_t CommonUtility::maxPathLength() {

--- a/src/libcommon/utility/utility.h
+++ b/src/libcommon/utility/utility.h
@@ -93,6 +93,7 @@ struct COMMON_EXPORT CommonUtility {
 
         static QString getRelativePathFromHome(const QString &dirPath);
 
+        static bool isFileSizeMismatchDetectionEnabled();
         static size_t maxPathLength();
 #if defined(_WIN32)
         static size_t maxPathLengthFolder();

--- a/src/libsyncengine/jobs/network/API_v2/csvfullfilelistwithcursorjob.cpp
+++ b/src/libsyncengine/jobs/network/API_v2/csvfullfilelistwithcursorjob.cpp
@@ -308,15 +308,15 @@ bool CsvFullFileListWithCursorJob::handleResponse(std::istream &is) {
         _ss << is.rdbuf();
     }
 
-    // Check that the stringstream ends by a LF (0x0A)
+    // Check that the stringstream is not empty (Can be caused by network issues)
     _ss.seekg(0, std::ios_base::end);
     int length = _ss.tellg();
     if (length == 0) {
-        // Folder is empty
-        LOG_DEBUG(_logger, "Reply " << jobId() << " received - length=" << length);
-        return true;
+        LOG_ERROR(_logger, "Reply " << jobId() << " received with empty content.");
+        return false;
     }
 
+    // Check that the stringstream ends by a LF (0x0A)
     _ss.seekg(length - 1, std::ios_base::beg);
     char lastChar = 0x00;
     _ss.read(&lastChar, 1);

--- a/src/libsyncengine/jobs/network/API_v2/csvfullfilelistwithcursorjob.cpp
+++ b/src/libsyncengine/jobs/network/API_v2/csvfullfilelistwithcursorjob.cpp
@@ -308,15 +308,15 @@ bool CsvFullFileListWithCursorJob::handleResponse(std::istream &is) {
         _ss << is.rdbuf();
     }
 
-    // Check that the stringstream is not empty (Can be caused by network issues)
+    // Check that the stringstream ends by a LF (0x0A)
     _ss.seekg(0, std::ios_base::end);
     int length = _ss.tellg();
     if (length == 0) {
-        LOG_ERROR(_logger, "Reply " << jobId() << " received with empty content.");
-        return false;
+        // Folder is empty
+        LOG_DEBUG(_logger, "Reply " << jobId() << " received - length=" << length);
+        return true;
     }
 
-    // Check that the stringstream ends by a LF (0x0A)
     _ss.seekg(length - 1, std::ios_base::beg);
     char lastChar = 0x00;
     _ss.read(&lastChar, 1);

--- a/src/libsyncengine/syncpal/syncpal.cpp
+++ b/src/libsyncengine/syncpal/syncpal.cpp
@@ -964,7 +964,7 @@ ExitCode SyncPal::updateSyncNode() {
     return ExitCode::Ok;
 }
 
-std::shared_ptr<Snapshot> SyncPal::snapshot(ReplicaSide side, bool copy) {
+std::shared_ptr<Snapshot> SyncPal::snapshot(ReplicaSide side, bool copy) const {
     if (side == ReplicaSide::Unknown) {
         LOG_ERROR(_logger, "Call to SyncPal::snapshot with 'ReplicaSide::Unknown').");
         return nullptr;
@@ -976,7 +976,7 @@ std::shared_ptr<Snapshot> SyncPal::snapshot(ReplicaSide side, bool copy) {
     }
 }
 
-std::shared_ptr<FSOperationSet> SyncPal::operationSet(ReplicaSide side) {
+std::shared_ptr<FSOperationSet> SyncPal::operationSet(ReplicaSide side) const {
     if (side == ReplicaSide::Unknown) {
         LOG_ERROR(_logger, "Call to SyncPal::operationSet with 'ReplicaSide::Unknown').");
         return nullptr;
@@ -984,7 +984,7 @@ std::shared_ptr<FSOperationSet> SyncPal::operationSet(ReplicaSide side) {
     return (side == ReplicaSide::Local ? _localOperationSet : _remoteOperationSet);
 }
 
-std::shared_ptr<UpdateTree> SyncPal::updateTree(ReplicaSide side) {
+std::shared_ptr<UpdateTree> SyncPal::updateTree(ReplicaSide side) const {
     if (side == ReplicaSide::Unknown) {
         LOG_ERROR(_logger, "Call to SyncPal::updateTree with 'ReplicaSide::Unknown').");
         return nullptr;

--- a/src/libsyncengine/syncpal/syncpal.h
+++ b/src/libsyncengine/syncpal/syncpal.h
@@ -221,6 +221,11 @@ class SYNCENGINE_EXPORT SyncPal : public std::enable_shared_from_this<SyncPal> {
         //! Makes copies of real-time snapshots to be used by synchronization workers.
         void copySnapshots();
 
+        std::shared_ptr<Snapshot> snapshot(ReplicaSide side, bool copy = false) const;
+        std::shared_ptr<FSOperationSet> operationSet(ReplicaSide side) const;
+        std::shared_ptr<UpdateTree> updateTree(ReplicaSide side) const;
+        inline std::shared_ptr<ComputeFSOperationWorker> computeFSOperationWorker() const { return _computeFSOperationsWorker; };
+
         SyncPath getLocalPath() const { return _localPath; };
         void setLocalPath(const SyncPath &path) { _localPath = path; };
 
@@ -321,9 +326,6 @@ class SYNCENGINE_EXPORT SyncPal : public std::enable_shared_from_this<SyncPal> {
         ExitCode listingCursor(std::string &value, int64_t &timestamp);
         ExitCode updateSyncNode(SyncNodeType syncNodeType);
         ExitCode updateSyncNode();
-        std::shared_ptr<Snapshot> snapshot(ReplicaSide side, bool copy = false);
-        std::shared_ptr<FSOperationSet> operationSet(ReplicaSide side);
-        std::shared_ptr<UpdateTree> updateTree(ReplicaSide side);
 
         // Progress info management
         void resetEstimateUpdates();

--- a/src/libsyncengine/syncpal/syncpalworker.cpp
+++ b/src/libsyncengine/syncpal/syncpalworker.cpp
@@ -27,6 +27,8 @@
 #include "propagation/operation_sorter/operationsorterworker.h"
 #include "propagation/executor/executorworker.h"
 #include "libcommonserver/utility/utility.h"
+#include "libcommon/utility/utility.h"
+
 
 #include <log4cplus/loggingmacros.h>
 
@@ -410,7 +412,8 @@ SyncStep SyncPalWorker::nextStep() const {
             logNbOps(ReplicaSide::Local);
             logNbOps(ReplicaSide::Remote);
 
-            if (!_syncPal->_computeFSOperationsWorker->getFileSizeMismatchMap().empty()) {
+            if (CommonUtility::isFileSizeMismatchDetectionEnabled() &&
+                !_syncPal->_computeFSOperationsWorker->getFileSizeMismatchMap().empty()) {
                 _syncPal->fixCorruptedFile(_syncPal->_computeFSOperationsWorker->getFileSizeMismatchMap());
                 _syncPal->_restart = true;
                 return SyncStep::Idle;

--- a/src/libsyncengine/syncpal/syncpalworker.cpp
+++ b/src/libsyncengine/syncpal/syncpalworker.cpp
@@ -283,7 +283,7 @@ void SyncPalWorker::initStep(SyncStep step, std::shared_ptr<ISyncWorker> (&worke
             _syncPal->refreshTmpBlacklist();
             break;
         case SyncStep::UpdateDetection1:
-            workers[0] = _syncPal->_computeFSOperationsWorker;
+            workers[0] = _syncPal->computeFSOperationWorker();
             workers[1] = nullptr;
             _syncPal->copySnapshots();
             inputSharedObject[0] = _syncPal->snapshot(ReplicaSide::Local, true);
@@ -413,8 +413,8 @@ SyncStep SyncPalWorker::nextStep() const {
             logNbOps(ReplicaSide::Remote);
 
             if (CommonUtility::isFileSizeMismatchDetectionEnabled() &&
-                !_syncPal->_computeFSOperationsWorker->getFileSizeMismatchMap().empty()) {
-                _syncPal->fixCorruptedFile(_syncPal->_computeFSOperationsWorker->getFileSizeMismatchMap());
+                !_syncPal->computeFSOperationWorker()->getFileSizeMismatchMap().empty()) {
+                _syncPal->fixCorruptedFile(_syncPal->computeFSOperationWorker()->getFileSizeMismatchMap());
                 _syncPal->_restart = true;
                 return SyncStep::Idle;
             }

--- a/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
@@ -598,7 +598,8 @@ ExitCode ComputeFSOperationWorker::checkFileIntegrity(const DbNode &dbNode) {
             _syncPal->snapshot(ReplicaSide::Remote, true)->lastModified(dbNode.nodeIdRemote().value());
 
         // A mismatch is detected if all timestamps are equal but the sizes in snapshots differ.
-        if (localSnapshotSize != remoteSnapshotSize && localSnapshotLastModified == dbNode.lastModifiedLocal().value() &&
+        if (CommonUtility::isFileSizeMismatchDetectionEnabled() && localSnapshotSize != remoteSnapshotSize &&
+            localSnapshotLastModified == dbNode.lastModifiedLocal().value() &&
             localSnapshotLastModified == remoteSnapshotLastModified) {
             SyncPath localSnapshotPath;
             if (!_syncPal->snapshot(ReplicaSide::Local, true)->path(dbNode.nodeIdLocal().value(), localSnapshotPath)) {

--- a/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
@@ -571,8 +571,15 @@ void ComputeFSOperationWorker::logOperationGeneration(const ReplicaSide side, co
 }
 
 ExitCode ComputeFSOperationWorker::checkFileIntegrity(const DbNode &dbNode) {
-    if (!CommonUtility::isFileSizeMismatchDetectionEnabled() || dbNode.type() != NodeType::File ||
-        !dbNode.nodeIdLocal().has_value() || !dbNode.nodeIdRemote().has_value() || !dbNode.lastModifiedLocal().has_value()) {
+    if (dbNode.type() != NodeType::File) {
+        return ExitCode::Ok;
+    }
+
+    if (!CommonUtility::isFileSizeMismatchDetectionEnabled()){
+        return ExitCode::Ok;
+    }
+
+    if (!dbNode.nodeIdLocal().has_value() || !dbNode.nodeIdRemote().has_value() || !dbNode.lastModifiedLocal().has_value()) {
         return ExitCode::Ok;
     }
 

--- a/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
@@ -571,60 +571,58 @@ void ComputeFSOperationWorker::logOperationGeneration(const ReplicaSide side, co
 }
 
 ExitCode ComputeFSOperationWorker::checkFileIntegrity(const DbNode &dbNode) {
-    if (CommonUtility::isFileSizeMismatchDetectionEnabled() && dbNode.type() == NodeType::File && dbNode.nodeIdLocal().has_value() &&
-        dbNode.nodeIdRemote().has_value() &&
-        dbNode.lastModifiedLocal().has_value()) {
-        
-        if (_fileSizeMismatchMap.contains(dbNode.nodeIdLocal().value())) {
-            // Size mismatch already detected
-            return ExitCode::Ok;
+    if (!CommonUtility::isFileSizeMismatchDetectionEnabled() || dbNode.type() != NodeType::File ||
+        !dbNode.nodeIdLocal().has_value() || !dbNode.nodeIdRemote().has_value() || !dbNode.lastModifiedLocal().has_value()) {
+        return ExitCode::Ok;
+    }
+
+    if (_fileSizeMismatchMap.contains(dbNode.nodeIdLocal().value())) {
+        // Size mismatch already detected
+        return ExitCode::Ok;
+    }
+
+    if (!_syncPal->snapshot(ReplicaSide::Local, true)->exists(dbNode.nodeIdLocal().value()) ||
+        !_syncPal->snapshot(ReplicaSide::Remote, true)->exists(dbNode.nodeIdRemote().value())) {
+        // Ignore if item does not exist
+        return ExitCode::Ok;
+    }
+
+    if (const bool localSnapshotIsLink = _syncPal->snapshot(ReplicaSide::Local, true)->isLink(dbNode.nodeIdLocal().value());
+        localSnapshotIsLink) {
+        // Local and remote links sizes are not always the same (macOS aliases, Windows junctions)
+        return ExitCode::Ok;
+    }
+
+    int64_t localSnapshotSize = _syncPal->snapshot(ReplicaSide::Local, true)->size(dbNode.nodeIdLocal().value());
+    int64_t remoteSnapshotSize = _syncPal->snapshot(ReplicaSide::Remote, true)->size(dbNode.nodeIdRemote().value());
+    SyncTime localSnapshotLastModified = _syncPal->snapshot(ReplicaSide::Local, true)->lastModified(dbNode.nodeIdLocal().value());
+    SyncTime remoteSnapshotLastModified =
+        _syncPal->snapshot(ReplicaSide::Remote, true)->lastModified(dbNode.nodeIdRemote().value());
+
+    // A mismatch is detected if all timestamps are equal but the sizes in snapshots differ.
+    if (localSnapshotSize != remoteSnapshotSize && localSnapshotLastModified == dbNode.lastModifiedLocal().value() &&
+        localSnapshotLastModified == remoteSnapshotLastModified) {
+        SyncPath localSnapshotPath;
+        if (!_syncPal->snapshot(ReplicaSide::Local, true)->path(dbNode.nodeIdLocal().value(), localSnapshotPath)) {
+            LOGW_SYNCPAL_WARN(_logger, L"Failed to retrieve path from snapshot for item "
+                                           << SyncName2WStr(dbNode.nameLocal()).c_str() << L" ("
+                                           << Utility::s2ws(dbNode.nodeIdLocal().value()).c_str() << L")");
+            setExitCause(ExitCause::InvalidSnapshot);
+            return ExitCode::DataError;
         }
 
-        if (!_syncPal->snapshot(ReplicaSide::Local, true)->exists(dbNode.nodeIdLocal().value()) ||
-            !_syncPal->snapshot(ReplicaSide::Remote, true)->exists(dbNode.nodeIdRemote().value())) {
-            // Ignore if item does not exist
-            return ExitCode::Ok;
-        }
+        // OS might fail to notify all delete events, therefor we check that the file still exists
+        SyncPath absoluteLocalPath = _syncPal->_localPath / localSnapshotPath;
 
-        if (const bool localSnapshotIsLink = _syncPal->snapshot(ReplicaSide::Local, true)->isLink(dbNode.nodeIdLocal().value());
-            localSnapshotIsLink) {
-            // Local and remote links sizes are not always the same (macOS aliases, Windows junctions)
-            return ExitCode::Ok;
-        }
-
-        int64_t localSnapshotSize = _syncPal->snapshot(ReplicaSide::Local, true)->size(dbNode.nodeIdLocal().value());
-        int64_t remoteSnapshotSize = _syncPal->snapshot(ReplicaSide::Remote, true)->size(dbNode.nodeIdRemote().value());
-        SyncTime localSnapshotLastModified =
-            _syncPal->snapshot(ReplicaSide::Local, true)->lastModified(dbNode.nodeIdLocal().value());
-        SyncTime remoteSnapshotLastModified =
-            _syncPal->snapshot(ReplicaSide::Remote, true)->lastModified(dbNode.nodeIdRemote().value());
-
-        // A mismatch is detected if all timestamps are equal but the sizes in snapshots differ.
-        if (localSnapshotSize != remoteSnapshotSize &&
-            localSnapshotLastModified == dbNode.lastModifiedLocal().value() &&
-            localSnapshotLastModified == remoteSnapshotLastModified) {
-            SyncPath localSnapshotPath;
-            if (!_syncPal->snapshot(ReplicaSide::Local, true)->path(dbNode.nodeIdLocal().value(), localSnapshotPath)) {
-                LOGW_SYNCPAL_WARN(_logger, L"Failed to retrieve path from snapshot for item "
-                                               << SyncName2WStr(dbNode.nameLocal()).c_str() << L" ("
-                                               << Utility::s2ws(dbNode.nodeIdLocal().value()).c_str() << L")");
-                setExitCause(ExitCause::InvalidSnapshot);
-                return ExitCode::DataError;
-            }
-
-            // OS might fail to notify all delete events, therefor we check that the file still exists
-            SyncPath absoluteLocalPath = _syncPal->_localPath / localSnapshotPath;
-
-            // No operations detected on this file but its size is not the same between remote and local replica
-            // Remove it from local replica and download the remote version
-            LOGW_SYNCPAL_DEBUG(_logger, L"File size mismatch for \"" << Path2WStr(absoluteLocalPath).c_str()
-                                                                     << L"\". Remote version will be downloaded again.");
-            _fileSizeMismatchMap.insert({dbNode.nodeIdLocal().value(), absoluteLocalPath});
+        // No operations detected on this file but its size is not the same between remote and local replica
+        // Remove it from local replica and download the remote version
+        LOGW_SYNCPAL_DEBUG(_logger, L"File size mismatch for \"" << Path2WStr(absoluteLocalPath).c_str()
+                                                                 << L"\". Remote version will be downloaded again.");
+        _fileSizeMismatchMap.insert({dbNode.nodeIdLocal().value(), absoluteLocalPath});
 #ifdef NDEBUG
-            sentry_capture_event(sentry_value_new_message_event(SENTRY_LEVEL_WARNING, "ComputeFSOperationWorker::exploreDbTree",
-                                                                "File size mismatch detected"));
+        sentry_capture_event(sentry_value_new_message_event(SENTRY_LEVEL_WARNING, "ComputeFSOperationWorker::exploreDbTree",
+                                                            "File size mismatch detected"));
 #endif
-        }
     }
 
     return ExitCode::Ok;

--- a/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
@@ -571,7 +571,8 @@ void ComputeFSOperationWorker::logOperationGeneration(const ReplicaSide side, co
 }
 
 ExitCode ComputeFSOperationWorker::checkFileIntegrity(const DbNode &dbNode) {
-    if (dbNode.type() == NodeType::File && dbNode.nodeIdLocal().has_value() && dbNode.nodeIdRemote().has_value() &&
+    if (CommonUtility::isFileSizeMismatchDetectionEnabled() && dbNode.type() == NodeType::File && dbNode.nodeIdLocal().has_value() &&
+        dbNode.nodeIdRemote().has_value() &&
         dbNode.lastModifiedLocal().has_value()) {
         if (_fileSizeMismatchMap.find(dbNode.nodeIdLocal().value()) != _fileSizeMismatchMap.end()) {
             // Size mismatch already detected
@@ -598,7 +599,7 @@ ExitCode ComputeFSOperationWorker::checkFileIntegrity(const DbNode &dbNode) {
             _syncPal->snapshot(ReplicaSide::Remote, true)->lastModified(dbNode.nodeIdRemote().value());
 
         // A mismatch is detected if all timestamps are equal but the sizes in snapshots differ.
-        if (CommonUtility::isFileSizeMismatchDetectionEnabled() && localSnapshotSize != remoteSnapshotSize &&
+        if (localSnapshotSize != remoteSnapshotSize &&
             localSnapshotLastModified == dbNode.lastModifiedLocal().value() &&
             localSnapshotLastModified == remoteSnapshotLastModified) {
             SyncPath localSnapshotPath;

--- a/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
@@ -574,7 +574,8 @@ ExitCode ComputeFSOperationWorker::checkFileIntegrity(const DbNode &dbNode) {
     if (CommonUtility::isFileSizeMismatchDetectionEnabled() && dbNode.type() == NodeType::File && dbNode.nodeIdLocal().has_value() &&
         dbNode.nodeIdRemote().has_value() &&
         dbNode.lastModifiedLocal().has_value()) {
-        if (_fileSizeMismatchMap.find(dbNode.nodeIdLocal().value()) != _fileSizeMismatchMap.end()) {
+        
+        if (_fileSizeMismatchMap.contains(dbNode.nodeIdLocal().value())) {
             // Size mismatch already detected
             return ExitCode::Ok;
         }

--- a/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.h
+++ b/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.h
@@ -78,7 +78,7 @@ class ComputeFSOperationWorker : public ISyncWorker {
 
         std::unordered_set<SyncPath, hashPathFunction> _dirPathToDeleteSet;
 
-        std::unordered_map<NodeId, SyncPath> _fileSizeMismatchMap;
+        std::unordered_map<NodeId, SyncPath> _fileSizeMismatchMap; // File size mismatch checks are only enabled when env var: KDRIVE_ENABLE_FILE_SIZE_MISMATCH_DETECTION is set
 
         void addFolderToDelete(const SyncPath &path);
         bool pathInDeletedFolder(const SyncPath &path);

--- a/test/libsyncengine/propagation/executor/testintegration.cpp
+++ b/test/libsyncengine/propagation/executor/testintegration.cpp
@@ -98,7 +98,7 @@ void TestIntegration::setUp() {
     Drive drive(_driveDbId, driveId, account.dbId(), std::string(), 0, std::string());
     ParmsDb::instance()->insertDrive(drive);
 
-    _localPath = testVariables.localPath;
+    _localPath = _localTmpDir.path();
     _remotePath = testVariables.remotePath;
     Sync sync(1, drive.dbId(), _localPath, _remotePath);
     ParmsDb::instance()->insertSync(sync);

--- a/test/libsyncengine/propagation/executor/testintegration.h
+++ b/test/libsyncengine/propagation/executor/testintegration.h
@@ -20,6 +20,7 @@
 
 #include "syncpal/syncpal.h"
 #include "testincludes.h"
+#include "test_utility/localtemporarydirectory.h"
 
 using namespace CppUnit;
 
@@ -97,6 +98,7 @@ class TestIntegration : public CppUnit::TestFixture {
         NodeId _newTestFileRemoteId;
 
         std::vector<testFctPtr> _testFctPtrVector;
+        LocalTemporaryDirectory _localTmpDir{"test_integration"};
 };
 
 }  // namespace KDC

--- a/test/libsyncengine/update_detection/file_system_observer/testcomputefsoperationworker.cpp
+++ b/test/libsyncengine/update_detection/file_system_observer/testcomputefsoperationworker.cpp
@@ -169,7 +169,7 @@ void TestComputeFSOperationWorker::setUp() {
     /// Activate big folder limit
     ParametersCache::instance()->parameters().setUseBigFolderSizeLimit(true);
 
-    _syncPal->computeFSOperationWorker() =
+    _syncPal->_computeFSOperationsWorker =
         std::make_shared<ComputeFSOperationWorker>(_syncPal, "Test Compute FS Operations", "TCOP");
     _syncPal->computeFSOperationWorker()->setTesting(true);
     _syncPal->_localPath = testhelpers::localTestDirPath;

--- a/test/libsyncengine/update_detection/file_system_observer/testcomputefsoperationworker.cpp
+++ b/test/libsyncengine/update_detection/file_system_observer/testcomputefsoperationworker.cpp
@@ -169,12 +169,12 @@ void TestComputeFSOperationWorker::setUp() {
     /// Activate big folder limit
     ParametersCache::instance()->parameters().setUseBigFolderSizeLimit(true);
 
-    _syncPal->_computeFSOperationsWorker =
+    _syncPal->computeFSOperationWorker() =
         std::make_shared<ComputeFSOperationWorker>(_syncPal, "Test Compute FS Operations", "TCOP");
-    _syncPal->_computeFSOperationsWorker->setTesting(true);
+    _syncPal->computeFSOperationWorker()->setTesting(true);
     _syncPal->_localPath = testhelpers::localTestDirPath;
     _syncPal->copySnapshots();
-    _syncPal->_computeFSOperationsWorker->execute();
+    _syncPal->computeFSOperationWorker()->execute();
 }
 
 void TestComputeFSOperationWorker::tearDown() {
@@ -183,7 +183,7 @@ void TestComputeFSOperationWorker::tearDown() {
 
 void TestComputeFSOperationWorker::testNoOps() {
     _syncPal->copySnapshots();
-    _syncPal->_computeFSOperationsWorker->execute();
+    _syncPal->computeFSOperationWorker()->execute();
     CPPUNIT_ASSERT_EQUAL(uint64_t(0), _syncPal->operationSet(ReplicaSide::Local)->nbOps());
 }
 
@@ -211,7 +211,7 @@ void TestComputeFSOperationWorker::testMultipleOps() {
     _syncPal->_remoteSnapshot->setName("rac", Str("AC-renamed"));
 
     _syncPal->copySnapshots();
-    _syncPal->_computeFSOperationsWorker->execute();
+    _syncPal->computeFSOperationWorker()->execute();
 
     FSOpPtr tmpOp = nullptr;
     CPPUNIT_ASSERT(_syncPal->_localOperationSet->findOp("lad", OperationType::Create, tmpOp));
@@ -239,7 +239,7 @@ void TestComputeFSOperationWorker::testLnkFileAlreadySynchronized() {
 
     // File is excluded by template, it does not appear in snapshot
     _syncPal->copySnapshots();
-    _syncPal->_computeFSOperationsWorker->execute();
+    _syncPal->computeFSOperationWorker()->execute();
     CPPUNIT_ASSERT_EQUAL(uint64_t(0), _syncPal->_localOperationSet->nbOps());
 }
 

--- a/test/test_utility/testhelpers.h
+++ b/test/test_utility/testhelpers.h
@@ -40,7 +40,6 @@ struct TestVariables {
         std::string driveId;
         std::string remoteDirId;
         std::string remotePath;
-        std::string localPath;
         std::string apiToken;
 
         TestVariables() {
@@ -49,7 +48,6 @@ struct TestVariables {
             driveId = loadEnvVariable("KDRIVE_TEST_CI_DRIVE_ID");
             remoteDirId = loadEnvVariable("KDRIVE_TEST_CI_REMOTE_DIR_ID");
             remotePath = loadEnvVariable("KDRIVE_TEST_CI_REMOTE_PATH");
-            localPath = loadEnvVariable("KDRIVE_TEST_CI_LOCAL_PATH");
             apiToken = loadEnvVariable("KDRIVE_TEST_CI_API_TOKEN");
         }
 };


### PR DESCRIPTION
File opened in [Logic Pro pour Mac](https://www.apple.com/fr/logic-pro/)  are renamed with conflicted suffix because of a size mismatch detected in step 2.
This happens when all the modification dates (local, remote and DB) are the same but the size differ between local and remote. This situation should never happen in theory, but actually does as it seems that `Logic Pro` is able to modify a file without updating its modification date.
Use an environment variable to activate the detection of partially dowloaded files. 