### PR TITLE
Kdesktop 1563 introducing an invalid character in a folder name causes an infinite synchronisation loop

### DIFF
--- a/src/gui/parametersdialog.cpp
+++ b/src/gui/parametersdialog.cpp
@@ -705,6 +705,12 @@ QString ParametersDialog::getInconsistencyText(InconsistencyType inconsistencyTy
                 tr("The item name coincides with the name of another item in the same directory.<br>"
                    "It has been temporarily blacklisted. Consider removing duplicate items.");
     }
+    if (bitWiseEnumToBool(inconsistencyType & InconsistencyType::ForbiddenCharOnlySpaces)) {
+        text += (text.isEmpty() ? "" : "\n");
+        text +=
+                tr("The item name contains only spaces.<br>"
+                   "It has been temporarily blacklisted.");
+    }
 
     return text;
 }

--- a/src/libcommon/utility/types.cpp
+++ b/src/libcommon/utility/types.cpp
@@ -265,6 +265,8 @@ std::string toString(const InconsistencyType e) {
             return "NotYetSupportedChar";
         case InconsistencyType::DuplicateNames:
             return "DuplicateNames";
+        case InconsistencyType::ForbiddenCharOnlySpaces:
+            return "ForbiddenCharOnlySpaces";
         default:
             return noConversionStr;
     }

--- a/src/libcommon/utility/types.h
+++ b/src/libcommon/utility/types.h
@@ -326,7 +326,8 @@ enum class InconsistencyType {
     NameLength = 0x08,
     PathLength = 0x10,
     NotYetSupportedChar = 0x20, // Char not yet supported, ie recent Unicode char (ex: U+1FA77 on pre macOS 13.4)
-    DuplicateNames = 0x40 // Two items have the same standardized paths with possibly different encodings (Windows 10 and 11).
+    DuplicateNames = 0x40, // Two items have the same standardized paths with possibly different encodings (Windows 10 and 11).
+    ForbiddenCharOnlySpaces = 0x80, // The name contains only spaces (not supported by back end)
 };
 std::string toString(InconsistencyType e);
 

