### PR TITLE
fix(compute-fs-operations): postpone the remote creation of newly created local items if they reuse the identifiers of deleted local items

### DIFF
--- a/src/libcommonserver/utility/utility.cpp
+++ b/src/libcommonserver/utility/utility.cpp
@@ -165,7 +165,7 @@ std::wstring Utility::quotedSyncName(const SyncName &name) {
 
 std::wstring Utility::formatSyncName(const SyncName &name) {
     std::wstringstream ss;
-    ss << L"name='" << quotedSyncName(name);
+    ss << L"name=" << quotedSyncName(name);
 
     return ss.str();
 }

--- a/src/libsyncengine/syncpal/syncpal.h
+++ b/src/libsyncengine/syncpal/syncpal.h
@@ -291,6 +291,9 @@ class SYNCENGINE_EXPORT SyncPal : public std::enable_shared_from_this<SyncPal> {
          *      behind the actual state of the filesystem.
          */
         const LiveSnapshot &liveSnapshot(ReplicaSide side) const;
+        void removeLocalOperation(const NodeId &localNodeId, const OperationType operationType) {
+            _localOperationSet->removeOp(localNodeId, operationType);
+        }
 
     protected:
         virtual void createWorkers(const std::chrono::seconds &startDelay = std::chrono::seconds(0));

--- a/src/libsyncengine/syncpal/syncpal.h
+++ b/src/libsyncengine/syncpal/syncpal.h
@@ -292,7 +292,7 @@ class SYNCENGINE_EXPORT SyncPal : public std::enable_shared_from_this<SyncPal> {
          */
         const LiveSnapshot &liveSnapshot(ReplicaSide side) const;
         void removeLocalOperation(const NodeId &localNodeId, const OperationType operationType) {
-            _localOperationSet->removeOp(localNodeId, operationType);
+            (void) _localOperationSet->removeOp(localNodeId, operationType);
         }
 
     protected:

--- a/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
@@ -44,7 +44,8 @@ ComputeFSOperationWorker::ComputeFSOperationWorker(SyncDbReadOnlyCache &testSync
 
 void ComputeFSOperationWorker::postponeCreateOperationsOnReusedIds() {
     for (const auto &localId: _localReusedIds) {
-        deleteLocalDescendantOps(localId);
+        _syncPal->removeLocalOperation(localId, OperationType::Create);
+        deleteLocalDescendantCreateOps(localId);
         SyncPath localPath;
         bool ignore = false;
         (void) _syncPal->snapshot(ReplicaSide::Local)->path(localId, localPath, ignore);
@@ -952,7 +953,7 @@ void ComputeFSOperationWorker::deleteChildOpRecursively(const std::shared_ptr<co
     }
 }
 
-void ComputeFSOperationWorker::deleteLocalDescendantOps(const NodeId &localNodeId) {
+void ComputeFSOperationWorker::deleteLocalDescendantCreateOps(const NodeId &localNodeId) {
     const auto localSnapshot = _syncPal->snapshot(ReplicaSide::Local);
     const auto descendantIds = localSnapshot->getDescendantIds(localNodeId);
 

--- a/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
@@ -47,7 +47,7 @@ void ComputeFSOperationWorker::postponeCreateOperationsOnReusedIds() {
         deleteLocalDescendantOps(localId);
         SyncPath localPath;
         bool ignore = false;
-        _syncPal->snapshot(ReplicaSide::Local)->path(localId, localPath, ignore);
+        (void) _syncPal->snapshot(ReplicaSide::Local)->path(localId, localPath, ignore);
         LOGW_SYNCPAL_DEBUG(_logger, L"Postponing the creation of local item with id='"
                                             << CommonUtility::s2ws(localId) << L"' and " << Utility::formatSyncPath(localPath)
                                             << L" and its descendants because this item, or one of its ancestors, has reused the "
@@ -947,7 +947,7 @@ void ComputeFSOperationWorker::deleteChildOpRecursively(const std::shared_ptr<co
         if (remoteSnapshot->type(childId) == NodeType::Directory) {
             deleteChildOpRecursively(remoteSnapshot, childId, tmpTooBigList);
         }
-        _syncPal->_remoteOperationSet->removeOp(remoteNodeId, OperationType::Create);
+        (void) _syncPal->_remoteOperationSet->removeOp(remoteNodeId, OperationType::Create);
         tmpTooBigList.erase(childId);
     }
 }

--- a/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
@@ -42,6 +42,21 @@ ComputeFSOperationWorker::ComputeFSOperationWorker(SyncDbReadOnlyCache &testSync
     ISyncWorker(nullptr, name, shortName, std::chrono::seconds(0), true),
     _syncDbReadOnlyCache(testSyncDbReadOnlyCache) {}
 
+void ComputeFSOperationWorker::postponeCreateOperationsOnReusedIds() {
+    for (const auto &localId: _localReusedIds) {
+        deleteLocalDescendantOps(localId);
+        SyncPath localPath;
+        bool ignore = false;
+        _syncPal->snapshot(ReplicaSide::Local)->path(localId, localPath, ignore);
+        LOGW_SYNCPAL_DEBUG(_logger, L"Postponing the creation of item with id='"
+                                            << CommonUtility::s2ws(localId) << L"' and " << Utility::formatSyncPath(localPath)
+                                            << L" and its descendants because this item, or one of its ancestors, has reused the "
+                                               L"identifier of a deleted item.");
+    }
+
+    _localReusedIds.clear();
+}
+
 void ComputeFSOperationWorker::execute() {
     ExitCode exitCode(ExitCode::Unknown);
 
@@ -78,7 +93,6 @@ void ComputeFSOperationWorker::execute() {
     updateUnsyncedList();
 
     _fileSizeMismatchMap.clear();
-    _localReusedIds.clear();
 
     NodeIdSet localIdsSet;
     NodeIdSet remoteIdsSet;
@@ -126,18 +140,7 @@ void ComputeFSOperationWorker::execute() {
         LOG_SYNCPAL_INFO(_logger, "FS operation sets generated in: " << elapsedSeconds.count() << "s");
     }
 
-    // The creation of the local items which reuse the identifiers of deleted items is postponed to the next synchronization.
-    // So is the creation of the descendants of those local items.
-    for (const auto &localId: _localReusedIds) {
-        deleteLocalDescendantOps(localId);
-        SyncPath localPath;
-        bool ignore = false;
-        _syncPal->snapshot(ReplicaSide::Local)->path(localId, localPath, ignore);
-        LOGW_SYNCPAL_DEBUG(_logger,
-                           L"Postponing the creation of item with id='"
-                                   << CommonUtility::s2ws(localId) << L"' and " << Utility::formatSyncPath(localPath)
-                                   << L" because this item or one of its ancestors reused the identifier of a deleted item.");
-    }
+    postponeCreateOperationsOnReusedIds();
 
     LOG_SYNCPAL_DEBUG(_logger, "Worker stopped: name=" << name());
     setDone(exitCode);
@@ -277,12 +280,8 @@ ExitCode ComputeFSOperationWorker::inferChangeFromDbNode(const ReplicaSide side,
             }
         }
 
-        if (checkTemplate) {
-            if (ExclusionTemplateCache::instance()->isExcluded(dbPath)) {
-                // The item is excluded
-                return ExitCode::Ok;
-            }
-        }
+        // Exits if the item is excluded.
+        if (checkTemplate && ExclusionTemplateCache::instance()->isExcluded(dbPath)) return ExitCode::Ok;
 
         // Delete operation
         const auto fsOp = std::make_shared<FSOperation>(OperationType::Delete, nodeId, dbNode.type(),
@@ -291,9 +290,7 @@ ExitCode ComputeFSOperationWorker::inferChangeFromDbNode(const ReplicaSide side,
         opSet->insertOp(fsOp);
         logOperationGeneration(snapshot->side(), fsOp);
 
-        if (nodeIdReused) {
-            _localReusedIds.insert(nodeId);
-        }
+        if (nodeIdReused) (void) _localReusedIds.insert(nodeId);
 
         if (dbNode.type() == NodeType::Directory && !addFolderToDelete(dbPath)) {
             LOGW_SYNCPAL_WARN(_logger,

--- a/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
@@ -48,7 +48,7 @@ void ComputeFSOperationWorker::postponeCreateOperationsOnReusedIds() {
         SyncPath localPath;
         bool ignore = false;
         _syncPal->snapshot(ReplicaSide::Local)->path(localId, localPath, ignore);
-        LOGW_SYNCPAL_DEBUG(_logger, L"Postponing the creation of item with id='"
+        LOGW_SYNCPAL_DEBUG(_logger, L"Postponing the creation of local item with id='"
                                             << CommonUtility::s2ws(localId) << L"' and " << Utility::formatSyncPath(localPath)
                                             << L" and its descendants because this item, or one of its ancestors, has reused the "
                                                L"identifier of a deleted item.");

--- a/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.h
+++ b/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.h
@@ -49,6 +49,7 @@ class ComputeFSOperationWorker : public ISyncWorker {
         SnapshotRevision _lastLocalSnapshotSyncedRevision = 0;
         SnapshotRevision _lastRemoteSnapshotSyncedRevision = 0;
 
+
         // Detect changes based on the database records: delete, move and edit operations
         ExitCode inferChangesFromDb(NodeIdSet &localIdsSet, NodeIdSet &remoteIdsSet);
         ExitCode inferChangesFromDb(const NodeType nodeType, NodeIdSet &localIdsSet, NodeIdSet &remoteIdsSet,
@@ -100,6 +101,10 @@ class ComputeFSOperationWorker : public ISyncWorker {
         void logOperationGeneration(const ReplicaSide side, const FSOpPtr fsOp);
         void notifyIgnoredItem(const NodeId &nodeId, const SyncPath &relativePath, NodeType nodeType);
         ExitInfo blacklistItem(const SyncPath &relativeLocalPath);
+
+        // The remote propagation of the creation of local items that reuse identifiers of deleted items is postponed to the next
+        // synchronization. So is the propagation of the creation of the descendants of those local items.
+        void postponeCreateOperationsOnReusedIds();
 
         SyncDbReadOnlyCache &_syncDbReadOnlyCache;
         Sync _sync;

--- a/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.h
+++ b/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.h
@@ -93,7 +93,7 @@ class ComputeFSOperationWorker : public ISyncWorker {
 
         void deleteChildOpRecursively(const std::shared_ptr<const Snapshot> remoteSnapshot, const NodeId &remoteNodeId,
                                       NodeSet &tmpTooBigList);
-        void deleteLocalDescendantOps(const NodeId &localNodeId);
+        void deleteLocalDescendantCreateOps(const NodeId &localNodeId);
 
         void updateUnsyncedList();
         ExitCode updateSyncNode(SyncNodeType syncNodeType);

--- a/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.h
+++ b/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.h
@@ -92,6 +92,7 @@ class ComputeFSOperationWorker : public ISyncWorker {
 
         void deleteChildOpRecursively(const std::shared_ptr<const Snapshot> remoteSnapshot, const NodeId &remoteNodeId,
                                       NodeSet &tmpTooBigList);
+        void deleteLocalDescendantOps(const NodeId &localNodeId);
 
         void updateUnsyncedList();
         ExitCode updateSyncNode(SyncNodeType syncNodeType);
@@ -106,6 +107,7 @@ class ComputeFSOperationWorker : public ISyncWorker {
         NodeIdSet _remoteUnsyncedList;
         NodeIdSet _remoteTmpUnsyncedList;
         NodeIdSet _localTmpUnsyncedList;
+        NodeIdSet _localReusedIds;
 
         std::unordered_set<SyncPath, PathHashFunction> _dirPathToDeleteSet;
         std::unordered_map<NodeId, SyncPath> _fileSizeMismatchMap; // File size mismatch checks are only enabled when env var:

--- a/src/libsyncengine/update_detection/file_system_observer/snapshot/snapshot.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/snapshot/snapshot.cpp
@@ -281,6 +281,27 @@ bool Snapshot::getChildrenIds(const NodeId &itemId, NodeSet &childrenIds) const 
     return true;
 }
 
+NodeSet Snapshot::getDescendantIds(const NodeId &itemId) const {
+    const std::scoped_lock lock(_mutex);
+    NodeSet descendantIds;
+
+    getDescendantIds(itemId, descendantIds);
+
+    return descendantIds;
+}
+
+void Snapshot::getDescendantIds(const NodeId &itemId, NodeSet &descendantIds) const {
+    const std::scoped_lock lock(_mutex);
+
+    std::unordered_set<std::shared_ptr<SnapshotItem>> children;
+    getChildren(itemId, children);
+
+    for (const auto &child: children) {
+        (void) descendantIds.insert(child->id());
+        getDescendantIds(child->id(), descendantIds);
+    }
+}
+
 void Snapshot::ids(NodeSet &ids) const {
     const std::scoped_lock lock(_mutex);
     ids.clear();

--- a/src/libsyncengine/update_detection/file_system_observer/snapshot/snapshot.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/snapshot/snapshot.cpp
@@ -294,7 +294,7 @@ void Snapshot::getDescendantIds(const NodeId &itemId, NodeSet &descendantIds) co
     const std::scoped_lock lock(_mutex);
 
     std::unordered_set<std::shared_ptr<SnapshotItem>> children;
-    getChildren(itemId, children);
+    (void) getChildren(itemId, children);
 
     for (const auto &child: children) {
         (void) descendantIds.insert(child->id());

--- a/src/libsyncengine/update_detection/file_system_observer/snapshot/snapshot.h
+++ b/src/libsyncengine/update_detection/file_system_observer/snapshot/snapshot.h
@@ -49,6 +49,7 @@ class Snapshot {
         bool isLink(const NodeId &itemId) const;
         SnapshotRevision lastChangeRevision(const NodeId &itemId) const;
         bool getChildrenIds(const NodeId &itemId, NodeSet &childrenIds) const;
+        NodeSet getDescendantIds(const NodeId &itemId) const;
 
         void ids(NodeSet &ids) const;
         /** Checks if ancestorItem is an ancestor of item.
@@ -88,6 +89,7 @@ class Snapshot {
     private:
         SnapshotRevision _revision = 0;
         bool getChildren(const NodeId &itemId, std::unordered_set<std::shared_ptr<SnapshotItem>> &children) const;
+        void getDescendantIds(const NodeId &itemId, NodeSet &descendantIds) const;
 
         ReplicaSide _side = ReplicaSide::Unknown;
         NodeId _rootFolderId;

--- a/test/libsyncengine/integration/testintegration.cpp
+++ b/test/libsyncengine/integration/testintegration.cpp
@@ -131,7 +131,7 @@ void TestIntegration::setUp() {
 }
 
 void TestIntegration::tearDown() {
-    _syncPal->stop(false, true, false);
+    if (_syncPal) _syncPal->stop(false, true, false);
     _remoteSyncDir.deleteDirectory();
 
     ParmsDb::instance()->close();
@@ -580,7 +580,7 @@ void TestIntegration::testNodeIdReuseFile2DirAndDir2File() {
     MockIoHelperFileStat mockIoHelper;
     // Create a file with a custom inode on the local side
     mockIoHelper.setPathWithFakeInode(absoluteLocalWorkingDir / "testNodeIdReuseFile", 2);
-    { const std::ofstream file((absoluteLocalWorkingDir / "testNodeIdReuseFile").string()); }
+    { const std::ofstream file(absoluteLocalWorkingDir / "testNodeIdReuseFile"); }
     waitForSyncToBeIdle(SourceLocation::currentLoc());
     CPPUNIT_ASSERT_EQUAL(NodeId("2"),
                          _syncPal->liveSnapshot(ReplicaSide::Local).itemId(relativeWorkingDirPath / "testNodeIdReuseFile"));
@@ -599,12 +599,15 @@ void TestIntegration::testNodeIdReuseFile2DirAndDir2File() {
     CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
     mockIoHelper.setPathWithFakeInode(absoluteLocalWorkingDir / "testNodeIdReuseDir", 2);
     IoHelper::createDirectory(absoluteLocalWorkingDir / "testNodeIdReuseDir", false, ioError);
+
+    // Create a child file within "testNodeIdReuseDir".
+    { const std::ofstream childFile(absoluteLocalWorkingDir / "testNodeIdReuseDir" / "childFile.txt"); }
     CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
 
     _syncPal->unpause();
     waitForSyncToBeIdle(SourceLocation::currentLoc());
 
-    // Check that the file has been replaced by a directory on the remote with a different ID
+    // Check that the file has been replaced by a directory on the remote replica with a different ID.
     const NodeId newRemoteDirId =
             _syncPal->liveSnapshot(ReplicaSide::Remote).itemId(relativeWorkingDirPath / "testNodeIdReuseDir");
     CPPUNIT_ASSERT(!newRemoteDirId.empty());
@@ -612,20 +615,26 @@ void TestIntegration::testNodeIdReuseFile2DirAndDir2File() {
     CPPUNIT_ASSERT_EQUAL(NodeType::Directory, _syncPal->liveSnapshot(ReplicaSide::Remote).type(newRemoteDirId));
     CPPUNIT_ASSERT(!_syncPal->liveSnapshot(ReplicaSide::Remote).exists(remoteFileId));
 
-    // Replace the directory with a file on the local side with the same id
+    // Check that the new directory contains the file "childFile.txt" that was created locally.
+    const NodeId newRemoteChildFileId =
+            _syncPal->liveSnapshot(ReplicaSide::Remote).itemId(relativeWorkingDirPath / "testNodeIdReuseDir" / "childFile.txt");
+    CPPUNIT_ASSERT(!newRemoteChildFileId.empty());
+    CPPUNIT_ASSERT_EQUAL(NodeType::File, _syncPal->liveSnapshot(ReplicaSide::Remote).type(newRemoteChildFileId));
+
+    // Replace the directory with a file on the local side with the same ID.
     _syncPal->pause();
     while (!_syncPal->isPaused()) {
         Utility::msleep(100);
     }
     IoHelper::deleteItem(absoluteLocalWorkingDir / "testNodeIdReuseDir", ioError);
     CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
-    { const std::ofstream file((absoluteLocalWorkingDir / "testNodeIdReuseFile").string()); }
+    { const std::ofstream file(absoluteLocalWorkingDir / "testNodeIdReuseFile"); }
     CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
 
     _syncPal->unpause();
     waitForSyncToBeIdle(SourceLocation::currentLoc());
 
-    // Check that the directory has been replaced by a file on the remote with a different ID
+    // Check that the directory has been replaced by a file on the remote with a different ID.
     const NodeId newRemoteFileId =
             _syncPal->liveSnapshot(ReplicaSide::Remote).itemId(relativeWorkingDirPath / "testNodeIdReuseFile");
     CPPUNIT_ASSERT(newRemoteFileId != "");
@@ -652,7 +661,7 @@ void TestIntegration::testNodeIdReuseFile2File() {
 
     MockIoHelperFileStat mockIoHelper;
     mockIoHelper.setPathWithFakeInode(absoluteLocalWorkingDir / "testNodeIdReuseFile", 2);
-    { const std::ofstream file((absoluteLocalWorkingDir / "testNodeIdReuseFile").string()); }
+    { const std::ofstream file(absoluteLocalWorkingDir / "testNodeIdReuseFile"); }
     waitForSyncToBeIdle(SourceLocation::currentLoc());
     CPPUNIT_ASSERT_EQUAL(NodeId("2"),
                          _syncPal->liveSnapshot(ReplicaSide::Local).itemId(relativeWorkingDirPath / "testNodeIdReuseFile"));

--- a/test/libsyncengine/integration/testintegration.cpp
+++ b/test/libsyncengine/integration/testintegration.cpp
@@ -599,10 +599,10 @@ void TestIntegration::testNodeIdReuseFile2DirAndDir2File() {
     CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
     mockIoHelper.setPathWithFakeInode(absoluteLocalWorkingDir / "testNodeIdReuseDir", 2);
     IoHelper::createDirectory(absoluteLocalWorkingDir / "testNodeIdReuseDir", false, ioError);
+    CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
 
     // Create a child file within "testNodeIdReuseDir".
     { const std::ofstream childFile(absoluteLocalWorkingDir / "testNodeIdReuseDir" / "childFile.txt"); }
-    CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
 
     _syncPal->unpause();
     waitForSyncToBeIdle(SourceLocation::currentLoc());
@@ -628,8 +628,8 @@ void TestIntegration::testNodeIdReuseFile2DirAndDir2File() {
     }
     IoHelper::deleteItem(absoluteLocalWorkingDir / "testNodeIdReuseDir", ioError);
     CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+
     { const std::ofstream file(absoluteLocalWorkingDir / "testNodeIdReuseFile"); }
-    CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
 
     _syncPal->unpause();
     waitForSyncToBeIdle(SourceLocation::currentLoc());

--- a/test/libsyncengine/update_detection/file_system_observer/testcomputefsoperationworker.cpp
+++ b/test/libsyncengine/update_detection/file_system_observer/testcomputefsoperationworker.cpp
@@ -554,6 +554,7 @@ void TestComputeFSOperationWorker::testUpdateSyncNode() {
     CPPUNIT_ASSERT(!syncNodes.contains("r_aa"));
 }
 
+#if defined(KD_LINUX)
 void TestComputeFSOperationWorker::testPostponeCreateOperationsOnReusedIds() {
     // Simulate a Delete operation of the local folder named "A".
     (void) _syncPal->_localFSObserverWorker->_liveSnapshot.removeItem("l_a");
@@ -585,5 +586,6 @@ void TestComputeFSOperationWorker::testPostponeCreateOperationsOnReusedIds() {
     CPPUNIT_ASSERT(_syncPal->operationSet(ReplicaSide::Local)->findOp("l_ab", OperationType::Delete, tmpOp));
     // Create operations have been removed.
 }
+#endif
 
 } // namespace KDC

--- a/test/libsyncengine/update_detection/file_system_observer/testcomputefsoperationworker.cpp
+++ b/test/libsyncengine/update_detection/file_system_observer/testcomputefsoperationworker.cpp
@@ -126,11 +126,11 @@ void TestComputeFSOperationWorker::testNoOps() {
 
 void TestComputeFSOperationWorker::testDeletionOfNestedFolders() {
     // Delete operations
-    _syncPal->_localFSObserverWorker->_liveSnapshot.removeItem("l_aa"); // Folder "AA" is contained in folder "A".
-    _syncPal->_localFSObserverWorker->_liveSnapshot.removeItem("l_ab"); // Folder "AB" is contained in folder "A".
-    _syncPal->_localFSObserverWorker->_liveSnapshot.removeItem(
+    (void) _syncPal->_localFSObserverWorker->_liveSnapshot.removeItem("l_aa"); // Folder "AA" is contained in folder "A".
+    (void) _syncPal->_localFSObserverWorker->_liveSnapshot.removeItem("l_ab"); // Folder "AB" is contained in folder "A".
+    (void) _syncPal->_localFSObserverWorker->_liveSnapshot.removeItem(
             "l_ac"); // Folder "AC" is contained in folder "A" but is blacklisted.
-    _syncPal->_localFSObserverWorker->_liveSnapshot.removeItem("l_a");
+    (void) _syncPal->_localFSObserverWorker->_liveSnapshot.removeItem("l_a");
 
     _syncPal->copySnapshots();
     _syncPal->computeFSOperationsWorker()->execute();
@@ -150,7 +150,7 @@ void TestComputeFSOperationWorker::testAccessDenied() {
         // BB (child of B) is deleted
         // B access is denied
         // Causes an Access Denied error in checkIfPathExists
-        _syncPal->_localFSObserverWorker->_liveSnapshot.removeItem("l_bb");
+        (void) _syncPal->_localFSObserverWorker->_liveSnapshot.removeItem("l_bb");
 
         SyncPath bNodePath = "B";
         std::error_code ec;
@@ -277,23 +277,23 @@ void TestComputeFSOperationWorker::testMultipleOps() {
     // Edit operation
     _syncPal->_localFSObserverWorker->_liveSnapshot.setLastModified("l_aa", testhelpers::defaultTime + 60);
     // Move operation
-    _syncPal->_localFSObserverWorker->_liveSnapshot.removeItem("l_ab");
-    _syncPal->_localFSObserverWorker->_liveSnapshot.updateItem(SnapshotItem(
+    (void) _syncPal->_localFSObserverWorker->_liveSnapshot.removeItem("l_ab");
+    (void) _syncPal->_localFSObserverWorker->_liveSnapshot.updateItem(SnapshotItem(
             "l_ab", "l_b", Str("AB"), testhelpers::defaultTime, testhelpers::defaultTime, NodeType::File, 0, false, true, true));
 
     // Rename operation
     _syncPal->_localFSObserverWorker->_liveSnapshot.setName("l_ba", Str("BA-renamed"));
     // Delete operation
-    _syncPal->_localFSObserverWorker->_liveSnapshot.removeItem("l_bb");
+    (void) _syncPal->_localFSObserverWorker->_liveSnapshot.removeItem("l_bb");
 
     // Create operation on a too big directory
-    _syncPal->_localFSObserverWorker->_liveSnapshot.updateItem(SnapshotItem("r_af", "r_a", Str("AF_too_big"),
-                                                                            testhelpers::defaultTime, testhelpers::defaultTime,
-                                                                            NodeType::Directory, 0, false, true, true));
-    _syncPal->_localFSObserverWorker->_liveSnapshot.updateItem(SnapshotItem("r_afa", "r_af", Str("AFA"), testhelpers::defaultTime,
-                                                                            testhelpers::defaultTime, NodeType::File,
-                                                                            550 * 1024 * 1024, false, true,
-                                                                            true)); // File size: 550MB
+    (void) _syncPal->_localFSObserverWorker->_liveSnapshot.updateItem(
+            SnapshotItem("r_af", "r_a", Str("AF_too_big"), testhelpers::defaultTime, testhelpers::defaultTime,
+                         NodeType::Directory, 0, false, true, true));
+    (void) _syncPal->_localFSObserverWorker->_liveSnapshot.updateItem(
+            SnapshotItem("r_afa", "r_af", Str("AFA"), testhelpers::defaultTime, testhelpers::defaultTime, NodeType::File,
+                         550 * 1024 * 1024, false, true,
+                         true)); // File size: 550MB
     // Rename operation on a blacklisted directory
     _syncPal->_localFSObserverWorker->_liveSnapshot.setName("r_ac", Str("AC-renamed"));
 
@@ -342,7 +342,7 @@ void TestComputeFSOperationWorker::testDifferentEncoding_NFC_NFD() {
     bool constraintError = false;
     _syncPal->syncDb()->insertNode(nodeTest, dbNodeIdTest, constraintError);
 
-    _syncPal->_localFSObserverWorker->_liveSnapshot.updateItem(
+    (void) _syncPal->_localFSObserverWorker->_liveSnapshot.updateItem(
             SnapshotItem("l_test", *_syncPal->syncDb()->rootNode().nodeIdLocal(), Str("testé.txt"), testhelpers::defaultTime,
                          testhelpers::defaultTime, NodeType::File, testhelpers::defaultFileSize, false, true, true));
 
@@ -362,7 +362,7 @@ void TestComputeFSOperationWorker::testDifferentEncoding_NFD_NFC() {
     bool constraintError = false;
     _syncPal->syncDb()->insertNode(nodeTest, dbNodeIdTest, constraintError);
 
-    _syncPal->_localFSObserverWorker->_liveSnapshot.updateItem(
+    (void) _syncPal->_localFSObserverWorker->_liveSnapshot.updateItem(
             SnapshotItem("l_test", *_syncPal->syncDb()->rootNode().nodeIdLocal(), Str("testé.txt"), testhelpers::defaultTime,
                          testhelpers::defaultTime, NodeType::File, testhelpers::defaultFileSize, false, true, true));
 
@@ -382,7 +382,7 @@ void TestComputeFSOperationWorker::testDifferentEncoding_NFD_NFD() {
     bool constraintError = false;
     _syncPal->syncDb()->insertNode(nodeTest, dbNodeIdTest, constraintError);
 
-    _syncPal->_localFSObserverWorker->_liveSnapshot.updateItem(
+    (void) _syncPal->_localFSObserverWorker->_liveSnapshot.updateItem(
             SnapshotItem("l_test", *_syncPal->syncDb()->rootNode().nodeIdLocal(), Str("testé.txt"), testhelpers::defaultTime,
                          testhelpers::defaultTime, NodeType::File, testhelpers::defaultFileSize, false, true, true));
 
@@ -403,7 +403,7 @@ void TestComputeFSOperationWorker::testDifferentEncoding_NFC_NFC() {
     bool constraintError = false;
     _syncPal->syncDb()->insertNode(nodeTest, dbNodeIdTest, constraintError);
 
-    _syncPal->_localFSObserverWorker->_liveSnapshot.updateItem(
+    (void) _syncPal->_localFSObserverWorker->_liveSnapshot.updateItem(
             SnapshotItem("l_test", *_syncPal->syncDb()->rootNode().nodeIdLocal(), Str("testé.txt"), testhelpers::defaultTime,
                          testhelpers::defaultTime, NodeType::File, testhelpers::defaultFileSize, false, true, true));
 
@@ -556,10 +556,10 @@ void TestComputeFSOperationWorker::testUpdateSyncNode() {
 
 void TestComputeFSOperationWorker::testPostponeCreateOperationsOnReusedIds() {
     // Simulate a Delete operation of the local folder named "A".
-    _syncPal->_localFSObserverWorker->_liveSnapshot.removeItem("l_a");
-    _syncPal->_localFSObserverWorker->_liveSnapshot.removeItem("l_aa"); // Folder "AA" is contained in folder "A".
-    _syncPal->_localFSObserverWorker->_liveSnapshot.removeItem("l_ab"); // Folder "AB" is contained in folder "A".
-    _syncPal->_localFSObserverWorker->_liveSnapshot.removeItem(
+    (void) _syncPal->_localFSObserverWorker->_liveSnapshot.removeItem("l_a");
+    (void) _syncPal->_localFSObserverWorker->_liveSnapshot.removeItem("l_aa"); // Folder "AA" is contained in folder "A".
+    (void) _syncPal->_localFSObserverWorker->_liveSnapshot.removeItem("l_ab"); // Folder "AB" is contained in folder "A".
+    (void) _syncPal->_localFSObserverWorker->_liveSnapshot.removeItem(
             "l_ac"); // Folder "AC" is contained in folder "A" but is blacklisted.
 
     // Simulate Create operations for "C" (folder) and "C/CA" (file).

--- a/test/libsyncengine/update_detection/file_system_observer/testcomputefsoperationworker.h
+++ b/test/libsyncengine/update_detection/file_system_observer/testcomputefsoperationworker.h
@@ -36,6 +36,7 @@ class MockComputeFSOperationWorker : public ComputeFSOperationWorker {
 
 class TestComputeFSOperationWorker : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST_SUITE(TestComputeFSOperationWorker);
+        /*
         CPPUNIT_TEST(testNoOps);
         CPPUNIT_TEST(testMultipleOps);
         CPPUNIT_TEST(testLnkFileAlreadySynchronized);
@@ -50,6 +51,8 @@ class TestComputeFSOperationWorker : public CppUnit::TestFixture, public TestBas
         CPPUNIT_TEST(testIsInUnsyncedList);
         CPPUNIT_TEST(testHasChangedSinceLastSeen);
         CPPUNIT_TEST(testUpdateSyncNode);
+*/
+        CPPUNIT_TEST(testPostponeCreateOperationsOnReusedIds);
         CPPUNIT_TEST_SUITE_END();
 
     public:
@@ -99,6 +102,10 @@ class TestComputeFSOperationWorker : public CppUnit::TestFixture, public TestBas
         void testUpdateSyncNode();
 
         void testHasChangedSinceLastSeen();
+
+        // Create operations on local items that reused the identifiers deleted local items are removed from the computed
+        // operation list. This also holds for every descendants of such items.
+        void testPostponeCreateOperationsOnReusedIds();
 
     private:
         void testIsInUnsyncedList(bool expectedResult, const NodeId &nodeId, ReplicaSide side) const;

--- a/test/libsyncengine/update_detection/file_system_observer/testcomputefsoperationworker.h
+++ b/test/libsyncengine/update_detection/file_system_observer/testcomputefsoperationworker.h
@@ -50,7 +50,9 @@ class TestComputeFSOperationWorker : public CppUnit::TestFixture, public TestBas
         CPPUNIT_TEST(testIsInUnsyncedList);
         CPPUNIT_TEST(testHasChangedSinceLastSeen);
         CPPUNIT_TEST(testUpdateSyncNode);
+#if defined(KD_LINUX)
         CPPUNIT_TEST(testPostponeCreateOperationsOnReusedIds);
+#endif
         CPPUNIT_TEST_SUITE_END();
 
     public:
@@ -101,9 +103,11 @@ class TestComputeFSOperationWorker : public CppUnit::TestFixture, public TestBas
 
         void testHasChangedSinceLastSeen();
 
+#if defined(KD_LINUX)
         // Create operations on local items that reused the identifiers deleted local items are removed from the computed
         // operation list. This also holds for every descendants of such items.
         void testPostponeCreateOperationsOnReusedIds();
+#endif
 
     private:
         void testIsInUnsyncedList(bool expectedResult, const NodeId &nodeId, ReplicaSide side) const;

--- a/test/libsyncengine/update_detection/file_system_observer/testcomputefsoperationworker.h
+++ b/test/libsyncengine/update_detection/file_system_observer/testcomputefsoperationworker.h
@@ -36,7 +36,6 @@ class MockComputeFSOperationWorker : public ComputeFSOperationWorker {
 
 class TestComputeFSOperationWorker : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST_SUITE(TestComputeFSOperationWorker);
-        /*
         CPPUNIT_TEST(testNoOps);
         CPPUNIT_TEST(testMultipleOps);
         CPPUNIT_TEST(testLnkFileAlreadySynchronized);
@@ -51,7 +50,6 @@ class TestComputeFSOperationWorker : public CppUnit::TestFixture, public TestBas
         CPPUNIT_TEST(testIsInUnsyncedList);
         CPPUNIT_TEST(testHasChangedSinceLastSeen);
         CPPUNIT_TEST(testUpdateSyncNode);
-*/
         CPPUNIT_TEST(testPostponeCreateOperationsOnReusedIds);
         CPPUNIT_TEST_SUITE_END();
 


### PR DESCRIPTION
The following events were not handled properly by the `desktop-kDrive` application:
- A local item is deleted.
- A non-empty local folder is created and reuses the identifier of the deleted item.

Such a situation leads to a corruption of the local update tree: the local update tree which contains a temporary node for the folder created locally but this node has no event of type `Create`.

The proposed changes address this situation in postponing the propagation creation of the local folder and all its descendants to the next synchronization. To this end, the local identifiers that are reused by the new items created locally are inserted into the ComputeFSOperationsWorker::_localReusedIds" and the `Create` operations detected on them or on any of their descendants are removed from the `SyncPal` operation list.