### PR TITLE
[TRELLO-1116] Allows users to set the kDrive temporary directory by means of the environment variable `KDRIVE_TMP_PATH`

### DIFF
--- a/src/libcommon/utility/utility.cpp
+++ b/src/libcommon/utility/utility.cpp
@@ -1089,7 +1089,7 @@ int CommonUtility::setenv(const char *name, const char *value, int overwrite) {
     }
     return _putenv_s(name, value);
 #else
-    return setenv(name, value, overwrite);
+    return ::setenv(name, value, overwrite);
 #endif
 }
 

--- a/src/libcommon/utility/utility.cpp
+++ b/src/libcommon/utility/utility.cpp
@@ -1078,6 +1078,21 @@ std::string CommonUtility::envVarValue(const std::string &name, bool &isSet) {
     return std::string();
 }
 
+int CommonUtility::setenv(const char *name, const char *value, int overwrite) {
+#if defined(KD_WINDOWS)
+    // https://stackoverflow.com/a/23616164/4675396
+    int errcode = 0;
+    if (!overwrite) {
+        size_t envsize = 0;
+        errcode = getenv_s(&envsize, NULL, 0, name);
+        if (errcode || envsize) return errcode;
+    }
+    return _putenv_s(name, value);
+#else
+    return setenv(name, value, overwrite);
+#endif
+}
+
 void CommonUtility::handleSignals(void (*sigHandler)(int)) {
     // Kills
     signal(SIGTERM, sigHandler); // Termination request, sent to the program

--- a/src/libcommon/utility/utility.cpp
+++ b/src/libcommon/utility/utility.cpp
@@ -1078,13 +1078,13 @@ std::string CommonUtility::envVarValue(const std::string &name, bool &isSet) {
     return std::string();
 }
 
-int CommonUtility::setenv(const char *name, const char *value, int overwrite) {
+int CommonUtility::setenv(const char *const name, const char *const value, const int overwrite) {
 #if defined(KD_WINDOWS)
     // https://stackoverflow.com/a/23616164/4675396
     int errcode = 0;
     if (!overwrite) {
         size_t envsize = 0;
-        errcode = getenv_s(&envsize, NULL, 0, name);
+        errcode = getenv_s(&envsize, nullptr, 0, name);
         if (errcode || envsize) return errcode;
     }
     return _putenv_s(name, value);

--- a/src/libcommon/utility/utility.h
+++ b/src/libcommon/utility/utility.h
@@ -145,7 +145,7 @@ struct COMMON_EXPORT CommonUtility {
 #endif
         static std::string envVarValue(const std::string &name);
         static std::string envVarValue(const std::string &name, bool &isSet);
-        static int setenv(const char *name, const char *value, int overwrite);
+        static int setenv(const char *const name, const char *const value, const int overwrite);
 
         static void handleSignals(void (*sigHandler)(int));
         static SyncPath signalFilePath(AppType appType, SignalCategory signalCategory);

--- a/src/libcommon/utility/utility.h
+++ b/src/libcommon/utility/utility.h
@@ -145,7 +145,7 @@ struct COMMON_EXPORT CommonUtility {
 #endif
         static std::string envVarValue(const std::string &name);
         static std::string envVarValue(const std::string &name, bool &isSet);
-        int setenv(const char *name, const char *value, int overwrite);
+        static int setenv(const char *name, const char *value, int overwrite);
 
         static void handleSignals(void (*sigHandler)(int));
         static SyncPath signalFilePath(AppType appType, SignalCategory signalCategory);

--- a/src/libcommon/utility/utility.h
+++ b/src/libcommon/utility/utility.h
@@ -145,6 +145,7 @@ struct COMMON_EXPORT CommonUtility {
 #endif
         static std::string envVarValue(const std::string &name);
         static std::string envVarValue(const std::string &name, bool &isSet);
+        int setenv(const char *name, const char *value, int overwrite);
 
         static void handleSignals(void (*sigHandler)(int));
         static SyncPath signalFilePath(AppType appType, SignalCategory signalCategory);

--- a/src/libcommongui/logger.cpp
+++ b/src/libcommongui/logger.cpp
@@ -215,8 +215,16 @@ void Logger::setLogDebug(bool debug) {
 }
 
 QString Logger::temporaryFolderLogDirPath() const {
-    QString dirName = APPLICATION_NAME + QString("-logdir");
-    return QDir::temp().filePath(dirName);
+    static const QString dirName = APPLICATION_NAME + QString("-logdir");
+
+    QDir kDriveTempDirectory;
+    if (const auto &value = CommonUtility::envVarValue("KDRIVE_TMP_PATH"); !value.empty()) {
+        kDriveTempDirectory = QDir(QString::fromStdString(value));
+    } else {
+        kDriveTempDirectory = QDir::temp();
+    }
+
+    return kDriveTempDirectory.filePath(dirName);
 }
 
 void Logger::setupTemporaryFolderLogDir() {

--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -610,9 +610,17 @@ bool IoHelper::getDirectorySize(const SyncPath &path, uint64_t &size, IoError &i
 
 bool IoHelper::tempDirectoryPath(SyncPath &directoryPath, IoError &ioError) noexcept {
     // Warning: never log anything in this method. If the logger is not set, the app will crash.
+    ioError = IoError::Success;
     std::error_code ec;
-    directoryPath = _tempDirectoryPath(ec); // The std::filesystem implementation returns an empty path on error.
+    if (const auto value = CommonUtility::envVarValue("KDRIVE_TMP_PATH"); !value.empty()) {
+        directoryPath = SyncPath(value);
+        std::filesystem::create_directories(directoryPath, ec);
+    } else {
+        directoryPath = _tempDirectoryPath(ec); // The std::filesystem implementation returns an empty path on error.
+    }
+
     ioError = stdError2ioError(ec);
+
     return ioError == IoError::Success;
 }
 

--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -614,7 +614,7 @@ bool IoHelper::tempDirectoryPath(SyncPath &directoryPath, IoError &ioError) noex
     std::error_code ec;
     if (const auto value = CommonUtility::envVarValue("KDRIVE_TMP_PATH"); !value.empty()) {
         directoryPath = SyncPath(value);
-        std::filesystem::create_directories(directoryPath, ec);
+        (void) std::filesystem::create_directories(directoryPath, ec);
     } else {
         directoryPath = _tempDirectoryPath(ec); // The std::filesystem implementation returns an empty path on error.
     }

--- a/test/libcommonserver/io/testio.cpp
+++ b/test/libcommonserver/io/testio.cpp
@@ -95,7 +95,7 @@ void TestIo::testTempDirectoryPath() {
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
 
         // Restores previous value.
-        setenv("KDRIVE_TMP_PATH", previousPath.c_str(), 1);
+        CommonUtility::setenv("KDRIVE_TMP_PATH", previousPath.c_str(), 1);
     }
 }
 

--- a/test/libcommonserver/io/testio.cpp
+++ b/test/libcommonserver/io/testio.cpp
@@ -82,10 +82,11 @@ void TestIo::testTempDirectoryPath() {
 
     {
         // Saves the current value of "KDRIVE_TMP_PATH".
-        const std::string previousPath = CommonUtility::envVarValue("KDRIVE_TMP_PATH");
+        const std::string previousPathString = CommonUtility::envVarValue("KDRIVE_TMP_PATH");
 
         LocalTemporaryDirectory temporaryDirectory;
-        (void) CommonUtility::setenv("KDRIVE_TMP_PATH", (temporaryDirectory.path() / "testTempDirectoryPath").c_str(), 1);
+        const auto pathStringToSet = Path2Str(SyncPath(temporaryDirectory.path() / "testTempDirectoryPath"));
+        (void) CommonUtility::setenv("KDRIVE_TMP_PATH", pathStringToSet.c_str(), 1);
 
         SyncPath tmpPath;
         IoError ioError = IoError::Unknown;
@@ -95,7 +96,7 @@ void TestIo::testTempDirectoryPath() {
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
 
         // Restores previous value.
-        (void) CommonUtility::setenv("KDRIVE_TMP_PATH", previousPath.c_str(), 1);
+        (void) CommonUtility::setenv("KDRIVE_TMP_PATH", previousPathString.c_str(), 1);
     }
 }
 

--- a/test/libcommonserver/io/testio.cpp
+++ b/test/libcommonserver/io/testio.cpp
@@ -85,7 +85,7 @@ void TestIo::testTempDirectoryPath() {
         const std::string previousPath = CommonUtility::envVarValue("KDRIVE_TMP_PATH");
 
         LocalTemporaryDirectory temporaryDirectory;
-        setenv("KDRIVE_TMP_PATH", (temporaryDirectory.path() / "testTempDirectoryPath").c_str(), 1);
+        (void) CommonUtility::setenv("KDRIVE_TMP_PATH", (temporaryDirectory.path() / "testTempDirectoryPath").c_str(), 1);
 
         SyncPath tmpPath;
         IoError ioError = IoError::Unknown;

--- a/test/libcommonserver/io/testio.cpp
+++ b/test/libcommonserver/io/testio.cpp
@@ -95,7 +95,7 @@ void TestIo::testTempDirectoryPath() {
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
 
         // Restores previous value.
-        CommonUtility::setenv("KDRIVE_TMP_PATH", previousPath.c_str(), 1);
+        (void) CommonUtility::setenv("KDRIVE_TMP_PATH", previousPath.c_str(), 1);
     }
 }
 


### PR DESCRIPTION
On the server component side, the value returned by`IoHelper::tempDirectoryPath` controls the location of:

- the kDrive server cache (subfolder of depth 1),
- the kDrive server logs (subfolder of depth 1),
- the temporary folder where the application is installed on Windows.

On the client component side, the logs are located inside `QDir::temp()` (subfolder of depth 1) which is also  the default value of `IoHelper::tempDirectoryPath`.

The proposed changes let the environment variable `KDRIVE_TMP_PATH` serve as the value returned by `IoHelper::tempDirectoryPath`, as well as the value of the parent directory of the client logs, provided this environment variable is set and non-empty.

The previous logic is left unchanged if  `KDRIVE_TMP_PATH` is not set with a non-empty value.
 