### PR TITLE
Restrain local access right on special folders

### DIFF
--- a/src/libcommonserver/CMakeLists.txt
+++ b/src/libcommonserver/CMakeLists.txt
@@ -42,7 +42,7 @@ set(libcommonserver_SRCS
     # Io
     io/filestat.h
     io/iohelper.h io/iohelper.cpp
-    io/permissionsholder.h
+    io/permissionsholder.h io/permissionsholder.cpp
     # VFS
     vfs/vfs.h vfs/vfs.cpp
     vfs/workerinfo.h vfs/vfsworker.h

--- a/src/libcommonserver/CMakeLists.txt
+++ b/src/libcommonserver/CMakeLists.txt
@@ -42,6 +42,8 @@ set(libcommonserver_SRCS
     # Io
     io/filestat.h
     io/iohelper.h io/iohelper.cpp
+    io/permissionsholder.h
+    # VFS
     vfs/vfs.h vfs/vfs.cpp
     vfs/workerinfo.h vfs/vfsworker.h
     vfs/plugin.h vfs/plugin.cpp

--- a/src/libcommonserver/io/filestat.h
+++ b/src/libcommonserver/io/filestat.h
@@ -31,6 +31,7 @@ struct FileStat {
         // Type of the item or target item if symlink
         // Value for a dangling symlink: NodeType::Unknown (macOS & Linux), NodeType::File/NodeType::Directory (Windows)
         NodeType nodeType = NodeType::Unknown;
+        uint32_t _flags{0};
 };
 
 } // namespace KDC

--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -296,7 +296,7 @@ bool IoHelper::_checkIfIsHiddenFile(const SyncPath &path, bool &isHidden, IoErro
 
 bool IoHelper::getRights(const SyncPath &path, bool &read, bool &write, bool &exec, IoError &ioError) noexcept {
     ioError = getRights(path, read, write, exec);
-    return isExpectedError(ioError);
+    return ioError == IoError::Success || isExpectedError(ioError);
 }
 
 IoError IoHelper::getRights(const SyncPath &path, bool &read, bool &write, bool &exec) noexcept {
@@ -1038,7 +1038,7 @@ void IoHelper::DirectoryIterator::disableRecursionPending() {
 // See iohelper_win.cpp for the Windows implementation
 bool IoHelper::setRights(const SyncPath &path, bool read, bool write, bool exec, IoError &ioError) noexcept {
     ioError = setRights(path, read, write, exec);
-    return isExpectedError(ioError);
+    return ioError == IoError::Success || isExpectedError(ioError);
 }
 
 IoError IoHelper::setRights(const SyncPath &path, bool read, bool write, bool exec) noexcept {

--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -327,7 +327,12 @@ IoError IoHelper::getRights(const SyncPath &path, bool &read, bool &write, bool 
 
     read = ((perms & std::filesystem::perms::owner_read) != std::filesystem::perms::none);
 #if defined(KD_MACOS)
-    write = isLocked(path) ? false : ((perms & std::filesystem::perms::owner_write) != std::filesystem::perms::none);
+    bool isLocked = false;
+    if (IoError ioError = IoHelper::isLocked(path, isLocked); ioError != IoError::Success) {
+        LOGW_DEBUG(Log::instance()->getLogger(), L"Fail to check if file is locked for: " << Utility::formatSyncPath(path));
+        return ioError;
+    }
+    write = isLocked ? false : ((perms & std::filesystem::perms::owner_write) != std::filesystem::perms::none);
 #elif defined(KD_LINUX)
     write = ((perms & std::filesystem::perms::owner_write) != std::filesystem::perms::none);
 #endif

--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -339,7 +339,6 @@ IoError IoHelper::getRights(const SyncPath &path, bool &read, bool &write, bool 
     exec = ((perms & std::filesystem::perms::owner_exec) != std::filesystem::perms::none);
     return IoError::Success;
 }
-
 #endif
 
 bool IoHelper::getItemType(const SyncPath &path, ItemType &itemType) noexcept {
@@ -1064,6 +1063,49 @@ IoError IoHelper::_setRightsStd(const SyncPath &path, bool read, bool write, boo
         return posixError2ioError(ec.value());
     }
 
+    return IoError::Success;
+}
+
+IoError IoHelper::setReadOnly(const SyncPath &path) noexcept {
+    // Retrieve `exec` rights. It is not modified by this method.
+    bool dummyRead = false;
+    bool dummyWrite = false;
+    bool exec = false;
+    if (IoError ioError = IoHelper::getRights(path, dummyRead, dummyWrite, exec); ioError != IoError::Success) {
+        LOGW_DEBUG(Log::instance()->getLogger(), L"Fail to set rights for: " << Utility::formatSyncPath(path));
+        return IoError::Unknown;
+    }
+
+    // Remove write right.
+    if (IoError ioError = IoHelper::setRights(path, true, false, exec); ioError != IoError::Success) {
+        LOGW_DEBUG(Log::instance()->getLogger(), L"Fail to set rights for: " << Utility::formatSyncPath(path));
+        return ioError;
+    }
+
+    // Lock the file.
+    return lock(path);
+}
+
+IoError IoHelper::setFullAccess(const SyncPath &path) noexcept {
+    // Retrieve `exec` rights. It is not modified by this method.
+    bool dummyRead = false;
+    bool dummyWrite = false;
+    bool exec = false;
+    if (IoError ioError = IoHelper::getRights(path, dummyRead, dummyWrite, exec); ioError != IoError::Success) {
+        LOGW_DEBUG(Log::instance()->getLogger(), L"Fail to set rights for: " << Utility::formatSyncPath(path));
+        return IoError::Unknown;
+    }
+
+    // The file must be unlocked before changing its access rights.
+    if (const auto ioError = unlock(path); ioError != IoError::Success) {
+        return ioError;
+    }
+
+    // Set full access rights.
+    if (IoError ioError = IoHelper::setRights(path, true, true, exec); ioError != IoError::Success) {
+        LOGW_DEBUG(Log::instance()->getLogger(), L"Fail to set rights for: " << Utility::formatSyncPath(path));
+        return IoError::Unknown;
+    }
     return IoError::Success;
 }
 

--- a/src/libcommonserver/io/iohelper.h
+++ b/src/libcommonserver/io/iohelper.h
@@ -418,6 +418,7 @@ struct IoHelper {
          */
         static bool checkIfFileIsDehydrated(const SyncPath &path, bool &isDehydrated, IoError &ioError) noexcept;
 
+        // Access right management
         //! Get the rights of the item indicated by `path`.
         /*!
          \param path is the file system path of the item.
@@ -440,10 +441,48 @@ struct IoHelper {
          \return true if no unexpected error occurred, false otherwise.
         */
         static bool setRights(const SyncPath &path, bool read, bool write, bool exec, IoError &ioError) noexcept;
+        //! Set the rights of the item indicated by `path`.
+        /*!
+         \param path is the file system path of the item.
+         \param read is a boolean indicating whether the item should be readable.
+         \param write is a boolean indicating whether the item should be writable.
+         \param exec is a boolean indicating whether the item should be executable.
+         \return An ioError representing the success or failure of the underlying OS API call.
+        */
         static IoError setRights(const SyncPath &path, bool read, bool write, bool exec) noexcept;
 
-        static IoError setReadOnly(const SyncPath &path);
-        static IoError unsetReadOnly(const SyncPath &path);
+        /**
+         * @brief Utility function to lock an item.
+         * @param path is the file system path of the item.
+         * @return An ioError representing the success or failure of the underlying OS API call.
+         */
+        static IoError lock(const SyncPath &path) noexcept;
+        /**
+         * @brief Utility function to unlock an item.
+         * @param path is the file system path of the item.
+         * @return An ioError representing the success or failure of the underlying OS API call.
+         */
+        static IoError unlock(const SyncPath &path) noexcept;
+        /**
+         * @brief Utility function to check if an item is locked.
+         * @param path is the file system path of the item.
+         * @param locked is a boolean indicating whether the item is locked.
+         * @return An ioError representing the success or failure of the underlying OS API call.
+         */
+        static IoError isLocked(const SyncPath &path, bool &locked) noexcept;
+
+        /**
+         * @brief Utility function to set, for the current user, read only access to an item.
+         * @param path is the file system path of the item.
+         * @return An ioError representing the success or failure of the underlying OS API call.
+         */
+        static IoError setReadOnly(const SyncPath &path) noexcept;
+        /**
+         * @brief Utility function to set, for the current user, full access to an item.
+         * @param path is the file system path of the item.
+         * @return An ioError representing the success or failure of the underlying OS API call.
+         */
+        static IoError setFullAccess(const SyncPath &path) noexcept;
 
         /**
          * @brief Set the dates using native API.

--- a/src/libcommonserver/io/iohelper.h
+++ b/src/libcommonserver/io/iohelper.h
@@ -428,6 +428,7 @@ struct IoHelper {
          \return true if no unexpected error occurred, false otherwise.
          */
         static bool getRights(const SyncPath &path, bool &read, bool &write, bool &exec, IoError &ioError) noexcept;
+        static IoError getRights(const SyncPath &path, bool &read, bool &write, bool &exec) noexcept;
 
         //! Set the rights of the item indicated by `path`.
         /*!
@@ -439,6 +440,10 @@ struct IoHelper {
          \return true if no unexpected error occurred, false otherwise.
         */
         static bool setRights(const SyncPath &path, bool read, bool write, bool exec, IoError &ioError) noexcept;
+        static IoError setRights(const SyncPath &path, bool read, bool write, bool exec) noexcept;
+
+        static IoError setReadOnly(const SyncPath &path);
+        static IoError unsetReadOnly(const SyncPath &path);
 
         /**
          * @brief Set the dates using native API.
@@ -504,7 +509,7 @@ struct IoHelper {
         static bool _setTargetType(ItemType &itemType) noexcept;
         static bool _checkIfIsHiddenFile(const SyncPath &path, bool &isHidden, IoError &ioError) noexcept;
 
-        static bool _setRightsStd(const SyncPath &path, bool read, bool write, bool exec, IoError &ioError) noexcept;
+        static IoError _setRightsStd(const SyncPath &path, bool read, bool write, bool exec) noexcept;
 
 #if defined(KD_WINDOWS)
         static bool _setRightsWindowsApiInheritance; // For windows tests only

--- a/src/libcommonserver/io/iohelper.h
+++ b/src/libcommonserver/io/iohelper.h
@@ -425,10 +425,18 @@ struct IoHelper {
          \param read is a boolean indicating whether the item is readable.
          \param write is a boolean indicating whether the item is writable.
          \param exec is a boolean indicating whether the item is executable.
-         \param exists is a boolean indicating whether the item exists.
+         \param ioError holds the error returned when an underlying OS API call fails.
          \return true if no unexpected error occurred, false otherwise.
          */
         static bool getRights(const SyncPath &path, bool &read, bool &write, bool &exec, IoError &ioError) noexcept;
+        //! Get the rights of the item indicated by `path`.
+        /*!
+         \param path is the file system path of the item.
+         \param read is a boolean indicating whether the item is readable.
+         \param write is a boolean indicating whether the item is writable.
+         \param exec is a boolean indicating whether the item is executable.
+         \return An ioError representing the success or failure of the underlying OS API call.
+         */
         static IoError getRights(const SyncPath &path, bool &read, bool &write, bool &exec) noexcept;
 
         //! Set the rights of the item indicated by `path`.

--- a/src/libcommonserver/io/iohelper_linux.cpp
+++ b/src/libcommonserver/io/iohelper_linux.cpp
@@ -122,4 +122,20 @@ IoError IoHelper::setFileDates(const SyncPath &filePath, const SyncTime /*creati
     return IoError::Success;
 }
 
+IoError IoHelper::setReadOnly(const SyncPath &path) {
+    if (IoError ioError = IoError::Unknown; !setRights(path, true, false, false, ioError) || ioError != IoError::Success) {
+        LOGW_ERROR(logger(), L"IoHelper::setReadOnly : " << Utility::formatSyncPath(path));
+        return ioError;
+    }
+    return IoError::Success;
+}
+
+IoError IoHelper::unsetReadOnly(const SyncPath &path) {
+    if (IoError ioError = IoError::Unknown; !setRights(path, true, true, true, ioError) || ioError != IoError::Success) {
+        LOGW_ERROR(logger(), L"IoHelper::setReadOnly : " << Utility::formatSyncPath(path));
+        return ioError;
+    }
+    return IoError::Success;
+}
+
 } // namespace KDC

--- a/src/libcommonserver/io/iohelper_linux.cpp
+++ b/src/libcommonserver/io/iohelper_linux.cpp
@@ -135,20 +135,4 @@ IoError IoHelper::isLocked(const SyncPath &path, bool &locked) noexcept {
     return IoError::Success;
 }
 
-IoError IoHelper::setReadOnly(const SyncPath &path) {
-    if (IoError ioError = IoError::Unknown; !setRights(path, true, false, true, ioError) || ioError != IoError::Success) {
-        LOGW_ERROR(logger(), L"IoHelper::setReadOnly : " << Utility::formatSyncPath(path));
-        return ioError;
-    }
-    return IoError::Success;
-}
-
-IoError IoHelper::setFullAccess(const SyncPath &path) {
-    if (IoError ioError = IoError::Unknown; !setRights(path, true, true, true, ioError) || ioError != IoError::Success) {
-        LOGW_ERROR(logger(), L"IoHelper::setReadOnly : " << Utility::formatSyncPath(path));
-        return ioError;
-    }
-    return IoError::Success;
-}
-
 } // namespace KDC

--- a/src/libcommonserver/io/iohelper_linux.cpp
+++ b/src/libcommonserver/io/iohelper_linux.cpp
@@ -136,7 +136,7 @@ IoError IoHelper::isLocked(const SyncPath &path, bool &locked) noexcept {
 }
 
 IoError IoHelper::setReadOnly(const SyncPath &path) {
-    if (IoError ioError = IoError::Unknown; !setRights(path, true, false, false, ioError) || ioError != IoError::Success) {
+    if (IoError ioError = IoError::Unknown; !setRights(path, true, false, true, ioError) || ioError != IoError::Success) {
         LOGW_ERROR(logger(), L"IoHelper::setReadOnly : " << Utility::formatSyncPath(path));
         return ioError;
     }

--- a/src/libcommonserver/io/iohelper_linux.cpp
+++ b/src/libcommonserver/io/iohelper_linux.cpp
@@ -122,6 +122,19 @@ IoError IoHelper::setFileDates(const SyncPath &filePath, const SyncTime /*creati
     return IoError::Success;
 }
 
+IoError IoHelper::lock(const SyncPath &path) noexcept {
+    return IoError::Success;
+}
+
+IoError IoHelper::unlock(const SyncPath &path) noexcept {
+    return IoError::Success;
+}
+
+IoError IoHelper::isLocked(const SyncPath &path, bool &locked) noexcept {
+    locked = false;
+    return IoError::Success;
+}
+
 IoError IoHelper::setReadOnly(const SyncPath &path) {
     if (IoError ioError = IoError::Unknown; !setRights(path, true, false, false, ioError) || ioError != IoError::Success) {
         LOGW_ERROR(logger(), L"IoHelper::setReadOnly : " << Utility::formatSyncPath(path));
@@ -130,7 +143,7 @@ IoError IoHelper::setReadOnly(const SyncPath &path) {
     return IoError::Success;
 }
 
-IoError IoHelper::unsetReadOnly(const SyncPath &path) {
+IoError IoHelper::setFullAccess(const SyncPath &path) {
     if (IoError ioError = IoError::Unknown; !setRights(path, true, true, true, ioError) || ioError != IoError::Success) {
         LOGW_ERROR(logger(), L"IoHelper::setReadOnly : " << Utility::formatSyncPath(path));
         return ioError;

--- a/src/libcommonserver/io/iohelper_mac.cpp
+++ b/src/libcommonserver/io/iohelper_mac.cpp
@@ -219,8 +219,17 @@ IoError IoHelper::isLocked(const SyncPath &path, bool &locked) noexcept {
 }
 
 IoError IoHelper::setReadOnly(const SyncPath &path) noexcept {
+    // Retrieve `exec` rights. It is not modified by this method.
+    bool dummyRead = false;
+    bool dummyWrite = false;
+    bool exec = false;
+    if (IoError ioError = IoHelper::getRights(path, dummyRead, dummyWrite, exec); ioError != IoError::Success) {
+        LOGW_DEBUG(Log::instance()->getLogger(), L"Fail to set rights for: " << Utility::formatSyncPath(path));
+        return IoError::Unknown;
+    }
+
     // Remove write right.
-    if (IoError ioError = IoHelper::setRights(path, true, false, true); ioError != IoError::Success) {
+    if (IoError ioError = IoHelper::setRights(path, true, false, exec); ioError != IoError::Success) {
         LOGW_DEBUG(Log::instance()->getLogger(), L"Fail to set rights for: " << Utility::formatSyncPath(path));
         return ioError;
     }
@@ -230,13 +239,22 @@ IoError IoHelper::setReadOnly(const SyncPath &path) noexcept {
 }
 
 IoError IoHelper::setFullAccess(const SyncPath &path) noexcept {
+    // Retrieve `exec` rights. It is not modified by this method.
+    bool dummyRead = false;
+    bool dummyWrite = false;
+    bool exec = false;
+    if (IoError ioError = IoHelper::getRights(path, dummyRead, dummyWrite, exec); ioError != IoError::Success) {
+        LOGW_DEBUG(Log::instance()->getLogger(), L"Fail to set rights for: " << Utility::formatSyncPath(path));
+        return IoError::Unknown;
+    }
+
     // The file must be unlocked before changing its access rights.
     if (const auto ioError = unlock(path); ioError != IoError::Success) {
         return ioError;
     }
 
     // Set full access rights.
-    if (IoError ioError = IoHelper::setRights(path, true, true, true); ioError != IoError::Success) {
+    if (IoError ioError = IoHelper::setRights(path, true, true, exec); ioError != IoError::Success) {
         LOGW_DEBUG(Log::instance()->getLogger(), L"Fail to set rights for: " << Utility::formatSyncPath(path));
         return IoError::Unknown;
     }

--- a/src/libcommonserver/io/iohelper_mac.cpp
+++ b/src/libcommonserver/io/iohelper_mac.cpp
@@ -218,47 +218,4 @@ IoError IoHelper::isLocked(const SyncPath &path, bool &locked) noexcept {
     return IoError::Success;
 }
 
-IoError IoHelper::setReadOnly(const SyncPath &path) noexcept {
-    // Retrieve `exec` rights. It is not modified by this method.
-    bool dummyRead = false;
-    bool dummyWrite = false;
-    bool exec = false;
-    if (IoError ioError = IoHelper::getRights(path, dummyRead, dummyWrite, exec); ioError != IoError::Success) {
-        LOGW_DEBUG(Log::instance()->getLogger(), L"Fail to set rights for: " << Utility::formatSyncPath(path));
-        return IoError::Unknown;
-    }
-
-    // Remove write right.
-    if (IoError ioError = IoHelper::setRights(path, true, false, exec); ioError != IoError::Success) {
-        LOGW_DEBUG(Log::instance()->getLogger(), L"Fail to set rights for: " << Utility::formatSyncPath(path));
-        return ioError;
-    }
-
-    // Lock the file.
-    return lock(path);
-}
-
-IoError IoHelper::setFullAccess(const SyncPath &path) noexcept {
-    // Retrieve `exec` rights. It is not modified by this method.
-    bool dummyRead = false;
-    bool dummyWrite = false;
-    bool exec = false;
-    if (IoError ioError = IoHelper::getRights(path, dummyRead, dummyWrite, exec); ioError != IoError::Success) {
-        LOGW_DEBUG(Log::instance()->getLogger(), L"Fail to set rights for: " << Utility::formatSyncPath(path));
-        return IoError::Unknown;
-    }
-
-    // The file must be unlocked before changing its access rights.
-    if (const auto ioError = unlock(path); ioError != IoError::Success) {
-        return ioError;
-    }
-
-    // Set full access rights.
-    if (IoError ioError = IoHelper::setRights(path, true, true, exec); ioError != IoError::Success) {
-        LOGW_DEBUG(Log::instance()->getLogger(), L"Fail to set rights for: " << Utility::formatSyncPath(path));
-        return IoError::Unknown;
-    }
-    return IoError::Success;
-}
-
 } // namespace KDC

--- a/src/libcommonserver/io/iohelper_mac.mm
+++ b/src/libcommonserver/io/iohelper_mac.mm
@@ -231,17 +231,6 @@ void IoHelper::setFileHidden(const SyncPath &path, bool hidden) noexcept {
     [pathURL setResourceValue:value forKey:NSURLIsHiddenKey error:NULL];
 }
 
-bool isLocked(const SyncPath &path) {
-    NSString *pathStr = [NSString stringWithCString:path.c_str() encoding:NSUTF8StringEncoding];
-    if (pathStr == nil) {
-        return false;
-    }
-
-    NSDictionary *attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:pathStr error:nil];
-    BOOL isLocked = [[attributes objectForKey:NSFileImmutable] boolValue];
-    return isLocked;
-}
-
 IoError IoHelper::setFileDates(const SyncPath &filePath, SyncTime creationDate, SyncTime modificationDate,
                                bool symlink) noexcept {
     NSDate *cDate = [[NSDate alloc] initWithTimeIntervalSince1970:creationDate];

--- a/src/libcommonserver/io/iohelper_win.cpp
+++ b/src/libcommonserver/io/iohelper_win.cpp
@@ -726,6 +726,19 @@ bool IoHelper::setRights(const SyncPath &path, bool read, bool write, bool exec,
     return _setRightsStd(path, read, write, exec, ioError);
 }
 
+IoError IoHelper::lock(const SyncPath &path) noexcept {
+    return IoError::Success;
+}
+
+IoError IoHelper::unlock(const SyncPath &path) noexcept {
+    return IoError::Success;
+}
+
+IoError IoHelper::isLocked(const SyncPath &path, bool &locked) noexcept {
+    locked = false;
+    return IoError::Success;
+}
+
 bool IoHelper::checkIfIsJunction(const SyncPath &path, bool &isJunction, IoError &ioError) noexcept {
     isJunction = false;
     ioError = IoError::Success;
@@ -1010,6 +1023,6 @@ bool IoHelper::getShortPathName(const SyncPath &path, SyncPath &shortPathName, I
 }
 
 IoError IoHelper::setReadOnly(const SyncPath &path) {}
-IoError IoHelper::unsetReadOnly(const SyncPath &path) {}
+IoError IoHelper::setFullAccess(const SyncPath &path) {}
 
 } // namespace KDC

--- a/src/libcommonserver/io/iohelper_win.cpp
+++ b/src/libcommonserver/io/iohelper_win.cpp
@@ -1009,4 +1009,7 @@ bool IoHelper::getShortPathName(const SyncPath &path, SyncPath &shortPathName, I
     return true;
 }
 
+IoError IoHelper::setReadOnly(const SyncPath &path) {}
+IoError IoHelper::unsetReadOnly(const SyncPath &path) {}
+
 } // namespace KDC

--- a/src/libcommonserver/io/iohelper_win.cpp
+++ b/src/libcommonserver/io/iohelper_win.cpp
@@ -1022,7 +1022,4 @@ bool IoHelper::getShortPathName(const SyncPath &path, SyncPath &shortPathName, I
     return true;
 }
 
-IoError IoHelper::setReadOnly(const SyncPath &path) {}
-IoError IoHelper::setFullAccess(const SyncPath &path) {}
-
 } // namespace KDC

--- a/src/libcommonserver/io/permissionsholder.cpp
+++ b/src/libcommonserver/io/permissionsholder.cpp
@@ -1,0 +1,81 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "permissionsholder.h"
+
+namespace KDC {
+
+struct AccessRights {
+        bool read{false};
+        bool write{false};
+        bool exec{false};
+        bool locked{false};
+};
+static std::unordered_map<SyncPath, std::pair<uint64_t, AccessRights>> heldPermissions;
+static std::mutex mutex;
+
+PermissionsHolder::PermissionsHolder(const SyncPath &path) :
+    _path(path) {
+    AccessRights accessRights;
+    if (IoError ioError = IoHelper::getRights(path, accessRights.read, accessRights.write, accessRights.exec);
+        ioError != IoError::Success) {
+        LOGW_DEBUG(Log::instance()->getLogger(), L"Fail to get rights for: " << Utility::formatSyncPath(path));
+        return;
+    }
+    if (IoError ioError = IoHelper::isLocked(path, accessRights.locked); ioError != IoError::Success) {
+        LOGW_DEBUG(Log::instance()->getLogger(), L"Fail to check if file is locked for: " << Utility::formatSyncPath(path));
+        return;
+    }
+    if (accessRights.read && accessRights.write && accessRights.exec && !accessRights.locked) {
+        // User has full access => nothing to do.
+        return;
+    }
+
+    std::scoped_lock scopedLock(mutex);
+    IoHelper::setFullAccess(_path);
+    heldPermissions.try_emplace(_path, 0, accessRights);
+    heldPermissions[_path].first++;
+    LOGW_DEBUG(Log::instance()->getLogger(),
+               L"PermissionsHolder unsetReadOnly: " << Utility::formatSyncPath(_path) << L" / " << heldPermissions[_path].first);
+}
+
+PermissionsHolder::~PermissionsHolder() {
+    std::scoped_lock scopedLock(mutex);
+    if (!heldPermissions.contains(_path)) return;
+
+    auto &[count, accessRights] = heldPermissions[_path];
+    count--;
+    LOGW_DEBUG(Log::instance()->getLogger(), L"PermissionsHolder value: " << Utility::formatSyncPath(_path) << L" / " << count);
+    if (count > 0) return; // Do not put back read only rights yet.
+
+    LOGW_DEBUG(Log::instance()->getLogger(),
+               L"PermissionsHolder setReadOnly: " << Utility::formatSyncPath(_path) << L" / " << count);
+    if (accessRights.locked) {
+        if (const auto ioError = IoHelper::lock(_path); ioError != IoError::Success) {
+            LOGW_ERROR(Log::instance()->getLogger(),
+                       L"PermissionsHolder setReadOnly: " << Utility::formatSyncPath(_path) << L" / " << count);
+        }
+    }
+    if (IoError ioError = IoHelper::setRights(_path, accessRights.read, accessRights.write, accessRights.exec);
+        ioError != IoError::Success) {
+        LOGW_ERROR(Log::instance()->getLogger(), L"Fail to set rights for: " << Utility::formatSyncPath(_path));
+    }
+    heldPermissions.erase(_path);
+}
+
+} // namespace KDC

--- a/src/libcommonserver/io/permissionsholder.h
+++ b/src/libcommonserver/io/permissionsholder.h
@@ -1,7 +1,7 @@
 /*
  * Infomaniak kDrive - Desktop
  * Copyright (C) 2023-2025 Infomaniak Network SA
- ** This program is free software: you can redistribute it and/or modify
+ * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
@@ -22,46 +22,10 @@
 
 namespace KDC {
 
-static std::unordered_map<SyncPath, uint64_t> counts;
-static std::mutex mutex;
-
 class PermissionsHolder {
     public:
-        PermissionsHolder(const SyncPath &path) :
-            _path(path) {
-            bool read = false;
-            bool write = false;
-            bool exec = false;
-            if (IoError ioError = IoHelper::getRights(path, read, write, exec); ioError != IoError::Success) {
-                LOGW_DEBUG(Log::instance()->getLogger(), L"Fail to get rights for: " << Utility::formatSyncPath(path));
-                return;
-            }
-            if (write) {
-                // TODO : for now, only items in read only mode are supported.
-                return;
-            }
-
-            std::scoped_lock lock(mutex);
-            IoHelper::unsetReadOnly(_path);
-            counts.try_emplace(_path, 0);
-            counts[_path]++;
-            LOGW_DEBUG(Log::instance()->getLogger(),
-                       L"PermissionsHolder unsetReadOnly: " << Utility::formatSyncPath(_path) << L" / " << counts[_path]);
-        }
-        ~PermissionsHolder() {
-            std::scoped_lock lock(mutex);
-            if (!counts.contains(_path)) return;
-
-            counts[_path]--;
-            LOGW_DEBUG(Log::instance()->getLogger(),
-                       L"PermissionsHolder value: " << Utility::formatSyncPath(_path) << L" / " << counts[_path]);
-            if (counts[_path] > 0) return; // Do not put back read only rights yet.
-
-            LOGW_DEBUG(Log::instance()->getLogger(),
-                       L"PermissionsHolder setReadOnly: " << Utility::formatSyncPath(_path) << L" / " << counts[_path]);
-            counts.erase(_path);
-            IoHelper::setReadOnly(_path);
-        }
+        PermissionsHolder(const SyncPath &path);
+        ~PermissionsHolder();
 
     private:
         SyncPath _path;

--- a/src/libcommonserver/io/permissionsholder.h
+++ b/src/libcommonserver/io/permissionsholder.h
@@ -1,0 +1,70 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2025 Infomaniak Network SA
+ ** This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "iohelper.h"
+#include "utility/types.h"
+
+namespace KDC {
+
+static std::unordered_map<SyncPath, uint64_t> counts;
+static std::mutex mutex;
+
+class PermissionsHolder {
+    public:
+        PermissionsHolder(const SyncPath &path) :
+            _path(path) {
+            bool read = false;
+            bool write = false;
+            bool exec = false;
+            if (IoError ioError = IoHelper::getRights(path, read, write, exec); ioError != IoError::Success) {
+                LOGW_DEBUG(Log::instance()->getLogger(), L"Fail to get rights for: " << Utility::formatSyncPath(path));
+                return;
+            }
+            if (write) {
+                // TODO : for now, only items in read only mode are supported.
+                return;
+            }
+
+            std::scoped_lock lock(mutex);
+            IoHelper::unsetReadOnly(_path);
+            counts.try_emplace(_path, 0);
+            counts[_path]++;
+            LOGW_DEBUG(Log::instance()->getLogger(),
+                       L"PermissionsHolder unsetReadOnly: " << Utility::formatSyncPath(_path) << L" / " << counts[_path]);
+        }
+        ~PermissionsHolder() {
+            std::scoped_lock lock(mutex);
+            if (!counts.contains(_path)) return;
+
+            counts[_path]--;
+            LOGW_DEBUG(Log::instance()->getLogger(),
+                       L"PermissionsHolder value: " << Utility::formatSyncPath(_path) << L" / " << counts[_path]);
+            if (counts[_path] > 0) return; // Do not put back read only rights yet.
+
+            LOGW_DEBUG(Log::instance()->getLogger(),
+                       L"PermissionsHolder setReadOnly: " << Utility::formatSyncPath(_path) << L" / " << counts[_path]);
+            counts.erase(_path);
+            IoHelper::setReadOnly(_path);
+        }
+
+    private:
+        SyncPath _path;
+};
+
+} // namespace KDC

--- a/src/libsyncengine/jobs/local/localcopyjob.cpp
+++ b/src/libsyncengine/jobs/local/localcopyjob.cpp
@@ -17,6 +17,8 @@
  */
 
 #include "localcopyjob.h"
+
+#include "io/permissionsholder.h"
 #include "libcommonserver/io/iohelper.h"
 #include "libcommonserver/utility/utility.h"
 
@@ -79,6 +81,9 @@ void LocalCopyJob::runJob() {
     if (!canRun()) {
         return;
     }
+
+    // Make sure we are allowed to propagate the change
+    PermissionsHolder _(_dest.parent_path());
 
     try {
         std::filesystem::copy(_source, _dest);

--- a/src/libsyncengine/jobs/local/localcreatedirjob.h
+++ b/src/libsyncengine/jobs/local/localcreatedirjob.h
@@ -24,7 +24,7 @@ namespace KDC {
 
 class LocalCreateDirJob : public AbstractJob {
     public:
-        LocalCreateDirJob(const SyncPath &destFilepath);
+        LocalCreateDirJob(const SyncPath &destFilepath, bool readOnly = false);
 
         SyncPath destFilePath() const { return _destFilePath; }
 
@@ -39,6 +39,7 @@ class LocalCreateDirJob : public AbstractJob {
         virtual void runJob() override;
 
         SyncPath _destFilePath;
+        bool _readOnly{false};
 
         NodeId _nodeId;
         SyncTime _modtime = 0;

--- a/src/libsyncengine/jobs/local/localdeletejob.cpp
+++ b/src/libsyncengine/jobs/local/localdeletejob.cpp
@@ -18,6 +18,7 @@
 
 #include "localdeletejob.h"
 #include "../network/API_v2/getfileinfojob.h"
+#include "io/permissionsholder.h"
 #include "libcommonserver/io/iohelper.h"
 #include "libcommonserver/utility/utility.h"
 #include "requests/parameterscache.h"
@@ -173,6 +174,9 @@ bool LocalDeleteJob::moveToTrash() {
 
 void LocalDeleteJob::runJob() {
     if (!canRun()) return;
+
+    // Make sure we are allowed to propagate the change
+    PermissionsHolder _(_absolutePath.parent_path());
 
     const bool tryMoveToTrash =
             (ParametersCache::instance()->parameters().moveToTrash() && !_isDehydratedPlaceholder) || _forceToTrash;

--- a/src/libsyncengine/jobs/local/localmovejob.cpp
+++ b/src/libsyncengine/jobs/local/localmovejob.cpp
@@ -17,6 +17,8 @@
  */
 
 #include "localmovejob.h"
+
+#include "io/permissionsholder.h"
 #include "libcommonserver/io/iohelper.h"
 #include "libcommonserver/utility/utility.h"
 
@@ -86,6 +88,9 @@ void LocalMoveJob::runJob() {
     if (!canRun()) {
         return;
     }
+
+    // Make sure we are allowed to propagate the change
+    PermissionsHolder _(_dest.parent_path());
 
     std::error_code ec;
     std::filesystem::rename(_source, _dest, ec);

--- a/src/libsyncengine/jobs/network/API_v2/downloadjob.cpp
+++ b/src/libsyncengine/jobs/network/API_v2/downloadjob.cpp
@@ -29,6 +29,7 @@
 #include <unistd.h>
 #endif
 
+#include "io/permissionsholder.h"
 #include "utility/timerutility.h"
 
 
@@ -488,6 +489,9 @@ bool DownloadJob::moveTmpFile() {
 #endif
         static const bool forceCopy = CommonUtility::envVarValue("KDRIVE_PRESERVE_PERMISSIONS_ON_CREATE") == "1";
         if (_isCreate && !forceCopy) {
+            // Make sure we are allowed to propagate the change
+            PermissionsHolder _(_localpath.parent_path());
+
             // Move file
             IoError ioError = IoError::Success;
             IoHelper::moveItem(_tmpPath, _localpath, ioError);
@@ -503,6 +507,9 @@ bool DownloadJob::moveTmpFile() {
         }
 
         if (!_isCreate || crossDeviceLinkError || forceCopy) {
+            // Make sure we are allowed to propagate the change
+            PermissionsHolder _(_localpath.parent_path());
+
             // Copy file content (i.e. when the target exists, do not change its node id).
             std::error_code ec;
             std::filesystem::copy(_tmpPath, _localpath, std::filesystem::copy_options::overwrite_existing, ec);

--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -536,7 +536,7 @@ ExitInfo ExecutorWorker::generateCreateJob(SyncOpPtr syncOp, std::shared_ptr<Abs
 
         } else {
             if (syncOp->affectedNode()->type() == NodeType::Directory) {
-                job = std::make_shared<LocalCreateDirJob>(absoluteLocalFilePath);
+                job = std::make_shared<LocalCreateDirJob>(absoluteLocalFilePath, syncOp->affectedNode()->isSpecialFolder());
             } else {
                 bool exists = false;
                 IoError ioError = IoError::Success;

--- a/src/libsyncengine/update_detection/update_detector/node.cpp
+++ b/src/libsyncengine/update_detection/update_detector/node.cpp
@@ -215,6 +215,10 @@ bool Node::isSharedFolder() const {
     return false;
 }
 
+bool Node::isSpecialFolder() const {
+    return isCommonDocumentsFolder() || isSharedFolder();
+}
+
 SyncPath Node::getPath() const {
     std::vector<SyncName> names;
     names.push_back(name());

--- a/src/libsyncengine/update_detection/update_detector/node.h
+++ b/src/libsyncengine/update_detection/update_detector/node.h
@@ -153,6 +153,7 @@ class Node {
         [[nodiscard]] bool isRoot() const;
         [[nodiscard]] bool isCommonDocumentsFolder() const;
         [[nodiscard]] bool isSharedFolder() const;
+        [[nodiscard]] bool isSpecialFolder() const;
         [[nodiscard]] bool isParentOf(std::shared_ptr<const Node> potentialChild) const;
 
         [[nodiscard]] SyncPath getPath() const;

--- a/test/libcommonserver/CMakeLists.txt
+++ b/test/libcommonserver/CMakeLists.txt
@@ -25,7 +25,7 @@ set(testcommonserver_SRCS
         db/testdb.h db/testdb.cpp
         # io
         io/testio.h io/testio.cpp io/testgetitemtype.cpp io/testgetfilesize.cpp io/testcheckifpathexists.cpp io/testgetnodeid.cpp io/testgetfilestat.cpp io/testgetrights.cpp io/testisfileaccessible.cpp io/testfilechanged.cpp
-        io/testcheckifisdirectory.cpp io/testcreatesymlink.cpp io/testcheckifdehydrated.cpp io/testcheckdirectoryiterator.cpp io/testchecksetgetrights.cpp io/testopenfile.cpp
+        io/testcheckifisdirectory.cpp io/testcreatesymlink.cpp io/testcheckifdehydrated.cpp io/testcheckdirectoryiterator.cpp io/testrights.cpp io/testopenfile.cpp
 )
 
 if(APPLE)

--- a/test/libcommonserver/io/testio.h
+++ b/test/libcommonserver/io/testio.h
@@ -31,6 +31,8 @@ namespace KDC {
 class TestIo : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST_SUITE(TestIo);
         CPPUNIT_TEST(testCheckSetAndGetRights); // Keep this test before any tests that may use set/get rights functions
+        CPPUNIT_TEST(testLock);
+        CPPUNIT_TEST(testReadOnly);
         CPPUNIT_TEST(testGetItemType);
         CPPUNIT_TEST(testGetFileSize);
         CPPUNIT_TEST(testTempDirectoryPath);
@@ -106,6 +108,8 @@ class TestIo : public CppUnit::TestFixture, public TestBase {
 #endif
         void testCheckIfFileIsDehydrated();
         void testCheckSetAndGetRights();
+        void testLock();
+        void testReadOnly();
 
     private:
         void testGetItemTypeSimpleCases();

--- a/test/test_utility/localtemporarydirectory.cpp
+++ b/test/test_utility/localtemporarydirectory.cpp
@@ -52,6 +52,7 @@ LocalTemporaryDirectory::LocalTemporaryDirectory(const std::string &testType, co
 
 LocalTemporaryDirectory::~LocalTemporaryDirectory() {
     auto ioError = IoError::Success;
+    (void) IoHelper::unlock(_path);
     (void) IoHelper::setRights(_path, true, true, true, ioError);
 
     std::error_code ec;


### PR DESCRIPTION
The goal of this PR is to restrain local access rights on special folders such as "Common documents" or "Shared".
Those folders will be made read-only so the actions such as file creation or drag&drop will be blocked by the OS. This change aims to reduce the possibilities to generate "blacklisted" files and to make the user experience more intuitive.