### PR TITLE
Crash in OperationSorterWorker

### DIFF
--- a/src/libsyncengine/propagation/operation_sorter/operationsorterfilter.cpp
+++ b/src/libsyncengine/propagation/operation_sorter/operationsorterfilter.cpp
@@ -61,7 +61,7 @@ void OperationSorterFilter::filterMoveBeforeCreateCandidates(const SyncOpPtr &op
     if (op->affectedNode()->hasChangeEvent(OperationType::Create)) {
         if (const auto &[_, ok] = moveBeforeCreateCandidates.try_emplace(op->affectedNode()->name(), op); !ok) {
             const auto &otherOp = moveBeforeCreateCandidates.at(op->affectedNode()->name());
-            if (op->targetSide() != otherOp->targetSide()) {
+            if (op->targetSide() != otherOp->targetSide() || !otherOp->affectedNode()->hasChangeEvent(OperationType::Move)) {
                 return;
             }
             (void) _fixMoveBeforeCreateCandidates.emplace_back(op, otherOp);
@@ -72,7 +72,7 @@ void OperationSorterFilter::filterMoveBeforeCreateCandidates(const SyncOpPtr &op
                     moveBeforeCreateCandidates.try_emplace(op->affectedNode()->moveOriginInfos().path().filename().native(), op);
             !ok) {
             const auto &otherOp = moveBeforeCreateCandidates.at(op->affectedNode()->name());
-            if (op->targetSide() != otherOp->targetSide()) {
+            if (op->targetSide() != otherOp->targetSide() || !otherOp->affectedNode()->hasChangeEvent(OperationType::Create)) {
                 return;
             }
             (void) _fixMoveBeforeCreateCandidates.emplace_back(op, otherOp);
@@ -159,7 +159,7 @@ void OperationSorterFilter::filterDeleteBeforeCreateCandidates(const SyncOpPtr &
     if (op->affectedNode()->hasChangeEvent(OperationType::Delete)) {
         if (const auto [_, ok] = deleteBeforeCreateCandidates.try_emplace(op->affectedNode()->name(), op); !ok) {
             const auto &otherOp = deleteBeforeCreateCandidates.at(op->affectedNode()->name());
-            if (op->targetSide() != otherOp->targetSide()) {
+            if (op->targetSide() != otherOp->targetSide() || !otherOp->affectedNode()->hasChangeEvent(OperationType::Create)) {
                 return;
             }
             (void) _fixDeleteBeforeCreateCandidates.emplace_back(op, otherOp);
@@ -168,7 +168,7 @@ void OperationSorterFilter::filterDeleteBeforeCreateCandidates(const SyncOpPtr &
     if (op->affectedNode()->hasChangeEvent(OperationType::Create)) {
         if (const auto [_, ok] = deleteBeforeCreateCandidates.try_emplace(op->affectedNode()->name(), op); !ok) {
             const auto &otherOp = deleteBeforeCreateCandidates.at(op->affectedNode()->name());
-            if (op->targetSide() != otherOp->targetSide()) {
+            if (op->targetSide() != otherOp->targetSide() || !otherOp->affectedNode()->hasChangeEvent(OperationType::Delete)) {
                 return;
             }
             (void) _fixDeleteBeforeCreateCandidates.emplace_back(op, otherOp);

--- a/src/libsyncengine/propagation/operation_sorter/operationsorterfilter.cpp
+++ b/src/libsyncengine/propagation/operation_sorter/operationsorterfilter.cpp
@@ -47,8 +47,8 @@ void OperationSorterFilter::filterOperations() {
 
 void OperationSorterFilter::filterDeleteBeforeMoveCandidates(const SyncOpPtr &op, NameToOpMap &deleteBeforeMoveCandidates) {
     if (op->affectedNode()->hasChangeEvent(OperationType::Delete) || op->affectedNode()->hasChangeEvent(OperationType::Move)) {
-        if (const auto [_, ok] = deleteBeforeMoveCandidates.try_emplace(op->affectedNode()->name(), op); !ok) {
-            const auto &otherOp = deleteBeforeMoveCandidates.at(op->affectedNode()->name());
+        if (const auto [_, ok] = deleteBeforeMoveCandidates.try_emplace(op->affectedNode()->normalizedName(), op); !ok) {
+            const auto &otherOp = deleteBeforeMoveCandidates.at(op->affectedNode()->normalizedName());
             if (op->targetSide() != otherOp->targetSide()) {
                 return;
             }
@@ -59,8 +59,8 @@ void OperationSorterFilter::filterDeleteBeforeMoveCandidates(const SyncOpPtr &op
 
 void OperationSorterFilter::filterMoveBeforeCreateCandidates(const SyncOpPtr &op, NameToOpMap &moveBeforeCreateCandidates) {
     if (op->affectedNode()->hasChangeEvent(OperationType::Create)) {
-        if (const auto &[_, ok] = moveBeforeCreateCandidates.try_emplace(op->affectedNode()->name(), op); !ok) {
-            const auto &otherOp = moveBeforeCreateCandidates.at(op->affectedNode()->name());
+        if (const auto &[_, ok] = moveBeforeCreateCandidates.try_emplace(op->affectedNode()->normalizedName(), op); !ok) {
+            const auto &otherOp = moveBeforeCreateCandidates.at(op->affectedNode()->normalizedName());
             if (op->targetSide() != otherOp->targetSide() || !otherOp->affectedNode()->hasChangeEvent(OperationType::Move)) {
                 return;
             }
@@ -71,7 +71,7 @@ void OperationSorterFilter::filterMoveBeforeCreateCandidates(const SyncOpPtr &op
         if (const auto &[_, ok] =
                     moveBeforeCreateCandidates.try_emplace(op->affectedNode()->moveOriginInfos().path().filename().native(), op);
             !ok) {
-            const auto &otherOp = moveBeforeCreateCandidates.at(op->affectedNode()->name());
+            const auto &otherOp = moveBeforeCreateCandidates.at(op->affectedNode()->normalizedName());
             if (op->targetSide() != otherOp->targetSide() || !otherOp->affectedNode()->hasChangeEvent(OperationType::Create)) {
                 return;
             }
@@ -154,11 +154,11 @@ void OperationSorterFilter::filterCreateBeforeMoveCandidates(const SyncOpPtr &op
 }
 void OperationSorterFilter::filterDeleteBeforeCreateCandidates(const SyncOpPtr &op, NameToOpMap &deleteBeforeCreateCandidates) {
     /**
-         * @brief delete before create, e.g. user deletes object "x" and then creates a new object at "x".
-         */
+     * @brief delete before create, e.g. user deletes object "x" and then creates a new object at "x".
+     */
     if (op->affectedNode()->hasChangeEvent(OperationType::Delete)) {
-        if (const auto [_, ok] = deleteBeforeCreateCandidates.try_emplace(op->affectedNode()->name(), op); !ok) {
-            const auto &otherOp = deleteBeforeCreateCandidates.at(op->affectedNode()->name());
+        if (const auto [_, ok] = deleteBeforeCreateCandidates.try_emplace(op->affectedNode()->normalizedName(), op); !ok) {
+            const auto &otherOp = deleteBeforeCreateCandidates.at(op->affectedNode()->normalizedName());
             if (op->targetSide() != otherOp->targetSide() || !otherOp->affectedNode()->hasChangeEvent(OperationType::Create)) {
                 return;
             }
@@ -166,8 +166,8 @@ void OperationSorterFilter::filterDeleteBeforeCreateCandidates(const SyncOpPtr &
         }
     }
     if (op->affectedNode()->hasChangeEvent(OperationType::Create)) {
-        if (const auto [_, ok] = deleteBeforeCreateCandidates.try_emplace(op->affectedNode()->name(), op); !ok) {
-            const auto &otherOp = deleteBeforeCreateCandidates.at(op->affectedNode()->name());
+        if (const auto [_, ok] = deleteBeforeCreateCandidates.try_emplace(op->affectedNode()->normalizedName(), op); !ok) {
+            const auto &otherOp = deleteBeforeCreateCandidates.at(op->affectedNode()->normalizedName());
             if (op->targetSide() != otherOp->targetSide() || !otherOp->affectedNode()->hasChangeEvent(OperationType::Delete)) {
                 return;
             }
@@ -181,7 +181,7 @@ void OperationSorterFilter::filterMoveBeforeMoveOccupiedCandidates(const SyncOpP
     if (!op->affectedNode()->hasChangeEvent(OperationType::Move)) return;
 
     const SyncName originName = op->affectedNode()->moveOriginInfos().path().filename().native();
-    const SyncName destinationName = op->affectedNode()->name();
+    const SyncName destinationName = op->affectedNode()->normalizedName();
 
     if (moveOriginNames.contains(destinationName)) {
         const auto &otherOp = moveOriginNames.at(destinationName);

--- a/src/libsyncengine/update_detection/update_detector/node.cpp
+++ b/src/libsyncengine/update_detection/update_detector/node.cpp
@@ -28,7 +28,14 @@ namespace KDC {
 Node::Node(const std::optional<DbNodeId> &idb, const ReplicaSide &side, const SyncName &name, NodeType type,
            OperationType changeEvents, const std::optional<NodeId> &id, std::optional<SyncTime> createdAt,
            std::optional<SyncTime> lastmodified, int64_t size, std::shared_ptr<Node> parentNode) :
-    _idb(idb), _side(side), _name(name), _type(type), _id(id), _createdAt(createdAt), _lastModified(lastmodified), _size(size),
+    _idb(idb),
+    _side(side),
+    _name(name),
+    _type(type),
+    _id(id),
+    _createdAt(createdAt),
+    _lastModified(lastmodified),
+    _size(size),
     _conflictsAlreadyConsidered(std::vector<ConflictType>()) {
     setParentNode(parentNode);
     setChangeEvents(changeEvents);
@@ -50,7 +57,10 @@ Node::Node(const ReplicaSide &side, const SyncName &name, NodeType type, Operati
     Node(std::nullopt, side, name, type, changeEvents, id, createdAt, lastmodified, size, parentNode) {}
 
 Node::Node(const ReplicaSide &side, const SyncName &name, NodeType type, std::shared_ptr<Node> parentNode) :
-    _side(side), _name(name), _type(type), _isTmp(true) {
+    _side(side),
+    _name(name),
+    _type(type),
+    _isTmp(true) {
     _id = "tmp_" + CommonUtility::generateRandomStringAlphaNum();
     setParentNode(parentNode);
 }
@@ -59,6 +69,19 @@ bool Node::operator==(const Node &n) const {
     return n._idb == _idb && n._name == _name;
 }
 
+const SyncName &Node::normalizedName() {
+    if (!_normalizedName.empty()) return _normalizedName;
+    if (!Utility::normalizedSyncName(_name, _normalizedName)) {
+        LOGW_WARN(Log::instance()->getLogger(), L"Failed to normalize: " << Utility::formatSyncName(_name));
+        return _name;
+    }
+    return _normalizedName;
+}
+
+void Node::setName(const SyncName &name) {
+    _name = name;
+    _normalizedName.clear();
+}
 bool Node::setParentNode(const std::shared_ptr<Node> &parentNode) {
     if (!parentNode) return true;
 

--- a/src/libsyncengine/update_detection/update_detector/node.h
+++ b/src/libsyncengine/update_detection/update_detector/node.h
@@ -36,7 +36,9 @@ class Node {
                 MoveOriginInfos() = default;
                 MoveOriginInfos(const MoveOriginInfos &) = default;
                 MoveOriginInfos(const SyncPath &path, const NodeId &parentNodeId) :
-                    _isValid(true), _path(path), _parentNodeId(parentNodeId) {}
+                    _isValid(true),
+                    _path(path),
+                    _parentNodeId(parentNodeId) {}
 
                 MoveOriginInfos &operator=(const MoveOriginInfos &newMoveOriginInfos) {
                     LOG_IF_FAIL(Log::instance()->getLogger(), newMoveOriginInfos.isValid());
@@ -91,6 +93,7 @@ class Node {
         inline std::optional<DbNodeId> idb() const { return _idb; }
         inline ReplicaSide side() const { return _side; }
         inline const SyncName &name() const { return _name; }
+        const SyncName &normalizedName();
         inline NodeType type() const { return _type; }
         inline InconsistencyType inconsistencyType() const { return _inconsistencyType; }
         inline OperationType changeEvents() const { return _changeEvents; }
@@ -108,7 +111,7 @@ class Node {
         }
 
         inline void setIdb(const std::optional<DbNodeId> &idb) { _idb = idb; }
-        void setName(const SyncName &name) { _name = name; }
+        void setName(const SyncName &name);
         inline void setInconsistencyType(InconsistencyType newInconsistencyType) { _inconsistencyType = newInconsistencyType; }
         inline void addInconsistencyType(InconsistencyType newInconsistencyType) { _inconsistencyType |= newInconsistencyType; }
         inline void setCreatedAt(const std::optional<SyncTime> &createdAt) { _createdAt = createdAt; }
@@ -164,7 +167,8 @@ class Node {
 
         std::optional<DbNodeId> _idb = std::nullopt;
         ReplicaSide _side = ReplicaSide::Unknown;
-        SyncName _name; // This name is NFC-normalized by constructors and setters.
+        SyncName _name;
+        SyncName _normalizedName;
         InconsistencyType _inconsistencyType = InconsistencyType::None;
         NodeType _type = NodeType::Unknown;
         OperationType _changeEvents = OperationType::None;

--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
@@ -32,13 +32,20 @@ namespace KDC {
 
 UpdateTreeWorker::UpdateTreeWorker(std::shared_ptr<SyncPal> syncPal, const std::string &name, const std::string &shortName,
                                    ReplicaSide side) :
-    ISyncWorker(syncPal, name, shortName), _syncDb(syncPal->_syncDb), _operationSet(syncPal->operationSet(side)),
-    _updateTree(syncPal->updateTree(side)), _side(side) {}
+    ISyncWorker(syncPal, name, shortName),
+    _syncDb(syncPal->_syncDb),
+    _operationSet(syncPal->operationSet(side)),
+    _updateTree(syncPal->updateTree(side)),
+    _side(side) {}
 
 UpdateTreeWorker::UpdateTreeWorker(std::shared_ptr<SyncDb> syncDb, std::shared_ptr<FSOperationSet> operationSet,
                                    std::shared_ptr<UpdateTree> updateTree, const std::string &name, const std::string &shortName,
                                    ReplicaSide side) :
-    ISyncWorker(nullptr, name, shortName), _syncDb(syncDb), _operationSet(operationSet), _updateTree(updateTree), _side(side) {}
+    ISyncWorker(nullptr, name, shortName),
+    _syncDb(syncDb),
+    _operationSet(operationSet),
+    _updateTree(updateTree),
+    _side(side) {}
 
 UpdateTreeWorker::~UpdateTreeWorker() {
     _operationSet.reset();

--- a/test/libsyncengine/propagation/operation_sorter/testoperationsorterworker.cpp
+++ b/test/libsyncengine/propagation/operation_sorter/testoperationsorterworker.cpp
@@ -517,7 +517,7 @@ void TestOperationSorterWorker::testCheckAllMethods() {
     (void) _syncPal->syncOps()->pushOp(createOp);
     (void) _syncPal->syncOps()->pushOp(moveOp);
 
-    // ... but apply all sorter method
+    // ... but apply all sorter methods
     const TimerUtility timer;
     _syncPal->_operationsSorterWorker->_filter.filterOperations();
     _syncPal->_operationsSorterWorker->fixDeleteBeforeMove();

--- a/test/libsyncengine/propagation/operation_sorter/testoperationsorterworker.cpp
+++ b/test/libsyncengine/propagation/operation_sorter/testoperationsorterworker.cpp
@@ -434,7 +434,7 @@ void TestOperationSorterWorker::testFixEditBeforeMove() {
 // relationships are now flipped).
 void TestOperationSorterWorker::testFixMoveBeforeMoveParentChildFlip() {
     generateLotsOfDummySyncOperations(OperationType::Move, OperationType::Move, NodeType::Directory);
-    
+
     // Move A/AA to E
     const auto nodeAA = _testSituationGenerator.moveNode(ReplicaSide::Local, "aa", {}, Str("E"));
     const auto moveOp1 = generateSyncOperation(OperationType::Move, nodeAA);
@@ -518,6 +518,33 @@ void TestOperationSorterWorker::testCheckAllMethods() {
     (void) _syncPal->syncOps()->pushOp(moveOp);
 
     // ... but apply all sorter methods
+    const TimerUtility timer;
+    _syncPal->_operationsSorterWorker->_filter.filterOperations();
+    _syncPal->_operationsSorterWorker->fixMoveBeforeCreate();
+    (void) timer.elapsed("Operations sorted in");
+
+    CPPUNIT_ASSERT_EQUAL(true, _syncPal->_operationsSorterWorker->hasOrderChanged());
+    CPPUNIT_ASSERT_EQUAL(moveOp->id(), _syncPal->syncOps()->opSortedList().front());
+    CPPUNIT_ASSERT_EQUAL(createOp->id(), _syncPal->syncOps()->opSortedList().back());
+}
+
+void TestOperationSorterWorker::testDifferentEncodings() {
+    // Generate a MoveBeforeCreate situation but with different encodings
+    const auto nodeNfc = _testSituationGenerator.createNode(ReplicaSide::Local, NodeType::File, "nfc", "", false);
+    nodeNfc->setName(testhelpers::makeNfcSyncName());
+
+    // Move "ééé" to B/"ééé"
+    _testSituationGenerator.moveNode(ReplicaSide::Local, nodeNfc->id().value(), "b");
+    const auto moveOp = generateSyncOperation(OperationType::Move, nodeNfc);
+
+    // Create "ééé" but NFD encoded
+    const auto nodeNfd = _testSituationGenerator.createNode(ReplicaSide::Local, NodeType::File, "nfd", "");
+    nodeNfd->setName(testhelpers::makeNfdSyncName());
+    const auto createOp = generateSyncOperation(OperationType::Create, nodeNfd);
+
+    (void) _syncPal->syncOps()->pushOp(createOp);
+    (void) _syncPal->syncOps()->pushOp(moveOp);
+
     const TimerUtility timer;
     _syncPal->_operationsSorterWorker->_filter.filterOperations();
     _syncPal->_operationsSorterWorker->fixDeleteBeforeMove();

--- a/test/libsyncengine/propagation/operation_sorter/testoperationsorterworker.cpp
+++ b/test/libsyncengine/propagation/operation_sorter/testoperationsorterworker.cpp
@@ -520,7 +520,15 @@ void TestOperationSorterWorker::testCheckAllMethods() {
     // ... but apply all sorter methods
     const TimerUtility timer;
     _syncPal->_operationsSorterWorker->_filter.filterOperations();
+    _syncPal->_operationsSorterWorker->fixDeleteBeforeMove();
     _syncPal->_operationsSorterWorker->fixMoveBeforeCreate();
+    _syncPal->_operationsSorterWorker->fixMoveBeforeDelete();
+    _syncPal->_operationsSorterWorker->fixCreateBeforeMove();
+    _syncPal->_operationsSorterWorker->fixDeleteBeforeCreate();
+    _syncPal->_operationsSorterWorker->fixMoveBeforeMoveOccupied();
+    _syncPal->_operationsSorterWorker->fixCreateBeforeCreate();
+    _syncPal->_operationsSorterWorker->fixEditBeforeMove();
+    _syncPal->_operationsSorterWorker->fixMoveBeforeMoveHierarchyFlip();
     (void) timer.elapsed("Operations sorted in");
 
     CPPUNIT_ASSERT_EQUAL(true, _syncPal->_operationsSorterWorker->hasOrderChanged());
@@ -534,7 +542,7 @@ void TestOperationSorterWorker::testDifferentEncodings() {
     nodeNfc->setName(testhelpers::makeNfcSyncName());
 
     // Move "ééé" to B/"ééé"
-    _testSituationGenerator.moveNode(ReplicaSide::Local, nodeNfc->id().value(), "b");
+    (void) _testSituationGenerator.moveNode(ReplicaSide::Local, nodeNfc->id().value(), "b");
     const auto moveOp = generateSyncOperation(OperationType::Move, nodeNfc);
 
     // Create "ééé" but NFD encoded
@@ -547,15 +555,7 @@ void TestOperationSorterWorker::testDifferentEncodings() {
 
     const TimerUtility timer;
     _syncPal->_operationsSorterWorker->_filter.filterOperations();
-    _syncPal->_operationsSorterWorker->fixDeleteBeforeMove();
     _syncPal->_operationsSorterWorker->fixMoveBeforeCreate();
-    _syncPal->_operationsSorterWorker->fixMoveBeforeDelete();
-    _syncPal->_operationsSorterWorker->fixCreateBeforeMove();
-    _syncPal->_operationsSorterWorker->fixDeleteBeforeCreate();
-    _syncPal->_operationsSorterWorker->fixMoveBeforeMoveOccupied();
-    _syncPal->_operationsSorterWorker->fixCreateBeforeCreate();
-    _syncPal->_operationsSorterWorker->fixEditBeforeMove();
-    _syncPal->_operationsSorterWorker->fixMoveBeforeMoveHierarchyFlip();
     (void) timer.elapsed("Operations sorted in");
 
     CPPUNIT_ASSERT_EQUAL(true, _syncPal->_operationsSorterWorker->hasOrderChanged());

--- a/test/libsyncengine/propagation/operation_sorter/testoperationsorterworker.h
+++ b/test/libsyncengine/propagation/operation_sorter/testoperationsorterworker.h
@@ -39,6 +39,7 @@ class TestOperationSorterWorker final : public CppUnit::TestFixture, public Test
         CPPUNIT_TEST(testFixMoveBeforeMoveParentChildFlip);
         CPPUNIT_TEST(testFixMoveBeforeMoveParentChildFlip2);
         CPPUNIT_TEST(testFixMoveBeforeMoveParentChildFlip3);
+        CPPUNIT_TEST(testCheckAllMethods);
         CPPUNIT_TEST(testFixImpossibleFirstMoveOp);
         CPPUNIT_TEST(testFindCompleteCycles);
         CPPUNIT_TEST(testBreakCycle);
@@ -62,6 +63,7 @@ class TestOperationSorterWorker final : public CppUnit::TestFixture, public Test
         void testFixMoveBeforeMoveParentChildFlip();
         void testFixMoveBeforeMoveParentChildFlip2();
         void testFixMoveBeforeMoveParentChildFlip3();
+        void testCheckAllMethods();
         void testFixImpossibleFirstMoveOp();
         void testFindCompleteCycles();
         void testBreakCycle();

--- a/test/libsyncengine/propagation/operation_sorter/testoperationsorterworker.h
+++ b/test/libsyncengine/propagation/operation_sorter/testoperationsorterworker.h
@@ -40,6 +40,7 @@ class TestOperationSorterWorker final : public CppUnit::TestFixture, public Test
         CPPUNIT_TEST(testFixMoveBeforeMoveParentChildFlip2);
         CPPUNIT_TEST(testFixMoveBeforeMoveParentChildFlip3);
         CPPUNIT_TEST(testCheckAllMethods);
+        CPPUNIT_TEST(testDifferentEncodings);
         CPPUNIT_TEST(testFixImpossibleFirstMoveOp);
         CPPUNIT_TEST(testFindCompleteCycles);
         CPPUNIT_TEST(testBreakCycle);
@@ -64,6 +65,7 @@ class TestOperationSorterWorker final : public CppUnit::TestFixture, public Test
         void testFixMoveBeforeMoveParentChildFlip2();
         void testFixMoveBeforeMoveParentChildFlip3();
         void testCheckAllMethods();
+        void testDifferentEncodings();
         void testFixImpossibleFirstMoveOp();
         void testFindCompleteCycles();
         void testBreakCycle();


### PR DESCRIPTION
There is a crash in `OperationSorterWorker` due to missing condition in the newly added "filter" class.