### PR TITLE
Kdesktop 1510 crash in 3.6.8

### DIFF
--- a/src/libsyncengine/syncpal/isyncworker.cpp
+++ b/src/libsyncengine/syncpal/isyncworker.cpp
@@ -24,8 +24,7 @@ namespace KDC {
 
 ISyncWorker::ISyncWorker(std::shared_ptr<SyncPal> syncPal, const std::string &name, const std::string &shortName,
                          bool testing /*= false*/) :
-    _logger(Log::instance()->getLogger()),
-    _syncPal(syncPal), _testing(testing), _name(name), _shortName(shortName) {}
+    _logger(Log::instance()->getLogger()), _syncPal(syncPal), _testing(testing), _name(name), _shortName(shortName) {}
 
 ISyncWorker::~ISyncWorker() {
     if (_isRunning) {

--- a/src/libsyncengine/syncpal/isyncworker.cpp
+++ b/src/libsyncengine/syncpal/isyncworker.cpp
@@ -24,13 +24,14 @@ namespace KDC {
 
 ISyncWorker::ISyncWorker(std::shared_ptr<SyncPal> syncPal, const std::string &name, const std::string &shortName,
                          bool testing /*= false*/) :
-    _logger(Log::instance()->getLogger()), _syncPal(syncPal), _testing(testing), _name(name), _shortName(shortName) {}
+    _logger(Log::instance()->getLogger()),
+    _syncPal(syncPal), _testing(testing), _name(name), _shortName(shortName) {}
 
 ISyncWorker::~ISyncWorker() {
     if (_isRunning) {
         ISyncWorker::stop();
     }
-
+    waitForExit();
     LOG_SYNCPAL_DEBUG(_logger, "Worker " << _name.c_str() << " destroyed");
     log4cplus::threadCleanup();
 }


### PR DESCRIPTION
There is a crash in the destructor of `ISyncWorker` if the worker has not been joined beforehand. This fix should prevent the crash and allow for a graceful exit.  

I am still investigating the issue that led to the destruction of a worker that has not been stopped yet.