### PR TITLE
Kdesktop 1531 optimize io helper directory iterator

### DIFF
--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -925,8 +925,8 @@ bool IoHelper::DirectoryIterator::next(DirectoryEntry &nextEntry, bool &endOfDir
         ioError = IoError::InvalidArgument;
         return false;
     }
-
-    if (_dirIterator == std::filesystem::end(std::filesystem::recursive_directory_iterator(_directoryPath, ec))) {
+    const auto dirIteratorEnd = std::filesystem::end(_dirIterator);
+    if (_dirIterator == dirIteratorEnd) {
         endOfDirectory = true;
         ioError = IoError::Success;
         return true;
@@ -949,7 +949,7 @@ bool IoHelper::DirectoryIterator::next(DirectoryEntry &nextEntry, bool &endOfDir
         _firstElement = false;
     }
 
-    if (_dirIterator != std::filesystem::end(std::filesystem::recursive_directory_iterator(_directoryPath, ec))) {
+    if (_dirIterator != dirIteratorEnd) {
         ioError = IoHelper::stdError2ioError(ec);
 
         if (ioError != IoError::Success) {

--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -938,11 +938,12 @@ bool IoHelper::DirectoryIterator::next(DirectoryEntry &nextEntry, bool &endOfDir
 
     if (!_firstElement) {
         _dirIterator.increment(ec);
-        ioError = IoHelper::stdError2ioError(ec);
-
-        if (ioError != IoError::Success) {
-            _invalid = true;
-            return true;
+        if (ec) {
+            ioError = IoHelper::stdError2ioError(ec);
+            if (ioError != IoError::Success) {
+                _invalid = true;
+                return true;
+            }
         }
 
     } else {
@@ -950,13 +951,6 @@ bool IoHelper::DirectoryIterator::next(DirectoryEntry &nextEntry, bool &endOfDir
     }
 
     if (_dirIterator != dirIteratorEnd) {
-        ioError = IoHelper::stdError2ioError(ec);
-
-        if (ioError != IoError::Success) {
-            _invalid = true;
-            return true;
-        }
-
 #ifdef _WIN32
         // skip_permission_denied doesn't work on Windows
         try {


### PR DESCRIPTION
### PR Description

`DirectoryIterator::next` was previously inefficient due to the creation of two iterators per call, just to obtain the `end` value. This is unnecessary, as we can retrieve the `end` value from the already constructed iterator.

Additionally, we frequently convert `std::error_code` to `ioError`, even when it’s not needed. Removing these redundant conversions simplifies the code and avoids unnecessary overhead.

These optimizations provide **significant performance improvements**:

#### Benchmark Results:

**Case 1: Recursive traversal of a folder containing 100 subfolders, each with 1,000 files and 1,000 empty directories (200,100 items)**  
- Before: **38.078s**  
- After: **6.959s**

**Case 2: Recursive traversal of a folder containing 100 subfolders, each with 2,000 files (200,100 items)**  
- Before: **20s**  
- After: **610ms**

### Summary

- No more spurrious Iterator creation.
- Removed unnecessary `ioError` conversions.
- **Up to 40x faster** in common scenarios.
- File traversal time is now almost negligible.
- As typical drives contain more files than directories, real-world improvements will generally align with the faster case.

This change significantly improves the performance of directory traversal operations, especially on large file systems.
