### PR TITLE
Kdesktop 1250 crash in executor worker concurrent access to  terminated jobs queue

### DIFF
--- a/src/libcommon/CMakeLists.txt
+++ b/src/libcommon/CMakeLists.txt
@@ -23,6 +23,7 @@ set(libcommon_SRCS
     utility/types.cpp
     utility/utility.h utility/utility.cpp
     utility/jsonparserutility.h
+    utility/threadsafecontainers/unorderedmapts.h
     keychainmanager/apitoken.h keychainmanager/apitoken.cpp
     keychainmanager/keychainmanager.h keychainmanager/keychainmanager.cpp
     info/userinfo.h info/userinfo.cpp

--- a/src/libcommon/utility/threadsafecontainers/unorderedmapts.h
+++ b/src/libcommon/utility/threadsafecontainers/unorderedmapts.h
@@ -1,0 +1,174 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2024 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <unordered_map>
+#include <mutex>
+#include <thread>
+#include <cassert>
+#include <chrono>
+#include "utility/types.h"
+#include "log/sentry/sentryhandler.h"
+
+constexpr int maxExclusiveAcessTime = 1000; // in ms
+
+namespace KDC {
+
+/// Thread-safe unordered map for any type of data
+template<typename Key, typename Value>
+class UnorderedMapTS {
+    private: /// Locker
+        class Locker {
+            public:
+                explicit Locker(UnorderedMapTS &map) : _map(map) { _map.lock(); }
+                ~Locker() { _map.unlock(); }
+
+            private:
+                UnorderedMapTS &_map;
+        };
+        friend UnorderedMapTS::Locker;
+
+    public:
+        UnorderedMapTS() = default;
+        UnorderedMapTS(const UnorderedMapTS &) = delete;
+        UnorderedMapTS &operator=(const UnorderedMapTS &) = delete;
+
+        std::unordered_map<Key, Value> &getRawReference(std::thread::id threadId) {
+            if (hasExclusiveAccess(threadId)) {
+                giveExclusiveAccess(threadId);
+                return _map;
+            }
+            lock();
+            giveExclusiveAccess(threadId);
+            return _map;
+        }
+
+        void releaseOneRawReference(std::thread::id threadId) {
+            if (!hasExclusiveAccess(threadId)) {
+                assert(false && "The current thread does not have exclusive access");
+                // LOG_ERROR("The current thread does not have exclusive access");
+                SentryHandler::instance()->captureMessage(SentryLevel::Error, "Multi-thread management error",
+                                                          "The current thread does not have exclusive access");
+                return;
+            }
+            handleExclusiveAccessRelease(threadId);
+            _ExclusiveAccessThreadId = std::thread::id();
+            unlock();
+        }
+
+        void insert(const std::pair<Key, Value> &pair) {
+            const Locker lock(*this);
+            _map.insert(pair);
+        }
+
+        void erase(const Key &key) {
+            const Locker lock(*this);
+            _map.erase(key);
+        }
+
+        [[nodiscard]] bool empty() {
+            const Locker lock(*this);
+            return _map.empty();
+        }
+
+        [[nodiscard]] size_t size() {
+            const Locker lock(*this);
+            return _map.size();
+        }
+
+        [[nodiscard]] bool contains(const Key &key) {
+            const Locker lock(*this);
+            return _map.contains(key);
+        }
+
+        [[nodiscard]] Value extract(const Key &key, bool &found) {
+            const Locker lock(*this);
+            auto extracted = _map.extract(key);
+            found = !extracted.empty();
+            return extracted.mapped();
+        }
+
+    private:
+        std::unordered_map<Key, Value> _map;
+        mutable std::mutex _mutex;
+
+        /// Exclusive access management
+        mutable std::mutex _ExclusiveAccessMutexHandler;
+        std::thread::id _ExclusiveAccessThreadId;
+        unsigned int _ExclusiveAccessCount = 0;
+        std::chrono::system_clock::time_point _ExclusiveAccessTime;
+        bool alertLongExclusiveAccess = false;
+
+        bool hasExclusiveAccess(std::thread::id threadId) {
+            std::scoped_lock lock(_ExclusiveAccessMutexHandler);
+            return _ExclusiveAccessThreadId == threadId;
+        }
+
+        bool giveExclusiveAccess(std::thread::id threadId) {
+            std::scoped_lock lock(_ExclusiveAccessMutexHandler);
+            if (_ExclusiveAccessThreadId == threadId) {
+                _ExclusiveAccessCount++;
+                return true;
+            }
+
+            _ExclusiveAccessThreadId = threadId;
+            _ExclusiveAccessCount = 1;
+            _ExclusiveAccessTime = std::chrono::system_clock::now();
+            return true;
+        }
+
+        bool handleExclusiveAccessRelease(std::thread::id threadId) {
+            std::scoped_lock lock(_ExclusiveAccessMutexHandler);
+            if (_ExclusiveAccessThreadId != threadId) {
+                assert(false && "The current thread does not have exclusive access");
+                // LOG_ERROR("The current thread does not have exclusive access");
+                SentryHandler::instance()->captureMessage(SentryLevel::Error, "Multi-thread management error",
+                                                          "The current thread does not have exclusive access");
+                return false;
+            }
+
+            _ExclusiveAccessCount--;
+            return _ExclusiveAccessCount == 0;
+        }
+
+        void lock() {
+            using std::chrono::system_clock;
+            while (true) {
+                if (_mutex.try_lock()) {
+                    return;
+                }
+                longExclusiveAccessDetector();
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            }
+        }
+
+        void unlock() { _mutex.unlock(); }
+
+        void longExclusiveAccessDetector() {
+            if (!alertLongExclusiveAccess && _ExclusiveAccessThreadId != std::thread::id() &&
+                std::chrono::system_clock::now() - _ExclusiveAccessTime > std::chrono::milliseconds(maxExclusiveAcessTime)) {
+                // LOG_ERROR("A thread has thread has exclusive access for too long");
+                assert(false && "A thread has exclusive access for too long");
+                SentryHandler::instance()->captureMessage(SentryLevel::Error, "Multi-thread management error",
+                                                          "A thread has exclusive access for too long");
+                alertLongExclusiveAccess = true;
+            }
+        }
+};
+
+} // namespace KDC

--- a/src/libsyncengine/jobs/network/API_v2/upload_session/abstractuploadsession.h
+++ b/src/libsyncengine/jobs/network/API_v2/upload_session/abstractuploadsession.h
@@ -20,6 +20,7 @@
 
 #include "jobs/abstractjob.h"
 #include "utility/types.h"
+#include "libcommon/utility/threadsafecontainers/unorderedmapts.h"
 #include "db/syncdb.h"
 #include "uploadsessionchunkjob.h"
 #include "uploadsessionfinishjob.h"
@@ -27,7 +28,6 @@
 #include "uploadsessioncanceljob.h"
 #include <log4cplus/logger.h>
 
-#include <unordered_map>
 
 namespace KDC {
 
@@ -36,7 +36,7 @@ class UploadSessionChunkJob;
 class AbstractUploadSession : public AbstractJob {
     public:
         AbstractUploadSession(const SyncPath &filepath, const SyncName &filename, uint64_t nbParalleleThread = 1);
-        inline virtual ~AbstractUploadSession() = default;
+        inline ~AbstractUploadSession() override = default;
         void uploadChunkCallback(UniqueId jobId);
         void abort() override;
         UploadSessionType _uploadSessionType = UploadSessionType::Unknown;
@@ -97,7 +97,7 @@ class AbstractUploadSession : public AbstractJob {
         uint64_t _totalChunks = 0;
         std::string _totalChunkHash; // This is not a content checksum. It is the hash of all the chunk hash concatenated
 
-        std::unordered_map<UniqueId, std::shared_ptr<UploadSessionChunkJob>> _ongoingChunkJobs;
+        UnorderedMapTS<UniqueId, std::shared_ptr<UploadSessionChunkJob>> _ongoingChunkJobs;
         uint64_t _threadCounter = 0; // Number of running
 
         std::recursive_mutex _mutex;

--- a/src/libsyncengine/propagation/executor/executorworker.h
+++ b/src/libsyncengine/propagation/executor/executorworker.h
@@ -48,8 +48,14 @@ class TerminatedJobsQueue {
             const std::scoped_lock lock(_mutex);
             _terminatedJobs.pop();
         }
-        [[nodiscard]] UniqueId front() const { return _terminatedJobs.front(); }
-        [[nodiscard]] bool empty() const { return _terminatedJobs.empty(); }
+        [[nodiscard]] UniqueId front() const {
+            const std::scoped_lock lock(_mutex);
+            return _terminatedJobs.front();
+        }
+        [[nodiscard]] bool empty() const {
+            const std::scoped_lock lock(_mutex);
+            return _terminatedJobs.empty();
+        }
 
     private:
         std::queue<UniqueId> _terminatedJobs;

--- a/src/libsyncengine/propagation/executor/executorworker.h
+++ b/src/libsyncengine/propagation/executor/executorworker.h
@@ -59,7 +59,7 @@ class TerminatedJobsQueue {
 
     private:
         std::queue<UniqueId> _terminatedJobs;
-        std::mutex _mutex;
+        mutable std::mutex _mutex;
 };
 
 class ExecutorWorker : public OperationProcessor {


### PR DESCRIPTION
This pull request aims to provide thread-safe containers for use when necessary, as there are at least two places in the code where we currently use std containers simultaneously in different threads, leading to crashes. These places are `_ongoingChunkJobs` in `AbstractUploadSession` and `_terminatedJob` in `ExecutorWork` (and maybe other).