### PR TITLE
Move string utility functions to libcommon

### DIFF
--- a/src/gui/adddrivelocalfolderwidget.cpp
+++ b/src/gui/adddrivelocalfolderwidget.cpp
@@ -26,7 +26,6 @@
 #include "clientgui.h"
 #include "libcommongui/matomoclient.h"
 #include "libcommon/utility/utility.h"
-#include "libcommonserver/utility/utility.h"
 
 #include <QBoxLayout>
 #include <QDesktopServices>

--- a/src/gui/adddrivelocalfolderwidget.cpp
+++ b/src/gui/adddrivelocalfolderwidget.cpp
@@ -26,6 +26,7 @@
 #include "clientgui.h"
 #include "libcommongui/matomoclient.h"
 #include "libcommon/utility/utility.h"
+#include "libcommonserver/utility/utility.h"
 
 #include <QBoxLayout>
 #include <QDesktopServices>
@@ -277,9 +278,9 @@ void AddDriveLocalFolderWidget::updateUI() {
 
         if (virtualFileMode == VirtualFileMode::Win || virtualFileMode == VirtualFileMode::Mac) {
             // Check file system
-            const QString fsName(KDC::CommonUtility::fileSystemName(_localFolderPath));
-            _folderCompatibleWithLiteSync = (virtualFileMode == VirtualFileMode::Win && fsName == "NTFS") ||
-                                            (virtualFileMode == VirtualFileMode::Mac && fsName == "apfs");
+            _folderCompatibleWithLiteSync =
+                    (virtualFileMode == VirtualFileMode::Win && CommonUtility::isNTFS(QStr2Path(_localFolderPath))) ||
+                    (virtualFileMode == VirtualFileMode::Mac && CommonUtility::isAPFS(QStr2Path(_localFolderPath)));
             if (!_folderCompatibleWithLiteSync) {
                 _warningLabel->setText(tr(R"(This folder is not compatible with Lite Sync.<br> 
 Please select another folder. If you continue Lite Sync will be disabled.<br> 

--- a/src/gui/localfolderdialog.cpp
+++ b/src/gui/localfolderdialog.cpp
@@ -25,7 +25,6 @@
 #include "guirequests.h"
 #include "libcommon/utility/utility.h"
 #include "libcommongui/matomoclient.h"
-#include "libcommonserver/utility/utility.h"
 
 #include <QBoxLayout>
 #include <QDesktopServices>

--- a/src/gui/localfolderdialog.cpp
+++ b/src/gui/localfolderdialog.cpp
@@ -25,6 +25,7 @@
 #include "guirequests.h"
 #include "libcommon/utility/utility.h"
 #include "libcommongui/matomoclient.h"
+#include "libcommonserver/utility/utility.h"
 
 #include <QBoxLayout>
 #include <QDesktopServices>
@@ -203,9 +204,9 @@ void LocalFolderDialog::updateUI() {
 
         if (virtualFileMode == VirtualFileMode::Win || virtualFileMode == VirtualFileMode::Mac) {
             // Check file system
-            QString fsName(KDC::CommonUtility::fileSystemName(_localFolderPath));
-            _folderCompatibleWithLiteSync = ((virtualFileMode == VirtualFileMode::Win && fsName == "NTFS") ||
-                                             (virtualFileMode == VirtualFileMode::Mac && fsName == "apfs"));
+            _folderCompatibleWithLiteSync =
+                    ((virtualFileMode == VirtualFileMode::Win && CommonUtility::isNTFS(QStr2Path(_localFolderPath))) ||
+                     (virtualFileMode == VirtualFileMode::Mac && CommonUtility::isAPFS(QStr2Path(_localFolderPath))));
             if (!_folderCompatibleWithLiteSync) {
                 _warningLabel->setText(tr(R"(This folder is not compatible with Lite Sync.<br>
 Please select another folder. If you continue Lite Sync will be disabled.<br>

--- a/src/libcommon/utility/types.h
+++ b/src/libcommon/utility/types.h
@@ -89,8 +89,8 @@ using OStringStream = std::wostringstream;
 #define Str(s) L##s
 #define SyncName2QStr(s) QString::fromStdWString(s)
 #define QStr2SyncName(s) s.toStdWString()
-#define Str2SyncName(s) Utility::s2ws(s)
-#define SyncName2Str(s) Utility::ws2s(s)
+#define Str2SyncName(s) CommonUtility::s2ws(s)
+#define SyncName2Str(s) CommonUtility::ws2s(s)
 #define WStr2SyncName(s) SyncName(s)
 #define SyncName2WStr(s) s
 #else
@@ -101,8 +101,8 @@ using OStringStream = std::ostringstream;
 #define QStr2SyncName(s) s.toStdString()
 #define Str2SyncName(s) SyncName(s)
 #define SyncName2Str(s) s
-#define WStr2SyncName(s) Utility::ws2s(s)
-#define SyncName2WStr(s) Utility::s2ws(s)
+#define WStr2SyncName(s) CommonUtility::ws2s(s)
+#define SyncName2WStr(s) CommonUtility::s2ws(s)
 #endif
 
 #define XMLStr2Str(s) Poco::XML::fromXMLString(s)
@@ -117,13 +117,13 @@ using OStringStream = std::ostringstream;
 // Fixed in next gcc-12 version
 // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95048
 #ifdef __GNUC__
-#define Path2WStr(p) KDC::Utility::s2ws(p.native())
+#define Path2WStr(p) CommonUtility::s2ws(p.native())
 #define Path2Str(p) p.native()
 #define Str2Path(s) std::filesystem::path(s)
 #else
 #define Path2WStr(p) p.native()
-#define Path2Str(p) KDC::Utility::ws2s(p.native())
-#define Str2Path(s) std::filesystem::path(KDC::Utility::s2ws(s))
+#define Path2Str(p) CommonUtility::ws2s(p.native())
+#define Str2Path(s) std::filesystem::path(CommonUtility::s2ws(s))
 #endif
 
 namespace event_dump_files {

--- a/src/libcommon/utility/utility.cpp
+++ b/src/libcommon/utility/utility.cpp
@@ -24,8 +24,14 @@
 #include <system_error>
 #include <sys/types.h>
 
-#ifdef Q_OS_UNIX
+#if defined(KD_MACOS)
 #include <sys/statvfs.h>
+#include <sys/mount.h>
+#elif defined(KD_LINUX)
+#include <sys/statvfs.h>
+#include <sys/statfs.h>
+#elif defined(KD_WINDOWS)
+#include <fileapi.h>
 #endif
 
 
@@ -184,17 +190,96 @@ const std::string &CommonUtility::currentVersion() {
     return str;
 }
 
-QString CommonUtility::fileSystemName(const QString &dirPath) {
-    if (QDir dir(dirPath); dir.exists()) {
-        if (const QStorageInfo info(dirPath); info.isValid()) {
-            return info.fileSystemType();
+static std::unordered_map<std::string, std::string> rootFsTypeMap;
+std::string getRootFsType(const SyncPath &targetPath) {
+    auto it = rootFsTypeMap.find(targetPath.root_name().string());
+    if (it == rootFsTypeMap.end()) {
+        const std::string fsType = CommonUtility::fileSystemName(targetPath);
+        const auto [it2, inserted] = rootFsTypeMap.try_emplace(targetPath.root_name().string(), CommonUtility::toUpper(fsType));
+        if (!inserted) {
+            return {};
         }
-    } else {
-        dir.cdUp();
-        return fileSystemName(dir.path());
+        it = it2;
     }
+    return it->second;
+}
 
-    return {};
+bool CommonUtility::isNTFS(const SyncPath &targetPath) {
+    static const std::string ntfs("NTFS");
+    return getRootFsType(targetPath) == ntfs;
+}
+
+bool CommonUtility::isAPFS(const SyncPath &targetPath) {
+    static const std::string apfs("APFS");
+    return getRootFsType(targetPath) == apfs;
+}
+
+bool CommonUtility::isFAT(const SyncPath &targetPath) {
+    static const std::string fat("FAT");
+    return contains(getRootFsType(targetPath), fat);
+}
+
+std::string CommonUtility::fileSystemName(const SyncPath &targetPath) {
+#if defined(KD_MACOS)
+    struct statfs stat;
+    if (statfs(targetPath.root_path().native().c_str(), &stat) == 0) {
+        return stat.f_fstypename;
+    }
+#elif defined(KD_WINDOWS)
+    TCHAR szFileSystemName[MAX_PATH + 1];
+    DWORD dwMaxFileNameLength = 0;
+    DWORD dwFileSystemFlags = 0;
+
+    if (GetVolumeInformation(targetPath.root_path().c_str(), NULL, 0, NULL, &dwMaxFileNameLength, &dwFileSystemFlags,
+                             szFileSystemName, sizeof(szFileSystemName)) == TRUE) {
+        return ws2s(szFileSystemName);
+    } else {
+        // Not all the requested information is retrieved
+        DWORD dwError = GetLastError();
+        LOGW_WARN(logger(), L"Error in GetVolumeInformation for " << formatSyncName(targetPath.root_name()) << L" ("
+                                                                  << utility_base::getErrorMessage(dwError) << L")");
+
+        // !!! File system name can be OK or not !!!
+        return ws2s(szFileSystemName);
+    }
+#elif defined(KD_LINUX)
+    struct statfs stat;
+    if (statfs(targetPath.root_path().native().c_str(), &stat) == 0) {
+        const auto formatFsName = [](const std::string &prettyName, long fsCode) {
+            std::stringstream stream;
+            stream << std::hex << fsCode;
+            return prettyName + " | 0x" + stream.str();
+        };
+        switch (stat.f_type) {
+            case 0x137d:
+                return formatFsName("EXT(1)", stat.f_type);
+            case 0xef51:
+                return formatFsName("EXT2", stat.f_type);
+            case 0xef53:
+                return formatFsName("EXT2/3/4", stat.f_type);
+            case 0xbad1dea:
+            case 0xa501fcf5:
+            case 0x58465342:
+                return formatFsName("XFS", stat.f_type);
+            case 0x9123683e:
+            case 0x73727279:
+                return formatFsName("BTRFS", stat.f_type);
+            case 0xf15f:
+                return formatFsName("ECRYPTFS", stat.f_type);
+            case 0x4244:
+                return formatFsName("HFS", stat.f_type);
+            case 0x5346544e:
+                return formatFsName("NTFS", stat.f_type);
+            case 0x858458f6:
+                return formatFsName("RAMFS", stat.f_type);
+            default:
+                return formatFsName("Unknown-see corresponding entry at https://man7.org/linux/man-pages/man2/statfs.2.html",
+                                    stat.f_type);
+        }
+    }
+#endif
+
+    return "Error";
 }
 
 void CommonUtility::resetTranslations() {
@@ -211,6 +296,81 @@ void CommonUtility::resetTranslations() {
             _qtTranslator = nullptr;
         }
     }
+}
+
+bool CommonUtility::startsWith(const std::string &str, const std::string &prefix) {
+    return str.size() >= prefix.size() &&
+           std::equal(prefix.begin(), prefix.end(), str.begin(), [](char c1, char c2) { return c1 == c2; });
+}
+
+bool CommonUtility::startsWithInsensitive(const std::string &str, const std::string &prefix) {
+    return str.size() >= prefix.size() && std::equal(prefix.begin(), prefix.end(), str.begin(), [](char c1, char c2) {
+               return std::tolower(c1, std::locale()) == std::tolower(c2, std::locale());
+           });
+}
+
+bool CommonUtility::endsWith(const std::string &str, const std::string &suffix) {
+    return str.size() >= suffix.size() && std::equal(str.begin() + static_cast<long>(str.length() - suffix.length()), str.end(),
+                                                     suffix.begin(), [](char c1, char c2) { return c1 == c2; });
+}
+
+bool CommonUtility::endsWithInsensitive(const std::string &str, const std::string &suffix) {
+    return str.size() >= suffix.size() &&
+           std::equal(str.begin() + static_cast<long>(str.length() - suffix.length()), str.end(), suffix.begin(),
+                      [](char c1, char c2) { return std::tolower(c1, std::locale()) == std::tolower(c2, std::locale()); });
+}
+
+bool CommonUtility::contains(const std::string &str, const std::string &substr) {
+    return str.find(substr) != std::string::npos;
+}
+
+std::string CommonUtility::toUpper(const std::string &str) {
+    std::string upperStr(str);
+    // std::ranges::transform(str, upperStr.begin(), [](unsigned char c) { return std::toupper(c); });   // Needs gcc-11
+    std::transform(str.begin(), str.end(), upperStr.begin(), [](unsigned char c) { return std::toupper(c); });
+    return upperStr;
+}
+
+#if defined(KD_WINDOWS)
+bool Utility::startsWithInsensitive(const SyncName &str, const SyncName &prefix) {
+    return str.size() >= prefix.size() && std::equal(prefix.begin(), prefix.end(), str.begin(), [](SyncChar c1, SyncChar c2) {
+               return std::tolower(c1, std::locale()) == std::tolower(c2, std::locale());
+           });
+}
+
+bool Utility::startsWith(const SyncName &str, const SyncName &prefix) {
+    return str.size() >= prefix.size() &&
+           std::equal(prefix.begin(), prefix.end(), str.begin(), [](SyncChar c1, SyncChar c2) { return c1 == c2; });
+}
+
+bool Utility::endsWith(const SyncName &str, const SyncName &suffix) {
+    return str.size() >= suffix.size() && std::equal(str.begin() + str.length() - suffix.length(), str.end(), suffix.begin(),
+                                                     [](char c1, char c2) { return c1 == c2; });
+}
+
+bool Utility::endsWithInsensitive(const SyncName &str, const SyncName &suffix) {
+    return str.size() >= suffix.size() &&
+           std::equal(str.begin() + str.length() - suffix.length(), str.end(), suffix.begin(),
+                      [](char c1, char c2) { return std::tolower(c1, std::locale()) == std::tolower(c2, std::locale()); });
+}
+#endif
+
+bool CommonUtility::isDescendantOrEqual(const SyncPath &potentialDescendant, const SyncPath &path) {
+    if (path == potentialDescendant) return true;
+    for (auto it = potentialDescendant.begin(), it2 = path.begin(); it != potentialDescendant.end(); ++it, ++it2) {
+        if (it2 == path.end()) {
+            return true;
+        }
+        if (*it != *it2) {
+            return false;
+        }
+    }
+    return false;
+}
+
+bool CommonUtility::isStrictDescendant(const SyncPath &potentialDescendant, const SyncPath &path) {
+    if (path == potentialDescendant) return false;
+    return isDescendantOrEqual(potentialDescendant, path);
 }
 
 QString CommonUtility::getIconPath(const IconType iconType) {

--- a/src/libcommon/utility/utility.h
+++ b/src/libcommon/utility/utility.h
@@ -163,13 +163,23 @@ struct COMMON_EXPORT CommonUtility {
         static bool startsWithInsensitive(const std::string &str, const std::string &prefix);
         static bool endsWith(const std::string &str, const std::string &suffix);
         static bool endsWithInsensitive(const std::string &str, const std::string &suffix);
-        static bool contains(const std::string &str, const std::string &substr);
-        static std::string toUpper(const std::string &str);
 #if defined(KD_WINDOWS)
         static bool startsWithInsensitive(const SyncName &str, const SyncName &prefix);
         static bool startsWith(const SyncName &str, const SyncName &prefix);
         static bool endsWith(const SyncName &str, const SyncName &suffix);
         static bool endsWithInsensitive(const SyncName &str, const SyncName &suffix);
+#endif
+        static bool contains(const std::string &str, const std::string &substr);
+        static std::string toUpper(const std::string &str);
+        static std::wstring s2ws(const std::string &str);
+        static std::string ws2s(const std::wstring &wstr);
+        static std::string ltrim(const std::string &s);
+        static std::string rtrim(const std::string &s);
+        static std::string trim(const std::string &s);
+#if defined(KD_WINDOWS)
+        static SyncName ltrim(const SyncName &s);
+        static SyncName rtrim(const SyncName &s);
+        static SyncName trim(const SyncName &s);
 #endif
 
         static bool isDescendantOrEqual(const SyncPath &potentialDescendant, const SyncPath &path);

--- a/src/libcommon/utility/utility.h
+++ b/src/libcommon/utility/utility.h
@@ -60,7 +60,11 @@ struct COMMON_EXPORT CommonUtility {
         static std::string generateRandomStringAlphaNum(int length = 10);
         static std::string generateRandomStringPKCE(int length = 10);
 
-        static QString fileSystemName(const QString &dirPath);
+        // File system type
+        static bool isNTFS(const SyncPath &targetPath);
+        static bool isAPFS(const SyncPath &targetPath);
+        static bool isFAT(const SyncPath &targetPath);
+        static std::string fileSystemName(const SyncPath &targetPath);
 
         static qint64 freeDiskSpace(const QString &path);
         static void crash();
@@ -153,6 +157,24 @@ struct COMMON_EXPORT CommonUtility {
         static SyncPath applicationFilePath();
 
         static void resetTranslations();
+
+        // String manipulation
+        static bool startsWith(const std::string &str, const std::string &prefix);
+        static bool startsWithInsensitive(const std::string &str, const std::string &prefix);
+        static bool endsWith(const std::string &str, const std::string &suffix);
+        static bool endsWithInsensitive(const std::string &str, const std::string &suffix);
+        static bool contains(const std::string &str, const std::string &substr);
+        static std::string toUpper(const std::string &str);
+#if defined(KD_WINDOWS)
+        static bool startsWithInsensitive(const SyncName &str, const SyncName &prefix);
+        static bool startsWith(const SyncName &str, const SyncName &prefix);
+        static bool endsWith(const SyncName &str, const SyncName &suffix);
+        static bool endsWithInsensitive(const SyncName &str, const SyncName &suffix);
+#endif
+
+        static bool isDescendantOrEqual(const SyncPath &potentialDescendant, const SyncPath &path);
+        static bool isStrictDescendant(const SyncPath &potentialDescendant, const SyncPath &path);
+
 
         static bool normalizedSyncName(const SyncName &name, SyncName &normalizedName,
                                        UnicodeNormalization normalization = UnicodeNormalization::NFC) noexcept;

--- a/src/libcommonserver/db/db.cpp
+++ b/src/libcommonserver/db/db.cpp
@@ -87,8 +87,7 @@ static std::string defaultJournalMode(const std::string &dbPath) {
         return "DELETE";
     }
 #elif defined(KD_WINDOWS)
-    std::string fsName = CommonUtility::fileSystemName(dbPath);
-    if (fsName.find("FAT") != std::string::npos) {
+    if (CommonUtility::isFAT(dbPath)) {
         return "DELETE";
     }
 #else

--- a/src/libcommonserver/db/db.cpp
+++ b/src/libcommonserver/db/db.cpp
@@ -83,11 +83,11 @@ namespace KDC {
 
 static std::string defaultJournalMode(const std::string &dbPath) {
 #if defined(KD_MACOS)
-    if (Utility::startsWith(dbPath, "/Volumes/")) {
+    if (CommonUtility::startsWith(dbPath, "/Volumes/")) {
         return "DELETE";
     }
 #elif defined(KD_WINDOWS)
-    std::string fsName = Utility::fileSystemName(dbPath);
+    std::string fsName = CommonUtility::fileSystemName(dbPath);
     if (fsName.find("FAT") != std::string::npos) {
         return "DELETE";
     }

--- a/src/libcommonserver/db/sqlitedb.cpp
+++ b/src/libcommonserver/db/sqlitedb.cpp
@@ -362,7 +362,7 @@ bool SqliteDb::openHelper(const std::filesystem::path &dbPath, int sqliteFlags) 
 
     if (_errId != SQLITE_OK) {
         LOGW_WARN(_logger,
-                  L"Opening database failed: " << _errId << L" " << Utility::s2ws(_error) << L" for " << Path2WStr(dbPath));
+                  L"Opening database failed: " << _errId << L" " << CommonUtility::s2ws(_error) << L" for " << Path2WStr(dbPath));
         if (_errId == SQLITE_CANTOPEN) {
             LOG_WARN(_logger, "CANTOPEN extended errcode: " << sqlite3_extended_errcode(_sqlite3Db.get()));
 #if SQLITE_VERSION_NUMBER >= 3012000

--- a/src/libcommonserver/db/sqlitequery.cpp
+++ b/src/libcommonserver/db/sqlitequery.cpp
@@ -240,15 +240,15 @@ int SqliteQuery::blobSize(int index) const {
 }
 
 bool SqliteQuery::isSelect() const {
-    return Utility::startsWithInsensitive(_sql, "SELECT");
+    return CommonUtility::startsWithInsensitive(_sql, "SELECT");
 }
 
 bool SqliteQuery::isInsert() const {
-    return Utility::startsWithInsensitive(_sql, "INSERT");
+    return CommonUtility::startsWithInsensitive(_sql, "INSERT");
 }
 
 bool SqliteQuery::isPragma() const {
-    return Utility::startsWithInsensitive(_sql, "PRAGMA");
+    return CommonUtility::startsWithInsensitive(_sql, "PRAGMA");
 }
 
 } // namespace KDC

--- a/src/libcommonserver/db/sqlitequery.cpp
+++ b/src/libcommonserver/db/sqlitequery.cpp
@@ -41,7 +41,7 @@ SqliteQuery::SqliteQuery(std::shared_ptr<sqlite3> sqlite3Db) :
     _sqlite3Db(sqlite3Db) {}
 
 int SqliteQuery::prepare(const std::string &sql, bool allow_failure) {
-    _sql = Utility::trim(sql);
+    _sql = CommonUtility::trim(sql);
     if (_stmt) {
         sqlite3_finalize(_stmt.get());
     }

--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -343,7 +343,7 @@ bool IoHelper::getItemType(const SyncPath &path, ItemType &itemType) noexcept {
 
     itemType.ioError = stdError2ioError(ec);
 #if defined(KD_WINDOWS)
-    const bool fsSupportsSymlinks = Utility::isNtfs(path);
+    const bool fsSupportsSymlinks = CommonUtility::isNTFS(path);
 #else
     const bool fsSupportsSymlinks =
             itemType.ioError != IoError::InvalidArgument; // If true, we assume that the file system in use does support symlinks.
@@ -754,7 +754,7 @@ bool IoHelper::checkIfPathExists(const SyncPath &path, bool &exists, IoError &io
     // found but located on a FAT32 disk. If the file is not found, it works as expected. This behavior is fixed when
     // compiling with VS2022, see
     // https://developercommunity.visualstudio.com/t/std::filesystem::is_symlink-is-broken-on/1638272
-    if (ioError == IoError::InvalidArgument && !Utility::isNtfs(path)) {
+    if (ioError == IoError::InvalidArgument && !CommonUtility::isNTFS(path)) {
         (void) std::filesystem::status(
                 path, ec); // Symlink are only supported on NTFS on Windows, there is no risk to follow a symlink.
         ioError = stdError2ioError(ec);

--- a/src/libcommonserver/io/iohelper_win.cpp
+++ b/src/libcommonserver/io/iohelper_win.cpp
@@ -254,10 +254,8 @@ bool IoHelper::_getFileStatFn(const SyncPath &path, FileStat *filestat, IoError 
                                            FileIdFullDirectoryInformation, true, &fn, TRUE);
 
     DWORD dwError = GetLastError();
-    const bool isNtfs = Utility::isNtfs(path);
-    if ((isNtfs && !NT_SUCCESS(status)) ||
-        (!isNtfs && dwError != 0)) { // On FAT32 file system, NT_SUCCESS will return false even if it is a success, therefore we
-                                     // also check GetLastError
+    // On FAT32 file system, NT_SUCCESS will return false even if it is a success, therefore we also check GetLastError
+    if ((Utility::isNtfs(path) && !NT_SUCCESS(status)) || (Utility::isFat(path) && dwError != 0)) {
         CloseHandle(hParent);
 
         if (!NT_SUCCESS(status)) {

--- a/src/libcommonserver/io/iohelper_win.cpp
+++ b/src/libcommonserver/io/iohelper_win.cpp
@@ -255,7 +255,7 @@ bool IoHelper::_getFileStatFn(const SyncPath &path, FileStat *filestat, IoError 
 
     DWORD dwError = GetLastError();
     // On FAT32 file system, NT_SUCCESS will return false even if it is a success, therefore we also check GetLastError
-    if ((Utility::isNtfs(path) && !NT_SUCCESS(status)) || (Utility::isFat(path) && dwError != 0)) {
+    if ((CommonUtility::isNTFS(path) && !NT_SUCCESS(status)) || (CommonUtility::isFAT(path) && dwError != 0)) {
         CloseHandle(hParent);
 
         if (!NT_SUCCESS(status)) {

--- a/src/libcommonserver/log/customrollingfileappender.cpp
+++ b/src/libcommonserver/log/customrollingfileappender.cpp
@@ -302,7 +302,7 @@ void CustomRollingFileAppender::checkForExpiredFiles() {
             const auto lastModified = std::chrono::system_clock::from_time_t(fileStat.modificationTime); // Only 1s precision.
             const auto expireDateTime = lastModified + std::chrono::seconds(_expire);
             if (expireDateTime < now) {
-                log4cplus::file_remove(Utility::s2ws(entry.path().string()));
+                log4cplus::file_remove(CommonUtility::s2ws(entry.path().string()));
                 continue;
             }
         }
@@ -312,9 +312,9 @@ void CustomRollingFileAppender::checkForExpiredFiles() {
             entry.path().filename().string().find(".gz") == std::string::npos &&
             entry.path().string().find(currentLogName.string()) == std::string::npos) {
             if (CommonUtility::compressFile(entry.path().string(), entry.path().string() + ".gz")) {
-                log4cplus::file_remove(Utility::s2ws(entry.path().string()));
+                log4cplus::file_remove(CommonUtility::s2ws(entry.path().string()));
             } else {
-                log4cplus::file_remove(Utility::s2ws(entry.path().string()) + LOG4CPLUS_TEXT(".gz"));
+                log4cplus::file_remove(CommonUtility::s2ws(entry.path().string()) + LOG4CPLUS_TEXT(".gz"));
             }
         }
     }

--- a/src/libcommonserver/log/log.h
+++ b/src/libcommonserver/log/log.h
@@ -47,7 +47,7 @@ namespace KDC {
         CustomLogWStream customLogWStream_;                                                                       \
         customLogWStream_ << logEvent;                                                                            \
         const auto &customLogWStreamStr_ = customLogWStream_.str();                                               \
-        sentry_value_t crumb = sentry_value_new_breadcrumb(nullptr, Utility::ws2s(customLogWStreamStr_).c_str()); \
+        sentry_value_t crumb = sentry_value_new_breadcrumb(nullptr, CommonUtility::ws2s(customLogWStreamStr_).c_str()); \
         sentry_value_set_by_key(crumb, "level", sentry_value_new_string("debug"));                                \
         sentry_add_breadcrumb(crumb);                                                                             \
         LOG4CPLUS_DEBUG(logger, customLogWStreamStr_.c_str());                                                    \
@@ -69,7 +69,7 @@ namespace KDC {
         CustomLogWStream customLogWStream_;                                                                       \
         customLogWStream_ << logEvent;                                                                            \
         const auto &customLogWStreamStr_ = customLogWStream_.str();                                               \
-        sentry_value_t crumb = sentry_value_new_breadcrumb(nullptr, Utility::ws2s(customLogWStreamStr_).c_str()); \
+        sentry_value_t crumb = sentry_value_new_breadcrumb(nullptr, CommonUtility::ws2s(customLogWStreamStr_).c_str()); \
         sentry_value_set_by_key(crumb, "level", sentry_value_new_string("info"));                                 \
         sentry_add_breadcrumb(crumb);                                                                             \
         LOG4CPLUS_INFO(logger, customLogWStreamStr_.c_str());                                                     \
@@ -92,7 +92,7 @@ namespace KDC {
         CustomLogWStream customLogWStream_;                                                                       \
         customLogWStream_ << logEvent;                                                                            \
         const auto &customLogWStreamStr_ = customLogWStream_.str();                                               \
-        sentry_value_t crumb = sentry_value_new_breadcrumb(nullptr, Utility::ws2s(customLogWStreamStr_).c_str()); \
+        sentry_value_t crumb = sentry_value_new_breadcrumb(nullptr, CommonUtility::ws2s(customLogWStreamStr_).c_str()); \
         sentry_value_set_by_key(crumb, "level", sentry_value_new_string("warning"));                              \
         sentry_add_breadcrumb(crumb);                                                                             \
         LOG4CPLUS_WARN(logger, customLogWStreamStr_.c_str());                                                     \
@@ -114,7 +114,7 @@ namespace KDC {
         CustomLogWStream customLogWStream_;                                                                       \
         customLogWStream_ << logEvent;                                                                            \
         const auto &customLogWStreamStr_ = customLogWStream_.str();                                               \
-        sentry_value_t crumb = sentry_value_new_breadcrumb(nullptr, Utility::ws2s(customLogWStreamStr_).c_str()); \
+        sentry_value_t crumb = sentry_value_new_breadcrumb(nullptr, CommonUtility::ws2s(customLogWStreamStr_).c_str()); \
         sentry_value_set_by_key(crumb, "level", sentry_value_new_string("error"));                                \
         sentry_add_breadcrumb(crumb);                                                                             \
         LOG4CPLUS_ERROR(logger, customLogWStreamStr_.c_str());                                                    \
@@ -137,10 +137,10 @@ namespace KDC {
         CustomLogWStream customLogWStream_;                                                                            \
         customLogWStream_ << logEvent;                                                                                 \
         const auto &customLogWStreamStr_ = customLogWStream_.str();                                                    \
-        sentry_value_t crumb = sentry_value_new_breadcrumb(nullptr, Utility::ws2s(customLogWStreamStr_).c_str());      \
+        sentry_value_t crumb = sentry_value_new_breadcrumb(nullptr, CommonUtility::ws2s(customLogWStreamStr_).c_str());      \
         sentry_value_set_by_key(crumb, "level", sentry_value_new_string("fatal"));                                     \
         sentry_add_breadcrumb(crumb);                                                                                  \
-        sentry::Handler::captureMessage(sentry::Level::Fatal, "Log fatal error", Utility::ws2s(customLogWStreamStr_)); \
+        sentry::Handler::captureMessage(sentry::Level::Fatal, "Log fatal error", CommonUtility::ws2s(customLogWStreamStr_)); \
         LOG4CPLUS_FATAL(logger, customLogWStreamStr_.c_str());                                                         \
     }
 #else

--- a/src/libcommonserver/utility/utility.cpp
+++ b/src/libcommonserver/utility/utility.cpp
@@ -84,7 +84,7 @@ struct VariantPrinter {
         std::wstring operator()(int value) { return std::to_wstring(value); }
         std::wstring operator()(int64_t value) { return std::to_wstring(value); }
         std::wstring operator()(double value) { return std::to_wstring(value); }
-        std::wstring operator()(const std::string &value) { return Utility::s2ws(value); }
+        std::wstring operator()(const std::string &value) { return CommonUtility::s2ws(value); }
         std::wstring operator()(const std::wstring &value) { return value; }
         std::wstring operator()(std::shared_ptr<std::vector<char>>) { return std::wstring(); }
 };
@@ -158,62 +158,6 @@ bool Utility::isCreationDateValid(int64_t creationDate) {
     return true;
 }
 
-std::wstring Utility::s2ws(const std::string &str) {
-    Poco::UnicodeConverter converter;
-    std::wstring output;
-    converter.convert(str, output);
-    return output;
-}
-
-std::string Utility::ws2s(const std::wstring &wstr) {
-    Poco::UnicodeConverter converter;
-    std::string output;
-    converter.convert(wstr, output);
-    return output;
-}
-
-std::string Utility::ltrim(const std::string &s) {
-    std::string sout(s);
-    const auto it =
-            std::find_if(sout.begin(), sout.end(), [](const char c) { return !std::isspace<char>(c, std::locale::classic()); });
-    sout.erase(sout.begin(), it);
-    return sout;
-}
-
-std::string Utility::rtrim(const std::string &s) {
-    std::string sout(s);
-    const auto it =
-            std::find_if(sout.rbegin(), sout.rend(), [](const char c) { return !std::isspace<char>(c, std::locale::classic()); });
-    sout.erase(it.base(), sout.end());
-    return sout;
-}
-
-std::string Utility::trim(const std::string &s) {
-    return ltrim(rtrim(s));
-}
-
-#if defined(KD_WINDOWS)
-SyncName Utility::ltrim(const SyncName &s) {
-    SyncName sout(s);
-    const auto it =
-            std::find_if(sout.begin(), sout.end(), [](const char c) { return !std::isspace<char>(c, std::locale::classic()); });
-    sout.erase(sout.begin(), it);
-    return sout;
-}
-
-SyncName Utility::rtrim(const SyncName &s) {
-    SyncName sout(s);
-    const auto it =
-            std::find_if(sout.rbegin(), sout.rend(), [](const char c) { return !std::isspace<char>(c, std::locale::classic()); });
-    sout.erase(it.base(), sout.end());
-    return sout;
-}
-
-SyncName Utility::trim(const SyncName &s) {
-    return ltrim(rtrim(s));
-}
-#endif
-
 void Utility::msleep(int msec) {
     std::chrono::milliseconds dura(msec);
     std::this_thread::sleep_for(dura);
@@ -249,7 +193,7 @@ std::wstring Utility::formatStdError(const std::error_code &ec) {
 #if defined(KD_WINDOWS)
     std::stringstream ss;
     ss << ec.message() << " (code: " << ec.value() << ")";
-    return s2ws(ss.str());
+    return CommonUtility::s2ws(ss.str());
 #elif defined(KD_LINUX)
     std::stringstream ss;
     ss << ec.message() << ". (code: " << ec.value() << ")";
@@ -268,7 +212,7 @@ std::wstring Utility::formatStdError(const SyncPath &path, const std::error_code
 
 std::wstring Utility::formatIoError(const IoError ioError) {
     std::wstringstream ss;
-    ss << s2ws(IoHelper::ioError2StdString(ioError));
+    ss << CommonUtility::s2ws(IoHelper::ioError2StdString(ioError));
 
     return ss.str();
 }

--- a/src/libcommonserver/utility/utility.h
+++ b/src/libcommonserver/utility/utility.h
@@ -93,21 +93,6 @@ struct COMMONSERVER_EXPORT Utility {
         static void logGenericServerError(const log4cplus::Logger &logger, const std::string &errorTitle,
                                           std::istream &inputStream, const Poco::Net::HTTPResponse &httpResponse);
 
-        static bool isNtfs(const SyncPath &targetPath);
-        static bool isFat(const SyncPath &targetPath);
-
-        static std::string fileSystemName(const SyncPath &targetPath);
-        static bool startsWith(const std::string &str, const std::string &prefix);
-        static bool startsWithInsensitive(const std::string &str, const std::string &prefix);
-        static bool endsWith(const std::string &str, const std::string &suffix);
-        static bool endsWithInsensitive(const std::string &str, const std::string &suffix);
-        static bool contains(const std::string &str, const std::string &substr);
-#if defined(KD_WINDOWS)
-        static bool startsWithInsensitive(const SyncName &str, const SyncName &prefix);
-        static bool startsWith(const SyncName &str, const SyncName &prefix);
-        static bool endsWith(const SyncName &str, const SyncName &suffix);
-        static bool endsWithInsensitive(const SyncName &str, const SyncName &suffix);
-#endif
         /**
          * Check if two paths coincide up to case and encoding of file names.
          * @param a SyncPath value to be compared.
@@ -116,8 +101,6 @@ struct COMMONSERVER_EXPORT Utility {
          * @return true if no normalization issue occurs when comparing.
          */
         static bool checkIfEqualUpToCaseAndEncoding(const SyncPath &a, const SyncPath &b, bool &isEqual);
-        static bool isDescendantOrEqual(const SyncPath &potentialDescendant, const SyncPath &path);
-        static bool isStrictDescendant(const SyncPath &potentialDescendant, const SyncPath &path);
         /**
          * Normalize the SyncName parameters before comparing them.
          * @param a SyncName value to be compared.
@@ -134,6 +117,7 @@ struct COMMONSERVER_EXPORT Utility {
          * @return true if no normalization issue.
          */
         static bool checkIfSameNormalization(const SyncPath &a, const SyncPath &b, bool &areSame);
+
 
         static bool moveItemToTrash(const SyncPath &itemPath);
 #if defined(KD_MACOS)
@@ -164,7 +148,6 @@ struct COMMONSERVER_EXPORT Utility {
         static SyncPath resourcesRelativePath();
         static SyncName logFileName();
         static SyncName logFileNameWithTime();
-        static std::string toUpper(const std::string &str);
 
         /* TODO : Replace with std::source_location when we will bump gcc version to 10 or higher
          *  static std::string errId(std::source_location location = std::source_location::current());

--- a/src/libcommonserver/utility/utility.h
+++ b/src/libcommonserver/utility/utility.h
@@ -93,9 +93,9 @@ struct COMMONSERVER_EXPORT Utility {
         static void logGenericServerError(const log4cplus::Logger &logger, const std::string &errorTitle,
                                           std::istream &inputStream, const Poco::Net::HTTPResponse &httpResponse);
 
-#if defined(KD_WINDOWS)
         static bool isNtfs(const SyncPath &targetPath);
-#endif
+        static bool isFat(const SyncPath &targetPath);
+
         static std::string fileSystemName(const SyncPath &targetPath);
         static bool startsWith(const std::string &str, const std::string &prefix);
         static bool startsWithInsensitive(const std::string &str, const std::string &prefix);

--- a/src/libcommonserver/utility/utility.h
+++ b/src/libcommonserver/utility/utility.h
@@ -63,16 +63,6 @@ struct COMMONSERVER_EXPORT Utility {
         static bool findNodeValue(const Poco::XML::Document &doc, const std::string &nodeName, std::string *outValue);
         static bool isCreationDateValid(int64_t creationDate);
 
-        static std::wstring s2ws(const std::string &str);
-        static std::string ws2s(const std::wstring &wstr);
-        static std::string ltrim(const std::string &s);
-        static std::string rtrim(const std::string &s);
-        static std::string trim(const std::string &s);
-#if defined(KD_WINDOWS)
-        static SyncName ltrim(const SyncName &s);
-        static SyncName rtrim(const SyncName &s);
-        static SyncName trim(const SyncName &s);
-#endif
         static void msleep(int msec);
         static std::wstring v2ws(const dbtype &v);
 

--- a/src/libcommonserver/utility/utility_win.cpp
+++ b/src/libcommonserver/utility/utility_win.cpp
@@ -63,11 +63,11 @@ static bool moveItemToTrash_private(const SyncPath &itemPath) {
         // Couldn't CoCreateInstance - clean up and return
         LOGW_WARN(Log::instance()->getLogger(), L"Error in CoCreateInstance - path="
                                                         << Path2WStr(itemPath) << L" err="
-                                                        << Utility::s2ws(std::system_category().message(hr)));
+                                                        << CommonUtility::s2ws(std::system_category().message(hr)));
 
         std::wstringstream errorStream;
         errorStream << L"Move to trash failed for item with " << Utility::formatSyncPath(itemPath)
-                    << L" - CoCreateInstance failed with error: " << Utility::s2ws(std::system_category().message(hr));
+                    << L" - CoCreateInstance failed with error: " << CommonUtility::s2ws(std::system_category().message(hr));
         std::wstring errorStr = errorStream.str();
         LOGW_WARN(Log::instance()->getLogger(), errorStr);
         sentry::Handler::captureMessage(sentry::Level::Error, "Utility::moveItemToTrash", "CoCreateInstance failed");
@@ -80,11 +80,11 @@ static bool moveItemToTrash_private(const SyncPath &itemPath) {
         // Couldn't add flags - clean up and return
         LOGW_WARN(Log::instance()->getLogger(), L"Error in SetOperationFlags path="
                                                         << Path2WStr(itemPath) << L" err="
-                                                        << Utility::s2ws(std::system_category().message(hr)));
+                                                        << CommonUtility::s2ws(std::system_category().message(hr)));
 
         std::wstringstream errorStream;
         errorStream << L"Move to trash failed for item " << Path2WStr(itemPath) << L" - SetOperationFlags failed with error: "
-                    << Utility::s2ws(std::system_category().message(hr));
+                    << CommonUtility::s2ws(std::system_category().message(hr));
         std::wstring errorStr = errorStream.str();
         LOGW_WARN(Log::instance()->getLogger(), errorStr);
 
@@ -101,11 +101,12 @@ static bool moveItemToTrash_private(const SyncPath &itemPath) {
         // Couldn't get file into an item - clean up and return (maybe the file doesn't exist?)
         LOGW_WARN(Log::instance()->getLogger(), L"Error in SHCreateItemFromParsingName - path="
                                                         << Path2WStr(itemPath) << L" err="
-                                                        << Utility::s2ws(std::system_category().message(hr)));
+                                                        << CommonUtility::s2ws(std::system_category().message(hr)));
 
         std::wstringstream errorStream;
         errorStream << L"Move to trash failed for item " << Path2WStr(itemPath)
-                    << L" - SHCreateItemFromParsingName failed with error: " << Utility::s2ws(std::system_category().message(hr));
+                    << L" - SHCreateItemFromParsingName failed with error: "
+                    << CommonUtility::s2ws(std::system_category().message(hr));
         std::wstring errorStr = errorStream.str();
         LOGW_WARN(Log::instance()->getLogger(), errorStr);
 
@@ -120,11 +121,11 @@ static bool moveItemToTrash_private(const SyncPath &itemPath) {
         // Failed to mark file/folder item for deletion - clean up and return
         LOGW_WARN(Log::instance()->getLogger(), L"Error in DeleteItem - path="
                                                         << Path2WStr(itemPath) << L" err="
-                                                        << Utility::s2ws(std::system_category().message(hr)));
+                                                        << CommonUtility::s2ws(std::system_category().message(hr)));
 
         std::wstringstream errorStream;
         errorStream << L"Move to trash failed for item " << Path2WStr(itemPath) << L" - DeleteItem failed with error: "
-                    << Utility::s2ws(std::system_category().message(hr));
+                    << CommonUtility::s2ws(std::system_category().message(hr));
         std::wstring errorStr = errorStream.str();
         LOGW_WARN(Log::instance()->getLogger(), errorStr);
         sentry::Handler::captureMessage(sentry::Level::Error, "Utility::moveItemToTrash", "DeleteItem failed");
@@ -140,11 +141,11 @@ static bool moveItemToTrash_private(const SyncPath &itemPath) {
         // failed to carry out delete - return
         LOGW_WARN(Log::instance()->getLogger(), L"Error in PerformOperations - path="
                                                         << Path2WStr(itemPath) << L" err="
-                                                        << Utility::s2ws(std::system_category().message(hr)));
+                                                        << CommonUtility::s2ws(std::system_category().message(hr)));
 
         std::wstringstream errorStream;
         errorStream << L"Move to trash failed for item " << Path2WStr(itemPath) << L" - PerformOperations failed with error: "
-                    << Utility::s2ws(std::system_category().message(hr));
+                    << CommonUtility::s2ws(std::system_category().message(hr));
         std::wstring errorStr = errorStream.str();
         LOGW_WARN(Log::instance()->getLogger(), errorStr);
 
@@ -161,7 +162,7 @@ static bool moveItemToTrash_private(const SyncPath &itemPath) {
         // failed to carry out delete - return
         LOGW_WARN(Log::instance()->getLogger(), L"Error in GetAnyOperationsAborted - path="
                                                         << Path2WStr(itemPath) << L" err="
-                                                        << Utility::s2ws(std::system_category().message(hr)));
+                                                        << CommonUtility::s2ws(std::system_category().message(hr)));
 
         std::wstringstream errorStream;
         errorStream << L"Move to trash aborted for item " << Path2WStr(itemPath);
@@ -206,7 +207,7 @@ static std::string userName_private() {
     DWORD len = userNameBufLen;
     wchar_t userName[userNameBufLen];
     GetUserName(userName, &len);
-    return Utility::ws2s(std::wstring(userName));
+    return CommonUtility::ws2s(std::wstring(userName));
 }
 
 } // namespace KDC

--- a/src/libcommonserver/vfs/mac/litesyncextconnector.mm
+++ b/src/libcommonserver/vfs/mac/litesyncextconnector.mm
@@ -546,10 +546,10 @@ bool checkIoErrorAndLogIfNeeded(IoError ioError, const std::string &itemType, co
 
     std::wstring message;
     if (ioError == IoError::NoSuchFileOrDirectory) {
-        message = Utility::s2ws(itemType + " doesn't exist: ");
+        message = CommonUtility::s2ws(itemType + " doesn't exist: ");
     }
     if (ioError == IoError::AccessDenied) {
-        message = Utility::s2ws(itemType + " or some containing directory, misses a permission: ");
+        message = CommonUtility::s2ws(itemType + " or some containing directory, misses a permission: ");
     }
 
     switch (mode) {
@@ -1211,7 +1211,7 @@ bool LiteSyncExtConnector::vfsUpdateFetchStatus(const QString &tmpFilePath, cons
             } @catch (NSException *e) {
                 LOGW_WARN(_logger, L"Could not copy tmp file from " << Utility::formatPath(tmpFilePath) << L" to "
                                                                     << Utility::formatPath(filePath) << L" err="
-                                                                    << Utility::s2ws(std::string([e.name UTF8String])));
+                                                                    << CommonUtility::s2ws(std::string([e.name UTF8String])));
                 return false;
             }
 

--- a/src/libcommonserver/vfs/win/vfs_win.cpp
+++ b/src/libcommonserver/vfs/win/vfs_win.cpp
@@ -89,7 +89,7 @@ ExitInfo VfsWin::startImpl(bool &, bool &, bool &) {
         return {ExitCode::SystemError, ExitCause::UnableToCreateVfs};
     }
 
-    _vfsSetupParams.namespaceCLSID = Utility::ws2s(std::wstring(clsid));
+    _vfsSetupParams.namespaceCLSID = CommonUtility::ws2s(std::wstring(clsid));
 
     return ExitCode::Ok;
 }
@@ -235,7 +235,7 @@ ExitInfo VfsWin::createPlaceholder(const SyncPath &relativeLocalPath, const Sync
     findData.ftLastAccessTime = findData.ftLastWriteTime;
     findData.dwFileAttributes = (item.type() == NodeType::Directory ? FILE_ATTRIBUTE_DIRECTORY : 0);
 
-    if (vfsCreatePlaceHolder(Utility::s2ws(item.remoteNodeId().value()).c_str(),
+    if (vfsCreatePlaceHolder(CommonUtility::s2ws(item.remoteNodeId().value()).c_str(),
                              relativeLocalPath.lexically_normal().native().c_str(),
                              _vfsSetupParams.localPath.lexically_normal().native().c_str(), &findData) != S_OK) {
         LOGW_WARN(logger(), L"Error in vfsCreatePlaceHolder: " << Utility::formatSyncPath(fullPath));
@@ -309,7 +309,7 @@ ExitInfo VfsWin::convertToPlaceholder(const SyncPath &pathStd, const SyncFileIte
         return {ExitCode::LogicError, ExitCause::InvalidArgument};
     }
 
-    if (!isPlaceholder && (vfsConvertToPlaceHolder(Utility::s2ws(item.localNodeId().value()).c_str(),
+    if (!isPlaceholder && (vfsConvertToPlaceHolder(CommonUtility::s2ws(item.localNodeId().value()).c_str(),
                                                    fullPath.lexically_normal().native().c_str()) != S_OK)) {
         LOGW_WARN(logger(), L"Error in vfsConvertToPlaceHolder: " << Utility::formatSyncPath(fullPath));
         return handleVfsError(fullPath);
@@ -464,7 +464,7 @@ ExitInfo VfsWin::forceStatus(const SyncPath &absolutePathStd, const VfsStatus &v
         NodeId localNodeId = std::to_string(filestat.inode);
 
         // Convert to placeholder
-        if (vfsConvertToPlaceHolder(Utility::s2ws(localNodeId).c_str(), absolutePathStd.native().c_str()) != S_OK) {
+        if (vfsConvertToPlaceHolder(CommonUtility::s2ws(localNodeId).c_str(), absolutePathStd.native().c_str()) != S_OK) {
             LOGW_WARN(logger(), L"Error in vfsConvertToPlaceHolder: " << Utility::formatSyncPath(absolutePathStd));
             return handleVfsError(absolutePathStd);
         }

--- a/src/libsyncengine/db/syncdb.cpp
+++ b/src/libsyncengine/db/syncdb.cpp
@@ -1233,7 +1233,7 @@ bool SyncDb::dbId(ReplicaSide side, const SyncPath &path, DbNodeId &dbNodeId, bo
             LOG_IF_FAIL(queryBindValue(id, 1, dbNodeId));
             LOG_IF_FAIL(queryBindValue(id, 2, name));
             if (!queryNext(id, found)) {
-                LOGW_WARN(_logger, L"Error getting query result: " << Utility::s2ws(id) << L" - parentNodeId="
+                LOGW_WARN(_logger, L"Error getting query result: " << CommonUtility::s2ws(id) << L" - parentNodeId="
                                                                    << std::to_wstring(dbNodeId) << L" and name="
                                                                    << Utility::formatSyncName(name));
                 return false;
@@ -1297,7 +1297,7 @@ bool SyncDb::id(ReplicaSide side, const SyncPath &path, std::optional<NodeId> &n
             LOG_IF_FAIL(queryBindValue(queryId, 1, nodeDbId));
             LOG_IF_FAIL(queryBindValue(queryId, 2, name));
             if (!queryNext(queryId, found)) {
-                LOGW_WARN(_logger, L"Error getting query result: " << Utility::s2ws(queryId) << L" - parentNodeId=" << nodeDbId
+                LOGW_WARN(_logger, L"Error getting query result: " << CommonUtility::s2ws(queryId) << L" - parentNodeId=" << nodeDbId
                                                                    << L" and name=" << Utility::formatSyncName(name));
                 return false;
             }

--- a/src/libsyncengine/jobs/local/localcopyjob.cpp
+++ b/src/libsyncengine/jobs/local/localcopyjob.cpp
@@ -86,7 +86,7 @@ void LocalCopyJob::runJob() {
         _exitInfo = ExitCode::Ok;
     } catch (std::filesystem::filesystem_error &fsError) {
         LOGW_WARN(_logger, L"Failed to copy item " << Path2WStr(_source) << L" to " << Path2WStr(_dest) << L": "
-                                                   << Utility::s2ws(fsError.what()) << L" (" << fsError.code().value() << L")");
+                                                   << CommonUtility::s2ws(fsError.what()) << L" (" << fsError.code().value() << L")");
         _exitInfo = ExitCode::SystemError;
         if (IoHelper::stdError2ioError(fsError.code()) == IoError::AccessDenied) {
             _exitInfo.setCause(ExitCause::FileAccessError);

--- a/src/libsyncengine/jobs/local/localmovejob.cpp
+++ b/src/libsyncengine/jobs/local/localmovejob.cpp
@@ -92,7 +92,7 @@ void LocalMoveJob::runJob() {
 
     if (ec.value() != 0) { // We consider this as a permission denied error
         LOGW_WARN(_logger, L"Failed to rename " << Path2WStr(_source) << L" to " << Path2WStr(_dest) << L": "
-                                                << Utility::s2ws(ec.message()) << L" (" << ec.value() << L")");
+                                                << CommonUtility::s2ws(ec.message()) << L" (" << ec.value() << L")");
         _exitInfo = {ExitCode::SystemError, ExitCause::FileAccessError};
         return;
     }

--- a/src/libsyncengine/jobs/network/API_v2/deletejob.cpp
+++ b/src/libsyncengine/jobs/network/API_v2/deletejob.cpp
@@ -47,7 +47,7 @@ bool DeleteJob::canRun() {
 
     if (_remoteItemId.empty() || _localItemId.empty() || _absoluteLocalFilepath.empty()) {
         LOGW_WARN(_logger, L"Error in DeleteJob::canRun: missing required input, remote ID:"
-                                   << Utility::s2ws(_remoteItemId) << L", local ID: " << Utility::s2ws(_localItemId) << L", "
+                                   << CommonUtility::s2ws(_remoteItemId) << L", local ID: " << CommonUtility::s2ws(_localItemId) << L", "
                                    << Utility::formatSyncPath(_absoluteLocalFilepath));
         _exitInfo = ExitCode::DataError;
         return false;
@@ -99,8 +99,8 @@ bool DeleteJob::canRun() {
         return false;
     } else if (!otherNodeId.empty() && _localItemId != otherNodeId) {
         LOGW_DEBUG(_logger, L"Item: " << Utility::formatSyncPath(_absoluteLocalFilepath)
-                                      << L" exists on local replica with another ID (" << Utility::s2ws(_localItemId) << L"/"
-                                      << Utility::s2ws(otherNodeId) << L")");
+                                      << L" exists on local replica with another ID (" << CommonUtility::s2ws(_localItemId) << L"/"
+                                      << CommonUtility::s2ws(otherNodeId) << L")");
 
         std::stringstream ss;
         ss << "File exists with another ID (" << _localItemId << "/" << otherNodeId << ")";

--- a/src/libsyncengine/jobs/network/API_v2/getfileinfojob.cpp
+++ b/src/libsyncengine/jobs/network/API_v2/getfileinfojob.cpp
@@ -74,7 +74,7 @@ bool GetFileInfoJob::handleResponse(std::istream &is) {
         if (!JsonParserUtility::extractValue(dataObj, pathKey, relativePathStr)) {
             return false;
         }
-        if (Utility::startsWith(relativePathStr, "/")) {
+        if (CommonUtility::startsWith(relativePathStr, "/")) {
             relativePathStr.erase(0, 1);
         }
 

--- a/src/libsyncengine/jobs/network/API_v2/listing/csvfullfilelistwithcursorjob.cpp
+++ b/src/libsyncengine/jobs/network/API_v2/listing/csvfullfilelistwithcursorjob.cpp
@@ -80,7 +80,7 @@ bool CsvFullFileListWithCursorJob::handleResponse(std::istream &is) {
 
     _ss.seekg(0, std::ios_base::beg);
     if (isExtendedLog()) {
-        LOGW_DEBUG(_logger, L"Reply " << jobId() << L" received - length=" << length << L" value=" << Utility::s2ws(_ss.str()));
+        LOGW_DEBUG(_logger, L"Reply " << jobId() << L" received - length=" << length << L" value=" << CommonUtility::s2ws(_ss.str()));
     }
     return true;
 }

--- a/src/libsyncengine/jobs/network/API_v2/listing/snapshotitemhandler.cpp
+++ b/src/libsyncengine/jobs/network/API_v2/listing/snapshotitemhandler.cpp
@@ -30,8 +30,8 @@ SnapshotItemHandler::SnapshotItemHandler(const log4cplus::Logger &logger) :
 void SnapshotItemHandler::logError(const std::wstring &methodName, const std::wstring &stdErrorType, const std::string &str,
                                    const std::exception &exc) {
     const std::wstring header = L"Error in SnapshotItem::" + methodName;
-    const std::wstring strStr = L"str='" + Utility::s2ws(str) + L"', ";
-    const std::wstring excStr = L"exc='" + stdErrorType + L"', " + L"err=" + Utility::s2ws(exc.what()) + L"'.";
+    const std::wstring strStr = L"str='" + CommonUtility::s2ws(str) + L"', ";
+    const std::wstring excStr = L"exc='" + stdErrorType + L"', " + L"err=" + CommonUtility::s2ws(exc.what()) + L"'.";
 
     const std::wstring msg = header + strStr + excStr;
 
@@ -79,7 +79,7 @@ bool SnapshotItemHandler::updateSnapshotItem(const std::string &str, const CsvIn
             }
 
             if (item.size() < 0) {
-                LOGW_WARN(_logger, L"Error in setSize, got a negative value - str='" << Utility::s2ws(str) << L"'");
+                LOGW_WARN(_logger, L"Error in setSize, got a negative value - str='" << CommonUtility::s2ws(str) << L"'");
                 return false;
             }
 
@@ -144,7 +144,7 @@ void SnapshotItemHandler::readSnapshotItemFields(SnapshotItem &item, const std::
             state.readingDoubleQuotedValue = false;
             state.prevCharDoubleQuotes = false;
             if (!updateSnapshotItem(state.tmp, state.index, item)) {
-                LOGW_WARN(_logger, L"Error in readSnapshotItemFields - line='" << Utility::s2ws(line) << L"'.");
+                LOGW_WARN(_logger, L"Error in readSnapshotItemFields - line='" << CommonUtility::s2ws(line) << L"'.");
                 error = true;
                 return;
             }
@@ -208,7 +208,7 @@ bool SnapshotItemHandler::getItem(SnapshotItem &item, std::stringstream &ss, boo
 
         // Ignore the lines containing escaped double quotes
         if (line.find(R"(\")") != std::string::npos) {
-            LOGW_WARN(_logger, L"Line containing an escaped double quotes, ignored it - line=" << Utility::s2ws(line));
+            LOGW_WARN(_logger, L"Line containing an escaped double quotes, ignored it - line=" << CommonUtility::s2ws(line));
             ignore = true;
             return true;
         }
@@ -238,7 +238,7 @@ bool SnapshotItemHandler::getItem(SnapshotItem &item, std::stringstream &ss, boo
 
     // Update last value
     if (!updateSnapshotItem(state.tmp, state.index, item)) {
-        LOGW_WARN(_logger, L"Error in updateSnapshotItem - line=" << Utility::s2ws(line));
+        LOGW_WARN(_logger, L"Error in updateSnapshotItem - line=" << CommonUtility::s2ws(line));
         error = true;
         return true;
     }

--- a/src/libsyncengine/jobs/network/API_v2/upload/upload_session/abstractuploadsession.cpp
+++ b/src/libsyncengine/jobs/network/API_v2/upload/upload_session/abstractuploadsession.cpp
@@ -45,26 +45,26 @@ AbstractUploadSession::AbstractUploadSession(const SyncPath &filepath, const Syn
     if (!IoHelper::getFileSize(_filePath, _filesize, ioError)) {
         const std::wstring exceptionMessage = L"Error in IoHelper::getFileSize for " + Utility::formatIoError(_filePath, ioError);
         LOGW_WARN(_logger, exceptionMessage);
-        throw std::runtime_error(Utility::ws2s(exceptionMessage).c_str());
+        throw std::runtime_error(CommonUtility::ws2s(exceptionMessage).c_str());
     }
 
     if (ioError == IoError::NoSuchFileOrDirectory) {
         const std::wstring exceptionMessage = L"File does not exist: " + Utility::formatSyncPath(_filePath);
         LOGW_WARN(_logger, exceptionMessage);
-        throw std::runtime_error(Utility::ws2s(exceptionMessage).c_str());
+        throw std::runtime_error(CommonUtility::ws2s(exceptionMessage).c_str());
     }
 
     if (ioError == IoError::AccessDenied) {
         const std::wstring exceptionMessage = L"File search permission missing: " + Utility::formatSyncPath(_filePath);
         LOGW_WARN(_logger, exceptionMessage);
-        throw std::runtime_error(Utility::ws2s(exceptionMessage).c_str());
+        throw std::runtime_error(CommonUtility::ws2s(exceptionMessage).c_str());
     }
 
     assert(ioError == IoError::Success);
     if (ioError != IoError::Success) {
         const std::wstring exceptionMessage = L"Unable to read file size for " + Utility::formatSyncPath(_filePath);
         LOGW_WARN(_logger, exceptionMessage);
-        throw std::runtime_error(Utility::ws2s(exceptionMessage).c_str());
+        throw std::runtime_error(CommonUtility::ws2s(exceptionMessage).c_str());
     }
 
     _isAsynchronous = _nbParallelThread > 1;

--- a/src/libsyncengine/jobs/network/API_v2/upload/uploadjob.cpp
+++ b/src/libsyncengine/jobs/network/API_v2/upload/uploadjob.cpp
@@ -255,7 +255,7 @@ ExitInfo UploadJob::readLink() {
             }
 
             LOGW_WARN(_logger, L"Failed to read symlink - path=" << Path2WStr(_absoluteFilePath) << L": "
-                                                                 << Utility::s2ws(ec.message()) << L" (" << ec.value() << L")");
+                                                                 << CommonUtility::s2ws(ec.message()) << L" (" << ec.value() << L")");
             return ExitCode::SystemError;
         }
 

--- a/src/libsyncengine/jobs/network/abstractnetworkjob.cpp
+++ b/src/libsyncengine/jobs/network/abstractnetworkjob.cpp
@@ -604,7 +604,7 @@ bool AbstractNetworkJob::extractJson(std::istream &is, Poco::JSON::Object::Ptr &
         jsonObj = Poco::JSON::Parser{}.parse(is).extract<Poco::JSON::Object::Ptr>();
     } catch (const Poco::Exception &exc) {
         LOGW_WARN(_logger, L"Reply " << jobId() << L" received doesn't contain a valid JSON payload: "
-                                     << Utility::s2ws(exc.displayText()));
+                                     << CommonUtility::s2ws(exc.displayText()));
         Utility::logGenericServerError(_logger, "Request error", is, _resHttp);
         _exitInfo = {ExitCode::BackError, ExitCause::ApiErr};
         return false;
@@ -613,7 +613,7 @@ bool AbstractNetworkJob::extractJson(std::istream &is, Poco::JSON::Object::Ptr &
     if (isExtendedLog()) {
         std::ostringstream os;
         jsonObj->stringify(os);
-        LOGW_DEBUG(_logger, L"Reply " << jobId() << L" received: " << Utility::s2ws(os.str()));
+        LOGW_DEBUG(_logger, L"Reply " << jobId() << L" received: " << CommonUtility::s2ws(os.str()));
     }
     return true;
 }

--- a/src/libsyncengine/jobs/network/login/abstractloginjob.cpp
+++ b/src/libsyncengine/jobs/network/login/abstractloginjob.cpp
@@ -81,7 +81,7 @@ bool AbstractLoginJob::handleError(std::istream &inputStream, const Poco::URI &u
     if (isExtendedLog()) {
         std::ostringstream os;
         jsonError->stringify(os);
-        LOGW_DEBUG(_logger, L"Reply " << jobId() << L" received: " << Utility::s2ws(os.str()));
+        LOGW_DEBUG(_logger, L"Reply " << jobId() << L" received: " << CommonUtility::s2ws(os.str()));
     }
 
     Poco::JSON::Object::Ptr errorObj = jsonError->getObject(errorKey);

--- a/src/libsyncengine/login/login.cpp
+++ b/src/libsyncengine/login/login.cpp
@@ -65,8 +65,8 @@ ExitCode Login::requestToken(const std::string &authorizationCode, const std::st
         std::string errorCode;
         std::string errorDescr;
         if (job.hasErrorApi(&errorCode, &errorDescr)) {
-            LOGW_WARN(_logger, L"Failed to retrieve authentification token. Error : " << KDC::Utility::s2ws(errorCode) << L" - "
-                                                                                      << KDC::Utility::s2ws(errorDescr));
+            LOGW_WARN(_logger, L"Failed to retrieve authentification token. Error : " << KDC::CommonUtility::s2ws(errorCode) << L" - "
+                                                                                      << KDC::CommonUtility::s2ws(errorDescr));
             _error = errorCode;
             _errorDescr = errorDescr;
             return ExitCode::BackError;

--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -570,7 +570,7 @@ ExitInfo ExecutorWorker::generateCreateJob(SyncOpPtr syncOp, std::shared_ptr<Abs
                                                             syncOp->affectedNode()->modificationTime().value_or(0), true);
                     } catch (std::exception const &e) {
                         LOGW_SYNCPAL_WARN(_logger, L"Error in DownloadJob::DownloadJob for driveDbId="
-                                                           << _syncPal->driveDbId() << L" : " << Utility::s2ws(e.what()));
+                                                           << _syncPal->driveDbId() << L" : " << CommonUtility::s2ws(e.what()));
                         return ExitCode::DataError;
                     }
 
@@ -603,7 +603,7 @@ ExitInfo ExecutorWorker::generateCreateJob(SyncOpPtr syncOp, std::shared_ptr<Abs
                                                      newCorrespondingParentNode->id().value_or(""), syncOp->newName());
             } catch (std::exception const &e) {
                 LOGW_SYNCPAL_WARN(_logger, L"Error in CreateDirJob::CreateDirJob for driveDbId="
-                                                   << _syncPal->driveDbId() << L" : " << Utility::s2ws(e.what()));
+                                                   << _syncPal->driveDbId() << L" : " << CommonUtility::s2ws(e.what()));
                 return ExitCode::DataError;
             }
         } else {
@@ -634,7 +634,7 @@ ExitInfo ExecutorWorker::generateCreateJob(SyncOpPtr syncOp, std::shared_ptr<Abs
                                                                syncOp->affectedNode()->modificationTime().value_or(0),
                                                                isLiteSyncActivated(), uploadSessionParallelJobs);
                 } catch (std::exception const &e) {
-                    LOGW_SYNCPAL_WARN(_logger, L"Error in DriveUploadSession::DriveUploadSession: " << Utility::s2ws(e.what()));
+                    LOGW_SYNCPAL_WARN(_logger, L"Error in DriveUploadSession::DriveUploadSession: " << CommonUtility::s2ws(e.what()));
                     return ExitCode::DataError;
                 }
             } else {
@@ -645,7 +645,7 @@ ExitInfo ExecutorWorker::generateCreateJob(SyncOpPtr syncOp, std::shared_ptr<Abs
                             syncOp->affectedNode()->modificationTime().value_or(0));
                 } catch (std::exception const &e) {
                     LOGW_SYNCPAL_WARN(_logger, L"Error in UploadJob::UploadJob for driveDbId=" << _syncPal->driveDbId() << L" : "
-                                                                                               << Utility::s2ws(e.what()));
+                                                                                               << CommonUtility::s2ws(e.what()));
                     return ExitCode::DataError;
                 }
             }
@@ -814,7 +814,7 @@ ExitInfo ExecutorWorker::generateEditJob(SyncOpPtr syncOp, std::shared_ptr<Abstr
                                                 syncOp->affectedNode()->modificationTime().value_or(0), false);
         } catch (std::exception const &e) {
             LOGW_SYNCPAL_WARN(_logger, L"Error in DownloadJob::DownloadJob for driveDbId=" << _syncPal->driveDbId() << L" : "
-                                                                                           << Utility::s2ws(e.what()));
+                                                                                           << CommonUtility::s2ws(e.what()));
             return ExitCode::DataError;
         }
 
@@ -847,7 +847,7 @@ ExitInfo ExecutorWorker::generateEditJob(SyncOpPtr syncOp, std::shared_ptr<Abstr
                                                            syncOp->affectedNode()->modificationTime().value_or(0),
                                                            isLiteSyncActivated(), uploadSessionParallelJobs);
             } catch (std::exception const &e) {
-                LOGW_SYNCPAL_WARN(_logger, L"Error in DriveUploadSession::DriveUploadSession: " << Utility::s2ws(e.what()));
+                LOGW_SYNCPAL_WARN(_logger, L"Error in DriveUploadSession::DriveUploadSession: " << CommonUtility::s2ws(e.what()));
                 return ExitCode::DataError;
             };
         } else {
@@ -857,7 +857,7 @@ ExitInfo ExecutorWorker::generateEditJob(SyncOpPtr syncOp, std::shared_ptr<Abstr
                                                   syncOp->affectedNode()->modificationTime().value_or(0));
             } catch (std::exception const &e) {
                 LOGW_SYNCPAL_WARN(_logger, L"Error in UploadJob::UploadJob for driveDbId=" << _syncPal->driveDbId() << L" : "
-                                                                                           << Utility::s2ws(e.what()));
+                                                                                           << CommonUtility::s2ws(e.what()));
                 return ExitCode::DataError;
             }
         }
@@ -870,7 +870,7 @@ ExitInfo ExecutorWorker::generateEditJob(SyncOpPtr syncOp, std::shared_ptr<Abstr
 ExitInfo ExecutorWorker::fixModificationDate(SyncOpPtr syncOp, const SyncPath &absolutePath) {
     const auto id = syncOp->affectedNode()->id().value_or("");
     LOGW_SYNCPAL_DEBUG(_logger, L"Do not upload dehydrated placeholders: " << Utility::formatSyncPath(absolutePath) << L" ("
-                                                                           << Utility::s2ws(id) << L")");
+                                                                           << CommonUtility::s2ws(id) << L")");
 
     // Update last modification date in order to avoid generating more EDIT operations.
     bool found = false;
@@ -1043,7 +1043,7 @@ ExitInfo ExecutorWorker::generateMoveJob(SyncOpPtr syncOp, bool &ignored, bool &
                                                   absoluteDestLocalFilePath);
             } catch (std::exception const &e) {
                 LOGW_SYNCPAL_WARN(_logger, L"Error in RenameJob::RenameJob for driveDbId=" << _syncPal->driveDbId() << L" : "
-                                                                                           << Utility::s2ws(e.what()));
+                                                                                           << CommonUtility::s2ws(e.what()));
                 return ExitCode::DataError;
             }
         } else {
@@ -1191,7 +1191,7 @@ ExitInfo ExecutorWorker::generateDeleteJob(SyncOpPtr syncOp, bool &ignored, bool
                                               syncOp->affectedNode()->type());
         } catch (std::exception const &e) {
             LOGW_SYNCPAL_WARN(_logger, L"Error in DeleteJob::DeleteJob for driveDbId=" << _syncPal->driveDbId() << L" : "
-                                                                                       << Utility::s2ws(e.what()));
+                                                                                       << CommonUtility::s2ws(e.what()));
             return ExitCode::DataError;
         }
     }
@@ -1712,8 +1712,8 @@ ExitInfo ExecutorWorker::propagateCreateToDbAndTree(SyncOpPtr syncOp, const Node
     if (ParametersCache::isExtendedLogEnabled()) {
         LOGW_SYNCPAL_DEBUG(_logger, L"Inserting in DB: " << L" localName=" << Utility::formatSyncName(localName)
                                                          << L" / remoteName=" << Utility::formatSyncName(remoteName)
-                                                         << L" / localId=" << Utility::s2ws(localId) << L" / remoteId="
-                                                         << Utility::s2ws(remoteId) << L" / parent DB ID="
+                                                         << L" / localId=" << CommonUtility::s2ws(localId) << L" / remoteId="
+                                                         << CommonUtility::s2ws(remoteId) << L" / parent DB ID="
                                                          << newCorrespondingParentNode->idb().value_or(-1) << L" / createdAt="
                                                          << newCreationTime.value_or(-1) << L" / lastModTime="
                                                          << newLastModificationTime.value_or(-1) << L" / type="
@@ -1731,8 +1731,8 @@ ExitInfo ExecutorWorker::propagateCreateToDbAndTree(SyncOpPtr syncOp, const Node
     bool constraintError = false;
     if (!_syncPal->syncDb()->insertNode(dbNode, newDbNodeId, constraintError)) {
         LOGW_SYNCPAL_WARN(_logger, L"Failed to insert node into DB:"
-                                           << L" local ID: " << Utility::s2ws(localId) << L", remote ID: "
-                                           << Utility::s2ws(remoteId) << L", local name: " << Utility::formatSyncName(localName)
+                                           << L" local ID: " << CommonUtility::s2ws(localId) << L", remote ID: "
+                                           << CommonUtility::s2ws(remoteId) << L", local name: " << Utility::formatSyncName(localName)
                                            << L", remote name: " << Utility::formatSyncName(remoteName) << L", parent DB ID: "
                                            << (newCorrespondingParentNode->idb().value_or(-1)));
 
@@ -1853,7 +1853,7 @@ ExitInfo ExecutorWorker::propagateEditToDbAndTree(SyncOpPtr syncOp, const NodeId
     if (ParametersCache::isExtendedLogEnabled()) {
         LOGW_SYNCPAL_DEBUG(_logger, L"Updating DB: " << L" / localName=" << Utility::formatSyncName(localName)
                                                      << L" / remoteName=" << Utility::formatSyncName(remoteName) << L" / localId="
-                                                     << Utility::s2ws(localId) << L" / remoteId=" << Utility::s2ws(remoteId)
+                                                     << CommonUtility::s2ws(localId) << L" / remoteId=" << CommonUtility::s2ws(remoteId)
                                                      << L" / parent DB ID=" << dbNode.parentNodeId().value_or(-1)
                                                      << L" / createdAt=" << newCreationTime.value_or(-1) << L" / lastModTime="
                                                      << newLastModificationTime.value_or(-1) << L" / type="
@@ -1862,8 +1862,8 @@ ExitInfo ExecutorWorker::propagateEditToDbAndTree(SyncOpPtr syncOp, const NodeId
 
     if (!_syncPal->syncDb()->updateNode(dbNode, found)) {
         LOGW_SYNCPAL_WARN(_logger, L"Failed to update node into DB: "
-                                           << L"local ID: " << Utility::s2ws(localId) << L", remote ID: "
-                                           << Utility::s2ws(remoteId) << L", local name: " << Utility::formatSyncName(localName)
+                                           << L"local ID: " << CommonUtility::s2ws(localId) << L", remote ID: "
+                                           << CommonUtility::s2ws(remoteId) << L", local name: " << Utility::formatSyncName(localName)
                                            << L", remote name: " << Utility::formatSyncName(remoteName) << L", parent DB ID: "
                                            << dbNode.parentNodeId().value_or(-1));
         return {ExitCode::DbError, ExitCause::DbAccessError};
@@ -1943,8 +1943,8 @@ ExitInfo ExecutorWorker::propagateMoveToDbAndTree(SyncOpPtr syncOp) {
     if (ParametersCache::isExtendedLogEnabled()) {
         LOGW_SYNCPAL_DEBUG(_logger, L"Updating DB: " << L" localName=" << Utility::formatSyncName(syncOp->newName())
                                                      << L" / remoteName=" << Utility::formatSyncName(syncOp->newName())
-                                                     << L" / localId=" << Utility::s2ws(localId) << L" / remoteId="
-                                                     << Utility::s2ws(remoteId) << L" / parent DB ID="
+                                                     << L" / localId=" << CommonUtility::s2ws(localId) << L" / remoteId="
+                                                     << CommonUtility::s2ws(remoteId) << L" / parent DB ID="
                                                      << dbNode.parentNodeId().value_or(-1) << L" / createdAt="
                                                      << syncOp->affectedNode()->createdAt().value_or(-1) << L" / lastModTime="
                                                      << syncOp->affectedNode()->modificationTime().value_or(-1) << L" / type="
@@ -1953,8 +1953,8 @@ ExitInfo ExecutorWorker::propagateMoveToDbAndTree(SyncOpPtr syncOp) {
 
     if (!_syncPal->syncDb()->updateNode(dbNode, found)) {
         LOGW_SYNCPAL_WARN(_logger, L"Failed to update node into DB: "
-                                           << L"local ID: " << Utility::s2ws(localId) << L", remote ID: "
-                                           << Utility::s2ws(remoteId) << L", local name: "
+                                           << L"local ID: " << CommonUtility::s2ws(localId) << L", remote ID: "
+                                           << CommonUtility::s2ws(remoteId) << L", local name: "
                                            << Utility::formatSyncName(syncOp->newName()) << L", remote name: "
                                            << Utility::formatSyncName(syncOp->newName()) << L", parent DB ID: "
                                            << dbNode.parentNodeId().value_or(-1));

--- a/src/libsyncengine/propagation/operation_sorter/operationsorterfilter.cpp
+++ b/src/libsyncengine/propagation/operation_sorter/operationsorterfilter.cpp
@@ -1,18 +1,20 @@
-// Infomaniak kDrive - Desktop
-// Copyright (C) 2023-2025 Infomaniak Network SA
-//
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #include "operationsorterfilter.h"
 
@@ -118,7 +120,7 @@ void OperationSorterFilter::filterMoveBeforeDeleteCandidates(const SyncOpPtr &op
             if (op->targetSide() != moveOp->targetSide()) {
                 continue;
             }
-            if (Utility::isDescendantOrEqual(normalizedMovePath, normalizedDeletedPath)) {
+            if (CommonUtility::isDescendantOrEqual(normalizedMovePath, normalizedDeletedPath)) {
                 (void) _fixMoveBeforeDeleteCandidates.emplace_back(op, moveOp);
             }
         }
@@ -133,7 +135,8 @@ void OperationSorterFilter::filterMoveBeforeDeleteCandidates(const SyncOpPtr &op
             if (op->targetSide() != deleteOp->targetSide()) {
                 continue;
             }
-            if (Utility::isDescendantOrEqual(op->affectedNode()->moveOriginInfos().normalizedPath(), normalizedDeletePath)) {
+            if (CommonUtility::isDescendantOrEqual(op->affectedNode()->moveOriginInfos().normalizedPath(),
+                                                   normalizedDeletePath)) {
                 (void) _fixMoveBeforeDeleteCandidates.emplace_back(op, deleteOp);
             }
         }
@@ -161,7 +164,7 @@ void OperationSorterFilter::filterCreateBeforeMoveCandidates(const SyncOpPtr &op
             if (op->targetSide() != moveOp->targetSide()) {
                 continue;
             }
-            if (Utility::isDescendantOrEqual(normalizedMovePath, normalizedCreatedPath)) {
+            if (CommonUtility::isDescendantOrEqual(normalizedMovePath, normalizedCreatedPath)) {
                 (void) _fixCreateBeforeMoveCandidates.emplace_back(op, moveOp);
             }
         }
@@ -182,7 +185,7 @@ void OperationSorterFilter::filterCreateBeforeMoveCandidates(const SyncOpPtr &op
             if (op->targetSide() != createOp->targetSide()) {
                 continue;
             }
-            if (Utility::isDescendantOrEqual(normalizedDestinationPath, normalizedCreatedPath)) {
+            if (CommonUtility::isDescendantOrEqual(normalizedDestinationPath, normalizedCreatedPath)) {
                 (void) _fixCreateBeforeMoveCandidates.emplace_back(op, createOp);
             }
         }
@@ -284,14 +287,14 @@ void OperationSorterFilter::filterMoveBeforeMoveHierarchyFlipCandidates(
 
         const auto &otherOriginPath = otherOp->affectedNode()->moveOriginInfos().normalizedPath();
 
-        if (Utility::isStrictDescendant(normalizedDestinationPath, otherDestinationPath) &&
-            Utility::isStrictDescendant(otherOriginPath, originPath)) {
+        if (CommonUtility::isStrictDescendant(normalizedDestinationPath, otherDestinationPath) &&
+            CommonUtility::isStrictDescendant(otherOriginPath, originPath)) {
             // op must be executed after otherOp
             (void) _fixMoveBeforeMoveHierarchyFlipCandidates.emplace_back(op, otherOp);
             continue;
         }
-        if (Utility::isStrictDescendant(otherDestinationPath, normalizedDestinationPath) &&
-            Utility::isStrictDescendant(originPath, otherOriginPath)) {
+        if (CommonUtility::isStrictDescendant(otherDestinationPath, normalizedDestinationPath) &&
+            CommonUtility::isStrictDescendant(originPath, otherOriginPath)) {
             // otherOp must be executed after op
             (void) _fixMoveBeforeMoveHierarchyFlipCandidates.emplace_back(otherOp, op);
         }

--- a/src/libsyncengine/propagation/operation_sorter/operationsorterworker.cpp
+++ b/src/libsyncengine/propagation/operation_sorter/operationsorterworker.cpp
@@ -389,7 +389,7 @@ std::optional<SyncOperationList> OperationSorterWorker::fixImpossibleFirstMoveOp
     const auto correspondingSourceNode = correspondingNodeInOtherTree(node);
     if (correspondingDestinationParentNode == nullptr || correspondingSourceNode == nullptr) {
         LOGW_SYNCPAL_ERROR(_logger, L"Missing corresponding nodes for node " << Utility::formatSyncName(node->name()) << L" ("
-                                                                             << Utility::s2ws(*node->id()) << L")");
+                                                                             << CommonUtility::s2ws(*node->id()) << L")");
         return std::nullopt; // Should never happen
     }
 

--- a/src/libsyncengine/propagation/operation_sorter/operationsorterworker.cpp
+++ b/src/libsyncengine/propagation/operation_sorter/operationsorterworker.cpp
@@ -381,7 +381,7 @@ std::optional<SyncOperationList> OperationSorterWorker::fixImpossibleFirstMoveOp
         normalizedPath = path;
     }
 
-    if (!Utility::isDescendantOrEqual(normalizedPath, node->moveOriginInfos().normalizedPath())) {
+    if (!CommonUtility::isDescendantOrEqual(normalizedPath, node->moveOriginInfos().normalizedPath())) {
         return std::nullopt; // firstOp is possible
     }
 

--- a/src/libsyncengine/reconciliation/conflict_finder/conflictfinderworker.cpp
+++ b/src/libsyncengine/reconciliation/conflict_finder/conflictfinderworker.cpp
@@ -52,9 +52,9 @@ void ConflictFinderWorker::findConflicts() {
             _syncPal->_conflictQueue->push(c);
             LOGW_SYNCPAL_INFO(_logger, c.type() << L" conflict found between local node "
                                                 << Utility::formatSyncName(c.localNode()->name()) << L" ("
-                                                << Utility::s2ws(*c.localNode()->id()) << L") and remote node "
+                                                << CommonUtility::s2ws(*c.localNode()->id()) << L") and remote node "
                                                 << Utility::formatSyncName(c.remoteNode()->name()) << L" ("
-                                                << Utility::s2ws(*c.remoteNode()->id()) << L")");
+                                                << CommonUtility::s2ws(*c.remoteNode()->id()) << L")");
         }
     }
 }
@@ -98,9 +98,9 @@ void ConflictFinderWorker::findConflictsInTree(const std::shared_ptr<UpdateTree>
                 LOGW_SYNCPAL_INFO(_logger, createCreateConf->type()
                                                    << L" conflict found between local node "
                                                    << Utility::formatSyncName(createCreateConf->localNode()->name()) << L" ("
-                                                   << Utility::s2ws(*createCreateConf->localNode()->id()) << L") and remote node "
+                                                   << CommonUtility::s2ws(*createCreateConf->localNode()->id()) << L") and remote node "
                                                    << Utility::formatSyncName(createCreateConf->remoteNode()->name()) << L" ("
-                                                   << Utility::s2ws(*createCreateConf->remoteNode()->id()) << L")");
+                                                   << CommonUtility::s2ws(*createCreateConf->remoteNode()->id()) << L")");
             }
         }
         // Edit - Edit_Edit conflict
@@ -110,9 +110,9 @@ void ConflictFinderWorker::findConflictsInTree(const std::shared_ptr<UpdateTree>
                 LOGW_SYNCPAL_INFO(_logger, editEditConf->type()
                                                    << L" conflict found between local node "
                                                    << Utility::formatSyncName(editEditConf->localNode()->name()) << L" ("
-                                                   << Utility::s2ws(*editEditConf->localNode()->id()) << L") and remote node "
+                                                   << CommonUtility::s2ws(*editEditConf->localNode()->id()) << L") and remote node "
                                                    << Utility::formatSyncName(editEditConf->remoteNode()->name()) << L" ("
-                                                   << Utility::s2ws(*editEditConf->remoteNode()->id()) << L")");
+                                                   << CommonUtility::s2ws(*editEditConf->remoteNode()->id()) << L")");
             }
         }
         // Delete
@@ -126,9 +126,9 @@ void ConflictFinderWorker::findConflictsInTree(const std::shared_ptr<UpdateTree>
                         LOGW_SYNCPAL_INFO(_logger, conflict.type()
                                                            << L" conflict found between local node "
                                                            << Utility::formatSyncName(conflict.localNode()->name()) << L" ("
-                                                           << Utility::s2ws(*conflict.localNode()->id()) << L") and remote node "
+                                                           << CommonUtility::s2ws(*conflict.localNode()->id()) << L") and remote node "
                                                            << Utility::formatSyncName(conflict.remoteNode()->name()) << L" ("
-                                                           << Utility::s2ws(*conflict.remoteNode()->id()) << L")");
+                                                           << CommonUtility::s2ws(*conflict.remoteNode()->id()) << L")");
                     }
                 }
                 if (createParentDeleteConf) {
@@ -137,9 +137,9 @@ void ConflictFinderWorker::findConflictsInTree(const std::shared_ptr<UpdateTree>
                         LOGW_SYNCPAL_INFO(_logger, conflict.type()
                                                            << L" conflict found between local node "
                                                            << Utility::formatSyncName(conflict.localNode()->name()) << L" ("
-                                                           << Utility::s2ws(*conflict.localNode()->id()) << L") and remote node "
+                                                           << CommonUtility::s2ws(*conflict.localNode()->id()) << L") and remote node "
                                                            << Utility::formatSyncName(conflict.remoteNode()->name()) << L" ("
-                                                           << Utility::s2ws(*conflict.remoteNode()->id()) << L")");
+                                                           << CommonUtility::s2ws(*conflict.remoteNode()->id()) << L")");
                     }
                 }
             }
@@ -150,18 +150,18 @@ void ConflictFinderWorker::findConflictsInTree(const std::shared_ptr<UpdateTree>
                 LOGW_SYNCPAL_INFO(_logger, moveDeleteConf->type()
                                                    << L" conflict found between local node "
                                                    << Utility::formatSyncName(moveDeleteConf->localNode()->name()) << L" ("
-                                                   << Utility::s2ws(*moveDeleteConf->localNode()->id()) << L") and remote node "
+                                                   << CommonUtility::s2ws(*moveDeleteConf->localNode()->id()) << L") and remote node "
                                                    << Utility::formatSyncName(moveDeleteConf->remoteNode()->name()) << L" ("
-                                                   << Utility::s2ws(*moveDeleteConf->remoteNode()->id()) << L")");
+                                                   << CommonUtility::s2ws(*moveDeleteConf->remoteNode()->id()) << L")");
             }
             if (editDeleteConf) {
                 _syncPal->_conflictQueue->push(*editDeleteConf);
                 LOGW_SYNCPAL_INFO(_logger, editDeleteConf->type()
                                                    << L" conflict found between local node "
                                                    << Utility::formatSyncName(editDeleteConf->localNode()->name()) << L" ("
-                                                   << Utility::s2ws(*editDeleteConf->localNode()->id()) << L") and remote node "
+                                                   << CommonUtility::s2ws(*editDeleteConf->localNode()->id()) << L") and remote node "
                                                    << Utility::formatSyncName(editDeleteConf->remoteNode()->name()) << L" ("
-                                                   << Utility::s2ws(*editDeleteConf->remoteNode()->id()) << L")");
+                                                   << CommonUtility::s2ws(*editDeleteConf->remoteNode()->id()) << L")");
             }
         }
 
@@ -172,9 +172,9 @@ void ConflictFinderWorker::findConflictsInTree(const std::shared_ptr<UpdateTree>
                 LOGW_SYNCPAL_INFO(_logger, moveCreateConf->type()
                                                    << L" conflict found between local node "
                                                    << Utility::formatSyncName(moveCreateConf->localNode()->name()) << L" ("
-                                                   << Utility::s2ws(*moveCreateConf->localNode()->id()) << L") and remote node "
+                                                   << CommonUtility::s2ws(*moveCreateConf->localNode()->id()) << L") and remote node "
                                                    << Utility::formatSyncName(moveCreateConf->remoteNode()->name()) << L" ("
-                                                   << Utility::s2ws(*moveCreateConf->remoteNode()->id()) << L")");
+                                                   << CommonUtility::s2ws(*moveCreateConf->remoteNode()->id()) << L")");
             }
             if (!node->hasConflictAlreadyConsidered(ConflictType::MoveMoveDest)) {
                 if (std::optional<Conflict> moveMoveDestConf = checkMoveMoveDestConflict(node)) {
@@ -182,10 +182,10 @@ void ConflictFinderWorker::findConflictsInTree(const std::shared_ptr<UpdateTree>
                     LOGW_SYNCPAL_INFO(_logger, moveMoveDestConf->type()
                                                        << L" conflict found between local node "
                                                        << Utility::formatSyncName(moveMoveDestConf->localNode()->name()) << L" ("
-                                                       << Utility::s2ws(*moveMoveDestConf->localNode()->id())
+                                                       << CommonUtility::s2ws(*moveMoveDestConf->localNode()->id())
                                                        << L") and remote node "
                                                        << Utility::formatSyncName(moveMoveDestConf->remoteNode()->name()) << L" ("
-                                                       << Utility::s2ws(*moveMoveDestConf->remoteNode()->id()) << L")");
+                                                       << CommonUtility::s2ws(*moveMoveDestConf->remoteNode()->id()) << L")");
                 }
             }
             if (!node->hasConflictAlreadyConsidered(ConflictType::MoveMoveSource)) {
@@ -194,10 +194,10 @@ void ConflictFinderWorker::findConflictsInTree(const std::shared_ptr<UpdateTree>
                     LOGW_SYNCPAL_INFO(_logger, moveMoveSrcConf->type()
                                                        << L" conflict found between local node "
                                                        << Utility::formatSyncName(moveMoveSrcConf->localNode()->name()) << L" ("
-                                                       << Utility::s2ws(*moveMoveSrcConf->localNode()->id())
+                                                       << CommonUtility::s2ws(*moveMoveSrcConf->localNode()->id())
                                                        << L") and remote node "
                                                        << Utility::formatSyncName(moveMoveSrcConf->remoteNode()->name()) << L" ("
-                                                       << Utility::s2ws(*moveMoveSrcConf->remoteNode()->id()) << L")");
+                                                       << CommonUtility::s2ws(*moveMoveSrcConf->remoteNode()->id()) << L")");
                 }
             }
         }

--- a/src/libsyncengine/reconciliation/conflict_finder/conflictfinderworker.cpp
+++ b/src/libsyncengine/reconciliation/conflict_finder/conflictfinderworker.cpp
@@ -405,10 +405,10 @@ std::optional<std::vector<Conflict>> ConflictFinderWorker::determineMoveMoveCycl
                 continue;
             }
 
-            if (Utility::isDescendantOrEqual(SyncPath(localDbPath).lexically_normal(),
-                                             SyncPath(remoteDbPath.native() + Str("/")).lexically_normal()) ||
-                Utility::isDescendantOrEqual(SyncPath(remoteDbPath).lexically_normal(),
-                                             SyncPath(localDbPath.native() + Str("/")).lexically_normal())) {
+            if (CommonUtility::isDescendantOrEqual(SyncPath(localDbPath).lexically_normal(),
+                                                   SyncPath(remoteDbPath.native() + Str("/")).lexically_normal()) ||
+                CommonUtility::isDescendantOrEqual(SyncPath(remoteDbPath).lexically_normal(),
+                                                   SyncPath(localDbPath.native() + Str("/")).lexically_normal())) {
                 continue;
             }
 

--- a/src/libsyncengine/reconciliation/conflict_resolver/conflictresolverworker.cpp
+++ b/src/libsyncengine/reconciliation/conflict_resolver/conflictresolverworker.cpp
@@ -55,9 +55,9 @@ void ConflictResolverWorker::execute() {
 ExitCode ConflictResolverWorker::generateOperations(const Conflict &conflict, bool &continueSolving) {
     LOGW_SYNCPAL_INFO(_logger, L"Solving " << conflict.type() << L" conflict for items "
                                            << Utility::formatSyncName(conflict.node()->name()) << L" ("
-                                           << Utility::s2ws(*conflict.node()->id()) << L") and "
+                                           << CommonUtility::s2ws(*conflict.node()->id()) << L") and "
                                            << Utility::formatSyncName(conflict.otherNode()->name()) << L" ("
-                                           << Utility::s2ws(*conflict.otherNode()->id()) << L")");
+                                           << CommonUtility::s2ws(*conflict.otherNode()->id()) << L")");
 
     continueSolving = false;
     auto res = handleConflictOnDehydratedPlaceholder(conflict, continueSolving);
@@ -416,12 +416,12 @@ std::wstring ConflictResolverWorker::getLogString(SyncOpPtr op, bool omit /*= fa
     std::wstringstream ss;
     if (omit) {
         ss << L"Operation " << op->type() << L" to be propagated on DB only for item "
-       << Utility::formatSyncName(op->correspondingNode()->name()) << L" (" << Utility::s2ws(*op->correspondingNode()->id())
+       << Utility::formatSyncName(op->correspondingNode()->name()) << L" (" << CommonUtility::s2ws(*op->correspondingNode()->id())
        << L")";
     }
     else {
         ss << L"Operation " << op->type() << L" to be propagated on " << op->targetSide() << L" replica for item "
-       << Utility::formatSyncName(op->correspondingNode()->name()) << L" (" << Utility::s2ws(*op->correspondingNode()->id())
+       << Utility::formatSyncName(op->correspondingNode()->name()) << L" (" << CommonUtility::s2ws(*op->correspondingNode()->id())
        << L")";
     }
     return ss.str();

--- a/src/libsyncengine/reconciliation/operation_generator/operationgeneratorworker.cpp
+++ b/src/libsyncengine/reconciliation/operation_generator/operationgeneratorworker.cpp
@@ -157,7 +157,7 @@ void OperationGeneratorWorker::generateCreateOperation(std::shared_ptr<Node> cur
             LOGW_SYNCPAL_DEBUG(_logger, L"Create operation "
                                                 << op->id() << L" to be propagated on " << op->targetSide()
                                                 << L" replica for item " << Utility::formatSyncPath(currentNode->getPath())
-                                                << L" (" << Utility::s2ws(currentNode->id() ? currentNode->id().value() : "-1")
+                                                << L" (" << CommonUtility::s2ws(currentNode->id() ? currentNode->id().value() : "-1")
                                                 << L")");
         }
 
@@ -212,7 +212,7 @@ void OperationGeneratorWorker::generateEditOperation(std::shared_ptr<Node> curre
             LOGW_SYNCPAL_DEBUG(_logger, L"Edit operation " << op->id() << L" to be propagated on " << op->targetSide()
                                                            << L" replica for item "
                                                            << Utility::formatSyncPath(currentNode->getPath()) << L"(ID: "
-                                                           << Utility::s2ws(currentNode->id() ? currentNode->id().value() : "-1")
+                                                           << CommonUtility::s2ws(currentNode->id() ? currentNode->id().value() : "-1")
                                                            << L")");
         }
 
@@ -267,7 +267,7 @@ void OperationGeneratorWorker::generateMoveOperation(std::shared_ptr<Node> curre
                                                 << op->id() << L" to be propagated on " << op->targetSide() << L" replica from "
                                                 << Utility::formatSyncPath(currentNode->moveOriginInfos().path()) << L" to "
                                                 << Utility::formatSyncPath(currentNode->getPath()) << L" (ID: "
-                                                << Utility::s2ws(currentNode->id() ? currentNode->id().value() : "-1") << L")");
+                                                << CommonUtility::s2ws(currentNode->id() ? currentNode->id().value() : "-1") << L")");
         }
     }
 }
@@ -316,7 +316,7 @@ void OperationGeneratorWorker::generateDeleteOperation(std::shared_ptr<Node> cur
             LOGW_SYNCPAL_DEBUG(_logger, L"Delete operation "
                                                 << op->id() << L" to be propagated on " << op->targetSide()
                                                 << L" replica for item " << Utility::formatSyncPath(currentNode->getPath())
-                                                << L" (" << Utility::s2ws(currentNode->id() ? currentNode->id().value() : "-1")
+                                                << L" (" << CommonUtility::s2ws(currentNode->id() ? currentNode->id().value() : "-1")
                                                 << L")");
         }
     }

--- a/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerutility.cpp
+++ b/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerutility.cpp
@@ -116,7 +116,7 @@ bool PlatformInconsistencyCheckerUtility::nameHasForbiddenChars(const SyncPath &
 }
 
 bool PlatformInconsistencyCheckerUtility::isNameOnlySpaces(const SyncName &name) {
-    return Utility::ltrim(name).empty();
+    return CommonUtility::ltrim(name).empty();
 }
 
 bool PlatformInconsistencyCheckerUtility::nameEndWithForbiddenSpace([[maybe_unused]] const SyncName &name) {
@@ -172,7 +172,7 @@ bool PlatformInconsistencyCheckerUtility::checkReservedNames(const SyncName &nam
     }
 
     for (const auto &reserved: reservedWinNames) {
-        if (Utility::startsWithInsensitive(name, Str2SyncName(reserved)) && name.size() == reserved.size()) {
+        if (CommonUtility::startsWithInsensitive(name, Str2SyncName(reserved)) && name.size() == reserved.size()) {
             return true;
         }
     }

--- a/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerworker.cpp
+++ b/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerworker.cpp
@@ -43,10 +43,10 @@ void PlatformInconsistencyCheckerWorker::execute() {
 
     for (const auto &[remoteId, localId]: _idsToBeRemoved) {
         if (!remoteId.empty() && !_syncPal->updateTree(ReplicaSide::Remote)->deleteNode(remoteId)) {
-            LOGW_SYNCPAL_WARN(_logger, L"Error in UpdateTree::deleteNode: node id=" << Utility::s2ws(remoteId));
+            LOGW_SYNCPAL_WARN(_logger, L"Error in UpdateTree::deleteNode: node id=" << CommonUtility::s2ws(remoteId));
         }
         if (!localId.empty() && !_syncPal->updateTree(ReplicaSide::Local)->deleteNode(localId)) {
-            LOGW_SYNCPAL_WARN(_logger, L"Error in UpdateTree::deleteNode: node id=" << Utility::s2ws(localId));
+            LOGW_SYNCPAL_WARN(_logger, L"Error in UpdateTree::deleteNode: node id=" << CommonUtility::s2ws(localId));
         }
     }
 

--- a/src/libsyncengine/requests/exclusiontemplatecache.cpp
+++ b/src/libsyncengine/requests/exclusiontemplatecache.cpp
@@ -229,10 +229,10 @@ bool ExclusionTemplateCache::isExcluded(const SyncPath &relativePath, bool &isWa
                     exclude = fileName.find(tmpStr) != std::string::npos;
                 } else if (atBeginning) {
                     // Must be at the end only
-                    exclude = Utility::endsWith(fileName, tmpStr);
+                    exclude = CommonUtility::endsWith(fileName, tmpStr);
                 } else {
                     // Must be at the beginning only
-                    exclude = Utility::startsWith(fileName, tmpStr);
+                    exclude = CommonUtility::startsWith(fileName, tmpStr);
                 }
 
                 if (exclude) {

--- a/src/libsyncengine/requests/exclusiontemplatecache.cpp
+++ b/src/libsyncengine/requests/exclusiontemplatecache.cpp
@@ -207,7 +207,7 @@ bool ExclusionTemplateCache::isExcluded(const SyncPath &relativePath, bool &isWa
                     if (ParametersCache::isExtendedLogEnabled()) {
                         LOGW_INFO(Log::instance()->getLogger(), L"Item \"" << Utility::formatSyncPath(relativePath)
                                                                            << L"\" rejected because of rule \""
-                                                                           << Utility::s2ws(exclusionTemplate.templ()) << L"\"");
+                                                                           << CommonUtility::s2ws(exclusionTemplate.templ()) << L"\"");
                     }
                     return true; // Filename match exactly the pattern
                 }
@@ -239,7 +239,7 @@ bool ExclusionTemplateCache::isExcluded(const SyncPath &relativePath, bool &isWa
                     if (ParametersCache::isExtendedLogEnabled()) {
                         LOGW_INFO(Log::instance()->getLogger(), L"Item \"" << Utility::formatSyncPath(relativePath)
                                                                            << L"\" rejected because of rule \""
-                                                                           << Utility::s2ws(exclusionTemplate.templ()) << L"\"");
+                                                                           << CommonUtility::s2ws(exclusionTemplate.templ()) << L"\"");
                     }
                     return true; // Filename contains the pattern
                 }
@@ -251,7 +251,7 @@ bool ExclusionTemplateCache::isExcluded(const SyncPath &relativePath, bool &isWa
                     if (ParametersCache::isExtendedLogEnabled()) {
                         LOGW_INFO(Log::instance()->getLogger(), L"Item \"" << Utility::formatSyncPath(relativePath)
                                                                            << L"\" rejected because of rule \""
-                                                                           << Utility::s2ws(exclusionTemplate.templ()) << L"\"");
+                                                                           << CommonUtility::s2ws(exclusionTemplate.templ()) << L"\"");
                     }
                     return true;
                 }

--- a/src/libsyncengine/syncpal/syncpal.cpp
+++ b/src/libsyncengine/syncpal/syncpal.cpp
@@ -516,7 +516,7 @@ bool SyncPal::createOrOpenDb(const SyncPath &syncDbPath, const std::string &vers
     try {
         _syncDb = std::shared_ptr<SyncDb>(new SyncDb(syncDbPath.string(), version, targetNodeId));
     } catch (std::exception const &e) {
-        const auto exceptionMsg = Utility::s2ws(std::string(e.what()));
+        const auto exceptionMsg = CommonUtility::s2ws(std::string(e.what()));
         LOGW_SYNCPAL_WARN(
                 _logger, L"Error in SyncDb::SyncDb: " << Utility::formatSyncPath(syncDbPath) << L", Exception: " << exceptionMsg);
         return false;
@@ -658,7 +658,7 @@ ExitCode SyncPal::addDlDirectJob(const SyncPath &relativePath, const SyncPath &l
         return ExitCode::DbError;
     }
     if (!found) {
-        LOGW_SYNCPAL_WARN(_logger, L"Node not found in node table for localNodeId=" << Utility::s2ws(*localNodeId));
+        LOGW_SYNCPAL_WARN(_logger, L"Node not found in node table for localNodeId=" << CommonUtility::s2ws(*localNodeId));
         return ExitCode::DataError;
     }
 
@@ -668,7 +668,7 @@ ExitCode SyncPal::addDlDirectJob(const SyncPath &relativePath, const SyncPath &l
         return ExitCode::DbError;
     }
     if (!found) {
-        LOGW_SYNCPAL_WARN(_logger, L"Node not found in node table for localNodeId=" << Utility::s2ws(*localNodeId));
+        LOGW_SYNCPAL_WARN(_logger, L"Node not found in node table for localNodeId=" << CommonUtility::s2ws(*localNodeId));
         return ExitCode::DataError;
     }
 
@@ -1357,7 +1357,7 @@ ExitInfo SyncPal::handleAccessDeniedItem(const SyncPath &relativeLocalPath, std:
     }
 
     LOGW_SYNCPAL_DEBUG(_logger, L"Item " << Utility::formatSyncPath(relativeLocalPath) << L" (NodeId: "
-                                         << Utility::s2ws(localNodeId)
+                                         << CommonUtility::s2ws(localNodeId)
                                          << L" is blacklisted temporarily because of a denied access.");
 
     NodeId remoteNodeId = liveSnapshot(ReplicaSide::Remote).itemId(relativeLocalPath);

--- a/src/libsyncengine/syncpal/syncpal.h
+++ b/src/libsyncengine/syncpal/syncpal.h
@@ -63,19 +63,19 @@ class GetSizeJob;
 #define LOG_SYNCDBID std::string("*" + std::to_string(SYNCDBID) + "*")
 
 #define LOG_SYNCPAL_DEBUG(logger, logEvent) LOG_DEBUG(logger, LOG_SYNCDBID << " " << logEvent)
-#define LOGW_SYNCPAL_DEBUG(logger, logEvent) LOGW_DEBUG(logger, Utility::s2ws(LOG_SYNCDBID) << L" " << logEvent)
+#define LOGW_SYNCPAL_DEBUG(logger, logEvent) LOGW_DEBUG(logger, CommonUtility::s2ws(LOG_SYNCDBID) << L" " << logEvent)
 
 #define LOG_SYNCPAL_INFO(logger, logEvent) LOG_INFO(logger, LOG_SYNCDBID << " " << logEvent)
-#define LOGW_SYNCPAL_INFO(logger, logEvent) LOGW_INFO(logger, Utility::s2ws(LOG_SYNCDBID) << L" " << logEvent)
+#define LOGW_SYNCPAL_INFO(logger, logEvent) LOGW_INFO(logger, CommonUtility::s2ws(LOG_SYNCDBID) << L" " << logEvent)
 
 #define LOG_SYNCPAL_WARN(logger, logEvent) LOG_WARN(logger, LOG_SYNCDBID << " " << logEvent)
-#define LOGW_SYNCPAL_WARN(logger, logEvent) LOGW_WARN(logger, Utility::s2ws(LOG_SYNCDBID) << L" " << logEvent)
+#define LOGW_SYNCPAL_WARN(logger, logEvent) LOGW_WARN(logger, CommonUtility::s2ws(LOG_SYNCDBID) << L" " << logEvent)
 
 #define LOG_SYNCPAL_ERROR(logger, logEvent) LOG_ERROR(logger, LOG_SYNCDBID << " " << logEvent)
-#define LOGW_SYNCPAL_ERROR(logger, logEvent) LOGW_ERROR(logger, Utility::s2ws(LOG_SYNCDBID) << L" " << logEvent)
+#define LOGW_SYNCPAL_ERROR(logger, logEvent) LOGW_ERROR(logger, CommonUtility::s2ws(LOG_SYNCDBID) << L" " << logEvent)
 
 #define LOG_SYNCPAL_FATAL(logger, logEvent) LOG_FATAL(logger, LOG_SYNCDBID << " " << logEvent)
-#define LOGW_SYNCPAL_FATAL(logger, logEvent) LOGW_FATAL(logger, Utility::s2ws(LOG_SYNCDBID) << L" " << logEvent)
+#define LOGW_SYNCPAL_FATAL(logger, logEvent) LOGW_FATAL(logger, CommonUtility::s2ws(LOG_SYNCDBID) << L" " << logEvent)
 
 struct SyncPalInfo {
         SyncPalInfo() = default;

--- a/src/libsyncengine/syncpal/tmpblacklistmanager.cpp
+++ b/src/libsyncengine/syncpal/tmpblacklistmanager.cpp
@@ -78,7 +78,7 @@ void TmpBlacklistManager::blacklistItem(const NodeId &nodeId, const SyncPath &re
 
     std::list<NodeId> toBeRemoved;
     for (const auto &[id, errorInfo]: errors) {
-        if (Utility::isDescendantOrEqual(errorInfo.path, relativePath) && id != nodeId) {
+        if (CommonUtility::isDescendantOrEqual(errorInfo.path, relativePath) && id != nodeId) {
             toBeRemoved.push_back(id);
         }
     }
@@ -120,14 +120,14 @@ void TmpBlacklistManager::removeItemFromTmpBlacklist(const SyncPath &relativePat
 
     // Find the node id of the item to be removed
     for (const auto &[nodeId, tmpInfo]: _localErrors) {
-        if (Utility::isDescendantOrEqual(tmpInfo.path, relativePath)) {
+        if (CommonUtility::isDescendantOrEqual(tmpInfo.path, relativePath)) {
             localId = nodeId;
             break;
         }
     }
 
     for (const auto &[nodeId, tmpInfo]: _remoteErrors) {
-        if (Utility::isDescendantOrEqual(tmpInfo.path, relativePath)) {
+        if (CommonUtility::isDescendantOrEqual(tmpInfo.path, relativePath)) {
             remotedId = nodeId;
             break;
         }
@@ -150,7 +150,7 @@ void TmpBlacklistManager::removeItemFromTmpBlacklist(const NodeId &nodeId, const
 
 bool TmpBlacklistManager::isTmpBlacklisted(const SyncPath &path, const ReplicaSide side) const {
     for (auto &errors = side == ReplicaSide::Local ? _localErrors : _remoteErrors; const auto &errorInfo: errors) {
-        if (Utility::isDescendantOrEqual(path, errorInfo.second.path)) return true;
+        if (CommonUtility::isDescendantOrEqual(path, errorInfo.second.path)) return true;
     }
 
     return false;

--- a/src/libsyncengine/syncpal/tmpblacklistmanager.cpp
+++ b/src/libsyncengine/syncpal/tmpblacklistmanager.cpp
@@ -37,7 +37,7 @@ TmpBlacklistManager::~TmpBlacklistManager() {
 
 void TmpBlacklistManager::logMessage(const std::wstring &msg, const NodeId &id, const ReplicaSide side,
                                      const SyncPath &path) const {
-    LOGW_SYNCPAL_INFO(Log::instance()->getLogger(), msg << L" - node ID='" << Utility::s2ws(id) << L"' - side='" << side
+    LOGW_SYNCPAL_INFO(Log::instance()->getLogger(), msg << L" - node ID='" << CommonUtility::s2ws(id) << L"' - side='" << side
                                                         << (path.empty() ? L"'" : (L"' - " + Utility::formatSyncPath(path))));
 }
 

--- a/src/libsyncengine/syncpal/virtualfilescleaner.cpp
+++ b/src/libsyncengine/syncpal/virtualfilescleaner.cpp
@@ -101,7 +101,7 @@ bool VirtualFilesCleaner::removePlaceholdersRecursively(const SyncPath &parentPa
                     if (!std::filesystem::remove(dirIt->path(), ec)) {
                         if (ec.value() != 0) {
                             LOGW_WARN(_logger, L"Failed to remove all " << Utility::formatSyncPath(absolutePath) << L": "
-                                                                        << Utility::s2ws(ec.message()) << L" (" << ec.value()
+                                                                        << CommonUtility::s2ws(ec.message()) << L" (" << ec.value()
                                                                         << L")");
                             _exitCode = ExitCode::SystemError;
                             _exitCause = ExitCause::FileAccessError;
@@ -228,7 +228,7 @@ bool VirtualFilesCleaner::removeDehydratedPlaceholders(std::vector<SyncPath> &fa
                     if (!std::filesystem::remove(filePath, ec)) {
                         if (ec.value() != 0) {
                             LOGW_WARN(_logger, L"Failed to remove " << SyncName2WStr(filePathStr) << L": "
-                                                                    << Utility::s2ws(ec.message()) << L" (" << ec.value()
+                                                                    << CommonUtility::s2ws(ec.message()) << L" (" << ec.value()
                                                                     << L")");
                             _exitCode = ExitCode::SystemError;
                             _exitCause = ExitCause::FileAccessError;

--- a/src/libsyncengine/update_detection/blacklist_changes_propagator/blacklistpropagator.cpp
+++ b/src/libsyncengine/update_detection/blacklist_changes_propagator/blacklistpropagator.cpp
@@ -229,7 +229,7 @@ ExitCode BlacklistPropagator::removeItem(const NodeId &localNodeId, const NodeId
     if (exists) {
         if (ParametersCache::isExtendedLogEnabled()) {
             LOGW_SYNCPAL_DEBUG(Log::instance()->getLogger(),
-                               L"Removing item with " << Utility::formatSyncPath(localPath) << L" (" << Utility::s2ws(localNodeId)
+                               L"Removing item with " << Utility::formatSyncPath(localPath) << L" (" << CommonUtility::s2ws(localNodeId)
                                                       << L") on local replica because it is blacklisted.");
         }
 
@@ -239,7 +239,7 @@ ExitCode BlacklistPropagator::removeItem(const NodeId &localNodeId, const NodeId
         if (job.exitInfo().code() != ExitCode::Ok) {
             LOGW_SYNCPAL_WARN(Log::instance()->getLogger(),
                               L"Failed to remove item with " << Utility::formatSyncPath(absolutePath) << L" ("
-                                                             << Utility::s2ws(localNodeId)
+                                                             << CommonUtility::s2ws(localNodeId)
                                                              << L") removed from local replica. It will not be blacklisted.");
 
             SyncPath destPath;
@@ -251,7 +251,7 @@ ExitCode BlacklistPropagator::removeItem(const NodeId &localNodeId, const NodeId
             _syncPal->addError(err);
         } else {
             LOGW_SYNCPAL_DEBUG(Log::instance()->getLogger(), L"Item with " << Utility::formatSyncPath(absolutePath) << L" ("
-                                                                           << Utility::s2ws(localNodeId)
+                                                                           << CommonUtility::s2ws(localNodeId)
                                                                            << L") removed from local replica.");
         }
     }

--- a/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
@@ -297,7 +297,7 @@ ExitCode ComputeFSOperationWorker::inferChangeFromDbNode(const ReplicaSide side,
             return ExitCode::Ok;
         }
         LOGW_SYNCPAL_WARN(_logger, L"Failed to retrieve path from snapshot for item " << SyncName2WStr(dbName) << L" ("
-                                                                                      << Utility::s2ws(nodeId) << L")");
+                                                                                      << CommonUtility::s2ws(nodeId) << L")");
         setExitCause(ExitCause::InvalidSnapshot);
         return ExitCode::DataError;
     }
@@ -499,7 +499,7 @@ ExitCode ComputeFSOperationWorker::exploreSnapshotTree(ReplicaSide side, const N
                 // Ignore orphans
                 if (ParametersCache::isExtendedLogEnabled()) {
                     LOGW_SYNCPAL_DEBUG(_logger, L"Ignoring orphan node " << SyncName2WStr(snapshot->name(nodeId)) << L" ("
-                                                                         << Utility::s2ws(nodeId) << L")");
+                                                                         << CommonUtility::s2ws(nodeId) << L")");
                 }
                 continue;
             }
@@ -549,7 +549,7 @@ void ComputeFSOperationWorker::logOperationGeneration(const ReplicaSide side, co
     } else {
         ss << L", " << Utility::formatSyncPath(fsOp->path());
     }
-    ss << L", id=" << Utility::s2ws(fsOp->nodeId());
+    ss << L", id=" << CommonUtility::s2ws(fsOp->nodeId());
     ss << L", last modification time=" << fsOp->lastModified();
     ss << L", created at=" << fsOp->createdAt();
     ss << L", size=" << fsOp->size();
@@ -605,7 +605,7 @@ ExitCode ComputeFSOperationWorker::checkFileIntegrity(const DbNode &dbNode) {
 
             LOGW_SYNCPAL_WARN(_logger, L"Failed to retrieve path from snapshot for item "
                                                << SyncName2WStr(dbNode.nameLocal()) << L" ("
-                                               << Utility::s2ws(dbNode.nodeIdLocal().value()) << L")");
+                                               << CommonUtility::s2ws(dbNode.nodeIdLocal().value()) << L")");
             setExitCause(ExitCause::InvalidSnapshot);
             return ExitCode::DataError;
         }
@@ -629,7 +629,7 @@ bool ComputeFSOperationWorker::isExcludedFromSync(const std::shared_ptr<const Sn
                                                   const NodeId &nodeId, const SyncPath &path, NodeType type, int64_t size) {
     if (isInUnsyncedListParentSearchInSnapshot(snapshot, nodeId, side)) {
         if (ParametersCache::isExtendedLogEnabled()) {
-            LOGW_SYNCPAL_DEBUG(_logger, L"Ignoring item " << Path2WStr(path) << L" (" << Utility::s2ws(nodeId)
+            LOGW_SYNCPAL_DEBUG(_logger, L"Ignoring item " << Path2WStr(path) << L" (" << CommonUtility::s2ws(nodeId)
                                                           << L") because it is not synced");
         }
         return true;
@@ -644,7 +644,7 @@ bool ComputeFSOperationWorker::isExcludedFromSync(const std::shared_ptr<const Sn
         if (type == NodeType::Directory && isTooBig(snapshot, nodeId, size)) {
             if (ParametersCache::isExtendedLogEnabled()) {
                 LOGW_SYNCPAL_DEBUG(_logger, L"Blacklisting item with " << Utility::formatSyncPath(path) << L" ("
-                                                                       << Utility::s2ws(nodeId) << L") because it is too big");
+                                                                       << CommonUtility::s2ws(nodeId) << L") because it is too big");
             }
             return true;
         }
@@ -807,7 +807,7 @@ void ComputeFSOperationWorker::isReusedNodeId(const NodeId &localNodeId, const D
     if (snapshot->type(localNodeId) != NodeType::Unknown && dbNode.type() != NodeType::Unknown &&
         snapshot->type(localNodeId) != dbNode.type()) {
         isReused = true;
-        LOGW_SYNCPAL_DEBUG(_logger, L"Node type has changed for " << Utility::s2ws(localNodeId) << L" from " << dbNode.type()
+        LOGW_SYNCPAL_DEBUG(_logger, L"Node type has changed for " << CommonUtility::s2ws(localNodeId) << L" from " << dbNode.type()
                                                                   << L" to " << snapshot->type(localNodeId));
         return;
     }
@@ -838,7 +838,7 @@ void ComputeFSOperationWorker::isReusedNodeId(const NodeId &localNodeId, const D
                                             << dbNode.created().value() << L" / new: " << snapshot->createdAt(localNodeId)
                                             << L") and name (old: " << Utility::formatSyncName(dbNode.nameLocal()) << L" / new: "
                                             << Utility::formatSyncName(snapshot->name(localNodeId)) << L") changed for"
-                                            << Utility::s2ws(localNodeId) << L". Node is reused.");
+                                            << CommonUtility::s2ws(localNodeId) << L". Node is reused.");
         return;
     }
 
@@ -859,7 +859,7 @@ void ComputeFSOperationWorker::isReusedNodeId(const NodeId &localNodeId, const D
                                         << snapshot->createdAt(localNodeId) << L" | " << snapshot->lastModified(localNodeId)
                                         << L") and name (old: " << Utility::formatSyncName(dbNode.nameLocal()) << L" / new: "
                                         << Utility::formatSyncName(snapshot->name(localNodeId)) << L") have all changed for "
-                                        << Utility::s2ws(localNodeId) << L". Node is reused.");
+                                        << CommonUtility::s2ws(localNodeId) << L". Node is reused.");
     isReused = true;
 }
 #endif

--- a/src/libsyncengine/update_detection/file_system_observer/folderwatcher_linux.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/folderwatcher_linux.cpp
@@ -44,7 +44,7 @@ SyncPath FolderWatcher_linux::makeSyncPath(const SyncPath &watchedFolderPath, co
 
 void FolderWatcher_linux::startWatching() {
     LOGW_DEBUG(_logger, L"Start watching folder " << Utility::formatSyncPath(_folder));
-    LOG_DEBUG(_logger, "File system format: " << Utility::fileSystemName(_folder));
+    LOG_DEBUG(_logger, "File system format: " << CommonUtility::fileSystemName(_folder));
 
     _fileDescriptor = inotify_init();
     if (_fileDescriptor == -1) {
@@ -258,7 +258,7 @@ void FolderWatcher_linux::removeFoldersBelow(const SyncPath &dirPath) {
     // Remove the entry and all subentries
     while (it != _pathToWatch.end()) {
         auto itPath = it->first;
-        if (!Utility::isDescendantOrEqual(itPath, dirPath)) {
+        if (!CommonUtility::isDescendantOrEqual(itPath, dirPath)) {
             break;
         }
 

--- a/src/libsyncengine/update_detection/file_system_observer/folderwatcher_linux.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/folderwatcher_linux.cpp
@@ -235,7 +235,7 @@ ExitInfo FolderWatcher_linux::addFolderRecursive(const SyncPath &path) {
         } else {
             if (ec) {
                 LOGW_WARN(_logger, L"Failed to check if path exists " << Utility::formatSyncPath(path) << L": "
-                                                                      << Utility::s2ws(ec.message()) << L" (" << ec.value()
+                                                                      << CommonUtility::s2ws(ec.message()) << L" (" << ec.value()
                                                                       << L")");
             }
             LOGW_DEBUG(_logger, L"    `-> discarded: " << Utility::formatSyncPath(subDirPath));

--- a/src/libsyncengine/update_detection/file_system_observer/folderwatcher_mac.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/folderwatcher_mac.cpp
@@ -96,7 +96,7 @@ static void callback([[maybe_unused]] ConstFSEventStreamRef streamRef, void *cli
 
 void FolderWatcher_mac::startWatching() {
     LOGW_DEBUG(_logger, L"Start watching folder: " << Utility::formatSyncPath(_folder));
-    LOG_DEBUG(_logger, "File system format: " << Utility::fileSystemName(_folder));
+    LOG_DEBUG(_logger, "File system format: " << CommonUtility::fileSystemName(_folder));
 
     CFStringRef path = CFStringCreateWithCString(nullptr, _folder.c_str(), kCFStringEncodingUTF8);
     CFArrayRef pathsToWatch = CFArrayCreate(nullptr, (const void **) &path, 1, nullptr);

--- a/src/libsyncengine/update_detection/file_system_observer/folderwatcher_mac.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/folderwatcher_mac.cpp
@@ -68,7 +68,7 @@ static void callback([[maybe_unused]] ConstFSEventStreamRef streamRef, void *cli
 
         if (ParametersCache::isExtendedLogEnabled()) {
             LOGW_DEBUG(fw->logger(),
-                       L"Operation " << opType << L" detected on item " << Utility::s2ws(pathPtr ? pathPtr : pathBuf));
+                       L"Operation " << opType << L" detected on item " << CommonUtility::s2ws(pathPtr ? pathPtr : pathBuf));
         }
 
         // TODO : to be tested to get inode (https://github.com/fsevents/fsevents/pull/360/files)

--- a/src/libsyncengine/update_detection/file_system_observer/folderwatcher_win.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/folderwatcher_win.cpp
@@ -49,7 +49,7 @@ ExitInfo FolderWatcher_win::changeDetected(const SyncPath &path, OperationType o
 
 void FolderWatcher_win::startWatching() {
     LOGW_DEBUG(_logger, L"Start watching folder: " << _folder.wstring());
-    LOG_DEBUG(_logger, "File system format: " << Utility::fileSystemName(_folder));
+    LOG_DEBUG(_logger, "File system format: " << CommonUtility::fileSystemName(_folder));
 
     _resultEventHandle = CreateEvent(nullptr, true, false, nullptr);
     _stopEventHandle = CreateEvent(nullptr, true, false, nullptr);

--- a/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
@@ -102,7 +102,7 @@ ExitInfo LocalFileSystemObserverWorker::changesDetected(
                     !existsWithSameId) {
                     if (_liveSnapshot.removeItem(prevNodeId)) {
                         LOGW_SYNCPAL_DEBUG(_logger, L"Item removed from local snapshot: " << Utility::formatSyncPath(absolutePath)
-                                                                                          << L" (" << Utility::s2ws(prevNodeId)
+                                                                                          << L" (" << CommonUtility::s2ws(prevNodeId)
                                                                                           << L")");
                     }
                     continue;
@@ -185,10 +185,10 @@ ExitInfo LocalFileSystemObserverWorker::changesDetected(
 
             if (_liveSnapshot.removeItem(itemId)) {
                 LOGW_SYNCPAL_DEBUG(_logger, L"Item removed from local snapshot: " << Utility::formatSyncPath(absolutePath)
-                                                                                  << L" (" << Utility::s2ws(itemId) << L")");
+                                                                                  << L" (" << CommonUtility::s2ws(itemId) << L")");
             } else {
                 LOGW_SYNCPAL_WARN(_logger, L"Fail to remove item: " << Utility::formatSyncPath(absolutePath) << L" ("
-                                                                    << Utility::s2ws(itemId) << L")");
+                                                                    << CommonUtility::s2ws(itemId) << L")");
                 tryToInvalidateSnapshot();
                 return ExitCode::DataError;
             }
@@ -252,7 +252,7 @@ ExitInfo LocalFileSystemObserverWorker::changesDetected(
 #else
                 if (ParametersCache::isExtendedLogEnabled()) {
                     LOGW_SYNCPAL_DEBUG(_logger, L"Ignoring spurious edit notification on file: "
-                                                        << Utility::formatSyncPath(absolutePath) << L" (" << Utility::s2ws(nodeId)
+                                                        << Utility::formatSyncPath(absolutePath) << L" (" << CommonUtility::s2ws(nodeId)
                                                         << L")");
                 }
 #endif
@@ -271,10 +271,10 @@ ExitInfo LocalFileSystemObserverWorker::changesDetected(
                 NodeId itemId = _liveSnapshot.itemId(relativePath);
                 if (!itemId.empty() && _liveSnapshot.removeItem(itemId)) {
                     LOGW_SYNCPAL_DEBUG(_logger, L"Item removed from local snapshot: " << Utility::formatSyncPath(absolutePath)
-                                                                                      << L" (" << Utility::s2ws(itemId) << L")");
+                                                                                      << L" (" << CommonUtility::s2ws(itemId) << L")");
                 } else {
                     LOGW_SYNCPAL_WARN(_logger, L"Failed to remove item: " << Utility::formatSyncPath(absolutePath) << L" ("
-                                                                          << Utility::s2ws(itemId) << L")");
+                                                                          << CommonUtility::s2ws(itemId) << L")");
                     tryToInvalidateSnapshot();
                     return ExitCode::DataError;
                 }
@@ -288,11 +288,11 @@ ExitInfo LocalFileSystemObserverWorker::changesDetected(
                 // inserted below anyway.
                 if (!previousItemId.empty() && _liveSnapshot.removeItem(previousItemId)) {
                     LOGW_SYNCPAL_DEBUG(_logger, L"Item removed from local snapshot: " << Utility::formatSyncPath(absolutePath)
-                                                                                      << L" (" << Utility::s2ws(previousItemId)
+                                                                                      << L" (" << CommonUtility::s2ws(previousItemId)
                                                                                       << L")");
                 } else {
                     LOGW_SYNCPAL_WARN(_logger, L"Failed to delete item: " << Utility::formatSyncPath(absolutePath) << L" ("
-                                                                          << Utility::s2ws(previousItemId) << L")");
+                                                                          << CommonUtility::s2ws(previousItemId) << L")");
                     tryToInvalidateSnapshot();
                     return ExitCode::DataError;
                 }
@@ -304,14 +304,14 @@ ExitInfo LocalFileSystemObserverWorker::changesDetected(
 
             if (!_liveSnapshot.updateItem(item)) {
                 LOGW_SYNCPAL_WARN(_logger, L"Failed to insert item: " << Utility::formatSyncPath(absolutePath) << L" ("
-                                                                      << Utility::s2ws(nodeId) << L")");
+                                                                      << CommonUtility::s2ws(nodeId) << L")");
                 tryToInvalidateSnapshot();
                 return ExitCode::DataError;
             }
 
             if (ParametersCache::isExtendedLogEnabled()) {
                 LOGW_SYNCPAL_DEBUG(_logger, L"Item inserted in local snapshot: " << Utility::formatSyncPath(absolutePath) << L" ("
-                                                                                 << Utility::s2ws(nodeId) << L") at "
+                                                                                 << CommonUtility::s2ws(nodeId) << L") at "
                                                                                  << fileStat.modificationTime);
 
                 //                if (nodeType == NodeType::File) {
@@ -366,7 +366,7 @@ ExitInfo LocalFileSystemObserverWorker::changesDetected(
         if (_liveSnapshot.updateItem(SnapshotItem(nodeId, parentNodeId, absolutePath.filename().native(), fileStat.creationTime,
                                                   fileStat.modificationTime, nodeType, fileStat.size, isLink, true, true))) {
             if (ParametersCache::isExtendedLogEnabled()) {
-                LOGW_SYNCPAL_DEBUG(_logger, L"Item: " << Utility::formatSyncPath(absolutePath) << L" (" << Utility::s2ws(nodeId)
+                LOGW_SYNCPAL_DEBUG(_logger, L"Item: " << Utility::formatSyncPath(absolutePath) << L" (" << CommonUtility::s2ws(nodeId)
                                                       << L") updated in local snapshot at " << fileStat.modificationTime);
             }
 
@@ -378,7 +378,7 @@ ExitInfo LocalFileSystemObserverWorker::changesDetected(
             }
         } else {
             LOGW_SYNCPAL_WARN(_logger, L"Failed to update item: " << Utility::formatSyncPath(absolutePath) << L" ("
-                                                                  << Utility::s2ws(nodeId) << L")");
+                                                                  << CommonUtility::s2ws(nodeId) << L")");
             tryToInvalidateSnapshot();
             return ExitCode::DataError;
         }
@@ -518,7 +518,7 @@ ExitCode LocalFileSystemObserverWorker::isEditValid(const NodeId &nodeId, const 
             return ExitCode::DbError;
         }
         if (!found) {
-            LOGW_SYNCPAL_WARN(_logger, L"Node not found in node table for nodeId=" << Utility::s2ws(nodeId));
+            LOGW_SYNCPAL_WARN(_logger, L"Node not found in node table for nodeId=" << CommonUtility::s2ws(nodeId));
             return ExitCode::DataError;
         }
 
@@ -528,7 +528,7 @@ ExitCode LocalFileSystemObserverWorker::isEditValid(const NodeId &nodeId, const 
             return ExitCode::DbError;
         }
         if (!found) {
-            LOGW_SYNCPAL_WARN(_logger, L"Node not found in node table: nodeId=" << Utility::s2ws(nodeId));
+            LOGW_SYNCPAL_WARN(_logger, L"Node not found in node table: nodeId=" << CommonUtility::s2ws(nodeId));
             return ExitCode::DataError;
         }
 
@@ -731,8 +731,8 @@ ExitInfo LocalFileSystemObserverWorker::exploreDir(const SyncPath &absoluteParen
                 if (ParametersCache::isExtendedLogEnabled()) {
                     LOGW_SYNCPAL_DEBUG(_logger, L"Item inserted in local snapshot: "
                                                         << Utility::formatSyncPath(absolutePath.filename()) << L" inode:"
-                                                        << Utility::s2ws(nodeId) << L" parent inode:"
-                                                        << Utility::s2ws(parentNodeId) << L" createdAt:" << fileStat.creationTime
+                                                        << CommonUtility::s2ws(nodeId) << L" parent inode:"
+                                                        << CommonUtility::s2ws(parentNodeId) << L" createdAt:" << fileStat.creationTime
                                                         << L" modificationTime:" << fileStat.modificationTime << L" isDir:"
                                                         << (itemType.nodeType == NodeType::Directory) << L" size:"
                                                         << fileStat.size << L" isLink:" << isLink);

--- a/src/libsyncengine/update_detection/file_system_observer/remotefilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/remotefilesystemobserverworker.cpp
@@ -205,7 +205,7 @@ ExitInfo RemoteFileSystemObserverWorker::processEvents() {
             } else {
                 std::ostringstream os;
                 resObj->stringify(os);
-                LOGW_SYNCPAL_WARN(_logger, L"Continue cursor listing request failed: " << Utility::s2ws(os.str()));
+                LOGW_SYNCPAL_WARN(_logger, L"Continue cursor listing request failed: " << CommonUtility::s2ws(os.str()));
                 exitInfo = ExitCode::BackError;
                 break;
             }
@@ -364,8 +364,8 @@ ExitInfo RemoteFileSystemObserverWorker::getItemsInDir(const NodeId &dirId, cons
         if (_liveSnapshot.updateItem(item)) {
             if (ParametersCache::isExtendedLogEnabled()) {
                 LOGW_SYNCPAL_DEBUG(_logger, L"Item inserted in remote snapshot: name:"
-                                                    << SyncName2WStr(item.name()) << L", inode:" << Utility::s2ws(item.id())
-                                                    << L", parent inode:" << Utility::s2ws(item.parentId()) << L", createdAt:"
+                                                    << SyncName2WStr(item.name()) << L", inode:" << CommonUtility::s2ws(item.id())
+                                                    << L", parent inode:" << CommonUtility::s2ws(item.parentId()) << L", createdAt:"
                                                     << item.createdAt() << L", modtime:" << item.lastModified() << L", isDir:"
                                                     << (item.type() == NodeType::Directory) << L", size:" << item.size()
                                                     << L", isLink:" << item.isLink());
@@ -388,7 +388,7 @@ ExitInfo RemoteFileSystemObserverWorker::getItemsInDir(const NodeId &dirId, cons
     while (nodeIdIt != nodeIds.end()) {
         if (_liveSnapshot.isOrphan(*nodeIdIt)) {
             LOGW_SYNCPAL_DEBUG(_logger, L"Node '" << SyncName2WStr(_liveSnapshot.name(*nodeIdIt)) << L"' ("
-                                                  << Utility::s2ws(*nodeIdIt) << L") is orphan. Removing it from "
+                                                  << CommonUtility::s2ws(*nodeIdIt) << L") is orphan. Removing it from "
                                                   << _liveSnapshot.side() << L" snapshot.");
             _liveSnapshot.removeItem(*nodeIdIt);
         }
@@ -675,7 +675,7 @@ ExitInfo RemoteFileSystemObserverWorker::processAction(ActionInfo &actionInfo, s
         case ActionCode::ActionCodeTrash:
             if (!_liveSnapshot.removeItem(actionInfo.snapshotItem.id())) {
                 LOGW_SYNCPAL_WARN(_logger, L"Fail to remove item: " << SyncName2WStr(actionInfo.snapshotItem.name()) << L" ("
-                                                                    << Utility::s2ws(actionInfo.snapshotItem.id()) << L")");
+                                                                    << CommonUtility::s2ws(actionInfo.snapshotItem.id()) << L")");
                 tryToInvalidateSnapshot();
                 return ExitCode::BackError;
             }
@@ -694,7 +694,7 @@ ExitInfo RemoteFileSystemObserverWorker::processAction(ActionInfo &actionInfo, s
         default:
             LOGW_SYNCPAL_DEBUG(_logger, L"Unknown operation received on item: "
                                                 << SyncName2WStr(actionInfo.snapshotItem.name()) << L" ("
-                                                << Utility::s2ws(actionInfo.snapshotItem.id()) << L")");
+                                                << CommonUtility::s2ws(actionInfo.snapshotItem.id()) << L")");
     }
 
 
@@ -722,7 +722,7 @@ ExitInfo RemoteFileSystemObserverWorker::checkRightsAndUpdateItem(const NodeId &
         }
 
         LOGW_SYNCPAL_WARN(_logger, L"Error while determining access rights on item: " << SyncName2WStr(snapshotItem.name())
-                                                                                      << L" (" << Utility::s2ws(snapshotItem.id())
+                                                                                      << L" (" << CommonUtility::s2ws(snapshotItem.id())
                                                                                       << L")");
         tryToInvalidateSnapshot();
         return ExitCode::BackError;

--- a/src/libsyncengine/update_detection/file_system_observer/snapshot/livesnapshot.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/snapshot/livesnapshot.cpp
@@ -68,8 +68,8 @@ bool LiveSnapshot::updateItem(const SnapshotItem &newItem) {
         for (const auto &child: newParent->children()) {
             if (child->normalizedName() == newItem.normalizedName() && child->id() != newItem.id()) {
                 LOGW_DEBUG(Log::instance()->getLogger(),
-                           L"Item: " << Utility::formatSyncName(newItem.name()) << L" (" << Utility::s2ws(newItem.id())
-                                     << L") already exists in parent: " << Utility::s2ws(newItem.parentId())
+                           L"Item: " << Utility::formatSyncName(newItem.name()) << L" (" << CommonUtility::s2ws(newItem.id())
+                                     << L") already exists in parent: " << CommonUtility::s2ws(newItem.parentId())
                                      << L" with a different id. Removing it and adding the new one.");
                 auto child2 = child; // removeItem cannot be called on a const ref, we need to make a copy.
                 if (!removeItem(child2)) return false;
@@ -121,7 +121,7 @@ bool LiveSnapshot::updateItem(const SnapshotItem &newItem) {
 
     if (ParametersCache::isExtendedLogEnabled()) {
         LOGW_DEBUG(Log::instance()->getLogger(), L"Item: " << Utility::formatSyncName(item->name()) << L" ("
-                                                           << Utility::s2ws(item->id()) << L") updated at:"
+                                                           << CommonUtility::s2ws(item->id()) << L") updated at:"
                                                            << item->lastModified());
     }
     return true;

--- a/src/libsyncengine/update_detection/file_system_observer/snapshot/snapshotitem.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/snapshot/snapshotitem.cpp
@@ -120,7 +120,7 @@ void SnapshotItem::setLastChangedSnapshotVersion(SnapshotRevision snapshotVersio
         LOGW_WARN(Log::instance()->getLogger(),
                   L"SnapshotItem::setLastChangedSnapshotVersion: "
                   L"Trying to set a lower version than the current one. Current version: "
-                          << _lastChangeRevision << L", new version: " << snapshotVersion << L" on " << Utility::s2ws(_id));
+                          << _lastChangeRevision << L", new version: " << snapshotVersion << L" on " << CommonUtility::s2ws(_id));
     }
 }
 

--- a/src/libsyncengine/update_detection/update_detector/updatetree.cpp
+++ b/src/libsyncengine/update_detection/update_detector/updatetree.cpp
@@ -200,8 +200,8 @@ bool UpdateTree::updateNodeId(std::shared_ptr<Node> node, const NodeId &newId) {
     }
 
     if (ParametersCache::isExtendedLogEnabled() && newId != oldId) {
-        LOGW_DEBUG(Log::instance()->getLogger(), _side << L" update tree: Node ID changed from '" << Utility::s2ws(oldId)
-                                                       << L"' to '" << Utility::s2ws(newId) << L"' for node "
+        LOGW_DEBUG(Log::instance()->getLogger(), _side << L" update tree: Node ID changed from '" << CommonUtility::s2ws(oldId)
+                                                       << L"' to '" << CommonUtility::s2ws(newId) << L"' for node "
                                                        << Utility::formatSyncName(node->name()) << L"'.");
     }
 

--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
@@ -1101,7 +1101,7 @@ bool UpdateTreeWorker::integrityCheck() {
     // TODO : check if this does not slow the process too much
     LOGW_SYNCPAL_INFO(_logger, _side << L" update tree integrity check started");
     for (const auto &node: _updateTree->nodes()) {
-        if (node.second->isTmp() || Utility::startsWith(*node.second->id(), "tmp_")) {
+        if (node.second->isTmp() || CommonUtility::startsWith(*node.second->id(), "tmp_")) {
             LOGW_SYNCPAL_WARN(_logger,
                               _side << L" update tree integrity check failed. A temporary node remains in the update tree: "
                                     << L" (node ID: '" << Utility::s2ws(node.second->id().value_or("")) << L"', DB ID: '"

--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
@@ -168,7 +168,7 @@ ExitCode UpdateTreeWorker::step3DeleteDirectory() {
                         _logger,
                         _side << L" update tree: Node '" << SyncName2WStr(currentNodeIt->second->name()).c_str()
                               << L"' (node ID: '"
-                              << Utility::s2ws(currentNodeIt->second->id().has_value() ? *currentNodeIt->second->id() : NodeId())
+                              << CommonUtility::s2ws(currentNodeIt->second->id().has_value() ? *currentNodeIt->second->id() : NodeId())
                                          .c_str()
                               << L"', DB ID: '" << (currentNodeIt->second->idb().has_value() ? *currentNodeIt->second->idb() : -1)
                               << L"') updated. Operation DELETE inserted in change events.");
@@ -225,7 +225,7 @@ ExitCode UpdateTreeWorker::step3DeleteDirectory() {
                     LOGW_SYNCPAL_DEBUG(_logger,
                                        _side << L" update tree: Node '" << SyncName2WStr(newNode->name()).c_str()
                                              << L"' (node ID: '"
-                                             << Utility::s2ws(newNode->id().has_value() ? *newNode->id() : NodeId()).c_str()
+                                             << CommonUtility::s2ws(newNode->id().has_value() ? *newNode->id() : NodeId()).c_str()
                                              << L"', DB ID: '" << (newNode->idb().has_value() ? *newNode->idb() : -1)
                                              << L"') updated. Operation DELETE inserted in change events.");
                 }
@@ -251,10 +251,10 @@ ExitCode UpdateTreeWorker::step3DeleteDirectory() {
                 if (ParametersCache::isExtendedLogEnabled()) {
                     LOGW_SYNCPAL_DEBUG(_logger,
                                        _side << L" update tree: Node '" << SyncName2WStr(newNode->name()) << L"' (node ID: '"
-                                             << Utility::s2ws(newNode->id().has_value() ? *newNode->id() : NodeId()).c_str()
+                                             << CommonUtility::s2ws(newNode->id().has_value() ? *newNode->id() : NodeId()).c_str()
                                              << L"', DB ID: '" << (newNode->idb().has_value() ? *newNode->idb() : -1)
                                              << L"', parent ID: '"
-                                             << Utility::s2ws(parentNode->id().has_value() ? *parentNode->id() : NodeId()).c_str()
+                                             << CommonUtility::s2ws(parentNode->id().has_value() ? *parentNode->id() : NodeId()).c_str()
                                              << L"') inserted. Operation DELETE inserted in change events.");
                 }
             }
@@ -322,15 +322,15 @@ void UpdateTreeWorker::logUpdate(const std::shared_ptr<Node> node, const Operati
     std::wstring parentIdStr;
     std::wstring updateTypeStr = L"updated";
     if (parentNode) {
-        parentIdStr = L"parent ID: '" + Utility::s2ws(parentNode->id() ? *parentNode->id() : NodeId()) + L"'";
+        parentIdStr = L"parent ID: '" + CommonUtility::s2ws(parentNode->id() ? *parentNode->id() : NodeId()) + L"'";
         updateTypeStr = L"inserted";
     }
 
-    const std::wstring updateTreeStr = Utility::s2ws(toString(_side)) + L" update tree";
+    const std::wstring updateTreeStr = CommonUtility::s2ws(toString(_side)) + L" update tree";
     const std::wstring nodeStr = L"Node '" + SyncName2WStr(node->name()) + L"'";
-    const std::wstring nodeIdStr = L"node ID: '" + Utility::s2ws(node->id() ? *node->id() : NodeId()) + L"'";
+    const std::wstring nodeIdStr = L"node ID: '" + CommonUtility::s2ws(node->id() ? *node->id() : NodeId()) + L"'";
     const std::wstring dbIdStr = L"DB ID: '" + std::to_wstring(node->idb() ? *node->idb() : -1) + L"'";
-    const std::wstring opTypeStr = Utility::s2ws(toString(opType));
+    const std::wstring opTypeStr = CommonUtility::s2ws(toString(opType));
 
     LOGW_SYNCPAL_DEBUG(_logger, updateTreeStr.c_str() << L": " << nodeStr << L" (" << nodeIdStr << L", " << dbIdStr << L", "
                                                       << parentIdStr << L") " << updateTypeStr << L". Operation " << opTypeStr
@@ -557,7 +557,7 @@ ExitCode UpdateTreeWorker::step5CreateDirectory() {
         if (ParametersCache::isExtendedLogEnabled()) {
             LOGW_SYNCPAL_DEBUG(
                     _logger, _side << L" update tree: Node '" << SyncName2WStr(currentNode->name()) << L"' (node ID: '"
-                                   << Utility::s2ws(currentNode->id().has_value() ? *currentNode->id() : std::string()).c_str()
+                                   << CommonUtility::s2ws(currentNode->id().has_value() ? *currentNode->id() : std::string()).c_str()
                                    << L"', DB ID: '" << (currentNode->idb().has_value() ? *currentNode->idb() : -1)
                                    << L"') inserted. Operation " << createOp->operationType() << L" inserted in change events.");
         }
@@ -602,9 +602,9 @@ ExitCode UpdateTreeWorker::step6CreateFile() {
                     LOGW_SYNCPAL_DEBUG(
                             _logger,
                             _side << L" update tree: Node '" << SyncName2WStr(newNode->name()) << L"' (node ID: '"
-                                  << Utility::s2ws(newNode->id().has_value() ? *newNode->id() : std::string()) << L"', DB ID: '"
+                                  << CommonUtility::s2ws(newNode->id().has_value() ? *newNode->id() : std::string()) << L"', DB ID: '"
                                   << (newNode->idb().has_value() ? *newNode->idb() : -1) << L"', parent ID: '"
-                                  << Utility::s2ws(parentNode->id().has_value() ? *parentNode->id() : "-1")
+                                  << CommonUtility::s2ws(parentNode->id().has_value() ? *parentNode->id() : "-1")
                                   << L"') updated. Operation " << operation->operationType() << L" inserted in change events.");
                 }
                 continue;
@@ -631,9 +631,9 @@ ExitCode UpdateTreeWorker::step6CreateFile() {
         _updateTree->nodes()[operation->nodeId()] = newNode;
         if (ParametersCache::isExtendedLogEnabled()) {
             LOGW_SYNCPAL_DEBUG(_logger, _side << L" update tree: Node '" << SyncName2WStr(newNode->name()) << L"' (node ID: '"
-                                              << Utility::s2ws(newNode->id().has_value() ? *newNode->id() : "") << L"', DB ID: '"
+                                              << CommonUtility::s2ws(newNode->id().has_value() ? *newNode->id() : "") << L"', DB ID: '"
                                               << (newNode->idb().has_value() ? *newNode->idb() : -1) << L"', parent ID: '"
-                                              << Utility::s2ws(parentNode->id().has_value() ? *parentNode->id() : "-1")
+                                              << CommonUtility::s2ws(parentNode->id().has_value() ? *parentNode->id() : "-1")
                                               << L"') inserted. Operation " << operation->operationType()
                                               << L" inserted in change events.");
         }
@@ -679,7 +679,7 @@ ExitCode UpdateTreeWorker::step7EditFile() {
             _updateTree->nodes()[editOp->nodeId()] = newNode;
             if (ParametersCache::isExtendedLogEnabled()) {
                 LOGW_SYNCPAL_DEBUG(_logger, _side << L" update tree: Node '" << SyncName2WStr(newNode->name()) << L"' (node ID: '"
-                                                  << Utility::s2ws(newNode->id().has_value() ? *newNode->id() : std::string())
+                                                  << CommonUtility::s2ws(newNode->id().has_value() ? *newNode->id() : std::string())
                                                   << L"', DB ID: '" << (newNode->idb().has_value() ? *newNode->idb() : -1)
                                                   << L"') updated. Operation " << editOp->operationType()
                                                   << L" inserted in change events.");
@@ -719,9 +719,9 @@ ExitCode UpdateTreeWorker::step7EditFile() {
         if (ParametersCache::isExtendedLogEnabled()) {
             LOGW_SYNCPAL_DEBUG(
                     _logger, _side << L" update tree: Node '" << SyncName2WStr(newNode->name()) << L"' (node ID: '"
-                                   << Utility::s2ws(newNode->id().has_value() ? *newNode->id() : std::string()) << L"', DB ID: '"
+                                   << CommonUtility::s2ws(newNode->id().has_value() ? *newNode->id() : std::string()) << L"', DB ID: '"
                                    << (newNode->idb().has_value() ? *newNode->idb() : -1) << L"', parent ID: '"
-                                   << Utility::s2ws(parentNode->id().has_value() ? *parentNode->id() : std::string())
+                                   << CommonUtility::s2ws(parentNode->id().has_value() ? *parentNode->id() : std::string())
                                    << L"') inserted. editOp " << editOp->operationType() << L" inserted in change events.");
         }
     }
@@ -844,10 +844,10 @@ ExitCode UpdateTreeWorker::step8CompleteUpdateTree() {
             if (ParametersCache::isExtendedLogEnabled()) {
                 LOGW_SYNCPAL_DEBUG(_logger,
                                    _side << L" update tree: Node '" << SyncName2WStr(newNode->name()) << L"' (node ID: '"
-                                         << Utility::s2ws(newNode->id().has_value() ? *newNode->id() : std::string())
+                                         << CommonUtility::s2ws(newNode->id().has_value() ? *newNode->id() : std::string())
                                          << L"', DB ID: '" << (newNode->idb().has_value() ? *newNode->idb() : 1)
                                          << L"', parent ID: '"
-                                         << Utility::s2ws(parentNode->id().has_value() ? *parentNode->id() : std::string())
+                                         << CommonUtility::s2ws(parentNode->id().has_value() ? *parentNode->id() : std::string())
                                          << L"') inserted. Without change events.");
             }
         }
@@ -945,10 +945,10 @@ ExitCode UpdateTreeWorker::createMoveNodes(const NodeType &nodeType) {
                 LOGW_SYNCPAL_DEBUG(
                         _logger,
                         _side << L" update tree: Node '" << SyncName2WStr(currentNode->name()) << L"' (node ID: '"
-                              << Utility::s2ws(currentNode->id().has_value() ? *currentNode->id() : std::string()).c_str()
+                              << CommonUtility::s2ws(currentNode->id().has_value() ? *currentNode->id() : std::string()).c_str()
                               << L"', DB ID: '" << (currentNode->idb().has_value() ? *currentNode->idb() : -1)
                               << L"', parent ID: '"
-                              << Utility::s2ws(parentNode->id().has_value() ? *parentNode->id() : std::string()).c_str()
+                              << CommonUtility::s2ws(parentNode->id().has_value() ? *parentNode->id() : std::string()).c_str()
                               << L"') inserted. Operation " << moveOp->operationType() << L" inserted in change events.");
             }
         } else {
@@ -993,9 +993,9 @@ ExitCode UpdateTreeWorker::createMoveNodes(const NodeType &nodeType) {
                 LOGW_SYNCPAL_DEBUG(
                         _logger,
                         _side << L" update tree: Node '" << SyncName2WStr(newNode->name()) << L"' (node ID: '"
-                              << Utility::s2ws(newNode->id().has_value() ? *newNode->id() : std::string()).c_str()
+                              << CommonUtility::s2ws(newNode->id().has_value() ? *newNode->id() : std::string()).c_str()
                               << L"', DB ID: '" << (newNode->idb().has_value() ? *newNode->idb() : -1) << L"', parent ID: '"
-                              << Utility::s2ws(parentNode->id().has_value() ? *parentNode->id() : std::string()).c_str()
+                              << CommonUtility::s2ws(parentNode->id().has_value() ? *parentNode->id() : std::string()).c_str()
                               << L"') inserted. Operation " << moveOp->operationType() << L" inserted in change events.");
             }
         }
@@ -1104,7 +1104,7 @@ bool UpdateTreeWorker::integrityCheck() {
         if (node.second->isTmp() || CommonUtility::startsWith(*node.second->id(), "tmp_")) {
             LOGW_SYNCPAL_WARN(_logger,
                               _side << L" update tree integrity check failed. A temporary node remains in the update tree: "
-                                    << L" (node ID: '" << Utility::s2ws(node.second->id().value_or("")) << L"', DB ID: '"
+                                    << L" (node ID: '" << CommonUtility::s2ws(node.second->id().value_or("")) << L"', DB ID: '"
                                     << node.second->idb().value_or(-1) << L"', name: '" << SyncName2WStr(node.second->name())
                                     << L"')");
             sentry::Handler::captureMessage(sentry::Level::Warning, "UpdateTreeWorker::integrityCheck",
@@ -1286,7 +1286,7 @@ ExitCode UpdateTreeWorker::updateTmpNode(const std::shared_ptr<Node> tmpNode) {
         return ExitCode::DbError;
     }
     if (!found) {
-        LOGW_SYNCPAL_WARN(_logger, L"Node not found for ID = " << Utility::s2ws(*id) << L" (Node name: '"
+        LOGW_SYNCPAL_WARN(_logger, L"Node not found for ID = " << CommonUtility::s2ws(*id) << L" (Node name: '"
                                                                << SyncName2WStr(tmpNode->name()) << L"', node valid name: '"
                                                                << SyncName2WStr(tmpNode->name()) << L"') on side" << _side);
         return ExitCode::DataError;
@@ -1314,10 +1314,10 @@ ExitCode UpdateTreeWorker::updateTmpNode(const std::shared_ptr<Node> tmpNode) {
             }
 
             LOGW_SYNCPAL_DEBUG(_logger, _side << L" update tree: Node '" << SyncName2WStr(childNode->name()) << L"' (node ID: '"
-                                              << Utility::s2ws((childNode->id().has_value() ? *childNode->id() : std::string()))
+                                              << CommonUtility::s2ws((childNode->id().has_value() ? *childNode->id() : std::string()))
                                               << L"') inserted in children list of node '" << SyncName2WStr(tmpNode->name())
                                               << L"' (node ID: '"
-                                              << Utility::s2ws((tmpNode->id().has_value() ? *tmpNode->id() : std::string()))
+                                              << CommonUtility::s2ws((tmpNode->id().has_value() ? *tmpNode->id() : std::string()))
                                               << L"')");
         }
 
@@ -1334,7 +1334,7 @@ ExitCode UpdateTreeWorker::updateTmpNode(const std::shared_ptr<Node> tmpNode) {
 
             LOGW_SYNCPAL_DEBUG(_logger, _side << L" update tree: Changed events to '" << prevNode->changeEvents()
                                               << L"' for node '" << SyncName2WStr(tmpNode->name()) << L"' (node ID: '"
-                                              << Utility::s2ws((tmpNode->id().has_value() ? *tmpNode->id() : std::string()))
+                                              << CommonUtility::s2ws((tmpNode->id().has_value() ? *tmpNode->id() : std::string()))
                                               << L"')");
         }
     }
@@ -1344,9 +1344,9 @@ ExitCode UpdateTreeWorker::updateTmpNode(const std::shared_ptr<Node> tmpNode) {
         LOGW_SYNCPAL_DEBUG(
                 _logger,
                 _side << L" update tree: Node '" << SyncName2WStr(tmpNode->name()) << L"' (node ID: '"
-                      << Utility::s2ws((tmpNode->id().has_value() ? *tmpNode->id() : std::string())) << L"', DB ID: '"
+                      << CommonUtility::s2ws((tmpNode->id().has_value() ? *tmpNode->id() : std::string())) << L"', DB ID: '"
                       << (tmpNode->idb().has_value() ? *tmpNode->idb() : -1) << L"', parent ID: '"
-                      << Utility::s2ws(tmpNode->parentNode()->id().has_value() ? *tmpNode->parentNode()->id() : std::string())
+                      << CommonUtility::s2ws(tmpNode->parentNode()->id().has_value() ? *tmpNode->parentNode()->id() : std::string())
                                  .c_str()
                       << L"') updated. Node updated with DB");
     }

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -2924,7 +2924,7 @@ void AppServer::logUsefulInformation() const {
         LOG_WARN(Log::instance()->getLogger(), "Error in ParmsDb::selectAllUsers");
     }
     for (const auto &user: userList) {
-        LOGW_INFO(Log::instance()->getLogger(), L"User ID: " << user.userId() << L", email: " << Utility::s2ws(user.email()));
+        LOGW_INFO(Log::instance()->getLogger(), L"User ID: " << user.userId() << L", email: " << CommonUtility::s2ws(user.email()));
     }
 
     // Log drive IDs

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -3905,7 +3905,7 @@ void AppServer::addError(const Error &error) {
         std::unordered_set<int64_t> toBeRemovedErrorIds;
         for (const Error &parentError: errorList) {
             for (const Error &childError: errorList) {
-                if (Utility::isDescendantOrEqual(childError.path(), parentError.path()) &&
+                if (CommonUtility::isDescendantOrEqual(childError.path(), parentError.path()) &&
                     childError.dbId() != parentError.dbId()) {
                     toBeRemovedErrorIds.insert(childError.dbId());
                 }

--- a/src/server/migration/migrationparams.cpp
+++ b/src/server/migration/migrationparams.cpp
@@ -739,7 +739,7 @@ ExitCode MigrationParams::getOldAppPwd(const std::string &keychainKey, std::stri
     }
 #elif defined(KD_WINDOWS)
     CREDENTIAL *cred;
-    bool result = ::CredRead(Utility::s2ws(keychainKey).c_str(), CRED_TYPE_GENERIC, 0, &cred);
+    bool result = ::CredRead(CommonUtility::s2ws(keychainKey).c_str(), CRED_TYPE_GENERIC, 0, &cred);
 
     if (result == TRUE) {
         LOGW_DEBUG(_logger, L"Application password found");
@@ -775,8 +775,8 @@ ExitCode MigrationParams::getTokenFromAppPassword(const std::string &email, cons
 
         LOG_DEBUG(_logger, "job.runSynchronously() done");
         if (job.hasErrorApi(&errorCode, &errorDescr)) {
-            LOGW_WARN(_logger, L"Failed to retrieve authentification token. code=" << KDC::Utility::s2ws(errorCode) << L" descr="
-                                                                                   << KDC::Utility::s2ws(errorDescr));
+            LOGW_WARN(_logger, L"Failed to retrieve authentification token. code=" << KDC::CommonUtility::s2ws(errorCode) << L" descr="
+                                                                                   << KDC::CommonUtility::s2ws(errorDescr));
             return ExitCode::BackError;
         }
 

--- a/src/server/migration/migrationparams.cpp
+++ b/src/server/migration/migrationparams.cpp
@@ -435,8 +435,7 @@ ExitCode MigrationParams::loadAccount(QSettings &settings) {
             QString vfsModeStr = settings.value(QString(virtualFilesModeC), "off").toString();
 
             // Check vfs support
-            QString fsName(KDC::CommonUtility::fileSystemName(SyncName2QStr(localPath.native())));
-            bool supportVfs = (fsName == "NTFS" || fsName == "apfs");
+            bool supportVfs = CommonUtility::isNTFS(localPath) || CommonUtility::isAPFS(localPath);
             sync.setSupportVfs(supportVfs);
             sync.setVirtualFileMode(modeFromString(vfsModeStr));
             sync.setNavigationPaneClsid(settings.value(QString(navigationPaneClsidC)).toString().toStdString());

--- a/src/server/requests/serverrequests.cpp
+++ b/src/server/requests/serverrequests.cpp
@@ -1517,8 +1517,7 @@ ExitCode ServerRequests::addSync(int driveDbId, const QString &localFolderPath, 
     sync.setPaused(false);
 
     // Check vfs support
-    const QString fsName(CommonUtility::fileSystemName(Path2QStr(sync.localPath())));
-    const auto supportVfs = (fsName == "NTFS" || fsName == "apfs");
+    const bool supportVfs = CommonUtility::isNTFS(sync.localPath()) || CommonUtility::isAPFS(sync.localPath());
     sync.setSupportVfs(supportVfs);
 
 #if defined(KD_MACOS)

--- a/src/server/socketapi.cpp
+++ b/src/server/socketapi.cpp
@@ -188,7 +188,7 @@ void SocketApi::executeCommand(const QString &commandLine, const SocketListener 
         staticMetaObject.method(indexOfMethod).invoke(this, Q_ARG(QString, argument));
     } else {
         LOGW_WARN(KDC::Log::instance()->getLogger(), L"The command is not supported by this version of the client - cmd="
-                                                             << KDC::Utility::s2ws(command.toStdString()) << L" arg="
+                                                             << KDC::CommonUtility::s2ws(command.toStdString()) << L" arg="
                                                              << argument.toStdWString());
     }
 }
@@ -1395,7 +1395,7 @@ FileData FileData::get(const KDC::SyncPath &path) {
             } else {
                 LOGW_WARN(KDC::Log::instance()->getLogger(), L"Failed to check if the path is a directory - "
                                                                      << Utility::formatPath(data.localPath) << L" err="
-                                                                     << KDC::Utility::s2ws(ec.message()) << L" (" << ec.value()
+                                                                     << KDC::CommonUtility::s2ws(ec.message()) << L" (" << ec.value()
                                                                      << L")");
             }
             return FileData();

--- a/test/libcommon/utility/testtypes.cpp
+++ b/test/libcommon/utility/testtypes.cpp
@@ -37,7 +37,7 @@ void TestTypes::testStreamConversion() {
     CPPUNIT_ASSERT_EQUAL(std::string("File(1)"), toStringWithCode(NodeType::File));
     CPPUNIT_ASSERT_EQUAL(std::string("Directory(2)"), toStringWithCode(NodeType::Directory));
     CPPUNIT_ASSERT_EQUAL(std::string("Directory(2)"), toStringWithCode(fromInt<NodeType>(2)));
-    CPPUNIT_ASSERT(Utility::startsWith(toStringWithCode(fromInt<NodeType>(3)), noConversionStr));
+    CPPUNIT_ASSERT(CommonUtility::startsWith(toStringWithCode(fromInt<NodeType>(3)), noConversionStr));
 
     CPPUNIT_ASSERT_EQUAL(std::string("None(0)"), toStringWithCode(OperationType::None));
     CPPUNIT_ASSERT_EQUAL(std::string("Create(1)"), toStringWithCode(OperationType::Create));
@@ -45,8 +45,8 @@ void TestTypes::testStreamConversion() {
     CPPUNIT_ASSERT_EQUAL(std::string("Edit(4)"), toStringWithCode(OperationType::Edit));
     CPPUNIT_ASSERT_EQUAL(std::string("Delete(8)"), toStringWithCode(OperationType::Delete));
     CPPUNIT_ASSERT_EQUAL(std::string("Rights(16)"), toStringWithCode(OperationType::Rights));
-    CPPUNIT_ASSERT(Utility::startsWith(toStringWithCode(fromInt<OperationType>(0x09)), noConversionStr));
-    CPPUNIT_ASSERT(Utility::startsWith(toStringWithCode(OperationType::Create | OperationType::Delete), noConversionStr));
+    CPPUNIT_ASSERT(CommonUtility::startsWith(toStringWithCode(fromInt<OperationType>(0x09)), noConversionStr));
+    CPPUNIT_ASSERT(CommonUtility::startsWith(toStringWithCode(OperationType::Create | OperationType::Delete), noConversionStr));
 
     // Test stream operator for enum class without unicode
     std::ostringstream os;

--- a/test/libcommon/utility/testurlhelper.cpp
+++ b/test/libcommon/utility/testurlhelper.cpp
@@ -51,19 +51,19 @@ void TestUrlHelper::testGetUrl() {
     }
 
 
-    CPPUNIT_ASSERT_EQUAL(usePreprod, Utility::contains(UrlHelper::infomaniakApiUrl(), preprodKeyWord));
-    CPPUNIT_ASSERT_EQUAL(false, Utility::contains(UrlHelper::infomaniakApiUrl(2, true), preprodKeyWord));
-    CPPUNIT_ASSERT_EQUAL(usePreprod, Utility::contains(UrlHelper::kDriveApiUrl(), preprodKeyWord));
-    CPPUNIT_ASSERT_EQUAL(usePreprod, Utility::contains(UrlHelper::notifyApiUrl(), preprodKeyWord));
-    CPPUNIT_ASSERT_EQUAL(usePreprod, Utility::contains(UrlHelper::loginApiUrl(), preprodKeyWord));
+    CPPUNIT_ASSERT_EQUAL(usePreprod, CommonUtility::contains(UrlHelper::infomaniakApiUrl(), preprodKeyWord));
+    CPPUNIT_ASSERT_EQUAL(false, CommonUtility::contains(UrlHelper::infomaniakApiUrl(2, true), preprodKeyWord));
+    CPPUNIT_ASSERT_EQUAL(usePreprod, CommonUtility::contains(UrlHelper::kDriveApiUrl(), preprodKeyWord));
+    CPPUNIT_ASSERT_EQUAL(usePreprod, CommonUtility::contains(UrlHelper::notifyApiUrl(), preprodKeyWord));
+    CPPUNIT_ASSERT_EQUAL(usePreprod, CommonUtility::contains(UrlHelper::loginApiUrl(), preprodKeyWord));
 
-    CPPUNIT_ASSERT_EQUAL(true, Utility::endsWith(UrlHelper::infomaniakApiUrl(), "/2"));
-    CPPUNIT_ASSERT_EQUAL(true, Utility::endsWith(UrlHelper::infomaniakApiUrl(123), "/123"));
-    CPPUNIT_ASSERT_EQUAL(true, Utility::endsWith(UrlHelper::infomaniakApiUrl(123, true), "/123"));
-    CPPUNIT_ASSERT_EQUAL(true, Utility::endsWith(UrlHelper::kDriveApiUrl(), "/2"));
-    CPPUNIT_ASSERT_EQUAL(true, Utility::endsWith(UrlHelper::kDriveApiUrl(123), "/123"));
-    CPPUNIT_ASSERT_EQUAL(true, Utility::endsWith(UrlHelper::notifyApiUrl(), "/2"));
-    CPPUNIT_ASSERT_EQUAL(true, Utility::endsWith(UrlHelper::notifyApiUrl(123), "/123"));
+    CPPUNIT_ASSERT_EQUAL(true, CommonUtility::endsWith(UrlHelper::infomaniakApiUrl(), "/2"));
+    CPPUNIT_ASSERT_EQUAL(true, CommonUtility::endsWith(UrlHelper::infomaniakApiUrl(123), "/123"));
+    CPPUNIT_ASSERT_EQUAL(true, CommonUtility::endsWith(UrlHelper::infomaniakApiUrl(123, true), "/123"));
+    CPPUNIT_ASSERT_EQUAL(true, CommonUtility::endsWith(UrlHelper::kDriveApiUrl(), "/2"));
+    CPPUNIT_ASSERT_EQUAL(true, CommonUtility::endsWith(UrlHelper::kDriveApiUrl(123), "/123"));
+    CPPUNIT_ASSERT_EQUAL(true, CommonUtility::endsWith(UrlHelper::notifyApiUrl(), "/2"));
+    CPPUNIT_ASSERT_EQUAL(true, CommonUtility::endsWith(UrlHelper::notifyApiUrl(123), "/123"));
 }
 
 } // namespace KDC

--- a/test/libcommon/utility/testutility.cpp
+++ b/test/libcommon/utility/testutility.cpp
@@ -810,4 +810,26 @@ void TestUtility::testFileSystemName() {
 #endif
 }
 
+void TestUtility::testS2ws() {
+    CPPUNIT_ASSERT(CommonUtility::s2ws("abcd") == L"abcd");
+    CPPUNIT_ASSERT(CommonUtility::s2ws("éèêà") == L"éèêà");
+}
+
+void TestUtility::testWs2s() {
+    CPPUNIT_ASSERT(CommonUtility::ws2s(L"abcd") == "abcd");
+    CPPUNIT_ASSERT(CommonUtility::ws2s(L"éèêà") == "éèêà");
+}
+
+void TestUtility::testLtrim() {
+    CPPUNIT_ASSERT(CommonUtility::ltrim("    ab    cd    ") == "ab    cd    ");
+}
+
+void TestUtility::testRtrim() {
+    CPPUNIT_ASSERT(CommonUtility::rtrim("    ab    cd    ") == "    ab    cd");
+}
+
+void TestUtility::testTrim() {
+    CPPUNIT_ASSERT(CommonUtility::trim("    ab    cd    ") == "ab    cd");
+}
+
 } // namespace KDC

--- a/test/libcommon/utility/testutility.cpp
+++ b/test/libcommon/utility/testutility.cpp
@@ -750,4 +750,64 @@ void TestUtility::testComputePathNormalizations() {
 #endif
 }
 
+void TestUtility::testStartsWith() {
+    CPPUNIT_ASSERT(CommonUtility::startsWith(SyncName(Str("abcdefg")), SyncName(Str("abcd"))));
+    CPPUNIT_ASSERT(!CommonUtility::startsWith(SyncName(Str("abcdefg")), SyncName(Str("ABCD"))));
+}
+
+void TestUtility::testStartsWithInsensitive() {
+    CPPUNIT_ASSERT(CommonUtility::startsWithInsensitive(SyncName(Str("abcdefg")), SyncName(Str("aBcD"))));
+    CPPUNIT_ASSERT(CommonUtility::startsWithInsensitive(SyncName(Str("abcdefg")), SyncName(Str("ABCD"))));
+}
+
+void TestUtility::testEndsWith() {
+    CPPUNIT_ASSERT(CommonUtility::endsWith(SyncName(Str("abcdefg")), SyncName(Str("defg"))));
+    CPPUNIT_ASSERT(!CommonUtility::endsWith(SyncName(Str("abcdefg")), SyncName(Str("abc"))));
+    CPPUNIT_ASSERT(!CommonUtility::endsWith(SyncName(Str("abcdefg")), SyncName(Str("dEfG"))));
+}
+
+void TestUtility::testEndsWithInsensitive() {
+    CPPUNIT_ASSERT(CommonUtility::endsWithInsensitive(SyncName(Str("abcdefg")), SyncName(Str("defg"))));
+    CPPUNIT_ASSERT(!CommonUtility::endsWithInsensitive(SyncName(Str("abcdefg")), SyncName(Str("abc"))));
+    CPPUNIT_ASSERT(CommonUtility::endsWithInsensitive(SyncName(Str("abcdefg")), SyncName(Str("dEfG"))));
+}
+
+void TestUtility::testToUpper() {
+    CPPUNIT_ASSERT_EQUAL(std::string("ABC"), CommonUtility::toUpper("abc"));
+    CPPUNIT_ASSERT_EQUAL(std::string("ABC"), CommonUtility::toUpper("ABC"));
+    CPPUNIT_ASSERT_EQUAL(std::string("ABC"), CommonUtility::toUpper("AbC"));
+    CPPUNIT_ASSERT_EQUAL(std::string(""), CommonUtility::toUpper(""));
+    CPPUNIT_ASSERT_EQUAL(std::string("123"), CommonUtility::toUpper("123"));
+
+    CPPUNIT_ASSERT_EQUAL(std::string("²&é~\"#'{([-|`è_\\ç^à@)]}=+*ù%µ£¤§:;,!.?/"),
+                         CommonUtility::toUpper("²&é~\"#'{([-|`è_\\ç^à@)]}=+*ù%µ£¤§:;,!.?/"));
+}
+
+void TestUtility::testIsSameOrParentPath() {
+    CPPUNIT_ASSERT(!CommonUtility::isDescendantOrEqual("", "a"));
+    CPPUNIT_ASSERT(!CommonUtility::isDescendantOrEqual("a", "a/b"));
+    CPPUNIT_ASSERT(!CommonUtility::isDescendantOrEqual("a", "a/b/c"));
+    CPPUNIT_ASSERT(!CommonUtility::isDescendantOrEqual("a/b", "a/b/c"));
+    CPPUNIT_ASSERT(!CommonUtility::isDescendantOrEqual("a/b/c", "a/b/c1"));
+    CPPUNIT_ASSERT(!CommonUtility::isDescendantOrEqual("a/b/c1", "a/b/c"));
+    CPPUNIT_ASSERT(!CommonUtility::isDescendantOrEqual("/a/b/c", "a/b/c"));
+
+    CPPUNIT_ASSERT(CommonUtility::isDescendantOrEqual("", ""));
+    CPPUNIT_ASSERT(CommonUtility::isDescendantOrEqual("a/b/c", "a/b/c"));
+    CPPUNIT_ASSERT(CommonUtility::isDescendantOrEqual("a", ""));
+    CPPUNIT_ASSERT(CommonUtility::isDescendantOrEqual("a/b/c", "a/b"));
+    CPPUNIT_ASSERT(CommonUtility::isDescendantOrEqual("a/b/c", "a"));
+}
+
+void TestUtility::testFileSystemName() {
+#if defined(KD_MACOS)
+    CPPUNIT_ASSERT(CommonUtility::fileSystemName("/") == "apfs");
+    CPPUNIT_ASSERT(CommonUtility::fileSystemName("/bin") == "apfs");
+#elif defined(KD_WINDOWS)
+    CPPUNIT_ASSERT(CommonUtility::fileSystemName(std::filesystem::temp_directory_path()) == "NTFS");
+    // CPPUNIT_ASSERT(CommonUtility::fileSystemName(R"(C:\)") == "NTFS");
+    // CPPUNIT_ASSERT(CommonUtility::fileSystemName(R"(C:\windows)") == "NTFS");
+#endif
+}
+
 } // namespace KDC

--- a/test/libcommon/utility/testutility.h
+++ b/test/libcommon/utility/testutility.h
@@ -48,6 +48,13 @@ class TestUtility : public CppUnit::TestFixture, public TestBase {
 #if defined(KD_WINDOWS)
         CPPUNIT_TEST(testGetLastErrorMessage);
 #endif
+        CPPUNIT_TEST(testStartsWith);
+        CPPUNIT_TEST(testStartsWithInsensitive);
+        CPPUNIT_TEST(testEndsWith);
+        CPPUNIT_TEST(testEndsWithInsensitive);
+        CPPUNIT_TEST(testToUpper);
+        CPPUNIT_TEST(testIsSameOrParentPath);
+        CPPUNIT_TEST(testFileSystemName);
         CPPUNIT_TEST_SUITE_END();
 
     public:
@@ -77,6 +84,13 @@ class TestUtility : public CppUnit::TestFixture, public TestBase {
 #if defined(KD_WINDOWS)
         void testGetLastErrorMessage();
 #endif
+        void testStartsWith();
+        void testStartsWithInsensitive();
+        void testEndsWith();
+        void testEndsWithInsensitive();
+        void testToUpper();
+        void testIsSameOrParentPath();
+        void testFileSystemName();
 
     private:
         /* Generate all the possible path for a set of items and separators

--- a/test/libcommon/utility/testutility.h
+++ b/test/libcommon/utility/testutility.h
@@ -55,6 +55,11 @@ class TestUtility : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST(testToUpper);
         CPPUNIT_TEST(testIsSameOrParentPath);
         CPPUNIT_TEST(testFileSystemName);
+        CPPUNIT_TEST(testS2ws);
+        CPPUNIT_TEST(testWs2s);
+        CPPUNIT_TEST(testLtrim);
+        CPPUNIT_TEST(testRtrim);
+        CPPUNIT_TEST(testTrim);
         CPPUNIT_TEST_SUITE_END();
 
     public:
@@ -91,6 +96,11 @@ class TestUtility : public CppUnit::TestFixture, public TestBase {
         void testToUpper();
         void testIsSameOrParentPath();
         void testFileSystemName();
+        void testS2ws();
+        void testWs2s();
+        void testLtrim();
+        void testRtrim();
+        void testTrim();
 
     private:
         /* Generate all the possible path for a set of items and separators

--- a/test/libcommonserver/io/testgetlongpathname.cpp
+++ b/test/libcommonserver/io/testgetlongpathname.cpp
@@ -18,7 +18,7 @@
 
 #include "testio.h"
 
-#include "libcommonserver/utility/utility.h" // Path2Str
+#include "libcommon/utility/utility.h" // Path2Str
 
 #include <windows.h>
 

--- a/test/libcommonserver/utility/testutility.cpp
+++ b/test/libcommonserver/utility/testutility.cpp
@@ -72,29 +72,6 @@ void TestUtility::testIsCreationDateValid(void) {
                            _testObj->isCreationDateValid(futureTimestamp));
 }
 
-
-void TestUtility::testS2ws() {
-    CPPUNIT_ASSERT(_testObj->s2ws("abcd") == L"abcd");
-    CPPUNIT_ASSERT(_testObj->s2ws("éèêà") == L"éèêà");
-}
-
-void TestUtility::testWs2s() {
-    CPPUNIT_ASSERT(_testObj->ws2s(L"abcd") == "abcd");
-    CPPUNIT_ASSERT(_testObj->ws2s(L"éèêà") == "éèêà");
-}
-
-void TestUtility::testLtrim() {
-    CPPUNIT_ASSERT(_testObj->ltrim("    ab    cd    ") == "ab    cd    ");
-}
-
-void TestUtility::testRtrim() {
-    CPPUNIT_ASSERT(_testObj->rtrim("    ab    cd    ") == "    ab    cd");
-}
-
-void TestUtility::testTrim() {
-    CPPUNIT_ASSERT(_testObj->trim("    ab    cd    ") == "ab    cd");
-}
-
 void TestUtility::testMsSleep() {
     auto start = std::chrono::high_resolution_clock::now();
     _testObj->msleep(1000);
@@ -354,7 +331,7 @@ void TestUtility::testFormatStdError() {
                            result.find(L"error: 0") != std::wstring::npos || result.find(L"code: 0") != std::wstring::npos);
     CPPUNIT_ASSERT_MESSAGE("The error message should contain a description.", (result.length() - path.native().length()) > 20);
     CPPUNIT_ASSERT_MESSAGE("The error message should contain the path.",
-                           result.find(Utility::s2ws(path.string())) != std::wstring::npos);
+                           result.find(CommonUtility::s2ws(path.string())) != std::wstring::npos);
 }
 
 void TestUtility::testFormatIoError() {
@@ -367,7 +344,7 @@ void TestUtility::testFormatIoError() {
         CPPUNIT_ASSERT_MESSAGE("The error message should contain a description.",
                                (result.length() - path.native().length()) > 20);
         CPPUNIT_ASSERT_MESSAGE("The error message should contain the path.",
-                               result.find(Utility::s2ws(path.string())) != std::wstring::npos);
+                               result.find(CommonUtility::s2ws(path.string())) != std::wstring::npos);
     }
 
     {
@@ -395,7 +372,7 @@ void TestUtility::testFormatPath() {
 
 void TestUtility::testFormatSyncPath() {
     const SyncPath path = "A/AA";
-    CPPUNIT_ASSERT(Utility::formatSyncPath(path).find(Utility::s2ws(path.string())) != std::wstring::npos);
+    CPPUNIT_ASSERT(Utility::formatSyncPath(path).find(CommonUtility::s2ws(path.string())) != std::wstring::npos);
 }
 
 void TestUtility::testFormatRequest() {

--- a/test/libcommonserver/utility/testutility.cpp
+++ b/test/libcommonserver/utility/testutility.cpp
@@ -123,39 +123,6 @@ void TestUtility::testV2ws() {
     CPPUNIT_ASSERT(_testObj->v2ws(stringValue) == L"hello");
 }
 
-void TestUtility::testFileSystemName() {
-#if defined(KD_MACOS)
-    CPPUNIT_ASSERT(_testObj->fileSystemName("/") == "apfs");
-    CPPUNIT_ASSERT(_testObj->fileSystemName("/bin") == "apfs");
-#elif defined(KD_WINDOWS)
-    CPPUNIT_ASSERT(_testObj->fileSystemName(std::filesystem::temp_directory_path()) == "NTFS");
-    // CPPUNIT_ASSERT(_testObj->fileSystemName(R"(C:\)") == "NTFS");
-    // CPPUNIT_ASSERT(_testObj->fileSystemName(R"(C:\windows)") == "NTFS");
-#endif
-}
-
-void TestUtility::testStartsWith() {
-    CPPUNIT_ASSERT(_testObj->startsWith(SyncName(Str("abcdefg")), SyncName(Str("abcd"))));
-    CPPUNIT_ASSERT(!_testObj->startsWith(SyncName(Str("abcdefg")), SyncName(Str("ABCD"))));
-}
-
-void TestUtility::testStartsWithInsensitive() {
-    CPPUNIT_ASSERT(_testObj->startsWithInsensitive(SyncName(Str("abcdefg")), SyncName(Str("aBcD"))));
-    CPPUNIT_ASSERT(_testObj->startsWithInsensitive(SyncName(Str("abcdefg")), SyncName(Str("ABCD"))));
-}
-
-void TestUtility::testEndsWith() {
-    CPPUNIT_ASSERT(_testObj->endsWith(SyncName(Str("abcdefg")), SyncName(Str("defg"))));
-    CPPUNIT_ASSERT(!_testObj->endsWith(SyncName(Str("abcdefg")), SyncName(Str("abc"))));
-    CPPUNIT_ASSERT(!_testObj->endsWith(SyncName(Str("abcdefg")), SyncName(Str("dEfG"))));
-}
-
-void TestUtility::testEndsWithInsensitive() {
-    CPPUNIT_ASSERT(_testObj->endsWithInsensitive(SyncName(Str("abcdefg")), SyncName(Str("defg"))));
-    CPPUNIT_ASSERT(!_testObj->endsWithInsensitive(SyncName(Str("abcdefg")), SyncName(Str("abc"))));
-    CPPUNIT_ASSERT(_testObj->endsWithInsensitive(SyncName(Str("abcdefg")), SyncName(Str("dEfG"))));
-}
-
 void TestUtility::testIsEqualUpToCaseAndEnc(void) {
     bool isEqual = false;
     const SyncPath pathA{"abcdefg"};
@@ -289,17 +256,6 @@ void TestUtility::testXxHash() {
     std::string contentHash = _testObj->computeXxHash(data);
 
     CPPUNIT_ASSERT(contentHash == "5dcc477e35136516");
-}
-
-void TestUtility::testToUpper() {
-    CPPUNIT_ASSERT_EQUAL(std::string("ABC"), _testObj->toUpper("abc"));
-    CPPUNIT_ASSERT_EQUAL(std::string("ABC"), _testObj->toUpper("ABC"));
-    CPPUNIT_ASSERT_EQUAL(std::string("ABC"), _testObj->toUpper("AbC"));
-    CPPUNIT_ASSERT_EQUAL(std::string(""), _testObj->toUpper(""));
-    CPPUNIT_ASSERT_EQUAL(std::string("123"), _testObj->toUpper("123"));
-
-    CPPUNIT_ASSERT_EQUAL(std::string("²&é~\"#'{([-|`è_\\ç^à@)]}=+*ù%µ£¤§:;,!.?/"),
-                         _testObj->toUpper("²&é~\"#'{([-|`è_\\ç^à@)]}=+*ù%µ£¤§:;,!.?/"));
 }
 
 void TestUtility::testErrId() {
@@ -504,22 +460,6 @@ bool TestUtility::checkNfcAndNfdNamesEqual(const SyncName &name, bool &equal) {
     }
     equal = (nfcNormalized == nfdNormalized);
     return true;
-}
-
-void TestUtility::testIsSameOrParentPath() {
-    CPPUNIT_ASSERT(!Utility::isDescendantOrEqual("", "a"));
-    CPPUNIT_ASSERT(!Utility::isDescendantOrEqual("a", "a/b"));
-    CPPUNIT_ASSERT(!Utility::isDescendantOrEqual("a", "a/b/c"));
-    CPPUNIT_ASSERT(!Utility::isDescendantOrEqual("a/b", "a/b/c"));
-    CPPUNIT_ASSERT(!Utility::isDescendantOrEqual("a/b/c", "a/b/c1"));
-    CPPUNIT_ASSERT(!Utility::isDescendantOrEqual("a/b/c1", "a/b/c"));
-    CPPUNIT_ASSERT(!Utility::isDescendantOrEqual("/a/b/c", "a/b/c"));
-
-    CPPUNIT_ASSERT(Utility::isDescendantOrEqual("", ""));
-    CPPUNIT_ASSERT(Utility::isDescendantOrEqual("a/b/c", "a/b/c"));
-    CPPUNIT_ASSERT(Utility::isDescendantOrEqual("a", ""));
-    CPPUNIT_ASSERT(Utility::isDescendantOrEqual("a/b/c", "a/b"));
-    CPPUNIT_ASSERT(Utility::isDescendantOrEqual("a/b/c", "a"));
 }
 
 void TestUtility::testUserName() {

--- a/test/libcommonserver/utility/testutility.h
+++ b/test/libcommonserver/utility/testutility.h
@@ -28,11 +28,6 @@ class TestUtility : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST_SUITE(TestUtility);
         CPPUNIT_TEST(testFreeDiskSpace);
         CPPUNIT_TEST(testIsCreationDateValid);
-        CPPUNIT_TEST(testS2ws);
-        CPPUNIT_TEST(testWs2s);
-        CPPUNIT_TEST(testLtrim);
-        CPPUNIT_TEST(testRtrim);
-        CPPUNIT_TEST(testTrim);
         CPPUNIT_TEST(testMsSleep);
         CPPUNIT_TEST(testV2ws);
         CPPUNIT_TEST(testFormatStdError);
@@ -66,11 +61,6 @@ class TestUtility : public CppUnit::TestFixture, public TestBase {
     protected:
         void testFreeDiskSpace();
         void testIsCreationDateValid();
-        void testS2ws();
-        void testWs2s();
-        void testLtrim();
-        void testRtrim();
-        void testTrim();
         void testMsSleep();
         void testV2ws();
         void testFormatStdError();

--- a/test/libcommonserver/utility/testutility.h
+++ b/test/libcommonserver/utility/testutility.h
@@ -41,11 +41,6 @@ class TestUtility : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST(testFormatPath);
         CPPUNIT_TEST(testFormatSyncPath);
         CPPUNIT_TEST(testFormatRequest);
-        CPPUNIT_TEST(testFileSystemName);
-        CPPUNIT_TEST(testStartsWith);
-        CPPUNIT_TEST(testStartsWithInsensitive);
-        CPPUNIT_TEST(testEndsWith);
-        CPPUNIT_TEST(testEndsWithInsensitive);
         CPPUNIT_TEST(testIsEqualUpToCaseAndEnc);
         CPPUNIT_TEST(testMoveItemToTrash);
         CPPUNIT_TEST(testStr2HexStr);
@@ -55,14 +50,12 @@ class TestUtility : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST(testPathDepth);
         CPPUNIT_TEST(testComputeMd5Hash);
         CPPUNIT_TEST(testXxHash);
-        CPPUNIT_TEST(testToUpper);
         CPPUNIT_TEST(testErrId);
         CPPUNIT_TEST(testCheckIfDirEntryIsManaged);
         CPPUNIT_TEST(testIsSubDir);
         CPPUNIT_TEST(testIsDiskRootFolder);
         CPPUNIT_TEST(testNormalizedSyncName);
         CPPUNIT_TEST(testNormalizedSyncPath);
-        CPPUNIT_TEST(testIsSameOrParentPath);
         CPPUNIT_TEST(testUserName);
         CPPUNIT_TEST_SUITE_END();
 
@@ -86,11 +79,6 @@ class TestUtility : public CppUnit::TestFixture, public TestBase {
         void testFormatSyncName();
         void testFormatSyncPath();
         void testFormatRequest();
-        void testFileSystemName();
-        void testStartsWith();
-        void testStartsWithInsensitive();
-        void testEndsWith();
-        void testEndsWithInsensitive();
         void testIsEqualUpToCaseAndEnc();
         void testMoveItemToTrash();
         void testGetLinuxDesktopType();
@@ -102,14 +90,12 @@ class TestUtility : public CppUnit::TestFixture, public TestBase {
         void testPathDepth();
         void testComputeMd5Hash();
         void testXxHash();
-        void testToUpper();
         void testErrId();
         void testIsSubDir();
         void testIsDiskRootFolder();
         void testCheckIfDirEntryIsManaged();
         void testNormalizedSyncName();
         void testNormalizedSyncPath();
-        void testIsSameOrParentPath();
         void testUserName();
 
     private:

--- a/test/libsyncengine/integration/testintegration.cpp
+++ b/test/libsyncengine/integration/testintegration.cpp
@@ -840,7 +840,7 @@ SyncPath TestIntegration::findLocalFileByNamePrefix(const SyncPath &parentAbsolu
     bool endOfDir = false;
     DirectoryEntry entry;
     while (dirIt.next(entry, endOfDir, ioError) && !endOfDir && ioError == IoError::Success) {
-        if (Utility::startsWith(entry.path().filename(), namePrefix)) return entry.path();
+        if (CommonUtility::startsWith(entry.path().filename(), namePrefix)) return entry.path();
     }
     return SyncPath();
 }

--- a/test/libsyncengine/jobs/network/testsnapshotitemhandler.cpp
+++ b/test/libsyncengine/jobs/network/testsnapshotitemhandler.cpp
@@ -21,6 +21,7 @@
 #include "jobs/network/API_v2/listing/snapshotitemhandler.h"
 #include "libcommonserver/log/log.h"
 #include "update_detection/file_system_observer/snapshot/snapshotitem.h"
+#include "libcommon/utility/utility.h"
 
 using namespace CppUnit;
 
@@ -49,7 +50,7 @@ Result compare(const SnapshotItem &lhs, const SnapshotItem &rhs) noexcept {
         CPPUNIT_ASSERT_EQUAL(lhs.isLink(), rhs.isLink());
     } catch (const CppUnit::Exception &e) {
         return Result{false, makeMessage(e)};
-    };
+    }
 
     return {};
 }

--- a/test/test_classes/testsituationgenerator.cpp
+++ b/test/test_classes/testsituationgenerator.cpp
@@ -186,8 +186,8 @@ void TestSituationGenerator::insertInAllSnapshot(const NodeType itemType, const 
         if (!(side == ReplicaSide::Local ? _localLiveSnapshot : _remoteLiveSnapshot).has_value()) continue;
         const auto size = itemType == NodeType::File ? testhelpers::defaultFileSize : testhelpers::defaultDirSize;
         const auto parentFinalId = parentId.empty() ? "1" : generateId(side, parentId);
-        const SnapshotItem item(generateId(side, id), parentFinalId, Str2SyncName(Utility::toUpper(id)), testhelpers::defaultTime,
-                                testhelpers::defaultTime, itemType, size, false, true, true);
+        const SnapshotItem item(generateId(side, id), parentFinalId, Str2SyncName(CommonUtility::toUpper(id)),
+                                testhelpers::defaultTime, testhelpers::defaultTime, itemType, size, false, true, true);
         (void) liveSnapshot(side).updateItem(item);
     }
 }
@@ -207,7 +207,7 @@ DbNodeId TestSituationGenerator::insertInDb(const NodeType itemType, const NodeI
     }
 
     const auto size = itemType == NodeType::File ? testhelpers::defaultFileSize : testhelpers::defaultDirSize;
-    const DbNode dbNode(parentNode.nodeId(), Str2SyncName(Utility::toUpper(id)), Str2SyncName(Utility::toUpper(id)),
+    const DbNode dbNode(parentNode.nodeId(), Str2SyncName(CommonUtility::toUpper(id)), Str2SyncName(CommonUtility::toUpper(id)),
                         generateId(ReplicaSide::Local, id), generateId(ReplicaSide::Remote, id), testhelpers::defaultTime,
                         testhelpers::defaultTime, testhelpers::defaultTime, itemType, size);
     DbNodeId dbNodeId = 0;
@@ -223,7 +223,7 @@ std::shared_ptr<Node> TestSituationGenerator::insertInUpdateTree(
             parentId.empty() ? updateTree(side)->rootNode() : updateTree(side)->getNodeById(generateId(side, parentId));
     const auto size = itemType == NodeType::File ? testhelpers::defaultFileSize : testhelpers::defaultDirSize;
     const auto node =
-            std::make_shared<Node>(dbNodeId, side, Str2SyncName(Utility::toUpper(id)), itemType, OperationType::None,
+            std::make_shared<Node>(dbNodeId, side, Str2SyncName(CommonUtility::toUpper(id)), itemType, OperationType::None,
                                    generateId(side, id), testhelpers::defaultTime, testhelpers::defaultTime, size, parentNode);
     updateTree(side)->insertNode(node);
     (void) parentNode->insertChildren(node);

--- a/test/test_utility/remotetemporarydirectory.cpp
+++ b/test/test_utility/remotetemporarydirectory.cpp
@@ -75,7 +75,7 @@ void RemoteTemporaryDirectory::createDirectory(const int driveDbId, const NodeId
         CPPUNIT_ASSERT_MESSAGE("RemoteTemporaryDirectory() Failed to extract the file id (2).", dataObj);
         _dirId = dataObj->get(idKey).toString();
         LOGW_INFO(Log::instance()->getLogger(), L"RemoteTemporaryDirectory created: " << Utility::formatSyncName(_dirName)
-                                                                                      << L" with ID: " << Utility::s2ws(_dirId));
+                                                                                      << L" with ID: " << CommonUtility::s2ws(_dirId));
         break;
     } while (true);
 }

--- a/test/test_utility/testhelpers.h
+++ b/test/test_utility/testhelpers.h
@@ -34,7 +34,7 @@ std::string loadEnvVariable(const std::string &key, bool mandatory);
 inline const SyncPath localTestDirPath() {
     static SyncPath localTestDirPath;
     if (!localTestDirPath.empty()) return localTestDirPath;
-    localTestDirPath = Utility::s2ws(loadEnvVariable("KDRIVE_TEST_CI_LOCAL_PATH", true));
+    localTestDirPath = CommonUtility::s2ws(loadEnvVariable("KDRIVE_TEST_CI_LOCAL_PATH", true));
     LOGW_INFO(Log::instance()->getLogger(), L"test_ci dir is: " << Utility::formatSyncPath(localTestDirPath));
     return localTestDirPath;
 }


### PR DESCRIPTION
Refactoring:
- move the string utility functions from `libcommonserver` to `libcommon`
- generalize functions to check filesystem type