### PR TITLE
Tiny enhancement of a french translation for sync progress

### DIFF
--- a/translations/client_fr.ts
+++ b/translations/client_fr.ts
@@ -2935,7 +2935,7 @@ Veuillez utiliser le lien suivant pour envoyer les logs au support: &lt;a style=
         <source>Sync in progress (%1 of %2)
 %3 left...</source>
         <translation>Synchronisation en cours (%1 sur %2)
-%3 restant...</translation>
+%3 restantes...</translation>
     </message>
     <message>
         <location filename="../src/gui/guiutility.cpp" line="348"/>


### PR DESCRIPTION
In **most** cases, the estimated remaining time before synchronisation completion (expressed in years, days, hours, minutes or seconds) will be of the **female and plural form** when translated to french.

In the example below, we will read _"7 heures restantes"_ instead of _"7 heures restant"_ after this change.

This pull-request does not address the case of singular or masculine forms (e.g, day(s)), as they are deemed less frequent. 

![Capture d’écran 2024-09-04 à 10 26 48](https://github.com/user-attachments/assets/5624a64a-3f2e-4e93-9058-cb984e16d724)
