### PR TITLE
Performance Improvement: `CommonUtility::RelativePath`  

### DIFF
--- a/src/libcommon/utility/utility.cpp
+++ b/src/libcommon/utility/utility.cpp
@@ -464,8 +464,8 @@ bool CommonUtility::colorThresholdCheck(const int red, const int green, const in
 }
 
 SyncPath CommonUtility::relativePath(const SyncPath &rootPath, const SyncPath &path) {
-    const auto pathStr = path.string();
-    const auto rootStr = rootPath.string();
+    const auto& pathStr = path.native();
+    const auto& rootStr = rootPath.native();
     auto rootIt = rootStr.begin();
     auto pathIt = pathStr.begin();
     const auto rootItEnd = rootStr.end();

--- a/src/libcommon/utility/utility.cpp
+++ b/src/libcommon/utility/utility.cpp
@@ -464,31 +464,24 @@ bool CommonUtility::colorThresholdCheck(const int red, const int green, const in
 }
 
 SyncPath CommonUtility::relativePath(const SyncPath &rootPath, const SyncPath &path) {
-    std::filesystem::path rootPathNormal(rootPath.lexically_normal());
-    std::filesystem::path pathNormal(path.lexically_normal());
-
-    if (rootPathNormal == pathNormal) {
-        return std::filesystem::path();
+    auto pathStr = path.string();
+    auto rootStr = rootPath.string();
+    auto rootIt = rootStr.begin();
+    auto pathIt = pathStr.begin();
+    const auto rootItEnd = rootStr.end();
+    const auto pathItEnd = pathStr.end();
+    while (rootIt != rootItEnd && pathIt != pathItEnd &&
+           (*rootIt == *pathIt || (*rootIt == '/' && *pathIt == '\\') || (*rootIt == '\\' && *pathIt == '/'))) {
+        ++rootIt;
+        ++pathIt;
     }
 
-    std::vector<SyncName> rootPathElts;
-    for (const auto &dir: rootPathNormal) {
-        rootPathElts.push_back(dir.native());
+    if (rootIt != rootItEnd || pathIt == pathItEnd) {
+        // path is not a subpath of rootPath or the relative Path is empty
+        return {};
     }
-
-    size_t index = 0;
-    std::filesystem::path relativePath;
-    for (const auto &dir: pathNormal) {
-        if (index >= rootPathElts.size()) {
-            relativePath /= dir;
-        } else if (dir != rootPathElts[index]) {
-            // path is not a sub path of rootPath
-            break;
-        }
-        index++;
-    }
-
-    return relativePath;
+    while (pathIt != pathItEnd && (*pathIt == '\\' || *pathIt == '/')) ++pathIt;
+    return {pathIt, pathItEnd};
 }
 
 QStringList CommonUtility::languageCodeList(const Language enforcedLocale) {

--- a/src/libcommon/utility/utility.cpp
+++ b/src/libcommon/utility/utility.cpp
@@ -464,8 +464,8 @@ bool CommonUtility::colorThresholdCheck(const int red, const int green, const in
 }
 
 SyncPath CommonUtility::relativePath(const SyncPath &rootPath, const SyncPath &path) {
-    auto pathStr = path.string();
-    auto rootStr = rootPath.string();
+    const auto pathStr = path.string();
+    const auto rootStr = rootPath.string();
     auto rootIt = rootStr.begin();
     auto pathIt = pathStr.begin();
     const auto rootItEnd = rootStr.end();

--- a/test/libcommon/utility/testutility.cpp
+++ b/test/libcommon/utility/testutility.cpp
@@ -473,7 +473,7 @@ void TestUtility::testLogIfFail() {
 
 void TestUtility::testRelativePath() {
     const std::vector<char> separators = {'/', '\\'};
-    const std::vector<std::string> rootPathItems = {"dir1", "dir2", "dir3"}; // "/dir1/dir2/dir3
+    const std::vector<std::string> rootPathItems = {"dir1", "dir2", "??"}; // "/dir1/dir2/??
     const std::vector<std::string> relativePathItems = {"syncDir1", "syncDir2", "syncDir3"}; // "syncDir1/syncDir2/syncDir3
 
     // Root path is empty

--- a/test/libcommon/utility/testutility.cpp
+++ b/test/libcommon/utility/testutility.cpp
@@ -473,23 +473,20 @@ void TestUtility::testLogIfFail() {
 
 void TestUtility::testRelativePath() {
     const std::vector<char> separators = {'/', '\\'};
-    const std::vector<std::string> rootPathItems = {"dir1", "dir2", "dir3"}; // "dir1/dir2/dir3
+    const std::vector<std::string> rootPathItems = {"dir1", "dir2", "dir3"}; // "/dir1/dir2/dir3
     const std::vector<std::string> relativePathItems = {"syncDir1", "syncDir2", "syncDir3"}; // "syncDir1/syncDir2/syncDir3
 
     // Root path is empty
     std::vector<SyncPath> relativePaths;
     generatePaths(relativePathItems, separators, false, relativePaths);
-    CPPUNIT_ASSERT_EQUAL(relativePaths.size(), static_cast<size_t>(3 * pow(2, relativePathItems.size() - 1)));
 
     for (const auto &relativePath: relativePaths) {
-        std::cout << "Relative paths: " << relativePath.string() << std::endl;
         CPPUNIT_ASSERT_EQUAL(relativePath, CommonUtility::relativePath(SyncPath(), relativePath));
     }
 
     // Absolute path is empty
     std::vector<SyncPath> rootPaths;
     generatePaths(rootPathItems, separators, true, rootPaths);
-    CPPUNIT_ASSERT_EQUAL(rootPaths.size(), static_cast<size_t>(3 * pow(2, rootPathItems.size())));
 
     for (const auto &rootPath: rootPaths) {
         CPPUNIT_ASSERT_EQUAL(SyncPath(), CommonUtility::relativePath(rootPath, SyncPath()));
@@ -500,8 +497,9 @@ void TestUtility::testRelativePath() {
 
     // Both paths are the same
     for (const auto &rootPath: rootPaths) {
-        std::cout << "Root paths: " << rootPath.string() << std::endl;
-        CPPUNIT_ASSERT_EQUAL(SyncPath(), CommonUtility::relativePath(rootPath, rootPath));
+        for (const auto &absolutePath: rootPaths) {
+            CPPUNIT_ASSERT_EQUAL(SyncPath(), CommonUtility::relativePath(rootPath, absolutePath));
+        }
     }
 
     // Absolute path is a subpath of the root path
@@ -512,7 +510,6 @@ void TestUtility::testRelativePath() {
             for (const auto &separator: separators) {
                 const SyncPath absolutePath = rootPath.string() + separator + relativePath.string();
                 (void) absolutePaths.emplace_back(absolutePath, relativePath);
-                std::cout << "Absolute paths: " << absolutePath.string() << std::endl;
             }
         }
     }
@@ -523,5 +520,8 @@ void TestUtility::testRelativePath() {
                                          relativePaths, CommonUtility::relativePath(rootPath, absolutePath));
         }
     }
+
+    // Absolute path is not a subpath of the root path
+    CPPUNIT_ASSERT_EQUAL(SyncPath(), CommonUtility::relativePath(SyncPath("dir1"), SyncPath("dir2/test")));
 }
 } // namespace KDC

--- a/test/libcommon/utility/testutility.h
+++ b/test/libcommon/utility/testutility.h
@@ -21,6 +21,7 @@
 #include <cppunit/TestFixture.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include "test_utility/testbase.h"
+#include "libcommon/utility/types.h"
 
 namespace KDC {
 
@@ -41,6 +42,7 @@ class TestUtility : public CppUnit::TestFixture, public TestBase {
 #ifdef _WIN32
         CPPUNIT_TEST(testGetLastErrorMessage);
 #endif
+        CPPUNIT_TEST(testRelativePath);
         CPPUNIT_TEST_SUITE_END();
 
     public:
@@ -60,9 +62,26 @@ class TestUtility : public CppUnit::TestFixture, public TestBase {
         void testIsSupportedLanguage();
         void testTruncateLongLogMessage();
         void testLogIfFail();
+        void testRelativePath();
 #ifdef _WIN32
         void testGetLastErrorMessage();
 #endif
+
+    private:
+        /* Generate all the possible path for a set of items and separators
+         * result vecor will contain all the generated paths, eg:
+         *  itemsNames = {"Dir1", "Dir2", "Dir3"}
+         *  separators = {'/', '\\'}
+         *  result = {"Dir1/Dir2/Dir3/", "Dir1\\Dir2/Dir3/", "Dir1/Dir2\\Dir3", "Dir1/Dir2/Dir3\\", "Dir1\\Dir2\\Dir3",
+         * "Dir1\\Dir2\\Dir3\\", ... }
+         *
+         * @param itemsNames: the list of items
+         * @param separators: the list of separators
+         * @param startWithSeparator: if the path should start with a separator
+         * @param result: the list of generated paths
+         */
+        void generatePaths(const std::vector<std::string> &itemsNames, const std::vector<char> &separators,
+                           bool startWithSeparator, std::vector<SyncPath> &result, const std::string &start = "", int pos = 0);
 };
 
 


### PR DESCRIPTION
This PR improves the time performance of the `CommonUtility::RelativePath` function.  

#### Function Overview  
The function takes a **root path** and a **target path** as input. It returns the portion of the target path that lies under the root path.  

#### Performance Improvement  

- **Before Optimization:**  
  - **Execution Time:** 8.3s for 200,000 calls  
  - **Complexity:** O(n) in relation to the path length  
    ![Before Optimization](https://github.com/user-attachments/assets/d85a928e-4029-4bc7-b45e-0efa2b70fea1)  

- **After Optimization:**  
  - **Execution Time:** 1.6s for the same conditions  
  - **Complexity:** Unchanged  
    ![After Optimization](https://github.com/user-attachments/assets/8337cab0-129a-43dc-a038-b825bbd36c80)  

#### Validation & Testing  

- Unit tests have been added and successfully executed on both the old and new implementations.  
- The only functional difference is that the old implementation did **not** support root paths ending with `/` or `\`, whereas the new one does.  
