### PR TITLE
KDESKTOP-1342-Encoding-issue-Remote-edition-leads-to-blacklist-and-deleted-file

### DIFF
--- a/src/libsyncengine/update_detection/file_system_observer/snapshot/snapshot.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/snapshot/snapshot.cpp
@@ -167,7 +167,9 @@ NodeId Snapshot::itemId(const SyncPath &path) const {
 
         bool idFound = false;
         for (const NodeId &childId: itemIt->second.childrenIds()) {
-            if (name(childId) == *pathIt) {
+            SyncName normalizedName;
+            Utility::normalizedSyncName(name(childId), normalizedName);
+            if (normalizedName == *pathIt) {
                 itemIt = _items.find(childId);
                 ret = childId;
                 idFound = true;

--- a/src/libsyncengine/update_detection/file_system_observer/snapshot/snapshot.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/snapshot/snapshot.cpp
@@ -167,9 +167,7 @@ NodeId Snapshot::itemId(const SyncPath &path) const {
 
         bool idFound = false;
         for (const NodeId &childId: itemIt->second.childrenIds()) {
-            SyncName normalizedName;
-            Utility::normalizedSyncName(name(childId), normalizedName);
-            if (normalizedName == *pathIt) {
+            if (name(childId) == *pathIt) {
                 itemIt = _items.find(childId);
                 ret = childId;
                 idFound = true;

--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
@@ -804,10 +804,9 @@ ExitCode UpdateTreeWorker::step8CompleteUpdateTree() {
 
             SyncTime lastModified =
                     _side == ReplicaSide::Local ? dbNode.lastModifiedLocal().value() : dbNode.lastModifiedRemote().value();
-            SyncName name = dbNode.nameRemote();
-            std::shared_ptr<Node> newNode =
-                    std::shared_ptr<Node>(new Node(dbNode.nodeId(), _side, name, dbNode.type(), {}, newNodeId, dbNode.created(),
-                                                   lastModified, dbNode.size(), parentNode));
+            SyncName name = _side == ReplicaSide::Local ? dbNode.nameLocal() : dbNode.nameRemote();
+            const auto newNode = std::shared_ptr<Node>(new Node(dbNode.nodeId(), _side, name, dbNode.type(), {}, newNodeId,
+                                                                dbNode.created(), lastModified, dbNode.size(), parentNode));
             if (newNode == nullptr) {
                 std::cout << "Failed to allocate memory" << std::endl;
                 LOG_SYNCPAL_ERROR(_logger, "Failed to allocate memory");


### PR DESCRIPTION
The file name in local update tree was retrieved from the remote name in DB, therefor encoded in NFC instead of NFD.