### PR TITLE
Kdesktop 1285 fix in folderwatcher.cpp

### DIFF
--- a/src/libsyncengine/syncpal/syncpalworker.cpp
+++ b/src/libsyncengine/syncpal/syncpalworker.cpp
@@ -285,6 +285,10 @@ void SyncPalWorker::initStep(SyncStep step, std::shared_ptr<ISyncWorker> (&worke
             workers[0] = _syncPal->computeFSOperationsWorker();
             workers[1] = nullptr;
             _syncPal->copySnapshots();
+            assert(_syncPal->snapshot(ReplicaSide::Local, true)->checkIntegrityRecursively() &&
+                   "Local snapshot is corrupted, see logs for details");
+            assert(_syncPal->snapshot(ReplicaSide::Remote, true)->checkIntegrityRecursively() &&
+                   "Remote snapshot is corrupted, see logs for details");
             inputSharedObject[0] = _syncPal->snapshot(ReplicaSide::Local, true);
             inputSharedObject[1] = _syncPal->snapshot(ReplicaSide::Remote, true);
             _syncPal->setRestart(false);

--- a/src/libsyncengine/update_detection/file_system_observer/folderwatcher_win.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/folderwatcher_win.cpp
@@ -149,7 +149,8 @@ void FolderWatcher_win::watchChanges() {
             SyncPath filepath = (_folder / wPathName).lexically_normal();
 
             bool skip = false;
-            const OperationType opType = operationFromAction(notifInfo->Action);
+            bool converted = false;
+            OperationType opType = operationFromAction(notifInfo->Action);
 
             if (notifInfo->Action == FILE_ACTION_MODIFIED) {
                 bool isDirectory = false;
@@ -161,10 +162,11 @@ void FolderWatcher_win::watchChanges() {
                 }
                 if (!isDirectory) {
                     if (ioError == IoError::NoSuchFileOrDirectory) {
-                        LOGW_DEBUG(_logger, L"Skip operation " << opType << L" detected on item with "
-                                                               << Utility::formatSyncPath(filepath).c_str()
-                                                               << L" (item doesn't exist)");
-                        skip = true;
+                        LOGW_DEBUG(_logger, L"Convert operation " << opType << L" detected on item "
+                                                                  << Utility::formatSyncPath(filepath).c_str()
+                                                                  << L" to Delete (item doesn't exist)");
+                        opType = OperationType::Delete;
+                        converted = true;
                     }
                 } else {
                     if (ParametersCache::isExtendedLogEnabled()) {
@@ -177,15 +179,16 @@ void FolderWatcher_win::watchChanges() {
 
             // Unless the file was removed or renamed, get its full long name
             SyncPath longfilepath = filepath;
-            if (!skip && notifInfo->Action != FILE_ACTION_REMOVED && notifInfo->Action != FILE_ACTION_RENAMED_OLD_NAME) {
+            if (!skip && opType != OperationType::Delete && notifInfo->Action != FILE_ACTION_RENAMED_OLD_NAME) {
                 bool notFound = false;
                 if (!KDC::Utility::longPath(filepath, longfilepath, notFound)) {
                     if (notFound) {
                         // Item doesn't exist anymore
-                        LOGW_DEBUG(_logger, L"Skip operation " << opType << L" detected on item "
-                                                               << Utility::formatSyncPath(longfilepath).c_str()
-                                                               << L" (item doesn't exist)");
-                        skip = true;
+                        LOGW_DEBUG(_logger, L"Convert operation " << opType << L" detected on item "
+                                                                  << Utility::formatSyncPath(longfilepath).c_str()
+                                                                  << L" to Delete (item doesn't exist)");
+                        opType = OperationType::Delete;
+                        converted = true;
                     } else {
                         // Keep original name
                         LOGW_WARN(KDC::Log::instance()->getLogger(),
@@ -196,7 +199,7 @@ void FolderWatcher_win::watchChanges() {
 
             if (!skip) {
                 if (ParametersCache::isExtendedLogEnabled()) {
-                    LOGW_DEBUG(_logger, L"Operation " << opType << L" detected on item with "
+                    LOGW_DEBUG(_logger, L"Operation " << opType << (converted ? L"(converted) " : L"") << L" detected on item with "
                                                       << Utility::formatSyncPath(longfilepath).c_str());
                 }
 

--- a/src/libsyncengine/update_detection/file_system_observer/snapshot/snapshot.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/snapshot/snapshot.cpp
@@ -496,11 +496,12 @@ bool Snapshot::checkIntegrityRecursively(const NodeId &parentId) {
 
         for (auto child2 = child; child2 != end; ++child2) {
             if (*child != *child2 && _items[*child].name() == _items[*child2].name()) {
-                LOG_ERROR(Log::instance()->getLogger(),
-                          "Snapshot integrity check failed, the folder named: \""
-                                  << SyncName2WStr(parrentItem.name()) << "\"(" << parrentItem.id().c_str() << ") contains: \""
-                                  << SyncName2WStr(_items[*child].name()) << "\" twice with two differents NodeId ("
-                                  << child->c_str() << " and " << child2->c_str() << ")");
+                LOG_ERROR(Log::instance()->getLogger(), "Snapshot integrity check failed, the folder named: \""
+                                                                << SyncName2Str(parrentItem.name()).c_str() << "\"("
+                                                                << parrentItem.id().c_str() << ") contains: \""
+                                                                << SyncName2Str(_items[*child].name()).c_str()
+                                                                << "\" twice with two differents NodeId (" << child->c_str()
+                                                                << " and " << child2->c_str() << ")");
                 return false;
             }
         }

--- a/src/libsyncengine/update_detection/file_system_observer/snapshot/snapshot.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/snapshot/snapshot.cpp
@@ -496,10 +496,11 @@ bool Snapshot::checkIntegrityRecursively(const NodeId &parentId) {
 
         for (auto child2 = child; child2 != end; ++child2) {
             if (*child != *child2 && _items[*child].name() == _items[*child2].name()) {
-                LOG_ERROR(
-                        Log::instance()->getLogger(), "Snapshot integrity check failed, the folder named: \""
-                                                              << parrentItem.name() << "\"(" << parrentItem.id().c_str() << ") contains: \"" << _items[*child].name()
-                                                                << "\" twice with two differents NodeId (" << child->c_str() << " and " << child2->c_str() << ")");
+                LOG_ERROR(Log::instance()->getLogger(),
+                          "Snapshot integrity check failed, the folder named: \""
+                                  << SyncName2WStr(parrentItem.name()) << "\"(" << parrentItem.id().c_str() << ") contains: \""
+                                  << SyncName2WStr(_items[*child].name()) << "\" twice with two differents NodeId ("
+                                  << child->c_str() << " and " << child2->c_str() << ")");
                 return false;
             }
         }

--- a/src/libsyncengine/update_detection/file_system_observer/snapshot/snapshot.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/snapshot/snapshot.cpp
@@ -482,6 +482,31 @@ void Snapshot::setValid(bool newIsValid) {
     _isValid = newIsValid;
 }
 
+bool Snapshot::checkIntegrityRecursively() {
+    return checkIntegrityRecursively(rootFolderId());
+}
+
+bool Snapshot::checkIntegrityRecursively(const NodeId &parentId) {
+    // Check that we do not have the same file twice in the same folder
+    const auto &parrentItem = _items[parentId];
+    for (auto child = parrentItem.childrenIds().begin(), end = parrentItem.childrenIds().end(); child != end; child++) {
+        if (!checkIntegrityRecursively(*child)) {
+            return false;
+        }
+
+        for (auto child2 = child; child2 != end; ++child2) {
+            if (*child != *child2 && _items[*child].name() == _items[*child2].name()) {
+                LOG_ERROR(
+                        Log::instance()->getLogger(), "Snapshot integrity check failed, the folder named: \""
+                                                              << parrentItem.name() << "\"(" << parrentItem.id().c_str() << ") contains: \"" << _items[*child].name()
+                                                                << "\" twice with two differents NodeId (" << child->c_str() << " and " << child2->c_str() << ")");
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
 void Snapshot::removeChildrenRecursively(const NodeId &parentId) {
     auto parentIt = _items.find(parentId);
     if (parentIt == _items.end()) {

--- a/src/libsyncengine/update_detection/file_system_observer/snapshot/snapshot.h
+++ b/src/libsyncengine/update_detection/file_system_observer/snapshot/snapshot.h
@@ -83,8 +83,10 @@ class Snapshot : public SharedObject {
         bool isValid() const;
         void setValid(bool newIsValid);
 
+        bool checkIntegrityRecursively();
     private:
         void removeChildrenRecursively(const NodeId &parentId);
+        bool checkIntegrityRecursively(const NodeId &parentId);
 
         ReplicaSide _side = ReplicaSide::Unknown;
         NodeId _rootFolderId;

--- a/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.h
+++ b/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.h
@@ -38,6 +38,7 @@ class TestLocalFileSystemObserverWorker : public CppUnit::TestFixture {
         CPPUNIT_TEST(testLFSOWithDuplicateFileNames);
         CPPUNIT_TEST(testLFSODeleteDir);
         CPPUNIT_TEST(testLFSOWithDirs);
+        CPPUNIT_TEST(testLFSOFastMoveDelete);
         CPPUNIT_TEST(testLFSOWithSpecialCases1);
         CPPUNIT_TEST(testLFSOWithSpecialCases2);
         CPPUNIT_TEST_SUITE_END();
@@ -53,13 +54,14 @@ class TestLocalFileSystemObserverWorker : public CppUnit::TestFixture {
         LocalTemporaryDirectory _tempDir;
         SyncPath _rootFolderPath;
         SyncPath _subDirPath;
-        NodeId _testFileId;
+        std::vector<std::pair<NodeId, SyncPath>> _testFiles;
 
         void testLFSOWithInitialSnapshot();
         void testLFSOWithFiles();
         void testLFSOWithDuplicateFileNames();
         void testLFSOWithDirs();
         void testLFSODeleteDir();
+        void testLFSOFastMoveDelete();
         void testLFSOWithSpecialCases1();
         void testLFSOWithSpecialCases2();
 };


### PR DESCRIPTION
This PR addresses an issue which generates duplicate entries in the snapshot. When the filesystem quickly sends a `MOVE` followed by a `DELETE` for the same file.