### PR TITLE
Quick Fix - Only get the pinState of placeholders

### DIFF
--- a/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
@@ -245,8 +245,8 @@ void LocalFileSystemObserverWorker::changesDetected(const std::list<std::pair<st
                     return;
                 }
 
-                PinState pinState = _syncPal->vfs()->pinState(absolutePath);
                 if (vfsStatus.isPlaceholder) {
+                    const PinState pinState = _syncPal->vfs()->pinState(absolutePath);
                     if ((vfsStatus.isHydrated && pinState == PinState::OnlineOnly) ||
                         (!vfsStatus.isHydrated && pinState == PinState::AlwaysLocal)) {
                         // Change status in order to start hydration/dehydration


### PR DESCRIPTION
It is not causing issues in the app behavior, but it leads to an assertion in debug when we create a file on Windows.