### PR TITLE
Fix missing normalization in exclusion

### DIFF
--- a/src/libsyncengine/requests/exclusiontemplatecache.cpp
+++ b/src/libsyncengine/requests/exclusiontemplatecache.cpp
@@ -117,8 +117,8 @@ void ExclusionTemplateCache::updateRegexPatterns() {
         SyncName nfcRegexPattern;
         SyncName nfdRegexPattern;
         bool normalizationSucceed =
-                !CommonUtility::normalizedSyncName(Str2SyncName(regexPattern), nfcRegexPattern, UnicodeNormalization::NFC) ||
-                !CommonUtility::normalizedSyncName(Str2SyncName(regexPattern), nfdRegexPattern, UnicodeNormalization::NFD);
+                CommonUtility::normalizedSyncName(Str2SyncName(regexPattern), nfcRegexPattern, UnicodeNormalization::NFC) &&
+                CommonUtility::normalizedSyncName(Str2SyncName(regexPattern), nfdRegexPattern, UnicodeNormalization::NFD);
 
         if (!normalizationSucceed || nfcRegexPattern == nfdRegexPattern) {
             (void) _regexPatterns.emplace_back(std::regex(regexPattern), exclPattern);

--- a/src/libsyncengine/requests/exclusiontemplatecache.cpp
+++ b/src/libsyncengine/requests/exclusiontemplatecache.cpp
@@ -134,7 +134,11 @@ void ExclusionTemplateCache::addRegexForAllNormalizationForms(std::string regexP
             LOG_WARN(Log::instance()->getLogger(), "Unable to normalize an exclusion template: [regex] "
                                                            << regexPattern << " | [template] " << exclusionTemplate.templ());
         }
-        (void) _regexPatterns.emplace_back(std::regex(regexPattern), exclusionTemplate);
+        if (std::find_if(_regexPatterns.begin(), _regexPatterns.end(), [&exclusionTemplate](const auto &value) {
+                return Str2SyncName(value.second.templ()) == Str2SyncName(exclusionTemplate.templ());
+            }) == _regexPatterns.end()) {
+            (void) _regexPatterns.emplace_back(std::regex(regexPattern), exclusionTemplate);
+        }
     } else {
         if (std::find_if(_regexPatterns.begin(), _regexPatterns.end(), [&nfcTemplate](const auto &value) {
                 return Str2SyncName(value.second.templ()) == nfcTemplate;

--- a/src/libsyncengine/requests/exclusiontemplatecache.cpp
+++ b/src/libsyncengine/requests/exclusiontemplatecache.cpp
@@ -127,13 +127,19 @@ void ExclusionTemplateCache::updateRegexPatterns() {
             SyncName nfcTempl;
             CommonUtility::normalizedSyncName(Str2SyncName(exclPattern.templ()), nfcTempl, UnicodeNormalization::NFC);
             exclusionTemplateNfc.setTempl(SyncName2Str(nfcTempl));
-            (void) _regexPatterns.emplace_back(std::regex(SyncName2Str(nfcRegexPattern)), exclusionTemplateNfc);
+            if (std::find(_regexPatterns.begin(), _regexPatterns.end(), std::regex(SyncName2Str(nfcRegexPattern))) ==
+                _regexPatterns.end()) {
+                (void) _regexPatterns.emplace_back(std::regex(SyncName2Str(nfcRegexPattern)), exclusionTemplateNfc);
+            }
 
             ExclusionTemplate exclusionTemplateNfd = exclPattern;
             SyncName nfdTempl;
             CommonUtility::normalizedSyncName(Str2SyncName(exclPattern.templ()), nfdTempl, UnicodeNormalization::NFD);
             exclusionTemplateNfd.setTempl(SyncName2Str(nfdTempl));
-            (void) _regexPatterns.emplace_back(std::regex(SyncName2Str(nfdRegexPattern)), exclusionTemplateNfd);
+            if (std::find(_regexPatterns.begin(), _regexPatterns.end(), std::regex(SyncName2Str(nfdRegexPattern))) ==
+                _regexPatterns.end()) {
+                (void) _regexPatterns.emplace_back(std::regex(SyncName2Str(nfdRegexPattern)), exclusionTemplateNfd);
+            }
         }
     }
 }

--- a/src/libsyncengine/requests/exclusiontemplatecache.h
+++ b/src/libsyncengine/requests/exclusiontemplatecache.h
@@ -48,6 +48,7 @@ class SYNCENGINE_EXPORT ExclusionTemplateCache {
         bool isExcluded(const SyncPath &relativePath, bool &isWarning) noexcept;
 
     private:
+        friend class TestExclusionTemplateCache;
         static std::shared_ptr<ExclusionTemplateCache> _instance;
         std::vector<ExclusionTemplate> _undeletedExclusionTemplates;
         std::vector<ExclusionTemplate> _defExclusionTemplates;
@@ -63,6 +64,8 @@ class SYNCENGINE_EXPORT ExclusionTemplateCache {
         void updateRegexPatterns();
 
         void escapeRegexSpecialChar(std::string &in);
+
+        void addRegexForAllNormalizationForms(std::string regexPattern, ExclusionTemplate exclusionTemplate);
 };
 
 } // namespace KDC

--- a/test/libsyncengine/requests/testexclusiontemplatecache.cpp
+++ b/test/libsyncengine/requests/testexclusiontemplatecache.cpp
@@ -138,5 +138,49 @@ void TestExclusionTemplateCache::testRescueFolderIsExcluded() {
     CPPUNIT_ASSERT(!isWarning);
 }
 
+void TestExclusionTemplateCache::testNFCNFDExclusion() {
+    // None of the name should be excluded by default
+    CPPUNIT_ASSERT(!ExclusionTemplateCache::instance()->isExcluded(testhelpers::makeNfcSyncName()));
+    CPPUNIT_ASSERT(!ExclusionTemplateCache::instance()->isExcluded(testhelpers::makeNfdSyncName()));
+
+    // Generate all the exclusion templates
+    const ExclusionTemplate nfcDefExclTemplate(SyncName2Str(testhelpers::makeNfcSyncName()), false, true);
+    const ExclusionTemplate nfdDefExclTemplate(SyncName2Str(testhelpers::makeNfdSyncName()), false, true);
+    const ExclusionTemplate nfcUsrExclTemplate(SyncName2Str(testhelpers::makeNfcSyncName()), false, false);
+    const ExclusionTemplate nfdUsrExclTemplate(SyncName2Str(testhelpers::makeNfdSyncName()), false, false);
+
+    // Test with only NFC version in def exclusion list
+    auto exclusionCacheDef = ExclusionTemplateCache::instance()->exclusionTemplates(true);
+    exclusionCacheDef.push_back(nfcDefExclTemplate);
+    ExclusionTemplateCache::instance()->update(true, exclusionCacheDef);
+    CPPUNIT_ASSERT(ExclusionTemplateCache::instance()->isExcluded(testhelpers::makeNfcSyncName()));
+    CPPUNIT_ASSERT(ExclusionTemplateCache::instance()->isExcluded(testhelpers::makeNfdSyncName()));
+
+    // Test with only NFD version in def exclusion list
+    exclusionCacheDef.pop_back();
+    exclusionCacheDef.push_back(nfdDefExclTemplate);
+    ExclusionTemplateCache::instance()->update(true, exclusionCacheDef);
+    CPPUNIT_ASSERT(ExclusionTemplateCache::instance()->isExcluded(testhelpers::makeNfcSyncName()));
+    CPPUNIT_ASSERT(ExclusionTemplateCache::instance()->isExcluded(testhelpers::makeNfdSyncName()));
+
+    // Reset def exclusion list
+    exclusionCacheDef.pop_back();
+    ExclusionTemplateCache::instance()->update(true, exclusionCacheDef);
+
+    // Test with only NFC version in def exclusion list
+    auto exclusionCacheUsr = ExclusionTemplateCache::instance()->exclusionTemplates(false);
+    exclusionCacheUsr.push_back(nfcUsrExclTemplate);
+    ExclusionTemplateCache::instance()->update(false, exclusionCacheUsr);
+    CPPUNIT_ASSERT(ExclusionTemplateCache::instance()->isExcluded(testhelpers::makeNfcSyncName()));
+    CPPUNIT_ASSERT(ExclusionTemplateCache::instance()->isExcluded(testhelpers::makeNfdSyncName()));
+
+    // Test with only NFD version in def exclusion list
+    exclusionCacheUsr.pop_back();
+    exclusionCacheUsr.push_back(nfdUsrExclTemplate);
+    ExclusionTemplateCache::instance()->update(false, exclusionCacheUsr);
+    CPPUNIT_ASSERT(ExclusionTemplateCache::instance()->isExcluded(testhelpers::makeNfcSyncName()));
+    CPPUNIT_ASSERT(ExclusionTemplateCache::instance()->isExcluded(testhelpers::makeNfdSyncName()));
+}
+
 
 } // namespace KDC

--- a/test/libsyncengine/requests/testexclusiontemplatecache.cpp
+++ b/test/libsyncengine/requests/testexclusiontemplatecache.cpp
@@ -141,14 +141,14 @@ void TestExclusionTemplateCache::testRescueFolderIsExcluded() {
 
 void TestExclusionTemplateCache::testNFCNFDExclusion() {
     // Ensure that all the values in the default sync exclusion list can be normalized to both NFC and NFD forms
-    { 
+    {
         auto exclusionCacheDef = ExclusionTemplateCache::instance()->exclusionTemplates(true);
-        for (const auto &exclusionTemplate : exclusionCacheDef) {
+        for (const auto &exclusionTemplate: exclusionCacheDef) {
             SyncName result;
             CPPUNIT_ASSERT(CommonUtility::normalizedSyncName(Str2SyncName(exclusionTemplate.templ()), result,
                                                              UnicodeNormalization::NFC));
             CPPUNIT_ASSERT(CommonUtility::normalizedSyncName(Str2SyncName(exclusionTemplate.templ()), result,
-                                                            UnicodeNormalization::NFD));
+                                                             UnicodeNormalization::NFD));
         }
     }
 
@@ -196,6 +196,32 @@ void TestExclusionTemplateCache::testNFCNFDExclusion() {
         CPPUNIT_ASSERT(ExclusionTemplateCache::instance()->isExcluded(testhelpers::makeNfcSyncName()));
         CPPUNIT_ASSERT(ExclusionTemplateCache::instance()->isExcluded(testhelpers::makeNfdSyncName()));
     }
+}
+
+void TestExclusionTemplateCache::testaddRegexForAllNormalizationForms() {
+    ExclusionTemplateCache::instance()->_regexPatterns.clear();
+
+    ExclusionTemplate nfcTemplate(SyncName2Str(testhelpers::makeNfcSyncName()));
+    std::string nfcRegex = SyncName2Str(testhelpers::makeNfcSyncName()); // Don't need to be a valid regex for this test.
+    ExclusionTemplate nfdTemplate(SyncName2Str(testhelpers::makeNfdSyncName()));
+    std::string nfdRegex = SyncName2Str(testhelpers::makeNfdSyncName()); // Don't need to be a valid regex for this test.
+
+    // Ensure that both encoding are inserted
+    ExclusionTemplateCache::instance()->addRegexForAllNormalizationForms(nfcRegex, nfcTemplate);
+    CPPUNIT_ASSERT_EQUAL(size_t(2), ExclusionTemplateCache::instance()->_regexPatterns.size());
+
+    ExclusionTemplateCache::instance()->_regexPatterns.clear();
+    ExclusionTemplateCache::instance()->addRegexForAllNormalizationForms(nfdRegex, nfdTemplate);
+    CPPUNIT_ASSERT_EQUAL(size_t(2), ExclusionTemplateCache::instance()->_regexPatterns.size());
+
+    // Ensure that we cannot have a duplicated regex
+    ExclusionTemplateCache::instance()->_regexPatterns.clear();
+    ExclusionTemplateCache::instance()->addRegexForAllNormalizationForms(nfdRegex, nfdTemplate);
+    CPPUNIT_ASSERT_EQUAL(size_t(2), ExclusionTemplateCache::instance()->_regexPatterns.size());
+    ExclusionTemplateCache::instance()->addRegexForAllNormalizationForms(nfdRegex, nfdTemplate);
+    CPPUNIT_ASSERT_EQUAL(size_t(2), ExclusionTemplateCache::instance()->_regexPatterns.size());
+    ExclusionTemplateCache::instance()->addRegexForAllNormalizationForms(nfcRegex, nfdTemplate);
+    CPPUNIT_ASSERT_EQUAL(size_t(2), ExclusionTemplateCache::instance()->_regexPatterns.size());
 }
 
 

--- a/test/libsyncengine/requests/testexclusiontemplatecache.cpp
+++ b/test/libsyncengine/requests/testexclusiontemplatecache.cpp
@@ -86,6 +86,7 @@ void TestExclusionTemplateCache::tearDown() {
     ParmsDb::reset();
     ParametersCache::reset();
     TestBase::stop();
+    ExclusionTemplateCache::reset();
 }
 
 void TestExclusionTemplateCache::testIsExcluded() {

--- a/test/libsyncengine/requests/testexclusiontemplatecache.cpp
+++ b/test/libsyncengine/requests/testexclusiontemplatecache.cpp
@@ -140,47 +140,62 @@ void TestExclusionTemplateCache::testRescueFolderIsExcluded() {
 }
 
 void TestExclusionTemplateCache::testNFCNFDExclusion() {
-    // None of the name should be excluded by default
-    CPPUNIT_ASSERT(!ExclusionTemplateCache::instance()->isExcluded(testhelpers::makeNfcSyncName()));
-    CPPUNIT_ASSERT(!ExclusionTemplateCache::instance()->isExcluded(testhelpers::makeNfdSyncName()));
+    // Ensure that all the values in the default sync exclusion list can be normalized to both NFC and NFD forms
+    { 
+        auto exclusionCacheDef = ExclusionTemplateCache::instance()->exclusionTemplates(true);
+        for (const auto &exclusionTemplate : exclusionCacheDef) {
+            SyncName result;
+            CPPUNIT_ASSERT(CommonUtility::normalizedSyncName(Str2SyncName(exclusionTemplate.templ()), result,
+                                                             UnicodeNormalization::NFC));
+            CPPUNIT_ASSERT(CommonUtility::normalizedSyncName(Str2SyncName(exclusionTemplate.templ()), result,
+                                                            UnicodeNormalization::NFD));
+        }
+    }
 
-    // Generate all the exclusion templates
-    const ExclusionTemplate nfcDefExclTemplate(SyncName2Str(testhelpers::makeNfcSyncName()), false, true);
-    const ExclusionTemplate nfdDefExclTemplate(SyncName2Str(testhelpers::makeNfdSyncName()), false, true);
-    const ExclusionTemplate nfcUsrExclTemplate(SyncName2Str(testhelpers::makeNfcSyncName()), false, false);
-    const ExclusionTemplate nfdUsrExclTemplate(SyncName2Str(testhelpers::makeNfdSyncName()), false, false);
+    // Ensure that ExclusionTemplateCache is cheking NFC and NFD names
+    {
+        // None of the name should be excluded by default
+        CPPUNIT_ASSERT(!ExclusionTemplateCache::instance()->isExcluded(testhelpers::makeNfcSyncName()));
+        CPPUNIT_ASSERT(!ExclusionTemplateCache::instance()->isExcluded(testhelpers::makeNfdSyncName()));
 
-    // Test with only NFC version in def exclusion list
-    auto exclusionCacheDef = ExclusionTemplateCache::instance()->exclusionTemplates(true);
-    exclusionCacheDef.push_back(nfcDefExclTemplate);
-    ExclusionTemplateCache::instance()->update(true, exclusionCacheDef);
-    CPPUNIT_ASSERT(ExclusionTemplateCache::instance()->isExcluded(testhelpers::makeNfcSyncName()));
-    CPPUNIT_ASSERT(ExclusionTemplateCache::instance()->isExcluded(testhelpers::makeNfdSyncName()));
+        // Generate all the exclusion templates
+        const ExclusionTemplate nfcDefExclTemplate(SyncName2Str(testhelpers::makeNfcSyncName()), false, true);
+        const ExclusionTemplate nfdDefExclTemplate(SyncName2Str(testhelpers::makeNfdSyncName()), false, true);
+        const ExclusionTemplate nfcUsrExclTemplate(SyncName2Str(testhelpers::makeNfcSyncName()), false, false);
+        const ExclusionTemplate nfdUsrExclTemplate(SyncName2Str(testhelpers::makeNfdSyncName()), false, false);
 
-    // Test with only NFD version in def exclusion list
-    exclusionCacheDef.pop_back();
-    exclusionCacheDef.push_back(nfdDefExclTemplate);
-    ExclusionTemplateCache::instance()->update(true, exclusionCacheDef);
-    CPPUNIT_ASSERT(ExclusionTemplateCache::instance()->isExcluded(testhelpers::makeNfcSyncName()));
-    CPPUNIT_ASSERT(ExclusionTemplateCache::instance()->isExcluded(testhelpers::makeNfdSyncName()));
+        // Test with only NFC version in def exclusion list
+        auto exclusionCacheDef = ExclusionTemplateCache::instance()->exclusionTemplates(true);
+        exclusionCacheDef.push_back(nfcDefExclTemplate);
+        ExclusionTemplateCache::instance()->update(true, exclusionCacheDef);
+        CPPUNIT_ASSERT(ExclusionTemplateCache::instance()->isExcluded(testhelpers::makeNfcSyncName()));
+        CPPUNIT_ASSERT(ExclusionTemplateCache::instance()->isExcluded(testhelpers::makeNfdSyncName()));
 
-    // Reset def exclusion list
-    exclusionCacheDef.pop_back();
-    ExclusionTemplateCache::instance()->update(true, exclusionCacheDef);
+        // Test with only NFD version in def exclusion list
+        exclusionCacheDef.pop_back();
+        exclusionCacheDef.push_back(nfdDefExclTemplate);
+        ExclusionTemplateCache::instance()->update(true, exclusionCacheDef);
+        CPPUNIT_ASSERT(ExclusionTemplateCache::instance()->isExcluded(testhelpers::makeNfcSyncName()));
+        CPPUNIT_ASSERT(ExclusionTemplateCache::instance()->isExcluded(testhelpers::makeNfdSyncName()));
 
-    // Test with only NFC version in def exclusion list
-    auto exclusionCacheUsr = ExclusionTemplateCache::instance()->exclusionTemplates(false);
-    exclusionCacheUsr.push_back(nfcUsrExclTemplate);
-    ExclusionTemplateCache::instance()->update(false, exclusionCacheUsr);
-    CPPUNIT_ASSERT(ExclusionTemplateCache::instance()->isExcluded(testhelpers::makeNfcSyncName()));
-    CPPUNIT_ASSERT(ExclusionTemplateCache::instance()->isExcluded(testhelpers::makeNfdSyncName()));
+        // Reset def exclusion list
+        exclusionCacheDef.pop_back();
+        ExclusionTemplateCache::instance()->update(true, exclusionCacheDef);
 
-    // Test with only NFD version in def exclusion list
-    exclusionCacheUsr.pop_back();
-    exclusionCacheUsr.push_back(nfdUsrExclTemplate);
-    ExclusionTemplateCache::instance()->update(false, exclusionCacheUsr);
-    CPPUNIT_ASSERT(ExclusionTemplateCache::instance()->isExcluded(testhelpers::makeNfcSyncName()));
-    CPPUNIT_ASSERT(ExclusionTemplateCache::instance()->isExcluded(testhelpers::makeNfdSyncName()));
+        // Test with only NFC version in def exclusion list
+        auto exclusionCacheUsr = ExclusionTemplateCache::instance()->exclusionTemplates(false);
+        exclusionCacheUsr.push_back(nfcUsrExclTemplate);
+        ExclusionTemplateCache::instance()->update(false, exclusionCacheUsr);
+        CPPUNIT_ASSERT(ExclusionTemplateCache::instance()->isExcluded(testhelpers::makeNfcSyncName()));
+        CPPUNIT_ASSERT(ExclusionTemplateCache::instance()->isExcluded(testhelpers::makeNfdSyncName()));
+
+        // Test with only NFD version in def exclusion list
+        exclusionCacheUsr.pop_back();
+        exclusionCacheUsr.push_back(nfdUsrExclTemplate);
+        ExclusionTemplateCache::instance()->update(false, exclusionCacheUsr);
+        CPPUNIT_ASSERT(ExclusionTemplateCache::instance()->isExcluded(testhelpers::makeNfcSyncName()));
+        CPPUNIT_ASSERT(ExclusionTemplateCache::instance()->isExcluded(testhelpers::makeNfdSyncName()));
+    }
 }
 
 

--- a/test/libsyncengine/requests/testexclusiontemplatecache.h
+++ b/test/libsyncengine/requests/testexclusiontemplatecache.h
@@ -26,9 +26,10 @@ namespace KDC {
 
 class TestExclusionTemplateCache : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST_SUITE(TestExclusionTemplateCache);
-        CPPUNIT_TEST(testIsExcluded);
-        CPPUNIT_TEST(testCacheFolderIsExcluded);
-        CPPUNIT_TEST(testRescueFolderIsExcluded);
+       // CPPUNIT_TEST(testIsExcluded);
+        //CPPUNIT_TEST(testCacheFolderIsExcluded);
+       //CPPUNIT_TEST(testRescueFolderIsExcluded);
+        CPPUNIT_TEST(testNFCNFDExclusion);
         CPPUNIT_TEST_SUITE_END();
 
     public:
@@ -39,6 +40,7 @@ class TestExclusionTemplateCache : public CppUnit::TestFixture, public TestBase 
         void testIsExcluded();
         void testCacheFolderIsExcluded();
         void testRescueFolderIsExcluded();
+        void testNFCNFDExclusion();
 };
 
 } // namespace KDC

--- a/test/libsyncengine/requests/testexclusiontemplatecache.h
+++ b/test/libsyncengine/requests/testexclusiontemplatecache.h
@@ -30,6 +30,7 @@ class TestExclusionTemplateCache : public CppUnit::TestFixture, public TestBase 
         CPPUNIT_TEST(testCacheFolderIsExcluded);
         CPPUNIT_TEST(testRescueFolderIsExcluded);
         CPPUNIT_TEST(testNFCNFDExclusion);
+        CPPUNIT_TEST(testaddRegexForAllNormalizationForms);
         CPPUNIT_TEST_SUITE_END();
 
     public:
@@ -41,6 +42,7 @@ class TestExclusionTemplateCache : public CppUnit::TestFixture, public TestBase 
         void testCacheFolderIsExcluded();
         void testRescueFolderIsExcluded();
         void testNFCNFDExclusion();
+        void testaddRegexForAllNormalizationForms();
 };
 
 } // namespace KDC

--- a/test/libsyncengine/requests/testexclusiontemplatecache.h
+++ b/test/libsyncengine/requests/testexclusiontemplatecache.h
@@ -26,9 +26,9 @@ namespace KDC {
 
 class TestExclusionTemplateCache : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST_SUITE(TestExclusionTemplateCache);
-       // CPPUNIT_TEST(testIsExcluded);
-        //CPPUNIT_TEST(testCacheFolderIsExcluded);
-       //CPPUNIT_TEST(testRescueFolderIsExcluded);
+        CPPUNIT_TEST(testIsExcluded);
+        CPPUNIT_TEST(testCacheFolderIsExcluded);
+        CPPUNIT_TEST(testRescueFolderIsExcluded);
         CPPUNIT_TEST(testNFCNFDExclusion);
         CPPUNIT_TEST_SUITE_END();
 


### PR DESCRIPTION
In a recent change, the normalization of the temporary exclusion `Icon\r` was modified in the exclusion template list.

As a result, these files are no longer excluded, which causes the folder icon to be lost on _macOS_. The file `Icon\r` is uploaded, but the backend automatically renames it to `Icon`, which triggers a local move. The file is then no longer recognized by _Finder_ as a folder icon file, since it no longer ends with `\r`.

To avoid such issues in the future, the `ExclusionTemplateCache` now automatically checks both NFD and NFC encodings when they differ.



