### PR TITLE
Kdesktop 1833 Fix synthesis popover actions menu

### DIFF
--- a/src/gui/synchronizeditemwidget.cpp
+++ b/src/gui/synchronizeditemwidget.cpp
@@ -320,40 +320,32 @@ void SynchronizedItemWidget::onMenuButtonClicked() {
         connect(openAction, &QWidgetAction::triggered, this, &SynchronizedItemWidget::onOpenActionTriggered);
         menu->addAction(openAction);
 
-        QWidgetAction *favoritesAction = new QWidgetAction(this);
-        MenuItemWidget *favoritesMenuItemWidget = new MenuItemWidget(tr("Add to favorites"));
-        favoritesMenuItemWidget->hide();
-        favoritesMenuItemWidget->setLeftIcon(":/client/resources/icons/actions/favorite.svg");
-        favoritesAction->setDefaultWidget(favoritesMenuItemWidget);
-        connect(favoritesAction, &QWidgetAction::triggered, this, &SynchronizedItemWidget::onFavoritesActionTriggered);
-        menu->addAction(favoritesAction);
+        if (!_item.fileId().isEmpty()) {
+            QWidgetAction *favoritesAction = new QWidgetAction(this);
+            MenuItemWidget *favoritesMenuItemWidget = new MenuItemWidget(tr("Add to favorites"));
+            favoritesMenuItemWidget->hide();
+            favoritesMenuItemWidget->setLeftIcon(":/client/resources/icons/actions/favorite.svg");
+            favoritesAction->setDefaultWidget(favoritesMenuItemWidget);
+            connect(favoritesAction, &QWidgetAction::triggered, this, &SynchronizedItemWidget::onFavoritesActionTriggered);
+            menu->addAction(favoritesAction);
 
-        /*QWidgetAction *rightsAndSharingAction = new QWidgetAction(this);
-        MenuItemWidget *rightsAndSharingMenuItemWidget = new MenuItemWidget(tr("Rights and sharing"));
-        rightsAndSharingMenuItemWidget->hide();
-        rightsAndSharingMenuItemWidget->setLeftIcon(":/client/resources/icons/actions/share.svg");
-        rightsAndSharingAction->setDefaultWidget(rightsAndSharingMenuItemWidget);
-        connect(rightsAndSharingAction, &QWidgetAction::triggered, this,
-        &SynchronizedItemWidget::onRightAndSharingActionTriggered); menu->addAction(rightsAndSharingAction);*/
+            QWidgetAction *copyLinkAction = new QWidgetAction(this);
+            MenuItemWidget *copyLinkMenuItemWidget = new MenuItemWidget(tr("Copy sharing link"));
+            copyLinkMenuItemWidget->setLeftIcon(":/client/resources/icons/actions/link.svg");
+            copyLinkAction->setDefaultWidget(copyLinkMenuItemWidget);
+            connect(copyLinkAction, &QWidgetAction::triggered, this, &SynchronizedItemWidget::onCopyLinkActionTriggered);
+            menu->addAction(copyLinkAction);
 
-        QWidgetAction *copyLinkAction = new QWidgetAction(this);
-        MenuItemWidget *copyLinkMenuItemWidget = new MenuItemWidget(tr("Copy sharing link"));
-        copyLinkMenuItemWidget->setLeftIcon(":/client/resources/icons/actions/link.svg");
-        copyLinkMenuItemWidget->setHidden(_item.fileId().isEmpty());
-        copyLinkAction->setDefaultWidget(copyLinkMenuItemWidget);
-        connect(copyLinkAction, &QWidgetAction::triggered, this, &SynchronizedItemWidget::onCopyLinkActionTriggered);
-        menu->addAction(copyLinkAction);
+            menu->addSeparator();
 
-        menu->addSeparator();
-
-        QWidgetAction *displayOnDriveAction = new QWidgetAction(this);
-        MenuItemWidget *displayOnDriveMenuItemWidget = new MenuItemWidget(tr("Display on kdrive.infomaniak.com"));
-        displayOnDriveMenuItemWidget->setLeftIcon(":/client/resources/icons/actions/webview.svg");
-        displayOnDriveMenuItemWidget->setHidden(_item.fileId().isEmpty());
-        displayOnDriveAction->setDefaultWidget(displayOnDriveMenuItemWidget);
-        connect(displayOnDriveAction, &QWidgetAction::triggered, this, &SynchronizedItemWidget::onDisplayOnDriveActionTriggered);
-        menu->addAction(displayOnDriveAction);
-
+            QWidgetAction *displayOnDriveAction = new QWidgetAction(this);
+            MenuItemWidget *displayOnDriveMenuItemWidget = new MenuItemWidget(tr("Display on kdrive.infomaniak.com"));
+            displayOnDriveMenuItemWidget->setLeftIcon(":/client/resources/icons/actions/webview.svg");
+            displayOnDriveAction->setDefaultWidget(displayOnDriveMenuItemWidget);
+            connect(displayOnDriveAction, &QWidgetAction::triggered, this,
+                    &SynchronizedItemWidget::onDisplayOnDriveActionTriggered);
+            menu->addAction(displayOnDriveAction);
+        }
         menu->exec(QWidget::mapToGlobal(_menuButton->geometry().center()));
         _isMenuOpened = false;
     }

