### PR TITLE
chore(sync-node-table): add unit tests for the `updateSyncNode` method

### DIFF
--- a/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
@@ -130,10 +130,9 @@ void ComputeFSOperationWorker::execute() {
 }
 
 // Remove deleted nodes from sync_node table & cache
-ExitCode ComputeFSOperationWorker::updateSyncNode(SyncNodeType syncNodeType) {
+ExitCode ComputeFSOperationWorker::updateSyncNode(const SyncNodeType syncNodeType) {
     NodeSet nodeIdSet;
-    ExitCode exitCode = SyncNodeCache::instance()->syncNodes(syncDbId(), syncNodeType, nodeIdSet);
-    if (exitCode != ExitCode::Ok) {
+    if (auto exitCode = SyncNodeCache::instance()->syncNodes(syncDbId(), syncNodeType, nodeIdSet); exitCode != ExitCode::Ok) {
         LOG_WARN(Log::instance()->getLogger(), "Error in SyncNodeCache::syncNodes");
         return exitCode;
     }
@@ -143,8 +142,7 @@ ExitCode ComputeFSOperationWorker::updateSyncNode(SyncNodeType syncNodeType) {
         return !ok;
     });
 
-    exitCode = SyncNodeCache::instance()->update(syncDbId(), syncNodeType, nodeIdSet);
-    if (exitCode != ExitCode::Ok) {
+    if (auto exitCode = SyncNodeCache::instance()->update(syncDbId(), syncNodeType, nodeIdSet); exitCode != ExitCode::Ok) {
         LOG_WARN(Log::instance()->getLogger(), "Error in SyncNodeCache::update");
         return exitCode;
     }
@@ -153,13 +151,12 @@ ExitCode ComputeFSOperationWorker::updateSyncNode(SyncNodeType syncNodeType) {
 }
 
 ExitCode ComputeFSOperationWorker::updateSyncNode() {
-    for (int syncNodeTypeIdx = toInt(SyncNodeType::WhiteList); syncNodeTypeIdx <= toInt(SyncNodeType::UndecidedList);
+    for (int syncNodeTypeIdx = toInt(SyncNodeType::BlackList); syncNodeTypeIdx <= toInt(SyncNodeType::UndecidedList);
          syncNodeTypeIdx++) {
-        auto syncNodeType = static_cast<SyncNodeType>(syncNodeTypeIdx);
+        const auto syncNodeType = static_cast<SyncNodeType>(syncNodeTypeIdx);
 
-        ExitCode exitCode = updateSyncNode(syncNodeType);
-        if (exitCode != ExitCode::Ok) {
-            LOG_WARN(Log::instance()->getLogger(), "Error in SyncPal::updateSyncNode for syncNodeType=" << toInt(syncNodeType));
+        if (auto exitCode = updateSyncNode(syncNodeType); exitCode != ExitCode::Ok) {
+            LOG_WARN(Log::instance()->getLogger(), "Error in SyncPal::updateSyncNode for syncNodeType=" << syncNodeType);
             return exitCode;
         }
     }

--- a/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
@@ -151,7 +151,7 @@ ExitCode ComputeFSOperationWorker::updateSyncNode(const SyncNodeType syncNodeTyp
 }
 
 ExitCode ComputeFSOperationWorker::updateSyncNode() {
-    for (int syncNodeTypeIdx = toInt(SyncNodeType::BlackList); syncNodeTypeIdx <= toInt(SyncNodeType::UndecidedList);
+    for (auto syncNodeTypeIdx = toInt(SyncNodeType::WhiteList); syncNodeTypeIdx <= toInt(SyncNodeType::UndecidedList);
          syncNodeTypeIdx++) {
         const auto syncNodeType = static_cast<SyncNodeType>(syncNodeTypeIdx);
 

--- a/test/libsyncengine/update_detection/file_system_observer/testcomputefsoperationworker.cpp
+++ b/test/libsyncengine/update_detection/file_system_observer/testcomputefsoperationworker.cpp
@@ -536,15 +536,20 @@ void TestComputeFSOperationWorker::testUpdateSyncNode() {
     (void) SyncNodeCache::instance()->syncNodes(_syncPal->syncDbId(), SyncNodeType::WhiteList, syncNodes);
     CPPUNIT_ASSERT(syncNodes.contains("r_aa"));
 
-    // The whitelisted item "r_aa" and the blacklisted item "r_ac" are removed from the remote replica.
-    _syncPal->_remoteFSObserverWorker->_liveSnapshot.removeItem("r_ac");
-    _syncPal->_remoteFSObserverWorker->_liveSnapshot.removeItem("r_aa");
+    // No blacklisted item should reside in the remote snapshot.
+    (void) _syncPal->_remoteFSObserverWorker->_liveSnapshot.removeItem("r_ac");
+
+    // Simulate that the whitelisted item "r_aa" was removed from the remote replica.
+    (void) _syncPal->_remoteFSObserverWorker->_liveSnapshot.removeItem("r_aa");
+
     _syncPal->copySnapshots();
 
     // Check that SyncDb's 'sync_node' table is updated accordingly.
     CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, _syncPal->computeFSOperationsWorker()->updateSyncNode());
     (void) SyncNodeCache::instance()->syncNodes(_syncPal->syncDbId(), SyncNodeType::BlackList, syncNodes);
-    CPPUNIT_ASSERT(!syncNodes.contains("r_ac"));
+    // Blacklisted items are removed from the `sync_node` only when they are known to have been deleted from the remote replica.
+    CPPUNIT_ASSERT(syncNodes.contains("r_ac"));
+
     (void) SyncNodeCache::instance()->syncNodes(_syncPal->syncDbId(), SyncNodeType::WhiteList, syncNodes);
     CPPUNIT_ASSERT(!syncNodes.contains("r_aa"));
 }

--- a/test/libsyncengine/update_detection/file_system_observer/testcomputefsoperationworker.cpp
+++ b/test/libsyncengine/update_detection/file_system_observer/testcomputefsoperationworker.cpp
@@ -91,6 +91,9 @@ void TestComputeFSOperationWorker::setUp() {
     /// Insert node "AC" in blacklist
     SyncNodeCache::instance()->update(_syncPal->syncDbId(), SyncNodeType::BlackList, {"r_ac"});
 
+    /// Insert node "AA" in whitelist
+    SyncNodeCache::instance()->update(_syncPal->syncDbId(), SyncNodeType::WhiteList, {"r_aa"});
+
     // Insert items to excluded templates in DB
     std::vector<ExclusionTemplate> templateVec = {ExclusionTemplate("*.lnk", true)};
     ExclusionTemplateCache::instance()->update(true, templateVec);
@@ -521,6 +524,29 @@ void TestComputeFSOperationWorker::testIsInUnsyncedList(const bool expectedResul
     CPPUNIT_ASSERT_EQUAL(expectedResult, _syncPal->computeFSOperationsWorker()->isInUnsyncedListParentSearchInDb(nodeId, side));
     CPPUNIT_ASSERT_EQUAL(expectedResult, _syncPal->computeFSOperationsWorker()->isInUnsyncedListParentSearchInSnapshot(
                                                  _syncPal->snapshot(side), nodeId, side));
+}
+
+void TestComputeFSOperationWorker::testUpdateSyncNode() {
+    _syncPal->copySnapshots();
+    CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, _syncPal->computeFSOperationsWorker()->updateSyncNode());
+
+    NodeSet syncNodes;
+    (void) SyncNodeCache::instance()->syncNodes(_syncPal->syncDbId(), SyncNodeType::BlackList, syncNodes);
+    CPPUNIT_ASSERT(syncNodes.contains("r_ac"));
+    (void) SyncNodeCache::instance()->syncNodes(_syncPal->syncDbId(), SyncNodeType::WhiteList, syncNodes);
+    CPPUNIT_ASSERT(syncNodes.contains("r_aa"));
+
+    // The whitelisted item "r_aa" and the blacklisted item "r_ac" are removed from the remote replica.
+    _syncPal->_remoteFSObserverWorker->_liveSnapshot.removeItem("r_ac");
+    _syncPal->_remoteFSObserverWorker->_liveSnapshot.removeItem("r_aa");
+    _syncPal->copySnapshots();
+
+    // Check that SyncDb's 'sync_node' table is updated accordingly.
+    CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, _syncPal->computeFSOperationsWorker()->updateSyncNode());
+    (void) SyncNodeCache::instance()->syncNodes(_syncPal->syncDbId(), SyncNodeType::BlackList, syncNodes);
+    CPPUNIT_ASSERT(!syncNodes.contains("r_ac"));
+    (void) SyncNodeCache::instance()->syncNodes(_syncPal->syncDbId(), SyncNodeType::WhiteList, syncNodes);
+    CPPUNIT_ASSERT(!syncNodes.contains("r_aa"));
 }
 
 } // namespace KDC

--- a/test/libsyncengine/update_detection/file_system_observer/testcomputefsoperationworker.h
+++ b/test/libsyncengine/update_detection/file_system_observer/testcomputefsoperationworker.h
@@ -49,6 +49,7 @@ class TestComputeFSOperationWorker : public CppUnit::TestFixture, public TestBas
         CPPUNIT_TEST(testExclusion);
         CPPUNIT_TEST(testIsInUnsyncedList);
         CPPUNIT_TEST(testHasChangedSinceLastSeen);
+        CPPUNIT_TEST(testUpdateSyncNode);
         CPPUNIT_TEST_SUITE_END();
 
     public:
@@ -93,6 +94,9 @@ class TestComputeFSOperationWorker : public CppUnit::TestFixture, public TestBas
         // Test exclusions
         void testExclusion();
         void testIsInUnsyncedList();
+
+        // Test updates of SyncDb's 'sync_node' table
+        void testUpdateSyncNode();
 
         void testHasChangedSinceLastSeen();
 


### PR DESCRIPTION
This PR adds unit tests  for the `ComputeFSOperationsWorker::updateSyncNode` method.

**Note.** This PR has changed its scope after realizing that the correct resolution of the blacklisted `sync_node` update problem should be done as in https://github.com/Infomaniak/desktop-kDrive/pull/998. After this change of scope, only the unit tests remain relevant.
