### PR TITLE
Fix run tests.sh

### DIFF
--- a/infomaniak-build-tools/run-test.sh
+++ b/infomaniak-build-tools/run-test.sh
@@ -38,14 +38,6 @@ fi
 dir="$1"
 tester="$2"
 
-conanrun=$(find . -type f -name "conanrun.sh" | head -n 1)
-if [[ -n "$conanrun" ]]; then
-    source "$conanrun"
-else
-    echo -e "${RED}conanrun.sh not found${NC}"
-    exit 1
-fi
-
 echo "${YELLOW}---------- Running $tester ----------${NC}"
 pushd "$dir" 1>/dev/null
 


### PR DESCRIPTION
This pull request updates the `./infomaniak-build-tools/run-tests.sh` script to add support for detecting the operating system and sourcing the appropriate configuration file for macOS or Linux. It also includes error handling for unsupported operating systems.

Operating system detection and configuration:

* Added logic to detect the operating system using `uname -s` and source the corresponding `conanrun.sh` file for macOS or Linux.


You can see the error that was generated [here](https://github.com/Infomaniak/desktop-kDrive/actions/runs/16412289543/job/46369956325?pr=956#step:7:18).