### PR TITLE
fix(parms-db-migration): upgrade columns before any other DB request

### DIFF
--- a/src/libparms/db/parmsdb.cpp
+++ b/src/libparms/db/parmsdb.cpp
@@ -1117,14 +1117,17 @@ bool ParmsDb::upgradeColumns() {
         return false;
     }
 
-    LOG_INFO(_logger, "Columns upgrade in << dbType()  << successfully completed.");
+    LOG_INFO(_logger, "Columns upgrade in " << dbType() << " successfully completed.");
 
     return true;
 }
 
 bool ParmsDb::upgrade(const std::string &fromVersion, const std::string &toVersion) {
     LOG_INFO(_logger, "Apply generic upgrade fixes to " << dbType() << " DB version " << fromVersion);
-    upgradeColumns();
+    if (!upgradeColumns()) {
+        LOG_WARN(_logger, "Failed to insert missing columns.");
+        return false;
+    }
 
     if (CommonUtility::isVersionLower(fromVersion, toVersion)) {
         LOG_INFO(_logger, "Upgrade " << dbType() << " DB from " << fromVersion << " to " << toVersion);
@@ -3107,7 +3110,7 @@ bool ParmsDb::selectAllMigrationSelectiveSync(std::vector<MigrationSelectiveSync
 
 #ifdef _WIN32
 bool ParmsDb::replaceShortDbPathsWithLongPaths() {
-    LOG_INFO(_logger, "Replacing short DB path names wiht long ones in sync table.")
+    LOG_INFO(_logger, "Replacing short DB path names with long ones in sync table.")
 
     if (!createAndPrepareRequest(SELECT_ALL_SYNCS_REQUEST_ID, SELECT_ALL_SYNCS_REQUEST)) return false;
     std::vector<Sync> syncList;

--- a/src/libparms/db/parmsdb.cpp
+++ b/src/libparms/db/parmsdb.cpp
@@ -1061,7 +1061,7 @@ bool ParmsDb::prepare() {
     return true;
 }
 
-bool ParmsDb::upgradeColumns() {
+bool ParmsDb::upgradeTables() {
     const std::string tableName = "parameters";
     std::string columnName = "maxAllowedCpu";
     if (!addIntegerColumnIfMissing(tableName, columnName)) {
@@ -1124,7 +1124,7 @@ bool ParmsDb::upgradeColumns() {
 
 bool ParmsDb::upgrade(const std::string &fromVersion, const std::string &toVersion) {
     LOG_INFO(_logger, "Apply generic upgrade fixes to " << dbType() << " DB version " << fromVersion);
-    if (!upgradeColumns()) {
+    if (!upgradeTables()) {
         LOG_WARN(_logger, "Failed to insert missing columns.");
         return false;
     }

--- a/src/libparms/db/parmsdb.h
+++ b/src/libparms/db/parmsdb.h
@@ -146,7 +146,7 @@ class PARMS_EXPORT ParmsDb : public Db {
 
         ParmsDb(const std::filesystem::path &dbPath, const std::string &version, bool autoDelete, bool test);
 
-        bool upgradeColumns();
+        bool upgradeTables();
         bool insertDefaultParameters();
         bool insertDefaultAppState();
         bool insertAppState(AppStateKey key, const std::string &value, bool updateOnlyIfEmpty = false);

--- a/src/libparms/db/parmsdb.h
+++ b/src/libparms/db/parmsdb.h
@@ -146,6 +146,7 @@ class PARMS_EXPORT ParmsDb : public Db {
 
         ParmsDb(const std::filesystem::path &dbPath, const std::string &version, bool autoDelete, bool test);
 
+        bool upgradeColumns();
         bool insertDefaultParameters();
         bool insertDefaultAppState();
         bool insertAppState(AppStateKey key, const std::string &value, bool updateOnlyIfEmpty = false);

--- a/test/libparms/db/testparmsdb.h
+++ b/test/libparms/db/testparmsdb.h
@@ -36,7 +36,7 @@ class TestParmsDb : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST(testSync);
         CPPUNIT_TEST(testExclusionTemplate);
         CPPUNIT_TEST(testUpdateExclusionTemplates);
-        CPPUNIT_TEST(testUpgrade);
+        CPPUNIT_TEST(testUpgradeOfExclusionTemplates);
 #ifdef __APPLE__
         CPPUNIT_TEST(testExclusionApp);
 #endif
@@ -60,7 +60,7 @@ class TestParmsDb : public CppUnit::TestFixture, public TestBase {
         void testExclusionTemplate();
         void testAppState();
         void testUpdateExclusionTemplates();
-        void testUpgrade();
+        void testUpgradeOfExclusionTemplates();
 #ifdef __APPLE__
         void testExclusionApp();
 #endif
@@ -71,6 +71,7 @@ class TestParmsDb : public CppUnit::TestFixture, public TestBase {
 
     private:
         LocalTemporaryDirectory _parmsDbTemporarDirectory;
+        bool deleteColumns();
 };
 
 } // namespace KDC


### PR DESCRIPTION
This PR makes sure to insert missing columns in the `Parameters` database (as part of the `upgrade` method) before any request involving the modified columns. 

Unit tests are added to prevent regressions.