### PR TITLE
openssl conan recipe: refactor recipe and build script to support zlib and improve universal build

### DIFF
--- a/infomaniak-build-tools/conan/recipes/openssl/all/conanfile.py
+++ b/infomaniak-build-tools/conan/recipes/openssl/all/conanfile.py
@@ -41,7 +41,7 @@ class OpenSSLUniversalConan(ConanFile):
 
         script = os.path.join(self.build_folder, "openssl_universal_build.sh")
 
-        self.run(f"/usr/bin/env bash {script} --version {self.version} --build-folder {self.build_folder} --zlib-include {unix_path(self, zlib_include)} --zlib-lib {unix_path(self, zlib_lib)}")
+        self.run(f"/usr/bin/env bash {script} --version {self.version} --build-folder {self.build_folder} --zlib-include {unix_path(self, zlib_include)} --zlib-lib {unix_path(self, zlib_lib)} --conan-arch {self.settings.arch}")
 
     def package(self):
         copy(self, "*.h", src=os.path.join(self.build_folder, "openssl.multi", "include"), dst=os.path.join(self.package_folder, "include"))

--- a/infomaniak-build-tools/conan/recipes/openssl/all/conanfile.py
+++ b/infomaniak-build-tools/conan/recipes/openssl/all/conanfile.py
@@ -44,10 +44,8 @@ class OpenSSLUniversalConan(ConanFile):
 
     def package(self):
         copy(self, "*.h", src=os.path.join(self.build_folder, "openssl.multi", "include"), dst=os.path.join(self.package_folder, "include"))
-        if self.options.shared:
-            copy(self, "*.dylib", src=os.path.join(self.build_folder, "openssl.multi", "lib"), dst=os.path.join(self.package_folder, "lib"))
-        else:
-            copy(self, "*.a", src=os.path.join(self.build_folder, "openssl.multi", "lib"), dst=os.path.join(self.package_folder, "lib"))
+        copy(self, "*.dylib", src=os.path.join(self.build_folder, "openssl.multi", "lib"), dst=os.path.join(self.package_folder, "lib"))
+        copy(self, "*.pc", src=os.path.join(self.build_folder, "openssl.x86_64"), dst=self.package_folder)
         fix_apple_shared_install_name(self)
 
         self._create_cmake_module_variables(

--- a/infomaniak-build-tools/conan/recipes/openssl/all/conanfile.py
+++ b/infomaniak-build-tools/conan/recipes/openssl/all/conanfile.py
@@ -140,7 +140,6 @@ class OpenSSLUniversalConan(ConanFile):
         self.cpp_info.set_property("cmake_build_modules", [self._module_file_rel_path])
 
     def package_id(self):
-        self.info.settings.rm_safe("arch")
         self.info.settings.rm_safe("compiler")
         self.info.settings.rm_safe("build_type")
         self.info.options.rm_safe("shared")

--- a/infomaniak-build-tools/conan/recipes/openssl/all/conanfile.py
+++ b/infomaniak-build-tools/conan/recipes/openssl/all/conanfile.py
@@ -47,7 +47,7 @@ class OpenSSLUniversalConan(ConanFile):
         )
 
     def requirements(self):
-        self.requires("zlib/[>=1.2.11 <2]", transitive_headers=True, options={"shared": True})
+        self.requires("zlib/[>=1.2.11 <2]", transitive_headers=True, options={"shared": False})
 
 
     def _create_cmake_module_variables(self, module_file):

--- a/infomaniak-build-tools/conan/recipes/openssl/all/conanfile.py
+++ b/infomaniak-build-tools/conan/recipes/openssl/all/conanfile.py
@@ -133,9 +133,6 @@ class OpenSSLUniversalConan(ConanFile):
 
         self.cpp_info.set_property("cmake_build_modules", [self._module_file_rel_path])
 
-        openssl_modules_dir = os.path.join(self.package_folder, "lib", "ossl-modules")
-        self.runenv_info.define_path("OPENSSL_MODULES", openssl_modules_dir)
-
     def package_id(self):
         self.info.settings.rm_safe("arch")
         self.info.settings.rm_safe("compiler")

