### PR TITLE
Kdesktop 1635 crash in updater

### DIFF
--- a/src/libcommon/utility/types.h
+++ b/src/libcommon/utility/types.h
@@ -525,6 +525,8 @@ struct VersionInfo {
         std::string buildMinOsVersion; // Optionnal. Minimum supported version of the OS. Examples: 10.15, 11, server 2005, ...
         std::string downloadUrl; // URL to download the version
 
+        bool operator==(const VersionInfo &other) const = default;
+
         [[nodiscard]] bool isValid() const {
             return channel != VersionChannel::Unknown && !tag.empty() && buildVersion != 0 && !downloadUrl.empty();
         }

--- a/src/server/updater/updatechecker.cpp
+++ b/src/server/updater/updatechecker.cpp
@@ -57,6 +57,7 @@ class VersionInfoCmp {
 };
 
 const VersionInfo &UpdateChecker::versionInfo(const VersionChannel choosedChannel) {
+    if (!_isVersionReceived) return _defaultVersionInfo;
     const VersionInfo &prodVersion = prodVersionInfo();
 
     // If the user wants only `Production` versions, just return the current `Production` version.

--- a/test/server/updater/testupdatechecker.cpp
+++ b/test/server/updater/testupdatechecker.cpp
@@ -67,16 +67,21 @@ void TestUpdateChecker::testVersionInfo() {
     UpdateChecker testObj;
     testObj._prodVersionChannel = VersionChannel::Prod;
 
+    // Check the returned value when version Infos are not available.
+    testObj._isVersionReceived = false;
+    CPPUNIT_ASSERT_EQUAL(testObj._defaultVersionInfo, testObj.versionInfo(VersionChannel::Prod));
+    CPPUNIT_ASSERT_EQUAL(testObj._defaultVersionInfo, testObj.versionInfo(VersionChannel::Next));
+    CPPUNIT_ASSERT_EQUAL(testObj._defaultVersionInfo, testObj.versionInfo(VersionChannel::Beta));
+    CPPUNIT_ASSERT_EQUAL(testObj._defaultVersionInfo, testObj.versionInfo(VersionChannel::Internal));
+
     auto testFunc = [&testObj](const VersionValue expectedValue, const VersionChannel expectedChannel,
                                const VersionChannel selectedChannel, const std::vector<VersionValue> &versionsNumber,
                                const CPPUNIT_NS::SourceLine &sourceline) {
         testObj._versionsInfo.clear();
-        testObj._versionsInfo.try_emplace(VersionChannel::Prod,
-                                          getVersionInfo(VersionChannel::Prod, versionsNumber[0]));
-        testObj._versionsInfo.try_emplace(VersionChannel::Beta,
-                                          getVersionInfo(VersionChannel::Beta, versionsNumber[1]));
-        testObj._versionsInfo.try_emplace(VersionChannel::Internal,
-                                          getVersionInfo(VersionChannel::Internal, versionsNumber[2]));
+        testObj._isVersionReceived = true;
+        testObj._versionsInfo.try_emplace(VersionChannel::Prod, getVersionInfo(VersionChannel::Prod, versionsNumber[0]));
+        testObj._versionsInfo.try_emplace(VersionChannel::Beta, getVersionInfo(VersionChannel::Beta, versionsNumber[1]));
+        testObj._versionsInfo.try_emplace(VersionChannel::Internal, getVersionInfo(VersionChannel::Internal, versionsNumber[2]));
         const auto &versionInfo = testObj.versionInfo(selectedChannel);
         CPPUNIT_NS::assertEquals(expectedChannel, versionInfo.channel, sourceline, "");
         CPPUNIT_NS::assertEquals(tag(expectedValue), versionInfo.tag, sourceline, "");

--- a/test/server/updater/testupdatechecker.cpp
+++ b/test/server/updater/testupdatechecker.cpp
@@ -69,10 +69,10 @@ void TestUpdateChecker::testVersionInfo() {
 
     // Check the returned value when version Infos are not available.
     testObj._isVersionReceived = false;
-    CPPUNIT_ASSERT_EQUAL(testObj._defaultVersionInfo, testObj.versionInfo(VersionChannel::Prod));
-    CPPUNIT_ASSERT_EQUAL(testObj._defaultVersionInfo, testObj.versionInfo(VersionChannel::Next));
-    CPPUNIT_ASSERT_EQUAL(testObj._defaultVersionInfo, testObj.versionInfo(VersionChannel::Beta));
-    CPPUNIT_ASSERT_EQUAL(testObj._defaultVersionInfo, testObj.versionInfo(VersionChannel::Internal));
+    CPPUNIT_ASSERT(testObj._defaultVersionInfo == testObj.versionInfo(VersionChannel::Prod));
+    CPPUNIT_ASSERT(testObj._defaultVersionInfo == testObj.versionInfo(VersionChannel::Next));
+    CPPUNIT_ASSERT(testObj._defaultVersionInfo == testObj.versionInfo(VersionChannel::Beta));
+    CPPUNIT_ASSERT(testObj._defaultVersionInfo == testObj.versionInfo(VersionChannel::Internal));
 
     auto testFunc = [&testObj](const VersionValue expectedValue, const VersionChannel expectedChannel,
                                const VersionChannel selectedChannel, const std::vector<VersionValue> &versionsNumber,

--- a/test/server/updater/testupdatechecker.cpp
+++ b/test/server/updater/testupdatechecker.cpp
@@ -67,7 +67,7 @@ void TestUpdateChecker::testVersionInfo() {
     UpdateChecker testObj;
     testObj._prodVersionChannel = VersionChannel::Prod;
 
-    // Check the returned value when version Infos are not available.
+    // Check the returned value when versionInfo is not available.
     testObj._isVersionReceived = false;
     CPPUNIT_ASSERT(testObj._defaultVersionInfo == testObj.versionInfo(VersionChannel::Prod));
     CPPUNIT_ASSERT(testObj._defaultVersionInfo == testObj.versionInfo(VersionChannel::Next));


### PR DESCRIPTION
### PR Description: Fix Crash When Network Is Disconnected After Ignoring an Update  

#### **Issue Summary**  
The app crashes when opening Preferences and Release Notes or clicking "Update" after ignoring an update and losing network access (for long enough to let a getVersion request fail)

#### **Steps to Reproduce**  
1. A new update is available.  
2. Start the app and wait for the update notification.  
3. Ignore the update.  
4. Turn off network access.  
5. Wait 1 hour, allowing a `getVersionInfo` job to fail.  
6. Open Preferences and Release Notes or click "Update" → the app crashes.  

#### **Root Cause**  
In `UpdateChecker::versionInfo`:
- When `_versionsInfo` is empty, `betaVersion`, `internalVersion`, and `prodVersion` were automatically set to the default version.  
- However, the default version tag is an empty string (`""`).  
- When inserting it into `sortedVersionList`, the `VersionInfoCmp` method attempts to call `stoi` on `""`, leading to a crash.  
