### PR TITLE
Conventional commits git hook

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 // A hook script to check that the commit message respect the conventional commit standards.
+// Based on https://dev.to/mbarzeev/a-git-hook-for-commit-messages-validation-no-husky-just-js-1hni
 
 const fs = require('fs');
 

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+// A hook script to check that the commit message respect the conventional commit standards.
+
+const fs = require('fs');
+
+const conventionalCommitMessageRegExp = /^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test){1}(\([\w\-\.]+\))?(!)?: ([\w ])+([\s\S]*)/g;
+let exitCode = 0;
+const commitMsgFile = process.argv[2];
+const message = fs.readFileSync(commitMsgFile, 'utf8');
+const isValid = conventionalCommitMessageRegExp.test(message);
+
+if(!isValid) {
+   console.log('Cannot commit: the commit message does not comply with conventional commits standards.');
+   exitCode = 1;
+}
+
+process.exit(exitCode);


### PR DESCRIPTION
A git hook to check that your commit message respect conventional commit standards.