### PR TITLE
KDESKTOP-1377-Fix-missing-return-in-case-of-error

### DIFF
--- a/src/server/updater/abstractupdater.cpp
+++ b/src/server/updater/abstractupdater.cpp
@@ -46,6 +46,7 @@ void AbstractUpdater::onAppVersionReceived() {
     if (!_updateChecker->versionInfo().isValid()) {
         setState(UpdateState::CheckError);
         LOG_WARN(Log::instance()->getLogger(), "Error while retrieving latest app version");
+        return;
     }
 
     const bool available =


### PR DESCRIPTION
Missing return statement leads to the error status never set