### PR TITLE
chore(matomo-client): remove unnecessary 'this' pointer in lambda connection

### DIFF
--- a/src/libcommongui/matomoclient.cpp
+++ b/src/libcommongui/matomoclient.cpp
@@ -71,7 +71,7 @@ MatomoClient::MatomoClient(QCoreApplication *app, const QString &clientId) :
          *
          */
         piwikNAM->setTransferTimeout(matomoTimeout);
-        connect(piwikNAM, &QNetworkAccessManager::finished, this, [this](const QNetworkReply* reply) {
+        connect(piwikNAM, &QNetworkAccessManager::finished, this, [](const QNetworkReply* reply) {
             if (reply->error() == QNetworkReply::TimeoutError              // Error given by the TransferTimeout
                 || reply->error() == QNetworkReply::ConnectionRefusedError // Error given when MATOMO_URL is blocked and return :: in ipv6 or 0.0.0.0 in ipv4
                 ) {


### PR DESCRIPTION
Fix this warning.

```
/Users/username/Projects/desktop-kdrive/src/libcommongui/matomoclient.cpp:74:68: warning: lambda capture 'this' is not used [-Wunused-lambda-capture]
   74 |         connect(piwikNAM, &QNetworkAccessManager::finished, this, [this](const QNetworkReply* reply) {
      |                                                                    ^~~~
1 warning generated.
```