--- a/infomaniak-build-tools/conan/recipes/openssl/all/conanfile.py
+++ b/infomaniak-build-tools/conan/recipes/openssl/all/conanfile.py
@@ -1,10 +1,12 @@
+import os
 import textwrap
 
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
+from conan.tools.apple import fix_apple_shared_install_name
 from conan.tools.files import copy, save
-from conan.tools.apple import fix_apple_shared_install_name, is_apple_os
-import os
+from conan.tools.microsoft import unix_path
+
 
 class OpenSSLUniversalConan(ConanFile):
     name = "openssl"
@@ -30,9 +32,16 @@ class OpenSSLUniversalConan(ConanFile):
             self.output.warning("This recipe only supports shared libraries on Apple platforms. The 'shared' option has been overwritten to True.")
 
     def build(self):
+
+        zlib_cpp_info = self.dependencies["zlib"].cpp_info.aggregated_components()
+        if not zlib_cpp_info.libs:
+            raise ConanInvalidConfiguration("zlib is required to build OpenSSL, but no libraries were found in the zlib package.")
+        zlib_include = zlib_cpp_info.includedirs[0]
+        zlib_lib = zlib_cpp_info.libdirs[0]
+
         script = os.path.join(self.build_folder, "openssl_universal_build.sh")
 
-        self.run(f"/usr/bin/env bash {script} --build-folder {self.build_folder}")
+        self.run(f"/usr/bin/env bash {script} --version {self.version} --build-folder {self.build_folder} --zlib-include {unix_path(self, zlib_include)} --zlib-lib {unix_path(self, zlib_lib)}")
 
     def package(self):
         copy(self, "*.h", src=os.path.join(self.build_folder, "openssl.multi", "include"), dst=os.path.join(self.package_folder, "include"))

--- a/infomaniak-build-tools/conan/recipes/openssl/all/conanfile.py
+++ b/infomaniak-build-tools/conan/recipes/openssl/all/conanfile.py
@@ -19,7 +19,7 @@ class OpenSSLUniversalConan(ConanFile):
     default_options = {
         "shared": True,
     }
-    exports_sources = "openssl_universal_build.sh"
+    exports_sources = "openssl_build.sh"
 
 
     def validate(self):
@@ -32,14 +32,13 @@ class OpenSSLUniversalConan(ConanFile):
             self.output.warning("This recipe only supports shared libraries on Apple platforms. The 'shared' option has been overwritten to True.")
 
     def build(self):
-
         zlib_cpp_info = self.dependencies["zlib"].cpp_info.aggregated_components()
         if not zlib_cpp_info.libs:
             raise ConanInvalidConfiguration("zlib is required to build OpenSSL, but no libraries were found in the zlib package.")
         zlib_include = zlib_cpp_info.includedirs[0]
         zlib_lib = zlib_cpp_info.libdirs[0]
 
-        script = os.path.join(self.build_folder, "openssl_universal_build.sh")
+        script = os.path.join(self.build_folder, "openssl_build.sh")
 
         self.run(f"/usr/bin/env bash {script} --version '{self.version}' --build-folder '{self.build_folder}' --zlib-include '{unix_path(self, zlib_include)}' --zlib-lib '{unix_path(self, zlib_lib)}' --conan-arch '{self.settings.arch}'")
 

--- a/infomaniak-build-tools/conan/recipes/openssl/all/conanfile.py
+++ b/infomaniak-build-tools/conan/recipes/openssl/all/conanfile.py
@@ -43,7 +43,12 @@ class OpenSSLUniversalConan(ConanFile):
 
         script = os.path.join(self.build_folder, "openssl_build.sh")
 
-        self.run(f"/usr/bin/env bash {script} --version '{self.version}' --build-folder '{self.build_folder}' --zlib-include '{unix_path(self, zlib_include)}' --zlib-lib '{unix_path(self, zlib_lib)}' --conan-arch '{self.settings.arch}'")
+        self.run(f"/usr/bin/env bash {script} "
+                 f"--version '{self.version}' "                        # to pass the version of OpenSSL
+                 f"--build-folder '{self.build_folder}' "              # to pass the build folder
+                 f"--zlib-include '{unix_path(self, zlib_include)}' "  # to pass the zlib include directory
+                 f"--zlib-lib '{unix_path(self, zlib_lib)}' "          # to pass the zlib lib directory
+                 f"--conan-arch '{self.settings.arch}'")               # to pass the conan profile defined of the architecture
 
     def package(self):
         copy(self, "*.h", src=os.path.join(self.build_folder, "openssl.multi", "include"), dst=os.path.join(self.package_folder, "include"))

