### PR TITLE
KDESKTOP 1764 - Windows Release Notes display fix

### DIFF
--- a/VERSION.cmake
+++ b/VERSION.cmake
@@ -1,6 +1,6 @@
 set( KDRIVE_VERSION_MAJOR 3 )
-set( KDRIVE_VERSION_MINOR 6 ) # TODO
-set( KDRIVE_VERSION_PATCH 10 ) # TODO changed to generate a new version alert to show the release notes.
+set( KDRIVE_VERSION_MINOR 7 )
+set( KDRIVE_VERSION_PATCH 1 )
 set( KDRIVE_VERSION_YEAR  2025 )
 set( KDRIVE_SOVERSION 0 )
 

--- a/VERSION.cmake
+++ b/VERSION.cmake
@@ -1,6 +1,6 @@
 set( KDRIVE_VERSION_MAJOR 3 )
-set( KDRIVE_VERSION_MINOR 7 )
-set( KDRIVE_VERSION_PATCH 1 )
+set( KDRIVE_VERSION_MINOR 6 ) # TODO
+set( KDRIVE_VERSION_PATCH 10 ) # TODO changed to generate a new version alert to show the release notes.
 set( KDRIVE_VERSION_YEAR  2025 )
 set( KDRIVE_SOVERSION 0 )
 

