### PR TITLE
feat(release-notes): decouple release notes from release date (CI upload script)

### DIFF
--- a/.github/workflows/kdrive-desktop-release.yml
+++ b/.github/workflows/kdrive-desktop-release.yml
@@ -63,7 +63,11 @@ jobs:
 
       - name: Check release notes
         run: |
-          VERSION_NUMBER="${{ steps.get-version.outputs.kDrive_version }}"
+          VERSION_NUMBER="${{ steps.get-version.outputs.kDrive_version }}"  # Example: 3.9.20.20250820
+          version_size=${#VERSION_NUMBER}
+          end_position=$((size - 9))
+          VERSION_NUMBER=${VERSION_NUMBER:0:$end_position}  # Removes the date, e.g., 20250820
+
           BASE_NAME="kDrive-${VERSION_NUMBER}"
           BASE_PATH="./release_notes/${BASE_NAME}"
           OS=( "win" "linux" "macos" )


### PR DESCRIPTION
After this [PR](https://github.com/Infomaniak/desktop-kDrive/pull/948), the names of the release notes files do not refer to any release date anymore.

The proposed changes make sure that the CI script which uploads the release notes take this simplification into account.