### PR TITLE
Clear operation sorter filter data on every new sync

### DIFF
--- a/src/libsyncengine/propagation/operation_sorter/operationsorterfilter.cpp
+++ b/src/libsyncengine/propagation/operation_sorter/operationsorterfilter.cpp
@@ -22,6 +22,8 @@ OperationSorterFilter::OperationSorterFilter(const std::unordered_map<UniqueId, 
     _ops(ops) {}
 
 void OperationSorterFilter::filterOperations() {
+    clear();
+
     NameToOpMap deleteBeforeMoveCandidates;
     NameToOpMap moveBeforeCreateCandidates;
     SyncPathToSyncOpMap deletedDirectoryPaths;
@@ -44,6 +46,18 @@ void OperationSorterFilter::filterOperations() {
         filterMoveBeforeMoveHierarchyFlipCandidates(op, moveBeforeMoveHierarchyFlipCandidates);
     }
 }
+
+void OperationSorterFilter::clear() {
+    _fixDeleteBeforeMoveCandidates.clear();
+    _fixMoveBeforeCreateCandidates.clear();
+    _fixMoveBeforeDeleteCandidates.clear();
+    _fixCreateBeforeMoveCandidates.clear();
+    _fixDeleteBeforeCreateCandidates.clear();
+    _fixMoveBeforeMoveOccupiedCandidates.clear();
+    _fixEditBeforeMoveCandidates.clear();
+    _fixMoveBeforeMoveHierarchyFlipCandidates.clear();
+}
+
 // delete before move, e.g. user deletes an object at path "x" and moves another object "a" to "x".
 void OperationSorterFilter::filterDeleteBeforeMoveCandidates(const SyncOpPtr &op, NameToOpMap &deleteBeforeMoveCandidates) {
     if (op->type() == OperationType::Delete || op->type() == OperationType::Move) {

--- a/src/libsyncengine/propagation/operation_sorter/operationsorterfilter.h
+++ b/src/libsyncengine/propagation/operation_sorter/operationsorterfilter.h
@@ -33,6 +33,7 @@ class OperationSorterFilter {
         explicit OperationSorterFilter(const std::unordered_map<UniqueId, SyncOpPtr> &ops);
 
         void filterOperations();
+        void clear();
 
         [[nodiscard]] const std::list<std::pair<SyncOpPtr, SyncOpPtr>> &fixDeleteBeforeMoveCandidates() const {
             return _fixDeleteBeforeMoveCandidates;


### PR DESCRIPTION
Operation sorter filter data structures were not cleared on every new sync, which mean that nodes previously inserted remains in the filter even if they are not susceptible to be rearranged anymore.