### PR TITLE
fix(conanfile): dynamically set CMAKE_MSVC_RUNTIME_LIBRARY based on build type

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -28,7 +28,7 @@ class KDriveDesktop(ConanFile):
             # (in the CI's profile, it is Release), yielding $<$<CONFIG:Release>:MultiThreadedDLL>. Other configs
             # (RelWithDebInfo, Debug) fall back to MSVC’s default CRT selection (/MT), here, we want /MD
             tc.blocks.remove("vs_runtime")
-            tc.blocks["override_vs_runtime"] = OverrideVSRuntimeBlock
+            tc.blocks["override_vs_runtime"] = OverrideVSRuntimeBlock(self, tc, "override_vs_runtime")
 
         if self.settings.os == "Macos":
             tc.variables["CMAKE_OSX_ARCHITECTURES"] = "x86_64;arm64"

--- a/conanfile.py
+++ b/conanfile.py
@@ -63,8 +63,15 @@ class KDriveDesktop(ConanFile):
             self.requires("openssl/3.2.4", options={ "shared": True }) # From https://conan.io/center/recipes/openssl
 
 class OverrideVSRuntimeBlock(VSRuntimeBlock):
-    template = textwrap.dedent("""\
-    cmake_policy(SET CMP0091 NEW)
-    message(STATUS "Conan toolchain: Setting CMAKE_MSVC_RUNTIME_LIBRARY=$<$<CONFIG:Debug>:MultiThreadedDebugDLL>$<$<NOT:$<CONFIG:Debug>>:MultiThreadedDLL>")
-    set(CMAKE_MSVC_RUNTIME_LIBRARY "$<$<CONFIG:Debug>:MultiThreadedDebugDLL>$<$<NOT:$<CONFIG:Debug>>:MultiThreadedDLL>" CACHE STRING "" FORCE)
-    """)
+    def __init__(self, conanfile, toolchain, name):
+        super().__init__(conanfile, toolchain, name)
+        build_type = str(conanfile.settings.build_type)
+        if build_type == "Debug":
+            runtime = "MultiThreadedDebugDLL"
+        else:
+            runtime = "MultiThreadedDLL"
+        self.template = textwrap.dedent(f"""\
+        cmake_policy(SET CMP0091 NEW)
+        message(STATUS "Conan toolchain: Setting CMAKE_MSVC_RUNTIME_LIBRARY={runtime}")
+        set(CMAKE_MSVC_RUNTIME_LIBRARY "{runtime}" CACHE STRING "" FORCE)
+        """)


### PR DESCRIPTION
Fix CMake toolchain configuration issue in Qt Creator

This PR addresses a problem with the CMake toolchain configuration when building the project using the Qt Creator IDE on Windows. Specifically, it replaces the conditional generator expression for `CMAKE_MSVC_RUNTIME_LIBRARY` with a literal value based on the current build type. This resolves a failure in `conan_provider.cmake`, which expects a concrete value instead of a CMake generator expression.

This change ensures compatibility between Conan's generated toolchain and Qt Creator's Conan integration.