### PR TITLE
refactor(cmake): avoid duplicate files inside the AppImage.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,14 +293,11 @@ elseif(BUILD_CLIENT)
         if(CMAKE_BUILD_TYPE STREQUAL "Debug")
             file(COPY sync-exclude-linux.lst DESTINATION ${CMAKE_BINARY_DIR}/bin)
             file(RENAME ${CMAKE_BINARY_DIR}/bin/sync-exclude-linux.lst ${CMAKE_BINARY_DIR}/bin/sync-exclude.lst)
-        else()
-            install(FILES sync-exclude-linux.lst DESTINATION ${SYSCONFDIR}/${APPLICATION_SHORTNAME} RENAME sync-exclude.lst)
         endif()
 
         # Sentry
         find_library(SENTRY_SHARED_LIBRARY NAMES sentry NO_CACHE)
         message(STATUS "sentry dll found in ${SENTRY_SHARED_LIBRARY}")
-        install(FILES ${SENTRY_SHARED_LIBRARY} DESTINATION ${SYSCONFDIR}/${APPLICATION_SHORTNAME})
 
         # Crashpad_handler
         get_target_property(CRASHPAD_HANDLER_PROGRAM


### PR DESCRIPTION
On Linux, inside the AppImage filesystem (SquashFS), two filenames are duplicated:
```bash
$ find squashfs-root/ \( -iname "libsentry.so" -o -iname "sync-exclude.lst" \)
squashfs-root/kDrive/libsentry.so
squashfs-root/kDrive/sync-exclude.lst
squashfs-root/usr/bin/sync-exclude.lst
squashfs-root/usr/lib/libsentry.so
```
This PR keeps only one copy of each.

You can also find any other duplicated files with the following commands:
```bash
./kDrive.AppImage --appimage-extract
find ./squashfs-root -type f -printf "%f\n" 2>/dev/null | sort | uniq -d | while read -r filename; do
  echo "duplicate: $filename"
  find ./squashfs-root -type f -name "$filename"
  echo
done
```