### PR TITLE
Kdesktop 1478 bug .lnk lors des maj windows

### DIFF
--- a/cmake/modules/NSIS.template.nsi.in
+++ b/cmake/modules/NSIS.template.nsi.in
@@ -233,7 +233,7 @@ Var kill_counter
    process_${processName}_ended:
 !macroend
 
-!macro CheckAndConfirmEndProcesses1 process1 
+!macro CheckAndConfirmEndProcesse1 process1 
  !insertmacro CheckAndConfirmEndProcesses3 ${process1} "null1" "null2"
 !macroend
 
@@ -285,24 +285,24 @@ Var kill_counter
   InitPluginsDir
   ;Save command in a temp file
   Push $R1
-  FileOpen $R1 $INSTDIR\tempfile.ps1 w
+  FileOpen $R1 $PLUGINSDIR\tempfile.ps1 w
   FileWrite $R1 "${PSCommand}"
   FileClose $R1
   Pop $R1
  
-  !insertmacro PowerShellExecFileMacro "$INSTDIR\tempfile.ps1"
+  !insertmacro PowerShellExecFileMacro "$PLUGINSDIR\tempfile.ps1"
 !macroend
  
 !macro PowerShellExecLogMacro PSCommand
   InitPluginsDir
   ;Save command in a temp file
   Push $R1
-  FileOpen $R1 $INSTDIR\tempfile.ps1 w
+  FileOpen $R1 $PLUGINSDIR\tempfile.ps1 w
   FileWrite $R1 "${PSCommand}" 
   FileClose $R1
   Pop $R1
 
-  !insertmacro PowerShellExecFileLogMacro "$INSTDIR\tempfile.ps1"
+  !insertmacro PowerShellExecFileLogMacro "$PLUGINSDIR\tempfile.ps1"
 !macroend
  
 !macro PowerShellExecFileMacro PSFile
@@ -368,18 +368,18 @@ Function PageReinstall
     Abort
 
    ;Detect version
-    ReadRegDWORD $R0 HKLM "${regkey}" "VersionMajor"
+   ReadRegDWORD $R0 HKLM "${regkey}" "VersionMajor"
    IntCmp $R0 ${VER_MAJOR} minor_check new_version older_version
-    minor_check:
-        ReadRegDWORD $R0 HKLM "${regkey}" "VersionMinor"
+   minor_check:
+      ReadRegDWORD $R0 HKLM "${regkey}" "VersionMinor"
       IntCmp $R0 ${VER_MINOR} rev_check new_version older_version
-    rev_check:
-        ReadRegDWORD $R0 HKLM "${regkey}" "VersionRevision"
+   rev_check:
+      ReadRegDWORD $R0 HKLM "${regkey}" "VersionRevision"
       IntCmp $R0 ${VER_PATCH} build_check new_version older_version
-    build_check:
-        ReadRegDWORD $R0 HKLM "${regkey}" "VersionBuild"
+   build_check:
+      ReadRegDWORD $R0 HKLM "${regkey}" "VersionBuild"
       IntCmp $R0 ${VER_BUILD} same_version new_version older_version
-
+ 
    new_version:
       !insertmacro INSTALLOPTIONS_WRITE "NSIS.InstallOptions.ini" "Field 1" "Text" $PageReinstall_NEW_Field_1
       !insertmacro MUI_HEADER_TEXT $PageReinstall_NEW_MUI_HEADER_TEXT_TITLE $PageReinstall_NEW_MUI_HEADER_TEXT_SUBTITLE
@@ -491,7 +491,7 @@ SectionEnd
       CreateDirectory "$INSTDIR\shellext\AppX"
       SetOutPath "$INSTDIR\shellext\AppX"
       File /nonfatal /a /r "${VFS_APPX_DIRECTORY}\"
-      !insertmacro CheckAndConfirmEndProcesses1 "${EXTENSION_NAME}"
+      !insertmacro CheckAndConfirmEndProcesse1 "${EXTENSION_NAME}"
       ${PowerShellExecLog} "Add-AppxPackage -Path '$INSTDIR\shellext\AppX\${VFS_APPX_BUNDLE}' -ForceApplicationShutdown -ForceUpdateFromAnyVersion"
       end_install_lite_sync_extension:
       

