### PR TITLE
test: Enhance disk space validation in download tests

### DIFF
--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -727,17 +727,27 @@ void TestNetworkJobs::testDownloadHasEnoughSpace() {
     const SyncPath smallPartitionPath = testhelpers::TestVariables().local8MoPartitionPath;
     if (smallPartitionPath.empty()) return;
 
-    // Enough disk space
+    // Enough disk space on both paths
     const LocalTemporaryDirectory temporaryDirectory("tmp");
     SyncPath lowDiskSpacePath;
-    CPPUNIT_ASSERT(DownloadJob::hasEnoughPlace(temporaryDirectory.path(), temporaryDirectory.path(), 7000000, lowDiskSpacePath,
+    CPPUNIT_ASSERT(DownloadJob::hasEnoughPlace(temporaryDirectory.path(), temporaryDirectory.path(), 9000000, lowDiskSpacePath,
                                                Log::instance()->getLogger()));
-    CPPUNIT_ASSERT(temporaryDirectory.path() == SyncPath{});
-
-    // Not Enough disk space
-    CPPUNIT_ASSERT(!DownloadJob::hasEnoughPlace(temporaryDirectory.path(), temporaryDirectory.path(), 9000000, lowDiskSpacePath,
+    CPPUNIT_ASSERT_EQUAL(SyncPath{}, lowDiskSpacePath);
+    
+    // Enough disk space on destination path, but not on tmp path
+    CPPUNIT_ASSERT(!DownloadJob::hasEnoughPlace(temporaryDirectory.path(), smallPartitionPath, 9000000, lowDiskSpacePath,
                                                 Log::instance()->getLogger()));
-    CPPUNIT_ASSERT(SyncPath{} == lowDiskSpacePath);
+    CPPUNIT_ASSERT_EQUAL(smallPartitionPath, lowDiskSpacePath);
+    
+    // Enough disk space on tmp path, but not on destination path
+    CPPUNIT_ASSERT(!DownloadJob::hasEnoughPlace(smallPartitionPath, temporaryDirectory.path(), 9000000, lowDiskSpacePath,
+                                                Log::instance()->getLogger()));
+    CPPUNIT_ASSERT_EQUAL(smallPartitionPath, lowDiskSpacePath);
+
+    // Not enough disk space on both paths
+    CPPUNIT_ASSERT(!DownloadJob::hasEnoughPlace(smallPartitionPath, smallPartitionPath, 9000000, lowDiskSpacePath,
+                                                Log::instance()->getLogger()));
+    CPPUNIT_ASSERT_EQUAL(smallPartitionPath, lowDiskSpacePath);
 }
 
 void TestNetworkJobs::testDownloadAborted() {


### PR DESCRIPTION
Fix nightly test (https://github.com/Infomaniak/desktop-kDrive/actions/runs/16282142172/job/45973740679)
Seems to be introduced here: https://github.com/Infomaniak/desktop-kDrive/pull/931/files#diff-a44011b4b2142730cdb600b754fc9df3f32479959030cd13cf167fda5bfc52ebR727

## Pull Request Overview

This PR fixes a failing nightly test for download disk space validation by enhancing the test scenarios and improving assertion clarity. The changes address test stability issues that were causing systematic failures.

- Expanded test coverage to include different disk space scenarios for temporary and destination paths
- Increased size thresholds and refined assertions to reduce false failures
- Improved test structure by removing redundant variables and adding clearer test case separation