--- a/src/libcommonserver/utility/utility.cpp
+++ b/src/libcommonserver/utility/utility.cpp
@@ -189,14 +189,16 @@ std::string Utility::ws2s(const std::wstring &wstr) {
 
 std::string Utility::ltrim(const std::string &s) {
     std::string sout(s);
-    auto it = std::find_if(sout.begin(), sout.end(), [](char c) { return !std::isspace<char>(c, std::locale::classic()); });
+    const auto it =
+            std::find_if(sout.begin(), sout.end(), [](const char c) { return !std::isspace<char>(c, std::locale::classic()); });
     sout.erase(sout.begin(), it);
     return sout;
 }
 
 std::string Utility::rtrim(const std::string &s) {
     std::string sout(s);
-    auto it = std::find_if(sout.rbegin(), sout.rend(), [](char c) { return !std::isspace<char>(c, std::locale::classic()); });
+    const auto it =
+            std::find_if(sout.rbegin(), sout.rend(), [](const char c) { return !std::isspace<char>(c, std::locale::classic()); });
     sout.erase(it.base(), sout.end());
     return sout;
 }
@@ -204,6 +206,28 @@ std::string Utility::rtrim(const std::string &s) {
 std::string Utility::trim(const std::string &s) {
     return ltrim(rtrim(s));
 }
+
+#ifdef _WIN32
+SyncName Utility::ltrim(const SyncName &s) {
+    SyncName sout(s);
+    const auto it =
+            std::find_if(sout.begin(), sout.end(), [](const char c) { return !std::isspace<char>(c, std::locale::classic()); });
+    sout.erase(sout.begin(), it);
+    return sout;
+}
+
+SyncName Utility::rtrim(const SyncName &s) {
+    SyncName sout(s);
+    const auto it =
+            std::find_if(sout.rbegin(), sout.rend(), [](const char c) { return !std::isspace<char>(c, std::locale::classic()); });
+    sout.erase(it.base(), sout.end());
+    return sout;
+}
+
+SyncName Utility::trim(const SyncName &s) {
+    return ltrim(rtrim(s));
+}
+#endif
 
 void Utility::msleep(int msec) {
     std::chrono::milliseconds dura(msec);

--- a/src/libcommonserver/utility/utility.h
+++ b/src/libcommonserver/utility/utility.h
@@ -70,6 +70,11 @@ struct COMMONSERVER_EXPORT Utility {
         static std::string ltrim(const std::string &s);
         static std::string rtrim(const std::string &s);
         static std::string trim(const std::string &s);
+#ifdef _WIN32
+        static SyncName ltrim(const SyncName &s);
+        static SyncName rtrim(const SyncName &s);
+        static SyncName trim(const SyncName &s);
+#endif
         static void msleep(int msec);
         static std::wstring v2ws(const dbtype &v);
 

--- a/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerutility.cpp
+++ b/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerutility.cpp
@@ -120,6 +120,10 @@ bool PlatformInconsistencyCheckerUtility::nameHasForbiddenChars(const SyncPath &
     return false;
 }
 
+bool PlatformInconsistencyCheckerUtility::isNameOnlySpaces(const SyncName &name) {
+    return Utility::ltrim(name).empty();
+}
+
 #ifdef _WIN32
 bool PlatformInconsistencyCheckerUtility::fixNameWithBackslash(const SyncName &name, SyncName &newName) {
     size_t pos = name.find('\\');

--- a/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerutility.h
+++ b/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerutility.h
@@ -36,6 +36,7 @@ class PlatformInconsistencyCheckerUtility {
         bool isNameTooLong(const SyncName &name) const;
         bool isPathTooLong(size_t pathSize);
         bool nameHasForbiddenChars(const SyncPath &name);
+        static bool isNameOnlySpaces(const SyncName &name);
 
 #ifdef _WIN32
         bool fixNameWithBackslash(const SyncName &name, SyncName &newName);

--- a/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerworker.cpp
+++ b/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerworker.cpp
@@ -128,14 +128,16 @@ ExitCode PlatformInconsistencyCheckerWorker::checkLocalTree(std::shared_ptr<Node
         blacklistNode(localNode, InconsistencyType::NameLength);
         return ExitCode::Ok;
     }
-    auto it = localNode->children().begin();
-    for (; it != localNode->children().end(); it++) {
+    if (!localNode->isRoot() && PlatformInconsistencyCheckerUtility::isNameOnlySpaces(localNode->name())) {
+        blacklistNode(localNode, InconsistencyType::ForbiddenCharOnlySpaces);
+        return ExitCode::Ok;
+    }
+    for (auto it = localNode->children().begin(); it != localNode->children().end(); ++it) {
         if (stopAsked()) {
             return ExitCode::Ok;
         }
 
-        const ExitCode exitCode = checkLocalTree(it->second, parentPath / localNode->name());
-        if (exitCode != ExitCode::Ok) {
+        if (const auto exitCode = checkLocalTree(it->second, parentPath / localNode->name()); exitCode != ExitCode::Ok) {
             return exitCode;
         }
     }

--- a/src/libsyncengine/syncpal/syncpal.cpp
+++ b/src/libsyncengine/syncpal/syncpal.cpp
@@ -56,9 +56,7 @@
 namespace KDC {
 
 SyncPal::SyncPal(const std::shared_ptr<Vfs> &vfs, const SyncPath &syncDbPath, const std::string &version,
-                 const bool hasFullyCompleted) :
-    _vfs(vfs),
-    _logger(Log::instance()->getLogger()) {
+                 const bool hasFullyCompleted) : _vfs(vfs), _logger(Log::instance()->getLogger()) {
     _syncInfo.syncHasFullyCompleted = hasFullyCompleted;
     LOGW_SYNCPAL_DEBUG(_logger, L"SyncPal init: " << Utility::formatSyncPath(syncDbPath));
     assert(_vfs);
@@ -1303,10 +1301,6 @@ void SyncPal::fixNodeTableDeleteItemsWithNullParentNodeId() {
 
 void SyncPal::increaseErrorCount(const NodeId &nodeId, NodeType type, const SyncPath &relativePath, ReplicaSide side) {
     _tmpBlacklistManager->increaseErrorCount(nodeId, type, relativePath, side);
-}
-
-int SyncPal::getErrorCount(const NodeId &nodeId, ReplicaSide side) const noexcept {
-    return _tmpBlacklistManager->getErrorCount(nodeId, side);
 }
 
 void SyncPal::blacklistTemporarily(const NodeId &nodeId, const SyncPath &relativePath, ReplicaSide side) {

--- a/src/libsyncengine/syncpal/syncpal.h
+++ b/src/libsyncengine/syncpal/syncpal.h
@@ -212,7 +212,6 @@ class SYNCENGINE_EXPORT SyncPal : public std::enable_shared_from_this<SyncPal> {
         void fixNodeTableDeleteItemsWithNullParentNodeId();
 
         virtual void increaseErrorCount(const NodeId &nodeId, NodeType type, const SyncPath &relativePath, ReplicaSide side);
-        virtual int getErrorCount(const NodeId &nodeId, ReplicaSide side) const noexcept;
         virtual void blacklistTemporarily(const NodeId &nodeId, const SyncPath &relativePath, ReplicaSide side);
         virtual bool isTmpBlacklisted(const SyncPath &relativePath, ReplicaSide side) const;
         virtual void refreshTmpBlacklist();

--- a/src/libsyncengine/syncpal/tmpblacklistmanager.cpp
+++ b/src/libsyncengine/syncpal/tmpblacklistmanager.cpp
@@ -34,13 +34,6 @@ TmpBlacklistManager::~TmpBlacklistManager() {
     LOG_SYNCPAL_DEBUG(Log::instance()->getLogger(), "TmpBlacklistManager destroyed");
 }
 
-int TmpBlacklistManager::getErrorCount(const NodeId &nodeId, const ReplicaSide side) const noexcept {
-    const auto &errors = side == ReplicaSide::Local ? _localErrors : _remoteErrors;
-    const auto errorItem = errors.find(nodeId);
-
-    return errorItem == errors.end() ? 0 : errorItem->second.count + 1;
-}
-
 void TmpBlacklistManager::logMessage(const std::wstring &msg, const NodeId &id, const ReplicaSide side,
                                      const SyncPath &path) const {
     LOGW_SYNCPAL_INFO(Log::instance()->getLogger(),
@@ -53,24 +46,19 @@ void TmpBlacklistManager::increaseErrorCount(const NodeId &nodeId, const NodeTyp
     auto &errors = side == ReplicaSide::Local ? _localErrors : _remoteErrors;
 
     if (const auto errorItem = errors.find(nodeId); errorItem != errors.end()) {
-        errorItem->second.count++;
         errorItem->second.lastErrorTime = std::chrono::steady_clock::now();
-        logMessage(L"Error counter increased", nodeId, side, relativePath);
+        insertInBlacklist(nodeId, side);
 
-        if (errorItem->second.count >= 1) { // We try only once. TODO: If we keep this logic, no need to keep _count
-            insertInBlacklist(nodeId, side);
-
-            sentry::Handler::captureMessage(sentry::Level::Warning, "TmpBlacklistManager::increaseErrorCount",
-                                            "Blacklisting item temporarily to avoid infinite loop");
-            const Error err(_syncPal->syncDbId(), "", nodeId, type, relativePath, ConflictType::None, InconsistencyType::None,
-                            CancelType::TmpBlacklisted);
-            _syncPal->addError(err);
-        }
+        sentry::Handler::captureMessage(sentry::Level::Warning, "TmpBlacklistManager::increaseErrorCount",
+                                        "Blacklisting item temporarily to avoid infinite loop");
+        const Error err(_syncPal->syncDbId(), "", nodeId, type, relativePath, ConflictType::None, InconsistencyType::None,
+                        CancelType::TmpBlacklisted);
+        _syncPal->addError(err);
     } else {
         TmpErrorInfo errorInfo;
         errorInfo.path = relativePath;
         (void) errors.try_emplace(nodeId, errorInfo);
-        logMessage(L"Item added in error list", nodeId, side, relativePath);
+        logMessage(L"First time we try to blacklist this item, it is not blacklisted yet", nodeId, side, relativePath);
     }
 }
 
@@ -78,7 +66,6 @@ void TmpBlacklistManager::blacklistItem(const NodeId &nodeId, const SyncPath &re
     auto &errors = side == ReplicaSide::Local ? _localErrors : _remoteErrors;
     if (const auto &errorItem = errors.find(nodeId); errorItem != errors.end()) {
         // Reset error timer
-        errorItem->second.count++;
         errorItem->second.lastErrorTime = std::chrono::steady_clock::now();
     } else {
         TmpErrorInfo errorInfo;

--- a/src/libsyncengine/syncpal/tmpblacklistmanager.h
+++ b/src/libsyncengine/syncpal/tmpblacklistmanager.h
@@ -27,7 +27,6 @@ namespace KDC {
 class TmpBlacklistManager {
     public:
         struct TmpErrorInfo {
-                int count = 0;
                 std::chrono::time_point<std::chrono::steady_clock> lastErrorTime = std::chrono::steady_clock::now();
                 SyncPath path;
         };
@@ -43,7 +42,6 @@ class TmpBlacklistManager {
         void removeItemFromTmpBlacklist(const SyncPath &relativePath);
         void removeItemFromTmpBlacklist(const NodeId &nodeId, ReplicaSide side);
         bool isTmpBlacklisted(const SyncPath &path, ReplicaSide side) const;
-        int getErrorCount(const NodeId &nodeId, ReplicaSide side) const noexcept;
 
     private:
         void insertInBlacklist(const NodeId &nodeId, ReplicaSide side) const;

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -1001,9 +1001,12 @@ void TestNetworkJobs::testUploadAborted() {
     }
     job->abort();
 
-    Utility::msleep(1000); // Wait 1sec
+    // Wait for job to finish
+    while (!JobManager::instance()->isJobFinished(job->jobId())) {
+        Utility::msleep(100);
+    }
 
-    NodeId newNodeId = job->nodeId();
+    const auto newNodeId = job->nodeId();
     CPPUNIT_ASSERT(newNodeId.empty());
 
     job.reset();

--- a/test/libsyncengine/reconciliation/platform_inconsistency_checker/testplatforminconsistencycheckerworker.cpp
+++ b/test/libsyncengine/reconciliation/platform_inconsistency_checker/testplatforminconsistencycheckerworker.cpp
@@ -83,7 +83,7 @@ void TestPlatformInconsistencyCheckerWorker::tearDown() {
     TestBase::stop();
 }
 
-void TestPlatformInconsistencyCheckerWorker::testFixNameSize() {
+void TestPlatformInconsistencyCheckerWorker::testIsNameTooLong() {
     SyncName shortName = Str("1234567890");
     CPPUNIT_ASSERT(!PlatformInconsistencyCheckerUtility::instance()->isNameTooLong(shortName));
 
@@ -284,6 +284,14 @@ void TestPlatformInconsistencyCheckerWorker::testNameSizeLocalTree() {
     CPPUNIT_ASSERT(!_syncPal->updateTree(ReplicaSide::Local)->exists("testNode2"));
     CPPUNIT_ASSERT(!_syncPal->updateTree(ReplicaSide::Local)->exists("bNode"));
     CPPUNIT_ASSERT(!_syncPal->updateTree(ReplicaSide::Local)->exists("BNode"));
+}
+
+void TestPlatformInconsistencyCheckerWorker::testOnlySpaces() {
+    CPPUNIT_ASSERT_EQUAL(true, PlatformInconsistencyCheckerUtility::isNameOnlySpaces(" "));
+    CPPUNIT_ASSERT_EQUAL(true, PlatformInconsistencyCheckerUtility::isNameOnlySpaces("     "));
+    CPPUNIT_ASSERT_EQUAL(false, PlatformInconsistencyCheckerUtility::isNameOnlySpaces(" 1"));
+    CPPUNIT_ASSERT_EQUAL(false, PlatformInconsistencyCheckerUtility::isNameOnlySpaces("1 "));
+    CPPUNIT_ASSERT_EQUAL(false, PlatformInconsistencyCheckerUtility::isNameOnlySpaces(" 1 "));
 }
 
 void TestPlatformInconsistencyCheckerWorker::initUpdateTree(ReplicaSide side) {

--- a/test/libsyncengine/reconciliation/platform_inconsistency_checker/testplatforminconsistencycheckerworker.cpp
+++ b/test/libsyncengine/reconciliation/platform_inconsistency_checker/testplatforminconsistencycheckerworker.cpp
@@ -287,11 +287,11 @@ void TestPlatformInconsistencyCheckerWorker::testNameSizeLocalTree() {
 }
 
 void TestPlatformInconsistencyCheckerWorker::testOnlySpaces() {
-    CPPUNIT_ASSERT_EQUAL(true, PlatformInconsistencyCheckerUtility::isNameOnlySpaces(" "));
-    CPPUNIT_ASSERT_EQUAL(true, PlatformInconsistencyCheckerUtility::isNameOnlySpaces("     "));
-    CPPUNIT_ASSERT_EQUAL(false, PlatformInconsistencyCheckerUtility::isNameOnlySpaces(" 1"));
-    CPPUNIT_ASSERT_EQUAL(false, PlatformInconsistencyCheckerUtility::isNameOnlySpaces("1 "));
-    CPPUNIT_ASSERT_EQUAL(false, PlatformInconsistencyCheckerUtility::isNameOnlySpaces(" 1 "));
+    CPPUNIT_ASSERT_EQUAL(true, PlatformInconsistencyCheckerUtility::isNameOnlySpaces(Str(" ")));
+    CPPUNIT_ASSERT_EQUAL(true, PlatformInconsistencyCheckerUtility::isNameOnlySpaces(Str("     ")));
+    CPPUNIT_ASSERT_EQUAL(false, PlatformInconsistencyCheckerUtility::isNameOnlySpaces(Str(" 1")));
+    CPPUNIT_ASSERT_EQUAL(false, PlatformInconsistencyCheckerUtility::isNameOnlySpaces(Str("1 ")));
+    CPPUNIT_ASSERT_EQUAL(false, PlatformInconsistencyCheckerUtility::isNameOnlySpaces(Str(" 1 ")));
 }
 
 void TestPlatformInconsistencyCheckerWorker::initUpdateTree(ReplicaSide side) {

--- a/test/libsyncengine/reconciliation/platform_inconsistency_checker/testplatforminconsistencycheckerworker.h
+++ b/test/libsyncengine/reconciliation/platform_inconsistency_checker/testplatforminconsistencycheckerworker.h
@@ -28,13 +28,14 @@ namespace KDC {
 
 class TestPlatformInconsistencyCheckerWorker : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST_SUITE(TestPlatformInconsistencyCheckerWorker);
-        CPPUNIT_TEST(testFixNameSize);
+        CPPUNIT_TEST(testIsNameTooLong);
         CPPUNIT_TEST(testCheckNameForbiddenChars);
         CPPUNIT_TEST(testCheckReservedNames);
         CPPUNIT_TEST(testNameClash);
         CPPUNIT_TEST(testNameClashAfterRename);
         CPPUNIT_TEST(testExecute);
         CPPUNIT_TEST(testNameSizeLocalTree);
+        CPPUNIT_TEST(testOnlySpaces);
         CPPUNIT_TEST_SUITE_END();
 
     public:
@@ -42,13 +43,14 @@ class TestPlatformInconsistencyCheckerWorker : public CppUnit::TestFixture, publ
         void tearDown() override;
 
     protected:
-        void testFixNameSize();
+        void testIsNameTooLong();
         void testCheckNameForbiddenChars();
         void testCheckReservedNames();
         void testNameClash();
         void testNameClashAfterRename();
         void testExecute();
         void testNameSizeLocalTree();
+        void testOnlySpaces();
 
     private:
         std::shared_ptr<SyncPal> _syncPal{nullptr};

--- a/test/libsyncengine/syncpal/testsyncpal.cpp
+++ b/test/libsyncengine/syncpal/testsyncpal.cpp
@@ -252,15 +252,11 @@ void TestSyncPal::testBlacklist() {
 
     // Make sure the local and remote items are blacklisted
     _syncPal->handleAccessDeniedItem("A", ExitCause::FileAccessError);
-    CPPUNIT_ASSERT_EQUAL(1, _syncPal->_tmpBlacklistManager->getErrorCount("la", ReplicaSide::Local));
-    CPPUNIT_ASSERT_EQUAL(1, _syncPal->_tmpBlacklistManager->getErrorCount("ra", ReplicaSide::Remote));
     CPPUNIT_ASSERT_EQUAL(true, _syncPal->_tmpBlacklistManager->isTmpBlacklisted(SyncPath("A/AA"), ReplicaSide::Local));
     CPPUNIT_ASSERT_EQUAL(true, _syncPal->_tmpBlacklistManager->isTmpBlacklisted(SyncPath("A/AA"), ReplicaSide::Remote));
 
     // Make sure the local and remote items are removed from blacklist (and the descendant)
     _syncPal->removeItemFromTmpBlacklist("ra", ReplicaSide::Remote);
-    CPPUNIT_ASSERT_EQUAL(0, _syncPal->_tmpBlacklistManager->getErrorCount("la", ReplicaSide::Local));
-    CPPUNIT_ASSERT_EQUAL(0, _syncPal->_tmpBlacklistManager->getErrorCount("ra", ReplicaSide::Remote));
     CPPUNIT_ASSERT_EQUAL(false, _syncPal->_tmpBlacklistManager->isTmpBlacklisted(SyncPath("A/AA"), ReplicaSide::Local));
     CPPUNIT_ASSERT_EQUAL(false, _syncPal->_tmpBlacklistManager->isTmpBlacklisted(SyncPath("A/AA"), ReplicaSide::Remote));
 }

--- a/test/test_classes/syncpaltest.h
+++ b/test/test_classes/syncpaltest.h
@@ -35,7 +35,6 @@ class SyncPalTest final : public SyncPal {
         // No implementation of the following methods in tests because `_tmpBlacklistManager` is not defined.
         void increaseErrorCount(const NodeId & /*nodeId*/, NodeType /*type*/, const SyncPath & /*relativePath*/,
                                 ReplicaSide /*side*/) override {}
-        int getErrorCount(const NodeId & /*nodeId*/, ReplicaSide /*side*/) const noexcept override { return 0; }
         void blacklistTemporarily(const NodeId & /*nodeId*/, const SyncPath & /*relativePath*/, ReplicaSide /*side*/) override {}
         void refreshTmpBlacklist() override {}
         void removeItemFromTmpBlacklist(const NodeId & /*nodeId*/, ReplicaSide /*side*/) override {}

--- a/test/test_utility/localtemporarydirectory.cpp
+++ b/test/test_utility/localtemporarydirectory.cpp
@@ -55,6 +55,7 @@ LocalTemporaryDirectory::~LocalTemporaryDirectory() {
     std::filesystem::remove_all(_path, ec);
     if (ec) {
         // Cannot remove directory
+        std::cout << ec.message() << std::endl;
         assert(false);
     }
 }


### PR DESCRIPTION
If a local item's name contains only spaces, it will be refused by the back end. However, the error message is not explicit in the app.

**Steps to reproduce:**
On macOS:
- Pause the sync
- Create a new directory on local replica named “ “ (single space character)
- Start the sync