### PR TITLE
feat(sync): enhance toString for SyncStep enumeration

### DIFF
--- a/src/libcommon/utility/types.cpp
+++ b/src/libcommon/utility/types.cpp
@@ -454,21 +454,21 @@ std::string toString(const SyncStep e) {
         case SyncStep::Idle:
             return "Idle";
         case SyncStep::UpdateDetection1:
-            return "UpdateDetection1";
+            return "UpdateDetection1 (Compute FS operations)";
         case SyncStep::UpdateDetection2:
-            return "UpdateDetection2";
+            return "UpdateDetection2 (Update Trees)";
         case SyncStep::Reconciliation1:
-            return "Reconciliation1";
+            return "Reconciliation1 (Platform Inconsistency Checker)";
         case SyncStep::Reconciliation2:
-            return "Reconciliation2";
+            return "Reconciliation2 (Conflict Finder)";
         case SyncStep::Reconciliation3:
-            return "Reconciliation3";
+            return "Reconciliation3 (Conflict Resolver)";
         case SyncStep::Reconciliation4:
-            return "Reconciliation4";
+            return "Reconciliation4 (Operation Generator)";
         case SyncStep::Propagation1:
-            return "Propagation1";
+            return "Propagation1 (Sorter)";
         case SyncStep::Propagation2:
-            return "Propagation2";
+            return "Propagation2 (Executor)";
         case SyncStep::Done:
             return "Done";
         default:


### PR DESCRIPTION
Updated the `toString` function to provide more descriptive return strings for SyncStep cases, adding context to each step in the synchronization process.