### PR TITLE
Reset Log::_instance before calling log4cplus::Logger::shutdown()

### DIFF
--- a/src/libcommonserver/log/log.cpp
+++ b/src/libcommonserver/log/log.cpp
@@ -36,6 +36,7 @@ const int Log::rfMaxBackupIdx = 4; // Max number of backup files
 std::shared_ptr<Log> Log::_instance = nullptr;
 
 Log::~Log() {
+    _instance = nullptr;
     log4cplus::Logger::shutdown();
 }
 


### PR DESCRIPTION
The current behavior may cause a crash if the destructor of a static variable that relies on the logger is invoked after the (static) logger instance has already been destroyed.

For instance, the `CacheDirectoryHandler` destructor calls `IoHelper::deleteItem`, which attempts to use the logger if it's available. Since `Log::_instance` was not reset during destruction, the logger appears to be available, resulting in a crash.