### PR TITLE
Add more Clang-format rules

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,8 +3,10 @@ AlignConsecutiveAssignments: false
 AlignConsecutiveDeclarations: false
 AlignOperands: true
 AlignTrailingComments: false
+AllowShortBlocksOnASingleLine: Empty
 AllowShortEnumsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: WithoutElse
 BraceWrapping:
   AfterCaseLabel: false
   AfterClass: false


### PR DESCRIPTION
Add more Clang format rules to avoid this behavior:
![Screenshot 2025-06-10 at 13 49 26](https://github.com/user-attachments/assets/4754f1cc-132b-496b-90fc-36539454cd19)

It looks like that the git hook that reformat on commit was doing it differently than CLion.