### PR TITLE
[KDESKTOP-1199] Defines a log-free normalizedSyncName function in libcommon/utility (to be used in gui)

### DIFF
--- a/src/libcommon/CMakeLists.txt
+++ b/src/libcommon/CMakeLists.txt
@@ -138,7 +138,11 @@ if(APPLE)
     target_link_libraries(${libcommon_NAME}
         ${FOUNDATION_LIBRARY}
         ${CORESERVICES_LIBRARY}
-        ${APPKIT_LIBRARY})
+        ${APPKIT_LIBRARY} utf8proc)
+endif()
+
+if(UNIX AND NOT APPLE)
+    target_link_libraries(${libcommon_NAME} utf8proc)
 endif()
 
 if(ZLIB_FOUND)

--- a/src/libcommon/CMakeLists.txt
+++ b/src/libcommon/CMakeLists.txt
@@ -138,10 +138,10 @@ if(APPLE)
     target_link_libraries(${libcommon_NAME}
         ${FOUNDATION_LIBRARY}
         ${CORESERVICES_LIBRARY}
-        ${APPKIT_LIBRARY} utf8proc)
+        ${APPKIT_LIBRARY})
 endif()
 
-if(UNIX AND NOT APPLE)
+if(UNIX)
     target_link_libraries(${libcommon_NAME} utf8proc)
 endif()
 

--- a/src/libcommon/utility/types.h
+++ b/src/libcommon/utility/types.h
@@ -763,6 +763,11 @@ struct VersionInfo {
 };
 using AllVersionsInfo = std::unordered_map<VersionChannel, VersionInfo>;
 
