### PR TITLE
Kdesktop 1356 mac os crash when a file is updated remotely and locked locally

### DIFF
--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -1107,6 +1107,10 @@ ExitInfo ExecutorWorker::checkLiteSyncInfoForEdit(SyncOpPtr syncOp, const SyncPa
                             syncOp->affectedNode()->size(),
                             syncOp->affectedNode()->id().has_value() ? *syncOp->affectedNode()->id() : std::string(), error);
                     syncOp->setOmit(true); // Do not propagate change in file system, only in DB
+                    // TODO: Vfs functions should return an ExitInfo struct
+                    if (!error.empty()) {
+                        return {ExitCode::SystemError, ExitCause::FileAccessError};
+                    }
                     break;
                 }
                 case PinState::Unspecified:

--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -1106,8 +1106,8 @@ ExitInfo ExecutorWorker::checkLiteSyncInfoForEdit(SyncOpPtr syncOp, const SyncPa
                             syncOp->affectedNode()->lastmodified().has_value() ? *syncOp->affectedNode()->lastmodified() : 0,
                             syncOp->affectedNode()->size(),
                             syncOp->affectedNode()->id().has_value() ? *syncOp->affectedNode()->id() : std::string(), error);
-                    syncOp->setOmit(true); // Do not propagate change in file system, only in DB
                     // TODO: Vfs functions should return an ExitInfo struct
+                    syncOp->setOmit(true); // Do not propagate change in file system, only in DB
                     if (!error.empty()) {
                         return {ExitCode::SystemError, ExitCause::FileAccessError};
                     }

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -2391,12 +2391,12 @@ bool AppServer::vfsUpdateMetadata(int syncDbId, const SyncPath &path, const Sync
         return false;
     }
 
-    QByteArray fileId(id.c_str());
-    QString *errorStr = nullptr;
-    if (!_vfsMap[syncDbId]->updateMetadata(SyncName2QStr(path.native()), creationTime, modtime, size, fileId, errorStr)) {
+    const QByteArray fileId(id.c_str());
+    QString errorStr;
+    if (!_vfsMap[syncDbId]->updateMetadata(SyncName2QStr(path.native()), creationTime, modtime, size, fileId, &errorStr)) {
         LOGW_WARN(Log::instance()->getLogger(),
                   L"Error in Vfs::updateMetadata for syncDbId=" << syncDbId << L" and path=" << Path2WStr(path).c_str());
-        error = errorStr ? errorStr->toStdString() : "";
+        error = errorStr.toStdString();
         return false;
     }
 


### PR DESCRIPTION
Vfs functions should return an ExitInfo struct:
https://infomaniak.atlassian.net/browse/KDESKTOP-1359?atlOrigin=eyJpIjoiNjIwYjRmMDUxNjIyNDE2Njk2ZTE4YjNiZDg5N2Q3YzgiLCJwIjoiaiJ9