### PR TITLE
Limit the number of folder in blacklist to 50

### DIFF
--- a/src/gui/adddrivewizard.cpp
+++ b/src/gui/adddrivewizard.cpp
@@ -295,6 +295,13 @@ void AddDriveWizard::onStepTerminated(bool next) {
         if (next) {
             _selectionSize = _addDriveServerFoldersWidget->selectionSize();
             _blackList = _addDriveServerFoldersWidget->createBlackList();
+            if (_blackList.size() > 50) {
+                CustomMessageBox msgBox(QMessageBox::Warning,
+                                        tr("You cannot blacklist more than 50 folders. Please uncheck a higher-level folder."),
+                                        QMessageBox::Ok, this);
+                (void) msgBox.exec();
+                return;
+            }
             _whiteList = _addDriveServerFoldersWidget->createWhiteList();
         }
         startNextStep(!next);

--- a/src/gui/drivepreferenceswidget.h
+++ b/src/gui/drivepreferenceswidget.h
@@ -108,6 +108,7 @@ class DrivePreferencesWidget : public LargeWidgetWithCustomToolTip {
                      const QString &serverFolderNodeId, QSet<QString> blackSet, QSet<QString> whiteSet);
         bool updateSelectiveSyncList(const QHash<int, QHash<const QString, bool>> &mapUndefinedFolders);
         void updateGuardedFoldersBlocs();
+        bool checkBlacklistSize(const size_t blacklistSize);
 
     private slots:
         void onErrorsWidgetClicked();

--- a/src/gui/foldertreeitemwidget.cpp
+++ b/src/gui/foldertreeitemwidget.cpp
@@ -258,9 +258,9 @@ void FolderTreeItemWidget::insertNode(QTreeWidgetItem *parent, const NodeInfo &n
 }
 
 QSet<QString> FolderTreeItemWidget::createBlackSet() {
-    QSet<QString> newBlackset = _oldBlackList.unite(_oldUndecidedList);
-    createBlackSet(nullptr, newBlackset);
-    return newBlackset;
+    QSet<QString> newBlackSet = _oldBlackList.unite(_oldUndecidedList);
+    createBlackSet(nullptr, newBlackSet);
+    return newBlackSet;
 }
 
 void FolderTreeItemWidget::createBlackSet(QTreeWidgetItem *parentItem, QSet<QString> &blackset) {


### PR DESCRIPTION
The number of folder in blacklist is now limited to 50. However, this limitation occurs only when settings the blacklisted folder, therefore, it has no impact on users that have currently more than 50 folders in their blacklist, as long as they don't modify it.