### PR TITLE
Error in update tree

### DIFF
--- a/src/libsyncengine/propagation/operation_sorter/operationsorterworker.cpp
+++ b/src/libsyncengine/propagation/operation_sorter/operationsorterworker.cpp
@@ -467,15 +467,17 @@ bool OperationSorterWorker::breakCycle(SyncOperationList &cycle, const SyncOpPtr
     // A cycle must contain a Delete or a Move operation
     // Generate a rename resolution operation
     renameResolutionOp->setType(OperationType::Move);
+    const auto affectedNode = matchOp->affectedNode();
+    affectedNode->setMoveOriginInfos({affectedNode->getPath(), affectedNode->parentNode()->id().value()});
     renameResolutionOp->setOmit(matchOp->omit());
     // Find the corresponding node of `matchOp`
-    const auto correspondingNode = correspondingNodeInOtherTree(matchOp->affectedNode());
+    const auto correspondingNode = correspondingNodeInOtherTree(affectedNode);
     if (!correspondingNode) {
-        LOG_SYNCPAL_WARN(_logger, "Error in correspondingNode with id = " << matchOp->affectedNode()->id()->c_str()
-                                                                          << " - idDb = " << *matchOp->affectedNode()->idb());
+        LOG_SYNCPAL_WARN(_logger, "Error in correspondingNode with id = " << affectedNode->id()->c_str()
+                                                                          << " - idDb = " << *affectedNode->idb());
         return false;
     }
-    renameResolutionOp->setAffectedNode(matchOp->affectedNode());
+    renameResolutionOp->setAffectedNode(affectedNode);
     renameResolutionOp->setCorrespondingNode(correspondingNode);
     renameResolutionOp->setNewParentNode(correspondingNode->parentNode()); // Parent not changed but needed in Executor
     renameResolutionOp->setIsBreakingCycleOp(true);
@@ -488,6 +490,7 @@ bool OperationSorterWorker::breakCycle(SyncOperationList &cycle, const SyncOpPtr
     LOGW_SYNCPAL_INFO(_logger, L"Breaking cycle by renaming temporarily item " << SyncName2WStr(correspondingNode->name())
                                                                                << L" to "
                                                                                << SyncName2WStr(renameResolutionOp->newName()));
+    _syncPal->setClearUpdateTrees(true);
     return true;
 }
 

--- a/src/libsyncengine/syncpal/syncpal.h
+++ b/src/libsyncengine/syncpal/syncpal.h
@@ -96,6 +96,7 @@ struct SyncPalInfo {
         SyncPath targetPath;
         VirtualFileMode vfsMode{VirtualFileMode::Off};
         bool restart{false};
+        bool clearUpdateTrees{false};
         bool isPaused{false};
         bool syncHasFullyCompleted{false};
 
@@ -150,6 +151,7 @@ class SYNCENGINE_EXPORT SyncPal : public std::enable_shared_from_this<SyncPal> {
         inline const SyncPath &localPath() const { return _syncInfo.localPath; }
         inline const NodeId &localNodeId() const { return _syncInfo.localNodeId; }
         inline bool restart() const { return _syncInfo.restart; }
+        inline bool clearUpdateTrees() const { return _syncInfo.clearUpdateTrees; }
         inline bool isAdvancedSync() const { return _syncInfo.isAdvancedSync(); }
 
         void setLocalPath(const SyncPath &path) { _syncInfo.localPath = path; }
@@ -157,6 +159,7 @@ class SYNCENGINE_EXPORT SyncPal : public std::enable_shared_from_this<SyncPal> {
         ExitInfo setLocalNodeId(const NodeId &localNodeId);
         void setSyncHasFullyCompleted(bool completed) { _syncInfo.syncHasFullyCompleted = completed; }
         void setRestart(bool shouldRestart) { _syncInfo.restart = shouldRestart; }
+        void setClearUpdateTrees(bool reset) { _syncInfo.clearUpdateTrees = reset; }
         void setVfsMode(const VirtualFileMode mode) { _syncInfo.vfsMode = mode; }
         void setIsPaused(const bool paused) { _syncInfo.isPaused = paused; }
 

--- a/src/libsyncengine/syncpal/syncpalworker.cpp
+++ b/src/libsyncengine/syncpal/syncpalworker.cpp
@@ -393,6 +393,12 @@ void SyncPalWorker::initStep(SyncStep step, std::shared_ptr<ISyncWorker> (&worke
                 _syncPal->resetSnapshotInvalidationCounters();
                 _syncPal->setSyncHasFullyCompletedInParms(true);
             }
+            if (_syncPal->clearUpdateTrees()) {
+                LOG_SYNCPAL_DEBUG(_logger, "Clearing update trees");
+                _syncPal->_localUpdateTree->clear();
+                _syncPal->_remoteUpdateTree->clear();
+                _syncPal->setClearUpdateTrees(false);
+            }
             sentry::pTraces::basic::Sync(syncDbId()).stop();
             break;
         default:

--- a/src/libsyncengine/update_detection/update_detector/updatetree.cpp
+++ b/src/libsyncengine/update_detection/update_detector/updatetree.cpp
@@ -224,14 +224,14 @@ void UpdateTree::clear() {
     init();
 }
 
-void UpdateTree::drawUpdateTree() {
+void UpdateTree::drawUpdateTree(const uint16_t step /*= 0*/) {
     if (const std::string drawUpdateTree = CommonUtility::envVarValue("KDRIVE_DEBUG_DRAW_UPDATETREE"); drawUpdateTree.empty()) {
         return;
     }
 
     SyncName treeStr;
     drawUpdateTreeRow(rootNode(), treeStr);
-    LOGW_INFO(Log::instance()->getLogger(), _side << L" update tree:\n" << SyncName2WStr(treeStr));
+    LOGW_INFO(Log::instance()->getLogger(), _side << L" update tree (step " << step << L"):\n" << SyncName2WStr(treeStr));
 }
 
 void UpdateTree::drawUpdateTreeRow(const std::shared_ptr<Node> node, SyncName &treeStr, uint64_t depth /*= 0*/) {

--- a/src/libsyncengine/update_detection/update_detector/updatetree.h
+++ b/src/libsyncengine/update_detection/update_detector/updatetree.h
@@ -60,7 +60,7 @@ class UpdateTree : public SharedObject {
         /**
          * Draw the update tree in the log file for debugging purpose
          */
-        void drawUpdateTree();
+        void drawUpdateTree(uint16_t step = 0);
 
     private:
         void drawUpdateTreeRow(std::shared_ptr<Node> node, SyncName &treeStr, uint64_t depth = 0);

--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.h
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.h
@@ -138,12 +138,17 @@ class UpdateTreeWorker : public ISyncWorker {
          */
         ExitCode handleCreateOperationsWithSamePath();
 
-        [[nodiscard]] ExitCode getOrCreateNodeFromPath(const SyncPath &path, bool isDeleted, std::shared_ptr<Node> &node);
-        [[nodiscard]] ExitCode getOrCreateNodeFromExistingPath(const SyncPath &path, std::shared_ptr<Node> &node) {
-            return getOrCreateNodeFromPath(path, false, node);
+        [[nodiscard]] ExitCode getNodeFromPath(const SyncPath &path, bool isDeleted, std::shared_ptr<Node> &node,
+                                               bool createNodesIfMissing = true);
+        [[nodiscard]] ExitCode createTmpNode(std::shared_ptr<Node> &tmpNode, const SyncName &name,
+                                             const std::shared_ptr<Node> &parentNode);
+        [[nodiscard]] ExitCode getNodeFromExistingPath(const SyncPath &path, std::shared_ptr<Node> &node,
+                                                       const bool createNodesIfMissing = true) {
+            return getNodeFromPath(path, false, node, createNodesIfMissing);
         }
-        [[nodiscard]] ExitCode getOrCreateNodeFromDeletedPath(const SyncPath &path, std::shared_ptr<Node> &node) {
-            return getOrCreateNodeFromPath(path, true, node);
+        [[nodiscard]] ExitCode getNodeFromDeletedPath(const SyncPath &path, std::shared_ptr<Node> &node,
+                                                      const bool createNodesIfMissing = true) {
+            return getNodeFromPath(path, true, node, createNodesIfMissing);
         }
         bool mergingTempNodeToRealNode(std::shared_ptr<Node> tmpNode, std::shared_ptr<Node> realNode);
 

--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.h
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.h
@@ -138,18 +138,24 @@ class UpdateTreeWorker : public ISyncWorker {
          */
         ExitCode handleCreateOperationsWithSamePath();
 
-        [[nodiscard]] ExitCode getNodeFromPath(const SyncPath &path, bool isDeleted, std::shared_ptr<Node> &node,
-                                               bool createNodesIfMissing = true);
+        [[nodiscard]] ExitCode getOrCreateNodeFromPath(const SyncPath &path, std::shared_ptr<Node> &node,
+                                                       bool existingBranchOnly = true);
         [[nodiscard]] ExitCode createTmpNode(std::shared_ptr<Node> &tmpNode, const SyncName &name,
                                              const std::shared_ptr<Node> &parentNode);
-        [[nodiscard]] ExitCode getNodeFromExistingPath(const SyncPath &path, std::shared_ptr<Node> &node,
-                                                       const bool createNodesIfMissing = true) {
-            return getNodeFromPath(path, false, node, createNodesIfMissing);
+        [[nodiscard]] ExitCode getOrCreateNodeFromExistingPath(const SyncPath &path, std::shared_ptr<Node> &node) {
+            return getOrCreateNodeFromPath(path, node, true);
         }
-        [[nodiscard]] ExitCode getNodeFromDeletedPath(const SyncPath &path, std::shared_ptr<Node> &node,
-                                                      const bool createNodesIfMissing = true) {
-            return getNodeFromPath(path, true, node, createNodesIfMissing);
-        }
+        // [[nodiscard]] ExitCode getOrCreateNodeFromDeletedPath(const SyncPath &path, std::shared_ptr<Node> &node) {
+        //     return getOrCreateNodeFromPath(path, true, node);
+        // }
+        /**
+         * @brief This method get a node from a deleted path recursively. Recursivity here ensure that, even if 2 branches have
+         * nodes with the same names, the deleted branch is retrieved.
+         * @param path The path of the node to be retrieved.
+         * @return A shared pointer to the node. If the node is not found, the shared pointer is invalid.
+         */
+        [[nodiscard]] std::shared_ptr<Node> getNodeFromDeletedPath(const SyncPath &path);
+
         bool mergingTempNodeToRealNode(std::shared_ptr<Node> tmpNode, std::shared_ptr<Node> realNode);
 
         /**

--- a/test/libsyncengine/integration/testintegration.cpp
+++ b/test/libsyncengine/integration/testintegration.cpp
@@ -151,15 +151,15 @@ void TestIntegration::testAll() {
     logStep("initialization");
 
     // Run test cases
-    // basicTests();
-    // inconsistencyTests();
-    // conflictTests();
-    // testBreakCycle();
-    // testBlacklist();
-    // testExclusionTemplates();
-    // testEncoding();
-    // testParentRename();
-    // testNegativeModificationTime();
+    basicTests();
+    inconsistencyTests();
+    conflictTests();
+    testBreakCycle();
+    testBlacklist();
+    testExclusionTemplates();
+    testEncoding();
+    testParentRename();
+    testNegativeModificationTime();
     testDeleteAndRecreateBranch();
 }
 

--- a/test/libsyncengine/integration/testintegration.cpp
+++ b/test/libsyncengine/integration/testintegration.cpp
@@ -151,15 +151,16 @@ void TestIntegration::testAll() {
     logStep("initialization");
 
     // Run test cases
-    basicTests();
-    inconsistencyTests();
-    conflictTests();
-    testBreakCycle();
-    testBlacklist();
-    testExclusionTemplates();
-    testEncoding();
-    testParentRename();
-    testNegativeModificationTime();
+    // basicTests();
+    // inconsistencyTests();
+    // conflictTests();
+    // testBreakCycle();
+    // testBlacklist();
+    // testExclusionTemplates();
+    // testEncoding();
+    // testParentRename();
+    // testNegativeModificationTime();
+    testDeleteAndRecreateBranch();
 }
 
 void TestIntegration::inconsistencyTests() {
@@ -560,6 +561,69 @@ void TestIntegration::testNegativeModificationTime() {
     }
 
     logStep("testNegativeModificationTime");
+}
+
+void TestIntegration::testDeleteAndRecreateBranch() {
+    waitForSyncToBeIdle(SourceLocation::currentLoc());
+
+    // Setup initial situation
+    // .
+    // └── A(a)
+    //     └── AA(aa)
+    //         └── AAA(aaa)
+    //             └── AAAA(aaaa)
+    _syncPal->pause(); // We need to pause the sync because the back might take some time to notify all the events.
+    const RemoteTemporaryDirectory tmpRemoteDir(_driveDbId, _remoteSyncDir.id());
+    NodeId nodeIdA;
+    NodeId nodeIdAA;
+    NodeId nodeIdAAA;
+    NodeId nodeIdAAAA;
+    const SyncPath filename = "AAAA";
+    const auto filepath = _syncPal->localPath() / tmpRemoteDir.name() / filename;
+    {
+        CreateDirJob jobA(nullptr, _driveDbId, tmpRemoteDir.id(), Str("A"));
+        (void) jobA.runSynchronously();
+        nodeIdA = jobA.nodeId();
+        CreateDirJob jobAA(nullptr, _driveDbId, jobA.nodeId(), Str("AA"));
+        (void) jobAA.runSynchronously();
+        nodeIdAA = jobAA.nodeId();
+        CreateDirJob jobAAA(nullptr, _driveDbId, nodeIdAA, Str("AAA"));
+        (void) jobAAA.runSynchronously();
+        nodeIdAAA = jobAAA.nodeId();
+
+        nodeIdAAAA = duplicateRemoteFile(_driveDbId, _testFileRemoteId, filename);
+        moveRemoteFile(_driveDbId, nodeIdAAAA, nodeIdAAA);
+    }
+    _syncPal->_remoteFSObserverWorker->forceUpdate(); // Make sure that the remote change is detected immediately
+    _syncPal->unpause();
+    waitForSyncToBeIdle(SourceLocation::currentLoc());
+
+    _syncPal->pause();
+
+    {
+        // Move test file outside deleted directory
+        moveRemoteFile(_driveDbId, nodeIdAAAA, tmpRemoteDir.id());
+
+        // Delete A/AA
+        deleteRemoteFile(_driveDbId, nodeIdAA);
+
+        // Create A/AA/AAA1
+        CreateDirJob jobAA(nullptr, _driveDbId, nodeIdA, Str("AA"));
+        (void) jobAA.runSynchronously();
+        nodeIdAA = jobAA.nodeId();
+        CreateDirJob jobAAA(nullptr, _driveDbId, nodeIdAA, Str("AAA1"));
+        (void) jobAAA.runSynchronously();
+
+        // Move back test file
+        moveRemoteFile(_driveDbId, nodeIdAAAA, jobAAA.nodeId());
+    }
+
+    _syncPal->unpause();
+    waitForSyncToBeIdle(SourceLocation::currentLoc());
+
+    CPPUNIT_ASSERT(std::filesystem::exists(_syncPal->localPath() / tmpRemoteDir.name() / "A" / "AA" / "AAA1"));
+
+    logStep("testDeleteAndRecreateBranch");
 }
 
 #if defined(KD_LINUX)

--- a/test/libsyncengine/integration/testintegration.h
+++ b/test/libsyncengine/integration/testintegration.h
@@ -81,6 +81,8 @@ class TestIntegration : public CppUnit::TestFixture, public TestBase {
         void testParentRename();
         void testNegativeModificationTime();
 
+        void testDeleteAndRecreateBranch();
+
         class MockIoHelperFileStat : public IoHelper {
             public:
                 MockIoHelperFileStat() {

--- a/test/libsyncengine/update_detection/update_detector/testupdatetreeworker.cpp
+++ b/test/libsyncengine/update_detection/update_detector/testupdatetreeworker.cpp
@@ -349,7 +349,7 @@ void TestUpdateTreeWorker::testUpdateTmpFileNode() {
                                           testhelpers::defaultTime, testhelpers::defaultFileSize, "Dir 5/File 5.1");
     {
         std::shared_ptr<Node> newNode;
-        CPPUNIT_ASSERT(_localUpdateTreeWorker->getOrCreateNodeFromExistingPath("Dir 5/File 5.1", newNode) == ExitCode::Ok);
+        CPPUNIT_ASSERT(_localUpdateTreeWorker->getNodeFromExistingPath("Dir 5/File 5.1", newNode) == ExitCode::Ok);
         CPPUNIT_ASSERT(newNode->id()->substr(0, 4) == "tmp_");
         CPPUNIT_ASSERT(newNode->isTmp());
 
@@ -368,7 +368,7 @@ void TestUpdateTreeWorker::testUpdateTmpFileNode() {
 
     {
         std::shared_ptr<Node> newNode;
-        CPPUNIT_ASSERT(_localUpdateTreeWorker->getOrCreateNodeFromExistingPath("Dir 5/File 5.1", newNode) == ExitCode::Ok);
+        CPPUNIT_ASSERT(_localUpdateTreeWorker->getNodeFromExistingPath("Dir 5/File 5.1", newNode) == ExitCode::Ok);
         CPPUNIT_ASSERT(newNode->id()->substr(0, 4) == "tmp_");
         CPPUNIT_ASSERT(newNode->isTmp());
 

--- a/test/libsyncengine/update_detection/update_detector/testupdatetreeworker.cpp
+++ b/test/libsyncengine/update_detection/update_detector/testupdatetreeworker.cpp
@@ -349,7 +349,7 @@ void TestUpdateTreeWorker::testUpdateTmpFileNode() {
                                           testhelpers::defaultTime, testhelpers::defaultFileSize, "Dir 5/File 5.1");
     {
         std::shared_ptr<Node> newNode;
-        CPPUNIT_ASSERT(_localUpdateTreeWorker->getNodeFromExistingPath("Dir 5/File 5.1", newNode) == ExitCode::Ok);
+        CPPUNIT_ASSERT(_localUpdateTreeWorker->getOrCreateNodeFromExistingPath("Dir 5/File 5.1", newNode) == ExitCode::Ok);
         CPPUNIT_ASSERT(newNode->id()->substr(0, 4) == "tmp_");
         CPPUNIT_ASSERT(newNode->isTmp());
 
@@ -368,7 +368,7 @@ void TestUpdateTreeWorker::testUpdateTmpFileNode() {
 
     {
         std::shared_ptr<Node> newNode;
-        CPPUNIT_ASSERT(_localUpdateTreeWorker->getNodeFromExistingPath("Dir 5/File 5.1", newNode) == ExitCode::Ok);
+        CPPUNIT_ASSERT(_localUpdateTreeWorker->getOrCreateNodeFromExistingPath("Dir 5/File 5.1", newNode) == ExitCode::Ok);
         CPPUNIT_ASSERT(newNode->id()->substr(0, 4) == "tmp_");
         CPPUNIT_ASSERT(newNode->isTmp());
 
@@ -1050,6 +1050,116 @@ void TestUpdateTreeWorker::testDeleteRecreateBranch() {
     CPPUNIT_ASSERT(!node1111new->hasChangeEvent(OperationType::Delete));
     CPPUNIT_ASSERT(node1111new->hasChangeEvent(OperationType::Create));
     CPPUNIT_ASSERT(node1111new->parentNode() == node111new);
+}
+
+void TestUpdateTreeWorker::testGetNodeFromDeletedPath() {
+    {
+        // Simple case where a branch is deleted and re-created.
+        auto updateTree = std::make_shared<UpdateTree>(ReplicaSide::Local, SyncDb::driveRootNode());
+        const auto updateTreeWorker = std::make_shared<UpdateTreeWorker>(_syncDb->cache(), _operationSet, updateTree,
+                                                                         "Test Update Tree Worker", "TUT", ReplicaSide::Local);
+
+        const auto nodeA = std::make_shared<Node>(ReplicaSide::Local, Str("A"), NodeType::Directory, OperationType::None,
+                                                  CommonUtility::generateRandomStringAlphaNum(), testhelpers::defaultTime,
+                                                  testhelpers::defaultTime, testhelpers::defaultDirSize, updateTree->rootNode());
+        updateTree->insertNode(nodeA);
+        (void) updateTree->rootNode()->insertChildren(nodeA);
+
+        // Created branch
+        const auto nodeAAcreate = std::make_shared<Node>(ReplicaSide::Local, Str("AA"), NodeType::Directory, nodeA);
+        updateTree->insertNode(nodeAAcreate);
+        (void) nodeA->insertChildren(nodeAAcreate);
+
+        const auto nodeAAAcreate =
+                std::make_shared<Node>(ReplicaSide::Local, Str("AAA"), NodeType::Directory, OperationType::Create,
+                                       CommonUtility::generateRandomStringAlphaNum(), testhelpers::defaultTime,
+                                       testhelpers::defaultTime, testhelpers::defaultDirSize, nodeAAcreate);
+        updateTree->insertNode(nodeAAAcreate);
+        (void) nodeAAcreate->insertChildren(nodeAAAcreate);
+
+        // Deleted branch
+        const auto nodeAAdelete =
+                std::make_shared<Node>(ReplicaSide::Local, Str("AA"), NodeType::Directory, OperationType::Delete,
+                                       CommonUtility::generateRandomStringAlphaNum(), testhelpers::defaultTime,
+                                       testhelpers::defaultTime, testhelpers::defaultDirSize, nodeA);
+        updateTree->insertNode(nodeAAdelete);
+        (void) nodeA->insertChildren(nodeAAdelete);
+
+        const auto nodeAAAdelete =
+                std::make_shared<Node>(ReplicaSide::Local, Str("AAA"), NodeType::Directory, OperationType::Delete,
+                                       CommonUtility::generateRandomStringAlphaNum(), testhelpers::defaultTime,
+                                       testhelpers::defaultTime, testhelpers::defaultDirSize, nodeAAdelete);
+        updateTree->insertNode(nodeAAAdelete);
+        (void) nodeAAdelete->insertChildren(nodeAAAdelete);
+
+        updateTree->drawUpdateTree(0);
+
+        std::shared_ptr<Node> node = updateTreeWorker->getNodeFromDeletedPath(SyncPath("/A/AA/AAA"));
+        CPPUNIT_ASSERT_EQUAL(nodeAAAdelete->id().value(), node->id().value());
+        (void) updateTreeWorker->getOrCreateNodeFromExistingPath(SyncPath("/A/AA/AAA"), node);
+        CPPUNIT_ASSERT_EQUAL(nodeAAAcreate->id().value(), node->id().value());
+    }
+    {
+        // More complex case where a branch is deleted and re-created, and a file is moved inside the newly created branch.
+        auto updateTree = std::make_shared<UpdateTree>(ReplicaSide::Local, SyncDb::driveRootNode());
+        const auto updateTreeWorker = std::make_shared<UpdateTreeWorker>(_syncDb->cache(), _operationSet, updateTree,
+                                                                         "Test Update Tree Worker", "TUT", ReplicaSide::Local);
+
+        const auto nodeA = std::make_shared<Node>(ReplicaSide::Local, Str("A"), NodeType::Directory, OperationType::None,
+                                                  CommonUtility::generateRandomStringAlphaNum(), testhelpers::defaultTime,
+                                                  testhelpers::defaultTime, testhelpers::defaultDirSize, updateTree->rootNode());
+        updateTree->insertNode(nodeA);
+        (void) updateTree->rootNode()->insertChildren(nodeA);
+
+        // Created branch
+        const auto nodeAAcreate = std::make_shared<Node>(ReplicaSide::Local, Str("AA"), NodeType::Directory, nodeA);
+        updateTree->insertNode(nodeAAcreate);
+        (void) nodeA->insertChildren(nodeAAcreate);
+
+        const auto nodeAAAcreate =
+                std::make_shared<Node>(ReplicaSide::Local, Str("AAA"), NodeType::Directory, OperationType::Create,
+                                       CommonUtility::generateRandomStringAlphaNum(), testhelpers::defaultTime,
+                                       testhelpers::defaultTime, testhelpers::defaultDirSize, nodeAAcreate);
+        updateTree->insertNode(nodeAAAcreate);
+        (void) nodeAAcreate->insertChildren(nodeAAAcreate);
+
+        // Deleted branch
+        const auto nodeAAdelete =
+                std::make_shared<Node>(ReplicaSide::Local, Str("AA"), NodeType::Directory, OperationType::Delete,
+                                       CommonUtility::generateRandomStringAlphaNum(), testhelpers::defaultTime,
+                                       testhelpers::defaultTime, testhelpers::defaultDirSize, nodeA);
+        updateTree->insertNode(nodeAAdelete);
+        (void) nodeA->insertChildren(nodeAAdelete);
+
+        const auto nodeAAAdelete =
+                std::make_shared<Node>(ReplicaSide::Local, Str("AAA"), NodeType::Directory, OperationType::Delete,
+                                       CommonUtility::generateRandomStringAlphaNum(), testhelpers::defaultTime,
+                                       testhelpers::defaultTime, testhelpers::defaultDirSize, nodeAAdelete);
+        updateTree->insertNode(nodeAAAdelete);
+        (void) nodeAAdelete->insertChildren(nodeAAAdelete);
+
+        const auto nodeAAA1delete = std::make_shared<Node>(ReplicaSide::Local, Str("AAA1"), NodeType::Directory, nodeAAdelete);
+        updateTree->insertNode(nodeAAA1delete);
+        (void) nodeAAdelete->insertChildren(nodeAAA1delete);
+
+        const auto nodeAAAAdelete =
+                std::make_shared<Node>(ReplicaSide::Local, Str("AAAA"), NodeType::File, OperationType::None,
+                                       CommonUtility::generateRandomStringAlphaNum(), testhelpers::defaultTime,
+                                       testhelpers::defaultTime, testhelpers::defaultDirSize, nodeAAA1delete);
+        nodeAAAAdelete->setMoveOriginInfos({SyncPath("/A/AA/AAA"), nodeAAA1delete->id().value()});
+        nodeAAAAdelete->setChangeEvents(OperationType::Move);
+        updateTree->insertNode(nodeAAAAdelete);
+        (void) nodeAAA1delete->insertChildren(nodeAAAAdelete);
+
+        updateTree->drawUpdateTree(0);
+
+        std::shared_ptr<Node> node = updateTreeWorker->getNodeFromDeletedPath(SyncPath("/A/AA/AAA"));
+        CPPUNIT_ASSERT_EQUAL(nodeAAAdelete->id().value(), node->id().value());
+        node = updateTreeWorker->getNodeFromDeletedPath(SyncPath("/A/AA/AAA1"));
+        CPPUNIT_ASSERT_EQUAL(nodeAAA1delete->id().value(), node->id().value());
+        (void) updateTreeWorker->getOrCreateNodeFromExistingPath(SyncPath("/A/AA/AAA"), node);
+        CPPUNIT_ASSERT_EQUAL(nodeAAAcreate->id().value(), node->id().value());
+    }
 }
 
 } // namespace KDC

--- a/test/libsyncengine/update_detection/update_detector/testupdatetreeworker.h
+++ b/test/libsyncengine/update_detection/update_detector/testupdatetreeworker.h
@@ -57,6 +57,7 @@ class TestUpdateTreeWorker : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST(testGetOriginPath5);
         CPPUNIT_TEST(testDeleteMove);
         CPPUNIT_TEST(testDeleteRecreateBranch);
+        CPPUNIT_TEST(testGetNodeFromDeletedPath);
         CPPUNIT_TEST_SUITE_END();
 
     public:
@@ -109,6 +110,8 @@ class TestUpdateTreeWorker : public CppUnit::TestFixture, public TestBase {
          * re-create it immediately with different IDs but same names.
          */
         void testDeleteRecreateBranch();
+
+        void testGetNodeFromDeletedPath();
 
     private:
         std::shared_ptr<UpdateTreeWorker> _localUpdateTreeWorker;


### PR DESCRIPTION
This PR fixes an issue to build the update tree in the following case:
**Initial situation:**
```
.
└── A(a)
    └── AA(aa)
        └── AAA(aaa)
            └── AAAA(aaaa)
```

**Steps:**
- Move /A/AA/AAA/AAAA to AAAA
- Delete /A/AA
- Create /A/AA/AAA1 (and therefor also /A/AA)
- Move AAAA to /A/AA/AAA1/AAAA

The chain of events leads to an error in `UpdateNodeWithDB` because a temporary node is not merge with the real associated node.