### PR TITLE
 fix(submodules): switch from SSH to HTTPS URLs for git submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src/3rdparty/keychain"]
 	path = src/3rdparty/keychain
-	url = git@github.com:hrantzsch/keychain.git
+	url = https://github.com/hrantzsch/keychain.git
 [submodule "src/3rdparty/qt-piwik-tracker"]
 	path = src/3rdparty/qt-piwik-tracker
-	url = git@github.com:pbek/qt-piwik-tracker.git
+	url = https://github.com/pbek/qt-piwik-tracker.git


### PR DESCRIPTION
### 🔧 Switch submodules from SSH to HTTPS

This PR updates the `.gitmodules` file to replace SSH URLs with HTTPS URLs for the following submodules:

- `keychain`  
- `qt-piwik-tracker`

### ✅ Why

Using HTTPS instead of SSH for Git submodules allows developers and CI environments to clone the repository without requiring:

- a GitHub account,
- an SSH key configured,
- or manual intervention on non-dev machines (e.g., fresh CI runners, Docker containers, etc.).

This change simplifies setup and improves portability and automation.

### 🔐 Notes

- The original PR https://github.com/Infomaniak/desktop-kDrive/pull/817 by @krop had the same goal but contained unsigned commits, preventing it from being merged.
- This new PR includes **signed commits** and revives that effort in a clean way.

