### PR TITLE
Keep local creation time if remote value is null

### DIFF
--- a/src/libcommon/utility/jsonparserutility.h
+++ b/src/libcommon/utility/jsonparserutility.h
@@ -27,17 +27,17 @@
 
 namespace KDC {
 
-struct COMMONSERVER_EXPORT JsonParserUtility {
+struct JsonParserUtility {
         template<typename T>
         static bool extractValue(const Poco::JSON::Object::Ptr obj, const std::string &key, T &val, const bool mandatory = true) {
             val = T();
             if (!obj) {
                 LOG_WARN(Log::instance()->getLogger(), "JSON object is NULL");
                 return false;
-            } // namespace KDC
+            }
 
             if (obj->has(key) && obj->isNull(key)) {
-                // Item exist in JSON but is null, this is ok
+                // Item exists in JSON but is null, this is ok
                 return true;
             }
 


### PR DESCRIPTION
If no creation time was previously set on remote side, after editing a file locally, its local value was lost and `0` was inserted in DB instead.
We now keep local creation time if the remote value is `null` or `0`.