### PR TITLE
Fix `update_kstore.yml` invalid workflow definition for `workflow_call`  

### DIFF
--- a/.github/workflows/update_kstore.yml
+++ b/.github/workflows/update_kstore.yml
@@ -52,6 +52,7 @@ on:
 jobs:
     dummy:
         runs-on: [ self-hosted, Linux, X64 ]
+        environment: ${{ inputs.environment }}
         steps:
             - name: Dummy step to allow the workflow to be called
               run: echo "This workflow is called to update the kStore for kDrive desktop."

--- a/.github/workflows/update_kstore.yml
+++ b/.github/workflows/update_kstore.yml
@@ -5,7 +5,7 @@ on:
     inputs:
         environment:
             description: 'The environment to update the kStore for'
-            type: environment
+            type: string
             required: true
             default: 'internal beta'
         tag:


### PR DESCRIPTION
This PR fixes the invalid workflow configuration in `.github/workflows/update_kstore.yml` that was causing GitHub to flag the file as invalid on every commit.  

The issue was that the workflow defined an input with `type: environment` under the `workflow_call` trigger.  
While `type: environment` is supported for `workflow_dispatch` (manual runs), it is **not** supported for `workflow_call` (when the workflow is invoked by another workflow). For `workflow_call`, only `string`, `boolean`, and `number` are valid input types.  

Because the file was invalid, GitHub’s workflow linter failed on every commit, even if the workflow wasn’t actually triggered. This made it look like the workflow was “failing” on each push.  

**Changes in this PR:**  
- Changed `type: environment` → `type: string` for the `environment` input under `workflow_call`.  
- Kept `type: environment` for `workflow_dispatch` to allow environment selection in the UI.  
- Added `environment: ${{ inputs.environment }}` to the job definition so that the selected environment is still applied when running via `workflow_call`.  

**Result:**  
- The workflow file is now valid for both triggers.  
- No more “Invalid workflow file” check failures on every commit.  
- Behavior for manual runs (UI environment selector) is unchanged.  