### PR TITLE
[3.6.8] File content exchange issue (#442)

### DIFF
--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -2165,9 +2165,10 @@ ExitInfo ExecutorWorker::propagateEditToDbAndTree(SyncOpPtr syncOp, const NodeId
     // that follow-up operations can execute correctly, as they are based on the
     // information in this structure
     if (!syncOp->omit()) {
-        syncOp->correspondingNode()->setId(syncOp->targetSide() == ReplicaSide::Local ? localId
-                                                                                      : remoteId); // ID might have changed in the
-                                                                                                   // case of a delete+create
+        _syncPal->updateTree(syncOp->targetSide())
+                ->updateNodeId(syncOp->affectedNode(),
+                               syncOp->targetSide() == ReplicaSide::Local ? localId : remoteId); // ID might have changed in the
+                                                                                                 // case of a delete+create
         syncOp->correspondingNode()->setLastModified(newLastModTime);
     }
     node = syncOp->correspondingNode();

--- a/src/libsyncengine/update_detection/update_detector/node.h
+++ b/src/libsyncengine/update_detection/update_detector/node.h
@@ -84,7 +84,6 @@ class Node {
         inline void setCreatedAt(const std::optional<SyncTime> &createdAt) { _createdAt = createdAt; }
         inline void setLastModified(const std::optional<SyncTime> &lastmodified) { _lastModified = lastmodified; }
         inline void setSize(int64_t size) { _size = size; }
-        inline void setId(const std::optional<NodeId> &nodeId) { _id = nodeId; }
         inline void setPreviousId(const std::optional<NodeId> &previousNodeId) { _previousId = previousNodeId; }
         bool setParentNode(const std::shared_ptr<Node> &parentNode);
         inline void setMoveOrigin(const std::optional<SyncPath> &moveOrigin) { _moveOrigin = moveOrigin; }
@@ -124,6 +123,13 @@ class Node {
         inline void setIsTmp(bool newIsTmp) { _isTmp = newIsTmp; }
 
     private:
+        friend class UpdateTree;
+        // The node id should not be changed without also changing the map in the UpdateTree and the parent/child relationship in
+        // other nodes
+        inline void setId(const std::optional<NodeId> &nodeId) {
+            _id = nodeId;
+        }
+
         std::optional<DbNodeId> _idb = std::nullopt;
         ReplicaSide _side = ReplicaSide::Unknown;
         SyncName _name; // This name is NFC-normalized by constructors and setters.

--- a/src/libsyncengine/update_detection/update_detector/updatetree.h
+++ b/src/libsyncengine/update_detection/update_detector/updatetree.h
@@ -54,7 +54,7 @@ class UpdateTree : public SharedObject {
 
         inline bool inconsistencyCheckDone() const { return _inconsistencyCheckDone; }
         inline void setInconsistencyCheckDone() { _inconsistencyCheckDone = true; }
-
+        [[nodiscard]] bool updateNodeId(std::shared_ptr<Node> node, const NodeId &newId);
         inline void setRootFolderId(const NodeId &nodeId) { _rootNode->setId(std::make_optional<NodeId>(nodeId)); }
 
     private:

--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.h
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.h
@@ -107,8 +107,6 @@ class UpdateTreeWorker : public ISyncWorker {
 
         ExitCode createMoveNodes(const NodeType &nodeType);
 
-        [[nodiscard]] bool updateNodeId(std::shared_ptr<Node> node, const NodeId &newId);
-
         ExitCode getNewPathAfterMove(const SyncPath &path, SyncPath &newPath);
         ExitCode updateNodeWithDb(const std::shared_ptr<Node> parentNode);
         ExitCode updateTmpNode(const std::shared_ptr<Node> tmpNode);


### PR DESCRIPTION
Ensure that Node::_id's are consistent with the key of UpdateTree:_nodes.