--- a/cmake/modules/NSIS.template.nsi.in
+++ b/cmake/modules/NSIS.template.nsi.in
@@ -298,7 +298,7 @@ Var kill_counter
   ;Save command in a temp file
   Push $R1
   FileOpen $R1 $PLUGINSDIR\tempfile.ps1 w
-  FileWrite $R1 "${PSCommand}" 
+  FileWrite $R1 "${PSCommand}"
   FileClose $R1
   Pop $R1
 

--- a/cmake/modules/NSIS.template.nsi.in
+++ b/cmake/modules/NSIS.template.nsi.in
@@ -50,9 +50,10 @@
 !define VER_BUILD "@KDRIVE_VERSION_BUILD@"
 !define VERSION "@KDRIVE_VERSION@"
 
-!define VFS_APPX_DIRECTORY "@{extpath}\FileExplorerExtensionPackage\\AppPackages\\FileExplorerExtensionPackage_${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}.0_Test"
+!define VFS_APPX_DIRECTORY "@{extpath}/FileExplorerExtensionPackage/AppPackages/FileExplorerExtensionPackage_${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}.0_Test"
 !define VFS_APPX_BUNDLE "FileExplorerExtensionPackage_${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}.0_x64_arm64.msixbundle"
 !define VFS_PACKAGE_NAME "Infomaniak.kDrive.Extension"
+!define EXTENSION_NAME "FileExplorerExtension.exe"
 
 Var InstallRunIfSilent
 Var NoAutomaticUpdates
@@ -232,7 +233,11 @@ Var kill_counter
    process_${processName}_ended:
 !macroend
 
-!macro CheckAndConfirmEndProcesses process1 process2
+!macro CheckAndConfirmEndProcesses1 process1 
+ !insertmacro CheckAndConfirmEndProcesses3 ${process1} "null1" "null2"
+!macroend
+
+!macro CheckAndConfirmEndProcesses3 process1 process2 process3
 
  !insertmacro INSTALLOPTIONS_READ $R1 "NSIS.InstallOptionsWithButtons.ini" "Field 2" "State"
    
@@ -249,6 +254,11 @@ Var kill_counter
       StrCpy $R2 "Y"
    no_process_${process2}_to_end:
    
+   !insertmacro CheckForProcess ${process3} process_${process3}_found no_process_${process3}_to_end
+   process_${process3}_found:
+      StrCpy $R2 "Y"
+   no_process_${process3}_to_end:
+   
    StrCmp $R2 "Y" 0 end_processes_finished 
    
    ; Ask user
@@ -260,7 +270,7 @@ Var kill_counter
    kill_processes:
       !insertmacro EndProcess ${process1}
       !insertmacro EndProcess ${process2}
-   
+      !insertmacro EndProcess ${process3}
    end_processes_finished:
    
 !macroend
@@ -275,24 +285,24 @@ Var kill_counter
   InitPluginsDir
   ;Save command in a temp file
   Push $R1
-  FileOpen $R1 $PLUGINSDIR\tempfile.ps1 w
+  FileOpen $R1 $INSTDIR\tempfile.ps1 w
   FileWrite $R1 "${PSCommand}"
   FileClose $R1
   Pop $R1
  
-  !insertmacro PowerShellExecFileMacro "$PLUGINSDIR\tempfile.ps1"
+  !insertmacro PowerShellExecFileMacro "$INSTDIR\tempfile.ps1"
 !macroend
  
 !macro PowerShellExecLogMacro PSCommand
   InitPluginsDir
   ;Save command in a temp file
   Push $R1
-  FileOpen $R1 $PLUGINSDIR\tempfile.ps1 w
-  FileWrite $R1 "${PSCommand}"
+  FileOpen $R1 $INSTDIR\tempfile.ps1 w
+  FileWrite $R1 "${PSCommand}" 
   FileClose $R1
   Pop $R1
- 
-  !insertmacro PowerShellExecFileLogMacro "$PLUGINSDIR\tempfile.ps1"
+
+  !insertmacro PowerShellExecFileLogMacro "$INSTDIR\tempfile.ps1"
 !macroend
  
 !macro PowerShellExecFileMacro PSFile
@@ -331,67 +341,9 @@ finish_${PSExecID}:
 !define PowerShellExecFile '!insertmacro PowerShellExecFileMacro'
 !define PowerShellExecFileLog '!insertmacro PowerShellExecFileLogMacro'
 
