### PR TITLE
Kdesktop 1171 implement user information collection for non add error sentries

### DIFF
--- a/src/libcommonserver/io/iohelper_win.cpp
+++ b/src/libcommonserver/io/iohelper_win.cpp
@@ -633,12 +633,8 @@ bool IoHelper::getRights(const SyncPath &path, bool &read, bool &write, bool &ex
             return true;
         }
         LOGW_WARN(logger(), L"Failed to get rights using Windows API, falling back to std::filesystem.");
-        sentry_value_t sentryUser = sentry_value_new_object();
-        sentry_value_set_by_key(sentryUser, "ip_address", sentry_value_new_string("{{auto}}"));
-        sentry_set_user(sentryUser);
         sentry_capture_event(sentry_value_new_message_event(
             SENTRY_LEVEL_WARNING, "IoHelper", "Failed to get rights using Windows API, falling back to std::filesystem."));
-        sentry_remove_user();
 
         IoHelper::getTrustee().ptstrName = nullptr;
         _getAndSetRightsMethod = 1;
@@ -713,12 +709,8 @@ bool IoHelper::setRights(const SyncPath &path, bool read, bool write, bool exec,
         }
 
         LOGW_WARN(logger(), L"Failed to set rights using Windows API, falling back to std::filesystem.");
-        sentry_value_t sentryUser = sentry_value_new_object();
-        sentry_value_set_by_key(sentryUser, "ip_address", sentry_value_new_string("{{auto}}"));
-        sentry_set_user(sentryUser);
         sentry_capture_event(sentry_value_new_message_event(
             SENTRY_LEVEL_WARNING, "IoHelper", "Failed to set rights using Windows API, falling back to std::filesystem."));
-        sentry_remove_user();
         IoHelper::getTrustee().ptstrName = nullptr;
         _getAndSetRightsMethod = 1;
     }

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -373,11 +373,9 @@ AppServer::AppServer(int &argc, char **argv)
     // Restart paused syncs
     connect(&_restartSyncsTimer, &QTimer::timeout, this, &AppServer::onRestartSyncs);
     _restartSyncsTimer.start(RESTART_SYNCS_INTERVAL);
-    sentry_capture_event(sentry_value_new_message_event(SENTRY_LEVEL_WARNING, "AppServer::TEST::Start", "blablabla..."));
 }
 
 AppServer::~AppServer() {
-    sentry_capture_event(sentry_value_new_message_event(SENTRY_LEVEL_WARNING, "AppServer::TEST::Close", "blablabla..."));
     LOG_DEBUG(_logger, "~AppServer");
 }
 

--- a/src/server/appserver.h
+++ b/src/server/appserver.h
@@ -238,6 +238,10 @@ class AppServer : public SharedTools::QtSingleApplication {
 
         void logExtendedLogActivationMessage(bool isExtendedLogEnabled) noexcept;
 
+        static void setDefaultSentryUsers();
+        static void setSpecificSentryUser(const User &user);  // Do not forget to call setDefaultSentryUsers() after calling this function
+
+
     private slots:
         void onLoadInfo();
         void onUpdateSyncsProgress();


### PR DESCRIPTION
# Description

Currently, Sentry events that do not originate from an "add error" do not include user information. This limitation prevents these events from being sorted and grouped by user, making it difficult to determine whether a large number of issues affect a diverse user base or a smaller subset of users experiencing recurring problems.