### PR TITLE
Kdesktop 1229 log rotation issue old logs being deleted instead of being renamed

### DIFF
--- a/src/libcommonserver/log/customrollingfileappender.cpp
+++ b/src/libcommonserver/log/customrollingfileappender.cpp
@@ -126,9 +126,9 @@ static void loglog_opening_result(helpers::LogLog &loglog, log4cplus::tostream c
     }
 }
 
-}  // namespace
+} // namespace
 
-}  // namespace log4cplus
+} // namespace log4cplus
 
 /***********************************/
 /********** namespace KDC **********/
@@ -172,11 +172,14 @@ static void rolloverFiles(const log4cplus::tstring &filename, unsigned int maxBa
 }
 
 CustomRollingFileAppender::CustomRollingFileAppender(const log4cplus::tstring &filename, long maxFileSize, int maxBackupIndex,
-                                                     bool immediateFlush, bool createDirs)
-    : RollingFileAppender(filename, maxFileSize, maxBackupIndex, immediateFlush, createDirs), _lastExpireCheck() {}
+                                                     bool immediateFlush, bool createDirs) :
+    RollingFileAppender(filename, LONG_MAX /*Let us handle a custom rollover*/, maxBackupIndex, immediateFlush, createDirs),
+    _maxFileSize(maxFileSize), _lastExpireCheck() {
+    checkForExpiredFiles();
+}
 
-CustomRollingFileAppender::CustomRollingFileAppender(const log4cplus::helpers::Properties &properties)
-    : RollingFileAppender(properties), _lastExpireCheck() {}
+CustomRollingFileAppender::CustomRollingFileAppender(const log4cplus::helpers::Properties &properties) :
+    RollingFileAppender(properties), _lastExpireCheck() {}
 
 void CustomRollingFileAppender::append(const log4cplus::spi::InternalLoggingEvent &event) {
     // Seek to the end of log file so that tellp() below returns the
@@ -184,7 +187,7 @@ void CustomRollingFileAppender::append(const log4cplus::spi::InternalLoggingEven
     if (useLockFile) out.seekp(0, std::ios_base::end);
 
     // Rotate log file if needed before appending to it.
-    if (out.tellp() > maxFileSize) customRollover(true);
+    if (out.tellp() > _maxFileSize) customRollover(true);
 
     try {
         RollingFileAppender::append(event);
@@ -196,7 +199,7 @@ void CustomRollingFileAppender::append(const log4cplus::spi::InternalLoggingEven
     }
 
     // Rotate log file if needed after appending to it.
-    if (out.tellp() > maxFileSize) customRollover(true);
+    if (out.tellp() > _maxFileSize) customRollover(true);
 
     // Check for expired files at startup and every hour
     if (_lastExpireCheck == std::chrono::time_point<std::chrono::system_clock>() ||
@@ -328,4 +331,4 @@ void CustomRollingFileAppender::checkForExpiredFiles() {
         }
     }
 }
-}  // namespace KDC
+} // namespace KDC

--- a/src/libcommonserver/log/customrollingfileappender.cpp
+++ b/src/libcommonserver/log/customrollingfileappender.cpp
@@ -184,7 +184,7 @@ void CustomRollingFileAppender::append(const log4cplus::spi::InternalLoggingEven
     if (useLockFile) out.seekp(0, std::ios_base::end);
 
     // Rotate log file if needed before appending to it.
-    if (out.tellp() > maxFileSize) rollover(true);
+    if (out.tellp() > maxFileSize) customRollover(true);
 
     try {
         RollingFileAppender::append(event);
@@ -196,7 +196,7 @@ void CustomRollingFileAppender::append(const log4cplus::spi::InternalLoggingEven
     }
 
     // Rotate log file if needed after appending to it.
-    if (out.tellp() > maxFileSize) rollover(true);
+    if (out.tellp() > maxFileSize) customRollover(true);
 
     // Check for expired files at startup and every hour
     if (_lastExpireCheck == std::chrono::time_point<std::chrono::system_clock>() ||
@@ -205,7 +205,7 @@ void CustomRollingFileAppender::append(const log4cplus::spi::InternalLoggingEven
     }
 }
 
-void CustomRollingFileAppender::rollover(bool alreadyLocked) {
+void CustomRollingFileAppender::customRollover(bool alreadyLocked) {
     log4cplus::helpers::LogLog &loglog = log4cplus::helpers::getLogLog();
     log4cplus::helpers::LockFileGuard guard;
 

--- a/src/libcommonserver/log/customrollingfileappender.h
+++ b/src/libcommonserver/log/customrollingfileappender.h
@@ -45,6 +45,7 @@ class CustomRollingFileAppender : public log4cplus::RollingFileAppender {
 
     private:
         int _expire = 0;
+        long _maxFileSize = 0;
         std::chrono::time_point<std::chrono::system_clock> _lastExpireCheck;
 
         void checkForExpiredFiles() noexcept(false);

--- a/src/libcommonserver/log/customrollingfileappender.h
+++ b/src/libcommonserver/log/customrollingfileappender.h
@@ -36,8 +36,8 @@ class CustomRollingFileAppender : public log4cplus::RollingFileAppender {
             _lastExpireCheck = std::chrono::system_clock::time_point();  // Force check on next append
         }
 
-        inline void setMaxFileSize(long newMaxFileSize) { maxFileSize = newMaxFileSize; }
-        inline int getMaxFileSize() const { return maxFileSize; }
+        inline void setMaxFileSize(long newMaxFileSize) { _maxFileSize = newMaxFileSize; }
+        inline int getMaxFileSize() const { return _maxFileSize; }
 
     protected:
         void append(const log4cplus::spi::InternalLoggingEvent &event) override;

--- a/src/libcommonserver/log/customrollingfileappender.h
+++ b/src/libcommonserver/log/customrollingfileappender.h
@@ -41,7 +41,7 @@ class CustomRollingFileAppender : public log4cplus::RollingFileAppender {
 
     protected:
         void append(const log4cplus::spi::InternalLoggingEvent &event) override;
-        void rollover(bool alreadyLocked = false);
+        void customRollover(bool alreadyLocked = false);
 
     private:
         int _expire = 0;


### PR DESCRIPTION
# Description

When the log reaches its maximum size, a new log is successfully created. However, it has been observed that the old log is being deleted instead of being renamed with a ".0" suffix as expected. This behavior is causing us to lose historical log data and making it difficult to troubleshoot issues.