### PR TITLE
Simplifies the implementation of CommonUtility::isVersionLower

### DIFF
--- a/src/libcommon/utility/utility.cpp
+++ b/src/libcommon/utility/utility.cpp
@@ -729,19 +729,11 @@ bool CommonUtility::isVersionLower(const std::string &currentVersion, const std:
     extractIntFromStrVersion(targetVersion, targetTabVersion);
 
     if (currTabVersion.size() != targetTabVersion.size()) {
-        // Should not happen
-        return false;
+        return false; // Should not happen
     }
 
-    for (size_t i = 0; i < targetTabVersion.size(); i++) {
-        if (currTabVersion[i] > targetTabVersion[i]) {
-            return false;
-        } else if (currTabVersion[i] < targetTabVersion[i]) {
-            return true;
-        }
-    }
-
-    return false;
+    return std::lexicographical_compare(currTabVersion.cbegin(), currTabVersion.cend(), targetTabVersion.cbegin(),
+                                        targetTabVersion.cend());
 }
 
 static std::string tmpDirName = "kdrive_" + CommonUtility::generateRandomStringAlphaNum();

--- a/src/libcommon/utility/utility.cpp
+++ b/src/libcommon/utility/utility.cpp
@@ -732,8 +732,7 @@ bool CommonUtility::isVersionLower(const std::string &currentVersion, const std:
         return false; // Should not happen
     }
 
-    return std::lexicographical_compare(currTabVersion.cbegin(), currTabVersion.cend(), targetTabVersion.cbegin(),
-                                        targetTabVersion.cend());
+    return std::ranges::lexicographical_compare(currTabVersion, targetTabVersion);
 }
 
 static std::string tmpDirName = "kdrive_" + CommonUtility::generateRandomStringAlphaNum();

--- a/test/libcommon/utility/testutility.cpp
+++ b/test/libcommon/utility/testutility.cpp
@@ -44,6 +44,7 @@ void TestUtility::testGetAppSupportDir() {
 void TestUtility::testIsVersionLower() {
     CPPUNIT_ASSERT(!CommonUtility::isVersionLower("3.5.8", "3.5.8"));
 
+    // Single digit major, minor or patch versions
     CPPUNIT_ASSERT(CommonUtility::isVersionLower("3.5.8", "3.5.9"));
     CPPUNIT_ASSERT(!CommonUtility::isVersionLower("3.5.8", "3.5.7"));
 
@@ -64,6 +65,20 @@ void TestUtility::testIsVersionLower() {
     CPPUNIT_ASSERT(!CommonUtility::isVersionLower("3.5.8", "2.5.9"));
     CPPUNIT_ASSERT(!CommonUtility::isVersionLower("3.5.8", "2.6.7"));
     CPPUNIT_ASSERT(!CommonUtility::isVersionLower("3.5.8", "2.6.9"));
+
+
+    // Double digit major, minor or patch versions
+    CPPUNIT_ASSERT(CommonUtility::isVersionLower("1.0.0", "55.0.0"));
+    CPPUNIT_ASSERT(CommonUtility::isVersionLower("9.0.0", "55.0.0"));
+
+    CPPUNIT_ASSERT(CommonUtility::isVersionLower("25.0.0", "55.0.0"));
+    CPPUNIT_ASSERT(!CommonUtility::isVersionLower("75.0.0", "55.0.0"));
+
+    CPPUNIT_ASSERT(CommonUtility::isVersionLower("55.0.25", "55.0.55"));
+    CPPUNIT_ASSERT(!CommonUtility::isVersionLower("55.0.75", "55.0.55"));
+
+    CPPUNIT_ASSERT(CommonUtility::isVersionLower("55.25.0", "55.55.0"));
+    CPPUNIT_ASSERT(!CommonUtility::isVersionLower("55.75.0", "55.55.0"));
 }
 
 void TestUtility::testStringToAppStateValue() {


### PR DESCRIPTION
The proposed changes replace a custom logic by a standard implementation of the lexicographical comparison of `std::vector<int>`. 