### PR TITLE
[HOTFIX] Initialize SyncPal even if Vfs has not started yet

### DIFF
--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -1132,7 +1132,6 @@ void AppServer::onRequestReceived(int id, RequestNum num, const QByteArray &para
 
                 if (ExitInfo exitInfo = tryCreateAndStartVfs(sync); !exitInfo) {
                     LOG_WARN(_logger, "Error in tryCreateAndStartVfs for syncDbId=" << sync.dbId() << " " << exitInfo);
-                    return;
                 }
 
                 // Create and start SyncPal


### PR DESCRIPTION
After installation, and depending on the time at which `LiteSync` authorizations are given by a MacOS user, the _Vfs_ start failure errors 
<img width="604" alt="Capture d’écran 2025-02-19 à 14 43 40" src="https://github.com/user-attachments/assets/58510f50-8cb0-435d-bf89-658ded4510c4" />

<img width="604" alt="Capture d’écran 2025-02-19 à 14 45 09" src="https://github.com/user-attachments/assets/c2ae50e6-5db3-4d0d-a9cc-9618eae147cf" />

remains persistently in _desktop-kDrive GUI_ even if the _Vfs_ is subsequently and successfully initialized.

The issue has been frequently reproduced.