### PR TITLE
Use pagination in file listing request

### DIFF
--- a/src/libsyncengine/jobs/network/kDrive_API/getfilelistjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/getfilelistjob.cpp
@@ -21,13 +21,13 @@
 namespace KDC {
 
 GetFileListJob::GetFileListJob(const int userDbId, const int driveId, const NodeId &fileId, const uint64_t page /*= 1*/,
-                               const bool dirOnly /*= false*/) :
-    GetRootFileListJob(userDbId, driveId, page, dirOnly),
+                               const bool dirOnly /*= false*/, uint64_t nbItemsPerPage /*= 1000*/) :
+    GetRootFileListJob(userDbId, driveId, page, dirOnly, nbItemsPerPage),
     _fileId(fileId) {}
 
 GetFileListJob::GetFileListJob(const int driveDbId, const NodeId &fileId, const uint64_t page /*= 1*/,
-                               const bool dirOnly /*= false*/) :
-    GetRootFileListJob(driveDbId, page, dirOnly),
+                               const bool dirOnly /*= false*/, uint64_t nbItemsPerPage /*= 1000*/) :
+    GetRootFileListJob(driveDbId, page, dirOnly, nbItemsPerPage),
     _fileId(fileId) {}
 
 std::string GetFileListJob::getSpecificUrl() {

--- a/src/libsyncengine/jobs/network/kDrive_API/getfilelistjob.h
+++ b/src/libsyncengine/jobs/network/kDrive_API/getfilelistjob.h
@@ -25,8 +25,10 @@ namespace KDC {
 
 class GetFileListJob : public GetRootFileListJob {
     public:
-        GetFileListJob(int userDbId, int driveId, const NodeId &fileId, uint64_t page = 1, bool dirOnly = false);
-        GetFileListJob(int driveDbId, const NodeId &fileId, uint64_t page = 1, bool dirOnly = false);
+        GetFileListJob(int userDbId, int driveId, const NodeId &fileId, uint64_t page = 1, bool dirOnly = false,
+                       uint64_t nbItemsPerPage = 1000);
+        GetFileListJob(int driveDbId, const NodeId &fileId, uint64_t page = 1, bool dirOnly = false,
+                       uint64_t nbItemsPerPage = 1000);
 
     private:
         std::string getSpecificUrl() override;

--- a/src/libsyncengine/jobs/network/kDrive_API/getrootfilelistjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/getrootfilelistjob.cpp
@@ -25,17 +25,20 @@
 namespace KDC {
 
 GetRootFileListJob::GetRootFileListJob(const int userDbId, const int driveId, const uint64_t page /*= 1*/,
-                                       const bool dirOnly /*= false*/) :
+                                       const bool dirOnly /*= false*/, uint64_t nbItemsPerPage /*= 1000*/) :
     AbstractTokenNetworkJob(ApiType::Drive, userDbId, 0, 0, driveId),
     _page(page),
-    _dirOnly(dirOnly) {
+    _dirOnly(dirOnly),
+    _nbItemsPerPage(nbItemsPerPage) {
     _httpMethod = Poco::Net::HTTPRequest::HTTP_GET;
 }
 
-GetRootFileListJob::GetRootFileListJob(const int driveDbId, const uint64_t page /*= 1*/, const bool dirOnly /*= false*/) :
+GetRootFileListJob::GetRootFileListJob(const int driveDbId, const uint64_t page /*= 1*/, const bool dirOnly /*= false*/,
+                                       uint64_t nbItemsPerPage /*= 1000*/) :
     AbstractTokenNetworkJob(ApiType::Drive, 0, 0, driveDbId, 0),
     _page(page),
-    _dirOnly(dirOnly) {
+    _dirOnly(dirOnly),
+    _nbItemsPerPage(nbItemsPerPage) {
     _httpMethod = Poco::Net::HTTPRequest::HTTP_GET;
 }
 
@@ -46,7 +49,7 @@ std::string GetRootFileListJob::getSpecificUrl() {
 }
 
 void GetRootFileListJob::setQueryParameters(Poco::URI &uri, bool &canceled) {
-    uri.addQueryParameter("per_page", nbItemPerPage);
+    uri.addQueryParameter("per_page", std::to_string(_nbItemsPerPage));
     if (_page > 0) {
         uri.addQueryParameter("page", std::to_string(_page));
     }

--- a/src/libsyncengine/jobs/network/kDrive_API/getrootfilelistjob.h
+++ b/src/libsyncengine/jobs/network/kDrive_API/getrootfilelistjob.h
@@ -29,14 +29,20 @@ class GetRootFileListJob : public AbstractTokenNetworkJob {
 
         void setWithPath(const bool val) { _withPath = val; }
 
+        [[nodiscard]] uint64_t totalPages() const { return _totalPages; }
+
     private:
         std::string getSpecificUrl() override;
         void setQueryParameters(Poco::URI &uri, bool &canceled) override;
         ExitInfo setData() override { return ExitCode::Ok; }
 
-        uint64_t _page;
-        bool _dirOnly;
-        bool _withPath = false;
+        bool handleResponse(std::istream &is) override;
+
+        uint64_t _page{0};
+        bool _dirOnly{false};
+        bool _withPath{false};
+
+        uint64_t _totalPages{0};
 };
 
 } // namespace KDC

--- a/src/libsyncengine/jobs/network/kDrive_API/getrootfilelistjob.h
+++ b/src/libsyncengine/jobs/network/kDrive_API/getrootfilelistjob.h
@@ -24,8 +24,8 @@ namespace KDC {
 
 class GetRootFileListJob : public AbstractTokenNetworkJob {
     public:
-        GetRootFileListJob(int userDbId, int driveId, uint64_t page = 1, bool dirOnly = false);
-        explicit GetRootFileListJob(int driveDbId, uint64_t page = 1, bool dirOnly = false);
+        GetRootFileListJob(int userDbId, int driveId, uint64_t page = 1, bool dirOnly = false, uint64_t nbItemsPerPage = 1000);
+        explicit GetRootFileListJob(int driveDbId, uint64_t page = 1, bool dirOnly = false, uint64_t nbItemsPerPage = 1000);
 
         void setWithPath(const bool val) { _withPath = val; }
 
@@ -40,6 +40,7 @@ class GetRootFileListJob : public AbstractTokenNetworkJob {
 
         uint64_t _page{0};
         bool _dirOnly{false};
+        uint64_t _nbItemsPerPage{0};
         bool _withPath{false};
 
         uint64_t _totalPages{0};

--- a/src/server/requests/serverrequests.cpp
+++ b/src/server/requests/serverrequests.cpp
@@ -581,15 +581,13 @@ ExitInfo ServerRequests::getSubFolders(const int userDbId, const int driveId, co
 
         Poco::JSON::Object::Ptr resObj = job->jsonRes();
         if (!resObj) {
-            LOG_WARN(Log::instance()->getLogger(), "GetFileListJob failed for userDbId=" << userDbId << " driveId=" << driveId
-                                                                                         << " nodeId=" << nodeId.toStdString());
+            LOG_WARN(Log::instance()->getLogger(), "GetFileListJob failed: no valid JSON message retrieved.");
             return ExitCode::BackError;
         }
 
         Poco::JSON::Array::Ptr dataArray = resObj->getArray(dataKey);
         if (!dataArray) {
-            LOG_WARN(Log::instance()->getLogger(), "GetFileListJob failed for userDbId=" << userDbId << " driveId=" << driveId
-                                                                                         << " nodeId=" << nodeId.toStdString());
+            LOG_WARN(Log::instance()->getLogger(), "GetFileListJob failed: missing `data` array in retrieved JSON message.");
             return ExitCode::BackError;
         }
 

--- a/src/server/requests/serverrequests.cpp
+++ b/src/server/requests/serverrequests.cpp
@@ -547,96 +547,104 @@ ExitCode ServerRequests::getUserAvailableDrives(int userDbId, QHash<int, DriveAv
 
 ExitInfo ServerRequests::getSubFolders(const int userDbId, const int driveId, const QString &nodeId, QList<NodeInfo> &list,
                                        const bool withPath /*= false*/) {
-    std::shared_ptr<GetRootFileListJob> job = nullptr;
-    if (nodeId.isEmpty()) {
-        try {
-            job = std::make_shared<GetRootFileListJob>(userDbId, driveId, 1, true);
-        } catch (const std::exception &e) {
-            LOG_WARN(Log::instance()->getLogger(), "Error in GetRootFileListJob::GetRootFileListJob for userDbId="
-                                                           << userDbId << " driveId=" << driveId << " error=" << e.what());
-            return AbstractTokenNetworkJob::exception2ExitCode(e);
-        }
-    } else {
-        try {
-            job = std::make_shared<GetFileListJob>(userDbId, driveId, nodeId.toStdString(), 1, true);
-        } catch (const std::exception &e) {
-            LOG_WARN(Log::instance()->getLogger(), "Error in GetFileListJob::GetFileListJob for userDbId="
-                                                           << userDbId << " driveId=" << driveId
-                                                           << " nodeId=" << nodeId.toStdString() << " error=" << e.what());
-            return AbstractTokenNetworkJob::exception2ExitCode(e);
-        }
-    }
-
-    job->setWithPath(withPath);
-    if (const auto exitInfo = job->runSynchronously(); exitInfo.code() != ExitCode::Ok) {
-        LOG_WARN(Log::instance()->getLogger(), "Error in GetFileListJob::runSynchronously for userDbId="
-                                                       << userDbId << " driveId=" << driveId << " nodeId=" << nodeId.toStdString()
-                                                       << " error=" << exitInfo);
-        return exitInfo;
-    }
-
-    Poco::JSON::Object::Ptr resObj = job->jsonRes();
-    if (!resObj) {
-        LOG_WARN(Log::instance()->getLogger(), "GetFileListJob failed for userDbId=" << userDbId << " driveId=" << driveId
-                                                                                     << " nodeId=" << nodeId.toStdString());
-        return ExitCode::BackError;
-    }
-
-    Poco::JSON::Array::Ptr dataArray = resObj->getArray(dataKey);
-    if (!dataArray) {
-        LOG_WARN(Log::instance()->getLogger(), "GetFileListJob failed for userDbId=" << userDbId << " driveId=" << driveId
-                                                                                     << " nodeId=" << nodeId.toStdString());
-        return ExitCode::BackError;
-    }
-
     list.clear();
-    for (Poco::JSON::Array::ConstIterator it = dataArray->begin(); it != dataArray->end(); ++it) {
-        Poco::JSON::Object::Ptr dirObj = it->extract<Poco::JSON::Object::Ptr>();
-        SyncTime modTime;
-        if (!JsonParserUtility::extractValue(dirObj, lastModifiedAtKey, modTime)) {
+    uint64_t page = 1;
+    uint64_t totalPages = 0;
+    do {
+        std::shared_ptr<GetRootFileListJob> job = nullptr;
+        if (nodeId.isEmpty()) {
+            try {
+                job = std::make_shared<GetRootFileListJob>(userDbId, driveId, page, true);
+            } catch (const std::exception &e) {
+                LOG_WARN(Log::instance()->getLogger(), "Error in GetRootFileListJob::GetRootFileListJob for userDbId="
+                                                               << userDbId << " driveId=" << driveId << " error=" << e.what());
+                return AbstractTokenNetworkJob::exception2ExitCode(e);
+            }
+        } else {
+            try {
+                job = std::make_shared<GetFileListJob>(userDbId, driveId, nodeId.toStdString(), page, true);
+            } catch (const std::exception &e) {
+                LOG_WARN(Log::instance()->getLogger(), "Error in GetFileListJob::GetFileListJob for userDbId="
+                                                               << userDbId << " driveId=" << driveId
+                                                               << " nodeId=" << nodeId.toStdString() << " error=" << e.what());
+                return AbstractTokenNetworkJob::exception2ExitCode(e);
+            }
+        }
+
+        job->setWithPath(withPath);
+        if (const auto exitInfo = job->runSynchronously(); exitInfo.code() != ExitCode::Ok) {
+            LOG_WARN(Log::instance()->getLogger(), "Error in GetFileListJob::runSynchronously for userDbId="
+                                                           << userDbId << " driveId=" << driveId
+                                                           << " nodeId=" << nodeId.toStdString() << " error=" << exitInfo);
+            return exitInfo;
+        }
+
+        Poco::JSON::Object::Ptr resObj = job->jsonRes();
+        if (!resObj) {
+            LOG_WARN(Log::instance()->getLogger(), "GetFileListJob failed for userDbId=" << userDbId << " driveId=" << driveId
+                                                                                         << " nodeId=" << nodeId.toStdString());
             return ExitCode::BackError;
         }
 
-        NodeId nodeId2;
-        if (!JsonParserUtility::extractValue(dirObj, idKey, nodeId2)) {
+        Poco::JSON::Array::Ptr dataArray = resObj->getArray(dataKey);
+        if (!dataArray) {
+            LOG_WARN(Log::instance()->getLogger(), "GetFileListJob failed for userDbId=" << userDbId << " driveId=" << driveId
+                                                                                         << " nodeId=" << nodeId.toStdString());
             return ExitCode::BackError;
         }
 
-        SyncName tmp;
-        if (!JsonParserUtility::extractValue(dirObj, nameKey, tmp)) {
-            return ExitCode::BackError;
-        }
-
-        SyncName name;
-        if (!Utility::normalizedSyncName(tmp, name)) {
-            LOGW_DEBUG(Log::instance()->getLogger(), L"Error in Utility::normalizedSyncName: " << Utility::formatSyncName(tmp));
-            // Ignore the folder
-            continue;
-        }
-
-        std::string parentId;
-        if (!JsonParserUtility::extractValue(dirObj, parentIdKey, parentId)) {
-            return ExitCode::BackError;
-        }
-
-        SyncName path;
-        if (withPath) {
-            if (!JsonParserUtility::extractValue(dirObj, pathKey, tmp)) {
+        for (Poco::JSON::Array::ConstIterator it = dataArray->begin(); it != dataArray->end(); ++it) {
+            Poco::JSON::Object::Ptr dirObj = it->extract<Poco::JSON::Object::Ptr>();
+            SyncTime modTime;
+            if (!JsonParserUtility::extractValue(dirObj, lastModifiedAtKey, modTime)) {
                 return ExitCode::BackError;
             }
-            if (!Utility::normalizedSyncName(tmp, path)) {
+
+            NodeId nodeId2;
+            if (!JsonParserUtility::extractValue(dirObj, idKey, nodeId2)) {
+                return ExitCode::BackError;
+            }
+
+            SyncName tmp;
+            if (!JsonParserUtility::extractValue(dirObj, nameKey, tmp)) {
+                return ExitCode::BackError;
+            }
+
+            SyncName name;
+            if (!Utility::normalizedSyncName(tmp, name)) {
                 LOGW_DEBUG(Log::instance()->getLogger(),
                            L"Error in Utility::normalizedSyncName: " << Utility::formatSyncName(tmp));
                 // Ignore the folder
                 continue;
             }
+
+            std::string parentId;
+            if (!JsonParserUtility::extractValue(dirObj, parentIdKey, parentId)) {
+                return ExitCode::BackError;
+            }
+
+            SyncName path;
+            if (withPath) {
+                if (!JsonParserUtility::extractValue(dirObj, pathKey, tmp)) {
+                    return ExitCode::BackError;
+                }
+                if (!Utility::normalizedSyncName(tmp, path)) {
+                    LOGW_DEBUG(Log::instance()->getLogger(),
+                               L"Error in Utility::normalizedSyncName: " << Utility::formatSyncName(tmp));
+                    // Ignore the folder
+                    continue;
+                }
+            }
+
+            NodeInfo nodeInfo(QString::fromStdString(nodeId2), SyncName2QStr(name),
+                              -1, // Size is not set here as it can be very long to evaluate
+                              parentId.c_str(), modTime, SyncName2QStr(path));
+            list << nodeInfo;
         }
 
-        NodeInfo nodeInfo(QString::fromStdString(nodeId2), SyncName2QStr(name),
-                          -1, // Size is not set here as it can be very long to evaluate
-                          parentId.c_str(), modTime, SyncName2QStr(path));
-        list << nodeInfo;
-    }
+        page++;
+        totalPages = job->totalPages();
+    } while (page <= totalPages);
 
     return ExitCode::Ok;
 }

--- a/src/server/requests/serverrequests.cpp
+++ b/src/server/requests/serverrequests.cpp
@@ -572,7 +572,7 @@ ExitInfo ServerRequests::getSubFolders(const int userDbId, const int driveId, co
         }
 
         job->setWithPath(withPath);
-        if (const auto exitInfo = job->runSynchronously(); exitInfo.code() != ExitCode::Ok) {
+        if (const auto exitInfo = job->runSynchronously(); !exitInfo) {
             LOG_WARN(Log::instance()->getLogger(), "Error in GetFileListJob::runSynchronously for userDbId="
                                                            << userDbId << " driveId=" << driveId
                                                            << " nodeId=" << nodeId.toStdString() << " error=" << exitInfo);

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -38,6 +38,7 @@
 #include "requests/parameterscache.h"
 #include "jobs/network/infomaniak_API/getappversionjob.h"
 #include "jobs/network/directdownloadjob.h"
+#include "jobs/network/kDrive_API/createdirjob.h"
 #include "jobs/network/kDrive_API/listing/csvfullfilelistwithcursorjob.h"
 #include "jobs/network/kDrive_API/upload/uploadjob.h"
 #include "jobs/network/kDrive_API/upload/upload_session/driveuploadsession.h"
@@ -843,16 +844,39 @@ void TestNetworkJobs::testGetFileInfo() {
 }
 
 void TestNetworkJobs::testGetFileList() {
-    GetFileListJob job(_driveDbId, pictureDirRemoteId);
-    const ExitCode exitCode = job.runSynchronously();
-    CPPUNIT_ASSERT(exitCode == ExitCode::Ok);
+    {
+        GetFileListJob job(_driveDbId, pictureDirRemoteId);
+        const ExitCode exitCode = job.runSynchronously();
+        CPPUNIT_ASSERT(exitCode == ExitCode::Ok);
 
-    int counter = 0;
-    Poco::JSON::Array::Ptr dataArray = job.jsonRes()->getArray(dataKey);
-    for (Poco::JSON::Array::ConstIterator it = dataArray->begin(); it != dataArray->end(); ++it) {
-        counter++;
+        int counter = 0;
+        Poco::JSON::Array::Ptr dataArray = job.jsonRes()->getArray(dataKey);
+        for (Poco::JSON::Array::ConstIterator it = dataArray->begin(); it != dataArray->end(); ++it) {
+            counter++;
+        }
+        CPPUNIT_ASSERT(counter == 5);
     }
-    CPPUNIT_ASSERT(counter == 5);
+    {
+        const RemoteTemporaryDirectory tmpRemoteDir(_driveDbId, _remoteDirId, "testGetFileList");
+        for (uint16_t i = 0; i < 11; i++) {
+            CreateDirJob job(nullptr, _driveDbId, tmpRemoteDir.id(), Str2SyncName(std::to_string(i)));
+            (void) job.runSynchronously();
+        }
+
+        for (uint16_t page = 1; page <= 2; page++) {
+            GetFileListJob job(_driveDbId, tmpRemoteDir.id(), page, true, 10);
+            (void) job.runSynchronously();
+            Poco::JSON::Object::Ptr resObj = job.jsonRes();
+            CPPUNIT_ASSERT(resObj);
+            Poco::JSON::Array::Ptr dataArray = resObj->getArray(dataKey);
+            CPPUNIT_ASSERT(dataArray);
+            if (page == 1) {
+                CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(10), dataArray->size());
+            } else {
+                CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(1), dataArray->size());
+            }
+        }
+    }
 }
 
 void TestNetworkJobs::testGetFileListWithCursor() {


### PR DESCRIPTION
When listing the items inside a directory for the tree view, we do not use pagination. Therefore, if there are more items in the directory than the limit (1'000), some items are missing in the tree view.

This PR activates the pagination and sends another request if there are more items to retrieve.