### PR TITLE
Fix app permissions

### DIFF
--- a/admin/osx/macosx.pkgproj.cmake
+++ b/admin/osx/macosx.pkgproj.cmake
@@ -33,7 +33,7 @@
 											<key>PATH_TYPE</key>
 											<integer>3</integer>
 											<key>PERMISSIONS</key>
-											<integer>493</integer>
+											<integer>509</integer>
 											<key>TYPE</key>
 											<integer>3</integer>
 											<key>UID</key>


### PR DESCRIPTION
Give the write permission to the "admin" group to allow to delete the app on macOS 15.3