### PR TITLE
KDESKTOP-1360-Issues-with-Sparkle-updater

### DIFF
--- a/src/server/updater/sparkleupdater.mm
+++ b/src/server/updater/sparkleupdater.mm
@@ -192,6 +192,7 @@ void SparkleUpdater::onUpdateFound() {
         return;
     }
     if ([d->updater sessionInProgress]) {
+        // An update window is already opened or installation is in progress, no need to start a new one
         LOG_INFO(KDC::Log::instance()->getLogger(), "A session is already in progress...");
         return;
     }

--- a/src/server/updater/sparkleupdater.mm
+++ b/src/server/updater/sparkleupdater.mm
@@ -192,8 +192,7 @@ void SparkleUpdater::onUpdateFound() {
         return;
     }
     if ([d->updater sessionInProgress]) {
-        // An update window is already opened or installation is in progress, no need to start a new one
-        LOG_INFO(KDC::Log::instance()->getLogger(), "A session is already in progress...");
+        LOG_INFO(KDC::Log::instance()->getLogger(), "An update window is already opened or installation is in progress. No need to start a new one.");
         return;
     }
     startInstaller();

--- a/src/server/updater/sparkleupdater.mm
+++ b/src/server/updater/sparkleupdater.mm
@@ -187,7 +187,14 @@ SparkleUpdater::~SparkleUpdater() {
 }
 
 void SparkleUpdater::onUpdateFound() {
-    if (isVersionSkipped(versionInfo().fullVersion())) return;
+    if (isVersionSkipped(versionInfo().fullVersion())) {
+        LOG_INFO(KDC::Log::instance()->getLogger(), "Version " << versionInfo().fullVersion().c_str() << " is skipped.");
+        return;
+    }
+    if ([d->updater sessionInProgress]) {
+        LOG_INFO(KDC::Log::instance()->getLogger(), "A session is already in progress...");
+        return;
+    }
     startInstaller();
 }
 


### PR DESCRIPTION
Once the update has been accepted by the user, the package is downloaded by Sparkle and the user needs to start the update. If another update windows pops up before the validation, the next updates will fail.

Fix : Do not start a new update process if one is already ongoing