### PR TITLE
Don't stop pTraces::basic::AppStart() more than once

### DIFF
--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -1916,7 +1916,10 @@ void AppServer::onRequestReceived(int id, RequestNum num, const QByteArray &para
             break;
         }
         case RequestNum::UTILITY_DISPLAY_CLIENT_REPORT: {
-            sentry::pTraces::basic::AppStart().stop();
+            if (static bool appStartPTraceStopped = false; !appStartPTraceStopped) {
+                appStartPTraceStopped = true;
+                sentry::pTraces::basic::AppStart().stop();
+            }
             break;
         }
         case RequestNum::SYNC_SETSUPPORTSVIRTUALFILES: {


### PR DESCRIPTION
Currently, if the client is restarted manually (in debug), it attempts to call pTraces::basic::AppStart(), which was already stopped by the previous client instance, leading to an assertion failure.