-Function UninstallFct
-   ReadRegStr $R0 HKLM "SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\kDrive" "DisplayVersion"
-   !define /redef InstalledVersion $R0
-   StrCmp ${InstalledVersion} "3.5.6" uninstall_old_version 0
-   StrCmp ${InstalledVersion} "3.5.7" uninstall_old_version uninstall_old_version_done
-   uninstall_old_version:
-
-   ; Delete Vfs keys
-   SetRegView 64
-   StrCpy $0 0
-   loop2:
-      ; Look at every registered explorer SyncRootManager for HKLM and check if it was added by our application
-      EnumRegKey $1 HKLM "Software\Microsoft\Windows\CurrentVersion\Explorer\SyncRootManager" $0
-      StrCmp $1 "" done2
-
-      ReadRegStr $R0 HKLM "Software\Microsoft\Windows\CurrentVersion\Explorer\SyncRootManager\$1" ""
-      StrCmp $R0 "${APPLICATION_NAME}" deleteSyncRootManager
-      ; Increment the index when not deleting the enumerated key.
-      IntOp $0 $0 + 1
-      goto loop2
-
-      deleteSyncRootManager:
-         ReadRegStr $R1 HKLM "Software\Microsoft\Windows\CurrentVersion\Explorer\SyncRootManager\$1" "NamespaceCLSID"
-         StrCmp $R1 "" done2
-
-         DetailPrint "Removing SyncRootManager $1"
-         DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Explorer\SyncRootManager\$1"
-
-         DetailPrint "Removing Navigation Pane CLSID $R1"
-         ; Should match FolderMan::updateCloudStorageRegistry
-         DeleteRegKey HKCU "Software\Classes\CLSID\$R1"
-         DeleteRegKey HKCU "Software\Classes\\WOW6432Node\CLSID\$R1"
-         DeleteRegKey HKCU "Software\Microsoft\Windows\CurrentVersion\Explorer\Desktop\NameSpace\$R1"
-         DeleteRegValue HKCU "Software\Microsoft\Windows\CurrentVersion\Explorer\HideDesktopIcons\NewStartPanel" $R1
-
-         goto loop2
-   done2:
-
-   ; Go back to the 32bit registry.
-   SetRegView lastused
-
-   ;Remove reg key
-   DeleteRegKey HKLM "SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\kDrive"
-
-   ;Remove extension
-   !define PackageFullName_x64 "${VFS_PACKAGE_NAME}_${InstalledVersion}.0_x64__dbrs6rk4qqhna"
-   IfFileExists "C:\Program Files\WindowsApps\${PackageFullName_x64}\*.*" uninstall_x64 uninstall_kdrive_ext_x64_done
-      uninstall_x64:
-      ${PowerShellExecLog} "Remove-AppxPackage ${PackageFullName_x64}"
-   !undef PackageFullName_x64
-   uninstall_kdrive_ext_x64_done:
-
-   uninstall_old_version_done:
-FunctionEnd
-
 Function EnsureKDriveShutdown
    ; Stop processes
-   !insertmacro CheckAndConfirmEndProcesses "${APPLICATION_SERVER_EXECUTABLE}" "${APPLICATION_CLIENT_EXECUTABLE}"
-
-   ;Hack - Uninstall if needed
-   Call UninstallFct
+   !insertmacro CheckAndConfirmEndProcesses3 "${APPLICATION_SERVER_EXECUTABLE}" "${APPLICATION_CLIENT_EXECUTABLE}" "${EXTENSION_NAME}"
 FunctionEnd
 
 Function InstallRedistributables
@@ -411,21 +363,21 @@ FunctionEnd
 ##############################################################################
 
 Function PageReinstall
-   ReadRegStr $R0 HKLM "${regkey}" ""
-   StrCmp $R0 "" 0 +2
-   Abort
+    ReadRegStr $R0 HKLM "${regkey}" ""
+    StrCmp $R0 "" 0 +2
+    Abort
 
    ;Detect version
-   ReadRegDWORD $R0 HKLM "${regkey}" "VersionMajor"
+    ReadRegDWORD $R0 HKLM "${regkey}" "VersionMajor"
    IntCmp $R0 ${VER_MAJOR} minor_check new_version older_version
-   minor_check:
-      ReadRegDWORD $R0 HKLM "${regkey}" "VersionMinor"
+    minor_check:
+        ReadRegDWORD $R0 HKLM "${regkey}" "VersionMinor"
       IntCmp $R0 ${VER_MINOR} rev_check new_version older_version
