### PR TITLE
Ensure kDrive Shell Overlay Icon Priority on Windows

### DIFF
--- a/extensions/windows/standard/KDOverlays/DllMain.cpp
+++ b/extensions/windows/standard/KDOverlays/DllMain.cpp
@@ -128,7 +128,7 @@ HRESULT UnregisterCLSID(LPCOLESTR guidStr, PCWSTR overlayStr) {
 
     hResult = KDOverlayRegistrationHandler::UnregisterCOMObject(guid);
 
-    if (!SUCCEEDED(hResult)) {
+    if (!SUCCEEDED(hResult) && hResult != HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND)) {
         return hResult;
     }
 

--- a/extensions/windows/standard/KDOverlays/KDOverlayRegistrationHandler.cpp
+++ b/extensions/windows/standard/KDOverlays/KDOverlayRegistrationHandler.cpp
@@ -25,7 +25,57 @@
 
 using namespace std;
 
-HRESULT KDOverlayRegistrationHandler::MakeRegistryEntries(const CLSID& clsid, PCWSTR friendlyName) {
+HRESULT KDOverlayRegistrationHandler::GetRegistryEntriesPrefix(PWSTR suffix, PDWORD size) {
+    if (suffix == nullptr || size == nullptr) {
+        return E_INVALIDARG;
+    }
+    // Reset the prefix to an empty string
+    wcsncpy_s(suffix, MAX_PATH, L"", 0);
+    *size = 0;
+    HRESULT hResult;
+    HKEY shellOverlayKey = nullptr;
+    // the key may not exist yet
+    hResult = HRESULT_FROM_WIN32(RegOpenKeyEx(HKEY_LOCAL_MACHINE, REGISTRY_OVERLAY_KEY, 0, KEY_READ, &shellOverlayKey));
+    if (!SUCCEEDED(hResult)) {
+        if (hResult == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND)) {
+            // If the key does not exist, we return S_OK with an empty prefix
+            return S_OK;
+        }
+    }
+
+    // Get the name of the first subkey
+    wchar_t subKeyName[MAX_PATH];
+    wcsncpy_s(subKeyName, MAX_PATH, L"", 0);
+    DWORD index = 0;
+    DWORD dwSize = sizeof(subKeyName);
+    hResult = HRESULT_FROM_WIN32(RegEnumKeyEx(shellOverlayKey, index, subKeyName, &dwSize, nullptr, nullptr, nullptr, nullptr));
+    if (hResult != ERROR_SUCCESS) {
+        // If there are no subkeys, we return S_OK with an empty prefix
+        return S_OK;
+    }
+
+    // Count the numbre of ' ' characters at the beginning of the subkey name
+    std::wstring subKeyNameW(subKeyName);
+    size_t pos = subKeyNameW.find_first_not_of(L' ');
+    if (pos == std::wstring::npos || pos > 30) {
+        // If the subkey name is empty, contains only spaces or has more than 30 spaces at the beginning,
+        // we return S_OK with an empty prefix
+        return S_OK;
+    }
+
+    std::wstring spaces = subKeyNameW.substr(0, pos);
+    // If the first key isn't a kDrive overlay add a space to the prefix
+    if (subKeyNameW.find(OVERLAY_APP_NAME) == std::wstring::npos) {
+        spaces += L" ";
+        ++pos;
+    }
+
+    wcsncpy_s(suffix, MAX_PATH, spaces.c_str(), pos);
+    *size = static_cast<DWORD>(pos);
+    return hResult;
+}
+
+HRESULT KDOverlayRegistrationHandler::MakeRegistryEntries(const CLSID &clsid, PCWSTR friendlyName) {
     HRESULT hResult;
     HKEY shellOverlayKey = nullptr;
     // the key may not exist yet
@@ -39,8 +89,19 @@ HRESULT KDOverlayRegistrationHandler::MakeRegistryEntries(const CLSID& clsid, PC
     }
 
     HKEY syncExOverlayKey = nullptr;
-    hResult = HRESULT_FROM_WIN32(RegCreateKeyEx(shellOverlayKey, friendlyName, 0, nullptr, REG_OPTION_NON_VOLATILE, KEY_WRITE,
-                                                nullptr, &syncExOverlayKey, nullptr));
+
+    wchar_t prefix[MAX_PATH];
+    DWORD pefixSize = 0;
+    hResult = GetRegistryEntriesPrefix(prefix, &pefixSize);
+    if (!SUCCEEDED(hResult)) {
+        return hResult;
+    }
+
+    // Append the friendly name to the prefix
+    std::wstring friendlyNameWithPrefix = std::wstring(prefix) + std::wstring(OVERLAY_APP_NAME) + std::wstring(friendlyName);
+
+    hResult = HRESULT_FROM_WIN32(RegCreateKeyEx(shellOverlayKey, friendlyNameWithPrefix.c_str(), 0, nullptr,
+                                                REG_OPTION_NON_VOLATILE, KEY_WRITE, nullptr, &syncExOverlayKey, nullptr));
 
     if (!SUCCEEDED(hResult)) {
         return hResult;
@@ -60,22 +121,31 @@ HRESULT KDOverlayRegistrationHandler::MakeRegistryEntries(const CLSID& clsid, PC
 HRESULT KDOverlayRegistrationHandler::RemoveRegistryEntries(PCWSTR friendlyName) {
     HRESULT hResult;
     HKEY shellOverlayKey = nullptr;
-    hResult = HRESULT_FROM_WIN32(RegOpenKeyEx(HKEY_LOCAL_MACHINE, REGISTRY_OVERLAY_KEY, 0, KEY_WRITE, &shellOverlayKey));
+    hResult =
+            HRESULT_FROM_WIN32(RegOpenKeyEx(HKEY_LOCAL_MACHINE, REGISTRY_OVERLAY_KEY, 0, KEY_WRITE | KEY_READ, &shellOverlayKey));
 
     if (!SUCCEEDED(hResult)) {
         return hResult;
     }
 
-    HKEY syncExOverlayKey = nullptr;
-    hResult = HRESULT_FROM_WIN32(RegDeleteKey(shellOverlayKey, friendlyName));
-    if (!SUCCEEDED(hResult)) {
-        return hResult;
+    wchar_t subKeyName[MAX_PATH];
+    DWORD index = 0;
+    DWORD dwSize = sizeof(subKeyName);
+    while (RegEnumKeyEx(shellOverlayKey, index, subKeyName, &dwSize, nullptr, nullptr, nullptr, nullptr) == ERROR_SUCCESS) {
+        std::wstring friendlyNameW = std::wstring(OVERLAY_APP_NAME) + std::wstring(friendlyName);
+        std::wstring subKeyNameW(subKeyName);
+        if (subKeyNameW.size() >= friendlyNameW.size() &&
+            subKeyNameW.substr(subKeyNameW.size() - friendlyNameW.size()) == friendlyNameW) {
+            HKEY syncExOverlayKey = nullptr;
+            hResult = HRESULT_FROM_WIN32(RegDeleteKey(shellOverlayKey, subKeyName));
+        }
+        index++;
+        dwSize = sizeof(subKeyName);
     }
-
     return hResult;
 }
 
-HRESULT KDOverlayRegistrationHandler::RegisterCOMObject(PCWSTR modulePath, PCWSTR friendlyName, const CLSID& clsid) {
+HRESULT KDOverlayRegistrationHandler::RegisterCOMObject(PCWSTR modulePath, PCWSTR friendlyName, const CLSID &clsid) {
     if (modulePath == nullptr) {
         return E_FAIL;
     }
@@ -127,7 +197,7 @@ HRESULT KDOverlayRegistrationHandler::RegisterCOMObject(PCWSTR modulePath, PCWST
     return S_OK;
 }
 
-HRESULT KDOverlayRegistrationHandler::UnregisterCOMObject(const CLSID& clsid) {
+HRESULT KDOverlayRegistrationHandler::UnregisterCOMObject(const CLSID &clsid) {
     wchar_t stringCLSID[MAX_PATH];
 
     StringFromGUID2(clsid, stringCLSID, ARRAYSIZE(stringCLSID));

--- a/extensions/windows/standard/KDOverlays/KDOverlayRegistrationHandler.cpp
+++ b/extensions/windows/standard/KDOverlays/KDOverlayRegistrationHandler.cpp
@@ -25,15 +25,14 @@
 
 using namespace std;
 
-HRESULT KDOverlayRegistrationHandler::GetRegistryEntriesPrefix(PWSTR suffix, PDWORD size) {
-    if (suffix == nullptr || size == nullptr) {
+HRESULT KDOverlayRegistrationHandler::GetRegistryEntriesPrefix(PWSTR prefix) {
+    if (prefix == nullptr) {
         return E_INVALIDARG;
     }
     // Reset the prefix to an empty string
-    if (wcsncpy_s(suffix, MAX_PATH, L"", 0) != 0) {
+    if (wcsncpy_s(prefix, MAX_PATH, L"", 0) != 0) {
         return E_FAIL;
     }
-    *size = 0;
     HRESULT hResult = S_OK;
     HKEY shellOverlayKey = nullptr;
     // the key may not exist yet
@@ -75,11 +74,10 @@ HRESULT KDOverlayRegistrationHandler::GetRegistryEntriesPrefix(PWSTR suffix, PDW
         ++pos;
     }
 
-    if (wcsncpy_s(suffix, MAX_PATH, spaces.c_str(), pos) != 0) {
+    if (wcsncpy_s(prefix, MAX_PATH, spaces.c_str(), pos) != 0) {
         return E_FAIL;
     }
 
-    *size = static_cast<DWORD>(pos);
     return hResult;
 }
 
@@ -99,8 +97,7 @@ HRESULT KDOverlayRegistrationHandler::MakeRegistryEntries(const CLSID &clsid, PC
     HKEY syncExOverlayKey = nullptr;
 
     wchar_t prefix[MAX_PATH];
-    DWORD pefixSize = 0;
-    hResult = GetRegistryEntriesPrefix(prefix, &pefixSize);
+    hResult = GetRegistryEntriesPrefix(prefix);
     if (!SUCCEEDED(hResult)) {
         return hResult;
     }

--- a/extensions/windows/standard/KDOverlays/KDOverlayRegistrationHandler.h
+++ b/extensions/windows/standard/KDOverlays/KDOverlayRegistrationHandler.h
@@ -26,5 +26,5 @@ class __declspec(dllexport) KDOverlayRegistrationHandler {
         static HRESULT UnregisterCOMObject(const CLSID &clsid);
 
     private:
-        static HRESULT GetRegistryEntriesPrefix(PWSTR fileType, PDWORD size);
+        static HRESULT GetRegistryEntriesPrefix(PWSTR fileType);
 };

--- a/extensions/windows/standard/KDOverlays/KDOverlayRegistrationHandler.h
+++ b/extensions/windows/standard/KDOverlays/KDOverlayRegistrationHandler.h
@@ -20,8 +20,11 @@
 
 class __declspec(dllexport) KDOverlayRegistrationHandler {
     public:
-        static HRESULT MakeRegistryEntries(const CLSID& clsid, PCWSTR fileType);
-        static HRESULT RegisterCOMObject(PCWSTR modulePath, PCWSTR friendlyName, const CLSID& clsid);
+        static HRESULT MakeRegistryEntries(const CLSID &clsid, PCWSTR fileType);
+        static HRESULT RegisterCOMObject(PCWSTR modulePath, PCWSTR friendlyName, const CLSID &clsid);
         static HRESULT RemoveRegistryEntries(PCWSTR friendlyName);
-        static HRESULT UnregisterCOMObject(const CLSID& clsid);
+        static HRESULT UnregisterCOMObject(const CLSID &clsid);
+
+    private:
+        static HRESULT GetRegistryEntriesPrefix(PWSTR fileType, PDWORD size);
 };

--- a/extensions/windows/standard/KDOverlays/OverlayConstants.h
+++ b/extensions/windows/standard/KDOverlays/OverlayConstants.h
@@ -31,10 +31,11 @@
     This could be done either each start of the kDrive App, or during installation
     source : https://devblogs.microsoft.com/oldnewthing/20190313-00/?p=101094
 */
-#define OVERLAY_NAME_ERROR L"   KDError"
-#define OVERLAY_NAME_OK L"   KDOK"
-#define OVERLAY_NAME_SYNC L"   KDSync"
-#define OVERLAY_NAME_WARNING L"   KDWarning"
+#define OVERLAY_APP_NAME L"kDrive"
+#define OVERLAY_NAME_ERROR L"Error"
+#define OVERLAY_NAME_OK L"OK"
+#define OVERLAY_NAME_SYNC L"Sync"
+#define OVERLAY_NAME_WARNING L"Warning"
 
 #define REGISTRY_OVERLAY_KEY L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\ShellIconOverlayIdentifiers"
 #define REGISTRY_CLSID L"CLSID"


### PR DESCRIPTION
### Context

Windows only supports 15 shell overlay icon identifiers, shared between all applications. If there are more, Windows simply ignores the ones at the end of the alphabetical list. Major apps like OneDrive (7 overlays) and Dropbox (10 overlays) already use leading spaces in their registry keys to ensure higher priority (OneDrive uses 4, Dropbox and kDrive previously used 3).

As a result, when both Dropbox and OneDrive are installed (which is very common), kDrive’s icons are often excluded.

### Solution

This PR introduces a dynamic solution:
- During installation or overlay registration, kDrive checks the registry for existing overlay icon keys.
- It automatically determines the maximum number of leading spaces used by other apps.
- kDrive then registers its overlays with **one more leading space** than the maximum found, ensuring our overlays get priority and are always displayed by Windows.

### TODO
Currently, the icons are set during installation.
We plan to check the position of our icon at each application startup.
If the kDrive icon index is higher than 15, a notification will prompt the user to ask if they want to bring the kDrive icon higher (exact wording to be defined).
If the user agrees, a privilege elevation dialog will appear to allow kDrive to reposition its icons (this action requires administrator rights).

Souhaites-tu une version plus formelle, technique ou friendly (type message utilisateur) ?


### References

- [Raymond Chen: The Old New Thing – Why does Windows only support 15 overlay icons?](https://devblogs.microsoft.com/oldnewthing/20190313-00/?p=101094)