### PR TITLE
Optimize executor speed

### DIFF
--- a/src/libsyncengine/progress/progressinfo.cpp
+++ b/src/libsyncengine/progress/progressinfo.cpp
@@ -163,7 +163,10 @@ bool ProgressInfo::setProgressComplete(const SyncPath &path, const SyncFileStatu
     if (it->second.empty()) {
         _currentItems.erase(normalizedPath);
     }
-    recomputeCompletedSize();
+
+    if (const auto currentItemsSize = _currentItems.size(); currentItemsSize < 100 || currentItemsSize % 1000 == 0) {
+        recomputeCompletedSize();
+    }
     return true;
 }
 


### PR DESCRIPTION
This PR optimizes the initial sync performance, particularly when syncing a directory for the first time in **lite sync mode**.

### Problem

In the current implementation, a significant amount of time is spent calculating the total download/upload progress during the initial sync.  
However, in **lite sync mode**, this is unnecessary as the total progress will **always be 0 bytes** (nothing is downloaded or uploaded).

### Solution

To reduce the overhead, we now compute the total progress of ongoing uploads/downloads only:
- Every **1000 completed items**, or
- When there are **fewer than 100 items left in the queue**

This simple heuristic drastically reduces the time spent on computing progress in lite sync without sacrificing accuracy in normal sync scenarios.

### Performance comparaison

Before (Initial synchronization of 264,063 items (executor step only)):
- Too lengthy to fully test, but after 3 hours and 29 minutes, 139,500 items were processed. over 

After (Initial synchronization of 264,063 items (executor step only)): 
- 264 063 items processed in  5min 40s


