### PR TITLE
KDESKTOP-1192-Files-downloaded-at-creation-in-LiteSync-mode

### DIFF
--- a/src/libcommon/utility/jsonparserutility.h
+++ b/src/libcommon/utility/jsonparserutility.h
@@ -28,12 +28,12 @@
 namespace KDC {
 
 struct COMMONSERVER_EXPORT JsonParserUtility {
-        template <typename T>
-        static bool extractValue(const Poco::JSON::Object::Ptr obj, const std::string &key, T &val, bool mandatory = true) {
+        template<typename T>
+        static bool extractValue(const Poco::JSON::Object::Ptr obj, const std::string &key, T &val, const bool mandatory = true) {
             if (!obj) {
                 LOG_WARN(Log::instance()->getLogger(), "JSON object is NULL");
                 return false;
-            }  // namespace KDC
+            } // namespace KDC
 
             if (obj->has(key) && obj->isNull(key)) {
                 // Item exist in JSON but is null, this is ok
@@ -45,7 +45,7 @@ struct COMMONSERVER_EXPORT JsonParserUtility {
                 var.convert(val);
             } catch (...) {
                 if (mandatory) {
-                    std::string msg = "Fail to extract value for key=" + key;
+                    const std::string msg = "Fail to extract value for key=" + key;
                     LOG_WARN(Log::instance()->getLogger(), msg.c_str());
                     SentryHandler::instance()->captureMessage(SentryLevel::Error, "JsonParserUtility::extractValue", msg);
                     return false;
@@ -84,4 +84,4 @@ struct COMMONSERVER_EXPORT JsonParserUtility {
         }
 };
 
-}  // namespace KDC
+} // namespace KDC

--- a/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
@@ -31,12 +31,12 @@
 
 namespace KDC {
 
-static const int defaultDiscoveryInterval = 60000;  // 60sec
-static const int waitForUpdateDelay = 1000;         // 1sec
+static const int defaultDiscoveryInterval = 60000; // 60sec
+static const int waitForUpdateDelay = 1000; // 1sec
 
 LocalFileSystemObserverWorker::LocalFileSystemObserverWorker(std::shared_ptr<SyncPal> syncPal, const std::string &name,
-                                                             const std::string &shortName)
-    : FileSystemObserverWorker(syncPal, name, shortName, ReplicaSide::Local), _rootFolder(syncPal->localPath()) {}
+                                                             const std::string &shortName) :
+    FileSystemObserverWorker(syncPal, name, shortName, ReplicaSide::Local), _rootFolder(syncPal->localPath()) {}
 
 LocalFileSystemObserverWorker::~LocalFileSystemObserverWorker() {
     LOG_SYNCPAL_DEBUG(_logger, "~LocalFileSystemObserverWorker");
@@ -72,7 +72,7 @@ void LocalFileSystemObserverWorker::changesDetected(const std::list<std::pair<st
         return;
     }
 
-    for (const auto &changedItem : changes) {
+    for (const auto &changedItem: changes) {
         if (stopAsked()) {
             _pendingFileEvents.clear();
             break;
@@ -97,8 +97,8 @@ void LocalFileSystemObserverWorker::changesDetected(const std::list<std::pair<st
                     !existsWithSameId) {
                     if (_snapshot->removeItem(prevNodeId)) {
                         LOGW_SYNCPAL_DEBUG(_logger, L"Item removed from local snapshot: "
-                                                        << Utility::formatSyncPath(absolutePath).c_str() << L" ("
-                                                        << Utility::s2ws(prevNodeId).c_str() << L")");
+                                                            << Utility::formatSyncPath(absolutePath).c_str() << L" ("
+                                                            << Utility::s2ws(prevNodeId).c_str() << L")");
                     }
                     continue;
                 }
@@ -148,7 +148,7 @@ void LocalFileSystemObserverWorker::changesDetected(const std::list<std::pair<st
                                                                                        isWarning, toExclude, ioError);
             if (!success) {
                 LOGW_SYNCPAL_WARN(_logger, L"Error in ExclusionTemplateCache::isExcluded: "
-                                               << Utility::formatIoError(absolutePath, ioError).c_str());
+                                                   << Utility::formatIoError(absolutePath, ioError).c_str());
                 invalidateSnapshot();
                 return;
             }
@@ -165,14 +165,14 @@ void LocalFileSystemObserverWorker::changesDetected(const std::list<std::pair<st
                     // Remove it from snapshot
                     _snapshot->removeItem(itemId);
                     LOGW_SYNCPAL_DEBUG(_logger, L"Item removed from sync because it's hidden: "
-                                                    << Utility::formatSyncPath(absolutePath).c_str());
+                                                        << Utility::formatSyncPath(absolutePath).c_str());
                 } else {
-                    LOGW_SYNCPAL_DEBUG(
-                        _logger, L"Item not processed because it's excluded: " << Utility::formatSyncPath(absolutePath).c_str());
+                    LOGW_SYNCPAL_DEBUG(_logger, L"Item not processed because it's excluded: "
+                                                        << Utility::formatSyncPath(absolutePath).c_str());
                 }
 
                 if (!_syncPal->vfsExclude(
-                        absolutePath)) {  // TODO : This class should never set any attribute or change anything on a file
+                            absolutePath)) { // TODO : This class should never set any attribute or change anything on a file
                     LOGW_SYNCPAL_WARN(_logger, L"Error in vfsExclude: " << Utility::formatSyncPath(absolutePath).c_str());
                 }
 
@@ -236,8 +236,8 @@ void LocalFileSystemObserverWorker::changesDetected(const std::list<std::pair<st
             const bool success = IoHelper::checkIfFileChanged(absolutePath, _snapshot->size(nodeId),
                                                               _snapshot->lastModified(nodeId), changed, ioError);
             if (!success) {
-                LOGW_SYNCPAL_WARN(
-                    _logger, L"Error in IoHelper::checkIfFileChanged: " << Utility::formatIoError(absolutePath, ioError).c_str());
+                LOGW_SYNCPAL_WARN(_logger, L"Error in IoHelper::checkIfFileChanged: "
+                                                   << Utility::formatIoError(absolutePath, ioError).c_str());
             }
             if (ioError == IoError::AccessDenied) {
                 LOGW_SYNCPAL_DEBUG(_logger,
@@ -272,7 +272,7 @@ void LocalFileSystemObserverWorker::changesDetected(const std::list<std::pair<st
                         // TODO : FileSystemObserver should not change file status, it should only monitor file system
                         if (!_syncPal->vfsFileStatusChanged(absolutePath, SyncFileStatus::Syncing)) {
                             LOGW_SYNCPAL_WARN(_logger, L"Error in SyncPal::vfsFileStatusChanged: "
-                                                           << Utility::formatSyncPath(absolutePath).c_str());
+                                                               << Utility::formatSyncPath(absolutePath).c_str());
                             invalidateSnapshot();
                             return;
                         }
@@ -282,8 +282,8 @@ void LocalFileSystemObserverWorker::changesDetected(const std::list<std::pair<st
 #else
                 if (ParametersCache::isExtendedLogEnabled()) {
                     LOGW_SYNCPAL_DEBUG(_logger, L"Ignoring spurious edit notification on file: "
-                                                    << Utility::formatSyncPath(absolutePath).c_str() << L" ("
-                                                    << Utility::s2ws(nodeId).c_str() << L")");
+                                                        << Utility::formatSyncPath(absolutePath).c_str() << L" ("
+                                                        << Utility::s2ws(nodeId).c_str() << L")");
                 }
 #endif
 
@@ -291,8 +291,8 @@ void LocalFileSystemObserverWorker::changesDetected(const std::list<std::pair<st
             }
         } else if (opTypeFromOS == OperationType::Rights) {
             if (!writePermission) {
-                LOGW_SYNCPAL_DEBUG(
-                    _logger, L"Item: " << Utility::formatSyncPath(absolutePath).c_str() << L" doesn't have write permissions!");
+                LOGW_SYNCPAL_DEBUG(_logger, L"Item: " << Utility::formatSyncPath(absolutePath).c_str()
+                                                      << L" doesn't have write permissions!");
                 sendAccessDeniedError(absolutePath);
             }
         }
@@ -304,8 +304,8 @@ void LocalFileSystemObserverWorker::changesDetected(const std::list<std::pair<st
                 NodeId itemId = _snapshot->itemId(relativePath);
                 if (_snapshot->removeItem(itemId)) {
                     LOGW_SYNCPAL_DEBUG(_logger, L"Item removed from local snapshot: "
-                                                    << Utility::formatSyncPath(absolutePath).c_str() << L" ("
-                                                    << Utility::s2ws(itemId).c_str() << L")");
+                                                        << Utility::formatSyncPath(absolutePath).c_str() << L" ("
+                                                        << Utility::s2ws(itemId).c_str() << L")");
                 } else {
                     LOGW_SYNCPAL_WARN(_logger, L"Failed to remove item: " << Utility::formatSyncPath(absolutePath).c_str()
                                                                           << L" (" << Utility::s2ws(itemId).c_str() << L")");
@@ -322,8 +322,8 @@ void LocalFileSystemObserverWorker::changesDetected(const std::list<std::pair<st
                 // below anyway
                 if (_snapshot->removeItem(previousItemId)) {
                     LOGW_SYNCPAL_DEBUG(_logger, L"Item removed from local snapshot: "
-                                                    << Utility::formatSyncPath(absolutePath).c_str() << L" ("
-                                                    << Utility::s2ws(previousItemId).c_str() << L")");
+                                                        << Utility::formatSyncPath(absolutePath).c_str() << L" ("
+                                                        << Utility::s2ws(previousItemId).c_str() << L")");
                 } else {
                     LOGW_SYNCPAL_WARN(_logger, L"Failed to delete item: " << Utility::formatSyncPath(absolutePath).c_str()
                                                                           << L" (" << Utility::s2ws(previousItemId).c_str()
@@ -335,7 +335,7 @@ void LocalFileSystemObserverWorker::changesDetected(const std::list<std::pair<st
 
             // This can be either Create, Move or Edit operation
             SnapshotItem item(nodeId, parentNodeId, absolutePath.filename().native(), fileStat.creationTime, fileStat.modtime,
-                              nodeType, fileStat.size, isLink);
+                              nodeType, fileStat.size, isLink, true, true);
 
             if (!_snapshot->updateItem(item)) {
                 LOGW_SYNCPAL_WARN(_logger, L"Failed to insert item: " << Utility::formatSyncPath(absolutePath).c_str() << L" ("
@@ -397,7 +397,7 @@ void LocalFileSystemObserverWorker::changesDetected(const std::list<std::pair<st
 
         // Update snapshot
         if (_snapshot->updateItem(SnapshotItem(nodeId, parentNodeId, absolutePath.filename().native(), fileStat.creationTime,
-                                               fileStat.modtime, nodeType, fileStat.size, isLink))) {
+                                               fileStat.modtime, nodeType, fileStat.size, isLink, true, true))) {
             if (ParametersCache::isExtendedLogEnabled()) {
                 LOGW_SYNCPAL_DEBUG(_logger, L"Item: " << Utility::formatSyncPath(absolutePath).c_str() << L" ("
                                                       << Utility::s2ws(nodeId).c_str() << L") updated in local snapshot at "
@@ -489,8 +489,8 @@ ExitCode LocalFileSystemObserverWorker::generateInitialSnapshot() {
     std::chrono::duration<double> elapsed_seconds = std::chrono::steady_clock::now() - start;
     if (res == ExitCode::Ok && !stopAsked()) {
         _snapshot->setValid(true);
-        LOG_SYNCPAL_INFO(
-            _logger, "Local snapshot generated in: " << elapsed_seconds.count() << "s for " << _snapshot->nbItems() << " items");
+        LOG_SYNCPAL_INFO(_logger, "Local snapshot generated in: " << elapsed_seconds.count() << "s for " << _snapshot->nbItems()
+                                                                  << " items");
     } else if (stopAsked()) {
         LOG_SYNCPAL_INFO(_logger, "Local snapshot generation stopped after: " << elapsed_seconds.count() << "s");
     } else {
@@ -652,8 +652,8 @@ ExitCode LocalFileSystemObserverWorker::exploreDir(const SyncPath &absoluteParen
     }
 
     if (itemType.ioError == IoError::AccessDenied) {
-        LOGW_SYNCPAL_WARN(
-            _logger, L"Sync localpath: " << Utility::formatSyncPath(absoluteParentDirPath).c_str() << L" misses read permission");
+        LOGW_SYNCPAL_WARN(_logger, L"Sync localpath: " << Utility::formatSyncPath(absoluteParentDirPath).c_str()
+                                                       << L" misses read permission");
         setExitCause(ExitCause::SyncDirReadError);
         return ExitCode::SystemError;
     }
@@ -666,7 +666,7 @@ ExitCode LocalFileSystemObserverWorker::exploreDir(const SyncPath &absoluteParen
     try {
         std::error_code ec;
         auto dirIt = std::filesystem::recursive_directory_iterator(
-            absoluteParentDirPath, std::filesystem::directory_options::skip_permission_denied, ec);
+                absoluteParentDirPath, std::filesystem::directory_options::skip_permission_denied, ec);
         if (ec) {
             LOGW_SYNCPAL_DEBUG(_logger, L"Error in exploreDir: " << Utility::formatStdError(ec).c_str());
             setExitCause(ExitCause::FileAccessError);
@@ -691,10 +691,10 @@ ExitCode LocalFileSystemObserverWorker::exploreDir(const SyncPath &absoluteParen
             // skip_permission_denied doesn't work on Windows if "Full control = Deny"
             try {
                 bool dummy = dirIt->exists();
-                (void)(dummy);
+                (void) (dummy);
             } catch (std::filesystem::filesystem_error &) {
-                LOGW_SYNCPAL_INFO(
-                    _logger, L"Item: " << Utility::formatSyncPath(absolutePath).c_str() << L" rejected because access is denied");
+                LOGW_SYNCPAL_INFO(_logger, L"Item: " << Utility::formatSyncPath(absolutePath).c_str()
+                                                     << L" rejected because access is denied");
                 toExclude = true;
                 denyFullControl = true;
             }
@@ -707,12 +707,12 @@ ExitCode LocalFileSystemObserverWorker::exploreDir(const SyncPath &absoluteParen
                 IoError ioError = IoError::Success;
                 if (!Utility::checkIfDirEntryIsManaged(dirIt, isManaged, isLink, ioError)) {
                     LOGW_SYNCPAL_WARN(_logger, L"Error in Utility::checkIfDirEntryIsManaged: "
-                                                   << Utility::formatSyncPath(absolutePath).c_str());
+                                                       << Utility::formatSyncPath(absolutePath).c_str());
                     dirIt.disable_recursion_pending();
                     continue;
                 } else if (ioError == IoError::NoSuchFileOrDirectory) {
-                    LOGW_SYNCPAL_DEBUG(
-                        _logger, L"Directory entry does not exist anymore: " << Utility::formatSyncPath(absolutePath).c_str());
+                    LOGW_SYNCPAL_DEBUG(_logger, L"Directory entry does not exist anymore: "
+                                                        << Utility::formatSyncPath(absolutePath).c_str());
                     dirIt.disable_recursion_pending();
                     continue;
                 } else if (ioError == IoError::AccessDenied) {
@@ -738,7 +738,7 @@ ExitCode LocalFileSystemObserverWorker::exploreDir(const SyncPath &absoluteParen
                                                                                            isWarning, isExcluded, ioError);
                 if (!success) {
                     LOGW_SYNCPAL_DEBUG(_logger, L"Error in ExclusionTemplateCache::isExcluded: "
-                                                    << Utility::formatIoError(absolutePath, ioError).c_str());
+                                                        << Utility::formatIoError(absolutePath, ioError).c_str());
                     dirIt.disable_recursion_pending();
                     continue;
                 }
@@ -754,15 +754,15 @@ ExitCode LocalFileSystemObserverWorker::exploreDir(const SyncPath &absoluteParen
             if (!toExclude) {
                 IoError ioError = IoError::Success;
                 if (!IoHelper::getFileStat(absolutePath, &fileStat, ioError)) {
-                    LOGW_SYNCPAL_DEBUG(
-                        _logger, L"Error in IoHelper::getFileStat: " << Utility::formatIoError(absolutePath, ioError).c_str());
+                    LOGW_SYNCPAL_DEBUG(_logger, L"Error in IoHelper::getFileStat: "
+                                                        << Utility::formatIoError(absolutePath, ioError).c_str());
                     dirIt.disable_recursion_pending();
                     continue;
                 }
 
                 if (ioError == IoError::NoSuchFileOrDirectory) {
-                    LOGW_SYNCPAL_DEBUG(
-                        _logger, L"Directory entry does not exist anymore: " << Utility::formatSyncPath(absolutePath).c_str());
+                    LOGW_SYNCPAL_DEBUG(_logger, L"Directory entry does not exist anymore: "
+                                                        << Utility::formatSyncPath(absolutePath).c_str());
                     dirIt.disable_recursion_pending();
                     continue;
                 } else if (ioError == IoError::AccessDenied) {
@@ -770,7 +770,7 @@ ExitCode LocalFileSystemObserverWorker::exploreDir(const SyncPath &absoluteParen
                                                          << L" rejected because access is denied");
                     sendAccessDeniedError(absolutePath);
                     toExclude = true;
-                } else {  // Check access permissions
+                } else { // Check access permissions
                     nodeId = std::to_string(fileStat.inode);
                     readPermission = false;
                     writePermission = false;
@@ -784,7 +784,7 @@ ExitCode LocalFileSystemObserverWorker::exploreDir(const SyncPath &absoluteParen
 
                     if (ioError == IoError::NoSuchFileOrDirectory) {
                         LOGW_SYNCPAL_DEBUG(_logger, L"Directory entry does not exist anymore: "
-                                                        << Utility::formatSyncPath(absolutePath).c_str());
+                                                            << Utility::formatSyncPath(absolutePath).c_str());
                         dirIt.disable_recursion_pending();
                         continue;
                     }
@@ -801,7 +801,7 @@ ExitCode LocalFileSystemObserverWorker::exploreDir(const SyncPath &absoluteParen
             if (toExclude) {
                 if (!denyFullControl) {
                     if (!_syncPal->vfsExclude(
-                            absolutePath)) {  // TODO : This class should never set any attribute or change anything on a file
+                                absolutePath)) { // TODO : This class should never set any attribute or change anything on a file
                         LOGW_SYNCPAL_WARN(_logger, L"Error in vfsExclude : " << Utility::formatSyncPath(absolutePath).c_str());
                     }
                 }
@@ -819,19 +819,19 @@ ExitCode LocalFileSystemObserverWorker::exploreDir(const SyncPath &absoluteParen
                 IoError ioError = IoError::Success;
                 if (!IoHelper::getFileStat(absolutePath.parent_path(), &parentFileStat, ioError)) {
                     LOGW_WARN(_logger, L"Error in IoHelper::getFileStat: "
-                                           << Utility::formatIoError(absolutePath.parent_path(), ioError).c_str());
+                                               << Utility::formatIoError(absolutePath.parent_path(), ioError).c_str());
                     setExitCause(ExitCause::FileAccessError);
                     return ExitCode::SystemError;
                 }
 
                 if (ioError == IoError::NoSuchFileOrDirectory) {
                     LOGW_SYNCPAL_DEBUG(_logger, L"Directory doesn't exist anymore: "
-                                                    << Utility::formatSyncPath(absolutePath.parent_path()).c_str());
+                                                        << Utility::formatSyncPath(absolutePath.parent_path()).c_str());
                     dirIt.disable_recursion_pending();
                     continue;
                 } else if (ioError == IoError::AccessDenied) {
                     LOGW_SYNCPAL_DEBUG(_logger, L"Directory misses search permission: "
-                                                    << Utility::formatSyncPath(absolutePath.parent_path()).c_str());
+                                                        << Utility::formatSyncPath(absolutePath.parent_path()).c_str());
                     dirIt.disable_recursion_pending();
                     continue;
                 }
@@ -841,21 +841,22 @@ ExitCode LocalFileSystemObserverWorker::exploreDir(const SyncPath &absoluteParen
 
             if (!IoHelper::getItemType(absolutePath, itemType)) {
                 LOGW_SYNCPAL_DEBUG(_logger, L"Error in IoHelper::getItemType: "
-                                                << Utility::formatIoError(absolutePath, itemType.ioError).c_str());
+                                                    << Utility::formatIoError(absolutePath, itemType.ioError).c_str());
                 dirIt.disable_recursion_pending();
                 continue;
             }
 
             SnapshotItem item(nodeId, parentNodeId, absolutePath.filename().native(), fileStat.creationTime, fileStat.modtime,
-                              itemType.nodeType, fileStat.size, isLink);
+                              itemType.nodeType, fileStat.size, isLink, true, true);
             if (_snapshot->updateItem(item)) {
                 if (ParametersCache::isExtendedLogEnabled()) {
                     LOGW_SYNCPAL_DEBUG(_logger, L"Item inserted in local snapshot: "
-                                                    << Utility::formatSyncPath(absolutePath.filename()).c_str() << L" inode:"
-                                                    << nodeId.c_str() << L" parent inode:" << Utility::s2ws(parentNodeId).c_str()
-                                                    << L" createdAt:" << fileStat.creationTime << L" modtime:" << fileStat.modtime
-                                                    << L" isDir:" << (itemType.nodeType == NodeType::Directory) << L" size:"
-                                                    << fileStat.size);
+                                                        << Utility::formatSyncPath(absolutePath.filename()).c_str() << L" inode:"
+                                                        << nodeId.c_str() << L" parent inode:"
+                                                        << Utility::s2ws(parentNodeId).c_str() << L" createdAt:"
+                                                        << fileStat.creationTime << L" modtime:" << fileStat.modtime << L" isDir:"
+                                                        << (itemType.nodeType == NodeType::Directory) << L" size:"
+                                                        << fileStat.size);
                 }
             } else {
                 LOGW_SYNCPAL_WARN(_logger, L"Failed to insert item: " << Utility::formatSyncPath(absolutePath.filename()).c_str()
@@ -875,4 +876,4 @@ ExitCode LocalFileSystemObserverWorker::exploreDir(const SyncPath &absoluteParen
     return ExitCode::Ok;
 }
 
-}  // namespace KDC
+} // namespace KDC

--- a/src/libsyncengine/update_detection/file_system_observer/remotefilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/remotefilesystemobserverworker.cpp
@@ -44,8 +44,8 @@
 namespace KDC {
 
 RemoteFileSystemObserverWorker::RemoteFileSystemObserverWorker(std::shared_ptr<SyncPal> syncPal, const std::string &name,
-                                                               const std::string &shortName)
-    : FileSystemObserverWorker(syncPal, name, shortName, ReplicaSide::Remote), _driveDbId(syncPal->driveDbId()) {}
+                                                               const std::string &shortName) :
+    FileSystemObserverWorker(syncPal, name, shortName, ReplicaSide::Remote), _driveDbId(syncPal->driveDbId()) {}
 
 RemoteFileSystemObserverWorker::~RemoteFileSystemObserverWorker() {
     LOG_SYNCPAL_DEBUG(_logger, "~RemoteFileSystemObserverWorker");
@@ -100,8 +100,8 @@ ExitCode RemoteFileSystemObserverWorker::generateInitialSnapshot() {
     const std::chrono::duration<double> elapsedSeconds = end - start;
     if (exitCode == ExitCode::Ok && !stopAsked()) {
         _snapshot->setValid(true);
-        LOG_SYNCPAL_INFO(
-            _logger, "Remote snapshot generated in: " << elapsedSeconds.count() << "s for " << _snapshot->nbItems() << " items");
+        LOG_SYNCPAL_INFO(_logger, "Remote snapshot generated in: " << elapsedSeconds.count() << "s for " << _snapshot->nbItems()
+                                                                   << " items");
     } else {
         invalidateSnapshot();
         LOG_SYNCPAL_WARN(_logger, "Remote snapshot generation stopped or failed after: " << elapsedSeconds.count() << "s");
@@ -175,7 +175,7 @@ ExitCode RemoteFileSystemObserverWorker::processEvents() {
             job = std::make_shared<ContinueFileListWithCursorJob>(_driveDbId, _cursor);
         } catch (std::exception const &e) {
             LOG_SYNCPAL_WARN(_logger, "Error in ContinueFileListWithCursorJob::ContinueFileListWithCursorJob for driveDbId="
-                                          << _driveDbId << " : " << e.what());
+                                              << _driveDbId << " : " << e.what());
             exitCode = ExitCode::DataError;
             break;
         }
@@ -272,7 +272,7 @@ ExitCode RemoteFileSystemObserverWorker::getItemsInDir(const NodeId &dirId, cons
     } catch (std::exception const &e) {
         std::string what = e.what();
         LOG_SYNCPAL_WARN(_logger, "Error in InitFileListWithCursorJob::InitFileListWithCursorJob for driveDbId="
-                                      << _driveDbId << " what =" << what.c_str());
+                                          << _driveDbId << " what =" << what.c_str());
         if (what == invalidToken) {
             return ExitCode::InvalidToken;
         }
@@ -364,11 +364,11 @@ ExitCode RemoteFileSystemObserverWorker::getItemsInDir(const NodeId &dirId, cons
         if (_snapshot->updateItem(item)) {
             if (ParametersCache::isExtendedLogEnabled()) {
                 LOGW_SYNCPAL_DEBUG(_logger, L"Item inserted in remote snapshot: name:"
-                                                << SyncName2WStr(item.name()).c_str() << L", inode:"
-                                                << Utility::s2ws(item.id()).c_str() << L", parent inode:"
-                                                << Utility::s2ws(item.parentId()).c_str() << L", createdAt:" << item.createdAt()
-                                                << L", modtime:" << item.lastModified() << L", isDir:"
-                                                << (item.type() == NodeType::Directory) << L", size:" << item.size());
+                                                    << SyncName2WStr(item.name()).c_str() << L", inode:"
+                                                    << Utility::s2ws(item.id()).c_str() << L", parent inode:"
+                                                    << Utility::s2ws(item.parentId()).c_str() << L", createdAt:"
+                                                    << item.createdAt() << L", modtime:" << item.lastModified() << L", isDir:"
+                                                    << (item.type() == NodeType::Directory) << L", size:" << item.size());
             }
         }
     }
@@ -413,8 +413,8 @@ ExitCode RemoteFileSystemObserverWorker::sendLongPoll(bool &changes) {
 
             {
                 const std::lock_guard<std::mutex> lock(_mutex);
-                if (_updating) {  // We want to update snapshot immediately, cancel LongPoll job and send a listing/continue
-                                  // request
+                if (_updating) { // We want to update snapshot immediately, cancel LongPoll job and send a listing/continue
+                                 // request
                     notifyJob->abort();
                     changes = true;
                     return ExitCode::Ok;
@@ -436,10 +436,10 @@ ExitCode RemoteFileSystemObserverWorker::sendLongPoll(bool &changes) {
             if (notifyJob->getStatusCode() == Poco::Net::HTTPResponse::HTTP_BAD_GATEWAY) {
                 // Ignore this error and check for changes anyway
                 LOG_SYNCPAL_INFO(_logger, "Notify changes request failed with error "
-                                              << Poco::Net::HTTPResponse::HTTP_BAD_GATEWAY
-                                              << "for drive: " << std::to_string(_driveDbId).c_str()
-                                              << " and cursor: " << _cursor.c_str() << ". Check for changes anyway.");
-                changes = true;  // TODO: perhaps not a good idea... what if longpoll crashed and not reachable for a long time???
+                                                  << Poco::Net::HTTPResponse::HTTP_BAD_GATEWAY
+                                                  << "for drive: " << std::to_string(_driveDbId).c_str()
+                                                  << " and cursor: " << _cursor.c_str() << ". Check for changes anyway.");
+                changes = true; // TODO: perhaps not a good idea... what if longpoll crashed and not reachable for a long time???
             } else {
                 LOG_SYNCPAL_WARN(_logger, "Notify changes request failed for drive: " << std::to_string(_driveDbId).c_str()
                                                                                       << " and cursor: " << _cursor.c_str());
@@ -538,13 +538,13 @@ ExitCode RemoteFileSystemObserverWorker::extractActionInfo(const Poco::JSON::Obj
     if (!JsonParserUtility::extractValue(actionObj, pathKey, actionInfo.path)) {
         return ExitCode::BackError;
     }
-    actionInfo.name = actionInfo.path.substr(actionInfo.path.find_last_of('/') + 1);  // +1 to ignore the last "/"
+    actionInfo.name = actionInfo.path.substr(actionInfo.path.find_last_of('/') + 1); // +1 to ignore the last "/"
 
     SyncName tmpSyncName;
     if (!JsonParserUtility::extractValue(actionObj, destinationKey, tmpSyncName, false)) {
         return ExitCode::BackError;
     }
-    actionInfo.destName = tmpSyncName.substr(tmpSyncName.find_last_of('/') + 1);  // +1 to ignore the last "/"
+    actionInfo.destName = tmpSyncName.substr(tmpSyncName.find_last_of('/') + 1); // +1 to ignore the last "/"
 
     if (!JsonParserUtility::extractValue(actionObj, createdAtKey, actionInfo.createdAt, false)) {
         return ExitCode::BackError;
@@ -565,6 +565,12 @@ ExitCode RemoteFileSystemObserverWorker::extractActionInfo(const Poco::JSON::Obj
         }
     }
 
+    std::string tmp;
+    if (!JsonParserUtility::extractValue(actionObj, symbolicLinkKey, tmp, false)) {
+        return ExitCode::BackError;
+    }
+    actionInfo.isLink = !tmp.empty();
+
     Poco::JSON::Object::Ptr capabilitiesObj = actionObj->getObject(capabilitiesKey);
     if (capabilitiesObj) {
         if (!JsonParserUtility::extractValue(capabilitiesObj, canWriteKey, actionInfo.canWrite)) {
@@ -578,7 +584,7 @@ ExitCode RemoteFileSystemObserverWorker::extractActionInfo(const Poco::JSON::Obj
 ExitCode RemoteFileSystemObserverWorker::processAction(const SyncName &usedName, const ActionInfo &actionInfo,
                                                        std::set<NodeId, std::less<>> &movedItems) {
     SnapshotItem item(actionInfo.nodeId, actionInfo.parentNodeId, usedName, actionInfo.createdAt, actionInfo.modtime,
-                      actionInfo.type, actionInfo.size, actionInfo.canWrite);
+                      actionInfo.type, actionInfo.size, actionInfo.isLink, actionInfo.canWrite, true);
 
     // Process action
     switch (actionInfo.actionCode) {
@@ -595,7 +601,7 @@ ExitCode RemoteFileSystemObserverWorker::processAction(const SyncName &usedName,
             if (ExitCode exitCode = checkRightsAndUpdateItem(actionInfo.nodeId, rightsOk, item); exitCode != ExitCode::Ok) {
                 return exitCode;
             }
-            if (!rightsOk) break;  // Current user does not have the right to access this item, ignore action.
+            if (!rightsOk) break; // Current user does not have the right to access this item, ignore action.
             [[fallthrough]];
         }
         case ActionCode::actionCodeMoveIn:
@@ -649,7 +655,7 @@ ExitCode RemoteFileSystemObserverWorker::processAction(const SyncName &usedName,
             if (ExitCode exitCode = checkRightsAndUpdateItem(actionInfo.nodeId, rightsOk, item); exitCode != ExitCode::Ok) {
                 return exitCode;
             }
-            if (rightsOk) break;  // Current user still have the right to access this item, ignore action.
+            if (rightsOk) break; // Current user still have the right to access this item, ignore action.
             [[fallthrough]];
         }
         case ActionCode::actionCodeMoveOut:
@@ -698,8 +704,8 @@ ExitCode RemoteFileSystemObserverWorker::checkRightsAndUpdateItem(const NodeId &
         }
 
         LOGW_SYNCPAL_WARN(_logger, L"Error while determining access rights on item: "
-                                       << SyncName2WStr(snapshotItem.name()).c_str() << L" ("
-                                       << Utility::s2ws(snapshotItem.id()).c_str() << L")");
+                                           << SyncName2WStr(snapshotItem.name()).c_str() << L" ("
+                                           << Utility::s2ws(snapshotItem.id()).c_str() << L")");
         invalidateSnapshot();
         return ExitCode::BackError;
     }
@@ -707,6 +713,7 @@ ExitCode RemoteFileSystemObserverWorker::checkRightsAndUpdateItem(const NodeId &
     snapshotItem.setCreatedAt(job.creationTime());
     snapshotItem.setLastModified(job.modtime());
     snapshotItem.setSize(job.size());
+    snapshotItem.setIsLink(job.isLink());
     hasRights = true;
     return ExitCode::Ok;
 }
@@ -723,16 +730,16 @@ bool RemoteFileSystemObserverWorker::hasUnsupportedCharacters(const SyncName &na
 
     if (!valid) {
         LOGW_SYNCPAL_DEBUG(_logger, L"The file/directory name contains a character not yet supported by the filesystem "
-                                        << SyncName2WStr(name).c_str() << L". Item is ignored.");
+                                            << SyncName2WStr(name).c_str() << L". Item is ignored.");
 
         Error err(_syncPal->syncDbId(), "", nodeId, type, name, ConflictType::None, InconsistencyType::NotYetSupportedChar);
         _syncPal->addError(err);
         return true;
     }
 #else
-    (void)name;
-    (void)nodeId;
-    (void)type;
+    (void) name;
+    (void) nodeId;
+    (void) type;
 #endif
     return false;
 }
@@ -740,11 +747,11 @@ bool RemoteFileSystemObserverWorker::hasUnsupportedCharacters(const SyncName &na
 void RemoteFileSystemObserverWorker::countListingRequests() {
     const auto listingFullTimerEnd = std::chrono::steady_clock::now();
     const std::chrono::duration<double> elapsedTime = listingFullTimerEnd - _listingFullTimer;
-    bool resetTimer = elapsedTime.count() > 3600;  // 1h
+    bool resetTimer = elapsedTime.count() > 3600; // 1h
     if (_listingFullCounter > 60) {
         // If there is more then 1 listing/full request per minute for an hour -> send a sentry
         SentryHandler::instance()->captureMessage(SentryLevel::Warning, "RemoteFileSystemObserverWorker::generateInitialSnapshot",
-                                                   "Too many listing/full requests, sync is looping");
+                                                  "Too many listing/full requests, sync is looping");
         resetTimer = true;
     }
 
@@ -756,4 +763,4 @@ void RemoteFileSystemObserverWorker::countListingRequests() {
     _listingFullCounter++;
 }
 
-}  // namespace KDC
+} // namespace KDC

--- a/src/libsyncengine/update_detection/file_system_observer/remotefilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/remotefilesystemobserverworker.cpp
@@ -500,8 +500,8 @@ ExitCode RemoteFileSystemObserverWorker::processActions(Poco::JSON::Array::Ptr a
 
 #ifdef _WIN32
         SyncName newName;
-        if (PlatformInconsistencyCheckerUtility::instance()->fixNameWithBackslash(usedName, newName)) {
-            usedName = newName;
+        if (PlatformInconsistencyCheckerUtility::instance()->fixNameWithBackslash(actionInfo.snapshotItem.name(), newName)) {
+            actionInfo.snapshotItem.setName(newName);
         }
 #endif
 

--- a/src/libsyncengine/update_detection/file_system_observer/remotefilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/remotefilesystemobserverworker.cpp
@@ -589,10 +589,6 @@ ExitCode RemoteFileSystemObserverWorker::extractActionInfo(const Poco::JSON::Obj
 }
 
 ExitCode RemoteFileSystemObserverWorker::processAction(ActionInfo &actionInfo, std::set<NodeId, std::less<>> &movedItems) {
-    // SnapshotItem item(actionInfo.snapshotItem.id(), actionInfo.parentNodeId, usedName, actionInfo.createdAt,
-    // actionInfo.modtime,
-    //                   actionInfo.type, actionInfo.size, actionInfo.isLink, actionInfo.canWrite, true);
-
     // Process action
     switch (actionInfo.actionCode) {
         // Item added

--- a/src/libsyncengine/update_detection/file_system_observer/remotefilesystemobserverworker.h
+++ b/src/libsyncengine/update_detection/file_system_observer/remotefilesystemobserverworker.h
@@ -41,27 +41,18 @@ class RemoteFileSystemObserverWorker : public FileSystemObserverWorker {
 
         ExitCode initWithCursor();
         ExitCode exploreDirectory(const NodeId &nodeId);
-        ExitCode getItemsInDir(const NodeId &dirId, const bool saveCursor);
+        ExitCode getItemsInDir(const NodeId &dirId, bool saveCursor);
 
         ExitCode sendLongPoll(bool &changes);
 
         struct ActionInfo {
                 ActionCode actionCode{ActionCode::actionCodeUnknown};
-                NodeId nodeId;
-                NodeId parentNodeId;
-                SyncName name;
+                SnapshotItem snapshotItem;
                 SyncName path;
-                SyncName destName;
-                SyncTime createdAt{0};
-                SyncTime modtime{0};
-                NodeType type{NodeType::Unknown};
-                int64_t size{0};
-                bool canWrite{true};
-                bool isLink{false};
         };
         ExitCode processActions(Poco::JSON::Array::Ptr filesArray);
-        ExitCode extractActionInfo(const Poco::JSON::Object::Ptr actionObj, ActionInfo &actionInfo);
-        ExitCode processAction(const SyncName &usedName, const ActionInfo &actionInfo, std::set<NodeId, std::less<>> &movedItems);
+        ExitCode extractActionInfo(Poco::JSON::Object::Ptr actionObj, ActionInfo &actionInfo);
+        ExitCode processAction(ActionInfo &actionInfo, std::set<NodeId, std::less<>> &movedItems);
 
         ExitCode checkRightsAndUpdateItem(const NodeId &nodeId, bool &hasRights, SnapshotItem &snapshotItem);
 

--- a/src/libsyncengine/update_detection/file_system_observer/remotefilesystemobserverworker.h
+++ b/src/libsyncengine/update_detection/file_system_observer/remotefilesystemobserverworker.h
@@ -57,6 +57,7 @@ class RemoteFileSystemObserverWorker : public FileSystemObserverWorker {
                 NodeType type{NodeType::Unknown};
                 int64_t size{0};
                 bool canWrite{true};
+                bool isLink{false};
         };
         ExitCode processActions(Poco::JSON::Array::Ptr filesArray);
         ExitCode extractActionInfo(const Poco::JSON::Object::Ptr actionObj, ActionInfo &actionInfo);
@@ -77,4 +78,4 @@ class RemoteFileSystemObserverWorker : public FileSystemObserverWorker {
         friend class TestRemoteFileSystemObserverWorker;
 };
 
-}  // namespace KDC
+} // namespace KDC

--- a/src/libsyncengine/update_detection/file_system_observer/snapshot/snapshot.h
+++ b/src/libsyncengine/update_detection/file_system_observer/snapshot/snapshot.h
@@ -39,7 +39,7 @@ class Snapshot : public SharedObject {
 
         void init();
 
-        bool updateItem(const SnapshotItem &item);
+        bool updateItem(const SnapshotItem &newItem);
         bool removeItem(const NodeId &id);
 
         NodeId itemId(const SyncPath &path) const;
@@ -88,9 +88,9 @@ class Snapshot : public SharedObject {
 
         ReplicaSide _side = ReplicaSide::Unknown;
         NodeId _rootFolderId;
-        std::unordered_map<NodeId, SnapshotItem> _items;  // key: id
+        std::unordered_map<NodeId, SnapshotItem> _items; // key: id
         bool _isValid = false;
         mutable std::recursive_mutex _mutex;
 };
 
-}  // namespace KDC
+} // namespace KDC

--- a/src/libsyncengine/update_detection/file_system_observer/snapshot/snapshotitem.h
+++ b/src/libsyncengine/update_detection/file_system_observer/snapshot/snapshotitem.h
@@ -29,35 +29,35 @@ namespace KDC {
 class SnapshotItem {
     public:
         SnapshotItem();
-        SnapshotItem(const NodeId &id);
+        explicit SnapshotItem(const NodeId &id);
         SnapshotItem(const NodeId &id, const NodeId &parentId, const SyncName &name, SyncTime createdAt, SyncTime lastModified,
                      NodeType type, int64_t size, bool isLink, bool canWrite, bool canShare);
         SnapshotItem(const SnapshotItem &other);
 
-        inline const NodeId &id() const { return _id; }
-        inline void setId(const NodeId &id) { _id = id; }
-        inline const NodeId &parentId() const { return _parentId; }
-        inline void setParentId(const NodeId &newParentId) { _parentId = newParentId; }
-        inline const std::unordered_set<NodeId> &childrenIds() const { return _childrenIds; }
-        inline void setChildrenIds(const std::unordered_set<NodeId> &newChildrenIds) { _childrenIds = newChildrenIds; }
-        inline const SyncName &name() const { return _name; }
-        inline void setName(const SyncName &newName) { _name = newName; }
-        inline SyncTime createdAt() const { return _createdAt; }
-        inline void setCreatedAt(SyncTime newCreatedAt) { _createdAt = newCreatedAt; }
-        inline SyncTime lastModified() const { return _lastModified; }
-        inline void setLastModified(SyncTime newLastModified) { _lastModified = newLastModified; }
-        inline NodeType type() const { return _type; }
-        inline void setType(NodeType type) { _type = type; }
-        inline int64_t size() const { return _size; }
-        inline void setSize(uint64_t newSize) { _size = newSize; }
-        inline bool isLink() const { return _isLink; }
-        inline void setIsLink(bool isLink) { _isLink = isLink; }
-        inline const std::string &contentChecksum() const { return _contentChecksum; }
-        inline void setContentChecksum(const std::string &newChecksum) { _contentChecksum = newChecksum; }
-        inline bool canWrite() const { return _canWrite; }
-        inline void setCanWrite(bool canWrite) { _canWrite = canWrite; }
-        inline bool canShare() const { return _canShare; }
-        inline void setCanShare(bool canShare) { _canShare = canShare; }
+        [[nodiscard]] const NodeId &id() const { return _id; }
+        void setId(const NodeId &id) { _id = id; }
+        [[nodiscard]] const NodeId &parentId() const { return _parentId; }
+        void setParentId(const NodeId &newParentId) { _parentId = newParentId; }
+        [[nodiscard]] const std::unordered_set<NodeId> &childrenIds() const { return _childrenIds; }
+        void setChildrenIds(const std::unordered_set<NodeId> &newChildrenIds) { _childrenIds = newChildrenIds; }
+        [[nodiscard]] const SyncName &name() const { return _name; }
+        void setName(const SyncName &newName) { _name = newName; }
+        [[nodiscard]] SyncTime createdAt() const { return _createdAt; }
+        void setCreatedAt(const SyncTime newCreatedAt) { _createdAt = newCreatedAt; }
+        [[nodiscard]] SyncTime lastModified() const { return _lastModified; }
+        void setLastModified(const SyncTime newLastModified) { _lastModified = newLastModified; }
+        [[nodiscard]] NodeType type() const { return _type; }
+        void setType(const NodeType type) { _type = type; }
+        [[nodiscard]] int64_t size() const { return _size; }
+        void setSize(const int64_t newSize) { _size = newSize; }
+        [[nodiscard]] bool isLink() const { return _isLink; }
+        void setIsLink(const bool isLink) { _isLink = isLink; }
+        [[nodiscard]] const std::string &contentChecksum() const { return _contentChecksum; }
+        void setContentChecksum(const std::string &newChecksum) { _contentChecksum = newChecksum; }
+        [[nodiscard]] bool canWrite() const { return _canWrite; }
+        void setCanWrite(const bool canWrite) { _canWrite = canWrite; }
+        [[nodiscard]] bool canShare() const { return _canShare; }
+        void setCanShare(bool canShare) { _canShare = canShare; }
         SnapshotItem &operator=(const SnapshotItem &other);
 
         void copyExceptChildren(const SnapshotItem &other);

--- a/src/libsyncengine/update_detection/file_system_observer/snapshot/snapshotitem.h
+++ b/src/libsyncengine/update_detection/file_system_observer/snapshot/snapshotitem.h
@@ -31,7 +31,7 @@ class SnapshotItem {
         SnapshotItem();
         SnapshotItem(const NodeId &id);
         SnapshotItem(const NodeId &id, const NodeId &parentId, const SyncName &name, SyncTime createdAt, SyncTime lastModified,
-                     NodeType type, int64_t size, bool isLink = false, bool canWrite = true, bool canShare = true);
+                     NodeType type, int64_t size, bool isLink, bool canWrite, bool canShare);
         SnapshotItem(const SnapshotItem &other);
 
         inline const NodeId &id() const { return _id; }
@@ -81,4 +81,4 @@ class SnapshotItem {
         std::unordered_set<NodeId> _childrenIds;
 };
 
-}  // namespace KDC
+} // namespace KDC

--- a/test/libsyncengine/jobs/network/testsnapshotitemhandler.cpp
+++ b/test/libsyncengine/jobs/network/testsnapshotitemhandler.cpp
@@ -51,7 +51,7 @@ Result compare(const SnapshotItem &lhs, const SnapshotItem &rhs) noexcept {
 
     return {};
 }
-}  // namespace snapshotitem_checker
+} // namespace snapshotitem_checker
 
 void TestSnapshotItemHandler::setUp() {}
 
@@ -85,7 +85,7 @@ void TestSnapshotItemHandler::testUpdateItem() {
         CPPUNIT_ASSERT(handler.updateSnapshotItem("124", SnapshotItemHandler::CsvIndexModtime, item));
         CPPUNIT_ASSERT_EQUAL(SyncTime(124), item.lastModified());
         CPPUNIT_ASSERT(handler.updateSnapshotItem("-1", SnapshotItemHandler::CsvIndexModtime,
-                                                  item));  // We can have negative values! (for dates before 1970)
+                                                  item)); // We can have negative values! (for dates before 1970)
         CPPUNIT_ASSERT_EQUAL(int64_t(-1), item.lastModified());
 
         CPPUNIT_ASSERT(handler.updateSnapshotItem("1", SnapshotItemHandler::CsvIndexCanWrite, item));
@@ -156,11 +156,11 @@ std::string toCsvString(const std::string &name) {
     bool encloseInDoubleQuotes = false;
     bool prevCharBackslash = false;
 
-    for (char c : name) {
+    for (char c: name) {
         if (c == '"') {
-            if (!prevCharBackslash) {  // If a double quote is preceded by a comma, do not insert a second double quote.
+            if (!prevCharBackslash) { // If a double quote is preceded by a comma, do not insert a second double quote.
                 encloseInDoubleQuotes = true;
-                ss << '"';  // Insert 2 double quotes instead of one
+                ss << '"'; // Insert 2 double quotes instead of one
             }
         }
 
@@ -239,7 +239,7 @@ void TestSnapshotItemHandler::testGetItem() {
         CPPUNIT_ASSERT(!error);
 
         const SnapshotItem expectedItem(NodeId("0"), NodeId("1"), Str2SyncName(std::string("kDrive2")), SyncTime(123),
-                                        SyncTime(124), NodeType::Directory, int64_t(1000), true, false);
+                                        SyncTime(124), NodeType::Directory, int64_t(1000), true, false, true);
 
         const auto result = snapshotitem_checker::compare(expectedItem, item);
         CPPUNIT_ASSERT_MESSAGE(result.message, result.success);
@@ -259,7 +259,7 @@ void TestSnapshotItemHandler::testGetItem() {
         CPPUNIT_ASSERT(!error);
 
         const SnapshotItem expectedItem(NodeId("0"), NodeId("1"), Str2SyncName(std::string(R"("kDrive2")")), SyncTime(123),
-                                        SyncTime(124), NodeType::Directory, int64_t(1000), true, false);
+                                        SyncTime(124), NodeType::Directory, int64_t(1000), true, false, true);
 
         const auto result = snapshotitem_checker::compare(expectedItem, item);
         CPPUNIT_ASSERT_MESSAGE(result.message, result.success);
@@ -294,7 +294,7 @@ void TestSnapshotItemHandler::testGetItem() {
         CPPUNIT_ASSERT(!error);
 
         const SnapshotItem expectedItem(NodeId("0"), NodeId("1"), Str2SyncName(std::string("kDrive\n2")), SyncTime(123),
-                                        SyncTime(124), NodeType::Directory, int64_t(1000), false, true);
+                                        SyncTime(124), NodeType::Directory, int64_t(1000), false, true, true);
 
         const auto result = snapshotitem_checker::compare(expectedItem, item);
         CPPUNIT_ASSERT_MESSAGE(result.message, result.success);
@@ -394,8 +394,8 @@ void TestSnapshotItemHandler::testGetItem() {
             CPPUNIT_ASSERT(!ignore);
             CPPUNIT_ASSERT(!error);
         }
-        CPPUNIT_ASSERT_EQUAL(2, counter);  // There should be 2 valid items
+        CPPUNIT_ASSERT_EQUAL(2, counter); // There should be 2 valid items
     }
 }
 
-}  // namespace KDC
+} // namespace KDC

--- a/test/libsyncengine/propagation/operation_sorter/testoperationsorterworker.cpp
+++ b/test/libsyncengine/propagation/operation_sorter/testoperationsorterworker.cpp
@@ -84,7 +84,7 @@ void TestOperationSorterWorker::testMoveFirstAfterSecond() {
     int opFirstId;
     int opSecondId;
     int i = 1;
-    for (const auto &opId : _syncPal->_syncOps->opSortedList()) {
+    for (const auto &opId: _syncPal->_syncOps->opSortedList()) {
         SyncOpPtr op = _syncPal->_syncOps->getOp(opId);
         if (op == op2) {
             opFirstId = i;
@@ -99,7 +99,7 @@ void TestOperationSorterWorker::testMoveFirstAfterSecond() {
     // nothing moved bc op5 is at 5 and op2 at 4
     _syncPal->_operationsSorterWorker->moveFirstAfterSecond(op5, op2);
     i = 1;
-    for (const auto &opId : _syncPal->_syncOps->opSortedList()) {
+    for (const auto &opId: _syncPal->_syncOps->opSortedList()) {
         SyncOpPtr op = _syncPal->_syncOps->getOp(opId);
         if (op == op5) {
             opFirstId = i;
@@ -114,7 +114,7 @@ void TestOperationSorterWorker::testMoveFirstAfterSecond() {
     // op4 is moved at 5 and op5 at 4
     _syncPal->_operationsSorterWorker->moveFirstAfterSecond(op4, op5);
     i = 1;
-    for (const auto &opId : _syncPal->_syncOps->opSortedList()) {
+    for (const auto &opId: _syncPal->_syncOps->opSortedList()) {
         SyncOpPtr op = _syncPal->_syncOps->getOp(opId);
         if (op == op4) {
             opFirstId = i;
@@ -169,9 +169,10 @@ void TestOperationSorterWorker::testFixDeleteBeforeMove() {
     SyncTime lastmodified = 1654788079;
     int64_t size = 12345;
 
-    std::shared_ptr<Node> rootNode(new Node(
-        _syncPal->syncDb()->rootNode().nodeId(), _syncPal->updateTree(ReplicaSide::Local)->side(), Str(""), NodeType::Directory,
-        OperationType::None, _syncPal->syncDb()->rootNode().nodeIdLocal(), createdAt, lastmodified, size, nullptr));
+    std::shared_ptr<Node> rootNode(new Node(_syncPal->syncDb()->rootNode().nodeId(),
+                                            _syncPal->updateTree(ReplicaSide::Local)->side(), Str(""), NodeType::Directory,
+                                            OperationType::None, _syncPal->syncDb()->rootNode().nodeIdLocal(), createdAt,
+                                            lastmodified, size, nullptr));
     std::shared_ptr<Node> node1(new Node(dbNodeIdDir1, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("Dir 1"),
                                          NodeType::Directory, OperationType::None, "d1", createdAt, lastmodified, size,
                                          rootNode));
@@ -191,9 +192,10 @@ void TestOperationSorterWorker::testFixDeleteBeforeMove() {
                                          NodeType::Directory, OperationType::None, "4", createdAt, lastmodified, size, rootNode));
     std::shared_ptr<Node> node5(new Node(dbnodeIdDir5, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("Dir 5"),
                                          NodeType::Directory, OperationType::None, "5", createdAt, lastmodified, size, rootNode));
-    std::shared_ptr<Node> rrootNode(new Node(
-        _syncPal->syncDb()->rootNode().nodeId(), _syncPal->updateTree(ReplicaSide::Remote)->side(), Str(""), NodeType::Directory,
-        OperationType::None, _syncPal->syncDb()->rootNode().nodeIdRemote(), createdAt, lastmodified, size, nullptr));
+    std::shared_ptr<Node> rrootNode(new Node(_syncPal->syncDb()->rootNode().nodeId(),
+                                             _syncPal->updateTree(ReplicaSide::Remote)->side(), Str(""), NodeType::Directory,
+                                             OperationType::None, _syncPal->syncDb()->rootNode().nodeIdRemote(), createdAt,
+                                             lastmodified, size, nullptr));
     std::shared_ptr<Node> rNode1(new Node(dbNodeIdDir1, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("Dir 1"),
                                           NodeType::Directory, OperationType::None, "r1", createdAt, lastmodified, size,
                                           rrootNode));
@@ -312,8 +314,8 @@ void TestOperationSorterWorker::testFixMoveBeforeCreate() {
     std::shared_ptr<Node> node5(new Node(dbnodeIdDir5, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("Dir 5"),
                                          NodeType::Directory, OperationType::None, "5", createdAt, lastmodified, size, rootNode));
     std::shared_ptr<Node> rrootNode(
-        new Node(_syncPal->_syncDb->rootNode().nodeId(), _syncPal->_remoteUpdateTree->side(), Str(""), NodeType::Directory,
-                 OperationType::None, _syncPal->_syncDb->rootNode().nodeIdRemote(), createdAt, lastmodified, size, nullptr));
+            new Node(_syncPal->_syncDb->rootNode().nodeId(), _syncPal->_remoteUpdateTree->side(), Str(""), NodeType::Directory,
+                     OperationType::None, _syncPal->_syncDb->rootNode().nodeIdRemote(), createdAt, lastmodified, size, nullptr));
     std::shared_ptr<Node> rNode1(new Node(dbNodeIdDir1, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("Dir 1"),
                                           NodeType::Directory, OperationType::None, "r1", createdAt, lastmodified, size,
                                           rrootNode));
@@ -414,9 +416,10 @@ void TestOperationSorterWorker::testFixMoveBeforeDelete() {
     SyncTime lastmodified = 1654788079;
     int64_t size = 12345;
 
-    std::shared_ptr<Node> rootNode(new Node(
-        _syncPal->syncDb()->rootNode().nodeId(), _syncPal->updateTree(ReplicaSide::Local)->side(), Str(""), NodeType::Directory,
-        OperationType::None, _syncPal->syncDb()->rootNode().nodeIdLocal(), createdAt, lastmodified, size, nullptr));
+    std::shared_ptr<Node> rootNode(new Node(_syncPal->syncDb()->rootNode().nodeId(),
+                                            _syncPal->updateTree(ReplicaSide::Local)->side(), Str(""), NodeType::Directory,
+                                            OperationType::None, _syncPal->syncDb()->rootNode().nodeIdLocal(), createdAt,
+                                            lastmodified, size, nullptr));
     std::shared_ptr<Node> node1(new Node(dbNodeIdDir1, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("Dir 1"),
                                          NodeType::Directory, OperationType::None, "d1", createdAt, lastmodified, size,
                                          rootNode));
@@ -436,9 +439,10 @@ void TestOperationSorterWorker::testFixMoveBeforeDelete() {
                                          NodeType::Directory, OperationType::None, "4", createdAt, lastmodified, size, rootNode));
     std::shared_ptr<Node> node5(new Node(dbnodeIdDir5, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("Dir 5"),
                                          NodeType::Directory, OperationType::None, "5", createdAt, lastmodified, size, rootNode));
-    std::shared_ptr<Node> rrootNode(new Node(
-        _syncPal->syncDb()->rootNode().nodeId(), _syncPal->updateTree(ReplicaSide::Remote)->side(), Str(""), NodeType::Directory,
-        OperationType::None, _syncPal->syncDb()->rootNode().nodeIdRemote(), createdAt, lastmodified, size, nullptr));
+    std::shared_ptr<Node> rrootNode(new Node(_syncPal->syncDb()->rootNode().nodeId(),
+                                             _syncPal->updateTree(ReplicaSide::Remote)->side(), Str(""), NodeType::Directory,
+                                             OperationType::None, _syncPal->syncDb()->rootNode().nodeIdRemote(), createdAt,
+                                             lastmodified, size, nullptr));
     std::shared_ptr<Node> rNode1(new Node(dbNodeIdDir1, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("Dir 1"),
                                           NodeType::Directory, OperationType::None, "r1", createdAt, lastmodified, size,
                                           rrootNode));
@@ -537,8 +541,8 @@ void TestOperationSorterWorker::testFixCreateBeforeMove() {
     int64_t size = 12345;
 
     std::shared_ptr<Node> rootNode(
-        new Node(_syncPal->_syncDb->rootNode().nodeId(), _syncPal->_localUpdateTree->side(), Str(""), NodeType::Directory,
-                 OperationType::None, _syncPal->syncDb()->rootNode().nodeIdLocal(), createdAt, lastmodified, size, nullptr));
+            new Node(_syncPal->_syncDb->rootNode().nodeId(), _syncPal->_localUpdateTree->side(), Str(""), NodeType::Directory,
+                     OperationType::None, _syncPal->syncDb()->rootNode().nodeIdLocal(), createdAt, lastmodified, size, nullptr));
     std::shared_ptr<Node> node1(new Node(dbNodeIdDir1, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("Dir 1"),
                                          NodeType::Directory, OperationType::None, "d1", createdAt, lastmodified, size,
                                          rootNode));
@@ -559,8 +563,8 @@ void TestOperationSorterWorker::testFixCreateBeforeMove() {
     std::shared_ptr<Node> node5(new Node(dbnodeIdDir5, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("Dir 5"),
                                          NodeType::Directory, OperationType::None, "5", createdAt, lastmodified, size, rootNode));
     std::shared_ptr<Node> rrootNode(
-        new Node(_syncPal->_syncDb->rootNode().nodeId(), _syncPal->_remoteUpdateTree->side(), Str(""), NodeType::Directory,
-                 OperationType::None, _syncPal->syncDb()->rootNode().nodeIdRemote(), createdAt, lastmodified, size, nullptr));
+            new Node(_syncPal->_syncDb->rootNode().nodeId(), _syncPal->_remoteUpdateTree->side(), Str(""), NodeType::Directory,
+                     OperationType::None, _syncPal->syncDb()->rootNode().nodeIdRemote(), createdAt, lastmodified, size, nullptr));
     std::shared_ptr<Node> rNode1(new Node(dbNodeIdDir1, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("Dir 1"),
                                           NodeType::Directory, OperationType::None, "r1", createdAt, lastmodified, size,
                                           rrootNode));
@@ -633,15 +637,16 @@ void TestOperationSorterWorker::testFixCreateBeforeMoveBis() {
     SyncTime lastmodified = 1654788079;
     int64_t size = 12345;
 
-    std::shared_ptr<Node> rootNode(new Node(
-        _syncPal->_syncDb->rootNode().nodeId(), _syncPal->updateTree(ReplicaSide::Local)->side(), Str(""), NodeType::Directory,
-        OperationType::None, _syncPal->syncDb()->rootNode().nodeIdLocal(), createdAt, lastmodified, size, nullptr));
+    std::shared_ptr<Node> rootNode(new Node(_syncPal->_syncDb->rootNode().nodeId(),
+                                            _syncPal->updateTree(ReplicaSide::Local)->side(), Str(""), NodeType::Directory,
+                                            OperationType::None, _syncPal->syncDb()->rootNode().nodeIdLocal(), createdAt,
+                                            lastmodified, size, nullptr));
     std::shared_ptr<Node> nodeA(new Node(dbNodeIdDirA, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("Dir A"),
                                          NodeType::Directory, OperationType::Move, "dA", createdAt, lastmodified, size,
                                          rootNode));
     std::shared_ptr<Node> rrootNode(
-        new Node(_syncPal->_syncDb->rootNode().nodeId(), _syncPal->_remoteUpdateTree->side(), Str(""), NodeType::Directory,
-                 OperationType::None, _syncPal->syncDb()->rootNode().nodeIdRemote(), createdAt, lastmodified, size, nullptr));
+            new Node(_syncPal->_syncDb->rootNode().nodeId(), _syncPal->_remoteUpdateTree->side(), Str(""), NodeType::Directory,
+                     OperationType::None, _syncPal->syncDb()->rootNode().nodeIdRemote(), createdAt, lastmodified, size, nullptr));
     std::shared_ptr<Node> rNodeA(new Node(dbNodeIdDirA, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("Dir A"),
                                           NodeType::Directory, OperationType::None, "rdA", createdAt, lastmodified, size,
                                           rrootNode));
@@ -711,9 +716,10 @@ void TestOperationSorterWorker::testFixDeleteBeforeCreate() {
     SyncTime lastmodified = 1654788079;
     int64_t size = 12345;
 
-    std::shared_ptr<Node> rootNode(new Node(
-        _syncPal->_syncDb->rootNode().nodeId(), _syncPal->updateTree(ReplicaSide::Local)->side(), Str(""), NodeType::Directory,
-        OperationType::None, _syncPal->syncDb()->rootNode().nodeIdLocal(), createdAt, lastmodified, size, nullptr));
+    std::shared_ptr<Node> rootNode(new Node(_syncPal->_syncDb->rootNode().nodeId(),
+                                            _syncPal->updateTree(ReplicaSide::Local)->side(), Str(""), NodeType::Directory,
+                                            OperationType::None, _syncPal->syncDb()->rootNode().nodeIdLocal(), createdAt,
+                                            lastmodified, size, nullptr));
     std::shared_ptr<Node> node1(new Node(dbNodeIdDir1, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("Dir 1"),
                                          NodeType::Directory, OperationType::None, "d1", createdAt, lastmodified, size,
                                          rootNode));
@@ -730,8 +736,8 @@ void TestOperationSorterWorker::testFixDeleteBeforeCreate() {
     std::shared_ptr<Node> node3(new Node(dbNodeIdDir3, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("Dir 3"),
                                          NodeType::Directory, OperationType::None, "3", createdAt, lastmodified, size, rootNode));
     std::shared_ptr<Node> rrootNode(
-        new Node(_syncPal->_syncDb->rootNode().nodeId(), _syncPal->_remoteUpdateTree->side(), Str(""), NodeType::Directory,
-                 OperationType::None, _syncPal->syncDb()->rootNode().nodeIdRemote(), createdAt, lastmodified, size, nullptr));
+            new Node(_syncPal->_syncDb->rootNode().nodeId(), _syncPal->_remoteUpdateTree->side(), Str(""), NodeType::Directory,
+                     OperationType::None, _syncPal->syncDb()->rootNode().nodeIdRemote(), createdAt, lastmodified, size, nullptr));
     std::shared_ptr<Node> rNode1(new Node(dbNodeIdDir1, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("Dir 1"),
                                           NodeType::Directory, OperationType::None, "r1", createdAt, lastmodified, size,
                                           rrootNode));
@@ -752,30 +758,30 @@ void TestOperationSorterWorker::testFixDeleteBeforeCreate() {
                                           rrootNode));
 
     _syncPal->_localSnapshot->updateItem(SnapshotItem("d1", _syncPal->syncDb()->rootNode().nodeIdLocal().value(), Str("Dir 1"),
-                                                      createdAt, lastmodified, NodeType::Directory, size));
+                                                      createdAt, lastmodified, NodeType::Directory, size, false, true, true));
     _syncPal->_localSnapshot->updateItem(
-        SnapshotItem("11", "d1", Str("Dir 1.1"), createdAt, lastmodified, NodeType::Directory, size));
+            SnapshotItem("11", "d1", Str("Dir 1.1"), createdAt, lastmodified, NodeType::Directory, size, false, true, true));
     _syncPal->_localSnapshot->updateItem(
-        SnapshotItem("111", "11", Str("Dir 1.1.1"), createdAt, lastmodified, NodeType::Directory, size));
-    _syncPal->_localSnapshot->updateItem(
-        SnapshotItem("1111c", "111", Str("File 1.1.1.1"), createdAt, lastmodified, NodeType::Directory, size));
+            SnapshotItem("111", "11", Str("Dir 1.1.1"), createdAt, lastmodified, NodeType::Directory, size, false, true, true));
+    _syncPal->_localSnapshot->updateItem(SnapshotItem("1111c", "111", Str("File 1.1.1.1"), createdAt, lastmodified,
+                                                      NodeType::Directory, size, false, true, true));
     _syncPal->_localSnapshot->updateItem(SnapshotItem("2", _syncPal->syncDb()->rootNode().nodeIdLocal().value(), Str("Dir 2"),
-                                                      createdAt, lastmodified, NodeType::Directory, size));
+                                                      createdAt, lastmodified, NodeType::Directory, size, false, true, true));
     _syncPal->_localSnapshot->updateItem(SnapshotItem("3", _syncPal->syncDb()->rootNode().nodeIdLocal().value(), Str("Dir 3"),
-                                                      createdAt, lastmodified, NodeType::Directory, size));
+                                                      createdAt, lastmodified, NodeType::Directory, size, false, true, true));
 
     _syncPal->_remoteSnapshot->updateItem(SnapshotItem("r1", _syncPal->syncDb()->rootNode().nodeIdRemote().value(), Str("Dir 1"),
-                                                       createdAt, lastmodified, NodeType::Directory, size));
+                                                       createdAt, lastmodified, NodeType::Directory, size, false, true, true));
     _syncPal->_remoteSnapshot->updateItem(
-        SnapshotItem("r11", "r1", Str("Dir 1.1"), createdAt, lastmodified, NodeType::Directory, size));
+            SnapshotItem("r11", "r1", Str("Dir 1.1"), createdAt, lastmodified, NodeType::Directory, size, false, true, true));
     _syncPal->_remoteSnapshot->updateItem(
-        SnapshotItem("r111", "r11", Str("Dir 1.1.1"), createdAt, lastmodified, NodeType::Directory, size));
-    _syncPal->_remoteSnapshot->updateItem(
-        SnapshotItem("r1111", "r111", Str("File 1.1.1.1"), createdAt, lastmodified, NodeType::Directory, size));
+            SnapshotItem("r111", "r11", Str("Dir 1.1.1"), createdAt, lastmodified, NodeType::Directory, size, false, true, true));
+    _syncPal->_remoteSnapshot->updateItem(SnapshotItem("r1111", "r111", Str("File 1.1.1.1"), createdAt, lastmodified,
+                                                       NodeType::Directory, size, false, true, true));
     _syncPal->_remoteSnapshot->updateItem(SnapshotItem("r2", _syncPal->syncDb()->rootNode().nodeIdRemote().value(), Str("Dir 2"),
-                                                       createdAt, lastmodified, NodeType::Directory, size));
+                                                       createdAt, lastmodified, NodeType::Directory, size, false, true, true));
     _syncPal->_remoteSnapshot->updateItem(SnapshotItem("r3", _syncPal->syncDb()->rootNode().nodeIdRemote().value(), Str("Dir 3"),
-                                                       createdAt, lastmodified, NodeType::Directory, size));
+                                                       createdAt, lastmodified, NodeType::Directory, size, false, true, true));
 
     std::shared_ptr<Node> node1111C(new Node(std::nullopt, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("File 1.1.1.1"),
                                              NodeType::File, OperationType::Create, "1111c", createdAt, lastmodified, size,
@@ -846,9 +852,10 @@ void TestOperationSorterWorker::testFixMoveBeforeMoveOccupied() {
                                          NodeType::Directory, OperationType::None, "2", createdAt, lastmodified, size, rootNode));
     std::shared_ptr<Node> node3(new Node(dbNodeIdDir3, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("Dir 3"),
                                          NodeType::Directory, OperationType::None, "3", createdAt, lastmodified, size, rootNode));
-    std::shared_ptr<Node> rrootNode(new Node(
-        _syncPal->_syncDb->rootNode().nodeId(), _syncPal->updateTree(ReplicaSide::Remote)->side(), Str(""), NodeType::Directory,
-        OperationType::None, _syncPal->syncDb()->rootNode().nodeIdRemote(), createdAt, lastmodified, size, nullptr));
+    std::shared_ptr<Node> rrootNode(new Node(_syncPal->_syncDb->rootNode().nodeId(),
+                                             _syncPal->updateTree(ReplicaSide::Remote)->side(), Str(""), NodeType::Directory,
+                                             OperationType::None, _syncPal->syncDb()->rootNode().nodeIdRemote(), createdAt,
+                                             lastmodified, size, nullptr));
     std::shared_ptr<Node> rNode1(new Node(dbNodeIdDir1, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("Dir 1"),
                                           NodeType::Directory, OperationType::None, "r1", createdAt, lastmodified, size,
                                           rrootNode));
@@ -952,9 +959,10 @@ void TestOperationSorterWorker::testFixCreateBeforeCreate() {
     SyncTime createdAt = 1654788079;
     SyncTime lastmodified = 1654788079;
     int64_t size = 12345;
-    std::shared_ptr<Node> rootNode(new Node(
-        _syncPal->_syncDb->rootNode().nodeId(), _syncPal->updateTree(ReplicaSide::Local)->side(), Str(""), NodeType::Directory,
-        OperationType::None, _syncPal->syncDb()->rootNode().nodeIdLocal(), createdAt, lastmodified, size, nullptr));
+    std::shared_ptr<Node> rootNode(new Node(_syncPal->_syncDb->rootNode().nodeId(),
+                                            _syncPal->updateTree(ReplicaSide::Local)->side(), Str(""), NodeType::Directory,
+                                            OperationType::None, _syncPal->syncDb()->rootNode().nodeIdLocal(), createdAt,
+                                            lastmodified, size, nullptr));
     std::shared_ptr<Node> nodeA(new Node(dbNodeIdDirA, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("A"),
                                          NodeType::Directory, OperationType::Create, "a", createdAt, lastmodified, size,
                                          rootNode));
@@ -1014,7 +1022,7 @@ void TestOperationSorterWorker::testFixCreateBeforeCreate() {
         _syncPal->_operationsSorterWorker->_unsortedList = *_syncPal->_syncOps;
         // Expected order: A AA AAA AAB AB B
         Console << Str("Initial ops order : ");
-        for (const auto &opId : _syncPal->_syncOps->_opSortedList) {
+        for (const auto &opId: _syncPal->_syncOps->_opSortedList) {
             SyncOpPtr op = _syncPal->_syncOps->_allOps[opId];
             Console << op->affectedNode()->name().c_str() << Str(" ");
         }
@@ -1025,7 +1033,7 @@ void TestOperationSorterWorker::testFixCreateBeforeCreate() {
         _syncPal->_operationsSorterWorker->fixCreateBeforeCreate();
 
         Console << Str("Final ops order : ");
-        for (const auto &opId : _syncPal->_syncOps->_opSortedList) {
+        for (const auto &opId: _syncPal->_syncOps->_opSortedList) {
             SyncOpPtr op = _syncPal->_syncOps->_allOps[opId];
             Console << op->affectedNode()->name().c_str() << Str(" ");
         }
@@ -1050,7 +1058,7 @@ void TestOperationSorterWorker::testFixCreateBeforeCreate() {
         _syncPal->_operationsSorterWorker->_unsortedList = *_syncPal->_syncOps;
         // Expected order: A AB AA AAB AAA B
         Console << Str("Initial ops order : ");
-        for (const auto &opId : _syncPal->_syncOps->_opSortedList) {
+        for (const auto &opId: _syncPal->_syncOps->_opSortedList) {
             SyncOpPtr op = _syncPal->_syncOps->_allOps[opId];
             Console << op->affectedNode()->name().c_str() << Str(" ");
         }
@@ -1060,7 +1068,7 @@ void TestOperationSorterWorker::testFixCreateBeforeCreate() {
         _syncPal->_operationsSorterWorker->fixCreateBeforeCreate();
 
         Console << Str("Final ops order : ");
-        for (const auto &opId : _syncPal->_syncOps->_opSortedList) {
+        for (const auto &opId: _syncPal->_syncOps->_opSortedList) {
             SyncOpPtr op = _syncPal->_syncOps->_allOps[opId];
             Console << op->affectedNode()->name().c_str() << Str(" ");
         }
@@ -1085,7 +1093,7 @@ void TestOperationSorterWorker::testFixCreateBeforeCreate() {
         _syncPal->_operationsSorterWorker->_unsortedList = *_syncPal->_syncOps;
         // Expected order: B A AB AA AAB AAA
         Console << Str("Initial ops order : ");
-        for (const auto &opId : _syncPal->_syncOps->_opSortedList) {
+        for (const auto &opId: _syncPal->_syncOps->_opSortedList) {
             SyncOpPtr op = _syncPal->_syncOps->_allOps[opId];
             Console << op->affectedNode()->name().c_str() << Str(" ");
         }
@@ -1095,7 +1103,7 @@ void TestOperationSorterWorker::testFixCreateBeforeCreate() {
         _syncPal->_operationsSorterWorker->fixCreateBeforeCreate();
 
         Console << Str("Final ops order : ");
-        for (const auto &opId : _syncPal->_syncOps->_opSortedList) {
+        for (const auto &opId: _syncPal->_syncOps->_opSortedList) {
             SyncOpPtr op = _syncPal->_syncOps->_allOps[opId];
             Console << op->affectedNode()->name().c_str() << Str(" ");
         }
@@ -1134,9 +1142,10 @@ void TestOperationSorterWorker::testFixMoveBeforeMoveParentChildFilp() {
     SyncTime lastmodified = 1654788079;
     int64_t size = 12345;
 
-    std::shared_ptr<Node> rootNode(new Node(
-        _syncPal->_syncDb->rootNode().nodeId(), _syncPal->updateTree(ReplicaSide::Local)->side(), Str(""), NodeType::Directory,
-        OperationType::None, _syncPal->syncDb()->rootNode().nodeIdLocal(), createdAt, lastmodified, size, nullptr));
+    std::shared_ptr<Node> rootNode(new Node(_syncPal->_syncDb->rootNode().nodeId(),
+                                            _syncPal->updateTree(ReplicaSide::Local)->side(), Str(""), NodeType::Directory,
+                                            OperationType::None, _syncPal->syncDb()->rootNode().nodeIdLocal(), createdAt,
+                                            lastmodified, size, nullptr));
     std::shared_ptr<Node> node1(new Node(dbNodeIdDir1, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("Dir 1"),
                                          NodeType::Directory, OperationType::Create, "d1", createdAt, lastmodified, size,
                                          rootNode));
@@ -1147,9 +1156,10 @@ void TestOperationSorterWorker::testFixMoveBeforeMoveParentChildFilp() {
                                          NodeType::Directory, OperationType::None, "2", createdAt, lastmodified, size, rootNode));
     std::shared_ptr<Node> node3(new Node(dbNodeIdDir3, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("Dir 3"),
                                          NodeType::Directory, OperationType::None, "3", createdAt, lastmodified, size, rootNode));
-    std::shared_ptr<Node> rrootNode(new Node(
-        _syncPal->_syncDb->rootNode().nodeId(), _syncPal->updateTree(ReplicaSide::Remote)->side(), Str(""), NodeType::Directory,
-        OperationType::None, _syncPal->syncDb()->rootNode().nodeIdRemote(), createdAt, lastmodified, size, nullptr));
+    std::shared_ptr<Node> rrootNode(new Node(_syncPal->_syncDb->rootNode().nodeId(),
+                                             _syncPal->updateTree(ReplicaSide::Remote)->side(), Str(""), NodeType::Directory,
+                                             OperationType::None, _syncPal->syncDb()->rootNode().nodeIdRemote(), createdAt,
+                                             lastmodified, size, nullptr));
     std::shared_ptr<Node> rNode1(new Node(dbNodeIdDir1, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("Dir 1"),
                                           NodeType::Directory, OperationType::None, "r1", createdAt, lastmodified, size,
                                           rrootNode));
@@ -1519,4 +1529,4 @@ void TestOperationSorterWorker::testBreakCycleEx2() {
 }
 
 
-}  // namespace KDC
+} // namespace KDC

--- a/test/libsyncengine/reconciliation/conflict_finder/testconflictfinderworker.cpp
+++ b/test/libsyncengine/reconciliation/conflict_finder/testconflictfinderworker.cpp
@@ -36,7 +36,7 @@ void TestConflictFinderWorker::setUp() {
     _syncPal->syncDb()->setAutoDelete(true);
 
     _syncPal->_conflictFinderWorker =
-        std::shared_ptr<ConflictFinderWorker>(new ConflictFinderWorker(_syncPal, "Conflict Finder", "COFD"));
+            std::shared_ptr<ConflictFinderWorker>(new ConflictFinderWorker(_syncPal, "Conflict Finder", "COFD"));
 
     _syncPal->updateTree(ReplicaSide::Local)->init();
     _syncPal->updateTree(ReplicaSide::Remote)->init();
@@ -123,85 +123,85 @@ void TestConflictFinderWorker::setUpTreesAndDb() {
     SyncTime createdAt = 1654788079;
     SyncTime lastmodified = 1654788079;
     int64_t size = 12345;
-    std::shared_ptr<Node> nodeA = std::shared_ptr<Node>(
-        new Node(dbNodeIdDirA, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("A"), NodeType::Directory,
-                 OperationType::None, "A", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Local)->rootNode()));
-    std::shared_ptr<Node> nodeB = std::shared_ptr<Node>(
-        new Node(dbNodeIdDirB, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("B"), NodeType::Directory,
-                 OperationType::None, "B", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Local)->rootNode()));
-    std::shared_ptr<Node> node1 = std::shared_ptr<Node>(
-        new Node(dbNodeIdDir1, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("Dir 1"), NodeType::Directory,
-                 OperationType::None, "1", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Local)->rootNode()));
-    std::shared_ptr<Node> node2 = std::shared_ptr<Node>(
-        new Node(dbNodeIdDir2, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("Dir 2"), NodeType::Directory,
-                 OperationType::None, "2", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Local)->rootNode()));
-    std::shared_ptr<Node> node3 = std::shared_ptr<Node>(
-        new Node(dbNodeIdDir3, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("Dir 3"), NodeType::Directory,
-                 OperationType::None, "3", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Local)->rootNode()));
-    std::shared_ptr<Node> node4 = std::shared_ptr<Node>(
-        new Node(dbnodeIdDir4, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("Dir 4"), NodeType::Directory,
-                 OperationType::None, "4", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Local)->rootNode()));
+    std::shared_ptr<Node> nodeA = std::shared_ptr<Node>(new Node(
+            dbNodeIdDirA, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("A"), NodeType::Directory, OperationType::None,
+            "A", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Local)->rootNode()));
+    std::shared_ptr<Node> nodeB = std::shared_ptr<Node>(new Node(
+            dbNodeIdDirB, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("B"), NodeType::Directory, OperationType::None,
+            "B", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Local)->rootNode()));
+    std::shared_ptr<Node> node1 = std::shared_ptr<Node>(new Node(
+            dbNodeIdDir1, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("Dir 1"), NodeType::Directory,
+            OperationType::None, "1", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Local)->rootNode()));
+    std::shared_ptr<Node> node2 = std::shared_ptr<Node>(new Node(
+            dbNodeIdDir2, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("Dir 2"), NodeType::Directory,
+            OperationType::None, "2", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Local)->rootNode()));
+    std::shared_ptr<Node> node3 = std::shared_ptr<Node>(new Node(
+            dbNodeIdDir3, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("Dir 3"), NodeType::Directory,
+            OperationType::None, "3", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Local)->rootNode()));
+    std::shared_ptr<Node> node4 = std::shared_ptr<Node>(new Node(
+            dbnodeIdDir4, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("Dir 4"), NodeType::Directory,
+            OperationType::None, "4", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Local)->rootNode()));
     std::shared_ptr<Node> node11 =
-        std::shared_ptr<Node>(new Node(std::nullopt, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("Dir 1.1"),
-                                       NodeType::Directory, OperationType::None, "11", createdAt, lastmodified, size, node1));
-    std::shared_ptr<Node> node111 =
-        std::shared_ptr<Node>(new Node(dbNodeIdDir111, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("Dir 1.1.1"),
-                                       NodeType::Directory, OperationType::None, "111", createdAt, lastmodified, size, node11));
-    std::shared_ptr<Node> node1111 =
-        std::shared_ptr<Node>(new Node(dbNodeIdFile1111, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("File 1.1.1.1"),
-                                       NodeType::File, OperationType::None, "1111", createdAt, lastmodified, size, node111));
+            std::shared_ptr<Node>(new Node(std::nullopt, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("Dir 1.1"),
+                                           NodeType::Directory, OperationType::None, "11", createdAt, lastmodified, size, node1));
+    std::shared_ptr<Node> node111 = std::shared_ptr<Node>(
+            new Node(dbNodeIdDir111, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("Dir 1.1.1"), NodeType::Directory,
+                     OperationType::None, "111", createdAt, lastmodified, size, node11));
+    std::shared_ptr<Node> node1111 = std::shared_ptr<Node>(
+            new Node(dbNodeIdFile1111, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("File 1.1.1.1"), NodeType::File,
+                     OperationType::None, "1111", createdAt, lastmodified, size, node111));
     std::shared_ptr<Node> node31 =
-        std::shared_ptr<Node>(new Node(dbNodeIdDir31, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("Dir 3.1"),
-                                       NodeType::Directory, OperationType::None, "31", createdAt, lastmodified, size, node3));
+            std::shared_ptr<Node>(new Node(dbNodeIdDir31, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("Dir 3.1"),
+                                           NodeType::Directory, OperationType::None, "31", createdAt, lastmodified, size, node3));
     std::shared_ptr<Node> node41 =
-        std::shared_ptr<Node>(new Node(dbnodeIdDir41, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("Dir 4.1"),
-                                       NodeType::Directory, OperationType::None, "41", createdAt, lastmodified, size, node4));
-    std::shared_ptr<Node> node411 =
-        std::shared_ptr<Node>(new Node(dbnodeIdDir411, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("Dir 4.1.1"),
-                                       NodeType::Directory, OperationType::None, "411", createdAt, lastmodified, size, node41));
-    std::shared_ptr<Node> node4111 =
-        std::shared_ptr<Node>(new Node(dbnodeIdfile4111, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("File 4.1.1.1"),
-                                       NodeType::File, OperationType::None, "4111", createdAt, lastmodified, size, node411));
+            std::shared_ptr<Node>(new Node(dbnodeIdDir41, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("Dir 4.1"),
+                                           NodeType::Directory, OperationType::None, "41", createdAt, lastmodified, size, node4));
+    std::shared_ptr<Node> node411 = std::shared_ptr<Node>(
+            new Node(dbnodeIdDir411, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("Dir 4.1.1"), NodeType::Directory,
+                     OperationType::None, "411", createdAt, lastmodified, size, node41));
+    std::shared_ptr<Node> node4111 = std::shared_ptr<Node>(
+            new Node(dbnodeIdfile4111, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("File 4.1.1.1"), NodeType::File,
+                     OperationType::None, "4111", createdAt, lastmodified, size, node411));
 
     std::shared_ptr<Node> rNodeA = std::shared_ptr<Node>(new Node(
-        dbNodeIdDirA, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("A"), NodeType::Directory, OperationType::None, "rA",
-        createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Remote)->rootNode()));
+            dbNodeIdDirA, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("A"), NodeType::Directory, OperationType::None,
+            "rA", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Remote)->rootNode()));
     std::shared_ptr<Node> rNodeB = std::shared_ptr<Node>(new Node(
-        dbNodeIdDirB, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("B"), NodeType::Directory, OperationType::None, "rB",
-        createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Remote)->rootNode()));
+            dbNodeIdDirB, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("B"), NodeType::Directory, OperationType::None,
+            "rB", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Remote)->rootNode()));
     std::shared_ptr<Node> rNode1 = std::shared_ptr<Node>(new Node(
-        dbNodeIdDir1, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("Dir 1"), NodeType::Directory, OperationType::None,
-        "r1", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Remote)->rootNode()));
+            dbNodeIdDir1, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("Dir 1"), NodeType::Directory,
+            OperationType::None, "r1", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Remote)->rootNode()));
     std::shared_ptr<Node> rNode2 = std::shared_ptr<Node>(new Node(
-        dbNodeIdDir2, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("Dir 2"), NodeType::Directory, OperationType::None,
-        "r2", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Remote)->rootNode()));
+            dbNodeIdDir2, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("Dir 2"), NodeType::Directory,
+            OperationType::None, "r2", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Remote)->rootNode()));
     std::shared_ptr<Node> rNode3 = std::shared_ptr<Node>(new Node(
-        dbNodeIdDir3, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("Dir 3"), NodeType::Directory, OperationType::None,
-        "r3", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Remote)->rootNode()));
+            dbNodeIdDir3, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("Dir 3"), NodeType::Directory,
+            OperationType::None, "r3", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Remote)->rootNode()));
     std::shared_ptr<Node> rNode4 = std::shared_ptr<Node>(new Node(
-        dbnodeIdDir4, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("Dir 4"), NodeType::Directory, OperationType::None,
-        "r4", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Remote)->rootNode()));
-    std::shared_ptr<Node> rNode11 =
-        std::shared_ptr<Node>(new Node(std::nullopt, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("Dir 1.1"),
-                                       NodeType::Directory, OperationType::None, "r11", createdAt, lastmodified, size, rNode1));
-    std::shared_ptr<Node> rNode111 =
-        std::shared_ptr<Node>(new Node(dbNodeIdDir111, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("Dir 1.1.1"),
-                                       NodeType::Directory, OperationType::None, "r111", createdAt, lastmodified, size, rNode11));
-    std::shared_ptr<Node> rNode1111 =
-        std::shared_ptr<Node>(new Node(dbNodeIdFile1111, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("File 1.1.1.1"),
-                                       NodeType::File, OperationType::None, "r1111", createdAt, lastmodified, size, rNode111));
-    std::shared_ptr<Node> rNode31 =
-        std::shared_ptr<Node>(new Node(dbNodeIdDir31, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("Dir 3.1"),
-                                       NodeType::Directory, OperationType::None, "r31", createdAt, lastmodified, size, rNode3));
-    std::shared_ptr<Node> rNode41 =
-        std::shared_ptr<Node>(new Node(dbnodeIdDir41, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("Dir 4.1"),
-                                       NodeType::Directory, OperationType::None, "r41", createdAt, lastmodified, size, rNode4));
-    std::shared_ptr<Node> rNode411 =
-        std::shared_ptr<Node>(new Node(dbnodeIdDir411, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("Dir 4.1.1"),
-                                       NodeType::Directory, OperationType::None, "r411", createdAt, lastmodified, size, rNode41));
-    std::shared_ptr<Node> rNode4111 =
-        std::shared_ptr<Node>(new Node(dbnodeIdfile4111, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("File 4.1.1.1"),
-                                       NodeType::File, OperationType::None, "r4111", createdAt, lastmodified, size, rNode411));
+            dbnodeIdDir4, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("Dir 4"), NodeType::Directory,
+            OperationType::None, "r4", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Remote)->rootNode()));
+    std::shared_ptr<Node> rNode11 = std::shared_ptr<Node>(
+            new Node(std::nullopt, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("Dir 1.1"), NodeType::Directory,
+                     OperationType::None, "r11", createdAt, lastmodified, size, rNode1));
+    std::shared_ptr<Node> rNode111 = std::shared_ptr<Node>(
+            new Node(dbNodeIdDir111, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("Dir 1.1.1"), NodeType::Directory,
+                     OperationType::None, "r111", createdAt, lastmodified, size, rNode11));
+    std::shared_ptr<Node> rNode1111 = std::shared_ptr<Node>(
+            new Node(dbNodeIdFile1111, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("File 1.1.1.1"), NodeType::File,
+                     OperationType::None, "r1111", createdAt, lastmodified, size, rNode111));
+    std::shared_ptr<Node> rNode31 = std::shared_ptr<Node>(
+            new Node(dbNodeIdDir31, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("Dir 3.1"), NodeType::Directory,
+                     OperationType::None, "r31", createdAt, lastmodified, size, rNode3));
+    std::shared_ptr<Node> rNode41 = std::shared_ptr<Node>(
+            new Node(dbnodeIdDir41, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("Dir 4.1"), NodeType::Directory,
+                     OperationType::None, "r41", createdAt, lastmodified, size, rNode4));
+    std::shared_ptr<Node> rNode411 = std::shared_ptr<Node>(
+            new Node(dbnodeIdDir411, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("Dir 4.1.1"), NodeType::Directory,
+                     OperationType::None, "r411", createdAt, lastmodified, size, rNode41));
+    std::shared_ptr<Node> rNode4111 = std::shared_ptr<Node>(
+            new Node(dbnodeIdfile4111, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("File 4.1.1.1"), NodeType::File,
+                     OperationType::None, "r4111", createdAt, lastmodified, size, rNode411));
 
     CPPUNIT_ASSERT(_syncPal->updateTree(ReplicaSide::Local)->rootNode()->insertChildren(nodeA));
     CPPUNIT_ASSERT(_syncPal->updateTree(ReplicaSide::Local)->rootNode()->insertChildren(nodeB));
