### PR TITLE
Resolve Concurrent Access Issue in TerminatedJobsQueue

### DIFF
--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -1513,6 +1513,7 @@ ExitInfo ExecutorWorker::waitForAllJobsToFinish() {
 ExitInfo ExecutorWorker::deleteFinishedAsyncJobs() {
     ExitInfo exitInfo = ExitCode::Ok;
     while (!_terminatedJobs.empty()) {
+        std::scoped_lock lock(_terminatedJobs);
         // Delete all terminated jobs
         if (exitInfo && _ongoingJobs.find(_terminatedJobs.front()) != _ongoingJobs.end()) {
             auto onGoingJobIt = _ongoingJobs.find(_terminatedJobs.front());

--- a/src/libsyncengine/propagation/executor/executorworker.h
+++ b/src/libsyncengine/propagation/executor/executorworker.h
@@ -38,22 +38,27 @@ class SyncDb;
  * In the context of `ExecutorWorker`, the terminated jobs queue is the only container that can be accessed from multiple threads,
  * namely, the job threads. Therefore, it is the only container that requires to be thread safe.
  */
-class TerminatedJobsQueue {
+class TerminatedJobsQueue : public std::recursive_mutex {
     public:
         void push(const UniqueId id) {
-            const std::scoped_lock lock(_mutex);
+            const std::scoped_lock lock(*this);
             _terminatedJobs.push(id);
         }
         void pop() {
-            const std::scoped_lock lock(_mutex);
+            const std::scoped_lock lock(*this);
             _terminatedJobs.pop();
         }
-        [[nodiscard]] UniqueId front() const { return _terminatedJobs.front(); }
-        [[nodiscard]] bool empty() const { return _terminatedJobs.empty(); }
+        [[nodiscard]] UniqueId front() {
+            const std::scoped_lock lock(*this);
+            return _terminatedJobs.front();
+        }
+        [[nodiscard]] bool empty() {
+            const std::scoped_lock lock(*this);
+            return _terminatedJobs.empty();
+        }
 
     private:
         std::queue<UniqueId> _terminatedJobs;
-        std::mutex _mutex;
 };
 
 class ExecutorWorker : public OperationProcessor {

--- a/test/libcommonserver/CMakeLists.txt
+++ b/test/libcommonserver/CMakeLists.txt
@@ -9,7 +9,7 @@ set(testcommonserver_SRCS
         ../test.cpp
         ../test_utility/localtemporarydirectory.cpp
         ../test_utility/testhelpers.h ../test_utility/testhelpers.cpp
-
+        ../test_utility/timechecker.h
         test.cpp
         # Utility
         utility/testutility.h utility/testutility.cpp

--- a/test/libsyncengine/propagation/executor/testexecutorworker.cpp
+++ b/test/libsyncengine/propagation/executor/testexecutorworker.cpp
@@ -198,6 +198,58 @@ void TestExecutorWorker::testIsValidDestination() {
     }
 }
 
+void TestExecutorWorker::testTerminatedJobsQueue() {
+    TerminatedJobsQueue terminatedJobsQueue;
+
+    int ended = 0; // count the number of ended threads
+
+    // Function objects to be used in the thread
+    std::function inserter = [&terminatedJobsQueue, &ended](const UniqueId id) {
+        terminatedJobsQueue.push(id);
+        ended++;
+    };
+    std::function popper = [&terminatedJobsQueue, &ended]() {
+        terminatedJobsQueue.pop();
+        ended++;
+    };
+    std::function fronter = [&terminatedJobsQueue, &ended]() {
+        [[maybe_unused]] auto foo = terminatedJobsQueue.front();
+        ended++;
+    };
+    std::function emptyChecker = [&terminatedJobsQueue, &ended]() {
+        [[maybe_unused]] auto foo = terminatedJobsQueue.empty();
+        ended++;
+    };
+
+    // Check that all functions are thread safe
+    terminatedJobsQueue.lock(); // Lock the queue for the current thread
+
+    std::thread t1(inserter, 1);
+    Utility::msleep(10); // Give enough time for the thread to terminate
+    CPPUNIT_ASSERT_EQUAL(0, ended);
+
+    std::thread t2(fronter);
+    Utility::msleep(10);
+    CPPUNIT_ASSERT_EQUAL(0, ended);
+
+    std::thread t3(popper);
+    Utility::msleep(10);
+    CPPUNIT_ASSERT_EQUAL(0, ended);
+
+    std::thread t4(emptyChecker);
+    Utility::msleep(10);
+    CPPUNIT_ASSERT_EQUAL(0, ended);
+
+    terminatedJobsQueue.unlock(); // Unlock the queue for the current thread
+    Utility::msleep(10);
+    CPPUNIT_ASSERT_EQUAL(4, ended);
+
+    t1.join();
+    t2.join();
+    t3.join();
+    t4.join(); // Wait for all threads to finish.
+}
+
 void TestExecutorWorker::testLogCorrespondingNodeErrorMsg() {
     SyncOpPtr op = generateSyncOperation(1, Str("test_file.txt"));
     _syncPal->_executorWorker->logCorrespondingNodeErrorMsg(op);

--- a/test/libsyncengine/propagation/executor/testexecutorworker.h
+++ b/test/libsyncengine/propagation/executor/testexecutorworker.h
@@ -33,6 +33,7 @@ class TestExecutorWorker : public CppUnit::TestFixture {
         CPPUNIT_TEST(testLogCorrespondingNodeErrorMsg);
         CPPUNIT_TEST(testRemoveDependentOps);
         CPPUNIT_TEST(testIsValidDestination);
+        CPPUNIT_TEST(testTerminatedJobsQueue);
         CPPUNIT_TEST_SUITE_END();
 
     public:
@@ -47,6 +48,7 @@ class TestExecutorWorker : public CppUnit::TestFixture {
         void testLogCorrespondingNodeErrorMsg();
         void testRemoveDependentOps();
         void testIsValidDestination();
+        void testTerminatedJobsQueue();
 
         bool opsExist(SyncOpPtr op);
         SyncOpPtr generateSyncOperation(const DbNodeId dbNodeId, const SyncName &filename,

--- a/test/test_utility/timechecker.h
+++ b/test/test_utility/timechecker.h
@@ -1,0 +1,49 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2024 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+class TimeChecker {
+    public:
+        explicit TimeChecker(bool start = false) {
+            if (start) this->start();
+        }
+        void start() { _time = std::chrono::steady_clock::now(); }
+        void stop() {
+            auto end = std::chrono::steady_clock::now();
+            _diff = std::chrono::duration_cast<std::chrono::milliseconds>(end - _time).count();
+        }
+        bool lessOrEqualThan(long long value) {
+            if (_diff > value) std::cout << "TimeChecker::lessThan: " << _diff << " >= " << value << std::endl;
+            return _diff <= value;
+        }
+        bool greaterOrEqualThan(long long value) {
+            if (_diff < value) std::cout << "TimeChecker::greaterThan: " << _diff << " <= " << value << std::endl;
+            return _diff >= value;
+        }
+        bool between(long long min, long long max) {
+            if (_diff < min || _diff > max)
+                std::cout << "TimeChecker::between: " << _diff << " <= " << min << " || " << _diff << " >= " << max
+                          << std::endl;
+            return _diff >= min && _diff <= max;
+        }
+
+    private:
+        std::chrono::steady_clock::time_point _time;
+        long long _diff{0};
+};


### PR DESCRIPTION
#### **Overview**
This PR addresses a critical issue in the `ExecutorWorker` class where concurrent access to the `TerminatedJobsQueue` caused a crash. It occurred during the execution of the `deleteFinishedAsyncJobs` method when multiple threads attempted to access `_terminatedJobs` without proper synchronization.

#### **Root Cause**
The root cause was identified as unsafe access to `_terminatedJobs`, a shared resource accessed concurrently by multiple threads. This led to race conditions and crashes, particularly when one thread was modifying the queue while another was reading or checking its contents (TerminatedJobsQueue::front()).

#### **Key Changes**
1. **Made `TerminatedJobsQueue` Thread-Safe:**
   - Converted `TerminatedJobsQueue` into a thread-safe container by inheriting from `std::recursive_mutex`.
   - Used `std::scoped_lock` for locking within all public methods of the queue (`push`, `pop`, `front`, `empty`) to ensure safe access across threads.

2. **Updated `deleteFinishedAsyncJobs` Logic:**
   - Added a `std::scoped_lock` within the `deleteFinishedAsyncJobs` method to ensure thread-safe access to `_terminatedJobs` and prevent that no item is inserted between a call to `TerminatedJobsQueue::first()` and `TerminatedJobsQueue::pop()`.

3. **Test Coverage:**
   - Implemented a new test, `testTerminatedJobsQueue`, in the `TestExecutorWorker` suite to verify that `TerminatedJobsQueue` operations (`push`, `pop`, `front`, `empty`) are thread-safe.

4. **Refactored `TimeOutChecker`:**
   - Introduced a new utility class, `TimeChecker`, to replace `TimeOutChecker` for cleaner and more precise timeout checks in test cases.