### PR TITLE
Missing log

### DIFF
--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -126,7 +126,9 @@ AppServer::AppServer(int &argc, char **argv) :
 }
 
 AppServer::~AppServer() {
-    LOG_DEBUG(_logger, "~AppServer");
+    if (Log::isSet()) {
+        LOG_DEBUG(_logger, "~AppServer");
+    }
 }
 
 void AppServer::init() {
@@ -136,20 +138,20 @@ void AppServer::init() {
     setWindowIcon(_theme->applicationIcon());
     setApplicationVersion(QString::fromStdString(_theme->version()));
 
-    // Setup logging with default parameters
-    if (!initLogging()) {
-        throw std::runtime_error("Unable to init logging.");
-    }
-
     parseOptions(_arguments);
     if (_helpAsked || _versionAsked || _clearSyncNodesAsked || _clearKeychainKeysAsked) {
-        LOG_INFO(_logger, "Command line options processed");
+        std::cout << "Command line options processed" << std::endl;
         return;
     }
 
     if (isRunning()) {
-        LOG_INFO(_logger, "AppServer already running");
+        std::cout << "AppServer already running" << std::endl;
         return;
+    }
+
+    // Setup logging with default parameters
+    if (!initLogging()) {
+        throw std::runtime_error("Unable to init logging.");
     }
 
     // Cleanup at quit

--- a/src/server/mainserver.cpp
+++ b/src/server/mainserver.cpp
@@ -168,10 +168,10 @@ std::int32_t exec(std::unique_ptr<KDC::AppServer> &appPtr) {
 
     // If the application is already running, notify it.
     if (appPtr->isRunning()) {
-        LOG_INFO(KDC::Log::instance()->getLogger(), "Server already running");
+        std::cout << "Server already running" << std::endl;
         if (appPtr->isSessionRestored()) {
             // This call is mirrored with the one in Application::slotParseMessage
-            LOG_DEBUG(KDC::Log::instance()->getLogger(), "Session was restored, don't notify app!");
+            std::cout << "Session was restored, don't notify app!" << std::endl;
             return -1;
         }
 
@@ -185,7 +185,7 @@ std::int32_t exec(std::unique_ptr<KDC::AppServer> &appPtr) {
             return 0;
         }
 
-        LOG_INFO(KDC::Log::instance()->getLogger(), "Asking the running server to start a newClient.");
+        std::cout << "Asking the running server to start a newClient." << std::endl;
         appPtr->sendRestartClientMsg();
         return 0;
     }


### PR DESCRIPTION
Sometimes, the log files are truncated or the app seems to stop logging. One explanation might be that the user try to start another instance of the app. Indeed, when starting the app, the log is initialized before checking if another process is already running. Therefore, the ongoing log is archived and the app that is actually running stop logging.
The fix is to initialize logging after checking if another process is already running.