### PR TITLE
Use a wide string to log errors in moveItemToTrash (MacOSX)

### DIFF
--- a/src/libcommonserver/utility/utility_mac.cpp
+++ b/src/libcommonserver/utility/utility_mac.cpp
@@ -18,6 +18,7 @@
 
 #include "log/log.h"
 #include "libcommon/utility/utility.h"
+#include "libcommonserver/utility/utility.h"
 
 #include <sstream>
 #include <string>
@@ -52,7 +53,8 @@ static bool moveItemToTrash_private(const SyncPath &itemPath) {
 
     std::wstring errorStr;
     if (!moveItemToTrash(itemPath, errorStr)) {
-        LOGW_WARN(Log::instance()->getLogger(), L"Error in moveItemToTrash - err=" << errorStr);
+        LOGW_WARN(Log::instance()->getLogger(),
+                  L"Error in moveItemToTrash on " << Utility::formatSyncPath(itemPath) << L" - err='" << errorStr << L"'.");
         return false;
     }
 

--- a/src/libcommonserver/utility/utility_mac.cpp
+++ b/src/libcommonserver/utility/utility_mac.cpp
@@ -39,7 +39,7 @@ static bool init_private() {
 
 static void makeMessage() {}
 
-bool moveItemToTrash(const SyncPath &itemPath, std::string &errorStr);
+bool moveItemToTrash(const SyncPath &itemPath, std::wstring &errorStr);
 bool preventSleeping(bool enable);
 bool preventSleeping();
 void restartFinderExtension();
@@ -50,9 +50,9 @@ static bool moveItemToTrash_private(const SyncPath &itemPath) {
         return false;
     }
 
-    std::string errorStr;
+    std::wstring errorStr;
     if (!moveItemToTrash(itemPath, errorStr)) {
-        LOG_WARN(Log::instance()->getLogger(), "Error in moveItemToTrash - err=" << errorStr.c_str());
+        LOGW_WARN(Log::instance()->getLogger(), L"Error in moveItemToTrash - err=" << errorStr);
         return false;
     }
 

--- a/src/libcommonserver/utility/utility_mac.mm
+++ b/src/libcommonserver/utility/utility_mac.mm
@@ -27,8 +27,14 @@
 
 namespace KDC {
 
-bool moveItemToTrash(const SyncPath &itemPath, std::string &errorStr) {
+bool moveItemToTrash(const SyncPath &itemPath, std::wstring &errorStr)
+{
     NSString *filePath = [NSString stringWithCString:itemPath.c_str() encoding:NSUTF8StringEncoding];
+
+    if (filePath == nullptr) {
+        errorStr = L"Error in stringWithCString. Failed to cast std filepath to NSString.";
+        return false;
+    }
     NSURL *fileURL = [NSURL fileURLWithPath:filePath];
 
     NSFileManager *fileManager = [NSFileManager defaultManager];
@@ -37,7 +43,9 @@ bool moveItemToTrash(const SyncPath &itemPath, std::string &errorStr) {
     BOOL success = [fileManager trashItemAtURL:fileURL resultingItemURL:nil error:&error];
 
     if (error != nil) {
-        errorStr = std::string([error.localizedDescription UTF8String]);
+        const auto wcharError = reinterpret_cast<const wchar_t *>(
+            [error.localizedDescription cStringUsingEncoding:NSUTF32LittleEndianStringEncoding]);
+        errorStr = std::wstring(wcharError);
     }
 
     return success;


### PR DESCRIPTION
The changes pertain only to the MacOSX platform.
 
The errors logged by `moveItemToTrash` are **not** readable in a text editor because of special quote characters. 
The proposed fixe makes these errors readable.