### PR TITLE
Optimize `IoHelper::getItemType` and `IoHelper::fileStat` calls in LFSO::explorDir

### DIFF
--- a/src/libcommonserver/utility/utility.h
+++ b/src/libcommonserver/utility/utility.h
@@ -186,6 +186,7 @@ struct COMMONSERVER_EXPORT Utility {
         static bool longPath(const SyncPath &shortPathIn, SyncPath &longPathOut, bool &notFound);
         static bool runDetachedProcess(std::wstring cmd);
 #endif
+        static bool checkIfDirEntryIsManaged(const DirectoryEntry &dirEntry, bool &isManaged, const ItemType &itemType, IoError &ioError);
         static bool checkIfDirEntryIsManaged(const DirectoryEntry &dirEntry, bool &isManaged, bool &isLink, IoError &ioError);
         static bool checkIfDirEntryIsManaged(const std::filesystem::recursive_directory_iterator &dirIt, bool &isManaged,
                                              bool &isLink, IoError &ioError);

--- a/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
@@ -629,12 +629,25 @@ ExitInfo LocalFileSystemObserverWorker::exploreDir(const SyncPath &absoluteParen
             const auto &absolutePath = entry.path();
             const auto relativePath = CommonUtility::relativePath(_syncPal->localPath(), absolutePath);
 
+            if (!IoHelper::getItemType(absolutePath, itemType)) {
+                LOGW_SYNCPAL_DEBUG(_logger,
+                                   L"Error in IoHelper::getItemType: " << Utility::formatIoError(absolutePath, itemType.ioError));
+                dirIt.disableRecursionPending();
+                continue;
+            }
+            if (itemType.ioError == IoError::AccessDenied) {
+                LOGW_SYNCPAL_DEBUG(_logger, L"getItemType failed for item: "
+                                                    << Utility::formatIoError(absoluteParentDirPath, ioError)
+                                                    << L". Blacklisting it temporarily");
+                sendAccessDeniedError(absolutePath);
+            }
+            
             bool toExclude = false;
-            bool isLink = false;
+            const bool isLink = itemType.linkType != LinkType::None;
 
             // Check if the directory entry is managed
             bool isManaged = false;
-            if (!Utility::checkIfDirEntryIsManaged(entry, isManaged, isLink, ioError)) {
+            if (!Utility::checkIfDirEntryIsManaged(entry, isManaged, itemType, ioError)) {
                 LOGW_SYNCPAL_WARN(_logger, L"Error in Utility::checkIfDirEntryIsManaged: "
                                                    << Utility::formatIoError(absoluteParentDirPath, ioError));
                 dirIt.disableRecursionPending();
@@ -712,41 +725,30 @@ ExitInfo LocalFileSystemObserverWorker::exploreDir(const SyncPath &absoluteParen
             if (absolutePath.parent_path() == _rootFolder) {
                 parentNodeId = *_syncPal->_syncDb->rootNode().nodeIdLocal();
             } else {
-                FileStat parentFileStat;
-                if (!IoHelper::getFileStat(absolutePath.parent_path(), &parentFileStat, ioError)) {
-                    LOGW_WARN(_logger,
-                              L"Error in IoHelper::getFileStat: " << Utility::formatIoError(absolutePath.parent_path(), ioError));
-                    setExitCause(ExitCause::FileAccessError);
-                    return ExitCode::SystemError;
+                parentNodeId = snapshot()->itemId(relativePath.parent_path());
+                if (parentNodeId.empty()) {
+                    FileStat parentFileStat;
+                    if (!IoHelper::getFileStat(absolutePath.parent_path(), &parentFileStat, ioError)) {
+                        LOGW_WARN(_logger, L"Error in IoHelper::getFileStat: "
+                                                   << Utility::formatIoError(absolutePath.parent_path(), ioError));
+                        setExitCause(ExitCause::FileAccessError);
+                        return ExitCode::SystemError;
+                    }
+
+                    if (ioError == IoError::NoSuchFileOrDirectory) {
+                        LOGW_SYNCPAL_DEBUG(_logger, L"Directory doesn't exist anymore: "
+                                                            << Utility::formatSyncPath(absolutePath.parent_path()));
+                        dirIt.disableRecursionPending();
+                        continue;
+                    } else if (ioError == IoError::AccessDenied) {
+                        LOGW_SYNCPAL_DEBUG(_logger, L"Directory misses search permission: "
+                                                            << Utility::formatSyncPath(absolutePath.parent_path()));
+                        dirIt.disableRecursionPending();
+                        sendAccessDeniedError(absolutePath);
+                        continue;
+                    }
+                    parentNodeId = std::to_string(parentFileStat.inode);
                 }
-
-                if (ioError == IoError::NoSuchFileOrDirectory) {
-                    LOGW_SYNCPAL_DEBUG(
-                            _logger, L"Directory doesn't exist anymore: " << Utility::formatSyncPath(absolutePath.parent_path()));
-                    dirIt.disableRecursionPending();
-                    continue;
-                } else if (ioError == IoError::AccessDenied) {
-                    LOGW_SYNCPAL_DEBUG(_logger, L"Directory misses search permission: "
-                                                        << Utility::formatSyncPath(absolutePath.parent_path()));
-                    dirIt.disableRecursionPending();
-                    sendAccessDeniedError(absolutePath);
-                    continue;
-                }
-
-                parentNodeId = std::to_string(parentFileStat.inode);
-            }
-
-            if (!IoHelper::getItemType(absolutePath, itemType)) {
-                LOGW_SYNCPAL_DEBUG(_logger,
-                                   L"Error in IoHelper::getItemType: " << Utility::formatIoError(absolutePath, itemType.ioError));
-                dirIt.disableRecursionPending();
-                continue;
-            }
-            if (itemType.ioError == IoError::AccessDenied) {
-                LOGW_SYNCPAL_DEBUG(_logger, L"getItemType failed for item: "
-                                                    << Utility::formatIoError(absoluteParentDirPath, ioError)
-                                                    << L". Blacklisting it temporarily");
-                sendAccessDeniedError(absolutePath);
             }
 
             SnapshotItem item(nodeId, parentNodeId, absolutePath.filename().native(), fileStat.creationTime, fileStat.modtime,


### PR DESCRIPTION
Currently, IoHelper::getItemType was call twice per item. Idem for IoHelper::fileStat. 
This is now reduce to once each per item (excepted if the parent isn't in the snapshot yet in this case we still have two call to IoHelper::fileStat.

Benchmark:
Before:
Local snapshot generated in: **in progress**s for 147335 items | **in progress**s for 147335 items

After:
Local snapshot generated in: 364.965s for 147335 items | 386.056s for 147335 items

~~Not the biggest improvement of the epic but it is always good to take. ~~