### PR TITLE
fix(action.yml): update patterns for DLL file matching

### DIFF
--- a/.github/actions/build_windows/action.yml
+++ b/.github/actions/build_windows/action.yml
@@ -102,7 +102,7 @@ runs:
             cmd /c `"$($conanRunBat.FullName)`"  # modifie l'environnement du shell cmd
           }
           
-          $patterns = @("libxxhash*.dll", "liblog4cplus*.dll", "libssl*.dll", "libcrypto*.dll")
+          $patterns = @("xxhash*.dll", "log4cplus*.dll", "libssl*.dll", "libcrypto*.dll")
           $paths = $env:PATH -split ';' | Where-Object { $_ -like '*\.conan2\p*' }
           foreach ($dir in $paths) {
             if (Test-Path $dir) {


### PR DESCRIPTION
fix(build_windows): remove 'lib' prefix from DLL patterns for Windows

On Windows, `xxhash` and `log4cplus` DLLs do not use the `lib` prefix. This fix updates the matching patterns in the CI to correctly detect and copy these Conan dependencies.