### PR TITLE
Revert "fix: do not sort operation that are omitted"

### DIFF
--- a/src/libsyncengine/propagation/operation_sorter/operationsorterfilter.cpp
+++ b/src/libsyncengine/propagation/operation_sorter/operationsorterfilter.cpp
@@ -60,7 +60,6 @@ void OperationSorterFilter::clear() {
 
 // delete before move, e.g. user deletes an object at path "x" and moves another object "a" to "x".
 void OperationSorterFilter::filterDeleteBeforeMoveCandidates(const SyncOpPtr &op, NameToOpMap &deleteBeforeMoveCandidates) {
-    if (op->omit()) return;
     if (op->type() == OperationType::Delete || op->type() == OperationType::Move) {
         if (const auto [_, ok] = deleteBeforeMoveCandidates.try_emplace(op->affectedNode()->normalizedName(), op); !ok) {
             const auto &otherOp = deleteBeforeMoveCandidates.at(op->affectedNode()->normalizedName());
@@ -73,7 +72,6 @@ void OperationSorterFilter::filterDeleteBeforeMoveCandidates(const SyncOpPtr &op
 }
 
 void OperationSorterFilter::filterMoveBeforeCreateCandidates(const SyncOpPtr &op, NameToOpMap &moveBeforeCreateCandidates) {
-    if (op->omit()) return;
     if (op->type() == OperationType::Create) {
         const SyncName name = op->affectedNode()->normalizedName();
         if (const auto &[_, ok] = moveBeforeCreateCandidates.try_emplace(name, op); !ok) {
@@ -99,7 +97,6 @@ void OperationSorterFilter::filterMoveBeforeCreateCandidates(const SyncOpPtr &op
 
 void OperationSorterFilter::filterMoveBeforeDeleteCandidates(const SyncOpPtr &op, SyncPathToSyncOpMap &deletedDirectoryPaths,
                                                              SyncPathToSyncOpMap &moveOriginPaths) {
-    if (op->omit()) return;
     if (op->type() == OperationType::Delete) {
         if (op->affectedNode()->type() != NodeType::Directory) {
             return;
@@ -142,7 +139,6 @@ void OperationSorterFilter::filterMoveBeforeDeleteCandidates(const SyncOpPtr &op
 
 void OperationSorterFilter::filterCreateBeforeMoveCandidates(const SyncOpPtr &op, SyncPathToSyncOpMap &createdDirectoryPaths,
                                                              SyncPathToSyncOpMap &moveDestinationPaths) {
-    if (op->omit()) return;
     if (op->type() == OperationType::Create) {
         if (op->affectedNode()->type() != NodeType::Directory) {
             return;
@@ -189,7 +185,6 @@ void OperationSorterFilter::filterCreateBeforeMoveCandidates(const SyncOpPtr &op
     }
 }
 void OperationSorterFilter::filterDeleteBeforeCreateCandidates(const SyncOpPtr &op, NameToOpMap &deleteBeforeCreateCandidates) {
-    if (op->omit()) return;
     if (op->type() == OperationType::Delete) {
         if (const auto [_, ok] = deleteBeforeCreateCandidates.try_emplace(op->affectedNode()->normalizedName(), op); !ok) {
             const auto &otherOp = deleteBeforeCreateCandidates.at(op->affectedNode()->normalizedName());
@@ -212,7 +207,7 @@ void OperationSorterFilter::filterDeleteBeforeCreateCandidates(const SyncOpPtr &
 
 void OperationSorterFilter::filterMoveBeforeMoveOccupiedCandidates(const SyncOpPtr &op, NameToOpMap &moveOriginNames,
                                                                    NameToOpMap &moveDestinationNames) {
-    if (op->type() != OperationType::Move || op->omit()) return;
+    if (op->type() != OperationType::Move) return;
 
     const SyncName originName = op->affectedNode()->moveOriginInfos().normalizedPath().filename().native();
     const SyncName destinationName = op->affectedNode()->normalizedName();
@@ -239,7 +234,6 @@ void OperationSorterFilter::filterMoveBeforeMoveOccupiedCandidates(const SyncOpP
 }
 
 void OperationSorterFilter::filterEditBeforeMoveCandidates(const SyncOpPtr &op) {
-    if (op->omit()) return;
     if (op->affectedNode()->hasChangeEvent(OperationType::Edit) && op->affectedNode()->hasChangeEvent(OperationType::Move)) {
         (void) _fixEditBeforeMoveCandidates[op->affectedNode()->idb().value()].emplace_back(op);
         return;
@@ -266,7 +260,7 @@ void OperationSorterFilter::filterEditBeforeMoveCandidates(const SyncOpPtr &op) 
 
 void OperationSorterFilter::filterMoveBeforeMoveHierarchyFlipCandidates(
         const SyncOpPtr &op, std::list<std::pair<SyncOpPtr, SyncPath>> &moveBeforeMoveHierarchyFlipCandidates) {
-    if (op->type() != OperationType::Move || op->nodeType() != NodeType::Directory || op->omit()) return;
+    if (op->type() != OperationType::Move || op->nodeType() != NodeType::Directory) return;
 
     const auto &originPath = op->affectedNode()->moveOriginInfos().normalizedPath();
     SyncPath normalizedDestinationPath;

--- a/src/libsyncengine/propagation/operation_sorter/operationsorterworker.cpp
+++ b/src/libsyncengine/propagation/operation_sorter/operationsorterworker.cpp
@@ -264,7 +264,7 @@ void OperationSorterWorker::fixCreateBeforeCreate() {
     for (const auto &opId: _syncPal->_syncOps->opSortedList()) {
         SyncOpPtr createOp = _syncPal->_syncOps->getOp(opId);
         LOG_IF_FAIL(createOp)
-        if (createOp->type() != OperationType::Create || createOp->omit()) {
+        if (createOp->type() != OperationType::Create) {
             continue;
         }
 

--- a/test/libsyncengine/propagation/operation_sorter/testoperationsorterworker.cpp
+++ b/test/libsyncengine/propagation/operation_sorter/testoperationsorterworker.cpp
@@ -357,44 +357,12 @@ void TestOperationSorterWorker::testFixCreateBeforeCreate() {
 
     _syncPal->syncOps()->clear();
     {
-        // Case : DA DAA DAB D DB but operations are omitted.
-        opDA->setOmit(true);
+        // Case : DA DAA DAB D DB
         (void) _syncPal->syncOps()->pushOp(opDA);
-        opDAA->setOmit(true);
-        (void) _syncPal->syncOps()->pushOp(opDAA);
-        opDAB->setOmit(true);
-        (void) _syncPal->syncOps()->pushOp(opDAB);
-        opD->setOmit(true);
-        (void) _syncPal->syncOps()->pushOp(opD);
-        opDB->setOmit(true);
-        (void) _syncPal->syncOps()->pushOp(opDB);
-
-        do {
-            _syncPal->_operationsSorterWorker->_hasOrderChanged = false;
-            _syncPal->_operationsSorterWorker->fixCreateBeforeCreate();
-        } while (_syncPal->_operationsSorterWorker->_hasOrderChanged);
-
-        CPPUNIT_ASSERT(isFirstBeforeSecond(_syncPal->syncOps(), opDA, opD));
-        CPPUNIT_ASSERT(isFirstBeforeSecond(_syncPal->syncOps(), opD, opDB));
-        CPPUNIT_ASSERT(isFirstBeforeSecond(_syncPal->syncOps(), opDA, opDAA));
-        CPPUNIT_ASSERT(isFirstBeforeSecond(_syncPal->syncOps(), opDA, opDAB));
-        CPPUNIT_ASSERT(isFirstBeforeSecond(_syncPal->syncOps(), opDAB, opDB));
-
-        opDA->setOmit(false);
-        opDAA->setOmit(false);
-        opDAB->setOmit(false);
-        opD->setOmit(false);
-        opDB->setOmit(false);
-    }
-
-    _syncPal->syncOps()->clear();
-    {
-        // Case : D DA DB DAA DAB
-        (void) _syncPal->syncOps()->pushOp(opD);
-        (void) _syncPal->syncOps()->pushOp(opDA);
-        (void) _syncPal->syncOps()->pushOp(opDB);
         (void) _syncPal->syncOps()->pushOp(opDAA);
         (void) _syncPal->syncOps()->pushOp(opDAB);
+        (void) _syncPal->syncOps()->pushOp(opD);
+        (void) _syncPal->syncOps()->pushOp(opDB);
 
         do {
             _syncPal->_operationsSorterWorker->_hasOrderChanged = false;


### PR DESCRIPTION
This PR address a regression introduced in : https://github.com/Infomaniak/desktop-kDrive/pull/935/commits.

Indeed, even pseudo conflict operations must be sorted because a parent item must be inserted in DB before its child. Otherwise, the child's `parentDbId` will be invalid.