### PR TITLE
KDesktop 1586: 0-byte files to develop

### DIFF
--- a/src/libsyncengine/jobs/network/API_v2/downloadjob.cpp
+++ b/src/libsyncengine/jobs/network/API_v2/downloadjob.cpp
@@ -605,7 +605,7 @@ bool DownloadJob::createTmpFile(std::optional<std::reference_wrapper<std::istrea
         setProgress(0);
         if (expectedSize != Poco::Net::HTTPMessage::UNKNOWN_CONTENT_LENGTH) {
             writeError = !hasEnoughPlace(_tmpPath, _localpath, expectedSize);
-            readError = expectedSize <= 0;
+            readError = expectedSize < 0;
         }
 
         if (!writeError && !readError) {

--- a/src/libsyncengine/jobs/network/API_v2/downloadjob.cpp
+++ b/src/libsyncengine/jobs/network/API_v2/downloadjob.cpp
@@ -604,8 +604,15 @@ bool DownloadJob::createTmpFile(std::optional<std::reference_wrapper<std::istrea
         expectedSize = _resHttp.getContentLength();
         setProgress(0);
         if (expectedSize != Poco::Net::HTTPMessage::UNKNOWN_CONTENT_LENGTH) {
-            writeError = !hasEnoughPlace(_tmpPath, _localpath, expectedSize);
-            readError = expectedSize < 0;
+            if (!hasEnoughPlace(_tmpPath, _localpath, expectedSize)) {
+                LOGW_WARN(_logger, L"Request " << jobId() << L": not enough place at " << Utility::formatSyncPath(_tmpPath) << L" or "
+                                             << Utility::formatSyncPath(_localpath));
+                writeError = true;
+            }
+            if (expectedSize < 0) {
+                LOG_WARN(_logger, "Request " << jobId() << ": invalid content length: " << expectedSize);
+                readError = true;
+            }
         }
 
         if (!writeError && !readError) {

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -464,7 +464,7 @@ void TestNetworkJobs::testDownload() {
         CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, uploadJob.exitCode());
         const NodeId remote0bytesFileId = uploadJob.nodeId();
         const LocalTemporaryDirectory temporaryDirectorySync("syncDir");
-        SyncPath localDestFilePath = temporaryDirectorySync.path() / "empty_file.txt";
+       const SyncPath localDestFilePath = temporaryDirectorySync.path() / "empty_file.txt";
         // Download an empty file
         {
             DownloadJob job(nullptr, _driveDbId, remote0bytesFileId, localDestFilePath, 0, 0, 0, false);

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -455,8 +455,7 @@ void TestNetworkJobs::testDownload() {
         const LocalTemporaryDirectory temporaryDirectory("tmp");
         const SyncPath local0bytesFilePath = temporaryDirectory.path() / "0bytes.txt";
         const RemoteTemporaryDirectory remoteTmpDir(_driveDbId, _remoteDirId, "testDownload0bytesFile");
-        std::ofstream ofs(local0bytesFilePath, std::ios::binary);
-        ofs.close();
+        { std::ofstream(local0bytesFilePath); }
 
         // Upload file
         UploadJob uploadJob(nullptr, _driveDbId, local0bytesFilePath, Str2SyncName("0bytes.txt"), remoteTmpDir.id(), 0);
@@ -464,7 +463,7 @@ void TestNetworkJobs::testDownload() {
         CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, uploadJob.exitCode());
         const NodeId remote0bytesFileId = uploadJob.nodeId();
         const LocalTemporaryDirectory temporaryDirectorySync("syncDir");
-       const SyncPath localDestFilePath = temporaryDirectorySync.path() / "empty_file.txt";
+        const SyncPath localDestFilePath = temporaryDirectorySync.path() / "empty_file.txt";
         // Download an empty file
         {
             DownloadJob job(nullptr, _driveDbId, remote0bytesFileId, localDestFilePath, 0, 0, 0, false);

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -449,6 +449,32 @@ void TestNetworkJobs::testDownload() {
                                          ExitInfo(ExitCode::SystemError, ExitCause::NotEnoughDiskSpace), exitInfo);
         }
     }
+
+    // Empty file
+    {
+        const LocalTemporaryDirectory temporaryDirectory("tmp");
+        const SyncPath local0bytesFilePath = temporaryDirectory.path() / "0bytes.txt";
+        const RemoteTemporaryDirectory remoteTmpDir(_driveDbId, _remoteDirId, "testDownload0bytesFile");
+        std::ofstream ofs(local0bytesFilePath, std::ios::binary);
+        ofs.close();
+
+        // Upload file
+        UploadJob uploadJob(nullptr, _driveDbId, local0bytesFilePath, Str2SyncName("0bytes.txt"), remoteTmpDir.id(), 0);
+        uploadJob.runSynchronously();
+        CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, uploadJob.exitCode());
+        const NodeId remote0bytesFileId = uploadJob.nodeId();
+        const LocalTemporaryDirectory temporaryDirectorySync("syncDir");
+        SyncPath localDestFilePath = temporaryDirectorySync.path() / "empty_file.txt";
+        // Download an empty file
+        {
+            DownloadJob job(nullptr, _driveDbId, remote0bytesFileId, localDestFilePath, 0, 0, 0, false);
+            (void) job.runSynchronously();
+            const ExitInfo exitInfo = {job.exitCode(), job.exitCause()};
+            CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), exitInfo);
+        }
+        // Check that the file has been copied
+        CPPUNIT_ASSERT(std::filesystem::exists(localDestFilePath));
+    }
 #ifdef __APPLE__
     {
         const LocalTemporaryDirectory temporaryDirectory("tmp");

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -455,7 +455,7 @@ void TestNetworkJobs::testDownload() {
         const LocalTemporaryDirectory temporaryDirectory("tmp");
         const SyncPath local0bytesFilePath = temporaryDirectory.path() / "0bytes.txt";
         const RemoteTemporaryDirectory remoteTmpDir(_driveDbId, _remoteDirId, "testDownload0bytesFile");
-        { std::ofstream(local0bytesFilePath); }
+        std::ofstream(local0bytesFilePath).close();
 
         // Upload file
         UploadJob uploadJob(nullptr, _driveDbId, local0bytesFilePath, Str2SyncName("0bytes.txt"), remoteTmpDir.id(), 0);


### PR DESCRIPTION
Due to recent changes in download job beahviour, a 0-byte file download now leads to a `BackError InvalidSize`, which  leads in turn to the sync failure.

Added a new test case in `TestNetworkJobs::testDownload` to verify that downloading an empty file is handled correctly.