### PR TITLE
File system changes occurring while sync is internally paused were not reflected in the snapshot.

### DIFF
--- a/src/libsyncengine/update_detection/file_system_observer/filesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/filesystemobserverworker.cpp
@@ -68,6 +68,7 @@ void FileSystemObserverWorker::init() {
     ISyncWorker::init();
     _updating = false;
     _initializing = true;
+    invalidateSnapshot();
 }
 
 } // namespace KDC


### PR DESCRIPTION
File system changes occurring while sync is internally paused were not reflected in the snapshot.

This was the cause of the fail of internalPause1 failure.