### PR TITLE
KDESKTOP-1497 - Fix clear history button

### DIFF
--- a/src/gui/drivepreferenceswidget.cpp
+++ b/src/gui/drivepreferenceswidget.cpp
@@ -575,7 +575,6 @@ void DrivePreferencesWidget::updateGuardedFoldersBlocs() {
             folderTreeItemWidget->setVisible(false);
             folderTreeBox->addWidget(folderTreeItemWidget);
 
-            connect(folderItemWidget, &FolderItemWidget::runSync, this, &DrivePreferencesWidget::runSync);
             connect(folderItemWidget, &FolderItemWidget::pauseSync, this, &DrivePreferencesWidget::pauseSync);
             connect(folderItemWidget, &FolderItemWidget::resumeSync, this, &DrivePreferencesWidget::resumeSync);
             connect(folderItemWidget, &FolderItemWidget::unSync, this, &DrivePreferencesWidget::onUnsyncTriggered);

--- a/src/gui/drivepreferenceswidget.h
+++ b/src/gui/drivepreferenceswidget.h
@@ -58,7 +58,6 @@ class DrivePreferencesWidget : public LargeWidgetWithCustomToolTip {
         void removeDrive(int driveDbId);
         void newBigFolderDiscovered(int syncDbId, const QString &path);
         void undecidedListsCleared();
-        void runSync(int syncDbId);
         void pauseSync(int syncDbId);
         void resumeSync(int syncDbId);
 

--- a/src/gui/folderitemwidget.cpp
+++ b/src/gui/folderitemwidget.cpp
@@ -408,10 +408,6 @@ void FolderItemWidget::onOpenFolder(const QString &link) {
     emit openFolder(syncInfoClient->localPath());
 }
 
-void FolderItemWidget::onSyncTriggered() {
-    emit runSync(_syncDbId);
-}
-
 void FolderItemWidget::onPauseTriggered() {
     emit pauseSync(_syncDbId);
 }

--- a/src/gui/folderitemwidget.h
+++ b/src/gui/folderitemwidget.h
@@ -51,7 +51,6 @@ class FolderItemWidget : public QWidget {
         void setToolTipsEnabled(bool enabled) noexcept;
 
     signals:
-        void runSync(int syncDbId);
         void pauseSync(int syncDbId);
         void resumeSync(int syncDbId);
         void unSync(int syncDbId);
@@ -93,7 +92,6 @@ class FolderItemWidget : public QWidget {
         void onCancelButtonClicked();
         void onValidateButtonClicked();
         void onOpenFolder(const QString &link);
-        void onSyncTriggered();
         void onPauseTriggered();
         void onResumeTriggered();
         void onUnsyncTriggered();

--- a/src/gui/parametersdialog.cpp
+++ b/src/gui/parametersdialog.cpp
@@ -274,7 +274,6 @@ void ParametersDialog::initUI() {
     connect(_drivePreferencesWidget, &DrivePreferencesWidget::displayErrors, this, &ParametersDialog::onDisplayDriveErrors);
     connect(_drivePreferencesWidget, &DrivePreferencesWidget::openFolder, this, &ParametersDialog::onOpenFolder);
     connect(_drivePreferencesWidget, &DrivePreferencesWidget::removeDrive, this, &ParametersDialog::onRemoveDrive);
-    connect(_drivePreferencesWidget, &DrivePreferencesWidget::runSync, this, &ParametersDialog::onRunSync);
     connect(_drivePreferencesWidget, &DrivePreferencesWidget::pauseSync, this, &ParametersDialog::onPauseSync);
     connect(_drivePreferencesWidget, &DrivePreferencesWidget::resumeSync, this, &ParametersDialog::onResumeSync);
     connect(_preferencesMenuBarWidget, &PreferencesMenuBarWidget::backButtonClicked, this,
@@ -1118,20 +1117,14 @@ void ParametersDialog::onResumeSync(int syncDbId) {
     emit executeSyncAction(ActionType::Start, ActionTarget::Sync, syncDbId);
 }
 
-void ParametersDialog::onRunSync(int syncDbId) {
-    Q_UNUSED(syncDbId)
-
-    // TODO: useless?
-}
-
-void ParametersDialog::onClearErrors(int driveDbId, bool autoResolved) {
+void ParametersDialog::onClearErrors(const int driveDbId, const bool autoResolved) {
     ErrorTabWidget *errorTabWidget = nullptr;
     QListWidget *listWidgetToClear = nullptr;
 
     if (driveDbId == 0) {
         LOG_IF_FAIL(_errorsStackedWidget->currentIndex() == static_cast<int>(DriveInfoClient::ParametersStackedWidget::General));
 
-        errorTabWidget = static_cast<ErrorTabWidget *>(_errorsStackedWidget->widget(_errorTabWidgetStackPosition));
+        errorTabWidget = dynamic_cast<ErrorTabWidget *>(_errorsStackedWidget->widget(_errorTabWidgetStackPosition));
 
         if (GuiRequests::deleteErrorsServer() != ExitCode::Ok) {
             qCWarning(lcParametersDialog()) << "Error in GuiRequests::deleteErrorsServer";
@@ -1144,13 +1137,13 @@ void ParametersDialog::onClearErrors(int driveDbId, bool autoResolved) {
             return;
         }
 
-        errorTabWidget =
-                static_cast<ErrorTabWidget *>(_errorsStackedWidget->widget(driveInfoMapIt->second.errorTabWidgetStackPosition()));
+        errorTabWidget = dynamic_cast<ErrorTabWidget *>(
+                _errorsStackedWidget->widget(driveInfoMapIt->second.errorTabWidgetStackPosition()));
 
-        for (const auto &syncInfoMapIt: _gui->syncInfoMap()) {
-            if (syncInfoMapIt.second.driveDbId() == driveDbId) {
-                if (GuiRequests::deleteErrorsForSync(syncInfoMapIt.first, autoResolved) != ExitCode::Ok) {
-                    qCWarning(lcParametersDialog()) << "Error in GuiRequests::deleteErrorsForSync syncId=" << syncInfoMapIt.first;
+        for (const auto &[syncDbId, syncInfo]: _gui->syncInfoMap()) {
+            if (syncInfo.driveDbId() == driveDbId) {
+                if (GuiRequests::deleteErrorsForSync(syncDbId, autoResolved) != ExitCode::Ok) {
+                    qCWarning(lcParametersDialog()) << "Error in GuiRequests::deleteErrorsForSync syncId=" << syncDbId;
                     return;
                 }
             }

--- a/src/gui/parametersdialog.h
+++ b/src/gui/parametersdialog.h
@@ -127,7 +127,6 @@ class ParametersDialog : public CustomDialog {
         void retranslateUi();
         void onPauseSync(int syncDbId = 0);
         void onResumeSync(int syncDbId = 0);
-        void onRunSync(int syncDbId = 0);
         void onClearErrors(int syncDbId, bool autoResolved);
 };
 


### PR DESCRIPTION
In case of Create-Create or Edit-Edit conflicts, the local file is renamed with the conflict suffix and an error is shown explaining to the user that its local file has been renamed. Those errors are cleared if the user resolve all existing conflict using the dedicated button "Resolve".
The errors should also be removed when user click on "Clear history" if the conflicted file does not exist anymore.