### PR TITLE
Check that the response is never empty for CsvFullFileListWithCursorJob.

### DIFF
--- a/src/libsyncengine/jobs/network/API_v2/csvfullfilelistwithcursorjob.cpp
+++ b/src/libsyncengine/jobs/network/API_v2/csvfullfilelistwithcursorjob.cpp
@@ -308,7 +308,7 @@ bool CsvFullFileListWithCursorJob::handleResponse(std::istream &is) {
         _ss << is.rdbuf();
     }
 
-    // Check that the stringstream is not empty (Can be caused by network issues)
+    // Check that the stringstream is not empty (network issues)
     _ss.seekg(0, std::ios_base::end);
     int length = _ss.tellg();
     if (length == 0) {

--- a/src/libsyncengine/jobs/network/API_v2/csvfullfilelistwithcursorjob.cpp
+++ b/src/libsyncengine/jobs/network/API_v2/csvfullfilelistwithcursorjob.cpp
@@ -308,15 +308,15 @@ bool CsvFullFileListWithCursorJob::handleResponse(std::istream &is) {
         _ss << is.rdbuf();
     }
 
-    // Check that the stringstream ends by a LF (0x0A)
+    // Check that the stringstream is not empty (Can be caused by network issues)
     _ss.seekg(0, std::ios_base::end);
     int length = _ss.tellg();
     if (length == 0) {
-        // Folder is empty
-        LOG_DEBUG(_logger, "Reply " << jobId() << " received - length=" << length);
-        return true;
+        LOG_ERROR(_logger, "Reply " << jobId() << " received with empty content.");
+        return false;
     }
 
+    // Check that the stringstream ends by a LF (0x0A)
     _ss.seekg(length - 1, std::ios_base::beg);
     char lastChar = 0x00;
     _ss.read(&lastChar, 1);


### PR DESCRIPTION
We encountered an issue due to network failure, as we only received the header but an empty CSV file. This led to the directory being considered empty and resulted in the deletion of local items. This was compounded by a bug in the security check during advanced sync, which caused actual deletions. This issue has been addressed in another pull request (PR).

Going forward, the back-end will always send a CSV header and we will systematically check for its presence to differentiate between network failures and empty CSV files.