### PR TITLE
[TRELLO-1107] Handle and log every error raised in `Utility::moveItemToTrash` (Windows)

### DIFF
--- a/src/libcommonserver/log/log.h
+++ b/src/libcommonserver/log/log.h
@@ -23,9 +23,8 @@
 #include <log4cplus/logger.h>
 #include <log4cplus/loggingmacros.h>
 
-
-#include "libcommon/log/customlogstreams.h"
 #include "libcommon/log/sentry/handler.h"
+#include "libcommon/log/customlogstreams.h"
 #include "libcommon/utility/types.h"
 #include "libcommon/utility/utility.h"
 

--- a/src/libcommonserver/log/log.h
+++ b/src/libcommonserver/log/log.h
@@ -23,8 +23,9 @@
 #include <log4cplus/logger.h>
 #include <log4cplus/loggingmacros.h>
 
-#include "libcommon/log/sentry/handler.h"
+
 #include "libcommon/log/customlogstreams.h"
+#include "libcommon/log/sentry/handler.h"
 #include "libcommon/utility/types.h"
 #include "libcommon/utility/utility.h"
 
@@ -120,29 +121,29 @@ namespace KDC {
         LOG4CPLUS_ERROR(logger, customLogWStreamStr_.c_str());                                                          \
     }
 
