### PR TITLE
KDESKTOP-1523-Move-issue-in-Update-Tree

### DIFF
--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
@@ -439,10 +439,16 @@ ExitCode UpdateTreeWorker::step4DeleteFile() {
             std::shared_ptr<Node> parentNode;
             if (const auto exitCode = searchForParentNode(op->path(), parentNode); exitCode != ExitCode::Ok) {
                 return exitCode;
-            };
+            }
 
             if (!parentNode) {
-                parentNode = getOrCreateNodeFromDeletedPath(op->path().parent_path());
+                SyncPath newPath;
+                if (const auto newPathExitCode = getNewPathAfterMove(deleteOp->path(), newPath);
+                    newPathExitCode != ExitCode::Ok) {
+                    LOG_SYNCPAL_WARN(_logger, "Error in UpdateTreeWorker::getNewPathAfterMove");
+                    return newPathExitCode;
+                }
+                parentNode = getOrCreateNodeFromDeletedPath(newPath.parent_path());
             }
 
             // find child node

--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
@@ -1185,8 +1185,7 @@ ExitCode UpdateTreeWorker::getNewPathAfterMove(const SyncPath &path, SyncPath &n
     }
 
     for (auto nameIt = names.rbegin(); nameIt != names.rend(); ++nameIt) {
-        FSOpPtr op = nullptr;
-        if (_operationSet->findOp(nameIt->second, OperationType::Move, op)) {
+        if (FSOpPtr op = nullptr; _operationSet->findOp(nameIt->second, OperationType::Move, op)) {
             newPath = op->destinationPath();
         } else {
             newPath.append(nameIt->first);

--- a/test/libsyncengine/update_detection/update_detector/testupdatetreeworker.h
+++ b/test/libsyncengine/update_detection/update_detector/testupdatetreeworker.h
@@ -31,6 +31,7 @@ class TestUpdateTreeWorker : public CppUnit::TestFixture {
         CPPUNIT_TEST(testUpdateTmpFileNode);
         CPPUNIT_TEST(testHandleCreateOperationsWithSamePath);
         CPPUNIT_TEST(testSearchForParentNode);
+        CPPUNIT_TEST(testGetNewPathAfterMove);
         CPPUNIT_TEST(testStep1);
         CPPUNIT_TEST(testStep2);
         CPPUNIT_TEST(testStep3);
@@ -67,6 +68,7 @@ class TestUpdateTreeWorker : public CppUnit::TestFixture {
         void testUpdateTmpFileNode();
         void testHandleCreateOperationsWithSamePath();
         void testSearchForParentNode();
+        void testGetNewPathAfterMove();
 
         // Test with already existing UpdateTree
         void testStep1();


### PR DESCRIPTION
For file (not directory), the path of deleted nodes in the update tree was not corrected if a parent was moved. Therefor, this leads to errors in the update tree and generated operations.

ex:
`2025-01-27 16:05:23:547 [D] (0x16dcbf000) operationgeneratorworker.cpp:268 - *1* Move operation 0 to be propagated on Remote(2) replica from "A" to "A" (ID: 48917403)`