### PR TITLE
Fix missing conflict case: remote edit of dir/file.txt and local removal of dir.

### DIFF
--- a/src/libsyncengine/reconciliation/conflict_resolver/conflictresolverworker.cpp
+++ b/src/libsyncengine/reconciliation/conflict_resolver/conflictresolverworker.cpp
@@ -203,11 +203,23 @@ ExitCode ConflictResolverWorker::generateEditDeleteConflictOperation(const Confl
     const auto deleteNode = conflict.node()->hasChangeEvent(OperationType::Delete) ? conflict.node() : conflict.otherNode();
     const auto editNode = conflict.node()->hasChangeEvent(OperationType::Edit) ? conflict.node() : conflict.otherNode();
     if (deleteNode->parentNode()->hasChangeEvent(OperationType::Delete)) {
-        // The edit operation happen in a deleted directory.
-        // Move the items that have been modified locally (if any).
-        // Delete operations will be propagated on next sync.
-        rescueModifiedLocalNodes(conflict, editNode);
-        continueSolving = true;
+        if (editNode->side() == ReplicaSide::Local) {
+            // Move the items that have been modified locally to the rescue folder.
+            // Delete operations will be propagated on next sync.
+            rescueModifiedLocalNodes(conflict, editNode);
+            continueSolving = true;
+        } else {
+            // Delete operation wins.
+            const auto deleteOp = std::make_shared<SyncOperation>();
+            deleteOp->setType(OperationType::Delete);
+            deleteOp->setAffectedNode(deleteNode); 
+            deleteOp->setCorrespondingNode(editNode);
+            deleteOp->setTargetSide(ReplicaSide::Remote);
+            deleteOp->setConflict(conflict);
+            continueSolving = true;
+            LOGW_SYNCPAL_INFO(_logger, getLogString(deleteOp));
+            (void) _syncPal->syncOps()->pushOp(deleteOp);
+        }
     } else {
         // Edit operation wins.
         // Remove the edited node from DB.

--- a/src/libsyncengine/reconciliation/conflict_resolver/conflictresolverworker.h
+++ b/src/libsyncengine/reconciliation/conflict_resolver/conflictresolverworker.h
@@ -79,7 +79,32 @@ class ConflictResolverWorker : public OperationProcessor {
          * @param continueSolving A boolean value indicating if we can generate more conflict resolution operations.
          * @return ExitCode indicating if the operation was successful.
          */
+
+        /**
+         * @brief Resolves a synchronization conflict between an edit and a delete operation (Edit vs Delete).
+         *
+         * This function handles cases where a file has been edited on one replica while being deleted on the other.
+         * It considers two main scenarios:
+         *
+         * 1. **The parent directory has not been deleted**:
+         *    - The edit operation takes precedence.
+         *    - The node is removed from the database, causing it to be detected as a new file in the next sync
+         *      cycle, effectively restoring it.
+         *
+         * 2. **The parent directory of the file has also been deleted**:
+         *    - If the edit happened locally and the delete happened remotely, the user's changes are preserved by moving the
+         *      modified file to a rescue folder.
+         *    - If the edit happened remotely, the file will be deleted anyway. The user can recover them from the kDrive
+         *      trash.
+         *    - In both cases, the delete operation takes precedence, as restoring the deleted hierarchy (similar to what is done
+         *      in case 1) could be expensive, undesired, and highly error-prone.
+         *
+         * @param conflict The conflict to be resolved.
+         * @param continueSolving A boolean value indicating if we can generate more conflict resolution operations.
+         * @return ExitCode indicating if the operation was successful.
+         */
         ExitCode generateEditDeleteConflictOperation(const Conflict &conflict, bool &continueSolving);
+
         /**
          * @brief If the moved item is local, revert the move operation. If the created item is local, rename it as a conflicted
          * file. Remote always wins.

--- a/test/libsyncengine/reconciliation/conflict_resolver/testconflictresolverworker.cpp
+++ b/test/libsyncengine/reconciliation/conflict_resolver/testconflictresolverworker.cpp
@@ -223,43 +223,65 @@ void TestConflictResolverWorker::testOmitEditDelete() {
 
 
 void TestConflictResolverWorker::testEditDelete1() {
-    // Simulate edit of file A/AA/AAA on local replica
-    const auto lNodeAAA = _testSituationGenerator.editNode(ReplicaSide::Local, "aaa");
+    std::function<SyncOpPtr(ReplicaSide editSide)> generateAndResolveConflict = [&](ReplicaSide editSide) {
+        _syncPal->_syncOps->clear();
 
-    // and delete of file A/AA/AAA on remote replica
-    const auto rNodeAAA = _testSituationGenerator.getNode(ReplicaSide::Remote, "aaa");
-    rNodeAAA->setChangeEvents(OperationType::Delete);
+        // Simulate edit of file A/AA/AAA on local replica
+        const auto editNodeAAA = _testSituationGenerator.editNode(editSide, "aaa");
+        editNodeAAA->setChangeEvents(OperationType::Edit);
 
-    const Conflict conflict(lNodeAAA, rNodeAAA, ConflictType::EditDelete);
-    _syncPal->_conflictQueue->push(conflict);
-    _syncPal->_conflictResolverWorker->execute();
+        // and delete of file A/AA/AAA on remote replica
+        const auto deleteNodeAAA = _testSituationGenerator.getNode(otherSide(editSide), "aaa");
+        deleteNodeAAA->setChangeEvents(OperationType::Delete);
 
-    CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(1), _syncPal->_syncOps->size());
-    const auto opId = _syncPal->_syncOps->opSortedList().front();
-    const auto op = _syncPal->_syncOps->getOp(opId);
-    CPPUNIT_ASSERT(op->newName().empty());
-    CPPUNIT_ASSERT(op->omit());
-    CPPUNIT_ASSERT_EQUAL(OperationType::Delete, op->type());
+        const Conflict conflict(editNodeAAA, deleteNodeAAA, ConflictType::EditDelete);
+        _syncPal->_conflictQueue->push(conflict);
+        _syncPal->_conflictResolverWorker->execute();
+        CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(1), _syncPal->_syncOps->size());
+        const auto opId = _syncPal->_syncOps->opSortedList().front();
+        return _syncPal->_syncOps->getOp(opId);
+    };
+
+    for (const auto side: {ReplicaSide::Local, ReplicaSide::Remote}) {
+        auto resolveOperation = generateAndResolveConflict(side);
+        CPPUNIT_ASSERT(resolveOperation);
+        CPPUNIT_ASSERT(resolveOperation->newName().empty());
+        CPPUNIT_ASSERT(resolveOperation->omit());
+        CPPUNIT_ASSERT_EQUAL(OperationType::Delete, resolveOperation->type());
+    }
 }
 
 void TestConflictResolverWorker::testEditDelete2() {
-    // Simulate edit of file A/AA/AAA on local replica
-    const auto lNodeAAA = _testSituationGenerator.editNode(ReplicaSide::Local, "aaa");
+    std::function<SyncOpPtr(ReplicaSide editSide)> generateAndResolveConflict = [&](ReplicaSide editSide) {
+        _syncPal->_syncOps->clear();
 
-    // and delete of dir A/AA (and all children) on remote replica
-    const auto rNodeAA = _testSituationGenerator.deleteNode(ReplicaSide::Remote, "aa");
-    const auto rNodeAAA = _testSituationGenerator.getNode(ReplicaSide::Remote, "aaa");
+        // Simulate edit of file A/AA/AAA on editSide replica
+        const auto editNodeAAA = _testSituationGenerator.editNode(editSide, "aaa");
+        editNodeAAA->setChangeEvents(OperationType::Edit);
 
-    const Conflict conflict(lNodeAAA, rNodeAAA, ConflictType::EditDelete);
-    _syncPal->_conflictQueue->push(conflict);
-    _syncPal->_conflictResolverWorker->execute();
+        // and delete of dir A/AA (and all children) on otherSide(editSide) replica
+        const auto deleteNodeAA = _testSituationGenerator.deleteNode(otherSide(editSide), "aa");
+        const auto deleteNodeAAA = _testSituationGenerator.getNode(otherSide(editSide), "aaa");
 
-    CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(1), _syncPal->_syncOps->size());
-    const auto opId = _syncPal->_syncOps->opSortedList().front();
-    const auto op = _syncPal->_syncOps->getOp(opId);
-    CPPUNIT_ASSERT(!op->omit());
-    CPPUNIT_ASSERT_EQUAL(OperationType::Move, op->type());
-    CPPUNIT_ASSERT_EQUAL(true, op->isRescueOperation());
+        const Conflict conflict(deleteNodeAAA, editNodeAAA, ConflictType::EditDelete);
+        _syncPal->_conflictQueue->push(conflict);
+        _syncPal->_conflictResolverWorker->execute();
+        CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(1), _syncPal->_syncOps->size());
+        const auto opId = _syncPal->_syncOps->opSortedList().front();
+        return _syncPal->_syncOps->getOp(opId);
+    };
+
+    const auto resolveOperationLocal = generateAndResolveConflict(ReplicaSide::Local);
+    CPPUNIT_ASSERT(!resolveOperationLocal->omit());
+    CPPUNIT_ASSERT_EQUAL(OperationType::Move, resolveOperationLocal->type());
+    CPPUNIT_ASSERT_EQUAL(ReplicaSide::Local, resolveOperationLocal->targetSide());
+    CPPUNIT_ASSERT_EQUAL(true, resolveOperationLocal->isRescueOperation());
+
+    const auto resolveOperationRemote = generateAndResolveConflict(ReplicaSide::Remote);
+    CPPUNIT_ASSERT(!resolveOperationLocal->omit());
+    CPPUNIT_ASSERT_EQUAL(OperationType::Delete, resolveOperationRemote->type());
+    CPPUNIT_ASSERT_EQUAL(ReplicaSide::Remote, resolveOperationRemote->targetSide());
+    CPPUNIT_ASSERT_EQUAL(true, resolveOperationLocal->isRescueOperation());
 }
 
 void TestConflictResolverWorker::testMoveDelete1() {


### PR DESCRIPTION
### Conflict Test: Edit + Delete on `Test/a.txt`

| Remote Operations     | Local Operations      | Expected Result                             | Result |   Old behaviour  |
|-----------------------|-----------------------|---------------------------------------------|----------|---------------------------------------------|
| `delete Test`            | `edit a.txt`              | `a.txt` is moved to the resuce folder      | ✅     |  `a.txt` is moved to the resuce folder     |
| `delete a.txt`            | `edit a.txt`              | `a.txt` is recreated on remote side      | ✅     |  `a.txt` is recreated on remote side    |
| `edit a.txt`            | `delete Test`              | `a.txt` is moved to trash on remote side      | ✅    |  ❌  Sync loop |
| `edit a.txt`            | `delete a.txt`              |`a.txt` is recreated on local side   | ✅     | `a.txt` is recreated on local side |


✅ = test conforme à l’attendu.