--- a/infomaniak-build-tools/conan/recipes/openssl/all/conanfile.py
+++ b/infomaniak-build-tools/conan/recipes/openssl/all/conanfile.py
@@ -30,6 +30,9 @@ class OpenSSLUniversalConan(ConanFile):
         if not self.options.shared:
             self.options.shared = True
             self.output.warning("This recipe only supports shared libraries on Apple platforms. The 'shared' option has been overwritten to True.")
+        if self.settings.build_type != "Release":
+            self.settings.build_type = "Release"
+            self.output.warning("This recipe will build OpenSSL in Release mode regardless of the build type specified in the profile.")
 
     def build(self):
         zlib_cpp_info = self.dependencies["zlib"].cpp_info.aggregated_components()

--- a/infomaniak-build-tools/conan/recipes/openssl/all/conanfile.py
+++ b/infomaniak-build-tools/conan/recipes/openssl/all/conanfile.py
@@ -41,7 +41,7 @@ class OpenSSLUniversalConan(ConanFile):
 
         script = os.path.join(self.build_folder, "openssl_universal_build.sh")
 
-        self.run(f"/usr/bin/env bash {script} --version {self.version} --build-folder {self.build_folder} --zlib-include {unix_path(self, zlib_include)} --zlib-lib {unix_path(self, zlib_lib)} --conan-arch {self.settings.arch}")
+        self.run(f"/usr/bin/env bash {script} --version {self.version} --build-folder {self.build_folder} --zlib-include {unix_path(self, zlib_include)} --zlib-lib {unix_path(self, zlib_lib)} --conan-arch '{self.settings.arch}'")
 
     def package(self):
         copy(self, "*.h", src=os.path.join(self.build_folder, "openssl.multi", "include"), dst=os.path.join(self.package_folder, "include"))

--- a/infomaniak-build-tools/conan/recipes/openssl/all/conanfile.py
+++ b/infomaniak-build-tools/conan/recipes/openssl/all/conanfile.py
@@ -41,7 +41,7 @@ class OpenSSLUniversalConan(ConanFile):
 
         script = os.path.join(self.build_folder, "openssl_universal_build.sh")
 
-        self.run(f"/usr/bin/env bash {script} --version {self.version} --build-folder {self.build_folder} --zlib-include {unix_path(self, zlib_include)} --zlib-lib {unix_path(self, zlib_lib)} --conan-arch '{self.settings.arch}'")
+        self.run(f"/usr/bin/env bash {script} --version '{self.version}' --build-folder '{self.build_folder}' --zlib-include '{unix_path(self, zlib_include)}' --zlib-lib '{unix_path(self, zlib_lib)}' --conan-arch '{self.settings.arch}'")
 
     def package(self):
         copy(self, "*.h", src=os.path.join(self.build_folder, "openssl.multi", "include"), dst=os.path.join(self.package_folder, "include"))

--- a/infomaniak-build-tools/conan/recipes/openssl/all/openssl_build.sh
+++ b/infomaniak-build-tools/conan/recipes/openssl/all/openssl_build.sh
@@ -35,7 +35,7 @@ while [[ $# -gt 0 ]]; do
       shift 2
       ;;
     --help|-h)
-      echo "Usage: $0 --version <openssl_version> --build-folder <build_folder> --zlib-include <zlib_include_path> --zlib-lib <zlib_lib_path>"
+      echo "Usage: $0 --version <openssl_version> --build-folder <build_folder> --zlib-include <zlib_include_path> --zlib-lib <zlib_lib_path> --conan-arch <conan_arch>"
       exit 0
       ;;
     *)
@@ -48,6 +48,7 @@ done
 [[ -z "$build_folder" ]]    && error "The --build-folder parameter is required."
 [[ -z "$zlib_include" ]]    && error "The --zlib-include parameter is required."
 [[ -z "$zlib_lib" ]]        && error "The --zlib-lib parameter is required."