--- a/src/gui/updater/updatedialog.cpp
+++ b/src/gui/updater/updatedialog.cpp
@@ -71,15 +71,6 @@ void UpdateDialog::initUi(const VersionInfo &versionInfo) {
     lbl->setWordWrap(true);
     subLayout->addWidget(lbl);
 
-    auto *releaseNoteLabel = new QLabel;
-    releaseNoteLabel->setText(tr("Release Notes:"));
-    releaseNoteLabel->setObjectName("largeMediumTextLabel");
-    releaseNoteLabel->setContextMenuPolicy(Qt::PreventContextMenu);
-    releaseNoteLabel->setWordWrap(true);
-    subLayout->addWidget(releaseNoteLabel);
-
-
-
     auto *releaseNoteContent = new QTextBrowser(this);
     releaseNoteContent->setFixedHeight(webviewHeight);
     subLayout->addWidget(releaseNoteContent);

--- a/src/gui/updater/updatedialog.cpp
+++ b/src/gui/updater/updatedialog.cpp
@@ -71,8 +71,8 @@ void UpdateDialog::initUi(const VersionInfo &versionInfo) {
     subLayout->addWidget(lbl);
 
     auto *releaseNoteContentWidget = new QTextBrowser(this);
-    releaseNoteContent->setFixedHeight(webviewHeight);
-    subLayout->addWidget(releaseNoteContent);
+    releaseNoteContentWidget->setFixedHeight(webviewHeight);
+    subLayout->addWidget(releaseNoteContentWidget);
 
     auto *manager = new QNetworkAccessManager(this);
     const Language language = ParametersCache::instance()->parametersInfo().language();
@@ -84,10 +84,10 @@ void UpdateDialog::initUi(const VersionInfo &versionInfo) {
     );
 
     connect(manager, &QNetworkAccessManager::finished, this,
-        [releaseNoteContent](QNetworkReply *reply) {
+        [releaseNoteContentWidget](QNetworkReply *reply) {
             if (reply->error() == QNetworkReply::NoError) {
                 const QByteArray html = reply->readAll();
-                releaseNoteContent->setHtml(QString::fromUtf8(html));
+                releaseNoteContentWidget->setHtml(QString::fromUtf8(html));
             }
             reply->deleteLater();
         });

--- a/src/gui/updater/updatedialog.cpp
+++ b/src/gui/updater/updatedialog.cpp
@@ -70,7 +70,7 @@ void UpdateDialog::initUi(const VersionInfo &versionInfo) {
     lbl->setWordWrap(true);
     subLayout->addWidget(lbl);
 
-    auto *releaseNoteContent = new QTextBrowser(this);
+    auto *releaseNoteContentWidget = new QTextBrowser(this);
     releaseNoteContent->setFixedHeight(webviewHeight);
     subLayout->addWidget(releaseNoteContent);
 

--- a/src/gui/updater/updatedialog.cpp
+++ b/src/gui/updater/updatedialog.cpp
@@ -36,7 +36,7 @@ namespace KDC {
 static const int mainBoxHMargin = 40;
 static const int mainBoxVBMargin = 40;
 static const int boxHSpacing = 10;
-static const int webviewHeight = 300;
+static const int releaseNoteContentWidgetHeight = 300;
 
 UpdateDialog::UpdateDialog(const VersionInfo &versionInfo, QWidget *parent /*= nullptr*/) :
     CustomDialog(false, parent) {
@@ -71,7 +71,7 @@ void UpdateDialog::initUi(const VersionInfo &versionInfo) {
     subLayout->addWidget(lbl);
 
     auto *releaseNoteContentWidget = new QTextBrowser(this);
-    releaseNoteContentWidget->setFixedHeight(webviewHeight);
+    releaseNoteContentWidget->setFixedHeight(releaseNoteContentWidgetHeight);
     subLayout->addWidget(releaseNoteContentWidget);
 
     auto *manager = new QNetworkAccessManager(this);

--- a/src/gui/updater/updatedialog.cpp
+++ b/src/gui/updater/updatedialog.cpp
@@ -119,6 +119,9 @@ void UpdateDialog::initUi(const VersionInfo &versionInfo) {
     connect(this, &CustomDialog::exit, this, &UpdateDialog::reject);
 
     subLayout->addLayout(hLayout);
+#ifdef Q_OS_WIN
+    MatomoClient::sendVisit(MatomoNameField::PG_Preferences_UpdateDialog)
+#endif
 }
 
 void UpdateDialog::reject() {

--- a/src/gui/updater/updatedialog.cpp
+++ b/src/gui/updater/updatedialog.cpp
@@ -120,7 +120,7 @@ void UpdateDialog::initUi(const VersionInfo &versionInfo) {
 
     subLayout->addLayout(hLayout);
 #ifdef Q_OS_WIN
-    MatomoClient::sendVisit(MatomoNameField::PG_Preferences_UpdateDialog)
+    MatomoClient::sendVisit(MatomoNameField::PG_Preferences_UpdateDialog);
 #endif
 }
 

--- a/src/gui/updater/updatedialog.cpp
+++ b/src/gui/updater/updatedialog.cpp
@@ -19,7 +19,6 @@
 #include "updatedialog.h"
 
 #include "../guiutility.h"
-#include "../wizard/webview.h"
 #include "../parameterscache.h"
 #include "libcommongui/matomoclient.h"
 #include "libcommon/utility/utility.h"

--- a/src/gui/updater/updatedialog.cpp
+++ b/src/gui/updater/updatedialog.cpp
@@ -89,8 +89,6 @@ void UpdateDialog::initUi(const VersionInfo &versionInfo) {
             if (reply->error() == QNetworkReply::NoError) {
                 const QByteArray html = reply->readAll();
                 releaseNoteContent->setHtml(QString::fromUtf8(html));
-            } else {
-                // TODO handle errors
             }
             reply->deleteLater();
         });

--- a/src/gui/updater/updatedialog.h
+++ b/src/gui/updater/updatedialog.h
@@ -21,6 +21,13 @@
 #include "../customdialog.h"
 #include "utility/types.h"
 
+/**
+ * This update dialog is only used on Windows.
+ *
+ * - MacOS: the update dialog is fully managed by Sparkle.
+ * - Linux: there is no update dialog (this `UpdateDialog` could be used in the future).
+ **/
+
 namespace KDC {
 
 class UpdateDialog : public CustomDialog {

--- a/src/gui/wizard/webview.cpp
+++ b/src/gui/wizard/webview.cpp
@@ -141,12 +141,6 @@ void WebView::loadFinished(bool ok) {
 
         if (host.contains("login.infomaniak.com", Qt::CaseSensitive)) { // Login Webview
             MatomoClient::sendVisit(MatomoNameField::VW_LoginPage);
-#ifdef Q_OS_WIN
-        } else if (host.contains(QUrl(APPLICATION_STORAGE_URL).host(),
-                                 Qt::CaseSensitive)) { // Release Notes Webview (only on windows, see
-                                                       // 'src/gui/updater/updatedialog.cpp')
-            MatomoClient::sendVisit(MatomoNameField::WV_ReleaseNotes);
-#endif
         } else { // Other Webview, shouldn't happen, there is no other Qt webview in the codebase.
             MatomoClient::sendVisit(MatomoNameField::Unknown);
         }

--- a/src/libcommongui/matomoclient.cpp
+++ b/src/libcommongui/matomoclient.cpp
@@ -102,9 +102,6 @@ void MatomoClient::sendEvent(const QString &category, const MatomoEventAction ac
  */
 void MatomoClient::initNameFieldMap() {
     _nameFieldMap = {
-#ifdef Q_OS_WIN
-            {MatomoNameField::WV_ReleaseNotes, {"webview", "release-notes"}},
-#endif
 #ifdef Q_OS_MAC
             {MatomoNameField::PG_Preferences_LiteSync, {"preferences/litesync", "litesync"}},
 #endif

--- a/src/libcommongui/matomoclient.cpp
+++ b/src/libcommongui/matomoclient.cpp
@@ -114,6 +114,9 @@ void MatomoClient::initNameFieldMap() {
             {MatomoNameField::PG_Preferences_Proxy, {"preferences/proxy", "proxy"}},
             {MatomoNameField::PG_Preferences_About, {"preferences/about", "about"}},
             {MatomoNameField::PG_Preferences_Beta, {"preferences/beta", "beta"}},
+#ifdef Q_OS_WIN
+            {MatomoNameField::PG_Preferences_UpdateDialog, {"preferences/update_dialog", "update_dialog"}},
+#endif
             {MatomoNameField::PG_Parameters, {"parameters", "parameters"}},
             {MatomoNameField::PG_Parameters_NewSync_LocalFolder, {"parameters/newsync", "local_folder"}},
             {MatomoNameField::PG_Parameters_NewSync_RemoteFolder, {"parameters/newsync", "remote_folder"}},

--- a/src/libcommongui/matomoclient.h
+++ b/src/libcommongui/matomoclient.h
@@ -29,9 +29,7 @@ inline Q_LOGGING_CATEGORY(lcMatomoClient, "gui.matomo", QtInfoMsg)
     enum class MatomoNameField : matomo_enum_t {
         /* WebView names*/
         VW_LoginPage, // Login
-#ifdef Q_OS_WIN
-        WV_ReleaseNotes, // Release Notes Webview (only rendered on windows)
-#endif
+
         /* Pages */
         PG_SynthesisPopover,
         PG_SynthesisPopover_KebabMenu,

--- a/src/libcommongui/matomoclient.h
+++ b/src/libcommongui/matomoclient.h
@@ -43,7 +43,9 @@ inline Q_LOGGING_CATEGORY(lcMatomoClient, "gui.matomo", QtInfoMsg)
 #endif
         PG_Preferences_About,
         PG_Preferences_Beta,
-
+#ifdef Q_OS_WIN
+        PG_Preferences_UpdateDialog,
+#endif
         PG_Parameters,
         PG_Parameters_NewSync_LocalFolder,
         PG_Parameters_NewSync_RemoteFolder,


### PR DESCRIPTION
This pull request updates the `UpdateDialog` UI in `src/gui/updater/updatedialog.cpp` by replacing the `QLabel` and `WebView` components with a `QTextBrowser` for displaying release notes.

* Replaced the `WebView` with a `QTextBrowser` to fix a rendering bug.
* Removed the static `QLabel`, as the "Release Notes" heading is included directly in the rendered HTML.
* Introduced `QNetworkAccessManager` to dynamically fetch release notes content.

 * Removal of the old Matomo PageVisit (webview)
   * And then creation of the new Matomo PageVisit tag
---

<div align="center">
  This fixes a bug where the release notes were incorrectly rendered in the legacy WebView.
</div>

<table align="center">
  <thead>
    <tr>
      <th>Bug</th>
      <th>Fixed</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td align="center">
        <img src="https://github.com/user-attachments/assets/9fe94ee9-da5b-4773-a9f6-9c3024e9d2b3" alt="bug_release_note" width="350">
      </td>
      <td align="center">
        <img src="https://github.com/user-attachments/assets/b812b575-b083-4886-96d8-f2e0039f56f7" alt="fix_rn_windows" width="350">
      </td>
    </tr>
  </tbody>
</table>