### PR TITLE
KDESKTOP-1621-Preprod-env-variable-should-be-read-at-runtime

### DIFF
--- a/infomaniak/kDrive.cmake
+++ b/infomaniak/kDrive.cmake
@@ -34,21 +34,6 @@ set( APPLICATION_TRASH_URL "https://kdrive.infomaniak.com/app/drive/%s/trash" CA
 set( APPLICATION_THUMBNAIL_URL "index.php/apps/files/api/v1/thumbnail/%1/%1/%2" CACHE STRING "App thumbnail URL" )
 set( APPLICATION_PREVIEW_URL "https://kdrive.infomaniak.com/app/drive/%1/redirect/%2" CACHE STRING "App preview URL" )
 
-if("$ENV{KDRIVE_DEBUG}" STREQUAL "1")
-    message( STATUS "Environment variable KDRIVE_DEBUG defined, using preprod URL" )
-    set( GLOBAL_API_V2_URL "https://api.preprod.dev.infomaniak.ch/2" )
-    set( KDRIVE_API_V2_URL "https://api.kdrive.preprod.dev.infomaniak.ch/2" )
-    set( NOTIFY_KDRIVE_V2_URL "https://notify.kdrive.preprod.dev.infomaniak.ch/2" )
-    set( LOGIN_URL "https://login.preprod.dev.infomaniak.ch" )
-else()
-    message( STATUS "Environment variable KDRIVE_DEBUG not defined, using prod URL" )
-    set( GLOBAL_API_V2_URL "https://api.infomaniak.com/2" )
-    set( KDRIVE_API_V2_URL "https://api.kdrive.infomaniak.com/2" )
-    set( NOTIFY_KDRIVE_V2_URL "https://notify.kdrive.infomaniak.com/2" )
-    set( LOGIN_URL "https://login.infomaniak.com" )
-endif()
-set( INFOMANIAK_API_URL "https://api.infomaniak.com/1" )
-
 set( TEST_DIR "${CMAKE_SOURCE_DIR}/test" )
 
 set ( CLIENT_ID "5EA39279-FF64-4BB8-A872-4A40B5786317" CACHE STRING "App client ID" )

--- a/src/gui/adddriveloginwidget.cpp
+++ b/src/gui/adddriveloginwidget.cpp
@@ -25,6 +25,7 @@
 #include "libcommon/theme/theme.h"
 #include "libcommon/utility/utility.h"
 #include "libcommongui/utility/utility.h"
+#include "utility/urlhelper.h"
 
 #include <QBoxLayout>
 #include <QLabel>
@@ -106,12 +107,11 @@ void AddDriveLoginWidget::onErrorReceived(const QString error, const QString err
 }
 
 QUrl AddDriveLoginWidget::generateUrl() {
-    QString loginUrl(LOGIN_URL);
-    QUrl url(loginUrl);
+    QUrl url(UrlHelper::loginApiUrl().c_str());
     url.setPath(authorizePath);
 
     _codeVerifier = generateCodeVerifier();
-    QString codeChallenge = generateCodeChallenge(_codeVerifier);
+    const QString codeChallenge = generateCodeChallenge(_codeVerifier);
 
     QUrlQuery query;
     query.addQueryItem(responseTypeKey, responseType);

--- a/src/libcommon/CMakeLists.txt
+++ b/src/libcommon/CMakeLists.txt
@@ -30,6 +30,7 @@ set(libcommon_SRCS
     utility/filename.h utility/commonmacros.h utility/coveragemacros.h
     utility/logiffail.h utility/qlogiffail.h
     utility/jsonparserutility.h
+    utility/urlhelper.h utility/urlhelper.cpp
     keychainmanager/apitoken.h keychainmanager/apitoken.cpp
     keychainmanager/keychainmanager.h keychainmanager/keychainmanager.cpp
     info/userinfo.h info/userinfo.cpp

--- a/src/libcommon/utility/types.h
+++ b/src/libcommon/utility/types.h
@@ -525,7 +525,7 @@ struct VersionInfo {
         std::string tag; // Version number. Example: 3.6.4
         // std::string changeLog; // List of changes in this version, not used for now.
         uint64_t buildVersion{0}; // Example: 20240816
-        std::string buildMinOsVersion; // Optionnal. Minimum supported version of the OS. Examples: 10.15, 11, server 2005, ...
+        std::string buildMinOsVersion; // Optional. Minimum supported version of the OS. Examples: 10.15, 11, server 2005, ...
         std::string downloadUrl; // URL to download the version
 
         [[nodiscard]] bool isValid() const {

--- a/src/libcommon/utility/urlhelper.cpp
+++ b/src/libcommon/utility/urlhelper.cpp
@@ -46,7 +46,7 @@ std::string UrlHelper::loginApiUrl() {
 }
 
 bool UrlHelper::usePreProdUrl() {
-    static bool usePreProdUrl = CommonUtility::envVarValue("KDRIVE_USE_PREPROD_URL") == "1";
+    static const bool usePreProdUrl = CommonUtility::envVarValue("KDRIVE_USE_PREPROD_URL") == "1";
     return usePreProdUrl;
 }
 

--- a/src/libcommon/utility/urlhelper.cpp
+++ b/src/libcommon/utility/urlhelper.cpp
@@ -1,0 +1,53 @@
+// Infomaniak kDrive - Desktop
+// Copyright (C) 2023-2025 Infomaniak Network SA
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "urlhelper.h"
+
+#include "utility.h"
+
+namespace KDC {
+
+static const std::string prodInfomaniakApiUrl = "https://api.infomaniak.com/";
+static const std::string preprodInfomaniakApiUrl = "https://api.preprod.dev.infomaniak.ch/";
+static const std::string prodKDriveApiUrl = "https://api.kdrive.infomaniak.com/";
+static const std::string preprodKDriveApiUrl = "https://api.kdrive.preprod.dev.infomaniak.ch/";
+static const std::string prodNotifyApiUrl = "https://notify.kdrive.infomaniak.com/";
+static const std::string preprodNotifyApiUrl = "https://notify.kdrive.preprod.dev.infomaniak.ch/";
+static const std::string prodLoginApiUrl = "https://login.infomaniak.com";
+static const std::string preprodLoginApiUrl = "https://login.preprod.dev.infomaniak.ch";
+
+std::string UrlHelper::infomaniakApiUrl(const uint8_t version /*= 2*/, const bool forceProd /*= false*/) {
+    return (usePreProdUrl() && !forceProd ? preprodInfomaniakApiUrl : prodInfomaniakApiUrl) + std::to_string(version);
+}
+
+std::string UrlHelper::kDriveApiUrl(const uint8_t version /*= 2*/) {
+    return (usePreProdUrl() ? preprodKDriveApiUrl : prodKDriveApiUrl) + std::to_string(version);
+}
+
+std::string UrlHelper::notifyApiUrl(const uint8_t version /*= 2*/) {
+    return (usePreProdUrl() ? preprodNotifyApiUrl : prodNotifyApiUrl) + std::to_string(version);
+}
+
+std::string UrlHelper::loginApiUrl() {
+    return usePreProdUrl() ? preprodLoginApiUrl : prodLoginApiUrl;
+}
+
+bool UrlHelper::usePreProdUrl() {
+    static bool usePreProdUrl = CommonUtility::envVarValue("KDRIVE_USE_PREPROD_URL") == "1";
+    return usePreProdUrl;
+}
+
+} // namespace KDC

--- a/src/libcommon/utility/urlhelper.h
+++ b/src/libcommon/utility/urlhelper.h
@@ -1,0 +1,32 @@
+// Infomaniak kDrive - Desktop
+// Copyright (C) 2023-2025 Infomaniak Network SA
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+namespace KDC {
+
+class UrlHelper {
+    public:
+        static std::string infomaniakApiUrl(uint8_t version = 2, bool forceProd = false);
+        static std::string kDriveApiUrl(uint8_t version = 2);
+        static std::string notifyApiUrl(uint8_t version = 2);
+        static std::string loginApiUrl();
+
+    private:
+        static bool usePreProdUrl();
+};
+
+} // namespace KDC

--- a/src/libcommonserver/utility/utility.cpp
+++ b/src/libcommonserver/utility/utility.cpp
@@ -420,6 +420,10 @@ bool Utility::isEqualInsensitive(const std::string &strA, const std::string &str
            });
 }
 
+bool Utility::contains(const std::string &str, const std::string &substr) {
+    return str.find(substr) != std::string::npos;
+}
+
 #ifdef _WIN32
 bool Utility::startsWithInsensitive(const SyncName &str, const SyncName &prefix) {
     return str.size() >= prefix.size() && std::equal(prefix.begin(), prefix.end(), str.begin(), [](SyncChar c1, SyncChar c2) {

--- a/src/libcommonserver/utility/utility.h
+++ b/src/libcommonserver/utility/utility.h
@@ -104,6 +104,7 @@ struct COMMONSERVER_EXPORT Utility {
         static bool endsWith(const std::string &str, const std::string &suffix);
         static bool endsWithInsensitive(const std::string &str, const std::string &suffix);
         static bool isEqualInsensitive(const std::string &strA, const std::string &strB);
+        static bool contains(const std::string &str, const std::string &substr);
 #ifdef _WIN32
         static bool startsWithInsensitive(const SyncName &str, const SyncName &prefix);
         static bool startsWith(const SyncName &str, const SyncName &prefix);

--- a/src/libsyncengine/jobs/network/API_v2/abstracttokennetworkjob.cpp
+++ b/src/libsyncengine/jobs/network/API_v2/abstracttokennetworkjob.cpp
@@ -23,6 +23,7 @@
 #include "libparms/db/parmsdb.h"
 #include "libcommon/keychainmanager/keychainmanager.h"
 #include "libcommon/utility/jsonparserutility.h"
+#include "utility/urlhelper.h"
 
 #include <unordered_map>
 
@@ -250,13 +251,13 @@ std::string AbstractTokenNetworkJob::getUrl() {
         case ApiType::Drive:
         case ApiType::DriveByUser:
         case ApiType::Desktop:
-            apiUrl = KDRIVE_API_V2_URL;
+            apiUrl = UrlHelper::kDriveApiUrl();
             break;
         case ApiType::NotifyDrive:
-            apiUrl = NOTIFY_KDRIVE_V2_URL;
+            apiUrl = UrlHelper::notifyApiUrl();
             break;
         case ApiType::Profile:
-            apiUrl = GLOBAL_API_V2_URL;
+            apiUrl = UrlHelper::infomaniakApiUrl();
             break;
     }
     return apiUrl + getSpecificUrl();

--- a/src/libsyncengine/jobs/network/getappversionjob.h
+++ b/src/libsyncengine/jobs/network/getappversionjob.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "API_v2/abstracttokennetworkjob.h"
+#include "utility/urlhelper.h"
 
 #include <config.h>
 
@@ -38,7 +39,7 @@ class GetAppVersionJob : public AbstractNetworkJob {
         [[nodiscard]] const VersionInfo &versionInfo(const VersionChannel channel) { return _versionsInfo[channel]; }
         [[nodiscard]] const AllVersionsInfo &versionsInfo() const { return _versionsInfo; }
 
-        std::string getUrl() override { return INFOMANIAK_API_URL + getSpecificUrl(); }
+        std::string getUrl() override { return UrlHelper::infomaniakApiUrl(1, true) + getSpecificUrl(); }
 
         static std::string toStr(Platform platform);
         static std::string toStr(VersionChannel channel);

--- a/src/libsyncengine/jobs/network/login/abstractloginjob.cpp
+++ b/src/libsyncengine/jobs/network/login/abstractloginjob.cpp
@@ -22,6 +22,7 @@
 #include "libcommonserver/utility/utility.h"
 #include "requests/parameterscache.h"
 #include "utility/jsonparserutility.h"
+#include "utility/urlhelper.h"
 
 #include <Poco/JSON/Parser.h>
 
@@ -50,7 +51,7 @@ std::string AbstractLoginJob::getSpecificUrl() {
 }
 
 std::string AbstractLoginJob::getUrl() {
-    return std::string(LOGIN_URL) + getSpecificUrl();
+    return std::string(UrlHelper::loginApiUrl()) + getSpecificUrl();
 }
 
 std::string AbstractLoginJob::getContentType(bool &canceled) {

--- a/test/libcommon/CMakeLists.txt
+++ b/test/libcommon/CMakeLists.txt
@@ -20,6 +20,7 @@ set(testcommon_SRCS
         api_token/testapitoken.cpp api_token/testapitoken.h
         utility/testutility.cpp utility/testutility.h
         utility/testtypes.cpp utility/testtypes.h
+        utility/testurlhelper.h utility/testurlhelper.cpp
         log/sentry/testsentryhandler.h log/sentry/testsentryhandler.cpp
 )
 

--- a/test/libcommon/test.cpp
+++ b/test/libcommon/test.cpp
@@ -22,12 +22,14 @@
 #include "utility/testutility.h"
 #include "utility/testtypes.h"
 #include "log/sentry/testsentryhandler.h"
+#include "utility/testurlhelper.h"
 
 namespace KDC {
 CPPUNIT_TEST_SUITE_REGISTRATION(TestApiToken);
 CPPUNIT_TEST_SUITE_REGISTRATION(TestUtility);
 CPPUNIT_TEST_SUITE_REGISTRATION(TestTypes);
 CPPUNIT_TEST_SUITE_REGISTRATION(TestSentryHandler);
+CPPUNIT_TEST_SUITE_REGISTRATION(TestUrlHelper);
 } // namespace KDC
 
 int main(int, char **) {

--- a/test/libcommon/utility/testurlhelper.cpp
+++ b/test/libcommon/utility/testurlhelper.cpp
@@ -29,16 +29,25 @@ void TestUrlHelper::testGetUrl() {
     // prod and preprod URLs. Therefore, we randomly test either prod or preprod.
     std::random_device rd;
     std::default_random_engine gen(rd());
-    std::uniform_int_distribution distrib(1, 2);
+    const std::uniform_int_distribution distrib(1, 2);
     const auto test = distrib(gen);
     const bool usePreprod = test == 1;
     if (usePreprod) {
+#ifdef _WIN32
+        _putenv_s("KDRIVE_USE_PREPROD_URL", "1");
+#else
         (void) setenv("KDRIVE_USE_PREPROD_URL", "1", true);
+#endif
         std::cout << " Testing preprod URLs";
     } else {
+#ifdef _WIN32
+        _putenv_s("KDRIVE_USE_PREPROD_URL", "0");
+#else
         (void) setenv("KDRIVE_USE_PREPROD_URL", "0", true);
+#endif
         std::cout << " Testing prod URLs";
     }
+
 
     CPPUNIT_ASSERT_EQUAL(usePreprod, Utility::contains(UrlHelper::infomaniakApiUrl(), preprodKeyWord));
     CPPUNIT_ASSERT_EQUAL(false, Utility::contains(UrlHelper::infomaniakApiUrl(2, true), preprodKeyWord));

--- a/test/libcommon/utility/testurlhelper.cpp
+++ b/test/libcommon/utility/testurlhelper.cpp
@@ -1,0 +1,58 @@
+// Infomaniak kDrive - Desktop
+// Copyright (C) 2023-2025 Infomaniak Network SA
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "testurlhelper.h"
+
+#include "libcommon/utility/utility.h"
+#include "utility/urlhelper.h"
+#include "utility/utility.h"
+
+namespace KDC {
+
+static const std::string preprodKeyWord = "preprod";
+
+void TestUrlHelper::testGetUrl() {
+    // Because UrlHelper evaluate KDRIVE_USE_PREPROD_URL only once and store it in a static variable, we cannot switch between
+    // prod and preprod URLs. Therefore, we randomly test either prod or preprod.
+    std::random_device rd;
+    std::default_random_engine gen(rd());
+    std::uniform_int_distribution distrib(1, 2);
+    const auto test = distrib(gen);
+    const bool usePreprod = test == 1;
+    if (usePreprod) {
+        (void) setenv("KDRIVE_USE_PREPROD_URL", "1", true);
+        std::cout << " Testing preprod URLs";
+    } else {
+        (void) setenv("KDRIVE_USE_PREPROD_URL", "0", true);
+        std::cout << " Testing prod URLs";
+    }
+
+    CPPUNIT_ASSERT_EQUAL(usePreprod, Utility::contains(UrlHelper::infomaniakApiUrl(), preprodKeyWord));
+    CPPUNIT_ASSERT_EQUAL(false, Utility::contains(UrlHelper::infomaniakApiUrl(2, true), preprodKeyWord));
+    CPPUNIT_ASSERT_EQUAL(usePreprod, Utility::contains(UrlHelper::kDriveApiUrl(), preprodKeyWord));
+    CPPUNIT_ASSERT_EQUAL(usePreprod, Utility::contains(UrlHelper::notifyApiUrl(), preprodKeyWord));
+    CPPUNIT_ASSERT_EQUAL(usePreprod, Utility::contains(UrlHelper::loginApiUrl(), preprodKeyWord));
+
+    CPPUNIT_ASSERT_EQUAL(true, Utility::endsWith(UrlHelper::infomaniakApiUrl(), "/2"));
+    CPPUNIT_ASSERT_EQUAL(true, Utility::endsWith(UrlHelper::infomaniakApiUrl(123), "/123"));
+    CPPUNIT_ASSERT_EQUAL(true, Utility::endsWith(UrlHelper::infomaniakApiUrl(123, true), "/123"));
+    CPPUNIT_ASSERT_EQUAL(true, Utility::endsWith(UrlHelper::kDriveApiUrl(), "/2"));
+    CPPUNIT_ASSERT_EQUAL(true, Utility::endsWith(UrlHelper::kDriveApiUrl(123), "/123"));
+    CPPUNIT_ASSERT_EQUAL(true, Utility::endsWith(UrlHelper::notifyApiUrl(), "/2"));
+    CPPUNIT_ASSERT_EQUAL(true, Utility::endsWith(UrlHelper::notifyApiUrl(123), "/123"));
+}
+
+} // namespace KDC

--- a/test/libcommon/utility/testurlhelper.cpp
+++ b/test/libcommon/utility/testurlhelper.cpp
@@ -29,7 +29,7 @@ void TestUrlHelper::testGetUrl() {
     // prod and preprod URLs. Therefore, we randomly test either prod or preprod.
     std::random_device rd;
     std::default_random_engine gen(rd());
-    const std::uniform_int_distribution distrib(1, 2);
+    std::uniform_int_distribution distrib(1, 2);
     const auto test = distrib(gen);
     const bool usePreprod = test == 1;
     if (usePreprod) {

--- a/test/libcommon/utility/testurlhelper.h
+++ b/test/libcommon/utility/testurlhelper.h
@@ -1,0 +1,36 @@
+// Infomaniak kDrive - Desktop
+// Copyright (C) 2023-2025 Infomaniak Network SA
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include "test_utility/testbase.h"
+
+namespace KDC {
+
+class TestUrlHelper final : public CppUnit::TestFixture, public TestBase {
+        CPPUNIT_TEST_SUITE(TestUrlHelper);
+        CPPUNIT_TEST(testGetUrl);
+        CPPUNIT_TEST_SUITE_END();
+
+    public:
+        void setUp() override { TestBase::start(); }
+        void tearDown() override { TestBase::stop(); }
+
+    protected:
+        void testGetUrl();
+};
+
+} // namespace KDC


### PR DESCRIPTION
Environment variable allowing to select prod or preprod URLs should be evaluated at runtime