@@ -265,29 +265,33 @@ void TestConflictFinderWorker::testCreateCreate() {
     // edit conflict
     std::string rootId = _syncPal->_localSnapshot->rootFolderId();
     std::string rRootId = _syncPal->_remoteSnapshot->rootFolderId();
-    _syncPal->_localSnapshot->updateItem(SnapshotItem("4", rootId, Str("Dir 4"), 222, 222, NodeType::Directory, 123, true));
-    _syncPal->_localSnapshot->updateItem(SnapshotItem("41", "4", Str("Dir 4.1"), 222, 222, NodeType::Directory, 123, true));
-    _syncPal->_localSnapshot->updateItem(SnapshotItem("411", "41", Str("Dir 4.1.1"), 222, 222, NodeType::Directory, 123, true));
     _syncPal->_localSnapshot->updateItem(
-        SnapshotItem("4111", "411", Str("File 4.1.1.1"), 222, 222, NodeType::File, 123, true, "1", "1"));
+            SnapshotItem("4", rootId, Str("Dir 4"), 222, 222, NodeType::Directory, 123, false, true, true));
+    _syncPal->_localSnapshot->updateItem(
+            SnapshotItem("41", "4", Str("Dir 4.1"), 222, 222, NodeType::Directory, 123, false, true, true));
+    _syncPal->_localSnapshot->updateItem(
+            SnapshotItem("411", "41", Str("Dir 4.1.1"), 222, 222, NodeType::Directory, 123, false, true, true));
+    _syncPal->_localSnapshot->updateItem(
+            SnapshotItem("4111", "411", Str("File 4.1.1.1"), 222, 222, NodeType::File, 123, true, "1", "1"));
 
