### PR TITLE
KDESKTOP-1366-App-ID-generated-on-a-limited-set-of-characters

### DIFF
--- a/src/libcommon/utility/utility.cpp
+++ b/src/libcommon/utility/utility.cpp
@@ -118,19 +118,6 @@ std::string CommonUtility::generateRandomStringPKCE(const int length /*= 10*/) {
     return generateRandomString(charArray, distrib, length);
 }
 
-std::string CommonUtility::generateAppId(const int length /*= 10*/) {
-    // The back only accept characters from `A` to `F`
-    static constexpr char charArray[] =
-            "0123456789"
-            "ABCDEF"
-            "abcdef";
-
-    static std::uniform_int_distribution<int> distrib(
-            0, sizeof(charArray) - 2); // -2 in order to avoid the null terminating character
-
-    return generateRandomString(charArray, distrib, length);
-}
-
 void CommonUtility::crash() {
     volatile int *a = (int *) (NULL);
     *a = 1;

--- a/src/libcommon/utility/utility.h
+++ b/src/libcommon/utility/utility.h
@@ -50,7 +50,6 @@ struct COMMON_EXPORT CommonUtility {
 
         static std::string generateRandomStringAlphaNum(int length = 10);
         static std::string generateRandomStringPKCE(int length = 10);
-        static std::string generateAppId(int length = 10);
 
         static QString fileSystemName(const QString &dirPath);
 

--- a/src/libparms/db/parmsdbappstate.cpp
+++ b/src/libparms/db/parmsdbappstate.cpp
@@ -103,7 +103,7 @@ bool ParmsDb::insertDefaultAppState() {
         return false;
     }
 
-    if (!insertAppState(AppStateKey::AppUid, CommonUtility::generateAppId(25), true)) {
+    if (!insertAppState(AppStateKey::AppUid, CommonUtility::generateRandomStringAlphaNum(25), true)) {
         LOG_WARN(_logger, "Error when inserting default value for LogUploadToken");
         return false;
     }


### PR DESCRIPTION
Because of a back limitation, the App ID was generated using a limited set of characters. This limitation has been removed on back side, we can remove it also on ours.