### PR TITLE
Do not ignore HTTP 500 errors in LongPoll

### DIFF
--- a/.github/workflows/build-and-run-extended-tests.yml
+++ b/.github/workflows/build-and-run-extended-tests.yml
@@ -69,25 +69,23 @@ jobs:
         shell: cmd
 
       - name: Execute tests
-        run: |
-          & "cov01.exe" "-1" # coverage on
-          & "cov01.exe" "-s" # show status
+        run: powershell ./infomaniak-build-tools/run-tests.ps1
+          # & "cov01.exe" "-1" # coverage on
+          # & "cov01.exe" "-s" # show status
 
-          ./infomaniak-build-tools/run-tests.ps1
+      # - name: Compute code coverage
+      #   run : |          
+      #     & "covselect.exe" "--add" 'exclude folder c:/'
+      #     & "covselect.exe" "--add" 'exclude folder ../'
+      #     & "covselect.exe" "--add" 'exclude folder 3rdparty/'
+      #     & "covselect.exe" "--add" 'exclude folder gui/'
+      #     & "cov01.exe" "-0" # coverage off
+      #     & "cov01.exe" "-s" # show status
+      #     & "covhtml.exe" "coverage_html"
 
-      - name: Compute code coverage
-        run : |          
-          & "covselect.exe" "--add" 'exclude folder c:/'
-          & "covselect.exe" "--add" 'exclude folder ../'
-          & "covselect.exe" "--add" 'exclude folder 3rdparty/'
-          & "covselect.exe" "--add" 'exclude folder gui/'
-          & "cov01.exe" "-0" # coverage off
-          & "cov01.exe" "-s" # show status
-          & "covhtml.exe" "coverage_html"
-
-      - name: Deactivate code coverage
-        run : "cov01.exe -0" # coverage off
-        if: always()
+      # - name: Deactivate code coverage
+      #   run : "cov01.exe -0" # coverage off
+      #   if: always()
 
       - name: Upload tests logs artifacts
         uses: actions/upload-artifact@v4

