### PR TITLE
Kdesktop 1837 loss of non ascii characters in rescue folder path on windows and crash

### DIFF
--- a/src/libcommon/utility/types.h
+++ b/src/libcommon/utility/types.h
@@ -91,7 +91,7 @@ using OStringStream = std::wostringstream;
 #define QStr2SyncName(s) s.toStdWString()
 #define Str2SyncName(s) Utility::s2ws(s)
 #define SyncName2Str(s) Utility::ws2s(s)
-#define WStr2SyncName(s) s
+#define WStr2SyncName(s) SyncName(s)
 #define SyncName2WStr(s) s
 #else
 using StringStream = std::stringstream;
@@ -99,7 +99,7 @@ using OStringStream = std::ostringstream;
 #define Str(s) s
 #define SyncName2QStr(s) QString::fromStdString(s)
 #define QStr2SyncName(s) s.toStdString()
-#define Str2SyncName(s) s
+#define Str2SyncName(s) SyncName(s)
 #define SyncName2Str(s) s
 #define WStr2SyncName(s) Utility::ws2s(s)
 #define SyncName2WStr(s) Utility::s2ws(s)

--- a/src/libsyncengine/propagation/executor/filerescuer.cpp
+++ b/src/libsyncengine/propagation/executor/filerescuer.cpp
@@ -86,8 +86,7 @@ SyncPath FileRescuer::getDestinationPath(const SyncPath &relativeOriginPath, con
     if (counter == 0) return _syncPal->localPath() / _rescueFolderName / relativeOriginPath.filename();
     const SyncName suffix =
             Str(" (") + Str2SyncName(std::to_string(counter)) + Str(")"); // TODO : use format when fully moved to c++20
-    const SyncName filename =
-            Str2SyncName(relativeOriginPath.stem().string()) + suffix + Str2SyncName(relativeOriginPath.extension().string());
+    const SyncName filename = relativeOriginPath.stem().native() + suffix + relativeOriginPath.extension().native();
     return _syncPal->localPath() / _rescueFolderName / filename;
 }
 

--- a/src/libsyncengine/propagation/executor/filerescuer.h
+++ b/src/libsyncengine/propagation/executor/filerescuer.h
@@ -37,6 +37,8 @@ class FileRescuer {
 
         std::shared_ptr<SyncPal> _syncPal;
         static const SyncPath _rescueFolderName;
+
+        friend class TestFileRescuer;
 };
 
 } // namespace KDC

--- a/test/libsyncengine/propagation/executor/testfilerescuer.cpp
+++ b/test/libsyncengine/propagation/executor/testfilerescuer.cpp
@@ -137,7 +137,7 @@ void TestFileRescuer::testGetDestinationPath() {
     CPPUNIT_ASSERT(res.filename().native() == Str2SyncName("test (1).txt"));
 
     // Test with a file name with special characters
-    SyncName fileName = WStr2SyncName(L"°.txt");
+    fileName = WStr2SyncName(L"°.txt");
     res = fileRescuer.getDestinationPath(fileName);
     CPPUNIT_ASSERT(res.filename().native() == L"°.txt");
     res = fileRescuer.getDestinationPath(fileName, 1);

--- a/test/libsyncengine/propagation/executor/testfilerescuer.cpp
+++ b/test/libsyncengine/propagation/executor/testfilerescuer.cpp
@@ -126,4 +126,21 @@ void TestFileRescuer::testFileRescuer() {
             true, std::filesystem::exists(_localTempDir.path() / FileRescuer::rescueFolderName() / (fileName + Str(" (1)"))));
 }
 
+void TestFileRescuer::testGetDestinationPath() {
+    FileRescuer fileRescuer(_syncPal);
+
+    // Test with a simple file name
+    SyncName fileName = WStr2SyncName(L"test.txt");
+    SyncPath res = fileRescuer.getDestinationPath(fileName);
+    CPPUNIT_ASSERT(res.filename().native() == Str2SyncName("test.txt"));
+    res = fileRescuer.getDestinationPath(fileName, 1);
+    CPPUNIT_ASSERT(res.filename().native() == Str2SyncName("test (1).txt"));
+
+    // Test with a file name with special characters
+    SyncName fileName = WStr2SyncName(L"°.txt");
+    res = fileRescuer.getDestinationPath(fileName);
+    CPPUNIT_ASSERT(res.filename().native() == L"°.txt");
+    res = fileRescuer.getDestinationPath(fileName, 1);
+    CPPUNIT_ASSERT(res.filename().native() == L"° (1).txt");
+}
 } // namespace KDC

--- a/test/libsyncengine/propagation/executor/testfilerescuer.cpp
+++ b/test/libsyncengine/propagation/executor/testfilerescuer.cpp
@@ -136,11 +136,13 @@ void TestFileRescuer::testGetDestinationPath() {
     res = fileRescuer.getDestinationPath(fileName, 1);
     CPPUNIT_ASSERT(res.filename().native() == Str2SyncName("test (1).txt"));
 
+#ifdef _WIN32
     // Test with a file name with special characters
     fileName = WStr2SyncName(L"°.txt");
     res = fileRescuer.getDestinationPath(fileName);
     CPPUNIT_ASSERT(res.filename().native() == L"°.txt");
     res = fileRescuer.getDestinationPath(fileName, 1);
     CPPUNIT_ASSERT(res.filename().native() == L"° (1).txt");
+#endif // _WIN32
 }
 } // namespace KDC

--- a/test/libsyncengine/propagation/executor/testfilerescuer.h
+++ b/test/libsyncengine/propagation/executor/testfilerescuer.h
@@ -27,6 +27,7 @@ namespace KDC {
 class TestFileRescuer final : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST_SUITE(TestFileRescuer);
         CPPUNIT_TEST(testFileRescuer);
+        CPPUNIT_TEST(testGetDestinationPath);
         CPPUNIT_TEST_SUITE_END();
 
     public:
@@ -35,6 +36,7 @@ class TestFileRescuer final : public CppUnit::TestFixture, public TestBase {
 
     private:
         void testFileRescuer();
+        void testGetDestinationPath();
 
         LocalTemporaryDirectory _localTempDir{"TestFileRescuer"};
         std::shared_ptr<SyncPal> _syncPal;


### PR DESCRIPTION
## Fix: Preserve Non-ASCII Characters in Rescue Folder Paths on Windows

### 🐞 Problem

Following the implementation of the **kDrive rescue folder**, an issue was identified on **Windows** platforms:

- The method `FileRescuer::getDestinationPath` performs an unnecessary round-trip conversion:
  - It converts a `w_str` (wide string) to a `str`, and then back to a `w_str`.
  - During this conversion, **non-ASCII characters** (e.g., `é`, `è`, `ê`, `â`, etc.) are **corrupted or lost**.
- The resulting destination path contains **unknown or invalid characters** in place of the original non-ASCII ones.
- This causes the app to **crash later during a path normalization**.

---

### 💥 Impact

This bug affects users in the following scenario:

1. A **conflict** occurs and triggers a file to be moved to the **rescue folder**.
2. The **original file path** contains **non-ASCII characters**.
3. A **file with the same name** already exists in the rescue folder.

In this case, the corrupted path prevents proper handling and leads to a crash.

---

### ✅ Solution

The fix ensures we avoid unnecessary conversions and preserve the integrity of non-ASCII characters in file paths.

---

### 🧪 Unit-Tests

- Verified with paths containing accented characters (e.g., `é`, `ç`, `ü`, etc.).
