### PR TITLE
Remove the HTML preview Github action: generated files are not supported

### DIFF
--- a/.github/workflows/build-and-run-extended-tests.yml
+++ b/.github/workflows/build-and-run-extended-tests.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Code coverage preview
         id: html_preview
-        uses: pavi2410/html-preview-action@v2
+        uses: pavi2410/html-preview-action@v4
         with:
           html_file: 'coverage_html/index.html'
           job_summary: true

--- a/.github/workflows/build-and-run-extended-tests.yml
+++ b/.github/workflows/build-and-run-extended-tests.yml
@@ -94,12 +94,6 @@ jobs:
           & "cov01.exe" "-1" # coverage on
           & "cov01.exe" "-s" # show status
 
-      - name: Code coverage preview
-        id: html_preview
-        uses: pavi2410/html-preview-action@v4
-        with:
-          html_file: 'coverage_html/index.html'
-          job_summary: true
 
       - name: Deactivate BullseyeCoverage
         run: |


### PR DESCRIPTION
As mentioned in the following issue, files generated by the runner which are not part of the git repository cannot be displayed as a preview: https://github.com/pavi2410/html-preview-action/issues/12

The scope of this PR has changed as it now removes the HTML preview action.