-#define LOG_FATAL(logger, logEvent)                                                                    \
-    {                                                                                                  \
-        CustomLogStream customLogStream_;                                                              \
-        customLogStream_ << logEvent;                                                                  \
-        const auto customLogStreamStr_ = customLogStream_.str();                                       \
-        sentry_value_t crumb = sentry_value_new_breadcrumb(nullptr, customLogStreamStr_.c_str());      \
-        sentry_value_set_by_key(crumb, "level", sentry_value_new_string("fatal"));                     \
-        sentry_add_breadcrumb(crumb);                                                                  \
+#define LOG_FATAL(logger, logEvent)                                                                              \
+    {                                                                                                            \
+        CustomLogStream customLogStream_;                                                                        \
+        customLogStream_ << logEvent;                                                                            \
+        const auto customLogStreamStr_ = customLogStream_.str();                                                 \
+        sentry_value_t crumb = sentry_value_new_breadcrumb(nullptr, customLogStreamStr_.c_str());                \
+        sentry_value_set_by_key(crumb, "level", sentry_value_new_string("fatal"));                               \
+        sentry_add_breadcrumb(crumb);                                                                            \
         KDC::sentry::Handler::captureMessage(KDC::sentry::Level::Fatal, "Log fatal error", customLogStreamStr_); \
-        LOG4CPLUS_FATAL(logger, customLogStreamStr_.c_str());                                          \
+        LOG4CPLUS_FATAL(logger, customLogStreamStr_.c_str());                                                    \
     }
 
-#define LOGW_FATAL(logger, logEvent)                                                                                         \
-    {                                                                                                                        \
-        CustomLogWStream customLogWStream_;                                                                                  \
-        customLogWStream_ << logEvent;                                                                                       \
-        const auto &customLogWStreamStr_ = customLogWStream_.str();                                                          \
-        sentry_value_t crumb = sentry_value_new_breadcrumb(nullptr, CommonUtility::ws2s(customLogWStreamStr_).c_str());      \
-        sentry_value_set_by_key(crumb, "level", sentry_value_new_string("fatal"));                                           \
-        sentry_add_breadcrumb(crumb);                                                                                        \
+#define LOGW_FATAL(logger, logEvent)                                                                                    \
+    {                                                                                                                   \
+        CustomLogWStream customLogWStream_;                                                                             \
+        customLogWStream_ << logEvent;                                                                                  \
+        const auto &customLogWStreamStr_ = customLogWStream_.str();                                                     \
+        sentry_value_t crumb = sentry_value_new_breadcrumb(nullptr, CommonUtility::ws2s(customLogWStreamStr_).c_str()); \
+        sentry_value_set_by_key(crumb, "level", sentry_value_new_string("fatal"));                                      \
+        sentry_add_breadcrumb(crumb);                                                                                   \
         KDC::sentry::Handler::captureMessage(KDC::sentry::Level::Fatal, "Log fatal error",                              \
-                                             CommonUtility::ws2s(customLogWStreamStr_)); \
-        LOG4CPLUS_FATAL(logger, customLogWStreamStr_.c_str());                                                               \
+                                             CommonUtility::ws2s(customLogWStreamStr_));                                \
+        LOG4CPLUS_FATAL(logger, customLogWStreamStr_.c_str());                                                          \
     }
 #else
 #define LOG_DEBUG(logger, logEvent)                              \

--- a/src/libcommonserver/utility/utility_win.cpp
+++ b/src/libcommonserver/utility/utility_win.cpp
@@ -161,30 +161,23 @@ bool Utility::moveItemToTrash(const SyncPath &itemPath) {
     }
 
     BOOL aborted = false;
+    BOOL result = true;
     hr = fileOperation->GetAnyOperationsAborted(&aborted);
-    if (!FAILED(hr) && aborted) {
-        // failed to carry out delete - return
-        LOGW_WARN(Log::instance()->getLogger(), L"Error in GetAnyOperationsAborted - path="
-                                                        << Path2WStr(itemPath) << L" err="
+    if (FAILED(hr)) {
+        LOGW_WARN(Log::instance()->getLogger(), L"Error in GetAnyOperationsAborted - "
+                                                        << Utility::formatSyncPath(itemPath) << L" err="
                                                         << CommonUtility::s2ws(std::system_category().message(hr)));
-
-        std::wstringstream errorStream;
-        errorStream << L"Move to trash aborted for item " << Path2WStr(itemPath);
-        std::wstring errorStr = errorStream.str();
-        LOGW_WARN(Log::instance()->getLogger(), errorStr);
-
-        sentry::Handler::captureMessage(sentry::Level::Error, "Utility::moveItemToTrash", "Move to trash aborted");
-
-        fileOrFolderItem->Release();
-        fileOperation->Release();
-        CoUninitialize();
-        return false;
+        result = false;
+    } else if (aborted) {
+        LOGW_WARN(Log::instance()->getLogger(), L"Move to trash aborted for item with " << Utility::formatSyncPath(itemPath));
+        result = false;
     }
 
     fileOrFolderItem->Release();
     fileOperation->Release();
     CoUninitialize();
-    return true;
+
+    return result;
 }
 
 bool Utility::totalRamAvailable(uint64_t &ram, int &errorCode) {

--- a/src/libcommonserver/utility/utility_win.cpp
+++ b/src/libcommonserver/utility/utility_win.cpp
@@ -171,6 +171,7 @@ bool Utility::moveItemToTrash(const SyncPath &itemPath) {
     } else if (aborted) {
         LOGW_WARN(Log::instance()->getLogger(), L"Move to trash aborted for item with " << Utility::formatSyncPath(itemPath));
         result = false;
+    } else {
     }
 
     fileOrFolderItem->Release();

--- a/src/libcommonserver/utility/utility_win.cpp
+++ b/src/libcommonserver/utility/utility_win.cpp
@@ -172,6 +172,7 @@ bool Utility::moveItemToTrash(const SyncPath &itemPath) {
         LOGW_WARN(Log::instance()->getLogger(), L"Move to trash aborted for item with " << Utility::formatSyncPath(itemPath));
         result = false;
     } else {
+        // MISRA Coding Guideline
     }
 
     fileOrFolderItem->Release();

--- a/test/libcommonserver/io/testchecksetgetrights.cpp
+++ b/test/libcommonserver/io/testchecksetgetrights.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "testio.h"
+#include "test_utility/testhelpers.h"
 
 #include <filesystem>
 
@@ -24,19 +25,7 @@ using namespace CppUnit;
 
 namespace KDC {
 
-struct RightsSet {
-        RightsSet(int rights) :
-            read(rights & 4),
-            write(rights & 2),
-            execute(rights & 1) {};
-        RightsSet(bool read, bool write, bool execute) :
-            read(read),
-            write(write),
-            execute(execute) {};
-        bool read;
-        bool write;
-        bool execute;
-};
+using namespace testhelpers;
 
 void TestIo::testCheckSetAndGetRights() {
     // Test if the rights are correctly set and get on a directory

--- a/test/libcommonserver/utility/testutility.cpp
+++ b/test/libcommonserver/utility/testutility.cpp
@@ -172,14 +172,13 @@ void TestUtility::testMoveItemToTrash(void) {
     CPPUNIT_ASSERT(!std::filesystem::exists(subdir, ec));
     CPPUNIT_ASSERT(!ec);
 
-#if defined(KD_WINDOWS)
     // A regular directory that misses all permissions:
     const testhelpers::RightsSet noPermission(false, false, false);
     CPPUNIT_ASSERT(IoHelper::setRights(subdir, noPermission.read, noPermission.write, noPermission.execute, rightsError));
     CPPUNIT_ASSERT(!Utility::moveItemToTrash(subdir));
     CPPUNIT_ASSERT(!std::filesystem::exists(subdir, ec));
     CPPUNIT_ASSERT(!ec);
-#endif
+    CPPUNIT_ASSERT(IoHelper::setRights(subdir, true, true, true, rightsError));
 }
 
 void TestUtility::testGetLinuxDesktopType() {

--- a/test/libcommonserver/utility/testutility.cpp
+++ b/test/libcommonserver/utility/testutility.cpp
@@ -171,8 +171,14 @@ void TestUtility::testMoveItemToTrash(void) {
     CPPUNIT_ASSERT(!std::filesystem::exists(path, ec));
     CPPUNIT_ASSERT_EQUAL(13, ec.value()); // EACCES 13 Permission denied
 #endif
+
     // A regular directory that misses owner exec permission:
+
+#if defined(KD_WINDOWS)
     CPPUNIT_ASSERT(!Utility::moveItemToTrash(subdir));
+#else
+    CPPUNIT_ASSERT(Utility::moveItemToTrash(subdir));
+#endif
     CPPUNIT_ASSERT(!std::filesystem::exists(subdir, ec));
     CPPUNIT_ASSERT(!ec);
 }

--- a/test/libcommonserver/utility/testutility.cpp
+++ b/test/libcommonserver/utility/testutility.cpp
@@ -153,13 +153,9 @@ void TestUtility::testMoveItemToTrash(void) {
     (void) std::filesystem::create_directory(subdir);
     path = subdir / "file.txt";
     { std::ofstream ofs(path); }
-#if defined(KD_WINDOWS)
-    const testhelpers::RightsSet rightSet(false, false, false);
+    const testhelpers::RightsSet rightSet(true, true, false);
     auto rightsError = IoError::Unknown;
     CPPUNIT_ASSERT(IoHelper::setRights(subdir, rightSet.read, rightSet.write, rightSet.execute, rightsError));
-#else
-    std::filesystem::permissions(subdir, std::filesystem::perms::owner_exec, std::filesystem::perm_options::remove);
-#endif
 
     std::error_code ec;
 #if defined(KD_WINDOWS)

--- a/test/libcommonserver/utility/testutility.cpp
+++ b/test/libcommonserver/utility/testutility.cpp
@@ -149,7 +149,7 @@ void TestUtility::testMoveItemToTrash(void) {
     // A regular file within a subdirectory that misses owner exec permission:
     // - No issue on Windows
     const SyncPath subdir = tempDir.path() / "permission_less_subdirectory";
-    std::filesystem::create_directory(subdir);
+    (void) std::filesystem::create_directory(subdir);
     path = subdir / "file.txt";
     { std::ofstream ofs(path); }
     std::filesystem::permissions(subdir, std::filesystem::perms::owner_exec, std::filesystem::perm_options::remove);

--- a/test/libcommonserver/utility/testutility.cpp
+++ b/test/libcommonserver/utility/testutility.cpp
@@ -137,7 +137,7 @@ void TestUtility::testMoveItemToTrash(void) {
     CPPUNIT_ASSERT(Utility::moveItemToTrash(path));
     CPPUNIT_ASSERT(!std::filesystem::exists(path));
 
-    // Test with a non existing file
+    // Test with a non-existing file
     CPPUNIT_ASSERT(!Utility::moveItemToTrash(tempDir.path() / "test2.txt"));
 
     // Test with a directory
@@ -152,7 +152,13 @@ void TestUtility::testMoveItemToTrash(void) {
     (void) std::filesystem::create_directory(subdir);
     path = subdir / "file.txt";
     { std::ofstream ofs(path); }
+#if defined(KD_WINDOWS)
+    const testhelpers::RightsSet rightSet(false, false, false);
+    auto rightsError = IoError::Unknown;
+    CPPUNIT_ASSERT(IoHelper::setRights(subdir, rightSet.read, rightSet.write, rightSet.execute, ioError));
+#else
     std::filesystem::permissions(subdir, std::filesystem::perms::owner_exec, std::filesystem::perm_options::remove);
+#endif
 
     std::error_code ec;
 #if defined(KD_WINDOWS)

--- a/test/libcommonserver/utility/testutility.cpp
+++ b/test/libcommonserver/utility/testutility.cpp
@@ -153,12 +153,13 @@ void TestUtility::testMoveItemToTrash(void) {
     path = subdir / "file.txt";
     { std::ofstream ofs(path); }
     std::filesystem::permissions(subdir, std::filesystem::perms::owner_exec, std::filesystem::perm_options::remove);
+
+    std::error_code ec;
 #if defined(KD_WINDOWS)
     CPPUNIT_ASSERT(Utility::moveItemToTrash(path));
     CPPUNIT_ASSERT(!std::filesystem::exists(path));
 #elif defined(KD_MACOS) || defined(KD_LINUX)
     CPPUNIT_ASSERT(!Utility::moveItemToTrash(path));
-    std::error_code ec;
     CPPUNIT_ASSERT(!std::filesystem::exists(path, ec));
     CPPUNIT_ASSERT_EQUAL(13, ec.value()); // EACCES 13 Permission denied
 #endif
@@ -173,7 +174,7 @@ void TestUtility::testGetLinuxDesktopType() {
     std::string currentDesktop;
 #if defined(KD_LINUX)
     CPPUNIT_ASSERT(Utility::getLinuxDesktopType(currentDesktop));
-    CPPUNIT_ASSERT(!currentDesktop.emty());
+    CPPUNIT_ASSERT(!currentDesktop.empty());
     return;
 #endif
     CPPUNIT_ASSERT(!Utility::getLinuxDesktopType(currentDesktop));

--- a/test/test_utility/testhelpers.h
+++ b/test/test_utility/testhelpers.h
@@ -84,6 +84,20 @@ struct TestVariables {
         }
 };
 
+struct RightsSet {
+        RightsSet(int rights) :
+            read(rights & 4),
+            write(rights & 2),
+            execute(rights & 1){};
+        RightsSet(bool read, bool write, bool execute) :
+            read(read),
+            write(write),
+            execute(execute){};
+        bool read;
+        bool write;
+        bool execute;
+};
+
 void generateOrEditTestFile(const SyncPath &path);
 /**
  * @brief Generate test files.


### PR DESCRIPTION
This pull request follows-up with reported failures when moving items to trash that 
- do not raise any error,
- do not leave any trace in logs.

The proposed changes make sure the remaining possible errors are handled and their messages are logged.