-    _syncPal->_remoteSnapshot->updateItem(SnapshotItem("r4", rRootId, Str("Dir 4"), 222, 222, NodeType::Directory, 123, true));
-    _syncPal->_remoteSnapshot->updateItem(SnapshotItem("r41", "r4", Str("Dir 4.1"), 222, 222, NodeType::Directory, 123, true));
     _syncPal->_remoteSnapshot->updateItem(
-        SnapshotItem("r411", "r41", Str("Dir 4.1.1"), 222, 222, NodeType::Directory, 123, true));
+            SnapshotItem("r4", rRootId, Str("Dir 4"), 222, 222, NodeType::Directory, 123, false, true, true));
     _syncPal->_remoteSnapshot->updateItem(
-        SnapshotItem("r4111", "r411", Str("File 4.1.1.1"), 221, 221, NodeType::File, 123, true, "0", "0"));
-
+            SnapshotItem("r41", "r4", Str("Dir 4.1"), 222, 222, NodeType::Directory, 123, false, true, true));
+    _syncPal->_remoteSnapshot->updateItem(
+            SnapshotItem("r411", "r41", Str("Dir 4.1.1"), 222, 222, NodeType::Directory, 123, false, true, true));
+    _syncPal->_remoteSnapshot->updateItem(
+            SnapshotItem("r4111", "r411", Str("File 4.1.1.1"), 221, 221, NodeType::File, 123, false, true, true));
 
     _syncPal->updateTree(ReplicaSide::Local)
