### PR TITLE
KDESKTOP-1325-kStore-Send-user-ID-when-checking-for-new-update

### DIFF
--- a/src/libsyncengine/jobs/network/getappversionjob.cpp
+++ b/src/libsyncengine/jobs/network/getappversionjob.cpp
@@ -40,7 +40,8 @@ static const std::string buildVersionKey = "build_version";
 static const std::string buildMinOsVersionKey = "build_min_os_version";
 static const std::string downloadUrlKey = "download_link";
 
-GetAppVersionJob::GetAppVersionJob(const Platform platform, const std::string &appID) : _platform(platform), _appId(appID) {
+GetAppVersionJob::GetAppVersionJob(const Platform platform, const std::string &appID, const std::list<int> &userIdList) :
+    _platform(platform), _appId(appID), _userIdList(userIdList) {
     _httpMethod = Poco::Net::HTTPRequest::HTTP_GET;
 }
 
@@ -67,6 +68,12 @@ std::string GetAppVersionJob::getSpecificUrl() {
 std::string GetAppVersionJob::getContentType(bool &canceled) {
     canceled = false;
     return {};
+}
+
+void GetAppVersionJob::setQueryParameters(Poco::URI &uri, bool &canceled) {
+    for (const auto id: _userIdList) {
+        uri.addQueryParameter("user_ids[]", std::to_string(id));
+    }
 }
 
 bool GetAppVersionJob::handleError(std::istream &, const Poco::URI &uri) {

--- a/src/libsyncengine/jobs/network/getappversionjob.h
+++ b/src/libsyncengine/jobs/network/getappversionjob.h
@@ -25,7 +25,7 @@
 namespace KDC {
 class GetAppVersionJob : public AbstractNetworkJob {
     public:
-        GetAppVersionJob(Platform platform, const std::string &appID);
+        GetAppVersionJob(Platform platform, const std::string &appID, const std::list<int> &userIdList);
         ~GetAppVersionJob() override = default;
 
         const VersionInfo &getVersionInfo(const DistributionChannel channel) { return _versionInfo[channel]; }
@@ -40,16 +40,15 @@ class GetAppVersionJob : public AbstractNetworkJob {
     private:
         std::string getSpecificUrl() override;
         std::string getContentType(bool &canceled) override;
-        void setQueryParameters(Poco::URI &, bool & /*canceled*/) override { /* no query parameters */
-        }
-        void setData(bool & /*canceled*/) override { /* no body parameters */
-        }
+        void setQueryParameters(Poco::URI &uri, bool &canceled) override;
+        void setData(bool & /*canceled*/) override { /* no body parameters */ }
         bool handleError(std::istream &is, const Poco::URI &uri) override;
 
         [[nodiscard]] DistributionChannel toDistributionChannel(const std::string &val) const;
 
         const Platform _platform{Platform::Unknown};
         const std::string _appId;
+        const std::list<int> _userIdList;
 
         bool _hasProdNext{false};
         std::unordered_map<DistributionChannel, VersionInfo> _versionInfo;

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -241,6 +241,9 @@ AppServer::AppServer(int &argc, char **argv) :
         addError(Error(errId(), ExitCode::SystemError, ExitCause::Unknown));
     }
 
+    // Log usefull infomation
+    logUsefulInformation();
+
     // Init ExclusionTemplateCache instance
     if (!ExclusionTemplateCache::instance()) {
         LOG_WARN(_logger, "Error in ExclusionTemplateCache::instance");
@@ -3021,6 +3024,25 @@ bool AppServer::initLogging() noexcept {
                                              .toStdString())
                                .c_str());
     return true;
+}
+void AppServer::logUsefulInformation() const {
+    // Log app ID
+    AppStateValue appStateValue = "";
+    if (bool found = false; !ParmsDb::instance()->selectAppState(AppStateKey::AppUid, appStateValue, found) || !found) {
+        LOG_WARN(Log::instance()->getLogger(), "Error in ParmsDb::selectAppState");
+    }
+    const auto &appUid = std::get<std::string>(appStateValue);
+    LOG_INFO(Log::instance()->getLogger(), "App ID: " << appUid.c_str());
+
+    // Log user IDs
+    std::vector<User> userList;
+    if (!ParmsDb::instance()->selectAllUsers(userList)) {
+        LOG_WARN(Log::instance()->getLogger(), "Error in ParmsDb::selectAllUsers");
+    }
+    std::list<int> userIdList;
+    for (const auto &user: userList) {
+        LOG_INFO(Log::instance()->getLogger(), "User ID: " << user.userId());
+    }
 }
 
 bool AppServer::setupProxy() noexcept {

--- a/src/server/appserver.h
+++ b/src/server/appserver.h
@@ -121,6 +121,7 @@ class AppServer : public SharedTools::QtSingleApplication {
 
         void parseOptions(const QStringList &);
         bool initLogging() noexcept;
+        void logUsefulInformation() const;
         bool setupProxy() noexcept;
         void handleCrashRecovery(bool &shouldQuit); // Sets `shouldQuit` with true if the crash recovery is successful, false if
                                                     // the application should exit.

--- a/src/server/updater/updatechecker.cpp
+++ b/src/server/updater/updatechecker.cpp
@@ -85,12 +85,22 @@ void UpdateChecker::versionInfoReceived(UniqueId jobId) {
 ExitCode UpdateChecker::generateGetAppVersionJob(std::shared_ptr<AbstractNetworkJob> &job) {
     AppStateValue appStateValue = "";
     if (bool found = false; !ParmsDb::instance()->selectAppState(AppStateKey::AppUid, appStateValue, found) || !found) {
-        LOG_ERROR(Log::instance()->getLogger(), "Error in ParmsDb::selectAppState");
+        LOG_WARN(Log::instance()->getLogger(), "Error in ParmsDb::selectAppState");
         return ExitCode::DbError;
     }
 
+    std::vector<User> userList;
+    if (!ParmsDb::instance()->selectAllUsers(userList)) {
+        LOG_WARN(Log::instance()->getLogger(), "Error in ParmsDb::selectAllUsers");
+        return ExitCode::DbError;
+    }
+    std::list<int> userIdList;
+    for (const auto &user: userList) {
+        userIdList.push_back(user.userId());
+    }
+
     const auto &appUid = std::get<std::string>(appStateValue);
-    job = std::make_shared<GetAppVersionJob>(CommonUtility::platform(), appUid);
+    job = std::make_shared<GetAppVersionJob>(CommonUtility::platform(), appUid, userIdList);
     return ExitCode::Ok;
 }
 

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -899,13 +899,37 @@ void TestNetworkJobs::testDriveUploadSessionAsynchronousAborted() {
 
 void TestNetworkJobs::testGetAppVersionInfo() {
     const auto appUid = "1234567890";
-    GetAppVersionJob job(CommonUtility::platform(), appUid);
-    job.runSynchronously();
-    CPPUNIT_ASSERT(!job.hasHttpError());
-    CPPUNIT_ASSERT(job.getVersionInfo(DistributionChannel::Internal).isValid());
-    CPPUNIT_ASSERT(job.getVersionInfo(DistributionChannel::Beta).isValid());
-    CPPUNIT_ASSERT(job.getVersionInfo(DistributionChannel::Next).isValid());
-    CPPUNIT_ASSERT(job.getVersionInfo(DistributionChannel::Prod).isValid());
+
+    // Without user IDs
+    {
+        GetAppVersionJob job(CommonUtility::platform(), appUid, {});
+        job.runSynchronously();
+        CPPUNIT_ASSERT(!job.hasHttpError());
+        CPPUNIT_ASSERT(job.getVersionInfo(DistributionChannel::Internal).isValid());
+        CPPUNIT_ASSERT(job.getVersionInfo(DistributionChannel::Beta).isValid());
+        CPPUNIT_ASSERT(job.getVersionInfo(DistributionChannel::Next).isValid());
+        CPPUNIT_ASSERT(job.getVersionInfo(DistributionChannel::Prod).isValid());
+    }
+    // With 1 user ID
+    {
+        GetAppVersionJob job(CommonUtility::platform(), appUid, {123});
+        job.runSynchronously();
+        CPPUNIT_ASSERT(!job.hasHttpError());
+        CPPUNIT_ASSERT(job.getVersionInfo(DistributionChannel::Internal).isValid());
+        CPPUNIT_ASSERT(job.getVersionInfo(DistributionChannel::Beta).isValid());
+        CPPUNIT_ASSERT(job.getVersionInfo(DistributionChannel::Next).isValid());
+        CPPUNIT_ASSERT(job.getVersionInfo(DistributionChannel::Prod).isValid());
+    }
+    // With several user IDs
+    {
+        GetAppVersionJob job(CommonUtility::platform(), appUid, {123, 456, 789});
+        job.runSynchronously();
+        CPPUNIT_ASSERT(!job.hasHttpError());
+        CPPUNIT_ASSERT(job.getVersionInfo(DistributionChannel::Internal).isValid());
+        CPPUNIT_ASSERT(job.getVersionInfo(DistributionChannel::Beta).isValid());
+        CPPUNIT_ASSERT(job.getVersionInfo(DistributionChannel::Next).isValid());
+        CPPUNIT_ASSERT(job.getVersionInfo(DistributionChannel::Prod).isValid());
+    }
 }
 
 void TestNetworkJobs::testDirectDownload() {

--- a/test/server/updater/testupdatechecker.cpp
+++ b/test/server/updater/testupdatechecker.cpp
@@ -34,7 +34,7 @@ static const std::string smallVersionJsonUpdateStr =
 class GetAppVersionJobTest final : public GetAppVersionJob {
     public:
         GetAppVersionJobTest(const Platform platform, const std::string &appID, const bool updateShouldBeAvailable) :
-            GetAppVersionJob(platform, appID), _updateShouldBeAvailable(updateShouldBeAvailable) {}
+            GetAppVersionJob(platform, appID, {}), _updateShouldBeAvailable(updateShouldBeAvailable) {}
 
         void runJob() noexcept override {
             const std::istringstream iss(_updateShouldBeAvailable ? bigVersionJsonUpdateStr : smallVersionJsonUpdateStr);


### PR DESCRIPTION
Add user IDs as query parameter to the GetAppVersion request.
Also log the app ID and all user IDs at start up.