### PR TITLE
Do not call JobManager::clear() twice

### DIFF
--- a/src/libsyncengine/jobs/jobmanager.cpp
+++ b/src/libsyncengine/jobs/jobmanager.cpp
@@ -157,11 +157,6 @@ JobManager::JobManager() : _logger(Log::instance()->getLogger()) {
     LOG_DEBUG(_logger, "Network Job Manager started with max " << _maxNbThread << " threads");
 }
 
-JobManager::~JobManager() {
-    stop();
-    clear();
-}
-
 void JobManager::run() noexcept {
     while (true) {
         if (_stop) {

--- a/src/libsyncengine/jobs/jobmanager.h
+++ b/src/libsyncengine/jobs/jobmanager.h
@@ -54,7 +54,6 @@ class JobManager {
         static std::shared_ptr<JobManager> instance() noexcept;
 
         JobManager(JobManager const &) = delete;
-        ~JobManager();
         void operator=(JobManager const &) = delete;
 
         static void stop();

--- a/test/libsyncengine/propagation/executor/testintegration.cpp
+++ b/test/libsyncengine/propagation/executor/testintegration.cpp
@@ -24,6 +24,7 @@
 #include "jobs/local/localcopyjob.h"
 #include "jobs/local/localdeletejob.h"
 #include "jobs/local/localmovejob.h"
+#include "jobs/jobmanager.h"
 #include "requests/syncnodecache.h"
 #include "requests/exclusiontemplatecache.h"
 #include "libcommon/utility/utility.h"
@@ -179,6 +180,9 @@ void TestIntegration::tearDown() {
     _syncPal->stop(false, true, false);
     ParmsDb::instance()->close();
     ParmsDb::reset();
+    JobManager::stop();
+    JobManager::clear();
+    JobManager::reset();
     TestBase::stop();
 }
 


### PR DESCRIPTION
**Avoid double call to `JobManager::clear()` without `reset()`**

Fixes a crash on macOS caused by calling `JobManager::clear()` twice without an intermediate call to `JobManager::reset()`. According to the Poco documentation, `Poco::ThreadPool::defaultPool().stopAll()` should only be called once and just before the thread pool is deleted. While this doesn't currently cause issues on Windows, it's explicitly discouraged and leads to the observed crash on macOS.