### PR TITLE
fix(cmake): update cppunit library links to use dynamic versions

### DIFF
--- a/test/libcommon/CMakeLists.txt
+++ b/test/libcommon/CMakeLists.txt
@@ -55,9 +55,9 @@ target_link_libraries(${testcommon_NAME}
 if (WIN32)
     target_link_libraries(${testcommon_NAME}
             debug
-            "C:/Program Files (x86)/cppunit/lib/cppunitd.lib"
+            "C:/Program Files (x86)/cppunit/lib/cppunitd_dll.lib"
             optimized
-            "C:/Program Files (x86)/cppunit/lib/cppunit.lib")
+            "C:/Program Files (x86)/cppunit/lib/cppunit_dll.lib")
 elseif (APPLE)
     target_link_libraries(${testcommon_NAME}
             "/usr/local/lib/libcppunit.dylib")

--- a/test/libcommon/CMakeLists.txt
+++ b/test/libcommon/CMakeLists.txt
@@ -53,7 +53,6 @@ target_link_libraries(${testcommon_NAME}
 )
 
 if (WIN32)
-    message(STATUS "Linking cppunit dll for ${testcommon_NAME}")
     target_link_libraries(${testcommon_NAME}
             debug
             "C:/Program Files (x86)/cppunit/lib/cppunitd_dll.lib"

--- a/test/libcommon/CMakeLists.txt
+++ b/test/libcommon/CMakeLists.txt
@@ -53,6 +53,7 @@ target_link_libraries(${testcommon_NAME}
 )
 
 if (WIN32)
+    message(STATUS "Linking cppunit dll for ${testcommon_NAME}")
     target_link_libraries(${testcommon_NAME}
             debug
             "C:/Program Files (x86)/cppunit/lib/cppunitd_dll.lib"

--- a/test/libcommonserver/CMakeLists.txt
+++ b/test/libcommonserver/CMakeLists.txt
@@ -64,9 +64,9 @@ target_link_libraries(${testcommonserver_NAME}
 if (WIN32)
     target_link_libraries(${testcommonserver_NAME}
             debug
-            "C:/Program Files (x86)/cppunit/lib/cppunitd.lib"
+            "C:/Program Files (x86)/cppunit/lib/cppunitd_dll.lib"
             optimized
-            "C:/Program Files (x86)/cppunit/lib/cppunit.lib")
+            "C:/Program Files (x86)/cppunit/lib/cppunit_dll.lib")
 elseif (APPLE)
     target_link_libraries(${testcommonserver_NAME}
             "/usr/local/lib/libcppunit.dylib")

--- a/test/libcommonserver/CMakeLists.txt
+++ b/test/libcommonserver/CMakeLists.txt
@@ -62,7 +62,6 @@ target_link_libraries(${testcommonserver_NAME}
 )
 
 if (WIN32)
-    message(STATUS "Linking cppunit dll for ${testcommonserver_NAME}")
     target_link_libraries(${testcommonserver_NAME}
             debug
             "C:/Program Files (x86)/cppunit/lib/cppunitd_dll.lib"

--- a/test/libcommonserver/CMakeLists.txt
+++ b/test/libcommonserver/CMakeLists.txt
@@ -62,6 +62,7 @@ target_link_libraries(${testcommonserver_NAME}
 )
 
 if (WIN32)
+    message(STATUS "Linking cppunit dll for ${testcommonserver_NAME}")
     target_link_libraries(${testcommonserver_NAME}
             debug
             "C:/Program Files (x86)/cppunit/lib/cppunitd_dll.lib"

--- a/test/libparms/CMakeLists.txt
+++ b/test/libparms/CMakeLists.txt
@@ -44,9 +44,9 @@ target_link_libraries(${testparms_NAME}
 if (WIN32)
     target_link_libraries(${testparms_NAME}
         debug
-        "C:/Program Files (x86)/cppunit/lib/cppunitd.lib"
+        "C:/Program Files (x86)/cppunit/lib/cppunitd_dll.lib"
         optimized
-        "C:/Program Files (x86)/cppunit/lib/cppunit.lib")
+        "C:/Program Files (x86)/cppunit/lib/cppunit_dll.lib")
 elseif(APPLE)
     target_link_libraries(${testparms_NAME}
         "/usr/local/lib/libcppunit.dylib")

--- a/test/libsyncengine/CMakeLists.txt
+++ b/test/libsyncengine/CMakeLists.txt
@@ -109,10 +109,10 @@ target_link_libraries(${testsyncengine_NAME}
 
 if (WIN32)
     target_link_libraries(${testsyncengine_NAME}
-            debug
-            "C:/Program Files (x86)/cppunit/lib/cppunitd_dll.lib"
-            optimized
-            "C:/Program Files (x86)/cppunit/lib/cppunit_dll.lib")
+        debug
+        "C:/Program Files (x86)/cppunit/lib/cppunitd_dll.lib"
+        optimized
+        "C:/Program Files (x86)/cppunit/lib/cppunit_dll.lib")
 elseif(APPLE)
     target_link_libraries(${testsyncengine_NAME}
             "/usr/local/lib/libcppunit.dylib")

--- a/test/libsyncengine/CMakeLists.txt
+++ b/test/libsyncengine/CMakeLists.txt
@@ -108,7 +108,6 @@ target_link_libraries(${testsyncengine_NAME}
 )
 
 if (WIN32)
-    message(STATUS "Linking cppunit dll for ${testsyncengine_NAME}")
     target_link_libraries(${testsyncengine_NAME}
             debug
             "C:/Program Files (x86)/cppunit/lib/cppunitd_dll.lib"

--- a/test/libsyncengine/CMakeLists.txt
+++ b/test/libsyncengine/CMakeLists.txt
@@ -109,10 +109,10 @@ target_link_libraries(${testsyncengine_NAME}
 
 if (WIN32)
     target_link_libraries(${testsyncengine_NAME}
-        debug
-        "C:/Program Files (x86)/cppunit/lib/cppunitd.lib"
-        optimized
-        "C:/Program Files (x86)/cppunit/lib/cppunit.lib")
+            debug
+            "C:/Program Files (x86)/cppunit/lib/cppunitd_dll.lib"
+            optimized
+            "C:/Program Files (x86)/cppunit/lib/cppunit_dll.lib")
 elseif(APPLE)
     target_link_libraries(${testsyncengine_NAME}
             "/usr/local/lib/libcppunit.dylib")

--- a/test/libsyncengine/CMakeLists.txt
+++ b/test/libsyncengine/CMakeLists.txt
@@ -108,6 +108,7 @@ target_link_libraries(${testsyncengine_NAME}
 )
 
 if (WIN32)
+    message(STATUS "Linking cppunit dll for ${testsyncengine_NAME}")
     target_link_libraries(${testsyncengine_NAME}
             debug
             "C:/Program Files (x86)/cppunit/lib/cppunitd_dll.lib"

--- a/test/server/CMakeLists.txt
+++ b/test/server/CMakeLists.txt
@@ -138,7 +138,6 @@ if (APPLE)
 endif()
 
 if (WIN32)
-    message(STATUS "Linking cppunit dll for ${testserver_NAME}")
     target_link_libraries(${testserver_NAME}
             debug
             "C:/Program Files (x86)/cppunit/lib/cppunitd_dll.lib"

--- a/test/server/CMakeLists.txt
+++ b/test/server/CMakeLists.txt
@@ -140,9 +140,9 @@ endif()
 if (WIN32)
     target_link_libraries(${testserver_NAME}
             debug
-            "C:/Program Files (x86)/cppunit/lib/cppunitd.lib"
+            "C:/Program Files (x86)/cppunit/lib/cppunitd_dll.lib"
             optimized
-            "C:/Program Files (x86)/cppunit/lib/cppunit.lib")
+            "C:/Program Files (x86)/cppunit/lib/cppunit_dll.lib")
 elseif (APPLE)
     target_link_libraries(${testserver_NAME}
             "/usr/local/lib/libcppunit.dylib")

--- a/test/server/CMakeLists.txt
+++ b/test/server/CMakeLists.txt
@@ -138,6 +138,7 @@ if (APPLE)
 endif()
 
 if (WIN32)
+    message(STATUS "Linking cppunit dll for ${testserver_NAME}")
     target_link_libraries(${testserver_NAME}
             debug
             "C:/Program Files (x86)/cppunit/lib/cppunitd_dll.lib"


### PR DESCRIPTION
This pull request updates the `CMakeLists.txt` files for multiple test libraries to use the dynamically linked versions of the CppUnit library on Windows. This change ensures consistency in linking and may address compatibility or runtime issues related to static vs. dynamic linking.

* `test/*/CMakeLists.txt`: Updated to use `cppunitd_dll.lib` and `cppunit_dll.lib` for debug and optimized builds, respectively, instead of their static counterparts.