### PR TITLE
Fix error in x64 Native Command Tool Prompt when executing the release build

### DIFF
--- a/infomaniak-build-tools/windows/build-drive.ps1
+++ b/infomaniak-build-tools/windows/build-drive.ps1
@@ -424,7 +424,7 @@ function Create-Archive {
 #                                                                                               #
 #################################################################################################
 
-$msbuildPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -version [16.0, 17.0] -products * -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe
+$msbuildPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" "-version" "[16.0, 17.0]" "-products" "*" "-requires" "Microsoft.Component.MSBuild" "-find" "MSBuild\**\Bin\MSBuild.exe"
 $7zaPath = "${env:ProgramFiles}\7-Zip\7za.exe"
 
 Set-Alias msbuild $msbuildPath


### PR DESCRIPTION
This PR fixes the following error raised when executing the command `powershell infomaniak-build-tools\windows\build-release.ps1` in a Windows `x64 Native Command Tool Prompt`:

```
& : Le terme «C:\Program Files (x86)\Microsoft» n'est pas reconnu comme nom d'applet de commande, fonction, fichier de
script ou programme exécutable. Vérifiez l'orthographe du nom, ou si un chemin d'accès existe, vérifiez que le chemin
d'accès est correct et réessayez.
Au caractère C:\Users\Luc\Projects\desktop-kDrive\infomaniak-build-tools\windows\build-drive.ps1:427 : 18
```
