### PR TITLE
Regression - Step 1 slow down

### DIFF
--- a/src/libsyncengine/update_detection/file_system_observer/remotefilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/remotefilesystemobserverworker.cpp
@@ -73,12 +73,13 @@ void RemoteFileSystemObserverWorker::execute() {
             }
         }
 
+        if (_initializing) _initializing = false;
+
         exitCode = processEvents();
         if (exitCode != ExitCode::Ok) {
             LOG_SYNCPAL_DEBUG(_logger, "Error in processEvents: code=" << exitCode);
             break;
         }
-        if (_initializing) _initializing = false;
         Utility::msleep(LOOP_EXEC_SLEEP_PERIOD);
     }
     LOG_SYNCPAL_DEBUG(_logger, "Worker stopped: name=" << name().c_str());

--- a/src/libsyncengine/update_detection/file_system_observer/remotefilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/remotefilesystemobserverworker.cpp
@@ -73,13 +73,12 @@ void RemoteFileSystemObserverWorker::execute() {
             }
         }
 
-        if (_initializing) _initializing = false;
-
         exitCode = processEvents();
         if (exitCode != ExitCode::Ok) {
             LOG_SYNCPAL_DEBUG(_logger, "Error in processEvents: code=" << exitCode);
             break;
         }
+        _initializing = false;
         Utility::msleep(LOOP_EXEC_SLEEP_PERIOD);
     }
     LOG_SYNCPAL_DEBUG(_logger, "Worker stopped: name=" << name().c_str());
@@ -140,7 +139,7 @@ ExitCode RemoteFileSystemObserverWorker::processEvents() {
         return exitCode;
     }
 
-    if (!_updating) {
+    if (!_updating && !_initializing) {
         // Send long poll request
         bool changes = false;
         exitCode = sendLongPoll(changes);


### PR DESCRIPTION
This is a regression introduced in https://github.com/Infomaniak/desktop-kDrive/pull/599 and  https://github.com/Infomaniak/desktop-kDrive/pull/544.

The `_initializing` must be set to `false` as soon as the remote snapshot is created and before sending the first LongPoll request