-   rev_check:
-      ReadRegDWORD $R0 HKLM "${regkey}" "VersionRevision"
+    rev_check:
+        ReadRegDWORD $R0 HKLM "${regkey}" "VersionRevision"
       IntCmp $R0 ${VER_PATCH} build_check new_version older_version
-   build_check:
-      ReadRegDWORD $R0 HKLM "${regkey}" "VersionBuild"
+    build_check:
+        ReadRegDWORD $R0 HKLM "${regkey}" "VersionBuild"
       IntCmp $R0 ${VER_BUILD} same_version new_version older_version
 
    new_version:
@@ -539,7 +491,8 @@ SectionEnd
       CreateDirectory "$INSTDIR\shellext\AppX"
       SetOutPath "$INSTDIR\shellext\AppX"
       File /nonfatal /a /r "${VFS_APPX_DIRECTORY}\"
-      ${PowerShellExecLog} "Add-AppxPackage -Path '${VFS_APPX_BUNDLE}'"
+      !insertmacro CheckAndConfirmEndProcesses1 "${EXTENSION_NAME}"
+      ${PowerShellExecLog} "Add-AppxPackage -Path '$INSTDIR\shellext\AppX\${VFS_APPX_BUNDLE}' -ForceApplicationShutdown -ForceUpdateFromAnyVersion"
       end_install_lite_sync_extension:
       
    ${MementoSectionEnd}
@@ -654,7 +607,7 @@ SectionEnd
 
 Function un.EnsureKDriveShutdown
    ; Stop processes
-   !insertmacro CheckAndConfirmEndProcesses "${APPLICATION_SERVER_EXECUTABLE}" "${APPLICATION_CLIENT_EXECUTABLE}"
+   !insertmacro CheckAndConfirmEndProcesses3 "${APPLICATION_SERVER_EXECUTABLE}" "${APPLICATION_CLIENT_EXECUTABLE}" "${EXTENSION_NAME}"
 FunctionEnd
 
 Function un.UninstallFct
@@ -665,65 +618,66 @@ Function un.UninstallFct
 
    ; Delete Navigation Pane entries added for Windows 10.
    ; On 64bit Windows, the client will be writing to the 64bit registry.
-   ${If} ${RunningX64}
-      SetRegView 64
+   ${IfNot} ${Silent}   
+       ${If} ${RunningX64}
+          SetRegView 64
+       ${EndIf}
+       StrCpy $0 0
+       loop:
+          ; Look at every registered explorer namespace for HKCU and check if it was added by our application
+          ; (we write to a custom "ApplicationName" value there).
+          EnumRegKey $1 HKCU "Software\Microsoft\Windows\CurrentVersion\Explorer\Desktop\NameSpace" $0
+          StrCmp $1 "" done
+
+          ReadRegStr $R0 HKCU "Software\Microsoft\Windows\CurrentVersion\Explorer\Desktop\NameSpace\$1" "ApplicationName"
+          StrCmp $R0 "${APPLICATION_NAME}" deleteClsid
+          ; Increment the index when not deleting the enumerated key.
+          IntOp $0 $0 + 1
+          goto loop
+
+          deleteClsid:
+             DetailPrint "Removing Navigation Pane CLSID $1"
+             ; Should match FolderMan::updateCloudStorageRegistry
+             DeleteRegKey HKCU "Software\Classes\CLSID\$1"
+             DeleteRegKey HKCU "Software\Classes\\WOW6432Node\CLSID\$1"
+             DeleteRegKey HKCU "Software\Microsoft\Windows\CurrentVersion\Explorer\Desktop\NameSpace\$1"
+             DeleteRegValue HKCU "Software\Microsoft\Windows\CurrentVersion\Explorer\HideDesktopIcons\NewStartPanel" $1
+             goto loop
+       done:
+
+       ; Delete Vfs keys
+       StrCpy $0 0
+       loop2:
+          ; Look at every registered explorer SyncRootManager for HKLM and check if it was added by our application
+          EnumRegKey $1 HKLM "Software\Microsoft\Windows\CurrentVersion\Explorer\SyncRootManager" $0
+          StrCmp $1 "" done2
+
+          ReadRegStr $R0 HKLM "Software\Microsoft\Windows\CurrentVersion\Explorer\SyncRootManager\$1" ""
+          StrCmp $R0 "${APPLICATION_NAME}" deleteSyncRootManager
+          ; Increment the index when not deleting the enumerated key.
+          IntOp $0 $0 + 1
+          goto loop2
+
+          deleteSyncRootManager:
+             ReadRegStr $R1 HKLM "Software\Microsoft\Windows\CurrentVersion\Explorer\SyncRootManager\$1" "NamespaceCLSID"
+             StrCmp $R1 "" done2
+
+             DetailPrint "Removing SyncRootManager $1"
+             DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Explorer\SyncRootManager\$1"
+
+             DetailPrint "Removing Navigation Pane CLSID $R1"
+             ; Should match FolderMan::updateCloudStorageRegistry
+             DeleteRegKey HKCU "Software\Classes\CLSID\$R1"
+             DeleteRegKey HKCU "Software\Classes\\WOW6432Node\CLSID\$R1"
+             DeleteRegKey HKCU "Software\Microsoft\Windows\CurrentVersion\Explorer\Desktop\NameSpace\$R1"
+             DeleteRegValue HKCU "Software\Microsoft\Windows\CurrentVersion\Explorer\HideDesktopIcons\NewStartPanel" $R1
+
+             goto loop2
+       done2:
+
+       ; Go back to the 32bit registry.
+       SetRegView lastused
    ${EndIf}
