### PR TITLE
KDESKTOP-1472-File-hydration-generate-a-lot-of-log-on-Windows

### DIFF
--- a/extensions/windows/cfapi/Vfs/cloudprovider.cpp
+++ b/extensions/windows/cfapi/Vfs/cloudprovider.cpp
@@ -310,19 +310,13 @@ bool CloudProvider::updateTransfer(const wchar_t *filePath, const wchar_t *fromF
             opParams.TransferData.Offset = fetchInfo._offset;
             opParams.TransferData.Length = lengthToRead;
 
-            Utilities::traceFileDates(filePath);
-
             try {
-                TRACE_DEBUG(L"Execute transfer: offset = %lld, size = %lld", opParams.TransferData.Offset.QuadPart,
-                            opParams.TransferData.Length.QuadPart);
                 winrt::check_hresult(CfExecute(&opInfo, &opParams));
             } catch (winrt::hresult_error const &ex) {
                 TRACE_ERROR(L"Error caught : hr %08x - %s", static_cast<HRESULT>(winrt::to_hresult()), ex.message().c_str());
                 res = false;
                 break;
             }
-
-            Utilities::traceFileDates(filePath);
 
             fetchInfo._offset.QuadPart += lengthToRead.QuadPart;
             totalLengthToRead.QuadPart -= lengthToRead.QuadPart;


### PR DESCRIPTION
On Windows, during file hydration, a lot of log is generated by the extension:
```
...
2025-01-08 10:11:24:510 [D] (11004) vfs_win.cpp:110 - "utilities.cpp" - 101 - File path = C:\Users\Clément\kDrive\test_big_folder\infomaniak\test_big_file: creationTime = 9:51:40, accessTime = 20:51:44, writeTime = 20:51:44
2025-01-08 10:11:24:514 [D] (11004) vfs_win.cpp:110 - "utilities.cpp" - 101 - File path = C:\Users\Clément\kDrive\test_big_folder\infomaniak\test_big_file: creationTime = 9:51:40, accessTime = 20:51:44, writeTime = 20:51:44
2025-01-08 10:11:24:514 [D] (11004) vfs_win.cpp:110 - "cloudprovider.cpp" - 316 - Execute transfer: offset = 3735552000, size = 4096000
2025-01-08 10:11:24:519 [D] (11004) vfs_win.cpp:110 - "utilities.cpp" - 101 - File path = C:\Users\Clément\kDrive\test_big_folder\infomaniak\test_big_file: creationTime = 9:51:40, accessTime = 20:51:44, writeTime = 20:51:44
2025-01-08 10:11:24:522 [D] (11004) vfs_win.cpp:110 - "utilities.cpp" - 101 - File path = C:\Users\Clément\kDrive\test_big_folder\infomaniak\test_big_file: creationTime = 9:51:40, accessTime = 20:51:44, writeTime = 20:51:44
2025-01-08 10:11:24:523 [D] (11004) vfs_win.cpp:110 - "cloudprovider.cpp" - 316 - Execute transfer: offset = 3739648000, size = 4096000
2025-01-08 10:11:24:527 [D] (11004) vfs_win.cpp:110 - "utilities.cpp" - 101 - File path = C:\Users\Clément\kDrive\test_big_folder\infomaniak\test_big_file: creationTime = 9:51:40, accessTime = 20:51:44, writeTime = 20:51:44
2025-01-08 10:11:24:530 [D] (11004) vfs_win.cpp:110 - "utilities.cpp" - 101 - File path = C:\Users\Clément\kDrive\test_big_folder\infomaniak\test_big_file: creationTime = 9:51:40, accessTime = 20:51:44, writeTime = 20:51:44
2025-01-08 10:11:24:530 [D] (11004) vfs_win.cpp:110 - "cloudprovider.cpp" - 316 - Execute transfer: offset = 3743744000, size = 4096000
2025-01-08 10:11:24:534 [D] (11004) vfs_win.cpp:110 - "utilities.cpp" - 101 - File path = C:\Users\Clément\kDrive\test_big_folder\infomaniak\test_big_file: creationTime = 9:51:40, accessTime = 20:51:44, writeTime = 20:51:44
2025-01-08 10:11:24:538 [D] (11004) vfs_win.cpp:110 - "utilities.cpp" - 101 - File path = C:\Users\Clément\kDrive\test_big_folder\infomaniak\test_big_file: creationTime = 9:51:40, accessTime = 20:51:44, writeTime = 20:51:44
2025-01-08 10:11:24:538 [D] (11004) vfs_win.cpp:110 - "cloudprovider.cpp" - 316 - Execute transfer: offset = 3747840000, size = 4096000
2025-01-08 10:11:24:542 [D] (11004) vfs_win.cpp:110 - "utilities.cpp" - 101 - File path = C:\Users\Clément\kDrive\test_big_folder\infomaniak\test_big_file: creationTime = 9:51:40, accessTime = 20:51:44, writeTime = 20:51:44
2025-01-08 10:11:24:546 [D] (11004) vfs_win.cpp:110 - "utilities.cpp" - 101 - File path = C:\Users\Clément\kDrive\test_big_folder\infomaniak\test_big_file: creationTime = 9:51:40, accessTime = 20:51:44, writeTime = 20:51:44
2025-01-08 10:11:24:546 [D] (11004) vfs_win.cpp:110 - "cloudprovider.cpp" - 316 - Execute transfer: offset = 3751936000, size = 4096000
2025-01-08 10:11:24:550 [D] (11004) vfs_win.cpp:110 - "utilities.cpp" - 101 - File path = C:\Users\Clément\kDrive\test_big_folder\infomaniak\test_big_file: creationTime = 9:51:40, accessTime = 20:51:44, writeTime = 20:51:44
2025-01-08 10:11:24:554 [D] (11004) vfs_win.cpp:110 - "utilities.cpp" - 101 - File path = C:\Users\Clément\kDrive\test_big_folder\infomaniak\test_big_file: creationTime = 9:51:40, accessTime = 20:51:44, writeTime = 20:51:44
...
```

This might slow down downlad and make the log harder to read