### PR TITLE
Never call the kStore api with a user id 0.

### DIFF
--- a/src/server/updater/updatechecker.cpp
+++ b/src/server/updater/updatechecker.cpp
@@ -127,6 +127,7 @@ ExitCode UpdateChecker::generateGetAppVersionJob(std::shared_ptr<AbstractNetwork
     }
     std::vector<int> userIdList;
     for (const auto &user: userList) {
+        if (user.userId() == 0) continue;
         userIdList.push_back(user.userId());
     }
 


### PR DESCRIPTION
Calling the api with a user id 0 lead to a 422 respons wich block the update process.