### PR TITLE
Change git checkout ref to default in the checkout Github action of the Windows runner

### DIFF
--- a/.github/workflows/build-and-run-extended-tests.yml
+++ b/.github/workflows/build-and-run-extended-tests.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Code coverage preview
         id: html_preview
-        uses: pavi2410/html-preview-action@v2
+        uses: pavi2410/html-preview-action@v4
         with:
           html_file: 'coverage_html/index.html'
           job_summary: true

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -111,6 +111,7 @@ jobs:
             --define sonar.cfamily.bullseye.reportPath="coverage.xml"
             --define sonar.scm.exclusions.disabled=true
             --define sonar.verbose=true
+            --define sonar.newCode.referenceBranch
             --define sonar.branch.name="${{ env.PR_SOURCE_BRANCH }}"
             --define sonar.branch.target="${{ env.PR_TARGET_BRANCH }}"
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,6 +25,8 @@ jobs:
   build-kDrive:
     runs-on: [ self-hosted, Windows, desktop-kdrive ]
     env:
+      PR_SOURCE_BRANCH: ${{ github.head_ref }}
+      PR_TARGET_BRANCH: ${{ github.base_ref }}
       COVFILE: ${{ github.workspace }}\\src\\test.cov
     steps:
       - name: Load system Path into Github environment
@@ -109,6 +111,8 @@ jobs:
             --define sonar.cfamily.bullseye.reportPath="coverage.xml"
             --define sonar.scm.exclusions.disabled=true
             --define sonar.verbose=true
+            --define sonar.branch.name=$Env:PR_SOURCE_BRANCH
+            --define sonar.branch.target=$Env:PR_TARGET_BRANCH
 
       - name: Deactivate BullseyeCoverage
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,8 +25,6 @@ jobs:
   build-kDrive:
     runs-on: [ self-hosted, Windows, desktop-kdrive ]
     env:
-      PR_SOURCE_BRANCH: ${{ github.head_ref }}
-      PR_TARGET_BRANCH: ${{ github.base_ref }}
       COVFILE: ${{ github.workspace }}\\src\\test.cov
     steps:
       - name: Load system Path into Github environment
@@ -36,7 +34,6 @@ jobs:
       - name: Checkout the PR
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
           submodules: recursive
           fetch-depth: 0
         
@@ -111,9 +108,6 @@ jobs:
             --define sonar.cfamily.bullseye.reportPath="coverage.xml"
             --define sonar.scm.exclusions.disabled=true
             --define sonar.verbose=true
-            --define sonar.newCode.referenceBranch
-            --define sonar.branch.name="${{ env.PR_SOURCE_BRANCH }}"
-            --define sonar.branch.target="${{ env.PR_TARGET_BRANCH }}"
 
       - name: Deactivate BullseyeCoverage
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -111,8 +111,8 @@ jobs:
             --define sonar.cfamily.bullseye.reportPath="coverage.xml"
             --define sonar.scm.exclusions.disabled=true
             --define sonar.verbose=true
-            --define sonar.branch.name=$PR_SOURCE_BRANCH
-            --define sonar.branch.target=$PR_TARGET_BRANCH
+            --define sonar.branch.name="${{ env.PR_SOURCE_BRANCH }}"
+            --define sonar.branch.target="${{ env.PR_TARGET_BRANCH }}"
 
       - name: Deactivate BullseyeCoverage
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -111,8 +111,8 @@ jobs:
             --define sonar.cfamily.bullseye.reportPath="coverage.xml"
             --define sonar.scm.exclusions.disabled=true
             --define sonar.verbose=true
-            --define sonar.branch.name=$Env:PR_SOURCE_BRANCH
-            --define sonar.branch.target=$Env:PR_TARGET_BRANCH
+            --define sonar.branch.name=$PR_SOURCE_BRANCH
+            --define sonar.branch.target=$PR_TARGET_BRANCH
 
       - name: Deactivate BullseyeCoverage
         run: |

--- a/src/libcommon/utility/types.cpp
+++ b/src/libcommon/utility/types.cpp
@@ -854,7 +854,7 @@ std::string toString(const SignalType e) {
 }
 
 std::string fakeFunction() {
-    static const uselessBoolean = false;
+    static const bool uselessBoolean = false;
     if (!uselessBoolean) {
         uselessBoolean = true;
         return "Initialized";

--- a/src/libcommon/utility/types.cpp
+++ b/src/libcommon/utility/types.cpp
@@ -854,7 +854,7 @@ std::string toString(const SignalType e) {
 }
 
 std::string fakeFunction() {
-    static const bool uselessBoolean = false;
+    static bool uselessBoolean = false;
     if (!uselessBoolean) {
         uselessBoolean = true;
         return "Initialized";

--- a/src/libcommon/utility/types.cpp
+++ b/src/libcommon/utility/types.cpp
@@ -853,4 +853,14 @@ std::string toString(const SignalType e) {
     }
 }
 
+std::string fakeFunction() {
+    static const uselessBoolean = false;
+    if (!uselessBoolean) {
+        uselessBoolean = true;
+        return "Initialized";
+    } else
+        return "Already set";
+}
+
+
 } // namespace KDC


### PR DESCRIPTION
This PR aims at fixing the inaccuracies observed in SonarCloud reports. The configuration of the `git checkout` action in our Github workflow seems to be the culprit. 

The Sonar's scanner parameters are documented [here](https://docs.sonarsource.com/sonarqube-cloud/advanced-setup/analysis-parameters/).
The corresponding github workflow variables are documented [here](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables).