### PR TITLE
KDESKTOP-1331-Updater-Hide-the-Checking-for-updates-window

### DIFF
--- a/src/server/updater/sparkleupdater.mm
+++ b/src/server/updater/sparkleupdater.mm
@@ -198,7 +198,7 @@ void SparkleUpdater::setQuitCallback(const std::function<void()> &quitCallback) 
 void SparkleUpdater::startInstaller() {
     reset(versionInfo().downloadUrl);
 
-    [d->updater checkForUpdates];
+    [d->updater checkForUpdatesInBackground];
     [d->spuStandardUserDriver showUpdateInFocus];
 }
 


### PR DESCRIPTION
A "Checking for updates" window with a progress bar briefly appears while starting Sparkle updater. It is not required since the information is already known from the kStore.