### PR TITLE
Performance improvement of `Utility::normalizedSyncName` on Windows.

### DIFF
--- a/src/libcommonserver/utility/utility.cpp
+++ b/src/libcommonserver/utility/utility.cpp
@@ -648,8 +648,7 @@ bool Utility::normalizedSyncName(const SyncName &name, SyncName &normalizedName,
     LPWSTR strResult = nullptr;
     HANDLE hHeap = GetProcessHeap();
 
-    int iSizeEstimated = NormalizeString(normalization == UnicodeNormalization::NFD ? NormalizationD : NormalizationC,
-                                         name.c_str(), -1, nullptr, 0);
+    size_t iSizeEstimated = (name.length() + 1) * 2;
     for (int i = 0; i < maxIterations; i++) {
         if (strResult) {
             HeapFree(hHeap, 0, strResult);
@@ -663,7 +662,7 @@ bool Utility::normalizedSyncName(const SyncName &name, SyncName &normalizedName,
         }
 
         if (iSizeEstimated <= 0) {
-            DWORD dwError = GetLastError();
+            const DWORD dwError = GetLastError();
             if (dwError != ERROR_INSUFFICIENT_BUFFER) {
                 // Real error, not buffer error
                 LOGW_DEBUG(logger(), L"Failed to normalize " << formatSyncName(name) << L" ("
@@ -683,7 +682,7 @@ bool Utility::normalizedSyncName(const SyncName &name, SyncName &normalizedName,
         return false;
     }
 
-    normalizedName = SyncName(strResult);
+    normalizedName.assign(strResult, iSizeEstimated - 1);
     HeapFree(hHeap, 0, strResult);
     return true;
 #else

--- a/src/libcommonserver/utility/utility.cpp
+++ b/src/libcommonserver/utility/utility.cpp
@@ -648,7 +648,7 @@ bool Utility::normalizedSyncName(const SyncName &name, SyncName &normalizedName,
     LPWSTR strResult = nullptr;
     HANDLE hHeap = GetProcessHeap();
 
-    size_t iSizeEstimated = (name.length() + 1) * 2;
+    long long iSizeEstimated = static_cast<long long>(name.length() + 1) * 2;
     for (int i = 0; i < maxIterations; i++) {
         if (strResult) {
             HeapFree(hHeap, 0, strResult);
@@ -682,7 +682,7 @@ bool Utility::normalizedSyncName(const SyncName &name, SyncName &normalizedName,
         return false;
     }
 
-    normalizedName.assign(strResult, iSizeEstimated - 1);
+    (void) normalizedName.assign(strResult, iSizeEstimated - 1);
     HeapFree(hHeap, 0, strResult);
     return true;
 #else

--- a/src/libcommonserver/utility/utility.cpp
+++ b/src/libcommonserver/utility/utility.cpp
@@ -648,7 +648,7 @@ bool Utility::normalizedSyncName(const SyncName &name, SyncName &normalizedName,
     LPWSTR strResult = nullptr;
     HANDLE hHeap = GetProcessHeap();
 
-    long long iSizeEstimated = static_cast<long long>(name.length() + 1) * 2;
+    int64_t iSizeEstimated = static_cast<int64_t>(name.length() + 1) * 2;
     for (int i = 0; i < maxIterations; i++) {
         if (strResult) {
             HeapFree(hHeap, 0, strResult);

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -773,7 +773,7 @@ void TestNetworkJobs::testFullFileListWithCursorJsonBlacklist() {
 void TestNetworkJobs::testFullFileListWithCursorCsvBlacklist() {
     CsvFullFileListWithCursorJob job(_driveDbId, "1", {pictureDirRemoteId}, true);
     const ExitCode exitCode = job.runSynchronously();
-    CPPUNIT_ASSERT(exitCode == ExitCode::Ok);
+    CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, exitCode);
 
     int counter = 0;
     std::string cursor = job.getCursor();
@@ -799,7 +799,7 @@ void TestNetworkJobs::testFullFileListWithCursorCsvBlacklist() {
 void TestNetworkJobs::testFullFileListWithCursorMissingEof() {
     CsvFullFileListWithCursorJob job(_driveDbId, "1");
     const ExitCode exitCode = job.runSynchronously();
-    CPPUNIT_ASSERT(exitCode == ExitCode::Ok);
+    CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, exitCode);
 
     int counter = 0;
     const std::string cursor = job.getCursor();
@@ -821,7 +821,7 @@ void TestNetworkJobs::testFullFileListWithCursorMissingEof() {
 void TestNetworkJobs::testGetInfoUser() {
     GetInfoUserJob job(_userDbId);
     const ExitCode exitCode = job.runSynchronously();
-    CPPUNIT_ASSERT(exitCode == ExitCode::Ok);
+    CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, exitCode);
 
     CPPUNIT_ASSERT_EQUAL(std::string("John Doe"), job.name());
     CPPUNIT_ASSERT_EQUAL(std::string("john.doe@nogafam.ch"), job.email());
@@ -831,7 +831,7 @@ void TestNetworkJobs::testGetInfoUser() {
 void TestNetworkJobs::testGetInfoDrive() {
     GetInfoDriveJob job(_driveDbId);
     const ExitCode exitCode = job.runSynchronously();
-    CPPUNIT_ASSERT(exitCode == ExitCode::Ok);
+    CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, exitCode);
 
     Poco::JSON::Object::Ptr data = job.jsonRes()->getObject(dataKey);
     CPPUNIT_ASSERT(data->get(nameKey).toString() == "kDrive Desktop Team");
@@ -840,7 +840,7 @@ void TestNetworkJobs::testGetInfoDrive() {
 void TestNetworkJobs::testThumbnail() {
     GetThumbnailJob job(_driveDbId, picture1RemoteId.c_str(), 50);
     const ExitCode exitCode = job.runSynchronously();
-    CPPUNIT_ASSERT(exitCode == ExitCode::Ok);
+    CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, exitCode);
 
     CPPUNIT_ASSERT(!job.octetStreamRes().empty());
 }
@@ -851,7 +851,7 @@ void TestNetworkJobs::testDuplicateRenameMove() {
     // Duplicate
     DuplicateJob dupJob(nullptr, _driveDbId, testFileRemoteId, Str("test_duplicate.txt"));
     ExitCode exitCode = dupJob.runSynchronously();
-    CPPUNIT_ASSERT(exitCode == ExitCode::Ok);
+    CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, exitCode);
 
     NodeId dupFileId;
     if (dupJob.jsonRes()) {
@@ -867,17 +867,17 @@ void TestNetworkJobs::testDuplicateRenameMove() {
     MoveJob moveJob(nullptr, _driveDbId, "", dupFileId, remoteTmpDir.id());
     moveJob.setBypassCheck(true);
     exitCode = moveJob.runSynchronously();
-    CPPUNIT_ASSERT(exitCode == ExitCode::Ok);
+    CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, exitCode);
 
     GetFileListJob fileListJob(_driveDbId, remoteTmpDir.id());
     exitCode = fileListJob.runSynchronously();
-    CPPUNIT_ASSERT(exitCode == ExitCode::Ok);
+    CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, exitCode);
 
     Poco::JSON::Object::Ptr resObj = fileListJob.jsonRes();
     CPPUNIT_ASSERT(resObj);
     Poco::JSON::Array::Ptr dataArray = resObj->getArray(dataKey);
-    CPPUNIT_ASSERT(dataArray->getObject(0)->get(idKey) == dupFileId);
-    CPPUNIT_ASSERT(dataArray->getObject(0)->get(nameKey) == "test_duplicate.txt");
+    CPPUNIT_ASSERT_EQUAL(dupFileId, NodeId(dataArray->getObject(0)->get(idKey).convert<std::string>()));
+    CPPUNIT_ASSERT_EQUAL(std::string("test_duplicate.txt"), dataArray->getObject(0)->get(nameKey).convert<std::string>());
 }
 
 void TestNetworkJobs::testRename() {


### PR DESCRIPTION
This PR optimizes the `Utility::normalizedSyncName` method on Windows, significantly improving its performance.  

**Benchmark Results:**  
- **Before optimization:** ~1.5s for 1,000,000 characters  
- **After optimization:** ~0.65s for 1,000,000 characters  
- **Performance gain:** More than **2x faster**  

### **Why This Matters:**  
This method is called frequently, particularly through `normalizeSyncPath` and `checkIfSameNormalization`, both of which are often used within loops. Reducing execution time here helps improve overall synchronization performance (🚀)
