### PR TITLE
KDESKTOP-1399-Updater-Update-proposed-even-if-it-was-skipped

### DIFF
--- a/src/server/updater/abstractupdater.cpp
+++ b/src/server/updater/abstractupdater.cpp
@@ -18,10 +18,12 @@
 
 #include "abstractupdater.h"
 
-#include "sparkleupdater.h"
 #include "libcommon/utility/utility.h"
 #include "log/log.h"
 #include "requests/parameterscache.h"
+#if defined(__APPLE__)
+#include "sparkleupdater.h"
+#endif
 
 namespace KDC {
 

--- a/src/server/updater/abstractupdater.cpp
+++ b/src/server/updater/abstractupdater.cpp
@@ -18,6 +18,7 @@
 
 #include "abstractupdater.h"
 
+#include "sparkleupdater.h"
 #include "libcommon/utility/utility.h"
 #include "log/log.h"
 #include "requests/parameterscache.h"
@@ -65,6 +66,9 @@ void AbstractUpdater::unskipVersion() {
         ParametersCache::instance()->parameters().setSeenVersion("");
         ParametersCache::instance()->save();
     }
+#if defined(__APPLE__)
+    SparkleUpdater::unskipVersion();
+#endif
 }
 
 bool AbstractUpdater::isVersionSkipped(const std::string& version) {

--- a/src/server/updater/sparkleupdater.h
+++ b/src/server/updater/sparkleupdater.h
@@ -32,6 +32,8 @@ class SparkleUpdater final : public AbstractUpdater {
         void setQuitCallback(const std::function<void()> &quitCallback) override;
         void startInstaller() override;
 
+        static void unskipVersion();
+
     private:
         void reset(const std::string &url);
         void deleteUpdater();

--- a/src/server/updater/sparkleupdater.mm
+++ b/src/server/updater/sparkleupdater.mm
@@ -209,6 +209,12 @@ void SparkleUpdater::startInstaller() {
     [d->spuStandardUserDriver showUpdateInFocus];
 }
 
+void SparkleUpdater::unskipVersion() {
+    // Discard skipped version in Sparkle
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey:@ "SUSkippedVersion"];
+    [[NSUserDefaults standardUserDefaults] synchronize];
+}
+
 void SparkleUpdater::reset(const std::string &url) {
     [d->spuStandardUserDriver dismissUpdateInstallation];
     deleteUpdater();

--- a/src/server/updater/sparkleupdater.mm
+++ b/src/server/updater/sparkleupdater.mm
@@ -126,9 +126,9 @@
 }
 
 // Sent when a valid update is not found.
-- (void)updaterDidNotFindUpdate:(SPUUpdater *)update {
+- (void)updaterDidNotFindUpdate:(SPUUpdater *)update error:(nonnull NSError *)error {
     (void)update;
-    LOG_DEBUG(KDC::Log::instance()->getLogger(), "No valid update found");
+    LOG_DEBUG(KDC::Log::instance()->getLogger(), "No valid update found - Error code: " << [error code] << ", reason: " << [error.userInfo[SPUNoUpdateFoundReasonKey] integerValue]);
 }
 
 // Sent immediately before installing the specified update.

--- a/src/server/updater/updatemanager.cpp
+++ b/src/server/updater/updatemanager.cpp
@@ -56,12 +56,7 @@ void UpdateManager::startInstaller() const {
     LOG_DEBUG(Log::instance()->getLogger(), "startInstaller called!");
 
     // Cleanup skipped version
-    ParametersCache::instance()->parameters().setSeenVersion("");
-    ParametersCache::instance()->save();
-#if defined(__APPLE__)
-    // Discard skipped version in Sparkle
-    std::system("defaults delete com.infomaniak.drive.desktopclient SUSkippedVersion");
-#endif
+    AbstractUpdater::unskipVersion();
 
     _updater->startInstaller();
 }

--- a/src/server/updater/updatemanager.cpp
+++ b/src/server/updater/updatemanager.cpp
@@ -54,6 +54,15 @@ UpdateManager::UpdateManager(QObject *parent) : QObject(parent) {
 
 void UpdateManager::startInstaller() const {
     LOG_DEBUG(Log::instance()->getLogger(), "startInstaller called!");
+
+    // Cleanup skipped version
+    ParametersCache::instance()->parameters().setSeenVersion("");
+    ParametersCache::instance()->save();
+#if defined(__APPLE__)
+    // Discard skipped version in Sparkle
+    std::system("defaults delete com.infomaniak.drive.desktopclient SUSkippedVersion");
+#endif
+
     _updater->startInstaller();
 }
 


### PR DESCRIPTION
Sparkle keep the skipped version "forever". This PR aims to "forget" the skipped version if the user click on the "Update" button.