### PR TITLE
[KDESKTOP-TRELLO-1027] Do not raise an error when a folder is removed before being registered

### DIFF
--- a/src/libsyncengine/update_detection/file_system_observer/folderwatcher_linux.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/folderwatcher_linux.cpp
@@ -181,8 +181,11 @@ ExitInfo FolderWatcher_linux::inotifyRegisterPath(const SyncPath &path) {
     if (std::error_code ec; !std::filesystem::exists(path, ec)) {
         if (ec) {
             LOGW_WARN(_logger, L"Failed to check if path exists for " << Utility::formatStdError(path, ec));
+            return {ExitCode::SystemError, ExitCause::Unknown};
         }
-        return {ExitCode::SystemError, ExitCause::Unknown};
+        LOGW_DEBUG(_logger, L"Folder " << Utility::formatSyncPath(path) << L" does not exist anymore. Registration aborted.");
+
+        return ExitCode::Ok;
     }
 
     const auto outcome = inotifyAddWatch(path);

--- a/src/libsyncengine/update_detection/file_system_observer/folderwatcher_linux.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/folderwatcher_linux.cpp
@@ -190,7 +190,7 @@ ExitInfo FolderWatcher_linux::inotifyRegisterPath(const SyncPath &path) {
 
     const auto outcome = inotifyAddWatch(path);
     if (outcome.returnValue == -1) {
-        switch (outcome.errorNumber) {
+        switch (outcome.errorNumber) { // Errors are documented at https://man7.org/linux/man-pages/man2/inotify_add_watch.2.html
             case ENOMEM:
                 LOG_ERROR(_logger, "Error in FolderWatcher_linux::inotifyAddWatch: Out of memory.");
                 return {ExitCode::SystemError, ExitCause::NotEnoughMemory};
@@ -201,9 +201,10 @@ ExitInfo FolderWatcher_linux::inotifyRegisterPath(const SyncPath &path) {
                 LOG_ERROR(_logger, "Limit number of inotify watches reached. The latter can be raised by the user.");
                 return {ExitCode::SystemError, ExitCause::NotEnoughINotifyWatches};
             default:
-                LOGW_ERROR(_logger, L"Error in FolderWatcher_linux::inotifyAddWatch: " << Utility::formatSyncPath(path)
-                                                                                       << L" errno=" << outcome.errorNumber);
-                return {ExitCode::SystemError, ExitCause::Unknown};
+                LOGW_ERROR(_logger, L"Unhandled error in FolderWatcher_linux::inotifyAddWatch: "
+                                            << Utility::formatSyncPath(path) << L" errno=" << outcome.errorNumber
+                                            << L". Folder registration failure. Ignoring it.");
+                return ExitCode::Ok;
         }
     }
 

--- a/test/libsyncengine/update_detection/file_system_observer/testfolderwatcherlinux.cpp
+++ b/test/libsyncengine/update_detection/file_system_observer/testfolderwatcherlinux.cpp
@@ -89,14 +89,21 @@ void TestFolderWatcherLinux::testInotifyRegisterPath() {
     FolderWatcherLinuxMock testObj(nullptr, "");
     const auto tempDir = LocalTemporaryDirectory("testInotifyRegisterPath");
 
+    // ENOSPC
     auto expectedExitInfo = ExitInfo{ExitCode::SystemError, ExitCause::NotEnoughINotifyWatches};
     CPPUNIT_ASSERT_EQUAL(expectedExitInfo, testObj.inotifyRegisterPath(tempDir.path()));
 
+    // ENOMEM
     expectedExitInfo = ExitInfo{ExitCode::SystemError, ExitCause::NotEnoughMemory};
     CPPUNIT_ASSERT_EQUAL(expectedExitInfo, testObj.inotifyRegisterPath(tempDir.path()));
 
-    expectedExitInfo = ExitInfo{ExitCode::SystemError, ExitCause::Unknown};
+    // EINVAL
+    expectedExitInfo = ExitCode::Ok; // Errors different form ENOSPC and ENOMEM are ignored for now.
     CPPUNIT_ASSERT_EQUAL(expectedExitInfo, testObj.inotifyRegisterPath(tempDir.path()));
+
+    // Deleted folders are harmless, hence ignored.
+    expectedExitInfo = ExitCode::Ok;
+    CPPUNIT_ASSERT_EQUAL(expectedExitInfo, testObj.inotifyRegisterPath(SyncPath{"this-path-does-not-exist"}));
 }
 
 void TestFolderWatcherLinux::testFindSubFolders() {


### PR DESCRIPTION
These changes relate to synchronization issues reported by Linux users (some of which are synchronizing virtual python environments or download folders).

The goal is to let the `inotifywatch` registration process continue as far as no known blocking issue is detected (e.g., insufficient memory or insufficient number of watches are blocking issues, for which a user action is required).

Details have been added to log messages. These messages should help debug and troubleshoot the unhandled (as of yet) registration issues. Note that such unhandled issues do not seem to have impacted negatively user synchronizations in the past in any **obvious way**. 