### PR TITLE
KDESKTOP-1544-Simplify-the-generation-of-data-structure-for-test

### DIFF
--- a/src/libsyncengine/syncpal/syncpal.h
+++ b/src/libsyncengine/syncpal/syncpal.h
@@ -243,6 +243,8 @@ class SYNCENGINE_EXPORT SyncPal : public std::enable_shared_from_this<SyncPal> {
             _computeFSOperationsWorker = worker;
         }
 
+        std::shared_ptr<UpdateTree> updateTree(ReplicaSide side) const;
+
     private:
         log4cplus::Logger _logger;
         SyncPalInfo _syncInfo;
@@ -312,7 +314,7 @@ class SYNCENGINE_EXPORT SyncPal : public std::enable_shared_from_this<SyncPal> {
         std::shared_ptr<Snapshot> snapshot(ReplicaSide side, bool copy = false) const;
         const std::shared_ptr<const Snapshot> snapshotCopy(ReplicaSide side) { return snapshot(side, true); }
         std::shared_ptr<FSOperationSet> operationSet(ReplicaSide side) const;
-        std::shared_ptr<UpdateTree> updateTree(ReplicaSide side) const;
+
 
         // Progress info management
         void createProgressInfo();

--- a/test/libsyncengine/CMakeLists.txt
+++ b/test/libsyncengine/CMakeLists.txt
@@ -13,6 +13,7 @@ set(testsyncengine_SRCS
         ../test_utility/localtemporarydirectory.h ../test_utility/localtemporarydirectory.cpp
         ../test_utility/remotetemporarydirectory.h ../test_utility/remotetemporarydirectory.cpp
         ../test_classes/syncpaltest.h ../test_classes/syncpaltest.cpp
+        ../test_classes/testinitialsituationgenerator.h ../test_classes/testinitialsituationgenerator.cpp
         # Database
         db/testsyncdb.h db/testsyncdb.cpp
         olddb/testoldsyncdb.h olddb/testoldsyncdb.cpp

--- a/test/libsyncengine/propagation/operation_sorter/testoperationsorterworker.h
+++ b/test/libsyncengine/propagation/operation_sorter/testoperationsorterworker.h
@@ -46,6 +46,8 @@ class TestOperationSorterWorker final : public CppUnit::TestFixture {
         void setUp() override;
         void tearDown() override;
 
+        void setupInitialSituation();
+
         void testMoveFirstAfterSecond();
         void testFixDeleteBeforeMove();
         void testFixMoveBeforeCreate();

--- a/test/test_classes/testinitialsituationgenerator.cpp
+++ b/test/test_classes/testinitialsituationgenerator.cpp
@@ -1,0 +1,101 @@
+// Infomaniak kDrive - Desktop
+// Copyright (C) 2023-2025 Infomaniak Network SA
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "testinitialsituationgenerator.h"
+
+#include "db/dbnode.h"
+#include "syncpal/syncpal.h"
+#include "test_utility/testhelpers.h"
+
+#include <Poco/JSON/Parser.h>
+
+namespace KDC {
+
+void TestInitialSituationGenerator::generateInitialSituation(const std::string &jsonInputStr) {
+    Poco::JSON::Object::Ptr obj;
+    try {
+        Poco::JSON::Parser parser;
+        obj = parser.parse(jsonInputStr).extract<Poco::JSON::Object::Ptr>();
+    } catch (Poco::Exception &) {
+        throw std::runtime_error("Invalid JSON input");
+    }
+
+    addItem(obj);
+}
+
+NodeId TestInitialSituationGenerator::generateId(const ReplicaSide side, const NodeId &rawId) {
+    return side == ReplicaSide::Local ? "l_" + rawId : "r_" + rawId;
+}
+
+void TestInitialSituationGenerator::addItem(Poco::JSON::Object::Ptr obj, const NodeId &parentId /*= {}*/) {
+    std::vector<std::string> keys;
+    obj->getNames(keys);
+
+    for (const auto &key: keys) {
+        const auto isFile = !obj->isObject(key) && obj->getValue<bool>(key);
+        addItem(isFile ? NodeType::File : NodeType::Directory, key, parentId);
+
+        if (obj->isObject(key)) {
+            const auto &childObj = obj->getObject(key);
+            addItem(childObj, key);
+        }
+    }
+}
+
+void TestInitialSituationGenerator::addItem(NodeType itemType, const NodeId &id, const NodeId &parentId) {
+    insertInDb(itemType, id, parentId);
+    insertInUpdateTrees(itemType, id, parentId);
+}
+
+void TestInitialSituationGenerator::insertInDb(NodeType itemType, const NodeId &id, const NodeId &parentId) const {
+    DbNode parentNode;
+    if (parentId.empty()) {
+        parentNode = _syncpal->syncDb()->rootNode();
+    } else {
+        bool found = false;
+        if (!_syncpal->syncDb()->node(ReplicaSide::Local, generateId(ReplicaSide::Local, parentId), parentNode, found)) {
+            throw std::runtime_error("Failed to find parent node");
+        }
+        if (!found) {
+            throw std::runtime_error("Failed to find parent node");
+        }
+    }
+
+    const auto size = itemType == NodeType::File ? testhelpers::defaultFileSize : testhelpers::defaultDirSize;
+    const DbNode dbNode(parentNode.nodeId(), Utility::toUpper(id), Utility::toUpper(id), generateId(ReplicaSide::Local, id),
+                        generateId(ReplicaSide::Remote, id), testhelpers::defaultTime, testhelpers::defaultTime,
+                        testhelpers::defaultTime, itemType, size, std::nullopt);
+    _syncpal->syncDb()->insertNode(dbNode);
+}
+
+void TestInitialSituationGenerator::insertInUpdateTrees(NodeType itemType, const NodeId &id, const NodeId &parentId) {
+    for (const auto side: {ReplicaSide::Local, ReplicaSide::Remote}) {
+        insertInUpdateTrees(side, itemType, id, parentId);
+    }
+}
+
+void TestInitialSituationGenerator::insertInUpdateTrees(ReplicaSide side, NodeType itemType, const NodeId &id,
+                                                        const NodeId &parentId) const {
+    const auto parentNode = parentId.empty() ? _syncpal->updateTree(side)->rootNode()
+                                             : _syncpal->updateTree(side)->getNodeById(generateId(side, parentId));
+    const auto size = itemType == NodeType::File ? testhelpers::defaultFileSize : testhelpers::defaultDirSize;
+    const auto node = std::make_shared<Node>(side, Utility::toUpper(id), itemType, OperationType::None, generateId(side, id),
+                                             testhelpers::defaultTime, testhelpers::defaultTime, size, parentNode);
+    _syncpal->updateTree(side)->insertNode(node);
+    (void) parentNode->insertChildren(node);
+}
+
+} // namespace KDC

--- a/test/test_classes/testinitialsituationgenerator.h
+++ b/test/test_classes/testinitialsituationgenerator.h
@@ -16,12 +16,15 @@
 
 #pragma once
 
+#include "db/dbnode.h"
+#include "update_detection/update_detector/node.h"
 #include "utility/types.h"
 
 #include <Poco/JSON/Object.h>
 
 namespace KDC {
 
+class Node;
 class SyncPal;
 
 /**
@@ -50,18 +53,23 @@ class SyncPal;
  */
 class TestInitialSituationGenerator {
     public:
+        TestInitialSituationGenerator() = default;
         explicit TestInitialSituationGenerator(const std::shared_ptr<SyncPal> &syncpal) : _syncpal(syncpal) {}
 
+        void setSyncpal(const std::shared_ptr<SyncPal> &syncpal) { _syncpal = syncpal; }
         void generateInitialSituation(const std::string &jsonInputStr);
+
+        [[nodiscard]] std::shared_ptr<Node> getNode(ReplicaSide side, const NodeId &rawId) const;
+        bool getDbNode(const NodeId &rawId, DbNode &dbNode) const;
 
         static NodeId generateId(ReplicaSide side, const NodeId &rawId);
 
     private:
         void addItem(Poco::JSON::Object::Ptr obj, const std::string &parentId = {});
-        void addItem(NodeType itemType, const std::string &id, const std::string &parentId);
+        void addItem(NodeType itemType, const std::string &id, const std::string &parentId) const;
 
         void insertInDb(NodeType itemType, const NodeId &id, const NodeId &parentId) const;
-        void insertInUpdateTrees(NodeType itemType, const NodeId &id, const NodeId &parentId);
+        void insertInUpdateTrees(NodeType itemType, const NodeId &id, const NodeId &parentId) const;
         void insertInUpdateTrees(ReplicaSide side, NodeType itemType, const NodeId &id, const NodeId &parentId) const;
 
         std::shared_ptr<SyncPal> _syncpal;

--- a/test/test_classes/testinitialsituationgenerator.h
+++ b/test/test_classes/testinitialsituationgenerator.h
@@ -1,0 +1,46 @@
+// Infomaniak kDrive - Desktop
+// Copyright (C) 2023-2025 Infomaniak Network SA
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include "utility/types.h"
+
+#include <Poco/JSON/Object.h>
+
+namespace KDC {
+
+class SyncPal;
+
+class TestInitialSituationGenerator {
+    public:
+        explicit TestInitialSituationGenerator(const std::shared_ptr<SyncPal> &syncpal) : _syncpal(syncpal) {}
+
+        void generateInitialSituation(const std::string &jsonInputStr);
+
+        static NodeId generateId(ReplicaSide side, const NodeId &rawId);
+
+    private:
+        void addItem(Poco::JSON::Object::Ptr obj, const std::string &parentId = {});
+        void addItem(NodeType itemType, const std::string &id, const std::string &parentId);
+
+        void insertInDb(NodeType itemType, const NodeId &id, const NodeId &parentId) const;
+        void insertInUpdateTrees(NodeType itemType, const NodeId &id, const NodeId &parentId);
+        void insertInUpdateTrees(ReplicaSide side, NodeType itemType, const NodeId &id, const NodeId &parentId) const;
+
+        std::shared_ptr<SyncPal> _syncpal;
+};
+
+} // namespace KDC

--- a/test/test_classes/testinitialsituationgenerator.h
+++ b/test/test_classes/testinitialsituationgenerator.h
@@ -24,6 +24,30 @@ namespace KDC {
 
 class SyncPal;
 
+/**
+ * @brief This class aims to provide a simple and efficient way to generate a data structure (Db and update trees) for testing.
+ * The structure is provided as a JSON file. For example, the following JSON :
+ * {
+ *    "a":
+ *    {
+ *        "aa":
+ *        {
+ *            "aaa": 1
+ *        }
+ *    },
+ *    "b": 0,
+ *    "c": 0
+ * }
+ * will generate this tree:
+ * .
+ * ├── A
+ * │   └── AA
+ * │       └── AAA
+ * ├── B
+ * └── C
+ *
+ * where "AAA" is a file, and the other nodes are directories.
+ */
 class TestInitialSituationGenerator {
     public:
         explicit TestInitialSituationGenerator(const std::shared_ptr<SyncPal> &syncpal) : _syncpal(syncpal) {}

--- a/test/test_utility/testhelpers.h
+++ b/test/test_utility/testhelpers.h
@@ -29,9 +29,10 @@
 
 namespace KDC::testhelpers {
 
-const SyncPath localTestDirPath(KDC::Utility::s2ws(TEST_DIR) + L"/test_ci");
+const SyncPath localTestDirPath(Utility::s2ws(TEST_DIR) + L"/test_ci");
 const SyncTime defaultTime = std::time(nullptr);
 constexpr int64_t defaultFileSize = 1654788079;
+constexpr int64_t defaultDirSize = 0;
 
 SyncName makeNfdSyncName();
 SyncName makeNfcSyncName();


### PR DESCRIPTION
Generating and filling data structures for tests (DB and update trees) is very off-putting and redundant.

This PR aims to create a simple helper class that will fill automatically those data. The user have to provide the desired structure as only input.