### PR TITLE
Fix bug in compute FS operation

### DIFF
--- a/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.h
+++ b/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.h
@@ -78,7 +78,8 @@ class ComputeFSOperationWorker : public ISyncWorker {
         bool isWhitelisted(const std::shared_ptr<const Snapshot> snapshot, const NodeId &nodeId) const;
         bool isTooBig(const std::shared_ptr<const Snapshot> remoteSnapshot, const NodeId &remoteNodeId, int64_t size);
         bool isPathTooLong(const SyncPath &path, const NodeId &nodeId, NodeType type) const;
-        ExitInfo isReusedNodeId(const NodeId &nodeId, const DbNode &dbNode, const std::shared_ptr<const Snapshot> &snapshot, bool &isReused) const;
+        ExitInfo isReusedNodeId(const NodeId &localNodeId, const DbNode &dbNode, const std::shared_ptr<const Snapshot> &snapshot,
+                                bool &isReused) const;
         ExitInfo checkIfOkToDelete(ReplicaSide side, const SyncPath &relativePath, const NodeId &nodeId, bool &isExcluded);
 
         void deleteChildOpRecursively(const std::shared_ptr<const Snapshot> remoteSnapshot, const NodeId &remoteNodeId,


### PR DESCRIPTION
This PR aims to fix a bug where the `computeFSOperationWorker` might abort on every sync, leading to the syncs restarting and looping indefinitely.
The problem is that the provided ID is always considered to be a local ID while it might be a remote one.

Regression inserted in commit : addacd110eee05ad58ddf2f5523094ae7cd6be5f

```
2025-04-15 16:00:57:660 [I] (0x16af6f000) syncpalworker.cpp:221 - *1* ***** Step <Compute FS operations> start
2025-04-15 16:00:57:660 [D] (0x16af6f000) isyncworker.cpp:45 - *1* Worker Compute FS Operations start
2025-04-15 16:00:57:660 [D] (0x16b573000) computefsoperationworker.cpp:42 - *1* Worker started: name=Compute FS Operations
2025-04-15 16:00:57:662 [D] (0x16b22b000) jobmanager.cpp:229 - Starting job 542 with priority 1
2025-04-15 16:00:57:662 [D] (0x16bda7000) abstractnetworkjob.cpp:335 - Sending GET request 542 : https://notify.kdrive.infomaniak.com/2/drive/322121/files/listing/longpoll?cursor=ppSQlQ4ABQC1ZP5nLE-yAAUA6AM&timeout=50s
2025-04-15 16:00:57:665 [W] (0x16b573000) computefsoperationworker.cpp:865 - *1* Node not found in DB
2025-04-15 16:00:57:665 [W] (0x16b573000) computefsoperationworker.cpp:376 - *1* Error in ComputeFSOperationWorker::inferChangeFromDbNode: side=Remote(2) path='test200 copy' code=DataError(4)
2025-04-15 16:00:57:665 [I] (0x16b573000) computefsoperationworker.cpp:103 - *1* FS operation aborted after: 0.00486337s
2025-04-15 16:00:57:665 [D] (0x16b573000) computefsoperationworker.cpp:110 - *1* Worker stopped: name=Compute FS Operations
2025-04-15 16:00:57:665 [D] (0x16b573000) isyncworker.cpp:100 - *1* Worker Compute FS Operations has finished with code=DataError(4) cause=DbEntryNotFound(3)
2025-04-15 16:00:57:765 [I] (0x16af6f000) syncpalworker.cpp:183 - *1* ***** Step <Compute FS operations> has aborted
```