### PR TITLE
JsonParserUtility::extractValue ensure to not return garbage value

### DIFF
--- a/src/libcommon/utility/jsonparserutility.h
+++ b/src/libcommon/utility/jsonparserutility.h
@@ -30,6 +30,7 @@ namespace KDC {
 struct COMMONSERVER_EXPORT JsonParserUtility {
         template<typename T>
         static bool extractValue(const Poco::JSON::Object::Ptr obj, const std::string &key, T &val, const bool mandatory = true) {
+            val = T();
             if (!obj) {
                 LOG_WARN(Log::instance()->getLogger(), "JSON object is NULL");
                 return false;


### PR DESCRIPTION
Before this PR, if the key was not found or was found but empty, the `JsonParserUtility::extractValue` method would return true and leave the `val` variable unchanged.

This behavior caused issues in the following scenario:

```cpp
if (!JsonParserUtility::extractValue(actionObj, fileTypeKey, tmpStr)) {
    return ExitCode::BackError;
}
actionInfo.snapshotItem.setType(tmpStr == fileKey ? NodeType::File : NodeType::Directory);

if (!JsonParserUtility::extractValue(actionObj, symbolicLinkKey, tmpStr, false)) {
    return ExitCode::BackError;
}
actionInfo.snapshotItem.setIsLink(!tmpStr.empty());
```

If `symbolicLinkKey` was not found, `tmpStr` would retain the value of `fileTypeKey`, mistakenly treating the item as a link by assuming the link URL was not empty.

This PR modifies `extractValue` to clear the `val` variable when the key is not found, preventing this unintended behavior.