+enum class UnicodeNormalization {
+    NFC,
+    NFD
+};
+
 namespace sentry {
 enum class ConfidentialityLevel {
     Anonymous, // The sentry will not be able to identify the user (no ip, no email, no username, ...)

--- a/src/libcommon/utility/utility.h
+++ b/src/libcommon/utility/utility.h
@@ -157,6 +157,10 @@ struct COMMON_EXPORT CommonUtility {
 
         static void resetTranslations();
 
+        static bool normalizedSyncName(const SyncName &name, SyncName &normalizedName,
+                                       UnicodeNormalization normalization = UnicodeNormalization::NFC) noexcept;
+
+
     private:
         static std::mutex _generateRandomStringMutex;
 

--- a/src/libcommon/utility/utility_win.cpp
+++ b/src/libcommon/utility/utility_win.cpp
@@ -63,4 +63,50 @@ static inline bool hasDarkSystray_private() {
 
     return !settings.value(QLatin1String(lightThemeKeyC), true).toBool();
 }
+
+// Be careful, some characters have 2 different encodings in Unicode
+// For example 'é' can be coded as 0x65 + 0xcc + 0x81  or 0xc3 + 0xa9
+bool CommonUtility::normalizedSyncName(const SyncName &name, SyncName &normalizedName,
+                                       const UnicodeNormalization normalization) noexcept {
+    if (name.empty()) {
+        normalizedName = name;
+        return true;
+    }
+
+    static const int maxIterations = 10;
+    LPWSTR strResult = nullptr;
+    HANDLE hHeap = GetProcessHeap();
+
+    int64_t iSizeEstimated = static_cast<int64_t>(name.length() + 1) * 2;
+    for (int i = 0; i < maxIterations; i++) {
+        if (strResult) {
+            HeapFree(hHeap, 0, strResult);
+        }
+        strResult = (LPWSTR) HeapAlloc(hHeap, 0, iSizeEstimated * sizeof(WCHAR));
+        iSizeEstimated = NormalizeString(normalization == UnicodeNormalization::NFD ? NormalizationD : NormalizationC,
+                                         name.c_str(), -1, strResult, iSizeEstimated);
+
+        if (iSizeEstimated > 0) {
+            break; // success
+        }
+
+        if (iSizeEstimated <= 0) {
+            if (dwError != ERROR_INSUFFICIENT_BUFFER) {
+                return false;
+            }
+
+            // New guess is negative of the return value.
+            iSizeEstimated = -iSizeEstimated;
+        }
+    }
+
+    if (iSizeEstimated <= 0) {
+        return false;
+    }
+
+    (void) normalizedName.assign(strResult, iSizeEstimated - 1);
+    HeapFree(hHeap, 0, strResult);
+    return true;
+}
+
 } // namespace KDC

--- a/src/libcommon/utility/utility_win.cpp
+++ b/src/libcommon/utility/utility_win.cpp
@@ -91,7 +91,8 @@ bool CommonUtility::normalizedSyncName(const SyncName &name, SyncName &normalize
         }
 
         if (iSizeEstimated <= 0) {
-            if (dwError != ERROR_INSUFFICIENT_BUFFER) {
+            if (GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
+                // Real error, not buffer error
                 return false;
             }
 

--- a/src/libcommon/utility/utility_win.cpp
+++ b/src/libcommon/utility/utility_win.cpp
@@ -73,14 +73,14 @@ bool CommonUtility::normalizedSyncName(const SyncName &name, SyncName &normalize
         return true;
     }
 
-    static const int maxIterations = 10;
+    static const uint32_t maxIterations = 10;
     LPWSTR strResult = nullptr;
-    HANDLE hHeap = GetProcessHeap();
+    const HANDLE hHeap = GetProcessHeap();
 
     int64_t iSizeEstimated = static_cast<int64_t>(name.length() + 1) * 2;
-    for (int i = 0; i < maxIterations; i++) {
+    for (uint32_t i = 0; i < maxIterations; ++i) {
         if (strResult) {
-            HeapFree(hHeap, 0, strResult);
+            (void) HeapFree(hHeap, 0, strResult);
         }
         strResult = (LPWSTR) HeapAlloc(hHeap, 0, iSizeEstimated * sizeof(WCHAR));
         iSizeEstimated = NormalizeString(normalization == UnicodeNormalization::NFD ? NormalizationD : NormalizationC,
@@ -106,7 +106,7 @@ bool CommonUtility::normalizedSyncName(const SyncName &name, SyncName &normalize
     }
 
     (void) normalizedName.assign(strResult, iSizeEstimated - 1);
-    HeapFree(hHeap, 0, strResult);
+    (void) HeapFree(hHeap, 0, strResult);
     return true;
 }
 

--- a/src/libcommonserver/CMakeLists.txt
+++ b/src/libcommonserver/CMakeLists.txt
@@ -160,8 +160,7 @@ elseif(APPLE)
         xxHash::xxhash
         ${FOUNDATION_LIBRARY}
         ${CORESERVICES_LIBRARY}
-        ${APPKIT_LIBRARY}
-        utf8proc)
+        ${APPKIT_LIBRARY})
 else()
     target_link_libraries(${libcommonserver_NAME}
         "/usr/local/lib/libxxhash.so"

--- a/src/libcommonserver/utility/utility.h
+++ b/src/libcommonserver/utility/utility.h
@@ -182,11 +182,6 @@ struct COMMONSERVER_EXPORT Utility {
          */
         static std::string _errId(const char *file, int line);
 
-
-        enum class UnicodeNormalization {
-            NFC,
-            NFD
-        };
         static bool normalizedSyncName(const SyncName &name, SyncName &normalizedName,
                                        UnicodeNormalization normalization = UnicodeNormalization::NFC) noexcept;
         static bool normalizedSyncPath(const SyncPath &path, SyncPath &normalizedPath,

--- a/src/libsyncengine/db/syncdb.cpp
+++ b/src/libsyncengine/db/syncdb.cpp
@@ -2372,13 +2372,13 @@ bool SyncDb::selectNamesWithDistinctEncodings(NamedNodeMap &namedNodeMap) {
         LOG_IF_FAIL(querySyncNameValue(requestId, 1, nameLocal));
 
         SyncName nfcNormalizedName;
-        if (!Utility::normalizedSyncName(nameLocal, nfcNormalizedName, Utility::UnicodeNormalization::NFC)) {
+        if (!Utility::normalizedSyncName(nameLocal, nfcNormalizedName, UnicodeNormalization::NFC)) {
             LOGW_DEBUG(_logger, L"Error in Utility::normalizedSyncName: " << Utility::formatSyncName(nameLocal));
             return false;
         }
 
         SyncName nfdNormalizedName;
-        if (!Utility::normalizedSyncName(nameLocal, nfdNormalizedName, Utility::UnicodeNormalization::NFD)) {
+        if (!Utility::normalizedSyncName(nameLocal, nfdNormalizedName, UnicodeNormalization::NFD)) {
             LOGW_DEBUG(_logger, L"Error in Utility::normalizedSyncName: " << Utility::formatSyncName(nameLocal));
             return false;
         }

--- a/src/server/requests/serverrequests.cpp
+++ b/src/server/requests/serverrequests.cpp
@@ -1504,7 +1504,7 @@ ExitCode ServerRequests::addSync(int driveDbId, const QString &localFolderPath, 
 #ifdef __APPLE__
     // On macOS, the special characters in file names are NFD encoded. However, we use QFileDialog::getExistingDirectory to
     // retrieve the selected sync path which return a NFC encoded path.
-    (void) Utility::normalizedSyncPath(localFolderPath.toStdString(), localPath, Utility::UnicodeNormalization::NFD);
+    (void) Utility::normalizedSyncPath(localFolderPath.toStdString(), localPath, UnicodeNormalization::NFD);
 #endif
     sync.setLocalPath(localPath);
     sync.setTargetPath(QStr2Path(serverFolderPath));

--- a/test/libcommonserver/utility/testutility.cpp
+++ b/test/libcommonserver/utility/testutility.cpp
@@ -179,7 +179,7 @@ void TestUtility::testIsEqualUpToCaseAndEnc(void) {
     SyncName nfcNormalizedName;
     CPPUNIT_ASSERT(Utility::normalizedSyncName(Str("éééé"), nfcNormalizedName));
     SyncName nfdNormalizedName;
-    CPPUNIT_ASSERT(Utility::normalizedSyncName(Str("éééé"), nfdNormalizedName, Utility::UnicodeNormalization::NFD));
+    CPPUNIT_ASSERT(Utility::normalizedSyncName(Str("éééé"), nfdNormalizedName, UnicodeNormalization::NFD));
     CPPUNIT_ASSERT(Utility::checkIfEqualUpToCaseAndEncoding(nfcNormalizedName, nfdNormalizedName, isEqual) && isEqual);
 }
 
@@ -482,7 +482,7 @@ bool TestUtility::checkNfcAndNfdNamesEqual(const SyncName &name, bool &equal) {
         return false;
     }
     SyncName nfdNormalized;
-    if (!Utility::normalizedSyncName(name, nfdNormalized, Utility::UnicodeNormalization::NFD)) {
+    if (!Utility::normalizedSyncName(name, nfdNormalized, UnicodeNormalization::NFD)) {
         return false;
     }
     equal = (nfcNormalized == nfdNormalized);

--- a/test/libsyncengine/update_detection/file_system_observer/testsnapshot.cpp
+++ b/test/libsyncengine/update_detection/file_system_observer/testsnapshot.cpp
@@ -93,7 +93,7 @@ void TestSnapshot::testItemId() {
     Utility::normalizedSyncName(Str("abà"), nfcNormalized);
 
     SyncName nfdNormalized;
-    Utility::normalizedSyncName(Str("abà"), nfdNormalized, Utility::UnicodeNormalization::NFD);
+    Utility::normalizedSyncName(Str("abà"), nfdNormalized, UnicodeNormalization::NFD);
 
     snapshot.updateItem(SnapshotItem("6", "4", nfcNormalized, 1640995202, 1640995202, NodeType::Directory, 0, false, true, true));
     CPPUNIT_ASSERT_EQUAL(NodeId("7"), snapshot.itemId(SyncPath("a/ab") / nfcNormalized / Str("abaa")));

--- a/test/test_utility/testhelpers.cpp
+++ b/test/test_utility/testhelpers.cpp
@@ -37,7 +37,7 @@ namespace KDC::testhelpers {
 
 SyncName makeNfdSyncName() {
     SyncName nfdNormalized;
-    if (!Utility::normalizedSyncName(Str("ééé"), nfdNormalized, Utility::UnicodeNormalization::NFD)) {
+    if (!Utility::normalizedSyncName(Str("ééé"), nfdNormalized, UnicodeNormalization::NFD)) {
         assert(false);
     }
     return nfdNormalized;


### PR DESCRIPTION
This PR aims at sharing the utility function that computes the NFC and NFD normalizations of a file name with the `gui` module. In a forthcoming PR, the function `normalizedSyncName` will be used to ensure that file exclusion via template takes both normalizations into account.