### PR TITLE
Kdesktop 1525 the sync restarts after blacklisting a dehydrated placeholder

### DIFF
--- a/src/libsyncengine/propagation/executor/executorworker.h
+++ b/src/libsyncengine/propagation/executor/executorworker.h
@@ -143,7 +143,8 @@ class ExecutorWorker : public OperationProcessor {
         void increaseErrorCount(SyncOpPtr syncOp);
 
         ExitInfo getFileSize(const SyncPath &path, uint64_t &size);
-        void logCorrespondingNodeErrorMsg(const SyncOpPtr syncOp);
+
+        bool deleteOpNodes(const SyncOpPtr syncOp);
 
         void setProgressComplete(const SyncOpPtr syncOp, SyncFileStatus status);
 

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -396,25 +396,21 @@ void TestNetworkJobs::testDownload() {
     {
         const LocalTemporaryDirectory temporaryDirectory("tmp");
         const SyncPath local9MoFilePath = temporaryDirectory.path() / "9Mo.txt";
-      const RemoteTemporaryDirectory remoteTmpDir(_driveDbId, _remoteDirId,
-                                                  "testDownload");
+        const RemoteTemporaryDirectory remoteTmpDir(_driveDbId, _remoteDirId, "testDownload");
         std::ofstream ofs(local9MoFilePath, std::ios::binary);
         ofs << std::string(9 * 1000000, 'a');
         ofs.close();
 
         // Upload file
-      UploadJob uploadJob(_driveDbId, local9MoFilePath, Str2SyncName("9Mo.txt"),
-                          remoteTmpDir.id(), 0);
+        UploadJob uploadJob(_driveDbId, local9MoFilePath, Str2SyncName("9Mo.txt"), remoteTmpDir.id(), 0);
         uploadJob.runSynchronously();
         CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, uploadJob.exitCode());
 
-      SyncPath smallPartitionPath =
-          testhelpers::TestVariables().local8MoPartitionPath;
+        SyncPath smallPartitionPath = testhelpers::TestVariables().local8MoPartitionPath;
         CPPUNIT_ASSERT(!smallPartitionPath.empty());
         IoError ioError = IoError::Unknown;
         bool exist = false;
-      CPPUNIT_ASSERT(
-          IoHelper::checkIfPathExists(smallPartitionPath, exist, ioError));
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(smallPartitionPath, exist, ioError));
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
         CPPUNIT_ASSERT(exist);
 

--- a/test/libsyncengine/propagation/executor/testexecutorworker.cpp
+++ b/test/libsyncengine/propagation/executor/testexecutorworker.cpp
@@ -323,7 +323,7 @@ void TestExecutorWorker::testTerminatedJobsQueue() {
     t4.join(); // Wait for all threads to finish.
 }
 
-void TestExecutorWorker::propagateConflictToDbAndTree() {
+void TestExecutorWorker::testPropagateConflictToDbAndTree() {
     bool propagateChange = false;
     const auto syncOp = generateSyncOperation(1, Str("test"));
 
@@ -382,12 +382,25 @@ void TestExecutorWorker::propagateConflictToDbAndTree() {
     CPPUNIT_ASSERT_EQUAL(false, propagateChange);
 }
 
-void TestExecutorWorker::testLogCorrespondingNodeErrorMsg() {
-    SyncOpPtr op = generateSyncOperation(1, Str("test_file.txt"));
-    _executorWorker->logCorrespondingNodeErrorMsg(op);
+void TestExecutorWorker::testDeleteOpNodes() {
+    const auto syncOp = generateSyncOperation(1, Str("test"));
+    syncOp->setTargetSide(ReplicaSide::Remote);
 
-    op->setCorrespondingNode(nullptr);
-    _executorWorker->logCorrespondingNodeErrorMsg(op);
+    {
+        _syncPal->updateTree(ReplicaSide::Local)->insertNode(syncOp->affectedNode());
+        _syncPal->updateTree(ReplicaSide::Remote)->insertNode(syncOp->correspondingNode());
+        CPPUNIT_ASSERT(_executorWorker->deleteOpNodes(syncOp));
+        CPPUNIT_ASSERT(!_syncPal->updateTree(ReplicaSide::Local)->exists(*syncOp->affectedNode()->id()));
+        CPPUNIT_ASSERT(!_syncPal->updateTree(ReplicaSide::Remote)->exists(*syncOp->correspondingNode()->id()));
+    }
+
+    {
+        // No corresponding node
+        syncOp->setCorrespondingNode(nullptr);
+        _syncPal->updateTree(ReplicaSide::Local)->insertNode(syncOp->affectedNode());
+        CPPUNIT_ASSERT(_executorWorker->deleteOpNodes(syncOp));
+        CPPUNIT_ASSERT(!_syncPal->updateTree(ReplicaSide::Local)->exists(*syncOp->affectedNode()->id()));
+    }
 }
 
 void TestExecutorWorker::testFixModificationDate() {

--- a/test/libsyncengine/propagation/executor/testexecutorworker.h
+++ b/test/libsyncengine/propagation/executor/testexecutorworker.h
@@ -57,11 +57,11 @@ class TestExecutorWorker : public CppUnit::TestFixture {
         CPPUNIT_TEST(testFixModificationDate);
         CPPUNIT_TEST(testAffectedUpdateTree);
         CPPUNIT_TEST(testTargetUpdateTree);
-        CPPUNIT_TEST(testLogCorrespondingNodeErrorMsg);
         CPPUNIT_TEST(testRemoveDependentOps);
         CPPUNIT_TEST(testIsValidDestination);
         CPPUNIT_TEST(testTerminatedJobsQueue);
-        CPPUNIT_TEST(propagateConflictToDbAndTree);
+        CPPUNIT_TEST(testPropagateConflictToDbAndTree);
+        CPPUNIT_TEST(testDeleteOpNodes);
         CPPUNIT_TEST_SUITE_END();
 
     public:
@@ -73,11 +73,11 @@ class TestExecutorWorker : public CppUnit::TestFixture {
         void testFixModificationDate();
         void testAffectedUpdateTree();
         void testTargetUpdateTree();
-        void testLogCorrespondingNodeErrorMsg();
         void testRemoveDependentOps();
         void testIsValidDestination();
         void testTerminatedJobsQueue();
-        void propagateConflictToDbAndTree();
+        void testPropagateConflictToDbAndTree();
+        void testDeleteOpNodes();
 
         bool opsExist(SyncOpPtr op);
         SyncOpPtr generateSyncOperation(const DbNodeId dbNodeId, const SyncName &filename,


### PR DESCRIPTION
Cause: Attempting to delete the operation corresponding node, that does not exist for a zombie placeholder.