### PR TITLE
fix(build-release-scripts): add `CONAN_DEP_DIR` variable to Linux Podman scripts

### DIFF
--- a/infomaniak-build-tools/linux/build-release-appimage-amd64.sh
+++ b/infomaniak-build-tools/linux/build-release-appimage-amd64.sh
@@ -54,6 +54,7 @@ build_folder="$PWD"
 cd /src
 
 conan_folder=/build/conan
+conan_dependencies_folder=/app/build/client/conan_dependencies/
 
 build_type="RelWithDebInfo"
 
@@ -75,6 +76,7 @@ cmake -DCMAKE_PREFIX_PATH="$QT_BASE_DIR" \
     -DKDRIVE_THEME_DIR="/src/infomaniak" \
     -DBUILD_UNIT_TESTS=0 \
     -DCMAKE_TOOLCHAIN_FILE="$conan_toolchain_file" \
+    -DCONAN_DEP_DIR="$conan_dependencies_folder" \
     "${CMAKE_PARAMS[@]}" \
     /src
 make "-j$(nproc)"

--- a/infomaniak-build-tools/linux/build-release-appimage-arm64.sh
+++ b/infomaniak-build-tools/linux/build-release-appimage-arm64.sh
@@ -54,6 +54,7 @@ build_folder=$PWD
 cd /src
 
 conan_folder=/build/conan
+conan_dependencies_folder=/app/build/client/conan_dependencies/
 
 build_type="RelWithDebInfo"
 
@@ -75,6 +76,7 @@ cmake -DCMAKE_PREFIX_PATH="$QT_BASE_DIR" \
     -DKDRIVE_THEME_DIR="/src/infomaniak" \
     -DBUILD_UNIT_TESTS=0 \
     -DCMAKE_TOOLCHAIN_FILE="$conan_toolchain_file" \
+    -DCONAN_DEP_DIR="$conan_dependencies_folder" \
     "${CMAKE_PARAMS[@]}" \
     /src
 make "-j$(nproc)"


### PR DESCRIPTION
This PR explicitly defines the `CONAN_DEP_DIR` variable in the build scripts for both `AMD64` and `ARM64` AppImage releases.

Previously, the default value of `CONAN_DEP_DIR` was implicitly set, but this behavior has been removed.
As a result, we now need to explicitly specify the path to the Conan dependencies folder to ensure the build process works correctly.

**Changes:**
- Introduced a new local variable:
  ```bash
  conan_dependencies_folder=/app/build/client/conan_dependencies/
  ```

- Injected the bash variable into the CMake variable:
  ```bash
  -DCONAN_DEP_DIR="$conan_dependencies_folder" \
  ```