### PR TITLE
Blacklist not updated correctly

### DIFF
--- a/src/gui/foldertreeitemwidget.cpp
+++ b/src/gui/foldertreeitemwidget.cpp
@@ -196,16 +196,15 @@ ExitCode FolderTreeItemWidget::updateBlackUndecidedSet() {
 }
 
 void FolderTreeItemWidget::updateBlacklistPathMap() {
-    for (int i = 0; i < 2; i++) {
+    for (auto i = 0; i < 2; i++) {
         for (const QString &nodeId: i == 0 ? _oldBlackList : _oldUndecidedList) {
             QString path;
-            ExitCode exitCode = GuiRequests::getNodePath(_syncDbId, nodeId, path);
-            if (exitCode != ExitCode::Ok) {
+            if (const auto exitCode = GuiRequests::getNodePath(_syncDbId, nodeId, path); exitCode != ExitCode::Ok) {
                 qCWarning(lcFolderTreeItemWidget()) << "Error in GuiRequests::getNodePath";
                 continue;
             }
 
-            _blacklistCache.insert(nodeId, path);
+            (void) _blacklistCache.insert(nodeId, path);
         }
     }
 }
@@ -230,7 +229,7 @@ void FolderTreeItemWidget::insertNode(QTreeWidgetItem *parent, const NodeInfo &n
                 bool isChecked = true;
                 foreach (const QString &blacklistItemPath, _blacklistCache) {
                     if (blacklistItemPath.startsWith(nodeInfo.path() + "/")) {
-                        // At least 1 children is blacklisted
+                        // At least 1 child is blacklisted
                         item->setCheckState(TreeWidgetColumn::Folder, Qt::PartiallyChecked);
                         isChecked = false;
                         break;
@@ -263,7 +262,7 @@ QSet<QString> FolderTreeItemWidget::createBlackSet() {
     return newBlackSet;
 }
 
-void FolderTreeItemWidget::createBlackSet(QTreeWidgetItem *parentItem, QSet<QString> &blackset) {
+void FolderTreeItemWidget::createBlackSet(const QTreeWidgetItem *parentItem, QSet<QString> &blackset) {
     if (!parentItem) {
         parentItem = topLevelItem(0);
     }
@@ -272,23 +271,39 @@ void FolderTreeItemWidget::createBlackSet(QTreeWidgetItem *parentItem, QSet<QStr
         return;
     }
 
-    QString parentNodeId = parentItem->data(TreeWidgetColumn::Folder, nodeIdRole).toString();
+    const auto parentNodeId = parentItem->data(TreeWidgetColumn::Folder, nodeIdRole).toString();
 
     switch (parentItem->checkState(TreeWidgetColumn::Folder)) {
         case Qt::Unchecked: {
-            blackset.insert(parentNodeId);
+            (void) blackset.insert(parentNodeId);
+            removeChildNodeFromSet(parentNodeId, blackset);
             return;
         }
         case Qt::Checked:
+            removeChildNodeFromSet(parentNodeId, blackset);
+            [[fallthrough]];
         case Qt::PartiallyChecked:
             break;
     }
 
-    blackset.remove(parentNodeId);
+    (void) blackset.remove(parentNodeId);
+    (void) _blacklistCache.remove(parentNodeId);
 
     if (parentItem->childCount()) {
-        for (int i = 0; i < parentItem->childCount(); ++i) {
+        for (auto i = 0; i < parentItem->childCount(); ++i) {
             createBlackSet(parentItem->child(i), blackset);
+        }
+    }
+}
+
+void FolderTreeItemWidget::removeChildNodeFromSet(const QString &parentId, QSet<QString> &blackset) {
+    const auto parentPath = _blacklistCache[parentId];
+    for (auto it = _blacklistCache.begin(); it != _blacklistCache.end(); it++) {
+        const auto &id = it.key();
+        const auto &path = it.value();
+        if (path.startsWith(parentPath + "/")) {
+            (void) blackset.remove(id);
+            (void) _blacklistCache.remove(id);
         }
     }
 }

--- a/src/gui/foldertreeitemwidget.h
+++ b/src/gui/foldertreeitemwidget.h
@@ -77,7 +77,7 @@ class FolderTreeItemWidget : public QTreeWidget {
         static const QColor _sizeTextColor;
         bool _inserting;
         QHash<QString, QTreeWidgetItem *> _subFoldersMap;
-        QHash<QString, QString> _blacklistCache;
+        QHash<QString, QString> _blacklistCache; // nodeId / path
         CustomTreeWidgetItem *_root = nullptr;
 
         // The set of items newly blacklisted by the user; they were
@@ -99,7 +99,8 @@ class FolderTreeItemWidget : public QTreeWidget {
         void insertNode(QTreeWidgetItem *parent, const NodeInfo &nodeInfo);
         void updateDirectories(QTreeWidgetItem *item, const QString &nodeId, QList<NodeInfo> list);
         ExitCode updateBlackUndecidedSet();
-        void createBlackSet(QTreeWidgetItem *parentItem, QSet<QString> &blackset);
+        void createBlackSet(const QTreeWidgetItem *parentItem, QSet<QString> &blackset);
+        void removeChildNodeFromSet(const QString &nodeId, QSet<QString> &blackset);
         void createWhiteSet(QTreeWidgetItem *parentItem, QSet<QString> &whiteSet);
         void updateBlacklistPathMap();
         void addTreeWidgetItemToQueue(const QString &nodeId, QTreeWidgetItem *item);


### PR DESCRIPTION
If a folder was partially checked in the tree view and the user check it (or uncheck it) without developing the tree, the children were kept into the blacklist.

The children of the checked or unchecked nodes are now removed from the blacklist.