-   StrCpy $0 0
-   loop:
-      ; Look at every registered explorer namespace for HKCU and check if it was added by our application
-      ; (we write to a custom "ApplicationName" value there).
-      EnumRegKey $1 HKCU "Software\Microsoft\Windows\CurrentVersion\Explorer\Desktop\NameSpace" $0
-      StrCmp $1 "" done
-
-      ReadRegStr $R0 HKCU "Software\Microsoft\Windows\CurrentVersion\Explorer\Desktop\NameSpace\$1" "ApplicationName"
-      StrCmp $R0 "${APPLICATION_NAME}" deleteClsid
-      ; Increment the index when not deleting the enumerated key.
-      IntOp $0 $0 + 1
-      goto loop
-
-      deleteClsid:
-         DetailPrint "Removing Navigation Pane CLSID $1"
-         ; Should match FolderMan::updateCloudStorageRegistry
-         DeleteRegKey HKCU "Software\Classes\CLSID\$1"
-         DeleteRegKey HKCU "Software\Classes\\WOW6432Node\CLSID\$1"
-         DeleteRegKey HKCU "Software\Microsoft\Windows\CurrentVersion\Explorer\Desktop\NameSpace\$1"
-         DeleteRegValue HKCU "Software\Microsoft\Windows\CurrentVersion\Explorer\HideDesktopIcons\NewStartPanel" $1
-         goto loop
-   done:
-
-   ; Delete Vfs keys
-   StrCpy $0 0
-   loop2:
-      ; Look at every registered explorer SyncRootManager for HKLM and check if it was added by our application
-      EnumRegKey $1 HKLM "Software\Microsoft\Windows\CurrentVersion\Explorer\SyncRootManager" $0
-      StrCmp $1 "" done2
-
-      ReadRegStr $R0 HKLM "Software\Microsoft\Windows\CurrentVersion\Explorer\SyncRootManager\$1" ""
-      StrCmp $R0 "${APPLICATION_NAME}" deleteSyncRootManager
-      ; Increment the index when not deleting the enumerated key.
-      IntOp $0 $0 + 1
-      goto loop2
-
-      deleteSyncRootManager:
-         ReadRegStr $R1 HKLM "Software\Microsoft\Windows\CurrentVersion\Explorer\SyncRootManager\$1" "NamespaceCLSID"
-         StrCmp $R1 "" done2
-
-         DetailPrint "Removing SyncRootManager $1"
-         DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Explorer\SyncRootManager\$1"
-
-         DetailPrint "Removing Navigation Pane CLSID $R1"
-         ; Should match FolderMan::updateCloudStorageRegistry
-         DeleteRegKey HKCU "Software\Classes\CLSID\$R1"
-         DeleteRegKey HKCU "Software\Classes\\WOW6432Node\CLSID\$R1"
-         DeleteRegKey HKCU "Software\Microsoft\Windows\CurrentVersion\Explorer\Desktop\NameSpace\$R1"
-         DeleteRegValue HKCU "Software\Microsoft\Windows\CurrentVersion\Explorer\HideDesktopIcons\NewStartPanel" $R1
-
-         goto loop2
-   done2:
-
-   ; Go back to the 32bit registry.
-   SetRegView lastused
-
    ;Delete registry keys.
    DeleteRegValue HKLM "${regkey}" "VersionBuild"
    DeleteRegValue HKLM "${regkey}" "VersionMajor"
