### PR TITLE
[KDESKTOP-1129] Designs updaters as singletons

### DIFF
--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -111,6 +111,8 @@ static void displayHelpText(const QString &t) // No console on Windows.
 
 #else
 
+std::unique_ptr<UpdateManager> AppServer::_updateManager;
+
 static void displayHelpText(const QString &t) {
     std::cout << qUtf8Printable(t);
 }
@@ -1981,7 +1983,7 @@ void AppServer::onRequestReceived(int id, RequestNum num, const QByteArray &para
             QString tmp;
             QDataStream paramsStream(params);
             paramsStream >> tmp;
-            AbstractUpdater::skipVersion(tmp.toStdString());
+            _updateManager->updater()->skipVersion(tmp.toStdString());
             break;
         }
         default: {
@@ -3739,7 +3741,7 @@ void AppServer::addError(const Error &error) {
         }
         if (!toBeRemovedErrorIds.empty()) sendErrorsCleared(error.syncDbId());
     } else if (error.exitCode() == ExitCode::UpdateRequired) {
-        AbstractUpdater::unskipVersion();
+        _updateManager->updater()->unskipVersion();
     }
 
     if (!ServerRequests::isAutoResolvedError(error) && !errorAlreadyExists) {

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -1983,7 +1983,7 @@ void AppServer::onRequestReceived(int id, RequestNum num, const QByteArray &para
             QString tmp;
             QDataStream paramsStream(params);
             paramsStream >> tmp;
-            _updateManager->updater()->skipVersion(tmp.toStdString());
+            AbstractUpdater::skipVersion(tmp.toStdString());
             break;
         }
         default: {

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -99,6 +99,8 @@ static constexpr char restartClientMsg[] = "restartClient";
 
 static const QString crashMsg = SharedTools::QtSingleApplication::tr("kDrive application will close due to a fatal error.");
 
+std::unique_ptr<UpdateManager> AppServer::_updateManager;
+
 // Helpers for displaying messages. Note that there is no console on Windows.
 #ifdef Q_OS_WIN
 static void displayHelpText(const QString &t) // No console on Windows.
@@ -110,8 +112,6 @@ static void displayHelpText(const QString &t) // No console on Windows.
 }
 
 #else
-
-std::unique_ptr<UpdateManager> AppServer::_updateManager;
 
 static void displayHelpText(const QString &t) {
     std::cout << qUtf8Printable(t);

--- a/src/server/appserver.h
+++ b/src/server/appserver.h
@@ -118,7 +118,7 @@ class AppServer : public SharedTools::QtSingleApplication {
         std::unordered_map<int, SyncCache> _syncCacheMap;
         std::unordered_map<int, std::unordered_set<NodeId>> _undecidedListCacheMap;
 
-        std::unique_ptr<UpdateManager> _updateManager;
+        static std::unique_ptr<UpdateManager> _updateManager;
 
         void parseOptions(const QStringList &);
         bool initLogging() noexcept;

--- a/src/server/updater/abstractupdater.cpp
+++ b/src/server/updater/abstractupdater.cpp
@@ -81,9 +81,6 @@ void AbstractUpdater::unskipVersion() {
         ParametersCache::instance()->parameters().setSeenVersion("");
         ParametersCache::instance()->save();
     }
-#if defined(__APPLE__)
-    SparkleUpdater::unskipVersion();
-#endif
 }
 
 bool AbstractUpdater::isVersionSkipped(const std::string& version) {
@@ -103,18 +100,15 @@ VersionChannel AbstractUpdater::currentVersionChannel() const {
     const std::unordered_map<VersionChannel, VersionInfo> allVersions = _updateChecker->versionsInfo();
     if (allVersions.empty()) return VersionChannel::Unknown;
     std::string currentVersion = getCurrentVersion();
-    if (allVersions.contains(VersionChannel::Prod) &&
-        allVersions.at(VersionChannel::Prod).fullVersion() == currentVersion) {
+    if (allVersions.contains(VersionChannel::Prod) && allVersions.at(VersionChannel::Prod).fullVersion() == currentVersion) {
         return VersionChannel::Prod;
     }
 
-    if (allVersions.contains(VersionChannel::Next) &&
-        allVersions.at(VersionChannel::Next).fullVersion() == currentVersion) {
+    if (allVersions.contains(VersionChannel::Next) && allVersions.at(VersionChannel::Next).fullVersion() == currentVersion) {
         return VersionChannel::Next;
     }
 
-    if (allVersions.contains(VersionChannel::Beta) &&
-        allVersions.at(VersionChannel::Beta).fullVersion() == currentVersion) {
+    if (allVersions.contains(VersionChannel::Beta) && allVersions.at(VersionChannel::Beta).fullVersion() == currentVersion) {
         return VersionChannel::Beta;
     }
 

--- a/src/server/updater/abstractupdater.h
+++ b/src/server/updater/abstractupdater.h
@@ -63,7 +63,7 @@ class AbstractUpdater {
         void setStateChangeCallback(const std::function<void(UpdateState)> &stateChangeCallback);
 
         static void skipVersion(const std::string &skippedVersion);
-        static void unskipVersion();
+        virtual void unskipVersion();
         [[nodiscard]] static bool isVersionSkipped(const std::string &version);
 
         void setCurrentChannel(const VersionChannel currentChannel) { _currentChannel = currentChannel; }

--- a/src/server/updater/linuxupdater.cpp
+++ b/src/server/updater/linuxupdater.cpp
@@ -26,7 +26,7 @@ std::shared_ptr<LinuxUpdater> LinuxUpdater::instance() {
     if (_instance == nullptr) {
         try {
             _instance = std::make_shared<LinuxUpdater>();
-        } catch (...) {
+        } catch (std::exception const &) {
             return nullptr;
         }
     }

--- a/src/server/updater/linuxupdater.cpp
+++ b/src/server/updater/linuxupdater.cpp
@@ -24,11 +24,7 @@ std::shared_ptr<LinuxUpdater> LinuxUpdater::_instance;
 
 std::shared_ptr<LinuxUpdater> LinuxUpdater::instance() {
     if (_instance == nullptr) {
-        try {
-            _instance = std::make_shared<LinuxUpdater>();
-        } catch (std::exception const &) {
-            return nullptr;
-        }
+        _instance = std::make_shared<LinuxUpdater>();
     }
 
     return _instance;

--- a/src/server/updater/linuxupdater.cpp
+++ b/src/server/updater/linuxupdater.cpp
@@ -20,6 +20,20 @@
 
 namespace KDC {
 
+std::shared_ptr<LinuxUpdater> LinuxUpdater::_instance;
+
+std::shared_ptr<LinuxUpdater> LinuxUpdater::instance() {
+    if (_instance == nullptr) {
+        try {
+            _instance = std::make_shared<LinuxUpdater>();
+        } catch (...) {
+            return nullptr;
+        }
+    }
+
+    return _instance;
+}
+
 void LinuxUpdater::onUpdateFound() {
     setState(UpdateState::ManualUpdateAvailable);
 }

--- a/src/server/updater/linuxupdater.h
+++ b/src/server/updater/linuxupdater.h
@@ -24,8 +24,13 @@ namespace KDC {
 
 class LinuxUpdater final : public AbstractUpdater {
     public:
+        static std::shared_ptr<LinuxUpdater> instance();
         void onUpdateFound() override;
-        void startInstaller() override { /* No automatic update on Linux for now */ }
+        void startInstaller() override { /* No automatic update on Linux for now */
+        }
+
+    private:
+        static std::shared_ptr<LinuxUpdater> _instance;
 };
 
 } // namespace KDC

--- a/src/server/updater/sparkleupdater.h
+++ b/src/server/updater/sparkleupdater.h
@@ -24,7 +24,7 @@ namespace KDC {
 
 class SparkleUpdater final : public AbstractUpdater {
     public:
-        SparkleUpdater();
+        static std::shared_ptr<SparkleUpdater> instance();
         ~SparkleUpdater() override;
 
         void onUpdateFound() override;
@@ -32,9 +32,12 @@ class SparkleUpdater final : public AbstractUpdater {
         void setQuitCallback(const std::function<void()> &quitCallback) override;
         void startInstaller() override;
 
-        static void unskipVersion();
+        void unskipVersion() override;
 
     private:
+        SparkleUpdater();
+        static std::shared_ptr<SparkleUpdater> _instance;
+
         void reset(const std::string &url = "");
         bool startSparkleUpdater();
 

--- a/src/server/updater/sparkleupdater.mm
+++ b/src/server/updater/sparkleupdater.mm
@@ -195,7 +195,7 @@ std::shared_ptr<SparkleUpdater> SparkleUpdater::instance() {
     if (_instance == nullptr) {
         try {
             _instance = std::shared_ptr<SparkleUpdater>(new SparkleUpdater());
-        } catch (...) {
+        } catch (std::exception const &) {
             return nullptr;
         }
     }

--- a/src/server/updater/sparkleupdater.mm
+++ b/src/server/updater/sparkleupdater.mm
@@ -193,11 +193,7 @@ std::shared_ptr<SparkleUpdater> SparkleUpdater::_instance;
 
 std::shared_ptr<SparkleUpdater> SparkleUpdater::instance() {
     if (_instance == nullptr) {
-        try {
-            _instance = std::shared_ptr<SparkleUpdater>(new SparkleUpdater());
-        } catch (std::exception const &) {
-            return nullptr;
-        }
+        _instance = std::shared_ptr<SparkleUpdater>(new SparkleUpdater());
     }
 
     return _instance;

--- a/src/server/updater/updatemanager.cpp
+++ b/src/server/updater/updatemanager.cpp
@@ -118,7 +118,7 @@ void UpdateManager::createUpdater() {
     _updater = std::make_unique<WindowsUpdater>();
 #else
     // the best we can do is notify about updates
-    _updater = std::make_unique<LinuxUpdater>();
+    _updater = LinuxUpdater::instance();
 #endif
 }
 

--- a/src/server/updater/updatemanager.cpp
+++ b/src/server/updater/updatemanager.cpp
@@ -115,7 +115,7 @@ void UpdateManager::createUpdater() {
 #if defined(__APPLE__)
     _updater = SparkleUpdater::instance();
 #elif defined(_WIN32)
-    _updater = std::make_unique<WindowsUpdater>();
+    _updater = WindowsUpdater::instance();
 #else
     // the best we can do is notify about updates
     _updater = LinuxUpdater::instance();

--- a/src/server/updater/updatemanager.cpp
+++ b/src/server/updater/updatemanager.cpp
@@ -32,6 +32,8 @@
 
 namespace KDC {
 
+std::shared_ptr<AbstractUpdater> UpdateManager::_updater;
+
 UpdateManager::UpdateManager(QObject *parent) : QObject(parent) {
     _currentChannel = ParametersCache::instance()->parameters().distributionChannel();
 
@@ -62,7 +64,7 @@ void UpdateManager::startInstaller() const {
     LOG_DEBUG(Log::instance()->getLogger(), "startInstaller called!");
 
     // Cleanup skipped version
-    AbstractUpdater::unskipVersion();
+    _updater->unskipVersion();
 
     _updater->startInstaller();
 }
@@ -111,7 +113,7 @@ void UpdateManager::slotUpdateStateChanged(const UpdateState newState) {
 
 void UpdateManager::createUpdater() {
 #if defined(__APPLE__)
-    _updater = std::make_unique<SparkleUpdater>();
+    _updater = SparkleUpdater::instance();
 #elif defined(_WIN32)
     _updater = std::make_unique<WindowsUpdater>();
 #else

--- a/src/server/updater/updatemanager.h
+++ b/src/server/updater/updatemanager.h
@@ -48,7 +48,7 @@ class UpdateManager final : public QObject {
         void startInstaller() const;
         void setQuitCallback(const std::function<void()> &quitCallback) const { _updater->setQuitCallback(quitCallback); }
 
-        std::shared_ptr<AbstractUpdater> updater() { return _updater; };
+        std::shared_ptr<AbstractUpdater> updater() const { return _updater; };
 
     signals:
         void updateAnnouncement(const QString &title, const QString &msg);

--- a/src/server/updater/updatemanager.h
+++ b/src/server/updater/updatemanager.h
@@ -48,6 +48,8 @@ class UpdateManager final : public QObject {
         void startInstaller() const;
         void setQuitCallback(const std::function<void()> &quitCallback) const { _updater->setQuitCallback(quitCallback); }
 
+        const std::shared_ptr<AbstractUpdater> updater() { return _updater; };
+
     signals:
         void updateAnnouncement(const QString &title, const QString &msg);
         void requestRestart();
@@ -66,7 +68,7 @@ class UpdateManager final : public QObject {
 
         void onUpdateStateChanged(UpdateState newState);
 
-        std::unique_ptr<AbstractUpdater> _updater;
+        static std::shared_ptr<AbstractUpdater> _updater;
         VersionChannel _currentChannel{VersionChannel::Unknown};
         QTimer _updateCheckTimer; /** Timer for the regular update check. */
 };

--- a/src/server/updater/updatemanager.h
+++ b/src/server/updater/updatemanager.h
@@ -48,7 +48,7 @@ class UpdateManager final : public QObject {
         void startInstaller() const;
         void setQuitCallback(const std::function<void()> &quitCallback) const { _updater->setQuitCallback(quitCallback); }
 
-        const std::shared_ptr<AbstractUpdater> updater() { return _updater; };
+        std::shared_ptr<AbstractUpdater> updater() { return _updater; };
 
     signals:
         void updateAnnouncement(const QString &title, const QString &msg);

--- a/src/server/updater/windowsupdater.cpp
+++ b/src/server/updater/windowsupdater.cpp
@@ -26,6 +26,20 @@
 
 namespace KDC {
 
+std::shared_ptr<WindowsUpdater> WindowsUpdater::_instance;
+
+std::shared_ptr<WindowsUpdater> WindowsUpdater::instance() {
+    if (_instance == nullptr) {
+        try {
+            _instance = std::make_shared<WindowsUpdater>();
+        } catch (...) {
+            return nullptr;
+        }
+    }
+
+    return _instance;
+}
+
 void WindowsUpdater::onUpdateFound() {
     // Check if version is already downloaded
     SyncPath filepath;

--- a/src/server/updater/windowsupdater.cpp
+++ b/src/server/updater/windowsupdater.cpp
@@ -30,11 +30,7 @@ std::shared_ptr<WindowsUpdater> WindowsUpdater::_instance;
 
 std::shared_ptr<WindowsUpdater> WindowsUpdater::instance() {
     if (_instance == nullptr) {
-        try {
-            _instance = std::make_shared<WindowsUpdater>();
-        } catch (std::exception const &) {
-            return nullptr;
-        }
+        _instance = std::make_shared<WindowsUpdater>();
     }
 
     return _instance;

--- a/src/server/updater/windowsupdater.cpp
+++ b/src/server/updater/windowsupdater.cpp
@@ -32,7 +32,7 @@ std::shared_ptr<WindowsUpdater> WindowsUpdater::instance() {
     if (_instance == nullptr) {
         try {
             _instance = std::make_shared<WindowsUpdater>();
-        } catch (...) {
+        } catch (std::exception const &) {
             return nullptr;
         }
     }

--- a/src/server/updater/windowsupdater.h
+++ b/src/server/updater/windowsupdater.h
@@ -24,10 +24,13 @@ namespace KDC {
 
 class WindowsUpdater final : public AbstractUpdater {
     public:
+        static std::shared_ptr<WindowsUpdater> instance();
         void onUpdateFound() override;
         void startInstaller() override;
 
     private:
+        static std::shared_ptr<WindowsUpdater> _instance;
+
         /**
          * @brief Start the synchronous download of the new version installer.
          */

--- a/test/server/updater/testabstractupdater.cpp
+++ b/test/server/updater/testabstractupdater.cpp
@@ -26,7 +26,7 @@
 #elif defined(_WIN32)
 #include "server/updater/windowsupdater.h"
 #elif defined(__linux__)
-#include "server/updater/linuxpdater.h"
+#include "server/updater/linuxupdater.h"
 #endif
 
 #include "libsyncengine/jobs/jobmanager.h"

--- a/test/server/updater/testabstractupdater.cpp
+++ b/test/server/updater/testabstractupdater.cpp
@@ -20,6 +20,7 @@
 
 #include "db/parmsdb.h"
 #include "requests/parameterscache.h"
+#include "server/updater/sparkleupdater.h"
 #include "libsyncengine/jobs/jobmanager.h"
 #include "version.h"
 
@@ -51,7 +52,7 @@ void TestAbstractUpdater::testSkipUnskipVersion() {
     CPPUNIT_ASSERT(parameters.seenVersion() == testStr);
 
 #ifdef __APPLE__
-    SparkleUpdater::instance()->unskipversion();
+    SparkleUpdater::instance()->unskipVersion();
 #elifdef _WIN32
     AbstractUpdate::unskipversion();
 #elifdef __linux__
@@ -93,7 +94,13 @@ void TestAbstractUpdater::testIsVersionSkipped() {
     CPPUNIT_ASSERT(AbstractUpdater::isVersionSkipped("3.3.0.20210101"));
     CPPUNIT_ASSERT(AbstractUpdater::isVersionSkipped("3.3.3.20200101"));
 
-    AbstractUpdater::unskipVersion();
+#ifdef __APPLE__
+    SparkleUpdater::instance()->unskipVersion();
+#elifdef _WIN32
+    AbstractUpdate::unskipversion();
+#elifdef __linux__
+    AbstractUpdate::unskipversion();
+#endif
 
     CPPUNIT_ASSERT(!AbstractUpdater::isVersionSkipped(skippedVersion));
 

--- a/test/server/updater/testabstractupdater.cpp
+++ b/test/server/updater/testabstractupdater.cpp
@@ -54,7 +54,7 @@ void TestAbstractUpdater::testSkipUnskipVersion() {
 #ifdef __APPLE__
     SparkleUpdater::instance()->unskipVersion();
 #elifdef _WIN32
-    AbstractUpdate::unskipversion();
+    WindowsUpdater::instance()->unskipVersion();
 #elifdef __linux__
     LinuxUpdater::instance()->unskipVersion();
 #endif
@@ -97,7 +97,7 @@ void TestAbstractUpdater::testIsVersionSkipped() {
 #ifdef __APPLE__
     SparkleUpdater::instance()->unskipVersion();
 #elifdef _WIN32
-    AbstractUpdate::unskipVersion();
+    WindowsUpdater::instance()->unskipVersion();
 #elifdef __linux__
     LinuxUpdater::instance()->unskipVersion();
 #endif

--- a/test/server/updater/testabstractupdater.cpp
+++ b/test/server/updater/testabstractupdater.cpp
@@ -56,7 +56,7 @@ void TestAbstractUpdater::testSkipUnskipVersion() {
 #elifdef _WIN32
     AbstractUpdate::unskipversion();
 #elifdef __linux__
-    AbstractUpdate::unskipversion();
+    LinuxUpdater::instance()->unskipVersion();
 #endif
 
     CPPUNIT_ASSERT(ParametersCache::instance()->parameters().seenVersion().empty());
@@ -97,9 +97,9 @@ void TestAbstractUpdater::testIsVersionSkipped() {
 #ifdef __APPLE__
     SparkleUpdater::instance()->unskipVersion();
 #elifdef _WIN32
-    AbstractUpdate::unskipversion();
+    AbstractUpdate::unskipVersion();
 #elifdef __linux__
-    AbstractUpdate::unskipversion();
+    LinuxUpdater::instance()->unskipVersion();
 #endif
 
     CPPUNIT_ASSERT(!AbstractUpdater::isVersionSkipped(skippedVersion));

--- a/test/server/updater/testabstractupdater.cpp
+++ b/test/server/updater/testabstractupdater.cpp
@@ -38,7 +38,7 @@
 namespace KDC {
 
 namespace {
-void skipVersion() {
+void unskipVersion() {
 #if defined(__APPLE__)
     SparkleUpdater::instance()->unskipVersion();
 #elif defined(_WIN32)
@@ -71,7 +71,7 @@ void TestAbstractUpdater::testSkipUnskipVersion() {
     ParmsDb::instance()->selectParameters(parameters, found);
     CPPUNIT_ASSERT(parameters.seenVersion() == testStr);
 
-    skipVersion();
+    unskipVersion();
 
     CPPUNIT_ASSERT(ParametersCache::instance()->parameters().seenVersion().empty());
 
@@ -108,7 +108,7 @@ void TestAbstractUpdater::testIsVersionSkipped() {
     CPPUNIT_ASSERT(AbstractUpdater::isVersionSkipped("3.3.0.20210101"));
     CPPUNIT_ASSERT(AbstractUpdater::isVersionSkipped("3.3.3.20200101"));
 
-    skipVersion();
+    unskipVersion();
 
     CPPUNIT_ASSERT(!AbstractUpdater::isVersionSkipped(skippedVersion));
 

--- a/test/server/updater/testabstractupdater.cpp
+++ b/test/server/updater/testabstractupdater.cpp
@@ -169,6 +169,7 @@ void TestAbstractUpdater::testCurrentVersionedChannel() {
     CPPUNIT_ASSERT_EQUAL(VersionChannel::Unknown, updater.currentVersionChannel());
 
     AllVersionsInfo emptyTestVersions;
+    updateChecker->setAllVersionInfo(testVersions);
     version = "11.0.1.20210101";
     CPPUNIT_ASSERT_EQUAL(VersionChannel::Unknown, updater.currentVersionChannel());
 }

--- a/test/server/updater/testabstractupdater.cpp
+++ b/test/server/updater/testabstractupdater.cpp
@@ -168,8 +168,7 @@ void TestAbstractUpdater::testCurrentVersionedChannel() {
     version = "9.0.0.20210102";
     CPPUNIT_ASSERT_EQUAL(VersionChannel::Unknown, updater.currentVersionChannel());
 
-    AllVersionsInfo emptyTestVersions;
-    updateChecker->setAllVersionInfo(testVersions);
+    updateChecker->setAllVersionInfo({});
     version = "11.0.1.20210101";
     CPPUNIT_ASSERT_EQUAL(VersionChannel::Unknown, updater.currentVersionChannel());
 }

--- a/test/server/updater/testabstractupdater.cpp
+++ b/test/server/updater/testabstractupdater.cpp
@@ -20,7 +20,15 @@
 
 #include "db/parmsdb.h"
 #include "requests/parameterscache.h"
+
+#if defined(__APPLE__)
 #include "server/updater/sparkleupdater.h"
+#elif defined(_WIN32)
+#include "server/updater/windowsupdater.h"
+#elif defined(__linux__)
+#include "server/updater/linuxpdater.h"
+#endif
+
 #include "libsyncengine/jobs/jobmanager.h"
 #include "version.h"
 

--- a/test/server/updater/testabstractupdater.cpp
+++ b/test/server/updater/testabstractupdater.cpp
@@ -167,5 +167,9 @@ void TestAbstractUpdater::testCurrentVersionedChannel() {
     // Check Unknown version (higher than prod)
     version = "9.0.0.20210102";
     CPPUNIT_ASSERT_EQUAL(VersionChannel::Unknown, updater.currentVersionChannel());
+
+    AllVersionsInfo emptyTestVersions;
+    version = "11.0.1.20210101";
+    CPPUNIT_ASSERT_EQUAL(VersionChannel::Unknown, updater.currentVersionChannel());
 }
 } // namespace KDC

--- a/test/server/updater/testabstractupdater.cpp
+++ b/test/server/updater/testabstractupdater.cpp
@@ -50,7 +50,13 @@ void TestAbstractUpdater::testSkipUnskipVersion() {
     ParmsDb::instance()->selectParameters(parameters, found);
     CPPUNIT_ASSERT(parameters.seenVersion() == testStr);
 
-    AbstractUpdater::unskipVersion();
+#ifdef __APPLE__
+    SparkleUpdater::instance()->unskipversion();
+#elifdef _WIN32
+    AbstractUpdate::unskipversion();
+#elifdef __linux__
+    AbstractUpdate::unskipversion();
+#endif
 
     CPPUNIT_ASSERT(ParametersCache::instance()->parameters().seenVersion().empty());
 

--- a/test/server/updater/testabstractupdater.cpp
+++ b/test/server/updater/testabstractupdater.cpp
@@ -29,6 +29,18 @@
 
 namespace KDC {
 
+namespace {
+void skipVersion() {
+#if defined(__APPLE__)
+    SparkleUpdater::instance()->unskipVersion();
+#elif defined(_WIN32)
+    WindowsUpdater::instance()->unskipVersion();
+#elif defined(__linux__)
+    LinuxUpdater::instance()->unskipVersion();
+#endif
+}
+} // namespace
+
 void TestAbstractUpdater::setUp() {
     TestBase::start();
     // Init parmsDb
@@ -51,13 +63,7 @@ void TestAbstractUpdater::testSkipUnskipVersion() {
     ParmsDb::instance()->selectParameters(parameters, found);
     CPPUNIT_ASSERT(parameters.seenVersion() == testStr);
 
-#ifdef __APPLE__
-    SparkleUpdater::instance()->unskipVersion();
-#elifdef _WIN32
-    WindowsUpdater::instance()->unskipVersion();
-#elifdef __linux__
-    LinuxUpdater::instance()->unskipVersion();
-#endif
+    skipVersion();
 
     CPPUNIT_ASSERT(ParametersCache::instance()->parameters().seenVersion().empty());
 
@@ -94,13 +100,7 @@ void TestAbstractUpdater::testIsVersionSkipped() {
     CPPUNIT_ASSERT(AbstractUpdater::isVersionSkipped("3.3.0.20210101"));
     CPPUNIT_ASSERT(AbstractUpdater::isVersionSkipped("3.3.3.20200101"));
 
-#ifdef __APPLE__
-    SparkleUpdater::instance()->unskipVersion();
-#elifdef _WIN32
-    WindowsUpdater::instance()->unskipVersion();
-#elifdef __linux__
-    LinuxUpdater::instance()->unskipVersion();
-#endif
+    skipVersion();
 
     CPPUNIT_ASSERT(!AbstractUpdater::isVersionSkipped(skippedVersion));
 

--- a/test/server/updater/testabstractupdater.cpp
+++ b/test/server/updater/testabstractupdater.cpp
@@ -168,7 +168,15 @@ void TestAbstractUpdater::testCurrentVersionedChannel() {
     version = "9.0.0.20210102";
     CPPUNIT_ASSERT_EQUAL(VersionChannel::Unknown, updater.currentVersionChannel());
 
+    // Emtpy version info.
     updateChecker->setAllVersionInfo({});
+    version = "11.0.1.20210101";
+    CPPUNIT_ASSERT_EQUAL(VersionChannel::Unknown, updater.currentVersionChannel());
+
+    // Non-empty invalid version info.
+    AllVersionsInfo invalidVersions;
+    testVersions[VersionChannel::Unknown].tag = "10.0.0";
+    updateChecker->setAllVersionInfo(invalidVersions);
     version = "11.0.1.20210101";
     CPPUNIT_ASSERT_EQUAL(VersionChannel::Unknown, updater.currentVersionChannel());
 }


### PR DESCRIPTION
The initial impetus of these changes comes from a `cppcheck` warning about the `static` method `AbstractUpdater::unskipVersion` that was redefined as another `static` method of the derived class `SparkelUpdater`.

The `static` qualifier of the method `unskipVersion` is now removed so that polymorphism can be used appropriately. Each derived class of `AbstractUpdater` is additionally turned into a singleton.
