### PR TITLE
macOS CI - Avoid "database is locked" build error

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -22,6 +22,9 @@ jobs:
     runs-on: [ self-hosted, macOS, desktop-kdrive ]
 
     steps:
+      - name: Clean-up XCode DerivedData
+        run : rm -rf /Users/runner/Library/Developer/Xcode/DerivedData
+        
       - name: Checkout the code
         uses: actions/checkout@v4.1.1
         with:


### PR DESCRIPTION
Avoid the error "database is locked Possibly there are two concurrent builds running in the same filesystem location"