--- a/src/gui/adddriveserverfolderswidget.cpp
+++ b/src/gui/adddriveserverfolderswidget.cpp
@@ -204,7 +204,7 @@ void AddDriveServerFoldersWidget::setLogoColor(const QColor &color) {
 void AddDriveServerFoldersWidget::onSubfoldersLoaded(const bool error, const ExitCause exitCause) {
     if (error) {
         QString errorMsg = tr("An error occurred while loading the list of subfolders.");
-        if (exitCause == ExitCause::ServiceUnavailable) {
+        if (exitCause == ExitCause::Http5xx) {
             QString driveLink = QString(APPLICATION_PREVIEW_URL).arg(_driveInfo.driveId()).arg("");
             errorMsg =
                     tr(R"(Impossible to load the list of subfolders. Your kDrive might be in maintenance.<br>)"

--- a/src/libcommon/utility/types.cpp
+++ b/src/libcommon/utility/types.cpp
@@ -214,10 +214,8 @@ std::string toString(const ExitCause e) {
             return "DriveAsleep";
         case ExitCause::DriveWakingUp:
             return "DriveWakingUp";
-        case ExitCause::ServiceUnavailable:
-            return "ServiceUnavailable";
-        case ExitCause::BadGateway:
-            return "BadGateway";
+        case ExitCause::Http5xx:
+            return "Http5xx";
         case ExitCause::NotEnoughINotifyWatches:
             return "NotEnoughINotifyWatches";
         default:

--- a/src/libcommon/utility/types.h
+++ b/src/libcommon/utility/types.h
@@ -308,8 +308,7 @@ enum class ExitCause {
     InvalidDestination,
     DriveAsleep,
     DriveWakingUp,
-    ServiceUnavailable,
-    BadGateway,
+    Http5xx,
     NotEnoughINotifyWatches,
     EnumEnd
 };

--- a/src/libcommonserver/utility/utility.cpp
+++ b/src/libcommonserver/utility/utility.cpp
@@ -926,4 +926,23 @@ std::string Utility::userName() {
     return userName_private();
 }
 
+bool Utility::isError500(const Poco::Net::HTTPResponse::HTTPStatus httpErrorCode) {
+    switch (httpErrorCode) {
+        case Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR:
+        case Poco::Net::HTTPResponse::HTTP_NOT_IMPLEMENTED:
+        case Poco::Net::HTTPResponse::HTTP_BAD_GATEWAY:
+        case Poco::Net::HTTPResponse::HTTP_SERVICE_UNAVAILABLE:
+        case Poco::Net::HTTPResponse::HTTP_GATEWAY_TIMEOUT:
+        case Poco::Net::HTTPResponse::HTTP_VERSION_NOT_SUPPORTED:
+        case Poco::Net::HTTPResponse::HTTP_VARIANT_ALSO_NEGOTIATES:
+        case Poco::Net::HTTPResponse::HTTP_INSUFFICIENT_STORAGE:
+        case Poco::Net::HTTPResponse::HTTP_LOOP_DETECTED:
+        case Poco::Net::HTTPResponse::HTTP_NOT_EXTENDED:
+        case Poco::Net::HTTPResponse::HTTP_NETWORK_AUTHENTICATION_REQUIRED:
+            return true;
+        default:
+            return false;
+    }
+}
+
 } // namespace KDC

--- a/src/libcommonserver/utility/utility.h
+++ b/src/libcommonserver/utility/utility.h
@@ -195,6 +195,8 @@ struct COMMONSERVER_EXPORT Utility {
         static SyncPath sharedFolderName();
         static std::string userName();
 
+        static bool isError500(const Poco::Net::HTTPResponse::HTTPStatus httpErrorCode);
+
     private:
         static log4cplus::Logger _logger;
 

--- a/src/libsyncengine/jobs/network/API_v2/listing/longpolljob.cpp
+++ b/src/libsyncengine/jobs/network/API_v2/listing/longpolljob.cpp
@@ -39,13 +39,4 @@ void LongPollJob::setSpecificQueryParameters(Poco::URI &uri) {
     uri.addQueryParameter("timeout", std::to_string(apiTimout) + "s");
 }
 
-bool LongPollJob::handleError(std::istream &is, const Poco::URI &uri) {
-    if (_resHttp.getStatus() == Poco::Net::HTTPResponse::HTTP_BAD_GATEWAY) {
-        _exitInfo = {ExitCode::NetworkError, ExitCause::BadGateway};
-        return true;
-    } else {
-        return AbstractListingJob::handleError(is, uri);
-    }
-}
-
 } // namespace KDC

--- a/src/libsyncengine/jobs/network/API_v2/listing/longpolljob.h
+++ b/src/libsyncengine/jobs/network/API_v2/listing/longpolljob.h
@@ -30,7 +30,6 @@ class LongPollJob final : public AbstractListingJob {
         std::string getSpecificUrl() override;
         void setSpecificQueryParameters(Poco::URI &uri) override;
         ExitInfo setData() override { return ExitCode::Ok; }
-        bool handleError(std::istream &is, const Poco::URI &uri) override;
 
         std::string _cursor;
 };

--- a/src/libsyncengine/jobs/network/abstractnetworkjob.cpp
+++ b/src/libsyncengine/jobs/network/abstractnetworkjob.cpp
@@ -86,9 +86,9 @@ AbstractNetworkJob::~AbstractNetworkJob() {
 
 bool AbstractNetworkJob::isManagedError(const ExitInfo exitInfo) noexcept {
     static const std::set managedExitCauses = {
-            ExitCause::InvalidName,       ExitCause::ApiErr,        ExitCause::FileTooBig, ExitCause::NotFound,
-            ExitCause::FileLocked,        ExitCause::QuotaExceeded, ExitCause::FileExists, ExitCause::ShareLinkAlreadyExists,
-            ExitCause::ServiceUnavailable};
+            ExitCause::InvalidName, ExitCause::ApiErr,        ExitCause::FileTooBig, ExitCause::NotFound,
+            ExitCause::FileLocked,  ExitCause::QuotaExceeded, ExitCause::FileExists, ExitCause::ShareLinkAlreadyExists,
+            ExitCause::Http5xx};
 
     switch (exitInfo.code()) {
         case ExitCode::BackError:
@@ -425,6 +425,12 @@ bool AbstractNetworkJob::receiveResponse(const Poco::URI &uri) {
     LOG_DEBUG(_logger,
               "Request " << jobId() << " finished with status: " << _resHttp.getStatus() << " / " << _resHttp.getReason());
 
+    if (Utility::isError500(_resHttp.getStatus())) {
+        _exitInfo = {ExitCode::BackError, ExitCause::Http5xx};
+        disableRetry();
+        return true;
+    }
+
     bool res = true;
     switch (_resHttp.getStatus()) {
         case Poco::Net::HTTPResponse::HTTP_OK: {
@@ -465,12 +471,6 @@ bool AbstractNetworkJob::receiveResponse(const Poco::URI &uri) {
             // Rate limitation
             _exitInfo = ExitCode::RateLimited;
             LOG_WARN(_logger, "Received HTTP_TOO_MANY_REQUESTS, rate limited");
-            break;
-        }
-        case Poco::Net::HTTPResponse::HTTP_SERVICE_UNAVAILABLE: {
-            _exitInfo = {ExitCode::BackError, ExitCause::ServiceUnavailable};
-            LOG_WARN(_logger, "Service unavailable");
-            disableRetry();
             break;
         }
         default: {

--- a/src/libsyncengine/syncpal/syncpalworker.cpp
+++ b/src/libsyncengine/syncpal/syncpalworker.cpp
@@ -49,13 +49,12 @@ bool hasSuccessfullyFinished(const std::shared_ptr<ISyncWorker> w1, const std::s
 bool shouldBePaused(const std::shared_ptr<ISyncWorker> w1, const std::shared_ptr<ISyncWorker> w2 = nullptr) {
     const auto networkIssue =
             (w1 && w1->exitCode() == ExitCode::NetworkError) || (w2 && w2->exitCode() == ExitCode::NetworkError);
-    const auto serviceUnavailable =
-            (w1 && w1->exitCode() == ExitCode::BackError && w1->exitCause() == ExitCause::ServiceUnavailable) ||
-            (w2 && w2->exitCode() == ExitCode::BackError && w2->exitCause() == ExitCause::ServiceUnavailable);
+    const auto http500error = (w1 && w1->exitCode() == ExitCode::BackError && w1->exitCause() == ExitCause::Http5xx) ||
+                              (w2 && w2->exitCode() == ExitCode::BackError && w2->exitCause() == ExitCause::Http5xx);
     const auto syncDirNotAccessible =
             (w1 && w1->exitCode() == ExitCode::SystemError && w1->exitCause() == ExitCause::SyncDirAccessError) ||
             (w2 && w2->exitCode() == ExitCode::SystemError && w2->exitCause() == ExitCause::SyncDirAccessError);
-    return networkIssue || serviceUnavailable || syncDirNotAccessible;
+    return networkIssue || http500error || syncDirNotAccessible;
 }
 
 bool shouldBeStoppedAndRestarted(const std::shared_ptr<ISyncWorker> w1, const std::shared_ptr<ISyncWorker> w2 = nullptr) {

--- a/src/libsyncengine/update_detection/file_system_observer/remotefilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/remotefilesystemobserverworker.cpp
@@ -439,11 +439,6 @@ ExitInfo RemoteFileSystemObserverWorker::sendLongPoll(bool &changes) {
 
             if (notifyJob->exitInfo() == ExitInfo(ExitCode::NetworkError, ExitCause::NetworkTimeout)) {
                 _syncPal->addError(Error(errId(), notifyJob->exitInfo()));
-            } else if (notifyJob->exitInfo() == ExitInfo(ExitCode::NetworkError, ExitCause::BadGateway)) {
-                // Ignore this error and check for changes anyway
-                LOG_SYNCPAL_INFO(_logger, "Bad gateway error, check for changes anyway.");
-                changes = true; // TODO: perhaps not a good idea... what if longpoll crashed and not reachable for a long time???
-                return ExitCode::Ok;
             }
 
             return notifyJob->exitInfo();


### PR DESCRIPTION
This PR is following the event https://infomaniakstatus.com/fr/JnqlybPlEr/ where an issue with the LongPoll on backend side leads to all the desktop apps to send thousands of `listing/continue` requests/s.

The correction consists in no longer ignoring 502 errors from LongPoll requests. They were previously considered as success and a `listing/continue` request was sent afterward.

In addition, all 5XX HTTP errors are now handled in the same way: the worker exit with exit code `BackError` and exit cause `Http5xx`, leading to the sync being paused for 1 minute.

Depends on #957 