### PR TITLE
Replace hardcoded ExitInfo int value.

### DIFF
--- a/src/libcommon/utility/types.h
+++ b/src/libcommon/utility/types.h
@@ -317,7 +317,7 @@ struct ExitInfo {
             // Example: "ExitInfo{Ok-Unknown}"
             return "ExitInfo{" + toString(code()) + "-" + toString(cause()) + srcLocStr() + "}";
         }
-        constexpr explicit operator bool() const { return _code == ExitCode::Ok; }
+        constexpr operator bool() const { return _code == ExitCode::Ok; }
         constexpr explicit operator int() const { return toInt(_code) * 100 + toInt(_cause); }
         constexpr bool operator==(const ExitInfo &other) const { return _code == other._code && _cause == other._cause; }
 

--- a/src/libcommon/utility/types.h
+++ b/src/libcommon/utility/types.h
@@ -317,7 +317,7 @@ struct ExitInfo {
             // Example: "ExitInfo{Ok-Unknown}"
             return "ExitInfo{" + toString(code()) + "-" + toString(cause()) + srcLocStr() + "}";
         }
-        constexpr operator bool() const { return _code == ExitCode::Ok; }
+        constexpr explicit operator bool() const { return _code == ExitCode::Ok; }
         constexpr explicit operator int() const { return toInt(_code) * 100 + toInt(_cause); }
         constexpr bool operator==(const ExitInfo &other) const { return _code == other._code && _cause == other._cause; }
 

--- a/test/libcommon/utility/testtypes.cpp
+++ b/test/libcommon/utility/testtypes.cpp
@@ -163,12 +163,18 @@ void TestTypes::testExitInfo() {
         exitInfo.merge(exitInfoToMerge, {ExitCode::SystemError, ExitCode::DbError, ExitCode::BackError});
         CPPUNIT_ASSERT_EQUAL(ExitCode::DbError, exitInfo.code());
     }
-    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok, ExitCause::Unknown), ExitInfo::fromInt(0));
-    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok, ExitCause::WorkerExited), ExitInfo::fromInt(1));
-    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Unknown, ExitCause::Unknown), ExitInfo::fromInt(100));
-    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::DataError, ExitCause::UnexpectedFileSystemEvent), ExitInfo::fromInt(414));
+
+    // Success code should remain 0 for readability, although comparing an enum to a hardcoded int is generally discouraged (forbidden)
+    // It should only be compared with the result of ExitInfo::operator int().
+    // The conversion to int is necessary for use in switch statements.
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok, ExitCause::Unknown), ExitInfo::fromInt(0)); 
+
+    // Ensure the int conversion is consistent in both directions.
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::DataError, ExitCause::UnexpectedFileSystemEvent),
+                         ExitInfo::fromInt(ExitInfo(ExitCode::DataError, ExitCause::UnexpectedFileSystemEvent).operator int()));
+
     // Because of the implementation of method ExitInfo::int(), we need to make sure that ExitCause enum never has more than 100
-    // values
+    // values.
     CPPUNIT_ASSERT(static_cast<int>(ExitCause::EnumEnd) < 100);
 }
 

--- a/test/libcommon/utility/testtypes.cpp
+++ b/test/libcommon/utility/testtypes.cpp
@@ -170,10 +170,8 @@ void TestTypes::testExitInfo() {
     CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok, ExitCause::Unknown), ExitInfo::fromInt(0)); 
 
     // Ensure the int conversion is consistent in both directions.
-    (CppUnit::assertEquals((ExitInfo(ExitCode::DataError, ExitCause::UnexpectedFileSystemEvent)),
-                           (ExitInfo::fromInt(static_cast<int>(ExitInfo(ExitCode::DataError, ExitCause::UnexpectedFileSystemEvent)))),
-                           CppUnit::SourceLine("C:\\Projects\\desktop-kDrive\\test\\libcommon\\utility\\testtypes.cpp", 174),
-                           ""));
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::DataError, ExitCause::UnexpectedFileSystemEvent),
+            ExitInfo::fromInt(static_cast<int>(ExitInfo(ExitCode::DataError, ExitCause::UnexpectedFileSystemEvent)))); 
 
     // Because of the implementation of method ExitInfo::int(), we need to make sure that ExitCause enum never has more than 100
     // values.

--- a/test/libcommon/utility/testtypes.cpp
+++ b/test/libcommon/utility/testtypes.cpp
@@ -170,8 +170,10 @@ void TestTypes::testExitInfo() {
     CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok, ExitCause::Unknown), ExitInfo::fromInt(0)); 
 
     // Ensure the int conversion is consistent in both directions.
-    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::DataError, ExitCause::UnexpectedFileSystemEvent),
-                         ExitInfo::fromInt(ExitInfo(ExitCode::DataError, ExitCause::UnexpectedFileSystemEvent)));
+    (CppUnit::assertEquals((ExitInfo(ExitCode::DataError, ExitCause::UnexpectedFileSystemEvent)),
+                           (ExitInfo::fromInt(static_cast<int>(ExitInfo(ExitCode::DataError, ExitCause::UnexpectedFileSystemEvent)))),
+                           CppUnit::SourceLine("C:\\Projects\\desktop-kDrive\\test\\libcommon\\utility\\testtypes.cpp", 174),
+                           ""));
 
     // Because of the implementation of method ExitInfo::int(), we need to make sure that ExitCause enum never has more than 100
     // values.

--- a/test/libcommon/utility/testtypes.cpp
+++ b/test/libcommon/utility/testtypes.cpp
@@ -171,7 +171,7 @@ void TestTypes::testExitInfo() {
 
     // Ensure the int conversion is consistent in both directions.
     CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::DataError, ExitCause::UnexpectedFileSystemEvent),
-                         ExitInfo::fromInt(ExitInfo(ExitCode::DataError, ExitCause::UnexpectedFileSystemEvent).operator int()));
+                         ExitInfo::fromInt(ExitInfo(ExitCode::DataError, ExitCause::UnexpectedFileSystemEvent)));
 
     // Because of the implementation of method ExitInfo::int(), we need to make sure that ExitCause enum never has more than 100
     // values.


### PR DESCRIPTION
The aim of this PR is to avoid having to edit the tests each time an Exicode or cause is added or removed.