### PR TITLE
Fix TestSyncPalWorker::testInternalPause1()

### DIFF
--- a/src/libsyncengine/syncpal/syncpalworker.cpp
+++ b/src/libsyncengine/syncpal/syncpalworker.cpp
@@ -438,9 +438,9 @@ SyncStep SyncPalWorker::nextStep() const {
             const bool areFSOWorkersRunning =
                     _syncPal->_localFSObserverWorker->isRunning() && _syncPal->_remoteFSObserverWorker->isRunning();
             const bool areFSOWorkersInitializing =
-                    _syncPal->_localFSObserverWorker->initializing() && _syncPal->_remoteFSObserverWorker->initializing();
+                    _syncPal->_localFSObserverWorker->initializing() || _syncPal->_remoteFSObserverWorker->initializing();
             const bool areFSOWorkersUpdating =
-                    _syncPal->_localFSObserverWorker->updating() && _syncPal->_remoteFSObserverWorker->updating();
+                    _syncPal->_localFSObserverWorker->updating() || _syncPal->_remoteFSObserverWorker->updating();
             const bool areSnapshotsUpdated =
                     _syncPal->snapshot(ReplicaSide::Local)->updated() || _syncPal->snapshot(ReplicaSide::Remote)->updated();
 

--- a/test/test_utility/timeouthelper.cpp
+++ b/test/test_utility/timeouthelper.cpp
@@ -35,8 +35,8 @@ bool TimeoutHelper::waitFor(std::function<bool()> condition, std::function<void(
                             const std::chrono::steady_clock::duration& loopWait) {
     TimeoutHelper timeout(duration, loopWait);
     while (!condition()) {
-        if (timeout.timedOut()) return false;
         stateCheck();
+        if (timeout.timedOut()) return false;
     }
     return true;
 }


### PR DESCRIPTION
TestSyncPalWorker::testInternalPause1() fails sometime. This PR aims to fix that