-        ->getNodeByPath("Dir 4/Dir 4.1/Dir 4.1.1/File 4.1.1.1")
-        ->setChangeEvents(OperationType::Create);
+            ->getNodeByPath("Dir 4/Dir 4.1/Dir 4.1.1/File 4.1.1.1")
+            ->setChangeEvents(OperationType::Create);
     _syncPal->updateTree(ReplicaSide::Remote)
-        ->getNodeByPath("Dir 4/Dir 4.1/Dir 4.1.1/File 4.1.1.1")
-        ->setChangeEvents(OperationType::Create);
+            ->getNodeByPath("Dir 4/Dir 4.1/Dir 4.1.1/File 4.1.1.1")
+            ->setChangeEvents(OperationType::Create);
 
     std::optional<Conflict> confTest = _syncPal->_conflictFinderWorker->checkCreateCreateConflict(
-        _syncPal->updateTree(ReplicaSide::Local)->getNodeByPath("Dir 4/Dir 4.1/Dir 4.1.1/File 4.1.1.1"));
+            _syncPal->updateTree(ReplicaSide::Local)->getNodeByPath("Dir 4/Dir 4.1/Dir 4.1.1/File 4.1.1.1"));
     CPPUNIT_ASSERT(confTest);
     CPPUNIT_ASSERT(confTest->node() ==
                    _syncPal->updateTree(ReplicaSide::Local)->getNodeByPath("Dir 4/Dir 4.1/Dir 4.1.1/File 4.1.1.1"));
