### PR TITLE
KDESKTOP-1408-Updater-crash-at-startup

### DIFF
--- a/src/server/updater/sparkleupdater.h
+++ b/src/server/updater/sparkleupdater.h
@@ -35,7 +35,7 @@ class SparkleUpdater final : public AbstractUpdater {
         static void unskipVersion();
 
     private:
-        void reset(const std::string &url);
+        void reset(const std::string &url = "");
         void deleteUpdater();
         bool startSparkleUpdater();
 

--- a/src/server/updater/sparkleupdater.mm
+++ b/src/server/updater/sparkleupdater.mm
@@ -179,6 +179,7 @@ class SparkleUpdater::Private {
 
 SparkleUpdater::SparkleUpdater() {
     d = new Private;
+    reset();
 }
 
 SparkleUpdater::~SparkleUpdater() {
@@ -215,7 +216,7 @@ void SparkleUpdater::unskipVersion() {
     [[NSUserDefaults standardUserDefaults] synchronize];
 }
 
-void SparkleUpdater::reset(const std::string &url) {
+void SparkleUpdater::reset(const std::string &url /*= ""*/) {
     [d->spuStandardUserDriver dismissUpdateInstallation];
     deleteUpdater();
 
@@ -247,10 +248,12 @@ void SparkleUpdater::reset(const std::string &url) {
     // Migrate away from using `-[SPUUpdater setFeedURL:]`
     [d->updater clearFeedURLFromUserDefaults];
 
-    [d->updaterDelegate setCustomFeedUrl:url];
+    if (!url.empty()) {
+        [d->updaterDelegate setCustomFeedUrl:url];
 
-    if(startSparkleUpdater()) {
-        LOG_INFO(KDC::Log::instance()->getLogger(), "Sparkle updater succesfully started with feed URL: " << url.c_str());
+        if(startSparkleUpdater()) {
+            LOG_INFO(KDC::Log::instance()->getLogger(), "Sparkle updater succesfully started with feed URL: " << url.c_str());
+        }
     }
 }
 


### PR DESCRIPTION
SparkleUpdater crashes on startup because its members were not initialized in the constructor