### PR TITLE
feat: add KDRIVE_PRESERVE_SYNC_PERMISSIONS to preserve file rights on create

### DIFF
--- a/src/libsyncengine/jobs/network/API_v2/downloadjob.cpp
+++ b/src/libsyncengine/jobs/network/API_v2/downloadjob.cpp
@@ -476,7 +476,8 @@ bool DownloadJob::moveTmpFile() {
 #ifdef _WIN32
         bool sharingViolationError = false;
 #endif
-        if (_isCreate) {
+        static const bool forceCopy = CommonUtility::envVarValue("KDRIVE_PRESERVE_PERMISSIONS_ON_CREATE") == "1";
+        if (_isCreate && !forceCopy) {
             // Move file
             IoError ioError = IoError::Success;
             IoHelper::moveItem(_tmpPath, _localpath, ioError);
@@ -491,7 +492,7 @@ bool DownloadJob::moveTmpFile() {
             }
         }
 
-        if (!_isCreate || crossDeviceLinkError) {
+        if (!_isCreate || crossDeviceLinkError || forceCopy) {
             // Copy file content (i.e. when the target exists, do not change its node id).
             std::error_code ec;
             std::filesystem::copy(_tmpPath, _localpath, std::filesystem::copy_options::overwrite_existing, ec);


### PR DESCRIPTION
On a sync **without the liteSync option**, when a file is created by the app (following a remote creation), the new file will inherit its ACL/rights from the temporary folder:

```
C:\Users\<username>\AppData\Local\Temp\
```
instead of the sync directory.

To address this, the environment variable **`KDRIVE_PRESERVE_SYNC_PERMISSIONS`** is introduced. When set to 1, it forces the file to be **copied** (instead of moved) from the temporary folder to the sync directory during creation. This ensures that the ACL of the copied file is inherited from the sync directory.
