### PR TITLE
KDESKTOP-1323-Updater-Use-flag-has_prod_next

### DIFF
--- a/src/libcommon/utility/types.h
+++ b/src/libcommon/utility/types.h
@@ -440,7 +440,7 @@ struct VersionInfo {
         DistributionChannel channel = DistributionChannel::Unknown;
         std::string tag; // Version number. Example: 3.6.4
         // std::string changeLog; // List of changes in this version, not used for now.
-        uint64_t buildVersion = 0; // Example: 20240816
+        uint64_t buildVersion{0}; // Example: 20240816
         std::string buildMinOsVersion; // Optionnal. Minimum supported version of the OS. Examples: 10.15, 11, server 2005, ...
         std::string downloadUrl; // URL to download the version
 
@@ -461,6 +461,7 @@ struct VersionInfo {
         }
 
         void clear() {
+            channel = DistributionChannel::Unknown;
             tag.clear();
             buildVersion = 0;
             buildMinOsVersion.clear();

--- a/src/libparms/db/parameters.h
+++ b/src/libparms/db/parameters.h
@@ -142,7 +142,7 @@ class PARMS_EXPORT Parameters {
         int _maxAllowedCpu;
         int _uploadSessionParallelJobs;
         int _jobPoolCapacityFactor;
-        DistributionChannel _distributionChannel{DistributionChannel::Next};
+        DistributionChannel _distributionChannel{DistributionChannel::Prod};
 };
 
 } // namespace KDC

--- a/src/libsyncengine/jobs/network/getappversionjob.cpp
+++ b/src/libsyncengine/jobs/network/getappversionjob.cpp
@@ -24,6 +24,7 @@
 
 namespace KDC {
 
+static const std::string hasProdNextKey = "has_prod_next";
 static const std::string applicationKey = "application";
 static const std::string publishedVersionsKey = "published_versions";
 static const std::string versionTypeProdKey = "production";
@@ -89,6 +90,10 @@ bool GetAppVersionJob::handleResponse(std::istream &is) {
 
     const Poco::JSON::Object::Ptr dataObj = JsonParserUtility::extractJsonObject(jsonRes(), dataKey);
     if (!dataObj) return false;
+
+    if (!JsonParserUtility::extractValue(dataObj, hasProdNextKey, _hasProdNext)) {
+        return false;
+    }
 
     const Poco::JSON::Object::Ptr applicationObj = JsonParserUtility::extractJsonObject(dataObj, applicationKey);
     if (!applicationObj) return false;

--- a/src/libsyncengine/jobs/network/getappversionjob.h
+++ b/src/libsyncengine/jobs/network/getappversionjob.h
@@ -26,10 +26,13 @@ namespace KDC {
 class GetAppVersionJob : public AbstractNetworkJob {
     public:
         GetAppVersionJob(Platform platform, const std::string &appID);
+        ~GetAppVersionJob() override = default;
 
         const VersionInfo &getVersionInfo(const DistributionChannel channel) { return _versionInfo[channel]; }
 
         std::string getUrl() override { return INFOMANIAK_API_URL + getSpecificUrl(); }
+
+        [[nodiscard]] bool hasProdNext() const { return _hasProdNext; }
 
     protected:
         bool handleResponse(std::istream &is) override;
@@ -46,6 +49,8 @@ class GetAppVersionJob : public AbstractNetworkJob {
         const Platform _platform{Platform::Unknown};
         const std::string _appId;
 
+        bool _hasProdNext{false};
         std::unordered_map<DistributionChannel, VersionInfo> _versionInfo;
 };
+
 } // namespace KDC

--- a/src/server/updater/updatechecker.cpp
+++ b/src/server/updater/updatechecker.cpp
@@ -66,7 +66,11 @@ void UpdateChecker::versionInfoReceived(UniqueId jobId) {
         SentryHandler::instance()->captureMessage(SentryLevel::Warning, "AbstractUpdater::checkUpdateAvailable", ss.str());
         LOG_ERROR(Log::instance()->getLogger(), ss.str().c_str());
     } else {
-        _versionInfo = getAppVersionJobPtr->getVersionInfo(_channel);
+        DistributionChannel channel = _channel;
+        // Check if there is a progressive update ongoing
+        if (channel == DistributionChannel::Prod && getAppVersionJobPtr->hasProdNext()) channel = DistributionChannel::Next;
+
+        _versionInfo = getAppVersionJobPtr->getVersionInfo(channel);
         if (!_versionInfo.isValid()) {
             std::string error = "Invalid version info!";
             SentryHandler::instance()->captureMessage(SentryLevel::Warning, "AbstractUpdater::checkUpdateAvailable", error);

--- a/src/server/updater/updatechecker.cpp
+++ b/src/server/updater/updatechecker.cpp
@@ -67,7 +67,8 @@ void UpdateChecker::versionInfoReceived(UniqueId jobId) {
         LOG_ERROR(Log::instance()->getLogger(), ss.str().c_str());
     } else {
         DistributionChannel channel = _channel;
-        // Check if there is a progressive update ongoing
+        // hasProdNext() is true if and only if the running application has been elected for an upgrade in the context of a
+        // progressive update
         if (channel == DistributionChannel::Prod && getAppVersionJobPtr->hasProdNext()) channel = DistributionChannel::Next;
 
         _versionInfo = getAppVersionJobPtr->getVersionInfo(channel);


### PR DESCRIPTION
The flag "has_prod_next" should be used to know if the current app has been selected for the progressive update