### PR TITLE
ci: Add uncached dependency handling for builds

### DIFF
--- a/.github/actions/build_linux_amd/action.yml
+++ b/.github/actions/build_linux_amd/action.yml
@@ -84,7 +84,6 @@ runs:
       - name: Fetch dependencies
         run: | 
           mkdir dependencies
-          cp ${{ github.workspace }}/build-linux/build/bin/sync-exclude.lst ./dependencies/
           cp /home/runner/Qt/6.2.3/gcc_64/lib/libQt6Widgets.* ./dependencies/ 
           cp /home/runner/Qt/6.2.3/gcc_64/lib/libQt6Gui.* ./dependencies/
           cp /home/runner/Qt/6.2.3/gcc_64/lib/libQt6Network.* ./dependencies/

--- a/.github/actions/build_linux_amd/action.yml
+++ b/.github/actions/build_linux_amd/action.yml
@@ -135,7 +135,7 @@ runs:
         shell: bash
         if: steps.build.outcome == 'success'
 
-      - name:  Fetch kDrive dependencies (.lst)
+      - name: Fetch kDrive dependencies (.lst)
         run: | 
           mkdir uncached_dependencies
           cp ${{ github.workspace }}/build-linux/build/bin/sync-exclude.lst ./uncached_dependencies/

--- a/.github/actions/build_linux_amd/action.yml
+++ b/.github/actions/build_linux_amd/action.yml
@@ -135,11 +135,27 @@ runs:
         shell: bash
         if: steps.build.outcome == 'success'
 
+      - name:  Fetch kDrive dependencies (.lst)
+        run: | 
+          mkdir uncached_dependencies
+          cp ${{ github.workspace }}/build-linux/build/bin/sync-exclude.lst ./uncached_dependencies/
+        shell: bash
+        if: steps.build.outcome == 'success'
+
       - name: Upload build common files
         uses: actions/upload-artifact@v4
         with:
           name: linux-build-common-files
           path: ./dependencies/
+          retention-days: 1
+          compression-level: 0
+        if: steps.build.outcome == 'success'
+     
+      - name: Upload uncached build common files
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-build-common-files-uncached
+          path: ./uncached_dependencies/
           retention-days: 1
           compression-level: 0
         if: steps.build.outcome == 'success'

--- a/.github/actions/build_macos/action.yml
+++ b/.github/actions/build_macos/action.yml
@@ -53,7 +53,7 @@ runs:
             fi
         shell: bash
 
-      - name: Fetch dependencies
+      - name: Fetch lib dependencies
         run: |
           mkdir dependencies
           cp -R ${{ github.workspace }}/build-macos/client/install/kDrive.app/Contents/Frameworks/QtWidgets.framework ./dependencies/
@@ -104,6 +104,15 @@ runs:
           done
         shell: bash
         if: ${{ steps.build.outcome == 'success' && inputs.release_build == 'false' }}
