### PR TITLE
Kdesktop 1714 Set move origin info in undo move

### DIFF
--- a/src/libsyncengine/reconciliation/conflict_resolver/conflictresolverworker.cpp
+++ b/src/libsyncengine/reconciliation/conflict_resolver/conflictresolverworker.cpp
@@ -24,7 +24,8 @@
 namespace KDC {
 
 ConflictResolverWorker::ConflictResolverWorker(std::shared_ptr<SyncPal> syncPal, const std::string &name,
-                                               const std::string &shortName) : OperationProcessor(syncPal, name, shortName) {}
+                                               const std::string &shortName) :
+    OperationProcessor(syncPal, name, shortName) {}
 
 void ConflictResolverWorker::execute() {
     LOG_SYNCPAL_DEBUG(_logger, "Worker started: name=" << name());
@@ -363,6 +364,8 @@ ExitCode ConflictResolverWorker::undoMove(const std::shared_ptr<Node> moveNode, 
 
     moveOp->setType(OperationType::Move);
     const auto correspondingNode = correspondingNodeInOtherTree(moveNode);
+    correspondingNode->setMoveOriginInfos({moveNode->getPath(), moveNode->parentNode()->id().value_or("")});
+    correspondingNode->insertChangeEvent(OperationType::Move);
     moveOp->setAffectedNode(correspondingNode);
     moveOp->setCorrespondingNode(moveNode);
     moveOp->setTargetSide(moveNode->side());

--- a/test/libsyncengine/reconciliation/conflict_resolver/testconflictresolverworker.cpp
+++ b/test/libsyncengine/reconciliation/conflict_resolver/testconflictresolverworker.cpp
@@ -97,6 +97,9 @@ void TestConflictResolverWorker::testEditEdit() {
     CPPUNIT_ASSERT(!op->newName().empty());
     CPPUNIT_ASSERT_EQUAL(ReplicaSide::Local, op->targetSide());
     CPPUNIT_ASSERT_EQUAL(OperationType::Move, op->type());
+    CPPUNIT_ASSERT(op->affectedNode()->hasChangeEvent(OperationType::Move));
+    CPPUNIT_ASSERT(op->affectedNode()->moveOriginInfos().parentNodeId() != defaultInvalidNodeId);
+    CPPUNIT_ASSERT(op->affectedNode()->moveOriginInfos().path() != defaultInvalidPath);
 }
 
 void TestConflictResolverWorker::testMoveCreate() {
@@ -565,6 +568,9 @@ void TestConflictResolverWorker::testMoveMoveSource() {
     CPPUNIT_ASSERT(!op->newName().empty());
     CPPUNIT_ASSERT_EQUAL(ReplicaSide::Local, op->targetSide());
     CPPUNIT_ASSERT_EQUAL(OperationType::Move, op->type());
+    CPPUNIT_ASSERT(op->affectedNode()->hasChangeEvent(OperationType::Move));
+    CPPUNIT_ASSERT(op->affectedNode()->moveOriginInfos().parentNodeId() != defaultInvalidNodeId);
+    CPPUNIT_ASSERT(op->affectedNode()->moveOriginInfos().path() != defaultInvalidPath);
 }
 
 void TestConflictResolverWorker::testMoveMoveSourceDehydratedPlaceholder() {
@@ -618,6 +624,9 @@ void TestConflictResolverWorker::testMoveMoveDest() {
     CPPUNIT_ASSERT(!op->newName().empty());
     CPPUNIT_ASSERT_EQUAL(ReplicaSide::Local, op->targetSide());
     CPPUNIT_ASSERT_EQUAL(OperationType::Move, op->type());
+    CPPUNIT_ASSERT(op->affectedNode()->hasChangeEvent(OperationType::Move));
+    CPPUNIT_ASSERT(op->affectedNode()->moveOriginInfos().parentNodeId() != defaultInvalidNodeId);
+    CPPUNIT_ASSERT(op->affectedNode()->moveOriginInfos().path() != defaultInvalidPath);
     const auto lNodeAA = _testSituationGenerator.getNode(ReplicaSide::Local, "aa");
     CPPUNIT_ASSERT_EQUAL(lNodeAA, op->newParentNode());
 }
@@ -676,6 +685,9 @@ void TestConflictResolverWorker::testMoveMoveCycle() {
     CPPUNIT_ASSERT_EQUAL(lNodeA, op->newParentNode());
     CPPUNIT_ASSERT_EQUAL(ReplicaSide::Local, op->targetSide());
     CPPUNIT_ASSERT_EQUAL(OperationType::Move, op->type());
+    CPPUNIT_ASSERT(op->affectedNode()->hasChangeEvent(OperationType::Move));
+    CPPUNIT_ASSERT(op->affectedNode()->moveOriginInfos().parentNodeId() != defaultInvalidNodeId);
+    CPPUNIT_ASSERT(op->affectedNode()->moveOriginInfos().path() != defaultInvalidPath);
 }
 
 void TestConflictResolverWorker::testMoveMoveCycle2() {
@@ -711,6 +723,9 @@ void TestConflictResolverWorker::testMoveMoveCycle2() {
     CPPUNIT_ASSERT_EQUAL(lNodeAA, op->newParentNode());
     CPPUNIT_ASSERT_EQUAL(ReplicaSide::Local, op->targetSide());
     CPPUNIT_ASSERT_EQUAL(OperationType::Move, op->type());
+    CPPUNIT_ASSERT(op->affectedNode()->hasChangeEvent(OperationType::Move));
+    CPPUNIT_ASSERT(op->affectedNode()->moveOriginInfos().parentNodeId() != defaultInvalidNodeId);
+    CPPUNIT_ASSERT(op->affectedNode()->moveOriginInfos().path() != defaultInvalidPath);
 }
 
 } // namespace KDC


### PR DESCRIPTION
This PR fixes in particular the following issue:
- Create and fully synchronize two folders `A` and `B`.
- Pause the synchronization.
- Locally, move `A` into `B`.
- Remotely, move `B` into `A`.

**Actual outcome:** 
- Assertion failure in _Debug_ mode (`node.cpp:276 - Condition failure: "isValid()" in file node.cpp`).
- The two folders are deleted in _Release_ Mode.

Once applied, this fix ensures that there is no assertion failure and the final situation is 
```
└── A
    └── B
```