@@ -301,29 +305,31 @@ void TestConflictFinderWorker::testEditEdit() {
     // edit conflict
     std::string rootId = _syncPal->_localSnapshot->rootFolderId();
     std::string rRootId = _syncPal->_remoteSnapshot->rootFolderId();
-    _syncPal->_localSnapshot->updateItem(SnapshotItem("1", rootId, Str("Dir 1"), 222, 222, NodeType::Directory, 123, true, "1"));
-    _syncPal->_localSnapshot->updateItem(SnapshotItem("11", "1", Str("Dir 1.1"), 222, 222, NodeType::Directory, 123, true, "11"));
     _syncPal->_localSnapshot->updateItem(
-        SnapshotItem("111", "11", Str("Dir 1.1.1"), 222, 222, NodeType::Directory, 123, true, "111"));
+            SnapshotItem("1", rootId, Str("Dir 1"), 222, 222, NodeType::Directory, 123, false, true, true));
     _syncPal->_localSnapshot->updateItem(
-        SnapshotItem("1111", "111", Str("File 1.1.1.1"), 222, 222, NodeType::File, 123, true, "36"));
+            SnapshotItem("11", "1", Str("Dir 1.1"), 222, 222, NodeType::Directory, 123, false, true, true));
+    _syncPal->_localSnapshot->updateItem(
+            SnapshotItem("111", "11", Str("Dir 1.1.1"), 222, 222, NodeType::Directory, 123, false, true, true));
+    _syncPal->_localSnapshot->updateItem(
+            SnapshotItem("1111", "111", Str("File 1.1.1.1"), 222, 222, NodeType::File, 123, false, true, true));
     _syncPal->_remoteSnapshot->updateItem(
-        SnapshotItem("r1", rRootId, Str("Dir 1"), 222, 222, NodeType::Directory, 123, true, "1"));
+            SnapshotItem("r1", rRootId, Str("Dir 1"), 222, 222, NodeType::Directory, 123, false, true, true));
     _syncPal->_remoteSnapshot->updateItem(
-        SnapshotItem("r11", "r1", Str("Dir 1.1"), 222, 222, NodeType::Directory, 123, true, "11"));
+            SnapshotItem("r11", "r1", Str("Dir 1.1"), 222, 222, NodeType::Directory, 123, false, true, true));
     _syncPal->_remoteSnapshot->updateItem(
-        SnapshotItem("r111", "r11", Str("Dir 1.1.1"), 222, 222, NodeType::Directory, 123, true, "111"));
+            SnapshotItem("r111", "r11", Str("Dir 1.1.1"), 222, 222, NodeType::Directory, 123, false, true, true));
     _syncPal->_remoteSnapshot->updateItem(
-        SnapshotItem("r1111", "r111", Str("File 1.1.1.1"), 222, 222, NodeType::File, 123, true, "63"));
+            SnapshotItem("r1111", "r111", Str("File 1.1.1.1"), 222, 222, NodeType::File, 123, false, true, true));
 
     _syncPal->updateTree(ReplicaSide::Local)
-        ->getNodeByPath("Dir 1/Dir 1.1/Dir 1.1.1/File 1.1.1.1")
-        ->setChangeEvents(OperationType::Edit);
+            ->getNodeByPath("Dir 1/Dir 1.1/Dir 1.1.1/File 1.1.1.1")
+            ->setChangeEvents(OperationType::Edit);
     _syncPal->updateTree(ReplicaSide::Remote)
-        ->getNodeByPath("Dir 1/Dir 1.1/Dir 1.1.1/File 1.1.1.1")
-        ->setChangeEvents(OperationType::Edit);
+            ->getNodeByPath("Dir 1/Dir 1.1/Dir 1.1.1/File 1.1.1.1")
+            ->setChangeEvents(OperationType::Edit);
     std::optional<Conflict> confTest = _syncPal->_conflictFinderWorker->checkEditEditConflict(
-        _syncPal->updateTree(ReplicaSide::Local)->getNodeByPath("Dir 1/Dir 1.1/Dir 1.1.1/File 1.1.1.1"));
+            _syncPal->updateTree(ReplicaSide::Local)->getNodeByPath("Dir 1/Dir 1.1/Dir 1.1.1/File 1.1.1.1"));
     CPPUNIT_ASSERT(confTest);
     CPPUNIT_ASSERT(confTest->node() ==
                    _syncPal->updateTree(ReplicaSide::Local)->getNodeByPath("Dir 1/Dir 1.1/Dir 1.1.1/File 1.1.1.1"));
@@ -337,7 +343,7 @@ void TestConflictFinderWorker::testMoveCreate() {
     _syncPal->updateTree(ReplicaSide::Local)->getNodeByPath("Dir 3/Dir 3.1")->setChangeEvents(OperationType::Create);
     _syncPal->updateTree(ReplicaSide::Remote)->getNodeByPath("Dir 3/Dir 3.1")->setChangeEvents(OperationType::Move);
     std::optional<Conflict> confTest = _syncPal->_conflictFinderWorker->checkMoveCreateConflict(
-        _syncPal->updateTree(ReplicaSide::Remote)->getNodeByPath("Dir 3/Dir 3.1"));
+            _syncPal->updateTree(ReplicaSide::Remote)->getNodeByPath("Dir 3/Dir 3.1"));
     CPPUNIT_ASSERT(confTest);
     CPPUNIT_ASSERT(confTest->node() == _syncPal->updateTree(ReplicaSide::Remote)->getNodeByPath("Dir 3/Dir 3.1"));
     CPPUNIT_ASSERT(confTest->correspondingNode() == _syncPal->updateTree(ReplicaSide::Local)->getNodeByPath("Dir 3/Dir 3.1"));
@@ -347,13 +353,13 @@ void TestConflictFinderWorker::testMoveCreate() {
 void TestConflictFinderWorker::testEditDelete() {
     setUpTreesAndDb();
     _syncPal->updateTree(ReplicaSide::Local)
-        ->getNodeByPath("Dir 4/Dir 4.1/Dir 4.1.1/File 4.1.1.1")
-        ->setChangeEvents(OperationType::Edit);
+            ->getNodeByPath("Dir 4/Dir 4.1/Dir 4.1.1/File 4.1.1.1")
+            ->setChangeEvents(OperationType::Edit);
     _syncPal->updateTree(ReplicaSide::Remote)
-        ->getNodeByPath("Dir 4/Dir 4.1/Dir 4.1.1/File 4.1.1.1")
-        ->setChangeEvents(OperationType::Delete);
+            ->getNodeByPath("Dir 4/Dir 4.1/Dir 4.1.1/File 4.1.1.1")
+            ->setChangeEvents(OperationType::Delete);
     std::optional<Conflict> confTest = _syncPal->_conflictFinderWorker->checkEditDeleteConflict(
-        _syncPal->updateTree(ReplicaSide::Remote)->getNodeByPath("Dir 4/Dir 4.1/Dir 4.1.1/File 4.1.1.1"));
+            _syncPal->updateTree(ReplicaSide::Remote)->getNodeByPath("Dir 4/Dir 4.1/Dir 4.1.1/File 4.1.1.1"));
     CPPUNIT_ASSERT(confTest);
     CPPUNIT_ASSERT(confTest->node() ==
                    _syncPal->updateTree(ReplicaSide::Remote)->getNodeByPath("Dir 4/Dir 4.1/Dir 4.1.1/File 4.1.1.1"));
@@ -365,13 +371,13 @@ void TestConflictFinderWorker::testEditDelete() {
 void TestConflictFinderWorker::testMoveDeleteFile() {
     setUpTreesAndDb();
     _syncPal->updateTree(ReplicaSide::Local)
-        ->getNodeByPath("Dir 4/Dir 4.1/Dir 4.1.1/File 4.1.1.1")
-        ->setChangeEvents(OperationType::Move);
+            ->getNodeByPath("Dir 4/Dir 4.1/Dir 4.1.1/File 4.1.1.1")
+            ->setChangeEvents(OperationType::Move);
     _syncPal->updateTree(ReplicaSide::Remote)
-        ->getNodeByPath("Dir 4/Dir 4.1/Dir 4.1.1/File 4.1.1.1")
-        ->setChangeEvents(OperationType::Delete);
+            ->getNodeByPath("Dir 4/Dir 4.1/Dir 4.1.1/File 4.1.1.1")
+            ->setChangeEvents(OperationType::Delete);
     std::optional<Conflict> confTest = _syncPal->_conflictFinderWorker->checkMoveDeleteConflict(
-        _syncPal->updateTree(ReplicaSide::Remote)->getNodeByPath("Dir 4/Dir 4.1/Dir 4.1.1/File 4.1.1.1"));
+            _syncPal->updateTree(ReplicaSide::Remote)->getNodeByPath("Dir 4/Dir 4.1/Dir 4.1.1/File 4.1.1.1"));
     CPPUNIT_ASSERT(confTest);
     CPPUNIT_ASSERT(confTest->node() ==
                    _syncPal->updateTree(ReplicaSide::Remote)->getNodeByPath("Dir 4/Dir 4.1/Dir 4.1.1/File 4.1.1.1"));
@@ -389,10 +395,10 @@ void TestConflictFinderWorker::testMoveParentDelete() {
     setUpTreesAndDb();
     _syncPal->updateTree(ReplicaSide::Local)->getNodeByPath("Dir 4/Dir 4.1/Dir 4.1.1")->setChangeEvents(OperationType::Delete);
     _syncPal->updateTree(ReplicaSide::Remote)
-        ->getNodeByPath("Dir 4/Dir 4.1/Dir 4.1.1/File 4.1.1.1")
-        ->setChangeEvents(OperationType::Move);
+            ->getNodeByPath("Dir 4/Dir 4.1/Dir 4.1.1/File 4.1.1.1")
+            ->setChangeEvents(OperationType::Move);
     std::optional<std::vector<Conflict>> confTest = _syncPal->_conflictFinderWorker->checkMoveParentDeleteConflicts(
-        _syncPal->updateTree(ReplicaSide::Local)->getNodeByPath("Dir 4/Dir 4.1/Dir 4.1.1"));
+            _syncPal->updateTree(ReplicaSide::Local)->getNodeByPath("Dir 4/Dir 4.1/Dir 4.1.1"));
     CPPUNIT_ASSERT(confTest);
     CPPUNIT_ASSERT(confTest->back().node() == _syncPal->updateTree(ReplicaSide::Local)->getNodeByPath("Dir 4/Dir 4.1/Dir 4.1.1"));
     CPPUNIT_ASSERT(confTest->back().correspondingNode() ==
@@ -404,10 +410,10 @@ void TestConflictFinderWorker::testCreateParentDelete() {
     setUpTreesAndDb();
     _syncPal->updateTree(ReplicaSide::Local)->getNodeByPath("Dir 4/Dir 4.1/Dir 4.1.1")->setChangeEvents(OperationType::Delete);
     _syncPal->updateTree(ReplicaSide::Remote)
-        ->getNodeByPath("Dir 4/Dir 4.1/Dir 4.1.1/File 4.1.1.1")
-        ->setChangeEvents(OperationType::Create);
+            ->getNodeByPath("Dir 4/Dir 4.1/Dir 4.1.1/File 4.1.1.1")
+            ->setChangeEvents(OperationType::Create);
     std::optional<std::vector<Conflict>> confTest = _syncPal->_conflictFinderWorker->checkCreateParentDeleteConflicts(
-        _syncPal->updateTree(ReplicaSide::Local)->getNodeByPath("Dir 4/Dir 4.1/Dir 4.1.1"));
+            _syncPal->updateTree(ReplicaSide::Local)->getNodeByPath("Dir 4/Dir 4.1/Dir 4.1.1"));
     CPPUNIT_ASSERT(confTest);
     CPPUNIT_ASSERT(confTest->back().node() == _syncPal->updateTree(ReplicaSide::Local)->getNodeByPath("Dir 4/Dir 4.1/Dir 4.1.1"));
     CPPUNIT_ASSERT(confTest->back().correspondingNode() ==
@@ -474,8 +480,8 @@ void TestConflictFinderWorker::testMoveMoveCycle() {
     _syncPal->updateTree(ReplicaSide::Remote)->rootNode()->deleteChildren(B);
 
     std::optional<std::vector<Conflict>> confTestList = _syncPal->_conflictFinderWorker->determineMoveMoveCycleConflicts(
-        {A, _syncPal->updateTree(ReplicaSide::Local)->getNodeByPath("Dir 1")},
-        {B, _syncPal->updateTree(ReplicaSide::Remote)->getNodeByPath("Dir 1")});
+            {A, _syncPal->updateTree(ReplicaSide::Local)->getNodeByPath("Dir 1")},
+            {B, _syncPal->updateTree(ReplicaSide::Remote)->getNodeByPath("Dir 1")});
     CPPUNIT_ASSERT(confTestList);
     CPPUNIT_ASSERT(confTestList->size() == 1);
     CPPUNIT_ASSERT(confTestList->back().node() == A);
@@ -498,17 +504,17 @@ void TestConflictFinderWorker::testCase55b() {
                    NodeType::Directory, 0, std::nullopt);
     _syncPal->syncDb()->insertNode(nodeDbA, dbNodeIdFileA, constraintError);
     _syncPal->_localSnapshot->updateItem(SnapshotItem("A", _syncPal->syncDb()->rootNode().nodeIdLocal().value(), Str("A"), 222,
-                                                      222, NodeType::File, 123, true, "36"));
+                                                      222, NodeType::File, 123, false, true, true));
     _syncPal->_remoteSnapshot->updateItem(SnapshotItem("rA", _syncPal->syncDb()->rootNode().nodeIdRemote().value(), Str("A"), 222,
-                                                       222, NodeType::File, 123, true, "63"));
+                                                       222, NodeType::File, 123, false, true, true));
 
     // Start situation
