### PR TITLE
Remove Sentry from VfsWin

### DIFF
--- a/src/libcommon/log/sentry/handler.cpp
+++ b/src/libcommon/log/sentry/handler.cpp
@@ -281,13 +281,6 @@ void Handler::init(AppType appType, int breadCrumbsSize) {
     _instance->_isSentryActivated = true;
 }
 
-void Handler::init(const std::shared_ptr<Handler> &initializedHandler) {
-    if (_instance) {
-        return;
-    }
-    _instance = initializedHandler;
-}
-
 void Handler::setAuthenticatedUser(const SentryUser &user) {
     std::scoped_lock lock(_mutex);
     _authenticatedUser = user;

--- a/src/libcommon/log/sentry/handler.h
+++ b/src/libcommon/log/sentry/handler.h
@@ -67,9 +67,6 @@ class Handler {
         virtual ~Handler();
         static std::shared_ptr<Handler> instance();
         static void init(AppType appType, int breadCrumbsSize = 100);
-
-        // Allow to have a unique hanlder across the dlls.
-        static void init(const std::shared_ptr<Handler> &initializedHandler);
         void setAuthenticatedUser(const SentryUser &user);
         void setGlobalConfidentialityLevel(sentry::ConfidentialityLevel level);
 

--- a/src/libcommonserver/vfs/win/vfs_win.cpp
+++ b/src/libcommonserver/vfs/win/vfs_win.cpp
@@ -39,7 +39,6 @@ namespace KDC {
 VfsWin::VfsWin(const VfsSetupParams &vfsSetupParams, QObject *parent) : Vfs(vfsSetupParams, parent) {
     // Initialize LiteSync ext connector
     LOG_INFO(logger(), "Initialize LiteSyncExtConnector");
-    sentry::Handler::init(vfsSetupParams.sentryHandler);
     TraceCbk debugCallback = std::bind(&VfsWin::debugCbk, this, std::placeholders::_1, std::placeholders::_2);
 
     Utility::setLogger(logger());
@@ -59,17 +58,16 @@ VfsWin::VfsWin(const VfsSetupParams &vfsSetupParams, QObject *parent) : Vfs(vfsS
 void VfsWin::debugCbk(TraceLevel level, const wchar_t *msg) {
     switch (level) {
         case TraceLevel::Info:
-            LOGW_INFO(logger(), msg);
+            LOGW_INFO(logger(), msg)
             break;
         case TraceLevel::Debug:
-            LOGW_DEBUG(logger(), msg);
+            LOGW_DEBUG(logger(), msg)
             break;
         case TraceLevel::Warning:
-            LOGW_WARN(logger(), msg);
+            LOGW_WARN(logger(), msg)
             break;
         case TraceLevel::Error:
-            LOGW_ERROR(logger(), msg);
-            sentry::Handler::captureMessage(sentry::Level::Error, "VfsWin::debugCbk", Utility::ws2s(msg));
+            LOGW_ERROR(logger(), msg)
             break;
     }
 }


### PR DESCRIPTION
Sharing a pointer between Vfs dll and main app was causing `sentry_close()` to block