### PR TITLE
Implement CustomLogWStream wich doesn't allow non wstring in LOGW_XXX

### DIFF
--- a/src/libcommonserver/log/log.h
+++ b/src/libcommonserver/log/log.h
@@ -42,7 +42,7 @@ namespace KDC {
 
 #define LOGW_DEBUG(logger, logEvent)                                                                      \
     {                                                                                                     \
-        std::wstringstream stream;                                                                        \
+        Log::CustomLogWStream stream;                                                                       \
         stream << logEvent;                                                                               \
         sentry_value_t crumb = sentry_value_new_breadcrumb(nullptr, Utility::ws2s(stream.str()).c_str()); \
         sentry_value_set_by_key(crumb, "level", sentry_value_new_string("debug"));                        \
@@ -62,7 +62,7 @@ namespace KDC {
 
 #define LOGW_INFO(logger, logEvent)                                                                       \
     {                                                                                                     \
-        std::wstringstream stream;                                                                        \
+        Log::CustomLogWStream stream;                                                                       \
         stream << logEvent;                                                                               \
         sentry_value_t crumb = sentry_value_new_breadcrumb(nullptr, Utility::ws2s(stream.str()).c_str()); \
         sentry_value_set_by_key(crumb, "level", sentry_value_new_string("info"));                         \
@@ -82,7 +82,7 @@ namespace KDC {
 
 #define LOGW_WARN(logger, logEvent)                                                                       \
     {                                                                                                     \
-        std::wstringstream stream;                                                                        \
+        Log::CustomLogWStream stream;                                                                       \
         stream << logEvent;                                                                               \
         sentry_value_t crumb = sentry_value_new_breadcrumb(nullptr, Utility::ws2s(stream.str()).c_str()); \
         sentry_value_set_by_key(crumb, "level", sentry_value_new_string("warning"));                      \
@@ -102,7 +102,7 @@ namespace KDC {
 
 #define LOGW_ERROR(logger, logEvent)                                                                      \
     {                                                                                                     \
-        std::wstringstream stream;                                                                        \
+        Log::CustomLogWStream stream;                                                                       \
         stream << logEvent;                                                                               \
         sentry_value_t crumb = sentry_value_new_breadcrumb(nullptr, Utility::ws2s(stream.str()).c_str()); \
         sentry_value_set_by_key(crumb, "level", sentry_value_new_string("error"));                        \
@@ -122,7 +122,7 @@ namespace KDC {
 
 #define LOGW_FATAL(logger, logEvent)                                                                      \
     {                                                                                                     \
-        std::wstringstream stream;                                                                        \
+        Log::CustomLogWStream stream;                                                                       \
         stream << logEvent;                                                                               \
         sentry_value_t crumb = sentry_value_new_breadcrumb(nullptr, Utility::ws2s(stream.str()).c_str()); \
         sentry_value_set_by_key(crumb, "level", sentry_value_new_string("fatal"));                        \
@@ -174,6 +174,24 @@ class COMMONSERVER_EXPORT Log {
         static const std::wstring rfPattern;
         static const int rfMaxBackupIdx;
 
+        class CustomLogWStream : private std::wstringstream {
+            public:
+                CustomLogWStream() = default;
+                CustomLogWStream(const CustomLogWStream &wstr) : std::basic_stringstream<wchar_t>(wstr.str()) {}
+                const std::wstring str() const { return std::basic_stringstream<wchar_t>::str(); }
+                CustomLogWStream operator<<(const wchar_t *str) {
+                    std::wstringstream::operator<<(str);
+                    return *this;
+                }
+                CustomLogWStream operator<<(int i) {
+                    std::wstringstream::operator<<(i);
+                    return *this;
+                }
+                CustomLogWStream operator<<(const std::wstring &str) {
+                    std::wstringstream::operator<<(str.c_str());
+                    return *this;
+                }
+        };
     private:
         friend class TestLog;
         friend class TestIo;


### PR DESCRIPTION
Currently, using LOGW_XXXX macros with non-wchar_t types leads to crashes that are difficult to diagnose and are not caught during compilation. A solution is required to prevent the misuse of these macros with incorrect types at compile-time.Prevent the use of LOGW_XXXX with non-wchar types