### PR TITLE
KDESKTOP-1488-Create-ParentDelete-conflict-Item-not-correctly-removed-from-DB

### DIFF
--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -1882,20 +1882,6 @@ ExitInfo ExecutorWorker::propagateConflictToDbAndTree(SyncOpPtr syncOp, bool &pr
             break;
         }
         case ConflictType::CreateParentDelete: // Indirect conflict pattern
-        {
-            // Remove node from update tree
-            std::shared_ptr<UpdateTree> updateTree = affectedUpdateTree(syncOp);
-            if (!updateTree->deleteNode(syncOp->affectedNode())) {
-                LOGW_SYNCPAL_WARN(_logger, L"Error in UpdateTree::deleteNode: node name="
-                                                   << Utility::formatSyncName(syncOp->affectedNode()->name()));
-            }
-
-            // Do not propagate changes to the DB
-            // The created node has been moved and will be discovered as new
-            // on next sync
-            propagateChange = false;
-            break;
-        }
         case ConflictType::MoveDelete: // Delete conflict pattern
         case ConflictType::MoveParentDelete: // Indirect conflict pattern
         case ConflictType::MoveMoveCycle: // Name clash conflict pattern


### PR DESCRIPTION
In case of Create-ParentDelete conflict, change (Delete operation) was not propagate to DB because of a previous conflict resolution behavior that is used anymore.
Previously, we tried to keep the created file by moving it to the root of the drive. Now, we simply propagate the Delete operation.