+
+      - name: Fetch kDrive dependencies (lst and vfs lib)
+        run: |
+          mkdir uncached_dependencies
+          cp ${{ github.workspace }}/build-macos/client/bin/*.lst ./uncached_dependencies/
+          cp ${{ github.workspace }}/build-macos/client/bin/kDrivecommonserver_vfs_mac.dylib ./uncached_dependencies/
+        shell: bash
+        if: ${{ steps.build.outcome == 'success' }}
+
 
       - name: Download sentry-cli for macOS
         run: curl -sL https://sentry.io/get-cli/ | sh || true
@@ -163,6 +172,14 @@ runs:
           retention-days: 1
           compression-level: 0
         if: ${{ steps.build.outcome == 'success' && inputs.release_build == 'false' }}
+
+      - name: Upload uncached build common files
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-build-common-files-uncached
+          path: ./uncached_dependencies
+          retention-days: 1
+        if: ${{ steps.build.outcome == 'success' }}
 
       - name: Upload build test common executable
         uses: actions/upload-artifact@v4

--- a/.github/actions/build_macos/action.yml
+++ b/.github/actions/build_macos/action.yml
@@ -53,7 +53,7 @@ runs:
             fi
         shell: bash
 
-      - name: Fetch lib dependencies
+      - name: Fetch dependencies
         run: |
           mkdir dependencies
           cp -R ${{ github.workspace }}/build-macos/client/install/kDrive.app/Contents/Frameworks/QtWidgets.framework ./dependencies/
@@ -112,7 +112,6 @@ runs:
           cp ${{ github.workspace }}/build-macos/client/bin/kDrivecommonserver_vfs_mac.dylib ./uncached_dependencies/
         shell: bash
         if: ${{ steps.build.outcome == 'success' }}
-
 
       - name: Download sentry-cli for macOS
         run: curl -sL https://sentry.io/get-cli/ | sh || true

--- a/.github/actions/build_macos/action.yml
+++ b/.github/actions/build_macos/action.yml
@@ -79,7 +79,10 @@ runs:
           cp /usr/local/lib/libzstd.1.dylib ./dependencies/
           cp ${{ github.workspace }}/build-macos/client/bin/crashpad_handler ./dependencies/
           cp ${{ github.workspace }}/build-macos/client/bin/*.lst ./dependencies/
-          cp ${{ github.workspace }}/build-macos/client/bin/*.dylib ./dependencies/
+          # This lib is not cached and therefore is uploaded as a separate artifact
+          find "${{ github.workspace }}/build-macos/client/bin" -name "*.dylib" \
+            -not -name "kDrivecommonserver_vfs_mac.dylib" \
+            -exec cp {} ./dependencies/ \;
         shell: bash
         if: ${{ steps.build.outcome == 'success' && inputs.release_build == 'false' }} # Only copy dependencies for debug builds, release builds will have them in the app bundle
 

--- a/.github/actions/build_macos/action.yml
+++ b/.github/actions/build_macos/action.yml
@@ -79,7 +79,7 @@ runs:
           cp /usr/local/lib/libzstd.1.dylib ./dependencies/
           cp ${{ github.workspace }}/build-macos/client/bin/crashpad_handler ./dependencies/
           cp ${{ github.workspace }}/build-macos/client/bin/*.lst ./dependencies/
-          # This lib is not cached and therefore is uploaded as a separate artifact
+          # kDrivecommonserver_vfs_mac lib is not cached and therefore is uploaded as a separate artifact
           find "${{ github.workspace }}/build-macos/client/bin" -name "*.dylib" \
             -not -name "kDrivecommonserver_vfs_mac.dylib" \
             -exec cp {} ./dependencies/ \;

--- a/.github/actions/build_windows/action.yml
+++ b/.github/actions/build_windows/action.yml
@@ -73,6 +73,7 @@ runs:
       - name: Fetch dependencies
         run: |
           mkdir dependencies
+          # kDrivecommonserver_vfs_win lib is not cached and therefore is uploaded as a separate artifact
           Get-ChildItem -Path ${{ github.workspace }}/build-windows/install/bin/ -Filter "*.dll" |
            Where-Object { $_.Name -ne "kDrivecommonserver_vfs_win.dll" } |
            Copy-Item -Destination ./dependencies/

--- a/.github/actions/build_windows/action.yml
+++ b/.github/actions/build_windows/action.yml
@@ -114,12 +114,31 @@ runs:
               }
             }
           }
+
+      - name:  Fetch kDrive dependencies (lst and vfs lib)
+        run: |
+          mkdir uncached_dependencies
+          cp "${{ github.workspace }}/build-windows/install/bin/sync-exclude.lst" ./uncached_dependencies/
+          cp "${{ github.workspace }}/build-windows/install/bin/kDrivecommonserver_vfs_win.dll" ./uncached_dependencies/
+        shell: powershell
+        if: steps.build.outcome == 'success'
+
       - name: Upload build common files
         uses: actions/upload-artifact@v4
         with:
           name: windows-build-common-files
           path: |
               ./dependencies/*
+          retention-days: 1
+          compression-level: 0
+        if: steps.build.outcome == 'success'
+
+      - name: Upload uncached build common files
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-build-common-files-uncached
+          path: |
+              ./uncached_dependencies/*
           retention-days: 1
           compression-level: 0
         if: steps.build.outcome == 'success'

--- a/.github/actions/build_windows/action.yml
+++ b/.github/actions/build_windows/action.yml
@@ -73,9 +73,9 @@ runs:
       - name: Fetch dependencies
         run: |
           mkdir dependencies
-          cp "${{ github.workspace }}/build-windows/install/bin/*.dll" ./dependencies/
-          cp "${{ github.workspace }}/build-windows/install/bin/sync-exclude.lst" ./dependencies/
-          cp "${{ github.workspace }}/build-windows/install/bin/*.dll" ./dependencies/
+          Get-ChildItem -Path ${{ github.workspace }}/build-windows/install/bin/ -Filter "*.dll" |
+           Where-Object { $_.Name -ne "kDrivecommonserver_vfs_win.dll" } |
+           Copy-Item -Destination ./dependencies/
           cp "C:\Qt\6.2.3\msvc2019_64\bin\Qt6Widgets.dll" ./dependencies/
           cp "C:\Qt\6.2.3\msvc2019_64\bin\Qt6Gui.dll" ./dependencies/
           cp "C:\Qt\6.2.3\msvc2019_64\bin\Qt6Network.dll" ./dependencies/

--- a/.github/actions/test_linux/action.yml
+++ b/.github/actions/test_linux/action.yml
@@ -38,6 +38,12 @@ runs:
             cp -r ${{ github.workspace }}/build-linux/cache/* ${{ github.workspace }}/build-linux/test/
         shell: bash
 
+      - name: Download uncached common files
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-build-common-files-uncached
+          path: ${{ github.workspace }}/build-linux/test/
+
       - name: Download test executable
         uses: actions/download-artifact@v4
         with:

--- a/.github/actions/test_macos/action.yml
+++ b/.github/actions/test_macos/action.yml
@@ -40,6 +40,12 @@ runs:
             cp -r ${{ github.workspace }}/build-macos/client/cache/* ${{ github.workspace }}/build-macos/client/bin/
         shell: bash
 
+      - name: Download uncached common files
+        uses: actions/download-artifact@v4
+        with:
+          name: macos-build-common-files-uncached
+          path: ${{ github.workspace }}/build-macos/client/bin/
+
       - name: Download test executable
         uses: actions/download-artifact@v4
         with:

--- a/.github/actions/test_windows/action.yml
+++ b/.github/actions/test_windows/action.yml
@@ -36,6 +36,12 @@ runs:
         run: cp -r ${{ github.workspace }}/build-windows/cache/ ${{ github.workspace }}/build-windows/test/
         shell: powershell
 
+      - name: Download uncached common files
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-build-common-files-uncached
+          path: ${{ github.workspace }}/build-windows/test/
+
       - name: Download test executable
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Added steps in `action.yml` to fetch and upload uncached dependencies for Linux, macOS, and Windows builds. These dependencies are the vfs lib and `.lst` files which can change often across PRs.