@@ -804,29 +758,30 @@ Function un.UninstallFct
       ${EndIf}
    ${EndIf}
 
+   ${IfNot} ${Silent}
+       ;Uninstall extension
+       ;${If} ${RunningX64}
+          !define PackageFullName_x64 "${VFS_PACKAGE_NAME}_${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}.0_x64__@{AUMID}"
+          IfFileExists "C:\Program Files\WindowsApps\${PackageFullName_x64}\*.*" uninstall_x64 uninstall_kdrive_ext_x64_done
+             uninstall_x64:
+             DetailPrint $UNINSTALL_EXTENSION
+             ${PowerShellExecLog} "Remove-AppxPackage ${PackageFullName_x64}"
+          !undef PackageFullName_x64
+          uninstall_kdrive_ext_x64_done:
+       ;${ElseIf} ${IsNativeARM64}
+          !define PackageFullName_arm64 "${VFS_PACKAGE_NAME}_${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}.0_arm64__@{AUMID}"
+          IfFileExists "C:\Program Files\WindowsApps\${PackageFullName_arm64}\*.*" uninstall_arm64 uninstall_kdrive_ext_arm64_done
+             uninstall_arm64:
+             DetailPrint $UNINSTALL_EXTENSION
+             ${PowerShellExecLog} "Remove-AppxPackage ${PackageFullName_arm64}"
+          !undef PackageFullName_arm64
+          uninstall_kdrive_ext_arm64_done:
+       ;${EndIf}
+       ;uninstall_kdrive_ext_done:
+   ${EndIf}
+   
    ;Remove all the Program Files.
    RMDir /r $INSTDIR
-
-   ;Uninstall extension
-   ;${If} ${RunningX64}
-      !define PackageFullName_x64 "${VFS_PACKAGE_NAME}_${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}.0_x64__@{AUMID}"
-      IfFileExists "C:\Program Files\WindowsApps\${PackageFullName_x64}\*.*" uninstall_x64 uninstall_kdrive_ext_x64_done
-         uninstall_x64:
-         DetailPrint $UNINSTALL_EXTENSION
-         ${PowerShellExecLog} "Remove-AppxPackage ${PackageFullName_x64}"
-      !undef PackageFullName_x64
-      uninstall_kdrive_ext_x64_done:
-   ;${ElseIf} ${IsNativeARM64}
-      !define PackageFullName_arm64 "${VFS_PACKAGE_NAME}_${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}.0_arm64__@{AUMID}"
-      IfFileExists "C:\Program Files\WindowsApps\${PackageFullName_arm64}\*.*" uninstall_arm64 uninstall_kdrive_ext_arm64_done
-         uninstall_arm64:
-         DetailPrint $UNINSTALL_EXTENSION
-         ${PowerShellExecLog} "Remove-AppxPackage ${PackageFullName_arm64}"
-      !undef PackageFullName_arm64
-      uninstall_kdrive_ext_arm64_done:
-   ;${EndIf}
-   ;uninstall_kdrive_ext_done:
-
 ;@{uninstallFiles}
 ;@{uninstallDirs}
 
@@ -866,7 +821,6 @@ Function .onInit
    ${IfNot} ${Errors}
       StrCpy $NoAutomaticUpdates "yes"
    ${EndIf}
-
 
    !insertmacro INSTALLOPTIONS_EXTRACT "NSIS.InstallOptions.ini"
 

--- a/extensions/windows/cfapi/Vfs/Vfs.vcxproj
+++ b/extensions/windows/cfapi/Vfs/Vfs.vcxproj
@@ -127,7 +127,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;VFS_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;VFS_EXPORTS;_WINDOWS;_USRDLL;KDC_AUMID=L"$(KDC_VIRTUAL_AUMID)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -163,8 +163,7 @@
       <Command>copy /Y "$(ProjectDir)..\Common\debug.h" "F:\Projects\desktop-kDrive\src\server\vfs\win\."
 copy /Y "$(ProjectDir)$(TargetName).h" "F:\Projects\desktop-kDrive\src\server\vfs\win\."
 copy /Y "$(TargetDir)$(TargetName).dll" "F:\Projects\build-desktop-kDrive-Desktop_Qt_6_2_3_MSVC2019_64bit-Debug\bin\."
