### PR TITLE
fix(IoHelperTestUtilities): update resetFunctions to set `std::filesystem:rename`

### DIFF
--- a/test/test_utility/iohelpertestutilities.cpp
+++ b/test/test_utility/iohelpertestutilities.cpp
@@ -53,6 +53,7 @@ void IoHelperTestUtilities::setReadAliasFunction(
 
 void IoHelperTestUtilities::resetFunctions() {
     // Reset to default std::filesytem implementation.
+    setRename(static_cast<void (*)(const SyncPath &srcPath, const SyncPath &destPath, std::error_code &ec)>(&std::filesystem::rename));
     setIsDirectoryFunction(static_cast<bool (*)(const SyncPath &path, std::error_code &ec)>(&std::filesystem::is_directory));
     setIsSymlinkFunction(static_cast<bool (*)(const SyncPath &path, std::error_code &ec)>(&std::filesystem::is_symlink));
     setReadSymlinkFunction(static_cast<SyncPath (*)(const SyncPath &path, std::error_code &ec)>(&std::filesystem::read_symlink));


### PR DESCRIPTION
# Summary
Add the reset of the function _rename defined inside the IoHelperTestUtilities class used to mock some `std::filesystem` functions.

## Changes
Added the following line inside the `void IoHelperTestUtilities::resetFunctions()`:
```cpp
setRename(static_cast<void (*)(const SyncPath &srcPath, const SyncPath &destPath, std::error_code &ec)>(&std::filesystem::rename));
```
to [iohelpertestutilities.cpp](https://github.com/Infomaniak/desktop-kDrive/blob/c1ae775856fa3a06564303991b9cb3bd781793bc/test/test_utility/iohelpertestutilities.cpp).

