### PR TITLE
Return a LogicError if syncPal is not found

### DIFF
--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -3613,7 +3613,7 @@ ExitInfo AppServer::setSupportsVirtualFiles(int syncDbId, bool value) {
         LOG_WARN(_logger, msg.str());
         sentry::Handler::captureMessage(sentry::Level::Error, "Error in setSupportsVirtualFiles",
                                         msg.str());
-        return ExitCode::DataError;
+        return ExitCode::LogicError;
     }
 
     Sync sync;

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -3607,6 +3607,15 @@ ExitInfo AppServer::stopVfs(int syncDbId, bool unregister) {
 }
 
 ExitInfo AppServer::setSupportsVirtualFiles(int syncDbId, bool value) {
+    if (!_syncPalMap.contains(syncDbId)) {
+        std::stringstream msg;
+        msg << "SyncPal not found in syncPalMap for syncDbId=" << syncDbId;
+        LOG_WARN(_logger, msg.str());
+        sentry::Handler::captureMessage(sentry::Level::Error, "Error in setSupportsVirtualFiles",
+                                        msg.str());
+        return ExitCode::DataError;
+    }
+
     Sync sync;
     bool found = false;
     if (!ParmsDb::instance()->selectSync(syncDbId, sync, found)) {


### PR DESCRIPTION
I could not reproduce the crash on Windows. However, based on the received sentry events, I tried to exit the function with an appropriate error before the crash.