### PR TITLE
KDESKTOP-1371-It-should-not-be-possible-to-activate-LiteSync-on-WindowsServer

### DIFF
--- a/src/libcommon/utility/types.cpp
+++ b/src/libcommon/utility/types.cpp
@@ -758,10 +758,12 @@ std::string toString(const VersionChannel e) {
 }
 std::string toString(const Platform e) {
     switch (e) {
-        case Platform::Windows:
-            return "Windows";
         case Platform::MacOS:
             return "MacOS";
+        case Platform::Windows:
+            return "Windows";
+        case Platform::WindowsServer:
+            return "WindowsServer";
         case Platform::LinuxAMD:
             return "LinuxAMD";
         case Platform::LinuxARM:

--- a/src/libcommon/utility/types.h
+++ b/src/libcommon/utility/types.h
@@ -514,7 +514,7 @@ std::string toString(UpdateState e);
 enum class VersionChannel { Prod, Next, Beta, Internal, Legacy, Unknown };
 std::string toString(VersionChannel e);
 
-enum class Platform { MacOS, Windows, LinuxAMD, LinuxARM, Unknown };
+enum class Platform { MacOS, Windows, WindowsServer, LinuxAMD, LinuxARM, Unknown };
 std::string toString(Platform e);
 
 struct VersionInfo {

--- a/src/libcommon/utility/utility.cpp
+++ b/src/libcommon/utility/utility.cpp
@@ -140,7 +140,10 @@ QString CommonUtility::platformName() {
 Platform CommonUtility::platform() {
     const QString name = platformName();
     if (name.contains("macos", Qt::CaseInsensitive)) return Platform::MacOS;
-    if (name.contains("windows", Qt::CaseInsensitive)) return Platform::Windows;
+    if (name.contains("windows", Qt::CaseInsensitive)) {
+        if (name.contains("server", Qt::CaseInsensitive)) return Platform::WindowsServer;
+        return Platform::Windows;
+    }
     // Otherwise we consider the OS to be Linux based
     if (platformArch().contains("arm", Qt::CaseInsensitive)) return Platform::LinuxARM;
 

--- a/src/libcommonserver/vfs/vfs.cpp
+++ b/src/libcommonserver/vfs/vfs.cpp
@@ -227,6 +227,8 @@ bool KDC::isVfsPluginAvailable(const VirtualFileMode virtualFileMode, QString &e
     }
 
     if (virtualFileMode == VirtualFileMode::Win) {
+        if (CommonUtility::platform() == Platform::WindowsServer) return false; // LiteSync not available on Windows Server
+
         if (QOperatingSystemVersion::current().currentType() == QOperatingSystemVersion::OSType::Windows &&
             QOperatingSystemVersion::current() >= QOperatingSystemVersion::Windows10 &&
             QOperatingSystemVersion::current().microVersion() >= MIN_WINDOWS10_MICROVERSION_FOR_CFAPI) {

--- a/src/libsyncengine/jobs/network/getappversionjob.cpp
+++ b/src/libsyncengine/jobs/network/getappversionjob.cpp
@@ -50,6 +50,7 @@ std::string GetAppVersionJob::toStr(const Platform platform) {
         case Platform::MacOS:
             return platformMacOsKey;
         case Platform::Windows:
+        case Platform::WindowsServer:
             return platformWindowsKey;
         case Platform::LinuxAMD:
             return platformLinuxAmdKey;


### PR DESCRIPTION
We should never offer to the user to use LiteSync on a Windows Server