--- a/src/gui/synchronizeditemwidget.cpp
+++ b/src/gui/synchronizeditemwidget.cpp
@@ -311,26 +311,26 @@ void SynchronizedItemWidget::onMenuButtonClicked() {
     if (_menuButton) {
         _isMenuOpened = true;
         MatomoClient::sendEvent("synchronizedItem", MatomoEventAction::Click, "openKebabMenu");
-        MenuWidget *menu = new MenuWidget(MenuWidget::Menu, this);
+        auto *menu = new MenuWidget(MenuWidget::Menu, this);
 
-        QWidgetAction *openAction = new QWidgetAction(this);
-        MenuItemWidget *openMenuItemWidget = new MenuItemWidget(tr("Open"));
+        auto *openAction = new QWidgetAction(this);
+        auto *openMenuItemWidget = new MenuItemWidget(tr("Open"));
         openMenuItemWidget->setLeftIcon(":/client/resources/icons/actions/view.svg");
         openAction->setDefaultWidget(openMenuItemWidget);
         connect(openAction, &QWidgetAction::triggered, this, &SynchronizedItemWidget::onOpenActionTriggered);
         menu->addAction(openAction);
 
         if (!_item.fileId().isEmpty()) {
-            QWidgetAction *favoritesAction = new QWidgetAction(this);
-            MenuItemWidget *favoritesMenuItemWidget = new MenuItemWidget(tr("Add to favorites"));
+            auto *favoritesAction = new QWidgetAction(this);
+            auto *favoritesMenuItemWidget = new MenuItemWidget(tr("Add to favorites"));
             favoritesMenuItemWidget->hide();
             favoritesMenuItemWidget->setLeftIcon(":/client/resources/icons/actions/favorite.svg");
             favoritesAction->setDefaultWidget(favoritesMenuItemWidget);
             connect(favoritesAction, &QWidgetAction::triggered, this, &SynchronizedItemWidget::onFavoritesActionTriggered);
             menu->addAction(favoritesAction);
 
-            QWidgetAction *copyLinkAction = new QWidgetAction(this);
-            MenuItemWidget *copyLinkMenuItemWidget = new MenuItemWidget(tr("Copy sharing link"));
+            auto *copyLinkAction = new QWidgetAction(this);
+            auto *copyLinkMenuItemWidget = new MenuItemWidget(tr("Copy sharing link"));
             copyLinkMenuItemWidget->setLeftIcon(":/client/resources/icons/actions/link.svg");
             copyLinkAction->setDefaultWidget(copyLinkMenuItemWidget);
             connect(copyLinkAction, &QWidgetAction::triggered, this, &SynchronizedItemWidget::onCopyLinkActionTriggered);
@@ -338,8 +338,8 @@ void SynchronizedItemWidget::onMenuButtonClicked() {
 
             menu->addSeparator();
 
-            QWidgetAction *displayOnDriveAction = new QWidgetAction(this);
-            MenuItemWidget *displayOnDriveMenuItemWidget = new MenuItemWidget(tr("Display on kdrive.infomaniak.com"));
+            auto *displayOnDriveAction = new QWidgetAction(this);
+            auto *displayOnDriveMenuItemWidget = new MenuItemWidget(tr("Display on kdrive.infomaniak.com"));
             displayOnDriveMenuItemWidget->setLeftIcon(":/client/resources/icons/actions/webview.svg");
             displayOnDriveAction->setDefaultWidget(displayOnDriveMenuItemWidget);
             connect(displayOnDriveAction, &QWidgetAction::triggered, this,

--- a/src/libsyncengine/progress/progressinfo.cpp
+++ b/src/libsyncengine/progress/progressinfo.cpp
@@ -180,7 +180,7 @@ bool ProgressInfo::setSyncFileItemRemoteId(const SyncPath &path, const NodeId &r
     const auto it = _currentItems.find(normalizedPath);
     if (it == _currentItems.end() || it->second.empty()) {
         LOGW_INFO(Log::instance()->getLogger(),
-                  L"Item not found in ProgressInfo list (normal for ommited operation): " << Utility::formatSyncPath(path));
+                  L"Item not found in ProgressInfo list (normal for omitted operation): " << Utility::formatSyncPath(path));
         return true;
     }
 

--- a/src/libsyncengine/progress/progressinfo.cpp
+++ b/src/libsyncengine/progress/progressinfo.cpp
@@ -171,6 +171,23 @@ bool ProgressInfo::setProgressComplete(const SyncPath &path, const SyncFileStatu
     return true;
 }
 
+bool ProgressInfo::setSyncFileItemRemoteId(const SyncPath &path, const NodeId &remoteId) {
+    SyncPath normalizedPath;
+    if (!Utility::normalizedSyncPath(path, normalizedPath)) {
+        LOGW_WARN(Log::instance()->getLogger(), L"Error in Utility::normalizedSyncPath: " << Utility::formatSyncPath(path));
+        return false;
+    }
+    const auto it = _currentItems.find(normalizedPath);
+    if (it == _currentItems.end() || it->second.empty()) {
+        LOGW_INFO(Log::instance()->getLogger(),
+                  L"Item not found in ProgressInfo list (normal for ommited operation): " << Utility::formatSyncPath(path));
+        return true;
+    }
+
+    it->second.front().item().setRemoteNodeId(remoteId);
+    return true;
+}
+
 bool ProgressInfo::isSizeDependent(const SyncFileItem &item) const {
     return !item.isDirectory() &&
            (item.instruction() == SyncFileInstruction::Update || item.instruction() == SyncFileInstruction::Get ||

--- a/src/libsyncengine/progress/progressinfo.h
+++ b/src/libsyncengine/progress/progressinfo.h
@@ -44,6 +44,7 @@ class ProgressInfo {
         [[nodiscard]] bool initProgress(const SyncFileItem &item);
         [[nodiscard]] bool setProgress(const SyncPath &path, int64_t completed);
         [[nodiscard]] bool setProgressComplete(const SyncPath &path, SyncFileStatus status);
+        [[nodiscard]] bool setSyncFileItemRemoteId(const SyncPath &path, const NodeId& remoteId);
         [[nodiscard]] bool getSyncFileItem(const SyncPath &path, SyncFileItem &item);
 
         [[nodiscard]] int64_t totalFiles() const { return _fileProgress.total(); }

--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -1320,14 +1320,7 @@ ExitInfo ExecutorWorker::deleteFinishedAsyncJobs() {
                         if (uploadJob) newRemoteNodeId = uploadJob->nodeId();
                         setProgressComplete(syncOp, SyncFileStatus::Success, newRemoteNodeId);
                     } else {
-                        if (syncOp->type() == OperationType::Create && syncOp->targetSide() == ReplicaSide::Remote) {
-                            std::shared_ptr<UploadJob> uploadJob = std::dynamic_pointer_cast<UploadJob>(job);
-                            NodeId newRemoteNodeId;
-                            if (uploadJob) newRemoteNodeId = uploadJob->nodeId();
-                            setProgressComplete(syncOp, SyncFileStatus::Success, newRemoteNodeId);
-                        } else {
-                            setProgressComplete(syncOp, SyncFileStatus::Success);
-                        }
+                        setProgressComplete(syncOp, SyncFileStatus::Success);
                     }
 
 

--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -1320,7 +1320,14 @@ ExitInfo ExecutorWorker::deleteFinishedAsyncJobs() {
                         if (uploadJob) newRemoteNodeId = uploadJob->nodeId();
                         setProgressComplete(syncOp, SyncFileStatus::Success, newRemoteNodeId);
                     } else {
-                        setProgressComplete(syncOp, SyncFileStatus::Success);
+                        if (syncOp->type() == OperationType::Create && syncOp->targetSide() == ReplicaSide::Remote) {
+                            std::shared_ptr<UploadJob> uploadJob = std::dynamic_pointer_cast<UploadJob>(job);
+                            NodeId newRemoteNodeId;
+                            if (uploadJob) newRemoteNodeId = uploadJob->nodeId();
+                            setProgressComplete(syncOp, SyncFileStatus::Success, newRemoteNodeId);
+                        } else {
+                            setProgressComplete(syncOp, SyncFileStatus::Success);
+                        }
                     }
 
 

--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -1314,16 +1314,15 @@ ExitInfo ExecutorWorker::deleteFinishedAsyncJobs() {
                 } else {
                     if (ignored) {
                         setProgressComplete(syncOp, SyncFileStatus::Ignored);
+                    } else if (syncOp->type() == OperationType::Create && syncOp->targetSide() == ReplicaSide::Remote) {
+                        std::shared_ptr<UploadJob> uploadJob = std::dynamic_pointer_cast<UploadJob>(job);
+                        NodeId newRemoteNodeId;
+                        if (uploadJob) newRemoteNodeId = uploadJob->nodeId();
+                        setProgressComplete(syncOp, SyncFileStatus::Success, newRemoteNodeId);
                     } else {
-                        if (syncOp->type() == OperationType::Create && syncOp->targetSide() == ReplicaSide::Remote) {
-                            std::shared_ptr<UploadJob> uploadJob = std::dynamic_pointer_cast<UploadJob>(job);
-                            NodeId newRemoteNodeId;
-                            if (uploadJob) newRemoteNodeId = uploadJob->nodeId();
-                            setProgressComplete(syncOp, SyncFileStatus::Success, newRemoteNodeId);
-                        } else {
-                            setProgressComplete(syncOp, SyncFileStatus::Success);
-                        }
+                        setProgressComplete(syncOp, SyncFileStatus::Success);
                     }
+
 
                     if (syncOp->affectedNode()->id().has_value()) {
                         NodeSet whiteList;

--- a/src/libsyncengine/propagation/executor/executorworker.h
+++ b/src/libsyncengine/propagation/executor/executorworker.h
@@ -144,7 +144,7 @@ class ExecutorWorker : public OperationProcessor {
 
         bool deleteOpNodes(SyncOpPtr syncOp);
 
-        void setProgressComplete(SyncOpPtr syncOp, SyncFileStatus status);
+        void setProgressComplete(SyncOpPtr syncOp, SyncFileStatus status, const NodeId &newRemoteNodeId = "");
 
         static void getNodeIdsFromOp(SyncOpPtr syncOp, NodeId &localNodeId, NodeId &remoteNodeId);
 

--- a/src/libsyncengine/syncpal/syncpal.cpp
+++ b/src/libsyncengine/syncpal/syncpal.cpp
@@ -579,7 +579,14 @@ bool SyncPal::setProgress(const SyncPath &relativePath, int64_t current) {
     return true;
 }
 
-bool SyncPal::setProgressComplete(const SyncPath &relativeLocalPath, SyncFileStatus status) {
+bool SyncPal::setProgressComplete(const SyncPath &relativeLocalPath, SyncFileStatus status, const NodeId &newRemoteNodeId) {
+    if(!newRemoteNodeId.empty()) {
+        if (!_progressInfo->setSyncFileItemRemoteId(relativeLocalPath, newRemoteNodeId)) {
+            LOG_SYNCPAL_WARN(_logger, "Error in ProgressInfo::setSyncFileItemRemoteId");
+            // Continue anyway as this is not critical, the share menu on activities will not be available for this file
+        }
+    }
+
     if (!_progressInfo->setProgressComplete(relativeLocalPath, status)) {
         LOG_SYNCPAL_WARN(_logger, "Error in ProgressInfo::setProgressComplete");
         return false;

--- a/src/libsyncengine/syncpal/syncpal.h
+++ b/src/libsyncengine/syncpal/syncpal.h
@@ -362,7 +362,7 @@ class SYNCENGINE_EXPORT SyncPal : public std::enable_shared_from_this<SyncPal> {
         [[nodiscard]] bool initProgress(const SyncFileItem &item);
         [[nodiscard]] bool setProgress(const SyncPath &relativePath, int64_t current);
         [[nodiscard]] bool setProgressComplete(const SyncPath &relativeLocalPath, SyncFileStatus status,
-                                               const NodeId &newRemoteNodeId = NodeId{});
+                                               const NodeId &newRemoteNodeId = {});
 
         // Direct download callback
         void directDownloadCallback(UniqueId jobId);

--- a/src/libsyncengine/syncpal/syncpal.h
+++ b/src/libsyncengine/syncpal/syncpal.h
@@ -362,7 +362,7 @@ class SYNCENGINE_EXPORT SyncPal : public std::enable_shared_from_this<SyncPal> {
         [[nodiscard]] bool initProgress(const SyncFileItem &item);
         [[nodiscard]] bool setProgress(const SyncPath &relativePath, int64_t current);
         [[nodiscard]] bool setProgressComplete(const SyncPath &relativeLocalPath, SyncFileStatus status,
-                                               const NodeId &newRemoteNodeId = "");
+                                               const NodeId &newRemoteNodeId = NodeId{});
 
         // Direct download callback
         void directDownloadCallback(UniqueId jobId);

--- a/src/libsyncengine/syncpal/syncpal.h
+++ b/src/libsyncengine/syncpal/syncpal.h
@@ -361,7 +361,8 @@ class SYNCENGINE_EXPORT SyncPal : public std::enable_shared_from_this<SyncPal> {
         void updateEstimates();
         [[nodiscard]] bool initProgress(const SyncFileItem &item);
         [[nodiscard]] bool setProgress(const SyncPath &relativePath, int64_t current);
-        [[nodiscard]] bool setProgressComplete(const SyncPath &relativeLocalPath, SyncFileStatus status);
+        [[nodiscard]] bool setProgressComplete(const SyncPath &relativeLocalPath, SyncFileStatus status,
+                                               const NodeId &newRemoteNodeId = "");
 
         // Direct download callback
         void directDownloadCallback(UniqueId jobId);


### PR DESCRIPTION
### 🛠️ Fix: Missing Node ID in Local Create synthesis & Crash on Menu Execution

This PR addresses two issues:

1. **Missing `nodeId` in local create operations synthesis**

   When performing a local create, the `SynchronizedItem` sent to the GUI was missing the `nodeId` of the new remote item. This prevented certain features from being available in the operation summary, such as:

   * **Sharing**
   * **Open in the web**

   **After the PR, these features are available:**
   ![image](https://github.com/user-attachments/assets/76805b5c-5c69-4801-b9ff-3281fa486d3f)

   This is now fixed: the `nodeId` is properly propagated to the GUI.

2. **Crash when using `MenuItemWidget::setHidden()` on Windows/macOS**

   On both Windows and macOS, calling `MenuItemWidget::setHidden()` caused `MenuWidget::exec()` to fail. This PR avoids unnecessary calls to `setHidden` that could lead to inconsistent or invalid menu states on those platforms.