+[[ -z "$conan_arch" ]]      && error "The --conan-arch parameter is required."
 [[ ! -d "$build_folder" || \
    ! -d "$zlib_include" || \
    ! -d "$zlib_lib" ]]      && error "The folder '$build_folder' does not exist." # Check if the folders build_folder, zlib_include, and zlib_lib exist

--- a/infomaniak-build-tools/conan/recipes/openssl/all/openssl_build.sh
+++ b/infomaniak-build-tools/conan/recipes/openssl/all/openssl_build.sh
@@ -53,9 +53,10 @@ done
    ! -d "$zlib_include" || \
    ! -d "$zlib_lib" ]]      && error "The folder '$build_folder' does not exist." # Check if the folders build_folder, zlib_include, and zlib_lib exist
 
-if ! command -v conan >/dev/null 2>&1; then
-  error "Conan is not installed. Please install it first."
-fi
+command -v conan >/dev/null 2>&1 || error "Conan is not installed. Please install it first."
+command -v curl >/dev/null 2>&1 || error "curl is not installed. Please install it first."
+command -v lipo >/dev/null 2>&1 || error "lipo is not installed. Please install the Xcode command line tools."
+command -v install_name_tool >/dev/null 2>&1 || error "install_name_tool is not installed. Please install the Xcode command line tools."
 
 if [[ "$conan_arch" != "armv8|x86_64" && "$conan_arch" != "x86_64|armv8" ]]; then
   error "Conan profile arch must be set to 'armv8|x86_64' or 'x86_64|armv8'. Current value: $conan_arch"
@@ -90,7 +91,7 @@ curl --silent -L -o "${archive_sha}" "${base_url}/${archive_sha}"
 log "OK"
 
 log "Verifying archive checksum..."
-sha256sum --check --status "${archive_sha}" || error "Checksum verification failed for ${archive}"
+shasum -a 256 -c "${archive_sha}" || error "Checksum verification failed for ${archive}"
 log "OK"
 
 log "Extracting archive..."

--- a/infomaniak-build-tools/conan/recipes/openssl/all/openssl_universal_build.sh
+++ b/infomaniak-build-tools/conan/recipes/openssl/all/openssl_universal_build.sh
@@ -68,10 +68,12 @@ lipo -create -output openssl.multi/lib/libcrypto.3.dylib  openssl.x86_64/libcryp
 install_name_tool -id "@rpath/libssl.3.dylib" openssl.multi/lib/libssl.3.dylib
 install_name_tool -id "@rpath/libcrypto.3.dylib" openssl.multi/lib/libcrypto.3.dylib
 
+# We add the `@loader_path` to the rpath because the utility macdeployqt will try to find the libraries relative to the loader, and libss.3.dylib load libcrypto.3.dylib.
+# If @loader_path is not set, it will fail to find the libcrypto.3.dylib and will replace it to /usr/local/lib/libcrypto.3.dylib which could not exists on the user's system.
 install_name_tool -add_rpath "@loader_path" openssl.multi/lib/libssl.3.dylib
 install_name_tool -add_rpath "@loader_path" openssl.multi/lib/libcrypto.3.dylib
 
-## Fixing dependencies for the merged libraries
+# Fixing dependencies for the merged libraries
 install_name_tool -change "/usr/local/lib/libcrypto.3.dylib" "@rpath/libcrypto.3.dylib" openssl.multi/lib/libssl.3.dylib
 install_name_tool -change "/usr/lib/libz.1.dylib"            "@rpath/libz.1.dylib"      openssl.multi/lib/libssl.3.dylib
 install_name_tool -change "/usr/lib/libz.1.dylib"            "@rpath/libz.1.dylib"      openssl.multi/lib/libcrypto.3.dylib

--- a/infomaniak-build-tools/conan/recipes/openssl/all/openssl_universal_build.sh
+++ b/infomaniak-build-tools/conan/recipes/openssl/all/openssl_universal_build.sh
@@ -56,8 +56,9 @@ if ! command -v conan >/dev/null 2>&1; then
   error "Conan is not installed. Please install it first."
 fi
 