-    std::shared_ptr<Node> nodeA = std::shared_ptr<Node>(
-        new Node(dbNodeIdFileA, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("A"), NodeType::File, OperationType::None,
-                 "A", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Local)->rootNode()));
-    std::shared_ptr<Node> rNodeA = std::shared_ptr<Node>(
-        new Node(dbNodeIdFileA, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("A"), NodeType::File, OperationType::None,
-                 "rA", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Remote)->rootNode()));
+    std::shared_ptr<Node> nodeA = std::shared_ptr<Node>(new Node(
+            dbNodeIdFileA, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("A"), NodeType::File, OperationType::None, "A",
+            createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Local)->rootNode()));
+    std::shared_ptr<Node> rNodeA = std::shared_ptr<Node>(new Node(
+            dbNodeIdFileA, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("A"), NodeType::File, OperationType::None, "rA",
+            createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Remote)->rootNode()));
     CPPUNIT_ASSERT(_syncPal->updateTree(ReplicaSide::Local)->rootNode()->insertChildren(nodeA));
     _syncPal->updateTree(ReplicaSide::Local)->insertNode(nodeA);
     CPPUNIT_ASSERT(_syncPal->updateTree(ReplicaSide::Remote)->rootNode()->insertChildren(rNodeA));
@@ -520,9 +526,9 @@ void TestConflictFinderWorker::testCase55b() {
     nodeA->setName(Str("B"));
     rNodeA->setChangeEvents(OperationType::Edit);
 
-    std::shared_ptr<Node> rNodeB = std::shared_ptr<Node>(
-        new Node(std::nullopt, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("B"), NodeType::File, OperationType::Create,
-                 "rB", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Remote)->rootNode()));
+    std::shared_ptr<Node> rNodeB = std::shared_ptr<Node>(new Node(
+            std::nullopt, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("B"), NodeType::File, OperationType::Create,
+            "rB", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Remote)->rootNode()));
     CPPUNIT_ASSERT(_syncPal->updateTree(ReplicaSide::Remote)->rootNode()->insertChildren(rNodeB));
     _syncPal->updateTree(ReplicaSide::Remote)->insertNode(rNodeB);
 
@@ -555,12 +561,12 @@ void TestConflictFinderWorker::testCase55c() {
     _syncPal->syncDb()->insertNode(nodeDbA, dbNodeIdFileA, constraintError);
 
     // Start situation
-    std::shared_ptr<Node> nodeA = std::shared_ptr<Node>(
-        new Node(dbNodeIdFileA, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("A"), NodeType::File, OperationType::None,
-                 "A", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Local)->rootNode()));
-    std::shared_ptr<Node> rNodeA = std::shared_ptr<Node>(
-        new Node(dbNodeIdFileA, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("A"), NodeType::File, OperationType::None,
-                 "rA", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Remote)->rootNode()));
+    std::shared_ptr<Node> nodeA = std::shared_ptr<Node>(new Node(
+            dbNodeIdFileA, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("A"), NodeType::File, OperationType::None, "A",
+            createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Local)->rootNode()));
+    std::shared_ptr<Node> rNodeA = std::shared_ptr<Node>(new Node(
+            dbNodeIdFileA, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("A"), NodeType::File, OperationType::None, "rA",
+            createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Remote)->rootNode()));
     CPPUNIT_ASSERT(_syncPal->updateTree(ReplicaSide::Local)->rootNode()->insertChildren(nodeA));
     _syncPal->updateTree(ReplicaSide::Local)->insertNode(nodeA);
     CPPUNIT_ASSERT(_syncPal->updateTree(ReplicaSide::Remote)->rootNode()->insertChildren(rNodeA));
@@ -574,15 +580,15 @@ void TestConflictFinderWorker::testCase55c() {
     rNodeA->setMoveOrigin("A");
     rNodeA->setName(Str("C"));
 
-    std::shared_ptr<Node> rNodeB = std::shared_ptr<Node>(
-        new Node(std::nullopt, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("B"), NodeType::File, OperationType::Create,
-                 "rB", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Remote)->rootNode()));
+    std::shared_ptr<Node> rNodeB = std::shared_ptr<Node>(new Node(
+            std::nullopt, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("B"), NodeType::File, OperationType::Create,
+            "rB", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Remote)->rootNode()));
     _syncPal->updateTree(ReplicaSide::Remote)->insertNode(rNodeB);
     CPPUNIT_ASSERT(_syncPal->updateTree(ReplicaSide::Remote)->rootNode()->insertChildren(rNodeB));
 
-    std::shared_ptr<Node> nodeC = std::shared_ptr<Node>(
-        new Node(std::nullopt, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("C"), NodeType::File, OperationType::Create,
-                 "C", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Local)->rootNode()));
+    std::shared_ptr<Node> nodeC = std::shared_ptr<Node>(new Node(
+            std::nullopt, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("C"), NodeType::File, OperationType::Create, "C",
+            createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Local)->rootNode()));
     _syncPal->updateTree(ReplicaSide::Local)->insertNode(nodeC);
     CPPUNIT_ASSERT(_syncPal->updateTree(ReplicaSide::Local)->rootNode()->insertChildren(nodeC));
 
@@ -618,24 +624,24 @@ void TestConflictFinderWorker::testCase57() {
     _syncPal->syncDb()->insertNode(nodeDbC, dbNodeIdFileC, constraintError);
 
     // Start situation
-    std::shared_ptr<Node> nodeA = std::shared_ptr<Node>(
-        new Node(dbNodeIdDirA, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("A"), NodeType::Directory,
-                 OperationType::None, "A", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Local)->rootNode()));
-    std::shared_ptr<Node> nodeB = std::shared_ptr<Node>(
-        new Node(dbNodeIdDirB, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("B"), NodeType::Directory,
-                 OperationType::None, "B", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Local)->rootNode()));
+    std::shared_ptr<Node> nodeA = std::shared_ptr<Node>(new Node(
+            dbNodeIdDirA, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("A"), NodeType::Directory, OperationType::None,
+            "A", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Local)->rootNode()));
+    std::shared_ptr<Node> nodeB = std::shared_ptr<Node>(new Node(
+            dbNodeIdDirB, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("B"), NodeType::Directory, OperationType::None,
+            "B", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Local)->rootNode()));
     std::shared_ptr<Node> nodeC =
-        std::shared_ptr<Node>(new Node(dbNodeIdFileC, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("c"), NodeType::File,
-                                       OperationType::None, "c", createdAt, lastmodified, size, nodeA));
+            std::shared_ptr<Node>(new Node(dbNodeIdFileC, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("c"),
+                                           NodeType::File, OperationType::None, "c", createdAt, lastmodified, size, nodeA));
     std::shared_ptr<Node> rNodeA = std::shared_ptr<Node>(new Node(
-        dbNodeIdDirA, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("A"), NodeType::Directory, OperationType::None, "rA",
-        createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Remote)->rootNode()));
+            dbNodeIdDirA, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("A"), NodeType::Directory, OperationType::None,
+            "rA", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Remote)->rootNode()));
     std::shared_ptr<Node> rNodeB = std::shared_ptr<Node>(new Node(
-        dbNodeIdDirB, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("B"), NodeType::Directory, OperationType::None, "rB",
-        createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Remote)->rootNode()));
+            dbNodeIdDirB, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("B"), NodeType::Directory, OperationType::None,
+            "rB", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Remote)->rootNode()));
     std::shared_ptr<Node> rNodeC =
-        std::shared_ptr<Node>(new Node(dbNodeIdFileC, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("c"), NodeType::File,
-                                       OperationType::None, "rc", createdAt, lastmodified, size, rNodeA));
+            std::shared_ptr<Node>(new Node(dbNodeIdFileC, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("c"),
+                                           NodeType::File, OperationType::None, "rc", createdAt, lastmodified, size, rNodeA));
     CPPUNIT_ASSERT(_syncPal->updateTree(ReplicaSide::Local)->rootNode()->insertChildren(nodeA));
     CPPUNIT_ASSERT(_syncPal->updateTree(ReplicaSide::Local)->rootNode()->insertChildren(nodeB));
     CPPUNIT_ASSERT(nodeA->insertChildren(nodeC));
@@ -696,18 +702,18 @@ void TestConflictFinderWorker::testCase59() {
     SyncTime createdAt = 1654788079;
     SyncTime lastmodified = 1654788079;
     int64_t size = 12345;
-    std::shared_ptr<Node> nodeA = std::shared_ptr<Node>(
-        new Node(dbNodeIdDirA, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("A"), NodeType::Directory,
-                 OperationType::None, "A", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Local)->rootNode()));
-    std::shared_ptr<Node> nodeB = std::shared_ptr<Node>(
-        new Node(dbNodeIdDirB, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("B"), NodeType::Directory,
-                 OperationType::None, "B", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Local)->rootNode()));
+    std::shared_ptr<Node> nodeA = std::shared_ptr<Node>(new Node(
+            dbNodeIdDirA, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("A"), NodeType::Directory, OperationType::None,
+            "A", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Local)->rootNode()));
+    std::shared_ptr<Node> nodeB = std::shared_ptr<Node>(new Node(
+            dbNodeIdDirB, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("B"), NodeType::Directory, OperationType::None,
+            "B", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Local)->rootNode()));
     std::shared_ptr<Node> rNodeA = std::shared_ptr<Node>(new Node(
-        dbNodeIdDirA, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("A"), NodeType::Directory, OperationType::None, "rA",
-        createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Remote)->rootNode()));
+            dbNodeIdDirA, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("A"), NodeType::Directory, OperationType::None,
+            "rA", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Remote)->rootNode()));
     std::shared_ptr<Node> rNodeB = std::shared_ptr<Node>(new Node(
-        dbNodeIdDirB, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("B"), NodeType::Directory, OperationType::None, "rB",
-        createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Remote)->rootNode()));
+            dbNodeIdDirB, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("B"), NodeType::Directory, OperationType::None,
+            "rB", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Remote)->rootNode()));
     CPPUNIT_ASSERT(_syncPal->updateTree(ReplicaSide::Local)->rootNode()->insertChildren(nodeA));
     CPPUNIT_ASSERT(_syncPal->updateTree(ReplicaSide::Local)->rootNode()->insertChildren(nodeB));
     _syncPal->updateTree(ReplicaSide::Local)->insertNode(nodeA);
@@ -750,18 +756,18 @@ void TestConflictFinderWorker::testCase510() {
     SyncTime createdAt = 1654788079;
     SyncTime lastmodified = 1654788079;
     int64_t size = 12345;
-    std::shared_ptr<Node> nodeA = std::shared_ptr<Node>(
-        new Node(dbNodeIdDirA, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("A"), NodeType::Directory,
-                 OperationType::None, "A", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Local)->rootNode()));
+    std::shared_ptr<Node> nodeA = std::shared_ptr<Node>(new Node(
+            dbNodeIdDirA, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("A"), NodeType::Directory, OperationType::None,
+            "A", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Local)->rootNode()));
     std::shared_ptr<Node> nodeX =
-        std::shared_ptr<Node>(new Node(dbNodeIdFileX, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("x"), NodeType::File,
-                                       OperationType::None, "X", createdAt, lastmodified, size, nodeA));
+            std::shared_ptr<Node>(new Node(dbNodeIdFileX, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("x"),
+                                           NodeType::File, OperationType::None, "X", createdAt, lastmodified, size, nodeA));
     std::shared_ptr<Node> rNodeA = std::shared_ptr<Node>(new Node(
-        dbNodeIdDirA, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("A"), NodeType::Directory, OperationType::None, "rA",
-        createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Remote)->rootNode()));
+            dbNodeIdDirA, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("A"), NodeType::Directory, OperationType::None,
+            "rA", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Remote)->rootNode()));
     std::shared_ptr<Node> rNodeX =
-        std::shared_ptr<Node>(new Node(dbNodeIdFileX, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("x"), NodeType::File,
-                                       OperationType::None, "rX", createdAt, lastmodified, size, rNodeA));
+            std::shared_ptr<Node>(new Node(dbNodeIdFileX, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("x"),
+                                           NodeType::File, OperationType::None, "rX", createdAt, lastmodified, size, rNodeA));
 
     CPPUNIT_ASSERT(_syncPal->updateTree(ReplicaSide::Local)->rootNode()->insertChildren(nodeA));
     CPPUNIT_ASSERT(nodeA->insertChildren(nodeX));
@@ -778,8 +784,8 @@ void TestConflictFinderWorker::testCase510() {
     CPPUNIT_ASSERT(_syncPal->updateTree(ReplicaSide::Local)->rootNode()->insertChildren(nodeX));
     CPPUNIT_ASSERT(nodeA->deleteChildren(nodeX));
     std::shared_ptr<Node> nodeX2 =
-        std::shared_ptr<Node>(new Node(std::nullopt, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("x"), NodeType::File,
-                                       OperationType::Create, "X2", createdAt, lastmodified, size, nodeA));
+            std::shared_ptr<Node>(new Node(std::nullopt, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("x"),
+                                           NodeType::File, OperationType::Create, "X2", createdAt, lastmodified, size, nodeA));
     _syncPal->updateTree(ReplicaSide::Local)->insertNode(nodeX2);
     CPPUNIT_ASSERT(nodeA->insertChildren(nodeX2));
     rNodeA->insertChangeEvent(OperationType::Delete);
@@ -815,18 +821,18 @@ void TestConflictFinderWorker::testCase511() {
     SyncTime createdAt = 1654788079;
     SyncTime lastmodified = 1654788079;
     int64_t size = 12345;
-    std::shared_ptr<Node> nodeA = std::shared_ptr<Node>(
-        new Node(dbNodeIdDirA, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("A"), NodeType::Directory,
-                 OperationType::None, "A", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Local)->rootNode()));
+    std::shared_ptr<Node> nodeA = std::shared_ptr<Node>(new Node(
+            dbNodeIdDirA, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("A"), NodeType::Directory, OperationType::None,
+            "A", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Local)->rootNode()));
     std::shared_ptr<Node> nodeB =
-        std::shared_ptr<Node>(new Node(dbNodeIdDirB, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("B"),
-                                       NodeType::Directory, OperationType::None, "B", createdAt, lastmodified, size, nodeA));
+            std::shared_ptr<Node>(new Node(dbNodeIdDirB, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("B"),
+                                           NodeType::Directory, OperationType::None, "B", createdAt, lastmodified, size, nodeA));
     std::shared_ptr<Node> rNodeA = std::shared_ptr<Node>(new Node(
-        dbNodeIdDirA, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("A"), NodeType::Directory, OperationType::None, "rA",
-        createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Remote)->rootNode()));
-    std::shared_ptr<Node> rNodeB =
-        std::shared_ptr<Node>(new Node(dbNodeIdDirB, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("B"),
-                                       NodeType::Directory, OperationType::None, "rB", createdAt, lastmodified, size, rNodeA));
+            dbNodeIdDirA, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("A"), NodeType::Directory, OperationType::None,
+            "rA", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Remote)->rootNode()));
+    std::shared_ptr<Node> rNodeB = std::shared_ptr<Node>(new Node(dbNodeIdDirB, _syncPal->updateTree(ReplicaSide::Remote)->side(),
+                                                                  Str("B"), NodeType::Directory, OperationType::None, "rB",
+                                                                  createdAt, lastmodified, size, rNodeA));
 
     CPPUNIT_ASSERT(_syncPal->updateTree(ReplicaSide::Local)->rootNode()->insertChildren(nodeA));
     CPPUNIT_ASSERT(nodeA->insertChildren(nodeB));
@@ -846,8 +852,8 @@ void TestConflictFinderWorker::testCase511() {
     rNodeB->setName(Str("B_moved"));
     rNodeB->insertChangeEvent(OperationType::Move);
     std::shared_ptr<Node> nodeNewFile =
-        std::shared_ptr<Node>(new Node(std::nullopt, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("new.txt"),
-                                       NodeType::File, OperationType::Create, "new", createdAt, lastmodified, size, rNodeB));
+            std::shared_ptr<Node>(new Node(std::nullopt, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("new.txt"),
+                                           NodeType::File, OperationType::Create, "new", createdAt, lastmodified, size, rNodeB));
     CPPUNIT_ASSERT(rNodeB->insertChildren(nodeNewFile));
     _syncPal->updateTree(ReplicaSide::Remote)->insertNode(nodeNewFile);
 
@@ -884,24 +890,24 @@ void TestConflictFinderWorker::testCase513() {
     SyncTime createdAt = 1654788079;
     SyncTime lastmodified = 1654788079;
     int64_t size = 12345;
-    std::shared_ptr<Node> nodeQ = std::shared_ptr<Node>(
-        new Node(dbNodeIdDirQ, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("q"), NodeType::Directory,
-                 OperationType::None, "q", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Local)->rootNode()));
-    std::shared_ptr<Node> nodeR = std::shared_ptr<Node>(
-        new Node(dbNodeIdDirR, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("r"), NodeType::Directory,
-                 OperationType::None, "r", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Local)->rootNode()));
+    std::shared_ptr<Node> nodeQ = std::shared_ptr<Node>(new Node(
+            dbNodeIdDirQ, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("q"), NodeType::Directory, OperationType::None,
+            "q", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Local)->rootNode()));
+    std::shared_ptr<Node> nodeR = std::shared_ptr<Node>(new Node(
+            dbNodeIdDirR, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("r"), NodeType::Directory, OperationType::None,
+            "r", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Local)->rootNode()));
     std::shared_ptr<Node> nodeN =
