### PR TITLE
fix(executor): Update creation time source in upload session

### DIFF
--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -1638,7 +1638,7 @@ ExitInfo ExecutorWorker::propagateChangeToDbAndTree(SyncOpPtr syncOp, std::share
                     auto uploadSessionJob(std::dynamic_pointer_cast<DriveUploadSession>(job));
                     if (uploadSessionJob) {
                         nodeId = uploadSessionJob->nodeId();
-                        newCreationTime = uploadJob->creationTime();
+                        newCreationTime = uploadSessionJob->creationTime();
                         newModificationTime = uploadSessionJob->modificationTime();
                         newSize = uploadSessionJob->size();
                         jobOk = true;


### PR DESCRIPTION
Changed the source of the `newCreationTime` variable to retrieve the creation time from `uploadSessionJob` instead of `uploadJob`.