-copy /Y "$(TargetDir)$(TargetName).pdb" "F:\Projects\build-desktop-kDrive-Desktop_Qt_6_2_3_MSVC2019_64bit-Debug\."
-</Command>
+copy /Y "$(TargetDir)$(TargetName).pdb" "F:\Projects\build-desktop-kDrive-Desktop_Qt_6_2_3_MSVC2019_64bit-Debug\."</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -173,7 +172,7 @@ copy /Y "$(TargetDir)$(TargetName).pdb" "F:\Projects\build-desktop-kDrive-Deskto
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;VFS_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;VFS_EXPORTS;_WINDOWS;_USRDLL;KDC_AUMID=L"$(KDC_PHYSICAL_AUMID)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>

--- a/extensions/windows/cfapi/Vfs/cloudproviderregistrar.cpp
+++ b/extensions/windows/cfapi/Vfs/cloudproviderregistrar.cpp
@@ -75,6 +75,18 @@ std::wstring CloudProviderRegistrar::registerWithShell(ProviderInfo *providerInf
                     TRACE_ERROR(L"Could not set default registry value");
                 }
 
+                // Update AMUID key
+                const std::wstring name(REGKEY_AUMID);
+                const std::wstring aumidValue = KDC_AUMID;
+                const std::wstring value = L"Infomaniak.kDrive.Extension_" + aumidValue + L"!App";
+
+                TRACE_INFO(L"AUMID value: %s", aumidValue.c_str());
+
+                if (RegSetValueEx(hKey, name.c_str(), 0, REG_SZ, (BYTE *) value.c_str(),
+                                  (DWORD) (value.size() + 1) * sizeof(wchar_t)) != ERROR_SUCCESS) {
+                    TRACE_ERROR(L"Could not set registry value %s=%s", name.c_str(), value.c_str());
+                }
+
                 if (RegCloseKey(hKey) != ERROR_SUCCESS) {
                     TRACE_ERROR(L"Could not close key %s", subKey.c_str());
                 }
@@ -169,21 +181,10 @@ std::wstring CloudProviderRegistrar::registerWithShell(ProviderInfo *providerInf
                 }
 
                 // Create AMUID key
-                std::wstring name(REGKEY_AUMID);
-                std::wstring value;
+                const std::wstring name(REGKEY_AUMID);
+                const std::wstring aumidValue = KDC_AUMID;
+                const std::wstring value = L"Infomaniak.kDrive.Extension_" + aumidValue + L"!App";
 