-if ! conan profile show 2>/dev/null | grep "arch=" | head -n 1 | cut -d'=' -f 2 | grep "armv8" | grep "x86_64" >/dev/null 2>&1; then
-  error "This script should be run with a Conan profile that has multi-architecture support enabled (arch=armv8|x86_64)."
+conan_arch_value="$(conan profile show --format json | jq -r '.host.settings.arch')"
+if [[ "$conan_arch_value" != "armv8|x86_64" && "$conan_arch_value" != "x86_64|armv8" ]]; then
+  error "Conan profile arch must be set to 'armv8|x86_64' or 'x86_64|armv8'. Current value: $conan_arch_value"
 fi
 
 pushd "$build_folder"

--- a/infomaniak-build-tools/conan/recipes/openssl/all/openssl_universal_build.sh
+++ b/infomaniak-build-tools/conan/recipes/openssl/all/openssl_universal_build.sh
@@ -55,6 +55,16 @@ conan_arch_value="$(conan profile show --format json | jq -r '.host.settings.arc
 if [[ "$conan_arch_value" != "armv8|x86_64" && "$conan_arch_value" != "x86_64|armv8" ]]; then
   error "Conan profile arch must be set to 'armv8|x86_64' or 'x86_64|armv8'. Current value: $conan_arch_value"
 fi
+echo
+log "---------------------------------------"
+log "OpenSSL version: $openssl_version"
+log "Build folder: $build_folder"
+log
+log "Zlib include path: $zlib_include"
+log "Zlib lib path: $zlib_lib"
+log "---------------------------------------"
+echo
+
 
 pushd "$build_folder"
 

--- a/infomaniak-build-tools/conan/recipes/openssl/all/openssl_universal_build.sh
+++ b/infomaniak-build-tools/conan/recipes/openssl/all/openssl_universal_build.sh
@@ -7,10 +7,11 @@ minimum_macos_version="10.15"
 log() { echo -e "[INFO] $*"; }
 error() { echo -e "[ERROR] $*" >&2; exit 1; }
 
+openssl_version=""
 build_folder=""
 zlib_include=""
 zlib_lib=""
-openssl_version=""
+conan_arch=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --version)
@@ -27,6 +28,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --zlib-lib)
       zlib_lib="$2"
+      shift 2
+      ;;
+    --conan-arch)
+      conan_arch="$2"
       shift 2
       ;;
     --help|-h)
@@ -51,9 +56,8 @@ if ! command -v conan >/dev/null 2>&1; then
   error "Conan is not installed. Please install it first."
 fi
 
-conan_arch_value="$(conan profile show --format json | jq -r '.host.settings.arch')"
-if [[ "$conan_arch_value" != "armv8|x86_64" && "$conan_arch_value" != "x86_64|armv8" ]]; then
-  error "Conan profile arch must be set to 'armv8|x86_64' or 'x86_64|armv8'. Current value: $conan_arch_value"
+if [[ "$conan_arch" != "armv8|x86_64" && "$conan_arch" != "x86_64|armv8" ]]; then
+  error "Conan profile arch must be set to 'armv8|x86_64' or 'x86_64|armv8'. Current value: $conan_arch"
 fi
 echo
 log "---------------------------------------"


### PR DESCRIPTION
This PR modernizes and improves the reliability of the OpenSSL Conan recipe used in `infomaniak-build-tools` by replacing the old `openssl_universal_build.sh` script with a new, more explicit and robust `openssl_build.sh`.

### ✅ Main improvements

- **Added zlib path handling** in the build command (`--zlib-include` / `--zlib-lib`), with explicit validation of zlib libraries presence.
- **Support for the `--version` parameter** to build the OpenSSL version declared in the Conan recipe.
- **Stronger validation in `validate()`**:
  - Force the build to `Release`
  - Warning if the `shared` option is disabled
- **Improved universal build**:
  - Clean download and extraction of sources (via curl + tar) instead of git
  - Separate builds for `x86_64` and `arm64`, then merge using `lipo`
  - Correct install name definition and addition of `@loader_path` to the rpath
- **Cleanup and simplification**:
  - Removal of the special case for `shared:false` (OpenSSL is always installed as shared)
  - Addition of `.pc` file installation
  - The `requires` for zlib now forces `shared=False` (more consistent with the multi-arch build)