### PR TITLE
Use https URLs for git submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src/3rdparty/keychain"]
 	path = src/3rdparty/keychain
-	url = git@github.com:hrantzsch/keychain.git
+	url = https://github.com/hrantzsch/keychain.git
 [submodule "src/3rdparty/qt-piwik-tracker"]
 	path = src/3rdparty/qt-piwik-tracker
-	url = git@github.com:pbek/qt-piwik-tracker.git
+	url = https://github.com/pbek/qt-piwik-tracker.git


### PR DESCRIPTION
Using ssh forks prevents cloning the git repo anonymously