### PR TITLE
Bug fix: setProgress  should not exit with an error when the item progress is not managed.

### DIFF
--- a/src/libsyncengine/progress/progressinfo.cpp
+++ b/src/libsyncengine/progress/progressinfo.cpp
@@ -119,7 +119,9 @@ bool ProgressInfo::setProgress(const SyncPath &path, const int64_t completed) {
 
     const auto it = _currentItems.find(normalizedPath);
     if (it == _currentItems.end() || it->second.empty()) {
-        return false;
+        LOG_INFO(Log::instance()->getLogger(),
+                 L"Item not found in ProgressInfo list (normal for ommited operation): " << Utility::formatSyncPath(path));
+        return true;
     }
 
     if (const SyncFileItem &item = it->second.front().item(); !shouldCountProgress(item)) {
@@ -140,7 +142,9 @@ bool ProgressInfo::setProgressComplete(const SyncPath &path, const SyncFileStatu
 
     const auto it = _currentItems.find(normalizedPath);
     if (it == _currentItems.end() || it->second.empty()) {
-        return false;
+        LOG_INFO(Log::instance()->getLogger(),
+                 L"Item not found in ProgressInfo list (normal for ommited operation): " << Utility::formatSyncPath(path));
+        return true;
     }
 
     SyncFileItem &item = it->second.front().item();

--- a/src/libsyncengine/progress/progressinfo.cpp
+++ b/src/libsyncengine/progress/progressinfo.cpp
@@ -119,7 +119,7 @@ bool ProgressInfo::setProgress(const SyncPath &path, const int64_t completed) {
 
     const auto it = _currentItems.find(normalizedPath);
     if (it == _currentItems.end() || it->second.empty()) {
-        LOG_INFO(Log::instance()->getLogger(),
+        LOGW_INFO(Log::instance()->getLogger(),
                  L"Item not found in ProgressInfo list (normal for ommited operation): " << Utility::formatSyncPath(path));
         return true;
     }
@@ -142,7 +142,7 @@ bool ProgressInfo::setProgressComplete(const SyncPath &path, const SyncFileStatu
 
     const auto it = _currentItems.find(normalizedPath);
     if (it == _currentItems.end() || it->second.empty()) {
-        LOG_INFO(Log::instance()->getLogger(),
+        LOGW_INFO(Log::instance()->getLogger(),
                  L"Item not found in ProgressInfo list (normal for ommited operation): " << Utility::formatSyncPath(path));
         return true;
     }


### PR DESCRIPTION
## Description 
Currently, calling ProgressInfo::setProgress on an item that is not in the _currentItems list returns an error. It should instead behave as if !shouldCountProgress and return successfully.

This is problematic in the case of omitted operations, which will systematically generate an error. This error prevent us to correctly set the vfs and status of the file.