### PR TITLE
KDESKTOP-1481-Do-not-allow-progressive-update-on-Linux

### DIFF
--- a/src/server/updater/updatechecker.h
+++ b/src/server/updater/updatechecker.h
@@ -73,7 +73,11 @@ class UpdateChecker {
          * @return const reference on a VersionInfo
          */
         const VersionInfo &prodVersionInfo() {
+#if defined(__APPLE__) || defined(_WIN32)
             return _versionsInfo.contains(_prodVersionChannel) ? _versionsInfo[_prodVersionChannel] : _defaultVersionInfo;
+#else
+            return _versionsInfo.contains(DistributionChannel::Prod) ? _versionsInfo[DistributionChannel::Prod] : _defaultVersionInfo;
+#endif
         }
 
         std::function<void()> _callback = nullptr;

--- a/src/server/updater/updatemanager.h
+++ b/src/server/updater/updatemanager.h
@@ -21,7 +21,6 @@
 #include "abstractupdater.h"
 #include "utility/types.h"
 
-#include <QObject>
 #include <QTimer>
 
 /**


### PR DESCRIPTION
Use only "Production" distribution channel as long as we do not have an automatic update mechanism on Linux