### PR TITLE
[KDESKTOP-1017] Refresh the sync folder links after drive selection

### DIFF
--- a/src/gui/synthesispopover.cpp
+++ b/src/gui/synthesispopover.cpp
@@ -797,6 +797,7 @@ void SynthesisPopover::onConfigRefreshed() {
 
     setSynchronizedDefaultPage(&_defaultSynchronizedPageWidget, this);
     _synthesisBar->refreshErrorsButton();
+    retranslateUi();
     forceRedraw();
 }
 
@@ -1023,6 +1024,8 @@ void SynthesisPopover::onDriveSelected(int driveDbId) {
     if (this->isVisible() && newAccountSelected) {
         emit updateItemList();
     }
+
+    retranslateUi();
 }
 
 void SynthesisPopover::onAddDrive() {


### PR DESCRIPTION
The links to the synchronization folders needed to be refreshed after each drive selection in synthesis pop-over widget.