-        std::shared_ptr<Node>(new Node(dbNodeIdDirN, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("n"),
-                                       NodeType::Directory, OperationType::None, "n", createdAt, lastmodified, size, nodeQ));
+            std::shared_ptr<Node>(new Node(dbNodeIdDirN, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("n"),
+                                           NodeType::Directory, OperationType::None, "n", createdAt, lastmodified, size, nodeQ));
     std::shared_ptr<Node> rNodeQ = std::shared_ptr<Node>(new Node(
-        dbNodeIdDirQ, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("q"), NodeType::Directory, OperationType::None, "rq",
-        createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Remote)->rootNode()));
+            dbNodeIdDirQ, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("q"), NodeType::Directory, OperationType::None,
+            "rq", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Remote)->rootNode()));
     std::shared_ptr<Node> rNodeR = std::shared_ptr<Node>(new Node(
-        dbNodeIdDirR, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("r"), NodeType::Directory, OperationType::None, "rr",
-        createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Remote)->rootNode()));
-    std::shared_ptr<Node> rNodeN =
-        std::shared_ptr<Node>(new Node(dbNodeIdDirN, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("n"),
-                                       NodeType::Directory, OperationType::None, "rn", createdAt, lastmodified, size, rNodeQ));
+            dbNodeIdDirR, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("r"), NodeType::Directory, OperationType::None,
+            "rr", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Remote)->rootNode()));
+    std::shared_ptr<Node> rNodeN = std::shared_ptr<Node>(new Node(dbNodeIdDirN, _syncPal->updateTree(ReplicaSide::Remote)->side(),
+                                                                  Str("n"), NodeType::Directory, OperationType::None, "rn",
+                                                                  createdAt, lastmodified, size, rNodeQ));
 
     CPPUNIT_ASSERT(_syncPal->updateTree(ReplicaSide::Local)->rootNode()->insertChildren(nodeQ));
     CPPUNIT_ASSERT(_syncPal->updateTree(ReplicaSide::Local)->rootNode()->insertChildren(nodeR));
@@ -964,30 +970,30 @@ void TestConflictFinderWorker::testCase516() {
     SyncTime createdAt = 1654788079;
     SyncTime lastmodified = 1654788079;
     int64_t size = 12345;
-    std::shared_ptr<Node> nodeQ = std::shared_ptr<Node>(
-        new Node(dbNodeIdDirQ, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("q"), NodeType::Directory,
-                 OperationType::None, "q", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Local)->rootNode()));
+    std::shared_ptr<Node> nodeQ = std::shared_ptr<Node>(new Node(
+            dbNodeIdDirQ, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("q"), NodeType::Directory, OperationType::None,
+            "q", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Local)->rootNode()));
     std::shared_ptr<Node> nodeM =
-        std::shared_ptr<Node>(new Node(dbNodeIdDirM, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("m"),
-                                       NodeType::Directory, OperationType::None, "m", createdAt, lastmodified, size, nodeQ));
-    std::shared_ptr<Node> nodeR = std::shared_ptr<Node>(
-        new Node(dbNodeIdDirR, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("r"), NodeType::Directory,
-                 OperationType::None, "r", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Local)->rootNode()));
+            std::shared_ptr<Node>(new Node(dbNodeIdDirM, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("m"),
+                                           NodeType::Directory, OperationType::None, "m", createdAt, lastmodified, size, nodeQ));
+    std::shared_ptr<Node> nodeR = std::shared_ptr<Node>(new Node(
+            dbNodeIdDirR, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("r"), NodeType::Directory, OperationType::None,
+            "r", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Local)->rootNode()));
     std::shared_ptr<Node> nodeN =
-        std::shared_ptr<Node>(new Node(dbNodeIdDirN, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("n"),
-                                       NodeType::Directory, OperationType::None, "n", createdAt, lastmodified, size, nodeR));
+            std::shared_ptr<Node>(new Node(dbNodeIdDirN, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("n"),
+                                           NodeType::Directory, OperationType::None, "n", createdAt, lastmodified, size, nodeR));
     std::shared_ptr<Node> rNodeQ = std::shared_ptr<Node>(new Node(
-        dbNodeIdDirQ, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("q"), NodeType::Directory, OperationType::None, "rq",
-        createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Remote)->rootNode()));
-    std::shared_ptr<Node> rNodeM =
-        std::shared_ptr<Node>(new Node(dbNodeIdDirM, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("m"),
-                                       NodeType::Directory, OperationType::None, "rm", createdAt, lastmodified, size, rNodeQ));
+            dbNodeIdDirQ, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("q"), NodeType::Directory, OperationType::None,
+            "rq", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Remote)->rootNode()));
+    std::shared_ptr<Node> rNodeM = std::shared_ptr<Node>(new Node(dbNodeIdDirM, _syncPal->updateTree(ReplicaSide::Remote)->side(),
+                                                                  Str("m"), NodeType::Directory, OperationType::None, "rm",
+                                                                  createdAt, lastmodified, size, rNodeQ));
     std::shared_ptr<Node> rNodeR = std::shared_ptr<Node>(new Node(
-        dbNodeIdDirR, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("r"), NodeType::Directory, OperationType::None, "rr",
-        createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Remote)->rootNode()));
-    std::shared_ptr<Node> rNodeN =
-        std::shared_ptr<Node>(new Node(dbNodeIdDirN, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("n"),
-                                       NodeType::Directory, OperationType::None, "rn", createdAt, lastmodified, size, rNodeR));
+            dbNodeIdDirR, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("r"), NodeType::Directory, OperationType::None,
+            "rr", createdAt, lastmodified, size, _syncPal->updateTree(ReplicaSide::Remote)->rootNode()));
+    std::shared_ptr<Node> rNodeN = std::shared_ptr<Node>(new Node(dbNodeIdDirN, _syncPal->updateTree(ReplicaSide::Remote)->side(),
+                                                                  Str("n"), NodeType::Directory, OperationType::None, "rn",
+                                                                  createdAt, lastmodified, size, rNodeR));
 
     CPPUNIT_ASSERT(_syncPal->updateTree(ReplicaSide::Local)->rootNode()->insertChildren(nodeQ));
     CPPUNIT_ASSERT(nodeQ->insertChildren(nodeM));
@@ -1053,4 +1059,4 @@ void TestConflictFinderWorker::testCase516() {
     CPPUNIT_ASSERT(_syncPal->_conflictQueue->top().correspondingNode()->side() == rNodeM->side());
 }
 
-}  // namespace KDC
+} // namespace KDC

--- a/test/libsyncengine/reconciliation/conflict_resolver/testconflictresolverworker.cpp
+++ b/test/libsyncengine/reconciliation/conflict_resolver/testconflictresolverworker.cpp
@@ -73,46 +73,46 @@ void TestConflictResolverWorker::setUp() {
 
     // Build update trees
     std::shared_ptr<Node> lNodeA =
-        std::make_shared<Node>(dbNodeIdA, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("A"), NodeType::Directory,
-                               OperationType::None, "lA", testhelpers::defaultTime, testhelpers::defaultTime,
-                               testhelpers::defaultFileSize, _syncPal->updateTree(ReplicaSide::Local)->rootNode());
+            std::make_shared<Node>(dbNodeIdA, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("A"), NodeType::Directory,
+                                   OperationType::None, "lA", testhelpers::defaultTime, testhelpers::defaultTime,
+                                   testhelpers::defaultFileSize, _syncPal->updateTree(ReplicaSide::Local)->rootNode());
     CPPUNIT_ASSERT(_syncPal->updateTree(ReplicaSide::Local)->rootNode()->insertChildren(lNodeA));
     _syncPal->updateTree(ReplicaSide::Local)->insertNode(lNodeA);
     std::shared_ptr<Node> lNodeAA = std::make_shared<Node>(
-        dbNodeIdAA, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("AA"), NodeType::Directory, OperationType::None, "lAA",
-        testhelpers::defaultTime, testhelpers::defaultTime, testhelpers::defaultFileSize, lNodeA);
+            dbNodeIdAA, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("AA"), NodeType::Directory, OperationType::None,
+            "lAA", testhelpers::defaultTime, testhelpers::defaultTime, testhelpers::defaultFileSize, lNodeA);
     CPPUNIT_ASSERT(lNodeA->insertChildren(lNodeAA));
     _syncPal->updateTree(ReplicaSide::Local)->insertNode(lNodeAA);
     std::shared_ptr<Node> lNodeAB = std::make_shared<Node>(
-        dbNodeIdAB, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("AB"), NodeType::Directory, OperationType::None, "lAB",
-        testhelpers::defaultTime, testhelpers::defaultTime, testhelpers::defaultFileSize, lNodeA);
+            dbNodeIdAB, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("AB"), NodeType::Directory, OperationType::None,
+            "lAB", testhelpers::defaultTime, testhelpers::defaultTime, testhelpers::defaultFileSize, lNodeA);
     CPPUNIT_ASSERT(lNodeA->insertChildren(lNodeAB));
     _syncPal->updateTree(ReplicaSide::Local)->insertNode(lNodeAB);
     std::shared_ptr<Node> lNodeAAA = std::make_shared<Node>(
-        dbNodeIdAAA, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("AAA"), NodeType::File, OperationType::None, "lAAA",
-        testhelpers::defaultTime, testhelpers::defaultTime, testhelpers::defaultFileSize, lNodeAA);
+            dbNodeIdAAA, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("AAA"), NodeType::File, OperationType::None,
+            "lAAA", testhelpers::defaultTime, testhelpers::defaultTime, testhelpers::defaultFileSize, lNodeAA);
     CPPUNIT_ASSERT(lNodeAA->insertChildren(lNodeAAA));
     _syncPal->updateTree(ReplicaSide::Local)->insertNode(lNodeAAA);
 
     std::shared_ptr<Node> rNodeA =
-        std::make_shared<Node>(dbNodeIdA, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("A"), NodeType::Directory,
-                               OperationType::None, "rA", testhelpers::defaultTime, testhelpers::defaultTime,
-                               testhelpers::defaultFileSize, _syncPal->updateTree(ReplicaSide::Remote)->rootNode());
+            std::make_shared<Node>(dbNodeIdA, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("A"), NodeType::Directory,
+                                   OperationType::None, "rA", testhelpers::defaultTime, testhelpers::defaultTime,
+                                   testhelpers::defaultFileSize, _syncPal->updateTree(ReplicaSide::Remote)->rootNode());
     CPPUNIT_ASSERT(_syncPal->updateTree(ReplicaSide::Remote)->rootNode()->insertChildren(rNodeA));
     _syncPal->updateTree(ReplicaSide::Remote)->insertNode(rNodeA);
     std::shared_ptr<Node> rNodeAA = std::make_shared<Node>(
-        dbNodeIdAA, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("AA"), NodeType::Directory, OperationType::None, "rAA",
-        testhelpers::defaultTime, testhelpers::defaultTime, testhelpers::defaultFileSize, rNodeA);
+            dbNodeIdAA, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("AA"), NodeType::Directory, OperationType::None,
+            "rAA", testhelpers::defaultTime, testhelpers::defaultTime, testhelpers::defaultFileSize, rNodeA);
     CPPUNIT_ASSERT(rNodeA->insertChildren(rNodeAA));
     _syncPal->updateTree(ReplicaSide::Remote)->insertNode(rNodeAA);
     std::shared_ptr<Node> rNodeAB = std::make_shared<Node>(
-        dbNodeIdAB, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("AB"), NodeType::Directory, OperationType::None, "rAB",
-        testhelpers::defaultTime, testhelpers::defaultTime, testhelpers::defaultFileSize, rNodeA);
+            dbNodeIdAB, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("AB"), NodeType::Directory, OperationType::None,
+            "rAB", testhelpers::defaultTime, testhelpers::defaultTime, testhelpers::defaultFileSize, rNodeA);
     CPPUNIT_ASSERT(rNodeA->insertChildren(rNodeAB));
     _syncPal->updateTree(ReplicaSide::Remote)->insertNode(rNodeAB);
     std::shared_ptr<Node> rNodeAAA = std::make_shared<Node>(
-        dbNodeIdAAA, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("AAA"), NodeType::File, OperationType::None, "rAAA",
-        testhelpers::defaultTime, testhelpers::defaultTime, testhelpers::defaultFileSize, rNodeAA);
+            dbNodeIdAAA, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("AAA"), NodeType::File, OperationType::None,
+            "rAAA", testhelpers::defaultTime, testhelpers::defaultTime, testhelpers::defaultFileSize, rNodeAA);
     CPPUNIT_ASSERT(rNodeAA->insertChildren(rNodeAAA));
     _syncPal->updateTree(ReplicaSide::Remote)->insertNode(rNodeAAA);
 }
@@ -129,21 +129,22 @@ void TestConflictResolverWorker::testCreateCreate() {
     // Simulate file creation on both replica
     std::shared_ptr<Node> lNodeAA = _syncPal->updateTree(ReplicaSide::Local)->getNodeById("lAA");
     std::shared_ptr<Node> lNodeAAB = std::make_shared<Node>(
-        std::nullopt, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("AAB.txt"), NodeType::File, OperationType::Create,
-        "lAAB", testhelpers::defaultTime, testhelpers::defaultTime, testhelpers::defaultFileSize, lNodeAA);
+            std::nullopt, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("AAB.txt"), NodeType::File, OperationType::Create,
+            "lAAB", testhelpers::defaultTime, testhelpers::defaultTime, testhelpers::defaultFileSize, lNodeAA);
     CPPUNIT_ASSERT(lNodeAA->insertChildren(lNodeAAB));
     _syncPal->updateTree(ReplicaSide::Local)->insertNode(lNodeAAB);
     _syncPal->_localSnapshot->updateItem(SnapshotItem("lAAB", "lAA", Str("AAB.txt"), testhelpers::defaultTime,
-                                                      testhelpers::defaultTime, NodeType::File, 123, "lcs1"));
+                                                      testhelpers::defaultTime, NodeType::File, 123, false, true, true));
 
     std::shared_ptr<Node> rNodeAA = _syncPal->updateTree(ReplicaSide::Remote)->getNodeById("rAA");
-    std::shared_ptr<Node> rNodeAAB = std::make_shared<Node>(
-        std::nullopt, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("AAB.txt"), NodeType::File, OperationType::Create,
-        "rAAB", testhelpers::defaultTime, testhelpers::defaultTime, testhelpers::defaultFileSize, rNodeAA);
+    std::shared_ptr<Node> rNodeAAB =
+            std::make_shared<Node>(std::nullopt, _syncPal->updateTree(ReplicaSide::Remote)->side(), Str("AAB.txt"),
+                                   NodeType::File, OperationType::Create, "rAAB", testhelpers::defaultTime,
+                                   testhelpers::defaultTime, testhelpers::defaultFileSize, rNodeAA);
     CPPUNIT_ASSERT(rNodeAA->insertChildren(rNodeAAB));
     _syncPal->updateTree(ReplicaSide::Remote)->insertNode(rNodeAAB);
     _syncPal->_remoteSnapshot->updateItem(SnapshotItem("rAAB", "rAA", Str("AAB.txt"), testhelpers::defaultTime,
-                                                       testhelpers::defaultTime, NodeType::File, 123, "rcs1"));
+                                                       testhelpers::defaultTime, NodeType::File, 123, false, true, true));
 
     Conflict conflict(lNodeAAB, rNodeAA, ConflictType::CreateCreate);
     _syncPal->_conflictQueue->push(conflict);
@@ -181,8 +182,8 @@ void TestConflictResolverWorker::testMoveCreate() {
     // Simulate create file ABA in AB on local replica
     std::shared_ptr<Node> lNodeAB = _syncPal->updateTree(ReplicaSide::Local)->getNodeById("lAB");
     std::shared_ptr<Node> lNodeABA = std::make_shared<Node>(
-        std::nullopt, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("ABA"), NodeType::File, OperationType::Create, "lABA",
-        testhelpers::defaultTime, testhelpers::defaultTime, testhelpers::defaultFileSize, lNodeAB);
+            std::nullopt, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("ABA"), NodeType::File, OperationType::Create,
+            "lABA", testhelpers::defaultTime, testhelpers::defaultTime, testhelpers::defaultFileSize, lNodeAB);
     CPPUNIT_ASSERT(lNodeAB->insertChildren(lNodeABA));
     _syncPal->updateTree(ReplicaSide::Local)->insertNode(lNodeABA);
 
@@ -256,7 +257,7 @@ void TestConflictResolverWorker::testEditDelete2() {
     _syncPal->_conflictResolverWorker->execute();
 
     CPPUNIT_ASSERT_EQUAL(size_t(2), _syncPal->_syncOps->size());
-    for (const auto &opId : _syncPal->_syncOps->opSortedList()) {
+    for (const auto &opId: _syncPal->_syncOps->opSortedList()) {
         SyncOpPtr op = _syncPal->_syncOps->getOp(opId);
         if (op->type() == OperationType::Move) {
             CPPUNIT_ASSERT(!op->newName().empty());
@@ -267,7 +268,7 @@ void TestConflictResolverWorker::testEditDelete2() {
             CPPUNIT_ASSERT(op->omit());
             CPPUNIT_ASSERT_EQUAL(rNodeAAA, op->affectedNode());
         } else {
-            CPPUNIT_ASSERT(false);  // Should not happen
+            CPPUNIT_ASSERT(false); // Should not happen
         }
     }
 }
@@ -332,8 +333,8 @@ void TestConflictResolverWorker::testMoveDelete2() {
     // Simulate create of node ABA on local replica
     std::shared_ptr<Node> lNodeAB = _syncPal->updateTree(ReplicaSide::Local)->getNodeById("lAB");
     std::shared_ptr<Node> lNodeABA = std::make_shared<Node>(
-        std::nullopt, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("ABA"), NodeType::File, OperationType::Create, "lABA",
-        testhelpers::defaultTime, testhelpers::defaultTime, testhelpers::defaultFileSize, lNodeAB);
+            std::nullopt, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("ABA"), NodeType::File, OperationType::Create,
+            "lABA", testhelpers::defaultTime, testhelpers::defaultTime, testhelpers::defaultFileSize, lNodeAB);
     CPPUNIT_ASSERT(lNodeAB->insertChildren(lNodeABA));
     _syncPal->updateTree(ReplicaSide::Local)->insertNode(lNodeABA);
 
@@ -463,9 +464,9 @@ void TestConflictResolverWorker::testMoveDelete4() {
     // Should have 1 move (orphan node) and 1 delete operation,
     // changes to be done in db only for both op
     // and on the remote replica only
-    CPPUNIT_ASSERT_EQUAL((size_t)2, _syncPal->_syncOps->size());
+    CPPUNIT_ASSERT_EQUAL((size_t) 2, _syncPal->_syncOps->size());
     CPPUNIT_ASSERT(!_syncPal->_conflictResolverWorker->registeredOrphans().empty());
-    for (const auto &opId : _syncPal->_syncOps->opSortedList()) {
+    for (const auto &opId: _syncPal->_syncOps->opSortedList()) {
         SyncOpPtr op = _syncPal->_syncOps->getOp(opId);
         CPPUNIT_ASSERT(op->omit());
 
@@ -476,7 +477,7 @@ void TestConflictResolverWorker::testMoveDelete4() {
         } else if (op->type() == OperationType::Delete) {
             CPPUNIT_ASSERT_EQUAL(rNodeA, op->affectedNode());
         } else {
-            CPPUNIT_ASSERT(false);  // Should not happen
+            CPPUNIT_ASSERT(false); // Should not happen
         }
     }
 }
@@ -547,12 +548,12 @@ void TestConflictResolverWorker::testCreateParentDelete() {
     // Simulate file creation on local replica
     std::shared_ptr<Node> lNodeAA = _syncPal->updateTree(ReplicaSide::Local)->getNodeById("lAA");
     std::shared_ptr<Node> lNodeAAB = std::make_shared<Node>(
-        std::nullopt, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("AAB.txt"), NodeType::File, OperationType::Create,
-        "lAAB", testhelpers::defaultTime, testhelpers::defaultTime, testhelpers::defaultFileSize, lNodeAA);
+            std::nullopt, _syncPal->updateTree(ReplicaSide::Local)->side(), Str("AAB.txt"), NodeType::File, OperationType::Create,
+            "lAAB", testhelpers::defaultTime, testhelpers::defaultTime, testhelpers::defaultFileSize, lNodeAA);
     CPPUNIT_ASSERT(lNodeAA->insertChildren(lNodeAAB));
     _syncPal->updateTree(ReplicaSide::Local)->insertNode(lNodeAAB);
     _syncPal->_localSnapshot->updateItem(SnapshotItem("lAAB", "lAA", Str("AAB.txt"), testhelpers::defaultTime,
-                                                      testhelpers::defaultTime, NodeType::File, 123, "lcs1"));
+                                                      testhelpers::defaultTime, NodeType::File, 123, false, true, true));
 
     // Simulate a delete of node AA on remote replica
     std::shared_ptr<Node> rNodeA = _syncPal->updateTree(ReplicaSide::Remote)->getNodeById("rA");
@@ -565,7 +566,7 @@ void TestConflictResolverWorker::testCreateParentDelete() {
 
     _syncPal->_conflictResolverWorker->execute();
 
-    CPPUNIT_ASSERT_EQUAL((size_t)1, _syncPal->_syncOps->size());
+    CPPUNIT_ASSERT_EQUAL((size_t) 1, _syncPal->_syncOps->size());
     UniqueId opId = _syncPal->_syncOps->opSortedList().front();
     SyncOpPtr op = _syncPal->_syncOps->getOp(opId);
     CPPUNIT_ASSERT_EQUAL(ReplicaSide::Local, op->targetSide());
@@ -609,7 +610,7 @@ void TestConflictResolverWorker::testMoveMoveSource() {
 void TestConflictResolverWorker::testMoveMoveSourceWithOrphanNodes() {
     // Initial state : Node AAA is orphan.
     const SyncName orphanName = PlatformInconsistencyCheckerUtility::instance()->generateNewValidName(
-        "AAA", PlatformInconsistencyCheckerUtility::SuffixTypeOrphan);
+            "AAA", PlatformInconsistencyCheckerUtility::SuffixTypeOrphan);
 
     std::shared_ptr<Node> lNodeAAA = _syncPal->updateTree(ReplicaSide::Local)->getNodeById("lAAA");
     lNodeAAA->setName(orphanName);
@@ -784,4 +785,4 @@ void TestConflictResolverWorker::testMoveMoveCycle2() {
     CPPUNIT_ASSERT_EQUAL(ReplicaSide::Local, op->targetSide());
     CPPUNIT_ASSERT_EQUAL(OperationType::Move, op->type());
 }
-}  // namespace KDC
+} // namespace KDC

--- a/test/libsyncengine/update_detection/file_system_observer/testcomputefsoperationworker.cpp
+++ b/test/libsyncengine/update_detection/file_system_observer/testcomputefsoperationworker.cpp
@@ -119,47 +119,47 @@ void TestComputeFSOperationWorker::setUp() {
     //// Insert dir in snapshot
     _syncPal->_localSnapshot->updateItem(SnapshotItem(
             nodeDirA.nodeIdLocal().value(), _syncPal->syncDb()->rootNode().nodeIdLocal().value(), nodeDirA.nameLocal(),
-            nodeDirA.created().value(), nodeDirA.lastModifiedLocal().value(), nodeDirA.type(), 123));
+            nodeDirA.created().value(), nodeDirA.lastModifiedLocal().value(), nodeDirA.type(), 123, false, true, true));
     _syncPal->_localSnapshot->updateItem(SnapshotItem(
             nodeDirB.nodeIdLocal().value(), _syncPal->syncDb()->rootNode().nodeIdLocal().value(), nodeDirB.nameLocal(),
-            nodeDirB.created().value(), nodeDirB.lastModifiedLocal().value(), nodeDirB.type(), 123));
+            nodeDirB.created().value(), nodeDirB.lastModifiedLocal().value(), nodeDirB.type(), 123, false, true, true));
 
     _syncPal->_remoteSnapshot->updateItem(SnapshotItem(
             nodeDirA.nodeIdRemote().value(), _syncPal->syncDb()->rootNode().nodeIdRemote().value(), nodeDirA.nameRemote(),
-            nodeDirA.created().value(), nodeDirA.lastModifiedRemote().value(), nodeDirA.type(), 123));
+            nodeDirA.created().value(), nodeDirA.lastModifiedRemote().value(), nodeDirA.type(), 123, false, true, true));
     _syncPal->_remoteSnapshot->updateItem(SnapshotItem(
             nodeDirB.nodeIdRemote().value(), _syncPal->syncDb()->rootNode().nodeIdRemote().value(), nodeDirB.nameRemote(),
-            nodeDirB.created().value(), nodeDirB.lastModifiedRemote().value(), nodeDirB.type(), 123));
+            nodeDirB.created().value(), nodeDirB.lastModifiedRemote().value(), nodeDirB.type(), 123, false, true, true));
 
     //// Insert files in snapshot