-                DWORD aumidValueSize = 65535;
-                std::wstring aumidValue;
-                aumidValue.resize(aumidValueSize);
-                LPCWSTR aumidEnvVarName = nullptr;
-#ifdef _DEBUG
-                aumidEnvVarName = L"KDC_VIRTUAL_AUMID";
-#else
-                aumidEnvVarName = L"KDC_PHYSICAL_AUMID";
-#endif
-                aumidValueSize = GetEnvironmentVariableW(aumidEnvVarName, &aumidValue[0], aumidValueSize);
-                aumidValue.resize(aumidValueSize);
-                value = L"Infomaniak.kDrive.Extension_" + aumidValue + L"!App";
                 TRACE_INFO(L"AUMID value: %s", aumidValue.c_str());
 
                 if (RegSetValueEx(hKey, name.c_str(), 0, REG_SZ, (BYTE *) value.c_str(),


### PR DESCRIPTION
# Fix broken `.lnk` files after each update on Windows

## Issue Description

Several clients reported that, on Windows, links (`.lnk`) to a file or folder inside a **kDrive sync directory** were systematically broken after each app update.

## Origin of the Issue

⚠️ **Note:** The following explanation is based on observations, assumptions, and limited documentation. It is sufficient to address our issue but should not be considered as an absolute truth.

After investigation, it appears that `.lnk` files do **not** point directly to a path but rather to an **item ID** (which is different from the `nodeId`). This mechanism allows links to remain valid even if the file or folder is moved.

However, in a **LiteSync** folder, items exist in a **dedicated namespace**, with their own set of unique IDs (which can be seen as a combination of `fileID` and `namespaceID` where the `namespace` is the syncfolder). 

When the sync is **removed**, the namespace is destroyed, and all files are moved to a **default namespace**. As a result, `.lnk` files can no longer resolve the item because the namespace ID has changed, **even if the file path remains unchanged**.

### Previous Behavior During Updates

Until now, each update process performed the following steps:

1. **Manually deleted** the namespace entry in the Windows Registry.
2. **Uninstalled** the old LiteSync version, which also removed the registry entry.

At the next startup, the app would recreate all namespaces, but from the OS perspective, this was equivalent to **completely deleting and recreating the sync**, causing `.lnk` files to break due to the change in namespace CLSID.

## Changes Introduced in This PR

### 🔧 Solution to the Issue

To prevent `.lnk` files from breaking at each update, this PR modifies the update process as follows:

- **Do not manually remove** the registry entry when updating (only remove it when fully uninstalling).
- **Update the `fileExplorer` package** instead of deleting and reinstalling it during updates.

### 🔄 Dynamic AUMID Handling

This PR also introduces a change allowing the app to dynamically update the **AUMID** of the extension linked to a sync folder.

- Since the sync entry in the registery is no longer recreated at each update, we must ensure that **certificate changes do not break existing syncs**.
- Additionally, this change simplifies switching between **debug** and **release** extensions, as it will no longer be necessary to unisntall the release app.

---

✅ **Expected Outcome:**  
With these modifications, `.lnk` files should remain functional after an update, and extension AUMID management should be more flexible.  

---
# 🛠 How to Test

Since this PR impacts both the **installer** and **uninstaller**, thorough QA testing is required.

### Test Setup

- This PR is expected to be included in **version 3.6.11**.
- Testing requires an upgrade from **3.6.10 → 3.6.11** and then from **3.6.11 → 3.6.12**.

---

## 🔍 Test Steps

### **1️⃣ Initial Setup**
1. Install **kDrive Desktop 3.6.10**.
2. Create a **LiteSync folder**.
3. Inside the LiteSync folder, create a file and a `.lnk` shortcut pointing to it (the `.lnk` can be inside or outside the sync folder).
4. Create another **sync folder** (without LiteSync).

---

### **2️⃣ Update to 3.6.11**
1. Update kDrive Desktop to **3.6.11** via **automatic update**.
2. Verify the following:
   - **The `.lnk` shortcut is now broken** (✅ Expected behavior since the 3.6.10 uninstaller was used).
   - **Icons** for both **LiteSync and non-LiteSync folders** display correctly.
   - **Hydration/Dehydration** functions properly for LiteSync.

3. **Check the File Explorer Extension process:**
   - Open **Task Manager** → Go to **Details**.
   - Search for **FileExplorerExtension.exe**.
   - Right-click on the process and select **"Open File Location"**.
   - Confirm that the file is located in a folder like:  
     ```
     ../Infomaniak.kDrive.Extension_3.6.11.0_x64__/FileExplorerExtension
     ```

4. **Fix the broken `.lnk`:**
   - Delete the broken `.lnk`.
   - Create a new `.lnk` pointing to a file inside the sync folder.

---

### **3️⃣ Update to 3.6.12**
1. Ask a kDrive Desktop team member (**@herve-er**) to build a **3.6.12 version** (identical to 3.6.11 but with a higher revision number) and make it available on **kStore**.
2. Update kDrive Desktop to **3.6.12**.
3. Verify the following:
   - **The `.lnk` shortcut remains functional** (✅ Expected behavior).
   - **Redo the previous checks**:
     - Icons for LiteSync and non-LiteSync folders.
     - Hydration/Dehydration on LiteSync.
     - **FileExplorerExtension.exe** process location:
       ```
       ../Infomaniak.kDrive.Extension_3.6.12.0_x64__/FileExplorerExtension
       ```
---

### **4️⃣ Test Full Uninstall**
1. - **Save the full path** of the `FileExplorerExtension` before uninstalling:
       ```
       ../Infomaniak.kDrive.Extension_3.6.12.0_x64__/FileExplorerExtension
       ```
2. **Uninstall kDrive Desktop:**
- Open the **Windows search bar**, search for "kDrive".
- **Right-click** on kDrive and select **Uninstall**.
- Follow the uninstaller steps.

3. **Verify cleanup:**
- **Check that no kDrive-related icons remain** in the left sidebar of **File Explorer**.
- **Ensure that the previously saved `FileExplorerExtension` path no longer exists**.
