### PR TITLE
Avoid spurrious edit-X conflict if the local edit is ommited

### DIFF
--- a/src/libsyncengine/reconciliation/conflict_resolver/conflictresolverworker.h
+++ b/src/libsyncengine/reconciliation/conflict_resolver/conflictresolverworker.h
@@ -52,9 +52,20 @@ class ConflictResolverWorker : public OperationProcessor {
          * @return ExitCode indicating if the operation was successful.
          */
         ExitCode handleConflictOnDehydratedPlaceholder(const Conflict &conflict, bool &continueSolving);
+
         /**
-         * @brief For Create-Create and Edit-Edit conflicts, the local file is renamed and excluded from the sync in order no to
-         * lose any changes. The remote file will be pulled on next sync.
+         * @brief If we have a conflict between a local edit and a remote operation, and if the local edit is omitted (ie, only
+         * propagation a creation date to db), the rempote operation always win
+         * @param conflict The conflict to be resolved.
+         * @param continueSolving A boolean value indicating if we can generate more conflict resolution operations.
+         * @return ExitCode indicating if the operation was successful.
+         */
+        void handleConflictOnOmittedEdit(const Conflict &conflict, bool &continueSolving);
+
+        /**
+         * @brief If we have a conflict between a local edit and a remote operation,
+         * and if the local edit is omitted (i.e., only propagating a creation date to the DB),
+         * the remote operation always wins.
          * @param conflict The conflict to be resolved.
          * @param continueSolving A boolean value indicating if we can generate more conflict resolution operations.
          * @return ExitCode indicating if the operation was successful.

--- a/src/libsyncengine/reconciliation/operation_generator/operationgeneratorworker.cpp
+++ b/src/libsyncengine/reconciliation/operation_generator/operationgeneratorworker.cpp
@@ -323,23 +323,6 @@ void OperationGeneratorWorker::generateDeleteOperation(std::shared_ptr<Node> cur
     _deletedNodes.insert(*currentNode->id());
 }
 
-bool OperationGeneratorWorker::editChangeShouldBePropagated(std::shared_ptr<Node> currentNode,
-                                                            std::shared_ptr<Node> correspondingNode) {
-    if (!currentNode || !correspondingNode) {
-        LOG_SYNCPAL_WARN(_logger,
-                         "hasChangeToPropagate: provided node is(are) null: " << (currentNode ? "" : "currentNode")
-                                                                              << (correspondingNode ? "" : " correspondingNode"));
-        return true;
-    }
-
-    if (currentNode->side() == ReplicaSide::Local && currentNode->size() == correspondingNode->size() &&
-        currentNode->lastmodified() == correspondingNode->lastmodified() &&
-        currentNode->createdAt() != correspondingNode->createdAt()) {
-        return false;
-    }
-    return true;
-}
-
 void OperationGeneratorWorker::findAndMarkAllChildNodes(std::shared_ptr<Node> parentNode) {
     for (auto &childNode: parentNode->children()) {
         if (childNode.second->type() == NodeType::Directory) {

--- a/src/libsyncengine/reconciliation/operation_generator/operationgeneratorworker.h
+++ b/src/libsyncengine/reconciliation/operation_generator/operationgeneratorworker.h
@@ -42,11 +42,6 @@ class OperationGeneratorWorker : public OperationProcessor {
         void generateDeleteOperation(std::shared_ptr<Node> currentNode, std::shared_ptr<Node> correspondingNode);
 
         void findAndMarkAllChildNodes(std::shared_ptr<Node> parentNode);
-
-        // Return false if only elements that are not synced with the corresponding side change (e.g., creation date). Else return
-        // true.
-        bool editChangeShouldBePropagated(std::shared_ptr<Node> currentNode, std::shared_ptr<Node> correspondingNode);
-
         std::queue<std::shared_ptr<Node>> _queuedToExplore;
         NodeSet _deletedNodes;
 

--- a/src/libsyncengine/syncpal/operationprocessor.h
+++ b/src/libsyncengine/syncpal/operationprocessor.h
@@ -29,6 +29,10 @@ class OperationProcessor : public ISyncWorker {
                            bool useSyncDbCache = true);
 
     protected:
+        // Return false if only elements that are not synced with the corresponding side change (e.g., creation date). Else return
+        // true.
+        bool editChangeShouldBePropagated(std::shared_ptr<Node> affectedNode, std::shared_ptr<Node> correspondingNode);
+        
         bool isPseudoConflict(std::shared_ptr<Node> node, std::shared_ptr<Node> correspondingNode);
         /**
          * Find the corresponding node in other tree.


### PR DESCRIPTION
As the way we retrieve the creation date on Linux has changed in version 3.7.0 (to handle node reuse), some users will see a difference between the snapshot creation date and the one stored in the database for all their files.

This will lead to an "omit edit" on every file to update the DB, this is the expected behavior. However, it could also result in numerous conflicts if there are pending changes on the remote side.

To avoid users having to resolve these manually (and to prevent potential Redmine tickets), I have added this case to the conflict resolver so it can be automatically resolved by the app, making it transparent for the user.

