### PR TITLE
KDESKTOP-1330-Remove-hasRight-method-from-Executor

### DIFF
--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -1720,7 +1720,8 @@ ExitInfo ExecutorWorker::handleForbiddenAction(SyncOpPtr syncOp, const SyncPath 
                         absoluteLocalFilePath, PlatformInconsistencyCheckerUtility::SuffixType::Blacklisted)) {
                 LOGW_SYNCPAL_WARN(_logger, L"PlatformInconsistencyCheckerUtility::renameLocalFile failed for: "
                                                    << Utility::formatSyncPath(absoluteLocalFilePath));
-                exitInfo = {ExitCode::SystemError, ExitCause::FileAccessError};
+                _syncPal->handleAccessDeniedItem(relativeLocalPath, ExitCause::FileAccessError);
+                return ExitCode::Ok;
             }
             removeFromDb = false;
             break;

--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -405,7 +405,7 @@ ExitInfo ExecutorWorker::handleCreateOp(SyncOpPtr syncOp, std::shared_ptr<Abstra
 
         if (job && syncOp->affectedNode()->type() == NodeType::Directory) {
             // Propagate the directory creation immediately in order to avoid blocking other dependant job creation
-            if (!runCreateDirJob(syncOp, job)) {
+            if (const ExitInfo exitInfoRunCreateDirJob = runCreateDirJob(syncOp, job); !exitInfoRunCreateDirJob ) {
                 std::shared_ptr<CreateDirJob> createDirJob = std::dynamic_pointer_cast<CreateDirJob>(job);
                 if (createDirJob && (createDirJob->getStatusCode() == Poco::Net::HTTPResponse::HTTP_BAD_REQUEST ||
                                      createDirJob->getStatusCode() == Poco::Net::HTTPResponse::HTTP_FORBIDDEN)) {
@@ -423,6 +423,7 @@ ExitInfo ExecutorWorker::handleCreateOp(SyncOpPtr syncOp, std::shared_ptr<Abstra
                     }
                     return {ExitCode::BackError, ExitCause::FileAccessError};
                 }
+            return exitInfoRunCreateDirJob;
             }
 
             if (const ExitInfo exitInfo =

--- a/src/libsyncengine/propagation/executor/executorworker.h
+++ b/src/libsyncengine/propagation/executor/executorworker.h
@@ -110,7 +110,7 @@ class ExecutorWorker : public OperationProcessor {
                                    bool &ignored, bool &bypassProgressComplete);
         ExitInfo handleForbiddenAction(SyncOpPtr syncOp, const SyncPath &relativeLocalPath, bool &ignored);
         void sendProgress();
-        bool hasRight(SyncOpPtr syncOp, bool &exists);
+        bool isValidDestination(SyncOpPtr syncOp);
         bool enoughLocalSpace(SyncOpPtr syncOp);
 
         ExitInfo propagateConflictToDbAndTree(SyncOpPtr syncOp, bool &propagateChange);


### PR DESCRIPTION
Following https://github.com/Infomaniak/desktop-kDrive/pull/359, the method `hasRight` in Executor is not needed anymore. Remove it but keep the logic on special folders ("Common documents" and "Shared")