-    _syncPal->_localSnapshot->updateItem(SnapshotItem(nodeFileAA.nodeIdLocal().value(), nodeDirA.nodeIdLocal().value(),
-                                                      nodeFileAA.nameLocal(), nodeFileAA.created().value(),
-                                                      nodeFileAA.lastModifiedLocal().value(), nodeFileAA.type(), 123));
-    _syncPal->_localSnapshot->updateItem(SnapshotItem(nodeFileAB.nodeIdLocal().value(), nodeDirA.nodeIdLocal().value(),
-                                                      nodeFileAB.nameLocal(), nodeFileAB.created().value(),
-                                                      nodeFileAB.lastModifiedLocal().value(), nodeFileAB.type(), 123));
-    _syncPal->_localSnapshot->updateItem(SnapshotItem(nodeFileBA.nodeIdLocal().value(), nodeDirB.nodeIdLocal().value(),
-                                                      nodeFileBA.nameLocal(), nodeFileBA.created().value(),
-                                                      nodeFileBA.lastModifiedLocal().value(), nodeFileBA.type(), 123));
-    _syncPal->_localSnapshot->updateItem(SnapshotItem(nodeFileBB.nodeIdLocal().value(), nodeDirB.nodeIdLocal().value(),
-                                                      nodeFileBB.nameLocal(), nodeFileBB.created().value(),
-                                                      nodeFileBB.lastModifiedLocal().value(), nodeFileBB.type(), 123));
+    _syncPal->_localSnapshot->updateItem(SnapshotItem(
+            nodeFileAA.nodeIdLocal().value(), nodeDirA.nodeIdLocal().value(), nodeFileAA.nameLocal(),
+            nodeFileAA.created().value(), nodeFileAA.lastModifiedLocal().value(), nodeFileAA.type(), 123, false, true, true));
+    _syncPal->_localSnapshot->updateItem(SnapshotItem(
+            nodeFileAB.nodeIdLocal().value(), nodeDirA.nodeIdLocal().value(), nodeFileAB.nameLocal(),
+            nodeFileAB.created().value(), nodeFileAB.lastModifiedLocal().value(), nodeFileAB.type(), 123, false, true, true));
+    _syncPal->_localSnapshot->updateItem(SnapshotItem(
+            nodeFileBA.nodeIdLocal().value(), nodeDirB.nodeIdLocal().value(), nodeFileBA.nameLocal(),
+            nodeFileBA.created().value(), nodeFileBA.lastModifiedLocal().value(), nodeFileBA.type(), 123, false, true, true));
+    _syncPal->_localSnapshot->updateItem(SnapshotItem(
+            nodeFileBB.nodeIdLocal().value(), nodeDirB.nodeIdLocal().value(), nodeFileBB.nameLocal(),
+            nodeFileBB.created().value(), nodeFileBB.lastModifiedLocal().value(), nodeFileBB.type(), 123, false, true, true));
 
-    _syncPal->_remoteSnapshot->updateItem(SnapshotItem(nodeFileAA.nodeIdRemote().value(), nodeDirA.nodeIdRemote().value(),
-                                                       nodeFileAA.nameRemote(), nodeFileAA.created().value(),
-                                                       nodeFileAA.lastModifiedRemote().value(), nodeFileAA.type(), 123));
-    _syncPal->_remoteSnapshot->updateItem(SnapshotItem(nodeFileAB.nodeIdRemote().value(), nodeDirA.nodeIdRemote().value(),
-                                                       nodeFileAB.nameRemote(), nodeFileAB.created().value(),
-                                                       nodeFileAB.lastModifiedRemote().value(), nodeFileAB.type(), 123));
-    _syncPal->_remoteSnapshot->updateItem(SnapshotItem(nodeFileBA.nodeIdRemote().value(), nodeDirB.nodeIdRemote().value(),
-                                                       nodeFileBA.nameRemote(), nodeFileBA.created().value(),
-                                                       nodeFileBA.lastModifiedRemote().value(), nodeFileBA.type(), 123));
-    _syncPal->_remoteSnapshot->updateItem(SnapshotItem(nodeFileBB.nodeIdRemote().value(), nodeDirB.nodeIdRemote().value(),
-                                                       nodeFileBB.nameRemote(), nodeFileBB.created().value(),
-                                                       nodeFileBB.lastModifiedRemote().value(), nodeFileBB.type(), 123));
+    _syncPal->_remoteSnapshot->updateItem(SnapshotItem(
+            nodeFileAA.nodeIdRemote().value(), nodeDirA.nodeIdRemote().value(), nodeFileAA.nameRemote(),
+            nodeFileAA.created().value(), nodeFileAA.lastModifiedRemote().value(), nodeFileAA.type(), 123, false, true, true));
+    _syncPal->_remoteSnapshot->updateItem(SnapshotItem(
+            nodeFileAB.nodeIdRemote().value(), nodeDirA.nodeIdRemote().value(), nodeFileAB.nameRemote(),
+            nodeFileAB.created().value(), nodeFileAB.lastModifiedRemote().value(), nodeFileAB.type(), 123, false, true, true));
+    _syncPal->_remoteSnapshot->updateItem(SnapshotItem(
+            nodeFileBA.nodeIdRemote().value(), nodeDirB.nodeIdRemote().value(), nodeFileBA.nameRemote(),
+            nodeFileBA.created().value(), nodeFileBA.lastModifiedRemote().value(), nodeFileBA.type(), 123, false, true, true));
+    _syncPal->_remoteSnapshot->updateItem(SnapshotItem(
+            nodeFileBB.nodeIdRemote().value(), nodeDirB.nodeIdRemote().value(), nodeFileBB.nameRemote(),
+            nodeFileBB.created().value(), nodeFileBB.lastModifiedRemote().value(), nodeFileBB.type(), 123, false, true, true));
     _syncPal->_remoteSnapshot->updateItem(SnapshotItem("rac", nodeDirA.nodeIdRemote().value(), Str("AC"),
                                                        testhelpers::defaultTime, testhelpers::defaultTime, NodeType::Directory,
-                                                       123));
+                                                       123, false, true, true));
 
     // Insert items to excluded templates in DB
     std::vector<ExclusionTemplate> templateVec = {ExclusionTemplate("*.lnk", true)};
@@ -210,9 +210,9 @@ void TestComputeFSOperationWorker::testDeletionOfNestedFolders() {
 
 void TestComputeFSOperationWorker::testCreateDuplicateNamesWithDistinctEncodings() {
     _syncPal->_localSnapshot->updateItem(SnapshotItem("la_nfc", "la", testhelpers::makeNfcSyncName(), testhelpers::defaultTime,
-                                                      testhelpers::defaultTime, NodeType::File, 123));
+                                                      testhelpers::defaultTime, NodeType::File, 123, false, true, true));
     _syncPal->_localSnapshot->updateItem(SnapshotItem("la_nfd", "la", testhelpers::makeNfdSyncName(), testhelpers::defaultTime,
-                                                      testhelpers::defaultTime, NodeType::File, 123));
+                                                      testhelpers::defaultTime, NodeType::File, 123, false, true, true));
 
     _syncPal->copySnapshots();
     _syncPal->computeFSOperationsWorker()->execute();
@@ -227,8 +227,8 @@ void TestComputeFSOperationWorker::testCreateDuplicateNamesWithDistinctEncodings
 void TestComputeFSOperationWorker::testMultipleOps() {
     // On local replica
     // Create operation
-    _syncPal->_localSnapshot->updateItem(
-            SnapshotItem("lad", "la", Str("AD"), testhelpers::defaultTime, testhelpers::defaultTime, NodeType::File, 123));
+    _syncPal->_localSnapshot->updateItem(SnapshotItem("lad", "la", Str("AD"), testhelpers::defaultTime, testhelpers::defaultTime,
+                                                      NodeType::File, 123, false, true, true));
     // Edit operation
     _syncPal->_localSnapshot->setLastModified("laa", testhelpers::defaultTime + 60);
     // Move operation
@@ -240,10 +240,10 @@ void TestComputeFSOperationWorker::testMultipleOps() {
 
     // Create operation on a too big directory
     _syncPal->_remoteSnapshot->updateItem(SnapshotItem("raf", "ra", Str("AF_too_big"), testhelpers::defaultTime,
-                                                       testhelpers::defaultTime, NodeType::Directory, 0));
+                                                       testhelpers::defaultTime, NodeType::Directory, 0, false, true, true));
     _syncPal->_remoteSnapshot->updateItem(SnapshotItem("rafa", "raf", Str("AFA"), testhelpers::defaultTime,
-                                                       testhelpers::defaultTime, NodeType::File,
-                                                       550 * 1024 * 1024)); // File size: 550MB
+                                                       testhelpers::defaultTime, NodeType::File, 550 * 1024 * 1024, false, true,
+                                                       true)); // File size: 550MB
     // Rename operation on a blacklisted directory
     _syncPal->_remoteSnapshot->setName("rac", Str("AC-renamed"));
 
@@ -291,7 +291,7 @@ void TestComputeFSOperationWorker::testDifferentEncoding_NFC_NFD() {
 
     _syncPal->_localSnapshot->updateItem(SnapshotItem("ltest", *_syncPal->syncDb()->rootNode().nodeIdLocal(), Str("testé.txt"),
                                                       testhelpers::defaultTime, testhelpers::defaultTime, NodeType::File,
-                                                      testhelpers::defaultFileSize));
+                                                      testhelpers::defaultFileSize, false, true, true));
 
     _syncPal->copySnapshots();
     _syncPal->computeFSOperationsWorker()->execute();
@@ -310,7 +310,7 @@ void TestComputeFSOperationWorker::testDifferentEncoding_NFD_NFC() {
 
     _syncPal->_localSnapshot->updateItem(SnapshotItem("ltest", *_syncPal->syncDb()->rootNode().nodeIdLocal(), Str("testé.txt"),
                                                       testhelpers::defaultTime, testhelpers::defaultTime, NodeType::File,
-                                                      testhelpers::defaultFileSize));
+                                                      testhelpers::defaultFileSize, false, true, true));
 
     _syncPal->copySnapshots();
     _syncPal->computeFSOperationsWorker()->execute();
@@ -329,7 +329,7 @@ void TestComputeFSOperationWorker::testDifferentEncoding_NFD_NFD() {
 
     _syncPal->_localSnapshot->updateItem(SnapshotItem("ltest", *_syncPal->syncDb()->rootNode().nodeIdLocal(), Str("testé.txt"),
                                                       testhelpers::defaultTime, testhelpers::defaultTime, NodeType::File,
-                                                      testhelpers::defaultFileSize));
+                                                      testhelpers::defaultFileSize, false, true, true));
 
     _syncPal->copySnapshots();
     _syncPal->computeFSOperationsWorker()->execute();
@@ -349,7 +349,7 @@ void TestComputeFSOperationWorker::testDifferentEncoding_NFC_NFC() {
 
     _syncPal->_localSnapshot->updateItem(SnapshotItem("ltest", *_syncPal->syncDb()->rootNode().nodeIdLocal(), Str("testé.txt"),
                                                       testhelpers::defaultTime, testhelpers::defaultTime, NodeType::File,
-                                                      testhelpers::defaultFileSize));
+                                                      testhelpers::defaultFileSize, false, true, true));
 
     _syncPal->copySnapshots();
     _syncPal->computeFSOperationsWorker()->execute();

--- a/test/libsyncengine/update_detection/file_system_observer/testsnapshot.cpp
+++ b/test/libsyncengine/update_detection/file_system_observer/testsnapshot.cpp
@@ -53,7 +53,7 @@ void TestSnapshot::testSnapshot() {
     Snapshot snapshot(ReplicaSide::Local, dummyRootNode);
 
     // Insert node A
-    const SnapshotItem itemA("a", rootNodeId, Str("A"), 1640995201, -1640995201, NodeType::Directory, 123);
+    const SnapshotItem itemA("a", rootNodeId, Str("A"), 1640995201, -1640995201, NodeType::Directory, 123, false, true, true);
     snapshot.updateItem(itemA);
     CPPUNIT_ASSERT(snapshot.exists("a"));
     CPPUNIT_ASSERT_EQUAL(std::string("A"), SyncName2Str(snapshot.name("a")));
@@ -63,24 +63,25 @@ void TestSnapshot::testSnapshot() {
     CPPUNIT_ASSERT(childrenIds.contains("a"));
 
     // Update node A
-    snapshot.updateItem(SnapshotItem("a", rootNodeId, Str("A*"), 1640995202, 1640995202, NodeType::Directory, 123));
+    snapshot.updateItem(
+            SnapshotItem("a", rootNodeId, Str("A*"), 1640995202, 1640995202, NodeType::Directory, 123, false, true, true));
     CPPUNIT_ASSERT_EQUAL(std::string("A*"), SyncName2Str(snapshot.name("a")));
 
     // Insert node B
-    const SnapshotItem itemB("b", rootNodeId, Str("B"), 1640995203, 1640995203, NodeType::Directory, 123);
+    const SnapshotItem itemB("b", rootNodeId, Str("B"), 1640995203, 1640995203, NodeType::Directory, 123, false, true, true);
     snapshot.updateItem(itemB);
     CPPUNIT_ASSERT(snapshot.exists("b"));
     snapshot.getChildrenIds(rootNodeId, childrenIds);
     CPPUNIT_ASSERT(childrenIds.contains("b"));
 
     // Insert child nodes
-    const SnapshotItem itemAA("aa", "a", Str("AA"), 1640995204, 1640995204, NodeType::Directory, 123);
+    const SnapshotItem itemAA("aa", "a", Str("AA"), 1640995204, 1640995204, NodeType::Directory, 123, false, true, true);
     snapshot.updateItem(itemAA);
     CPPUNIT_ASSERT(snapshot.exists("aa"));
     snapshot.getChildrenIds("a", childrenIds);
     CPPUNIT_ASSERT(childrenIds.contains("aa"));
 
-    const SnapshotItem itemAAA("aaa", "aa", Str("AAA"), 1640995205, 1640995205, NodeType::File, 123);
+    const SnapshotItem itemAAA("aaa", "aa", Str("AAA"), 1640995205, 1640995205, NodeType::File, 123, false, true, true);
     snapshot.updateItem(itemAAA);
     CPPUNIT_ASSERT(snapshot.exists("aaa"));
     snapshot.getChildrenIds("aa", childrenIds);
@@ -92,11 +93,11 @@ void TestSnapshot::testSnapshot() {
     CPPUNIT_ASSERT_EQUAL(std::string("AAA"), SyncName2Str(snapshot.name("aaa")));
     CPPUNIT_ASSERT_EQUAL(static_cast<SyncTime>(1640995205), snapshot.lastModified("aaa"));
     CPPUNIT_ASSERT_EQUAL(NodeType::File, snapshot.type("aaa"));
-    CPPUNIT_ASSERT(snapshot.contentChecksum("aaa").empty());  // Checksum never computed for now
+    CPPUNIT_ASSERT(snapshot.contentChecksum("aaa").empty()); // Checksum never computed for now
     CPPUNIT_ASSERT_EQUAL(NodeId("aaa"), snapshot.itemId(std::filesystem::path("A*/AA/AAA")));
 
     // Move node AA under B
-    snapshot.updateItem(SnapshotItem("aa", "b", Str("AA"), 1640995204, -1640995204, NodeType::Directory, 123));
+    snapshot.updateItem(SnapshotItem("aa", "b", Str("AA"), 1640995204, -1640995204, NodeType::Directory, 123, false, true, true));
     CPPUNIT_ASSERT(snapshot.parentId("aa") == "b");
     snapshot.getChildrenIds("b", childrenIds);
     CPPUNIT_ASSERT(childrenIds.contains("aa"));
@@ -123,10 +124,10 @@ void TestSnapshot::testSnapshotInsertionWithDifferentEncodings() {
                                std::nullopt, NodeType::Directory, 0, std::nullopt);
     Snapshot snapshot(ReplicaSide::Local, dummyRootNode);
 
-    const SnapshotItem nfcItem("A", rootNodeId, testhelpers::makeNfcSyncName(), 1640995201, -1640995201, NodeType::Directory,
-                               123);
-    const SnapshotItem nfdItem("B", rootNodeId, testhelpers::makeNfdSyncName(), 1640995201, -1640995201, NodeType::Directory,
-                               123);
+    const SnapshotItem nfcItem("A", rootNodeId, testhelpers::makeNfcSyncName(), 1640995201, -1640995201, NodeType::Directory, 123,
+                               false, true, true);
+    const SnapshotItem nfdItem("B", rootNodeId, testhelpers::makeNfdSyncName(), 1640995201, -1640995201, NodeType::Directory, 123,
+                               false, true, true);
     {
         snapshot.updateItem(nfcItem);
         SyncPath syncPath;
@@ -141,4 +142,4 @@ void TestSnapshot::testSnapshotInsertionWithDifferentEncodings() {
     }
 }
 
-}  // namespace KDC
+} // namespace KDC


### PR DESCRIPTION
All files created on remote while the app was running were detected as link. Therefore, the app would download the file content even in LiteSync mode.
