### PR TITLE
Remove calls to Bullseye

### DIFF
--- a/.github/workflows/build-and-run-extended-tests.yml
+++ b/.github/workflows/build-and-run-extended-tests.yml
@@ -69,25 +69,23 @@ jobs:
         shell: cmd
 
       - name: Execute tests
-        run: |
-          & "cov01.exe" "-1" # coverage on
-          & "cov01.exe" "-s" # show status
+        run: powershell ./infomaniak-build-tools/run-tests.ps1
+          # & "cov01.exe" "-1" # coverage on
+          # & "cov01.exe" "-s" # show status
 
-          ./infomaniak-build-tools/run-tests.ps1
+      # - name: Compute code coverage
+      #   run : |          
+      #     & "covselect.exe" "--add" 'exclude folder c:/'
+      #     & "covselect.exe" "--add" 'exclude folder ../'
+      #     & "covselect.exe" "--add" 'exclude folder 3rdparty/'
+      #     & "covselect.exe" "--add" 'exclude folder gui/'
+      #     & "cov01.exe" "-0" # coverage off
+      #     & "cov01.exe" "-s" # show status
+      #     & "covhtml.exe" "coverage_html"
 
-      - name: Compute code coverage
-        run : |          
-          & "covselect.exe" "--add" 'exclude folder c:/'
-          & "covselect.exe" "--add" 'exclude folder ../'
-          & "covselect.exe" "--add" 'exclude folder 3rdparty/'
-          & "covselect.exe" "--add" 'exclude folder gui/'
-          & "cov01.exe" "-0" # coverage off
-          & "cov01.exe" "-s" # show status
-          & "covhtml.exe" "coverage_html"
-
-      - name: Deactivate code coverage
-        run : "cov01.exe -0" # coverage off
-        if: always()
+      # - name: Deactivate code coverage
+      #   run : "cov01.exe -0" # coverage off
+      #   if: always()
 
       - name: Upload tests logs artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
The CI with extended test failed on Windows with the following error:
```
Run & "cov01.exe" "-1" # coverage on
& : The term 'cov01.exe' is not recognized as the name of a cmdlet, function, script file, or operable program. Check 
the spelling of the name, or if a path was included, verify that the path is correct and try again.
At C:\actions-runner\_work\_temp\153327d1-3ca3-4e23-a9d8-f02c9ddcb0e8.ps1:2 char:3
+ & "cov01.exe" "-1" # coverage on
+   ~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (cov01.exe:String) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : CommandNotFoundException
 
Error: Process completed with exit code 1.
```

Therefore, calls to Bulleyes have been deactivated for now