### PR TITLE
Kdesktop 1368 mac os finder status icons shortcut unavailable after an external disc containing a sync folder is mounted

### DIFF
--- a/src/gui/parametersdialog.cpp
+++ b/src/gui/parametersdialog.cpp
@@ -507,6 +507,12 @@ QString ParametersDialog::getSyncPalErrorText(const QString &fctCode, const Exit
                         "this "
                         "time.<br>"
                         "The application will use system proxy settings instead.");
+            } else if (exitCause == ExitCause::SyncDirDoesntExist) {
+                return tr(
+                        "Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at "
+                        "this "
+                        "time.<br>"
+                        "The application will use system proxy settings instead.");
             } else {
                 return tr("A technical error has occurred (error %1).<br>"
                           "Synchronization has been restarted. Please empty the history and if the error persists, please "

--- a/src/libsyncengine/jobs/local/localcopyjob.cpp
+++ b/src/libsyncengine/jobs/local/localcopyjob.cpp
@@ -49,7 +49,7 @@ bool LocalCopyJob::canRun() {
 
     if (exists) {
         LOGW_DEBUG(_logger, L"Item " << Path2WStr(_dest).c_str() << L" already exist. Aborting current sync and restart.");
-        _exitInfo = {ExitCode::DataError, ExitCause::UnexpectedFileSystemEvent};
+        _exitInfo = {ExitCode::DataError, ExitCause::FileAlreadyExists};
         return false;
     }
 
@@ -68,7 +68,7 @@ bool LocalCopyJob::canRun() {
     if (!exists) {
         LOGW_DEBUG(_logger,
                    L"Item does not exist anymore. Aborting current sync and restart. - path=" << Path2WStr(_source).c_str());
-        _exitInfo = {ExitCode::DataError, ExitCause::UnexpectedFileSystemEvent};
+        _exitInfo = {ExitCode::DataError, ExitCause::NotFound};
         return false;
     }
 

--- a/src/libsyncengine/jobs/local/localdeletejob.cpp
+++ b/src/libsyncengine/jobs/local/localdeletejob.cpp
@@ -118,7 +118,7 @@ bool LocalDeleteJob::canRun() {
     if (!exists) {
         LOGW_DEBUG(_logger, L"Item does not exist anymore. Aborting current sync and restart: "
                                     << Utility::formatSyncPath(_absolutePath).c_str());
-        _exitInfo = {ExitCode::DataError, ExitCause::UnexpectedFileSystemEvent};
+        _exitInfo = {ExitCode::DataError, ExitCause::NotFound};
         return false;
     }
 

--- a/src/libsyncengine/jobs/local/localmovejob.cpp
+++ b/src/libsyncengine/jobs/local/localmovejob.cpp
@@ -75,7 +75,7 @@ bool LocalMoveJob::canRun() {
 
     if (!exists) {
         LOGW_DEBUG(_logger, L"Item does not exist anymore: " << Utility::formatSyncPath(_source));
-        _exitInfo = {ExitCode::DataError, ExitCause::InvalidDestination};
+        _exitInfo = {ExitCode::DataError, ExitCause::NotFound};
         return false;
     }
 

--- a/src/libsyncengine/jobs/network/API_v2/downloadjob.cpp
+++ b/src/libsyncengine/jobs/network/API_v2/downloadjob.cpp
@@ -136,6 +136,20 @@ bool DownloadJob::canRun() {
         return false;
     }
 
+    // Check that parent folder exist
+    if (!IoHelper::checkIfPathExists(_localpath.parent_path(), exists, ioError)) {
+        LOGW_WARN(_logger, L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(_localpath, ioError));
+        _exitInfo = {ExitCode::SystemError, ExitCause::FileAccessError};
+        return false;
+    }
+
+    if (!exists) {
+        LOGW_DEBUG(_logger, L"Impossible to download item " << Utility::formatSyncPath(_localpath)
+                                                            << L" because the parent does not exist.");
+        _exitInfo = {ExitCode::DataError, ExitCause::NotFound};
+        return false;
+    }
+
     return true;
 }
 

--- a/src/libsyncengine/syncpal/isyncworker.h
+++ b/src/libsyncengine/syncpal/isyncworker.h
@@ -56,8 +56,6 @@ class ISyncWorker {
 
         bool _testing{false};
         virtual void init();
-
-    protected:
         //! Wait for a delay. Allows to postpone the start of the worker to smooth the load.
         /*!
           \param awakenByStop will be true if a stop of the worker has been requested, false otherwise.

--- a/src/libsyncengine/syncpal/syncpal.cpp
+++ b/src/libsyncengine/syncpal/syncpal.cpp
@@ -1168,8 +1168,8 @@ bool SyncPal::pauseAsked() const {
     return _syncPalWorker && _syncPalWorker->pauseAsked();
 }
 
-bool SyncPal::shouldBeRestarted() const {
-    return _syncPalWorker && _syncPalWorker->shouldBeRestarted();
+bool SyncPal::shouldRetry() const {
+    return _syncPalWorker && _syncPalWorker->shouldRetry();
 }
 
 bool SyncPal::isIdle() const {

--- a/src/libsyncengine/syncpal/syncpal.cpp
+++ b/src/libsyncengine/syncpal/syncpal.cpp
@@ -1046,7 +1046,7 @@ void SyncPal::start(const std::chrono::seconds &startDelay) {
 
     // Load VFS mode
     Sync sync;
-    bool found;
+    bool found = false;
     if (!ParmsDb::instance()->selectSync(syncDbId(), sync, found)) {
         LOG_SYNCPAL_WARN(_logger, "Error in ParmsDb::selectSync");
         addError(Error(syncDbId(), errId(), ExitCode::DbError, ExitCause::Unknown));
@@ -1060,8 +1060,8 @@ void SyncPal::start(const std::chrono::seconds &startDelay) {
     setVfsMode(sync.virtualFileMode());
 
     // Clear tmp blacklist
-    SyncNodeCache::instance()->update(syncDbId(), SyncNodeType::TmpRemoteBlacklist, NodeSet());
-    SyncNodeCache::instance()->update(syncDbId(), SyncNodeType::TmpLocalBlacklist, NodeSet());
+    (void) SyncNodeCache::instance()->update(syncDbId(), SyncNodeType::TmpRemoteBlacklist, NodeSet());
+    (void) SyncNodeCache::instance()->update(syncDbId(), SyncNodeType::TmpLocalBlacklist, NodeSet());
 
     // Create and init shared objects
     createSharedObjects();
@@ -1166,6 +1166,10 @@ bool SyncPal::isPaused() const {
 
 bool SyncPal::pauseAsked() const {
     return _syncPalWorker && _syncPalWorker->pauseAsked();
+}
+
+bool SyncPal::shouldBeRestarted() const {
+    return _syncPalWorker && _syncPalWorker->shouldBeRestarted();
 }
 
 bool SyncPal::isIdle() const {

--- a/src/libsyncengine/syncpal/syncpal.h
+++ b/src/libsyncengine/syncpal/syncpal.h
@@ -192,7 +192,7 @@ class SYNCENGINE_EXPORT SyncPal : public std::enable_shared_from_this<SyncPal> {
         std::chrono::time_point<std::chrono::steady_clock> pauseTime() const;
         bool isPaused() const;
         bool pauseAsked() const;
-        bool shouldBeRestarted() const;
+        bool shouldRetry() const;
         bool isIdle() const;
         bool isRunning() const;
 

--- a/src/libsyncengine/syncpal/syncpal.h
+++ b/src/libsyncengine/syncpal/syncpal.h
@@ -192,6 +192,7 @@ class SYNCENGINE_EXPORT SyncPal : public std::enable_shared_from_this<SyncPal> {
         std::chrono::time_point<std::chrono::steady_clock> pauseTime() const;
         bool isPaused() const;
         bool pauseAsked() const;
+        bool shouldBeRestarted() const;
         bool isIdle() const;
         bool isRunning() const;
 

--- a/src/libsyncengine/syncpal/syncpalworker.cpp
+++ b/src/libsyncengine/syncpal/syncpalworker.cpp
@@ -52,7 +52,7 @@ void SyncPalWorker::execute() {
 #endif
     }
 
-    _restartLater = false;
+    _retryLater = false;
 
     // Wait before really starting
     bool awakenByStop = false;
@@ -189,7 +189,7 @@ void SyncPalWorker::execute() {
                     const auto exitCause = stepWorkers[0] ? stepWorkers[0]->exitCause() : stepWorkers[1]->exitCause();
                     switch (exitCause) {
                         case ExitCause::SyncDirDoesntExist:
-                            restartLater();
+                            retryLater();
                             [[fallthrough]];
                         case ExitCause::NotEnoughDiskSpace:
                         case ExitCause::FileAccessError:
@@ -284,9 +284,15 @@ void SyncPalWorker::unpause() {
     _syncPal->setRestart(true);
 }
 
-void SyncPalWorker::restartLater() {
-    _restartLater = true;
+void SyncPalWorker::retryLater() {
+    _retryLater = true;
     _pauseTime = std::chrono::steady_clock::now();
+}
+
+bool SyncPalWorker::shouldRetry() {
+    const auto val = _retryLater;
+    _retryLater = false;
+    return val;
 }
 
 std::string SyncPalWorker::stepName(SyncStep step) {

--- a/src/libsyncengine/syncpal/syncpalworker.cpp
+++ b/src/libsyncengine/syncpal/syncpalworker.cpp
@@ -184,13 +184,9 @@ void SyncPalWorker::execute() {
                     (stepWorkers[1] && workersExitCode[1] == ExitCode::SystemError)) {
                     const auto exitCause = stepWorkers[0] ? stepWorkers[0]->exitCause() : stepWorkers[1]->exitCause();
                     if (exitCause == ExitCause::NotEnoughDiskSpace || exitCause == ExitCause::FileAccessError ||
-                        exitCause == ExitCause::SyncDirAccesError) {
+                        exitCause == ExitCause::SyncDirAccesError || exitCause == ExitCause::SyncDirDoesntExist) {
                         // Exit without error
                         exitCode = ExitCode::Ok;
-                        break;
-                    }
-                    if (exitCause == ExitCause::SyncDirDoesntExist) {
-                        exitCode = ExitCode::SystemError;
                         break;
                     }
                 }

--- a/src/libsyncengine/syncpal/syncpalworker.h
+++ b/src/libsyncengine/syncpal/syncpalworker.h
@@ -37,11 +37,19 @@ class SyncPalWorker : public ISyncWorker {
         inline bool isPaused() const { return _isPaused; }
         inline bool pauseAsked() const { return _pauseAsked; }
         void unpause();
-        void restartLater();
-        inline bool shouldBeRestarted() const { return _restartLater; }
         inline SyncStep step() const { return _step; }
         inline std::chrono::time_point<std::chrono::steady_clock> pauseTime() const { return _pauseTime; }
         static std::string stepName(SyncStep step);
+
+        /**
+         * @brief Schedule a restart of the sync.
+         */
+        void retryLater();
+        /**
+         * @brief Check if we should retry to start the sync and reset the flag to `false`.
+         * @return `true` if the sync should be restarted.
+         */
+        bool shouldRetry();
 
     private:
         SyncStep _step{SyncStep::Idle};
@@ -49,7 +57,7 @@ class SyncPalWorker : public ISyncWorker {
         bool _pauseAsked{false};
         bool _unpauseAsked{false};
         bool _isPaused{false};
-        bool _restartLater{false};
+        bool _retryLater{false};
         std::thread _resetVfsFilesStatusThread;
         void initStep(SyncStep step, std::shared_ptr<ISyncWorker> (&workers)[2],
                       std::shared_ptr<SharedObject> (&inputSharedObject)[2]);

--- a/src/libsyncengine/syncpal/syncpalworker.h
+++ b/src/libsyncengine/syncpal/syncpalworker.h
@@ -37,6 +37,8 @@ class SyncPalWorker : public ISyncWorker {
         inline bool isPaused() const { return _isPaused; }
         inline bool pauseAsked() const { return _pauseAsked; }
         void unpause();
+        void restartLater();
+        inline bool shouldBeRestarted() const { return _restartLater; }
         inline SyncStep step() const { return _step; }
         inline std::chrono::time_point<std::chrono::steady_clock> pauseTime() const { return _pauseTime; }
         static std::string stepName(SyncStep step);
@@ -47,6 +49,7 @@ class SyncPalWorker : public ISyncWorker {
         bool _pauseAsked{false};
         bool _unpauseAsked{false};
         bool _isPaused{false};
+        bool _restartLater{false};
         std::thread _resetVfsFilesStatusThread;
         void initStep(SyncStep step, std::shared_ptr<ISyncWorker> (&workers)[2],
                       std::shared_ptr<SharedObject> (&inputSharedObject)[2]);

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -4269,10 +4269,12 @@ void AppServer::onRestartSyncs() {
 
     for (const auto &[syncId, syncPtr]: _syncPalMap) {
         if (!syncPtr) continue;
-        if ((syncPtr->isPaused() || syncPtr->pauseAsked()) &&
-            syncPtr->pauseTime() + std::chrono::minutes(1) < std::chrono::steady_clock::now()) {
+        if (syncPtr->pauseTime() + std::chrono::minutes(1) > std::chrono::steady_clock::now()) return;
+        if (syncPtr->isPaused() || syncPtr->pauseAsked()) {
             syncPtr->unpause();
         }
+        if (syncPtr->shouldBeRestarted()) syncPtr->start();
     }
 }
+
 } // namespace KDC

--- a/src/server/appserver.h
+++ b/src/server/appserver.h
@@ -160,10 +160,13 @@ class AppServer : public SharedTools::QtSingleApplication {
         void startSyncsAndRetryOnError();
         [[nodiscard]] ExitInfo startSyncs();
         [[nodiscard]] ExitInfo startSyncs(User &user);
+        void startSyncAndRetryOnError(int syncDbId);
+        [[nodiscard]] ExitInfo startSync(int syncDbId, std::chrono::seconds startDelay = std::chrono::seconds::zero());
+        [[nodiscard]] ExitInfo startSync(const Sync &sync, std::chrono::seconds startDelay = std::chrono::seconds::zero());
         [[nodiscard]] ExitInfo processMigratedSyncOnceConnected(int userDbId, int driveId, Sync &sync, QSet<QString> &blackList,
                                                                 QSet<QString> &undecidedList, bool &syncUpdated);
         ExitCode clearErrors(int syncDbId, bool autoResolved = false);
-        // Check if the synchronization `sync` is registred in the sync database and
+        // Check if the synchronization `sync` is registered in the sync database and
         // if the `sync` folder does not contain any other sync subfolder.
         [[nodiscard]] ExitInfo checkIfSyncIsValid(const Sync &sync);
 


### PR DESCRIPTION
The sync was not correctly restarted once an external drive on which there is a synchronization is plugged in.
This PR include a simple refactoring of the methods used to start a sync in `AppServer` allowing to simplify the restart of a single sync.