### PR TITLE
feat: XPC shared object library

### DIFF
--- a/.github/workflows/test_XPCSharedTypes.yml
+++ b/.github/workflows/test_XPCSharedTypes.yml
@@ -1,0 +1,22 @@
+name: CI workflow XPC library
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build_and_test_XPC_shared_types_macOS:
+    name: Build and Test XPCSharedTypes library on macOS
+    runs-on: [ self-hosted, macOS ]
+
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build
+        run: swift build --package-path ./src/libxpc/MacOSX/XPCSharedTypes
+      - name: Test
+        run: swift test --package-path ./src/libxpc/MacOSX/XPCSharedTypes

--- a/src/libxpc/MacOSX/XPCSharedTypes/.gitignore
+++ b/src/libxpc/MacOSX/XPCSharedTypes/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/src/libxpc/MacOSX/XPCSharedTypes/Package.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version: 6.2
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "XPCSharedTypes",
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "XPCSharedTypes",
+            targets: ["XPCSharedTypes"]
+        ),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "XPCSharedTypes"
+        ),
+        .testTarget(
+            name: "XPCSharedTypesTests",
+            dependencies: ["XPCSharedTypes"]
+        ),
+    ]
+)

--- a/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/AccountInfo.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/AccountInfo.swift
@@ -1,0 +1,53 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+
+protocol AccountInfoProtocol {
+    var dbId: NSInteger { get }
+    var userDbId: NSInteger { get }
+
+    init(dbId: NSInteger, userDbId: NSInteger)
+}
+
+@objc public class AccountInfo: NSObject, NSSecureCoding, AccountInfoProtocol {
+    public static let supportsSecureCoding = true
+
+    public let dbId: NSInteger
+    public let userDbId: NSInteger
+
+    required init(dbId: NSInteger, userDbId: NSInteger) {
+        self.dbId = dbId
+        self.userDbId = userDbId
+    }
+
+    public required init?(coder: NSCoder) {
+        guard let dbId = coder.decodeObject(forKey: "dbId") as? NSInteger,
+              let userDbId = coder.decodeObject(forKey: "userDbId") as? NSInteger else {
+            return nil
+        }
+
+        self.dbId = dbId
+        self.userDbId = userDbId
+    }
+
+    public func encode(with coder: NSCoder) {
+        coder.encode(dbId, forKey: "dbId")
+        coder.encode(userDbId, forKey: "userDbId")
+    }
+}

--- a/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/AccountInfo.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/AccountInfo.swift
@@ -37,10 +37,8 @@ protocol AccountInfoProtocol {
     }
 
     public required init?(coder: NSCoder) {
-        guard let dbId = coder.decodeObject(forKey: "dbId") as? NSInteger,
-              let userDbId = coder.decodeObject(forKey: "userDbId") as? NSInteger else {
-            return nil
-        }
+        let dbId = coder.decodeInteger(forKey: "dbId")
+        let userDbId = coder.decodeInteger(forKey: "userDbId")
 
         self.dbId = dbId
         self.userDbId = userDbId

--- a/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/AccountInfo.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/AccountInfo.swift
@@ -31,7 +31,7 @@ protocol AccountInfoProtocol {
     public let dbId: NSInteger
     public let userDbId: NSInteger
 
-    required init(dbId: NSInteger, userDbId: NSInteger) {
+    public required init(dbId: NSInteger, userDbId: NSInteger) {
         self.dbId = dbId
         self.userDbId = userDbId
     }

--- a/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/DriveAvailableInfo.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/DriveAvailableInfo.swift
@@ -39,7 +39,7 @@ protocol DriveAvailableInfoProtocol {
     public let hexColor: NSString
     public let userDbId: NSInteger
 
-    required init(
+    public required init(
         driveId: NSInteger,
         userId: NSInteger,
         userDbId: NSInteger,

--- a/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/DriveAvailableInfo.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/DriveAvailableInfo.swift
@@ -56,14 +56,15 @@ protocol DriveAvailableInfoProtocol {
     }
 
     public required init?(coder: NSCoder) {
-        guard let driveId = coder.decodeObject(forKey: "driveId") as? NSInteger,
-              let userId = coder.decodeObject(forKey: "userId") as? NSInteger,
-              let accountId = coder.decodeObject(forKey: "accountId") as? NSInteger,
-              let userDbId = coder.decodeObject(forKey: "userDbId") as? NSInteger,
-              let name = coder.decodeObject(forKey: "name") as? NSString,
+        guard let name = coder.decodeObject(forKey: "name") as? NSString,
               let hexColor = coder.decodeObject(forKey: "hexColor") as? NSString else {
             return nil
         }
+
+        let driveId = coder.decodeInteger(forKey: "driveId")
+        let userId = coder.decodeInteger(forKey: "userId")
+        let accountId = coder.decodeInteger(forKey: "accountId")
+        let userDbId = coder.decodeInteger(forKey: "userDbId")
 
         self.driveId = driveId
         self.userId = userId

--- a/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/DriveAvailableInfo.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/DriveAvailableInfo.swift
@@ -1,0 +1,84 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+
+protocol DriveAvailableInfoProtocol {
+    var driveId: NSInteger { get }
+    var userId: NSInteger { get }
+    var accountId: NSInteger { get }
+    var name: NSString { get }
+    var hexColor: NSString { get }
+    var userDbId: NSInteger { get }
+
+    init(driveId: NSInteger, userId: NSInteger, userDbId: NSInteger, accountId: NSInteger, name: NSString, hexColor: NSString)
+}
+
+@objc public class DriveAvailableInfo: NSObject, NSSecureCoding, DriveAvailableInfoProtocol {
+    public static let supportsSecureCoding = true
+
+    public let driveId: NSInteger
+    public let userId: NSInteger
+    public let accountId: NSInteger
+    public let name: NSString
+    public let hexColor: NSString
+    public let userDbId: NSInteger
+
+    required init(
+        driveId: NSInteger,
+        userId: NSInteger,
+        userDbId: NSInteger,
+        accountId: NSInteger,
+        name: NSString,
+        hexColor: NSString
+    ) {
+        self.driveId = driveId
+        self.userId = userId
+        self.accountId = accountId
+        self.userDbId = userDbId
+        self.name = name
+        self.hexColor = hexColor
+    }
+
+    public required init?(coder: NSCoder) {
+        guard let driveId = coder.decodeObject(forKey: "driveId") as? NSInteger,
+              let userId = coder.decodeObject(forKey: "userId") as? NSInteger,
+              let accountId = coder.decodeObject(forKey: "accountId") as? NSInteger,
+              let userDbId = coder.decodeObject(forKey: "userDbId") as? NSInteger,
+              let name = coder.decodeObject(forKey: "name") as? NSString,
+              let hexColor = coder.decodeObject(forKey: "hexColor") as? NSString else {
+            return nil
+        }
+
+        self.driveId = driveId
+        self.userId = userId
+        self.accountId = accountId
+        self.userDbId = userDbId
+        self.name = name
+        self.hexColor = hexColor
+    }
+
+    public func encode(with coder: NSCoder) {
+        coder.encode(driveId, forKey: "driveId")
+        coder.encode(userId, forKey: "userId")
+        coder.encode(accountId, forKey: "accountId")
+        coder.encode(userDbId, forKey: "userDbId")
+        coder.encode(name, forKey: "name")
+        coder.encode(hexColor, forKey: "hexColor")
+    }
+}

--- a/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/DriveInfo.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/DriveInfo.swift
@@ -58,18 +58,16 @@ protocol DriveInfoProtocol {
     public let locked: Bool
     public let accessDenied: Bool
 
-    required init(
-        dbId: NSInteger,
-        id: NSInteger,
-        accountDbId: NSInteger,
-        name: NSString,
-        hexColor: NSString,
-        notifications: Bool,
-        admin: Bool,
-        maintenance: Bool,
-        locked: Bool,
-        accessDenied: Bool
-    ) {
+    public required init(dbId: NSInteger,
+                         id: NSInteger,
+                         accountDbId: NSInteger,
+                         name: NSString,
+                         hexColor: NSString,
+                         notifications: Bool,
+                         admin: Bool,
+                         maintenance: Bool,
+                         locked: Bool,
+                         accessDenied: Bool) {
         self.dbId = dbId
         self.id = id
         self.accountDbId = accountDbId

--- a/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/DriveInfo.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/DriveInfo.swift
@@ -1,0 +1,125 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+
+protocol DriveInfoProtocol {
+    var dbId: NSInteger { get }
+    var id: NSInteger { get }
+    var accountDbId: NSInteger { get }
+    var name: NSString { get }
+    var hexColor: NSString { get }
+    var notifications: Bool { get }
+    var admin: Bool { get }
+    var maintenance: Bool { get }
+    var locked: Bool { get }
+    var accessDenied: Bool { get }
+
+    init(
+        dbId: NSInteger,
+        id: NSInteger,
+        accountDbId: NSInteger,
+        name: NSString,
+        hexColor: NSString,
+        notifications: Bool,
+        admin: Bool,
+        maintenance: Bool,
+        locked: Bool,
+        accessDenied: Bool
+    )
+}
+
+@objc public class DriveInfo: NSObject, NSSecureCoding, DriveInfoProtocol {
+    public static let supportsSecureCoding = true
+
+    public let dbId: NSInteger
+    public let id: NSInteger
+    public let accountDbId: NSInteger
+    public let name: NSString
+    public let hexColor: NSString
+    public let notifications: Bool
+    public let admin: Bool
+    public let maintenance: Bool
+    public let locked: Bool
+    public let accessDenied: Bool
+
+    required init(
+        dbId: NSInteger,
+        id: NSInteger,
+        accountDbId: NSInteger,
+        name: NSString,
+        hexColor: NSString,
+        notifications: Bool,
+        admin: Bool,
+        maintenance: Bool,
+        locked: Bool,
+        accessDenied: Bool
+    ) {
+        self.dbId = dbId
+        self.id = id
+        self.accountDbId = accountDbId
+        self.name = name
+        self.hexColor = hexColor
+        self.notifications = notifications
+        self.admin = admin
+        self.maintenance = maintenance
+        self.locked = locked
+        self.accessDenied = accessDenied
+    }
+
+    public required init?(coder: NSCoder) {
+        guard let name = coder.decodeObject(forKey: "name") as? NSString,
+              let hexColor = coder.decodeObject(forKey: "hexColor") as? NSString else {
+            return nil
+        }
+
+        let dbId = coder.decodeInteger(forKey: "dbId")
+        let id = coder.decodeInteger(forKey: "id")
+        let accountDbId = coder.decodeInteger(forKey: "accountDbId")
+
+        let notifications = coder.decodeBool(forKey: "notifications")
+        let admin = coder.decodeBool(forKey: "admin")
+        let maintenance = coder.decodeBool(forKey: "maintenance")
+        let locked = coder.decodeBool(forKey: "locked")
+        let accessDenied = coder.decodeBool(forKey: "accessDenied")
+
+        self.dbId = dbId
+        self.id = id
+        self.accountDbId = accountDbId
+        self.name = name
+        self.hexColor = hexColor
+        self.notifications = notifications
+        self.admin = admin
+        self.maintenance = maintenance
+        self.locked = locked
+        self.accessDenied = accessDenied
+    }
+
+    public func encode(with coder: NSCoder) {
+        coder.encode(dbId, forKey: "dbId")
+        coder.encode(id, forKey: "id")
+        coder.encode(accountDbId, forKey: "accountDbId")
+        coder.encode(name, forKey: "name")
+        coder.encode(hexColor, forKey: "hexColor")
+        coder.encode(notifications, forKey: "notifications")
+        coder.encode(admin, forKey: "admin")
+        coder.encode(maintenance, forKey: "maintenance")
+        coder.encode(locked, forKey: "locked")
+        coder.encode(accessDenied, forKey: "accessDenied")
+    }
+}

--- a/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/ErrorInfo.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/ErrorInfo.swift
@@ -1,0 +1,180 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+
+protocol ErrorInfoProtocol {
+    var dbId: Int64 { get }
+    var time: Int64 { get }
+    var level: NSInteger { get }
+    var functionName: NSString { get }
+    var syncDbId: NSInteger { get }
+    var workerName: NSString { get }
+    var exitCode: NSInteger { get }
+    var exitCause: NSInteger { get }
+    var localNodeId: NSString { get }
+    var remoteNodeId: NSString { get }
+    var nodeType: NSInteger { get }
+    var path: NSString { get }
+    var destinationPath: NSString { get }
+    var conflictType: NSInteger { get }
+    var inconsistencyType: NSInteger { get }
+    var cancelType: NSInteger { get }
+    var autoResolved: Bool { get }
+
+    init(
+        dbId: Int64,
+        time: Int64,
+        level: NSInteger,
+        functionName: NSString,
+        syncDbId: NSInteger,
+        workerName: NSString,
+        exitCode: NSInteger,
+        exitCause: NSInteger,
+        localNodeId: NSString,
+        remoteNodeId: NSString,
+        nodeType: NSInteger,
+        path: NSString,
+        destinationPath: NSString,
+        conflictType: NSInteger,
+        inconsistencyType: NSInteger,
+        cancelType: NSInteger,
+        autoResolved: Bool
+    )
+}
+
+@objc public class ErrorInfo: NSObject, NSSecureCoding, ErrorInfoProtocol {
+    public static let supportsSecureCoding = true
+
+    public let dbId: Int64
+    public let time: Int64
+    public let level: NSInteger
+    public let functionName: NSString
+    public let syncDbId: NSInteger
+    public let workerName: NSString
+    public let exitCode: NSInteger
+    public let exitCause: NSInteger
+    public let localNodeId: NSString
+    public let remoteNodeId: NSString
+    public let nodeType: NSInteger
+    public let path: NSString
+    public let destinationPath: NSString
+    public let conflictType: NSInteger
+    public let inconsistencyType: NSInteger
+    public let cancelType: NSInteger
+    public let autoResolved: Bool
+
+    public required init(dbId: Int64,
+                         time: Int64,
+                         level: NSInteger,
+                         functionName: NSString,
+                         syncDbId: NSInteger,
+                         workerName: NSString,
+                         exitCode: NSInteger,
+                         exitCause: NSInteger,
+                         localNodeId: NSString,
+                         remoteNodeId: NSString,
+                         nodeType: NSInteger,
+                         path: NSString,
+                         destinationPath: NSString,
+                         conflictType: NSInteger,
+                         inconsistencyType: NSInteger,
+                         cancelType: NSInteger,
+                         autoResolved: Bool) {
+        self.dbId = dbId
+        self.time = time
+        self.level = level
+        self.functionName = functionName
+        self.syncDbId = syncDbId
+        self.workerName = workerName
+        self.exitCode = exitCode
+        self.exitCause = exitCause
+        self.localNodeId = localNodeId
+        self.remoteNodeId = remoteNodeId
+        self.nodeType = nodeType
+        self.path = path
+        self.destinationPath = destinationPath
+        self.conflictType = conflictType
+        self.inconsistencyType = inconsistencyType
+        self.cancelType = cancelType
+        self.autoResolved = autoResolved
+    }
+
+    public required init?(coder: NSCoder) {
+        guard let functionName = coder.decodeObject(forKey: "functionName") as? NSString,
+              let workerName = coder.decodeObject(forKey: "workerName") as? NSString,
+              let localNodeId = coder.decodeObject(forKey: "localNodeId") as? NSString,
+              let remoteNodeId = coder.decodeObject(forKey: "remoteNodeId") as? NSString,
+              let path = coder.decodeObject(forKey: "path") as? NSString,
+              let destinationPath = coder.decodeObject(forKey: "destinationPath") as? NSString else {
+            return nil
+        }
+
+        let dbId = coder.decodeInt64(forKey: "dbId")
+        let time = coder.decodeInt64(forKey: "time")
+
+        let level = coder.decodeInteger(forKey: "level")
+        let syncDbId = coder.decodeInteger(forKey: "syncDbId")
+        let exitCode = coder.decodeInteger(forKey: "exitCode")
+        let exitCause = coder.decodeInteger(forKey: "exitCause")
+        let nodeType = coder.decodeInteger(forKey: "nodeType")
+        let conflictType = coder.decodeInteger(forKey: "conflictType")
+        let inconsistencyType = coder.decodeInteger(forKey: "inconsistencyType")
+        let cancelType = coder.decodeInteger(forKey: "cancelType")
+
+        let autoResolved = coder.decodeBool(forKey: "autoResolved")
+
+        self.dbId = dbId
+        self.time = time
+        self.level = level
+        self.functionName = functionName
+        self.syncDbId = syncDbId
+        self.workerName = workerName
+        self.exitCode = exitCode
+        self.exitCause = exitCause
+        self.localNodeId = localNodeId
+        self.remoteNodeId = remoteNodeId
+        self.nodeType = nodeType
+        self.path = path
+        self.destinationPath = destinationPath
+        self.conflictType = conflictType
+        self.inconsistencyType = inconsistencyType
+        self.cancelType = cancelType
+        self.autoResolved = autoResolved
+    }
+
+    public func encode(with coder: NSCoder) {
+        coder.encode(dbId, forKey: "dbId")
+        coder.encode(time, forKey: "time")
+        coder.encode(level, forKey: "level")
+        coder.encode(functionName, forKey: "functionName")
+        coder.encode(syncDbId, forKey: "syncDbId")
+        coder.encode(workerName, forKey: "workerName")
+        coder.encode(exitCode, forKey: "exitCode")
+        coder.encode(exitCause, forKey: "exitCause")
+        coder.encode(localNodeId, forKey: "localNodeId")
+        coder.encode(remoteNodeId, forKey: "remoteNodeId")
+        coder.encode(nodeType, forKey: "nodeType")
+        coder.encode(path, forKey: "path")
+        coder.encode(destinationPath, forKey: "destinationPath")
+        coder.encode(conflictType, forKey: "conflictType")
+        coder.encode(inconsistencyType, forKey: "inconsistencyType")
+        coder.encode(cancelType, forKey: "cancelType")
+        coder.encode(autoResolved, forKey: "autoResolved")
+    }
+}

--- a/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/ExclusionAppInfo.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/ExclusionAppInfo.swift
@@ -33,7 +33,7 @@ protocol ExclusionAppInfoProtocol {
     public let exclusionDescription: NSString
     public let isDefault: Bool
 
-    required init(appId: NSString, description: NSString, isDefault: Bool) {
+    public required init(appId: NSString, description: NSString, isDefault: Bool) {
         self.appId = appId
         self.exclusionDescription = description
         self.isDefault = isDefault

--- a/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/ExclusionAppInfo.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/ExclusionAppInfo.swift
@@ -1,0 +1,59 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+
+protocol ExclusionAppInfoProtocol {
+    var appId: NSString { get }
+    var exclusionDescription: NSString { get } // description is reserved in NSObject
+    var isDefault: Bool { get }
+
+    init(appId: NSString, description: NSString, isDefault: Bool)
+}
+
+@objc public class ExclusionAppInfo: NSObject, NSSecureCoding, ExclusionAppInfoProtocol {
+    public static let supportsSecureCoding = true
+
+    public let appId: NSString
+    public let exclusionDescription: NSString
+    public let isDefault: Bool
+
+    required init(appId: NSString, description: NSString, isDefault: Bool) {
+        self.appId = appId
+        self.exclusionDescription = description
+        self.isDefault = isDefault
+    }
+
+    public required init?(coder: NSCoder) {
+        guard let appId = coder.decodeObject(forKey: "appId") as? NSString,
+              let exclusionDescription = coder.decodeObject(forKey: "description") as? NSString else {
+            return nil
+        }
+        let isDefault = coder.decodeBool(forKey: "isDefault")
+
+        self.appId = appId
+        self.exclusionDescription = exclusionDescription
+        self.isDefault = isDefault
+    }
+
+    public func encode(with coder: NSCoder) {
+        coder.encode(appId, forKey: "appId")
+        coder.encode(exclusionDescription, forKey: "description")
+        coder.encode(isDefault, forKey: "isDefault")
+    }
+}

--- a/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/ExclusionTemplateInfo.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/ExclusionTemplateInfo.swift
@@ -35,7 +35,7 @@ protocol ExclusionTemplateInfoProtocol {
     public let isDefault: Bool
     public let isDeleted: Bool
 
-    required init(template: NSString, warning: Bool, isDefault: Bool, isDeleted: Bool) {
+    public required init(template: NSString, warning: Bool, isDefault: Bool, isDeleted: Bool) {
         self.template = template
         self.warning = warning
         self.isDefault = isDefault

--- a/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/ExclusionTemplateInfo.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/ExclusionTemplateInfo.swift
@@ -1,0 +1,66 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+
+protocol ExclusionTemplateInfoProtocol {
+    var template: NSString { get }
+    var warning: Bool { get }
+    var isDefault: Bool { get }
+    var isDeleted: Bool { get }
+
+    init(template: NSString, warning: Bool, isDefault: Bool, isDeleted: Bool)
+}
+
+@objc public class ExclusionTemplateInfo: NSObject, NSSecureCoding, ExclusionTemplateInfoProtocol {
+    public static let supportsSecureCoding = true
+
+    public let template: NSString
+    public let warning: Bool
+    public let isDefault: Bool
+    public let isDeleted: Bool
+
+    required init(template: NSString, warning: Bool, isDefault: Bool, isDeleted: Bool) {
+        self.template = template
+        self.warning = warning
+        self.isDefault = isDefault
+        self.isDeleted = isDeleted
+    }
+
+    public required init?(coder: NSCoder) {
+        guard let template = coder.decodeObject(forKey: "template") as? NSString else {
+            return nil
+        }
+
+        let warning: Bool = coder.decodeBool(forKey: "warning")
+        let isDefault: Bool = coder.decodeBool(forKey: "isDefault")
+        let isDeleted: Bool = coder.decodeBool(forKey: "isDeleted")
+
+        self.template = template
+        self.warning = warning
+        self.isDefault = isDefault
+        self.isDeleted = isDeleted
+    }
+
+    public func encode(with coder: NSCoder) {
+        coder.encode(template, forKey: "template")
+        coder.encode(warning, forKey: "warning")
+        coder.encode(isDefault, forKey: "isDefault")
+        coder.encode(isDeleted, forKey: "isDeleted")
+    }
+}

--- a/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/NodeInfo.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/NodeInfo.swift
@@ -39,7 +39,7 @@ protocol NodeInfoProtocol {
     public let modTime: Int64
     public let path: NSString
 
-    required init(nodeId: NSString, name: NSString, size: Int64, parentNodeId: NSString, modTime: Int64, path: NSString) {
+    public required init(nodeId: NSString, name: NSString, size: Int64, parentNodeId: NSString, modTime: Int64, path: NSString) {
         self.nodeId = nodeId
         self.name = name
         self.size = size

--- a/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/NodeInfo.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/NodeInfo.swift
@@ -1,0 +1,78 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+
+protocol NodeInfoProtocol {
+    var nodeId: NSString { get }
+    var name: NSString { get }
+    var size: Int64 { get }
+    var parentNodeId: NSString { get }
+    var modTime: Int64 { get }
+    var path: NSString { get }
+
+    init(nodeId: NSString, name: NSString, size: Int64, parentNodeId: NSString, modTime: Int64, path: NSString)
+}
+
+@objc public class NodeInfo: NSObject, NSSecureCoding, NodeInfoProtocol {
+    public static let supportsSecureCoding = true
+
+    public let nodeId: NSString
+    public let name: NSString
+    public let size: Int64
+    public let parentNodeId: NSString
+    public let modTime: Int64
+    public let path: NSString
+
+    required init(nodeId: NSString, name: NSString, size: Int64, parentNodeId: NSString, modTime: Int64, path: NSString) {
+        self.nodeId = nodeId
+        self.name = name
+        self.size = size
+        self.parentNodeId = parentNodeId
+        self.modTime = modTime
+        self.path = path
+    }
+
+    public required init?(coder: NSCoder) {
+        guard let nodeId: NSString = coder.decodeObject(forKey: "nodeId") as? NSString,
+              let name: NSString = coder.decodeObject(forKey: "name") as? NSString,
+              let parentNodeId = coder.decodeObject(forKey: "parentNodeId") as? NSString,
+              let path = coder.decodeObject(forKey: "path") as? NSString else {
+            return nil
+        }
+
+        let size: Int64 = coder.decodeInt64(forKey: "size")
+        let modTime: Int64 = coder.decodeInt64(forKey: "modtime")
+
+        self.nodeId = nodeId
+        self.name = name
+        self.size = size
+        self.parentNodeId = parentNodeId
+        self.modTime = modTime
+        self.path = path
+    }
+
+    public func encode(with coder: NSCoder) {
+        coder.encode(nodeId, forKey: "nodeId")
+        coder.encode(name, forKey: "name")
+        coder.encode(size, forKey: "size")
+        coder.encode(parentNodeId, forKey: "parentNodeId")
+        coder.encode(modTime, forKey: "modtime")
+        coder.encode(path, forKey: "path")
+    }
+}

--- a/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/ParametersInfo.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/ParametersInfo.swift
@@ -1,0 +1,168 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+
+protocol ParametersInfoProtocol {
+    var language: NSString { get }
+    var monoIcons: Bool { get }
+    var autoStart: Bool { get }
+    var moveToTrash: Bool { get }
+    var darkTheme: Bool { get }
+    var showShortcuts: Bool { get }
+
+    var notificationsDisabled: Bool { get }
+
+    var useLog: Bool { get }
+    var logLevel: NSInteger { get }
+    var extendedLog: Bool { get }
+    var purgeOldLogs: Bool { get }
+
+    var useBigFolderSizeLimit: Bool { get }
+    var bigFolderSizeLimit: Int64 { get }
+    var maxAllowedCpu: Int { get }
+    var distributionChannel: NSInteger { get }
+
+    init(
+        language: NSString,
+        monoIcons: Bool,
+        autoStart: Bool,
+        moveToTrash: Bool,
+        darkTheme: Bool,
+        showShortcuts: Bool,
+        notificationsDisabled: Bool,
+        useLog: Bool,
+        logLevel: NSInteger,
+        extendedLog: Bool,
+        purgeOldLogs: Bool,
+        useBigFolderSizeLimit: Bool,
+        bigFolderSizeLimit: Int64,
+        maxAllowedCpu: Int,
+        distributionChannel: NSInteger
+    )
+}
+
+@objc public class ParametersInfo: NSObject, NSSecureCoding, ParametersInfoProtocol {
+    public static let supportsSecureCoding = true
+
+    public let language: NSString
+    public let monoIcons: Bool
+    public let autoStart: Bool
+    public let moveToTrash: Bool
+    public let darkTheme: Bool
+    public let showShortcuts: Bool
+    public let notificationsDisabled: Bool
+    public let useLog: Bool
+    public let logLevel: NSInteger
+    public let extendedLog: Bool
+    public let purgeOldLogs: Bool
+    public let useBigFolderSizeLimit: Bool
+    public let bigFolderSizeLimit: Int64
+    public let maxAllowedCpu: Int
+    public let distributionChannel: NSInteger
+
+    public required init(
+        language: NSString,
+        monoIcons: Bool,
+        autoStart: Bool,
+        moveToTrash: Bool,
+        darkTheme: Bool,
+        showShortcuts: Bool,
+        notificationsDisabled: Bool,
+        useLog: Bool,
+        logLevel: NSInteger,
+        extendedLog: Bool,
+        purgeOldLogs: Bool,
+        useBigFolderSizeLimit: Bool,
+        bigFolderSizeLimit: Int64,
+        maxAllowedCpu: Int,
+        distributionChannel: NSInteger
+    ) {
+        self.language = language
+        self.monoIcons = monoIcons
+        self.autoStart = autoStart
+        self.moveToTrash = moveToTrash
+        self.darkTheme = darkTheme
+        self.showShortcuts = showShortcuts
+        self.notificationsDisabled = notificationsDisabled
+        self.useLog = useLog
+        self.logLevel = logLevel
+        self.extendedLog = extendedLog
+        self.purgeOldLogs = purgeOldLogs
+        self.useBigFolderSizeLimit = useBigFolderSizeLimit
+        self.bigFolderSizeLimit = bigFolderSizeLimit
+        self.maxAllowedCpu = maxAllowedCpu
+        self.distributionChannel = distributionChannel
+    }
+
+    public required init?(coder: NSCoder) {
+        guard let language: NSString = coder.decodeObject(forKey: "language") as? NSString else {
+            return nil
+        }
+
+        let bigFolderSizeLimit: Int64 = coder.decodeInt64(forKey: "bigFolderSizeLimit")
+        let maxAllowedCpu: Int = coder.decodeInteger(forKey: "maxAllowedCpu")
+        let logLevel: Int = coder.decodeInteger(forKey: "logLevel")
+        let distributionChannel: Int = coder.decodeInteger(forKey: "distributionChannel")
+
+        let monoIcons = coder.decodeBool(forKey: "monoIcons")
+        let autoStart = coder.decodeBool(forKey: "autoStart")
+        let moveToTrash = coder.decodeBool(forKey: "moveToTrash")
+        let darkTheme = coder.decodeBool(forKey: "darkTheme")
+        let showShortcuts = coder.decodeBool(forKey: "showShortcuts")
+        let notificationsDisabled = coder.decodeBool(forKey: "notificationsDisabled")
+        let useLog = coder.decodeBool(forKey: "useLog")
+        let extendedLog = coder.decodeBool(forKey: "extendedLog")
+        let purgeOldLogs = coder.decodeBool(forKey: "purgeOldLogs")
+        let useBigFolderSizeLimit = coder.decodeBool(forKey: "useBigFolderSizeLimit")
+
+        self.language = language
+        self.monoIcons = monoIcons
+        self.autoStart = autoStart
+        self.moveToTrash = moveToTrash
+        self.darkTheme = darkTheme
+        self.showShortcuts = showShortcuts
+        self.notificationsDisabled = notificationsDisabled
+        self.useLog = useLog
+        self.logLevel = logLevel
+        self.extendedLog = extendedLog
+        self.purgeOldLogs = purgeOldLogs
+        self.useBigFolderSizeLimit = useBigFolderSizeLimit
+        self.bigFolderSizeLimit = bigFolderSizeLimit
+        self.maxAllowedCpu = maxAllowedCpu
+        self.distributionChannel = distributionChannel
+    }
+
+    public func encode(with coder: NSCoder) {
+        coder.encode(language, forKey: "language")
+        coder.encode(monoIcons, forKey: "monoIcons")
+        coder.encode(autoStart, forKey: "autoStart")
+        coder.encode(moveToTrash, forKey: "moveToTrash")
+        coder.encode(darkTheme, forKey: "darkTheme")
+        coder.encode(showShortcuts, forKey: "showShortcuts")
+        coder.encode(notificationsDisabled, forKey: "notificationsDisabled")
+        coder.encode(useLog, forKey: "useLog")
+        coder.encode(logLevel, forKey: "logLevel")
+        coder.encode(extendedLog, forKey: "extendedLog")
+        coder.encode(purgeOldLogs, forKey: "purgeOldLogs")
+        coder.encode(useBigFolderSizeLimit, forKey: "useBigFolderSizeLimit")
+        coder.encode(bigFolderSizeLimit, forKey: "bigFolderSizeLimit")
+        coder.encode(maxAllowedCpu, forKey: "maxAllowedCpu")
+        coder.encode(distributionChannel, forKey: "distributionChannel")
+    }
+}

--- a/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/ProxyConfigInfo.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/ProxyConfigInfo.swift
@@ -39,7 +39,7 @@ protocol ProxyConfigInfoProtocol {
     public let user: NSString
     public let pwd: NSString
 
-    required init(type: NSString, hostName: NSString, port: NSInteger, needsAuth: Bool, user: NSString, pwd: NSString) {
+    public required init(type: NSString, hostName: NSString, port: NSInteger, needsAuth: Bool, user: NSString, pwd: NSString) {
         self.type = type
         self.hostName = hostName
         self.port = port

--- a/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/ProxyConfigInfo.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/ProxyConfigInfo.swift
@@ -1,0 +1,78 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+
+protocol ProxyConfigInfoProtocol {
+    var type: NSString { get }
+    var hostName: NSString { get }
+    var port: NSInteger { get }
+    var needsAuth: Bool { get }
+    var user: NSString { get }
+    var pwd: NSString { get }
+
+    init(type: NSString, hostName: NSString, port: NSInteger, needsAuth: Bool, user: NSString, pwd: NSString)
+}
+
+@objc public class ProxyConfigInfo: NSObject, NSSecureCoding, ProxyConfigInfoProtocol {
+    public static let supportsSecureCoding = true
+
+    public let type: NSString
+    public let hostName: NSString
+    public let port: NSInteger
+    public let needsAuth: Bool
+    public let user: NSString
+    public let pwd: NSString
+
+    required init(type: NSString, hostName: NSString, port: NSInteger, needsAuth: Bool, user: NSString, pwd: NSString) {
+        self.type = type
+        self.hostName = hostName
+        self.port = port
+        self.needsAuth = needsAuth
+        self.user = user
+        self.pwd = pwd
+    }
+
+    public required init?(coder: NSCoder) {
+        guard let type = coder.decodeObject(forKey: "type") as? NSString,
+              let hostName = coder.decodeObject(forKey: "hostName") as? NSString,
+              let user = coder.decodeObject(forKey: "user") as? NSString,
+              let pwd = coder.decodeObject(forKey: "pwd") as? NSString else {
+            return nil
+        }
+
+        let port = coder.decodeInteger(forKey: "port")
+        let needsAuth = coder.decodeBool(forKey: "needsAuth")
+
+        self.type = type
+        self.hostName = hostName
+        self.port = port
+        self.needsAuth = needsAuth
+        self.user = user
+        self.pwd = pwd
+    }
+
+    public func encode(with coder: NSCoder) {
+        coder.encode(type, forKey: "type")
+        coder.encode(hostName, forKey: "hostName")
+        coder.encode(port, forKey: "port")
+        coder.encode(needsAuth, forKey: "needsAuth")
+        coder.encode(user, forKey: "user")
+        coder.encode(pwd, forKey: "pwd")
+    }
+}

--- a/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/SearchInfo.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/SearchInfo.swift
@@ -33,7 +33,7 @@ protocol SearchInfoProtocol {
     public let name: NSString
     public let type: NSInteger
 
-    required init(id: NSString, name: NSString, type: NSInteger) {
+    public required init(id: NSString, name: NSString, type: NSInteger) {
         self.id = id
         self.name = name
         self.type = type

--- a/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/SearchInfo.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/SearchInfo.swift
@@ -1,0 +1,60 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+
+protocol SearchInfoProtocol {
+    var id: NSString { get }
+    var name: NSString { get }
+    var type: NSInteger { get }
+
+    init(id: NSString, name: NSString, type: NSInteger)
+}
+
+@objc public class SearchInfo: NSObject, NSSecureCoding, SearchInfoProtocol {
+    public static let supportsSecureCoding = true
+
+    public let id: NSString
+    public let name: NSString
+    public let type: NSInteger
+
+    required init(id: NSString, name: NSString, type: NSInteger) {
+        self.id = id
+        self.name = name
+        self.type = type
+    }
+
+    public required init?(coder: NSCoder) {
+        guard let id = coder.decodeObject(forKey: "id") as? NSString,
+              let name = coder.decodeObject(forKey: "name") as? NSString else {
+            return nil
+        }
+
+        let type = coder.decodeInteger(forKey: "type")
+
+        self.id = id
+        self.name = name
+        self.type = type
+    }
+
+    public func encode(with coder: NSCoder) {
+        coder.encode(id, forKey: "id")
+        coder.encode(name, forKey: "name")
+        coder.encode(type, forKey: "type")
+    }
+}

--- a/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/SyncInfo.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/SyncInfo.swift
@@ -1,0 +1,104 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+
+protocol SyncInfoProtocol {
+    var dbId: NSInteger { get }
+    var driveDbId: NSInteger { get }
+    var localPath: NSString { get }
+    var targetPath: NSString { get }
+    var targetNodeId: NSString { get }
+    var supportVfs: Bool { get }
+    var virtualFileMode: NSInteger { get }
+    var navigationPaneClsid: NSString { get }
+
+    init(dbId: NSInteger,
+         driveDbId: NSInteger,
+         localPath: NSString,
+         targetPath: NSString,
+         targetNodeId: NSString,
+         supportVfs: Bool,
+         virtualFileMode: NSInteger,
+         navigationPaneClsid: NSString)
+}
+
+@objc public class SyncInfo: NSObject, NSSecureCoding, SyncInfoProtocol {
+    public static let supportsSecureCoding = true
+
+    let dbId: NSInteger
+    let driveDbId: NSInteger
+    let localPath: NSString
+    let targetPath: NSString
+    let targetNodeId: NSString
+    let supportVfs: Bool
+    let virtualFileMode: NSInteger
+    let navigationPaneClsid: NSString
+
+    required init(dbId: NSInteger,
+                  driveDbId: NSInteger,
+                  localPath: NSString,
+                  targetPath: NSString,
+                  targetNodeId: NSString,
+                  supportVfs: Bool,
+                  virtualFileMode: NSInteger,
+                  navigationPaneClsid: NSString) {
+        self.dbId = dbId
+        self.driveDbId = driveDbId
+        self.localPath = localPath
+        self.targetPath = targetPath
+        self.targetNodeId = targetNodeId
+        self.supportVfs = supportVfs
+        self.virtualFileMode = virtualFileMode
+        self.navigationPaneClsid = navigationPaneClsid
+    }
+
+    public required init?(coder: NSCoder) {
+        guard let localPath = coder.decodeObject(forKey: "localPath") as? NSString,
+              let targetPath = coder.decodeObject(forKey: "targetPath") as? NSString,
+              let targetNodeId = coder.decodeObject(forKey: "targetNodeId") as? NSString,
+              let navigationPaneClsid = coder.decodeObject(forKey: "navigationPaneClsid") as? NSString else {
+            return nil
+        }
+
+        let dbId = coder.decodeInteger(forKey: "dbId")
+        let driveDbId = coder.decodeInteger(forKey: "driveDbId")
+        let virtualFileMode = coder.decodeInteger(forKey: "virtualFileMode")
+        let supportVfs = coder.decodeBool(forKey: "supportVfs")
+
+        self.dbId = dbId
+        self.driveDbId = driveDbId
+        self.localPath = localPath
+        self.targetPath = targetPath
+        self.targetNodeId = targetNodeId
+        self.supportVfs = supportVfs
+        self.virtualFileMode = virtualFileMode
+        self.navigationPaneClsid = navigationPaneClsid
+    }
+
+    public func encode(with coder: NSCoder) {
+        coder.encode(dbId, forKey: "dbId")
+        coder.encode(driveDbId, forKey: "driveDbId")
+        coder.encode(localPath, forKey: "localPath")
+        coder.encode(targetPath, forKey: "targetPath")
+        coder.encode(targetNodeId, forKey: "targetNodeId")
+        coder.encode(supportVfs, forKey: "supportVfs")
+        coder.encode(virtualFileMode, forKey: "virtualFileMode")
+        coder.encode(navigationPaneClsid, forKey: "navigationPaneClsid")
+    }
+}

--- a/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/SyncInfo.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/SyncInfo.swift
@@ -41,23 +41,23 @@ protocol SyncInfoProtocol {
 @objc public class SyncInfo: NSObject, NSSecureCoding, SyncInfoProtocol {
     public static let supportsSecureCoding = true
 
-    let dbId: NSInteger
-    let driveDbId: NSInteger
-    let localPath: NSString
-    let targetPath: NSString
-    let targetNodeId: NSString
-    let supportVfs: Bool
-    let virtualFileMode: NSInteger
-    let navigationPaneClsid: NSString
+    public let dbId: NSInteger
+    public let driveDbId: NSInteger
+    public let localPath: NSString
+    public let targetPath: NSString
+    public let targetNodeId: NSString
+    public let supportVfs: Bool
+    public let virtualFileMode: NSInteger
+    public let navigationPaneClsid: NSString
 
-    required init(dbId: NSInteger,
-                  driveDbId: NSInteger,
-                  localPath: NSString,
-                  targetPath: NSString,
-                  targetNodeId: NSString,
-                  supportVfs: Bool,
-                  virtualFileMode: NSInteger,
-                  navigationPaneClsid: NSString) {
+    public required init(dbId: NSInteger,
+                         driveDbId: NSInteger,
+                         localPath: NSString,
+                         targetPath: NSString,
+                         targetNodeId: NSString,
+                         supportVfs: Bool,
+                         virtualFileMode: NSInteger,
+                         navigationPaneClsid: NSString) {
         self.dbId = dbId
         self.driveDbId = driveDbId
         self.localPath = localPath

--- a/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/UserInfo.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/UserInfo.swift
@@ -1,0 +1,107 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+
+protocol UserInfoProtocol {
+    var dbId: NSInteger { get }
+    var userId: NSInteger { get }
+    var name: NSString { get }
+    var email: NSString { get }
+    var avatar: NSData { get }
+    var connected: Bool { get }
+    var credentialsAsked: Bool { get }
+    var isStaff: Bool { get }
+
+    init(
+        dbId: NSInteger,
+        userId: NSInteger,
+        name: NSString,
+        email: NSString,
+        avatar: NSData,
+        connected: Bool,
+        credentialsAsked: Bool,
+        isStaff: Bool
+    )
+}
+
+@objc public class UserInfo: NSObject, NSSecureCoding, UserInfoProtocol {
+    public static let supportsSecureCoding = true
+
+    public let dbId: NSInteger
+    public let userId: NSInteger
+    public let name: NSString
+    public let email: NSString
+    public let avatar: NSData
+    public let connected: Bool
+    public let credentialsAsked: Bool
+    public let isStaff: Bool
+
+    public required init(dbId: NSInteger,
+                         userId: NSInteger,
+                         name: NSString,
+                         email: NSString,
+                         avatar: NSData,
+                         connected: Bool,
+                         credentialsAsked: Bool,
+                         isStaff: Bool) {
+        self.dbId = dbId
+        self.userId = userId
+        self.name = name
+        self.email = email
+        self.avatar = avatar
+        self.connected = connected
+        self.credentialsAsked = credentialsAsked
+        self.isStaff = isStaff
+    }
+
+    public required init?(coder: NSCoder) {
+        guard let name = coder.decodeObject(forKey: "name") as? NSString,
+              let email = coder.decodeObject(forKey: "email") as? NSString,
+              let avatar = coder.decodeObject(forKey: "avatar") as? NSData else {
+            return nil
+        }
+
+        let dbId = coder.decodeInteger(forKey: "dbId")
+        let userId = coder.decodeInteger(forKey: "userId")
+
+        let connected = coder.decodeBool(forKey: "connected")
+        let credentialsAsked = coder.decodeBool(forKey: "credentialsAsked")
+        let isStaff = coder.decodeBool(forKey: "isStaff")
+
+        self.dbId = dbId
+        self.userId = userId
+        self.name = name
+        self.email = email
+        self.avatar = avatar
+        self.connected = connected
+        self.credentialsAsked = credentialsAsked
+        self.isStaff = isStaff
+    }
+
+    public func encode(with coder: NSCoder) {
+        coder.encode(dbId, forKey: "dbId")
+        coder.encode(userId, forKey: "userId")
+        coder.encode(name, forKey: "name")
+        coder.encode(email, forKey: "email")
+        coder.encode(avatar, forKey: "avatar")
+        coder.encode(connected, forKey: "connected")
+        coder.encode(credentialsAsked, forKey: "credentialsAsked")
+        coder.encode(isStaff, forKey: "isStaff")
+    }
+}

--- a/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/XPCSharedTypes.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/XPCSharedTypes.swift
@@ -1,2 +1,0 @@
-// The Swift Programming Language
-// https://docs.swift.org/swift-book

--- a/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/XPCSharedTypes.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Sources/XPCSharedTypes/XPCSharedTypes.swift
@@ -1,0 +1,2 @@
+// The Swift Programming Language
+// https://docs.swift.org/swift-book

--- a/src/libxpc/MacOSX/XPCSharedTypes/Tests/XPCSharedTypesTests/UTAccountInfo.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Tests/XPCSharedTypesTests/UTAccountInfo.swift
@@ -1,0 +1,33 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Testing
+@testable import XPCSharedTypes
+
+@Test func accountInfoConstructor() async throws {
+    // GIVEN
+    let expectedDbId = Int.random(in: 0...1000)
+    let expectedUserDbId = Int.random(in: 0...1000)
+
+    // WHEN
+    let accountInfo = AccountInfo(dbId: expectedDbId, userDbId: expectedUserDbId)
+
+    // THEN
+    #expect(accountInfo.dbId == expectedDbId)
+    #expect(accountInfo.userDbId == expectedUserDbId)
+}

--- a/src/libxpc/MacOSX/XPCSharedTypes/Tests/XPCSharedTypesTests/UTAccountInfo.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Tests/XPCSharedTypesTests/UTAccountInfo.swift
@@ -17,12 +17,12 @@
  */
 
 import Testing
-@testable import XPCSharedTypes
+import XPCSharedTypes
 
 @Test func accountInfoConstructor() async throws {
     // GIVEN
-    let expectedDbId = Int.random(in: 0...1000)
-    let expectedUserDbId = Int.random(in: 0...1000)
+    let expectedDbId = Int.random(in: 0 ... 1000)
+    let expectedUserDbId = Int.random(in: 0 ... 1000)
 
     // WHEN
     let accountInfo = AccountInfo(dbId: expectedDbId, userDbId: expectedUserDbId)

--- a/src/libxpc/MacOSX/XPCSharedTypes/Tests/XPCSharedTypesTests/UTDriveAvailableInfo.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Tests/XPCSharedTypesTests/UTDriveAvailableInfo.swift
@@ -1,0 +1,47 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+import Testing
+@testable import XPCSharedTypes
+
+@Test func driveAvailableInfoConstructor() async throws {
+    // GIVEN
+    let expectedDriveId = Int.random(in: 0...1000)
+    let expectedUserId = Int.random(in: 0...1000)
+    let expectedUserDbId = Int.random(in: 0...1000)
+    let expectedAccountId = Int.random(in: 0...1000)
+    let expectedName: NSString = "hello world"
+    let expectedHexColor: NSString = "#FFFFFFFF"
+
+    // WHEN
+    let driveAvailableInfo = DriveAvailableInfo(driveId: expectedDriveId,
+                                                userId: expectedUserId,
+                                                userDbId: expectedUserDbId,
+                                                accountId: expectedAccountId,
+                                                name: expectedName,
+                                                hexColor: expectedHexColor)
+
+    // THEN
+    #expect(driveAvailableInfo.driveId == expectedDriveId)
+    #expect(driveAvailableInfo.userId == expectedUserId)
+    #expect(driveAvailableInfo.userDbId == expectedUserDbId)
+    #expect(driveAvailableInfo.accountId == expectedAccountId)
+    #expect(driveAvailableInfo.name == expectedName)
+    #expect(driveAvailableInfo.hexColor == expectedHexColor)
+}

--- a/src/libxpc/MacOSX/XPCSharedTypes/Tests/XPCSharedTypesTests/UTDriveAvailableInfo.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Tests/XPCSharedTypesTests/UTDriveAvailableInfo.swift
@@ -18,14 +18,14 @@
 
 import Foundation
 import Testing
-@testable import XPCSharedTypes
+import XPCSharedTypes
 
 @Test func driveAvailableInfoConstructor() async throws {
     // GIVEN
-    let expectedDriveId = Int.random(in: 0...1000)
-    let expectedUserId = Int.random(in: 0...1000)
-    let expectedUserDbId = Int.random(in: 0...1000)
-    let expectedAccountId = Int.random(in: 0...1000)
+    let expectedDriveId = Int.random(in: 0 ... 1000)
+    let expectedUserId = Int.random(in: 0 ... 1000)
+    let expectedUserDbId = Int.random(in: 0 ... 1000)
+    let expectedAccountId = Int.random(in: 0 ... 1000)
     let expectedName: NSString = "hello world"
     let expectedHexColor: NSString = "#FFFFFFFF"
 

--- a/src/libxpc/MacOSX/XPCSharedTypes/Tests/XPCSharedTypesTests/UTDriveInfo.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Tests/XPCSharedTypesTests/UTDriveInfo.swift
@@ -18,13 +18,13 @@
 
 import Foundation
 import Testing
-@testable import XPCSharedTypes
+import XPCSharedTypes
 
 @Test func driveInfoConstructor() async throws {
     // GIVEN
-    let expectedDbId = Int.random(in: 0...1000)
-    let expectedId = Int.random(in: 0...1000)
-    let expectedAccountDbId = Int.random(in: 0...1000)
+    let expectedDbId = Int.random(in: 0 ... 1000)
+    let expectedId = Int.random(in: 0 ... 1000)
+    let expectedAccountDbId = Int.random(in: 0 ... 1000)
     let expectedName: NSString = "hello name"
     let expectedHexColor: NSString = "#AABBCCDD"
     let expectedNotifications = Bool.random()

--- a/src/libxpc/MacOSX/XPCSharedTypes/Tests/XPCSharedTypesTests/UTDriveInfo.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Tests/XPCSharedTypesTests/UTDriveInfo.swift
@@ -1,0 +1,59 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+import Testing
+@testable import XPCSharedTypes
+
+@Test func driveInfoConstructor() async throws {
+    // GIVEN
+    let expectedDbId = Int.random(in: 0...1000)
+    let expectedId = Int.random(in: 0...1000)
+    let expectedAccountDbId = Int.random(in: 0...1000)
+    let expectedName: NSString = "hello name"
+    let expectedHexColor: NSString = "#AABBCCDD"
+    let expectedNotifications = Bool.random()
+    let expectedAdmin = Bool.random()
+    let expectedMaintenance = Bool.random()
+    let expectedLocked = Bool.random()
+    let expectedAccessDenied = Bool.random()
+
+    // WHEN
+    let driveInfo = DriveInfo(dbId: expectedDbId,
+                              id: expectedId,
+                              accountDbId: expectedAccountDbId,
+                              name: expectedName,
+                              hexColor: expectedHexColor,
+                              notifications: expectedNotifications,
+                              admin: expectedAdmin,
+                              maintenance: expectedMaintenance,
+                              locked: expectedLocked,
+                              accessDenied: expectedAccessDenied)
+
+    // THEN
+    #expect(driveInfo.dbId == expectedDbId)
+    #expect(driveInfo.id == expectedId)
+    #expect(driveInfo.accountDbId == expectedAccountDbId)
+    #expect(driveInfo.name == expectedName)
+    #expect(driveInfo.hexColor == expectedHexColor)
+    #expect(driveInfo.notifications == expectedNotifications)
+    #expect(driveInfo.admin == expectedAdmin)
+    #expect(driveInfo.maintenance == expectedMaintenance)
+    #expect(driveInfo.locked == expectedLocked)
+    #expect(driveInfo.accessDenied == expectedAccessDenied)
+}

--- a/src/libxpc/MacOSX/XPCSharedTypes/Tests/XPCSharedTypesTests/UTExclusionAppInfo.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Tests/XPCSharedTypesTests/UTExclusionAppInfo.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 import Testing
-@testable import XPCSharedTypes
+import XPCSharedTypes
 
 @Test func exclusionAppInfoConstructor() async throws {
     // GIVEN
@@ -28,8 +28,8 @@ import Testing
 
     // WHEN
     let exclusionAppInfo = ExclusionAppInfo(appId: expectedAppId,
-                                       description: expectedDescription,
-                                       isDefault: expectedIsDefault)
+                                            description: expectedDescription,
+                                            isDefault: expectedIsDefault)
 
     // THEN
     #expect(exclusionAppInfo.appId == expectedAppId)

--- a/src/libxpc/MacOSX/XPCSharedTypes/Tests/XPCSharedTypesTests/UTExclusionAppInfo.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Tests/XPCSharedTypesTests/UTExclusionAppInfo.swift
@@ -1,0 +1,38 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+import Testing
+@testable import XPCSharedTypes
+
+@Test func exclusionAppInfoConstructor() async throws {
+    // GIVEN
+    let expectedAppId: NSString = "com.example.test"
+    let expectedDescription: NSString = "hello description"
+    let expectedIsDefault = Bool.random()
+
+    // WHEN
+    let exclusionAppInfo = ExclusionAppInfo(appId: expectedAppId,
+                                       description: expectedDescription,
+                                       isDefault: expectedIsDefault)
+
+    // THEN
+    #expect(exclusionAppInfo.appId == expectedAppId)
+    #expect(exclusionAppInfo.exclusionDescription == expectedDescription)
+    #expect(exclusionAppInfo.isDefault == expectedIsDefault)
+}

--- a/src/libxpc/MacOSX/XPCSharedTypes/Tests/XPCSharedTypesTests/UTExclusionTemplateInfo.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Tests/XPCSharedTypesTests/UTExclusionTemplateInfo.swift
@@ -1,0 +1,41 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+import Testing
+@testable import XPCSharedTypes
+
+@Test func exclusionTemplateInfoConstructor() async throws {
+    // GIVEN
+    let expectedTemplate: NSString = "com.example.test"
+    let expectedWarning = Bool.random()
+    let expectedIsDefault = Bool.random()
+    let expectedIsDeleted = Bool.random()
+
+    // WHEN
+    let exclusionTemplateInfo = ExclusionTemplateInfo(template: expectedTemplate,
+                                                      warning: expectedWarning,
+                                                      isDefault: expectedIsDefault,
+                                                      isDeleted: expectedIsDeleted)
+
+    // THEN
+    #expect(exclusionTemplateInfo.template == expectedTemplate)
+    #expect(exclusionTemplateInfo.warning == expectedWarning)
+    #expect(exclusionTemplateInfo.isDefault == expectedIsDefault)
+    #expect(exclusionTemplateInfo.isDeleted == expectedIsDeleted)
+}

--- a/src/libxpc/MacOSX/XPCSharedTypes/Tests/XPCSharedTypesTests/UTExclusionTemplateInfo.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Tests/XPCSharedTypesTests/UTExclusionTemplateInfo.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 import Testing
-@testable import XPCSharedTypes
+import XPCSharedTypes
 
 @Test func exclusionTemplateInfoConstructor() async throws {
     // GIVEN

--- a/src/libxpc/MacOSX/XPCSharedTypes/Tests/XPCSharedTypesTests/UTNodeInfo.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Tests/XPCSharedTypesTests/UTNodeInfo.swift
@@ -1,0 +1,47 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+import Testing
+@testable import XPCSharedTypes
+
+@Test func nodeInfoConstructor() async throws {
+    // GIVEN
+    let expectedNodeId = NSString(string: UUID().uuidString)
+    let expectedName: NSString = "hello name"
+    let expectedSize = Int64.random(in: 0...1000)
+    let expectedParentNodeId = NSString(string: UUID().uuidString)
+    let expectedModTime = Int64.random(in: 0...1000)
+    let expectedPath: NSString = "/dev/null"
+
+    // WHEN
+    let nodeInfo = NodeInfo(nodeId: expectedNodeId,
+                            name: expectedName,
+                            size: expectedSize,
+                            parentNodeId: expectedParentNodeId,
+                            modTime: expectedModTime,
+                            path: expectedPath)
+
+    // THEN
+    #expect(nodeInfo.nodeId == expectedNodeId)
+    #expect(nodeInfo.name == expectedName)
+    #expect(nodeInfo.size == expectedSize)
+    #expect(nodeInfo.parentNodeId == expectedParentNodeId)
+    #expect(nodeInfo.modTime == expectedModTime)
+    #expect(nodeInfo.path == expectedPath)
+}

--- a/src/libxpc/MacOSX/XPCSharedTypes/Tests/XPCSharedTypesTests/UTNodeInfo.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Tests/XPCSharedTypesTests/UTNodeInfo.swift
@@ -18,15 +18,15 @@
 
 import Foundation
 import Testing
-@testable import XPCSharedTypes
+import XPCSharedTypes
 
 @Test func nodeInfoConstructor() async throws {
     // GIVEN
     let expectedNodeId = NSString(string: UUID().uuidString)
     let expectedName: NSString = "hello name"
-    let expectedSize = Int64.random(in: 0...1000)
+    let expectedSize = Int64.random(in: 0 ... 1000)
     let expectedParentNodeId = NSString(string: UUID().uuidString)
-    let expectedModTime = Int64.random(in: 0...1000)
+    let expectedModTime = Int64.random(in: 0 ... 1000)
     let expectedPath: NSString = "/dev/null"
 
     // WHEN

--- a/src/libxpc/MacOSX/XPCSharedTypes/Tests/XPCSharedTypesTests/UTProxyConfigInfo.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Tests/XPCSharedTypesTests/UTProxyConfigInfo.swift
@@ -1,0 +1,47 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+import Testing
+@testable import XPCSharedTypes
+
+@Test func proxyConfigInfoConstructor() async throws {
+    // GIVEN
+    let expectedType: NSString = "hello type"
+    let expectedHostName: NSString = "hello host name"
+    let expectedPort: NSInteger = 8080
+    let expectedNeedsAuth = Bool.random()
+    let expectedUser: NSString = "hello user"
+    let expectedPwd: NSString = "hello pwd"
+
+    // WHEN
+    let proxyConfigInfo = ProxyConfigInfo(type: expectedType,
+                                          hostName: expectedHostName,
+                                          port: expectedPort,
+                                          needsAuth: expectedNeedsAuth,
+                                          user: expectedUser,
+                                          pwd: expectedPwd)
+
+    // THEN
+    #expect(proxyConfigInfo.type == expectedType)
+    #expect(proxyConfigInfo.hostName == expectedHostName)
+    #expect(proxyConfigInfo.port == expectedPort)
+    #expect(proxyConfigInfo.needsAuth == expectedNeedsAuth)
+    #expect(proxyConfigInfo.user == expectedUser)
+    #expect(proxyConfigInfo.pwd == expectedPwd)
+}

--- a/src/libxpc/MacOSX/XPCSharedTypes/Tests/XPCSharedTypesTests/UTProxyConfigInfo.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Tests/XPCSharedTypesTests/UTProxyConfigInfo.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 import Testing
-@testable import XPCSharedTypes
+import XPCSharedTypes
 
 @Test func proxyConfigInfoConstructor() async throws {
     // GIVEN

--- a/src/libxpc/MacOSX/XPCSharedTypes/Tests/XPCSharedTypesTests/UTSearchInfo.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Tests/XPCSharedTypesTests/UTSearchInfo.swift
@@ -1,0 +1,37 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+import Testing
+@testable import XPCSharedTypes
+
+@Test func searchInfoConstructor() async throws {
+    // GIVEN
+    let expectedId = UUID().uuidString as NSString
+    let expectedName = "Test Search" as NSString
+    let expectedType: NSInteger = 1234
+    
+
+    // WHEN
+    let searchInfo = SearchInfo(id: expectedId, name: expectedName, type: expectedType)
+
+    // THEN
+    #expect(searchInfo.id == expectedId)
+    #expect(searchInfo.name == expectedName)
+    #expect(searchInfo.type == expectedType)
+}

--- a/src/libxpc/MacOSX/XPCSharedTypes/Tests/XPCSharedTypesTests/UTSearchInfo.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Tests/XPCSharedTypesTests/UTSearchInfo.swift
@@ -18,14 +18,13 @@
 
 import Foundation
 import Testing
-@testable import XPCSharedTypes
+import XPCSharedTypes
 
 @Test func searchInfoConstructor() async throws {
     // GIVEN
     let expectedId = UUID().uuidString as NSString
     let expectedName = "Test Search" as NSString
     let expectedType: NSInteger = 1234
-    
 
     // WHEN
     let searchInfo = SearchInfo(id: expectedId, name: expectedName, type: expectedType)

--- a/src/libxpc/MacOSX/XPCSharedTypes/Tests/XPCSharedTypesTests/UTSyncInfo.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Tests/XPCSharedTypesTests/UTSyncInfo.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 import Testing
-@testable import XPCSharedTypes
+import XPCSharedTypes
 
 @Test func syncInfoConstructor() async throws {
     // GIVEN

--- a/src/libxpc/MacOSX/XPCSharedTypes/Tests/XPCSharedTypesTests/UTSyncInfo.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Tests/XPCSharedTypesTests/UTSyncInfo.swift
@@ -1,0 +1,53 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+import Testing
+@testable import XPCSharedTypes
+
+@Test func syncInfoConstructor() async throws {
+    // GIVEN
+    let expectedDbId = Int.random(in: 0 ... 1000)
+    let expectedDriveDbId = Int.random(in: 0 ... 1000)
+    let expectedLocalPath = "/dev/null" as NSString
+    let expectedTargetPath = "/dev/null" as NSString
+    let expectedTargetNodeId = UUID().uuidString as NSString
+    let expectedSupportVfs = Bool.random()
+    let expectedVirtualFileMode = Int.random(in: 0 ... 1000)
+    let expectedNavigationPaneClsid = UUID().uuidString as NSString
+
+    // WHEN
+    let syncInfo = SyncInfo(dbId: expectedDbId,
+                            driveDbId: expectedDriveDbId,
+                            localPath: expectedLocalPath,
+                            targetPath: expectedTargetPath,
+                            targetNodeId: expectedTargetNodeId,
+                            supportVfs: expectedSupportVfs,
+                            virtualFileMode: expectedVirtualFileMode,
+                            navigationPaneClsid: expectedNavigationPaneClsid)
+
+    // THEN
+    #expect(syncInfo.dbId == expectedDbId)
+    #expect(syncInfo.driveDbId == expectedDriveDbId)
+    #expect(syncInfo.localPath == expectedLocalPath)
+    #expect(syncInfo.targetPath == expectedTargetPath)
+    #expect(syncInfo.targetNodeId == expectedTargetNodeId)
+    #expect(syncInfo.supportVfs == expectedSupportVfs)
+    #expect(syncInfo.virtualFileMode == expectedVirtualFileMode)
+    #expect(syncInfo.navigationPaneClsid == expectedNavigationPaneClsid)
+}

--- a/src/libxpc/MacOSX/XPCSharedTypes/Tests/XPCSharedTypesTests/UTUserInfo.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Tests/XPCSharedTypesTests/UTUserInfo.swift
@@ -1,0 +1,54 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+import Testing
+import XPCSharedTypes
+
+@Test func userInfoConstructor() async throws {
+    // GIVEN
+    let expectedDbId = Int.random(in: 0 ... 1000)
+    let expectedUserId = Int.random(in: 0 ... 1000)
+    let expectedName: NSString = "hello name"
+    let expectedEmail: NSString = "hello email"
+    let expectedAvatar = NSData()
+    let expectedConnected = Bool.random()
+    let expectedCredentialsAsked = Bool.random()
+    let expectedIsStaff = Bool.random()
+
+    // WHEN
+    let userInfo = UserInfo(dbId: expectedDbId,
+                            userId: expectedUserId,
+                            name: expectedName,
+                            email: expectedEmail,
+                            avatar: expectedAvatar,
+                            connected: expectedConnected,
+                            credentialsAsked: expectedCredentialsAsked,
+                            isStaff: expectedIsStaff)
+
+    // THEN
+    #expect(userInfo.dbId == expectedDbId)
+    #expect(userInfo.userId == expectedUserId)
+    #expect(userInfo.name == expectedName)
+    #expect(userInfo.email == expectedEmail)
+    #expect(userInfo.avatar == expectedAvatar)
+    #expect(userInfo.connected == expectedConnected)
+    #expect(userInfo.credentialsAsked == expectedCredentialsAsked)
+    #expect(userInfo.isStaff == expectedIsStaff)
+    #expect(userInfo.dbId == expectedDbId)
+}

--- a/src/libxpc/MacOSX/XPCSharedTypes/Tests/XPCSharedTypesTests/XPCSharedTypesTests.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Tests/XPCSharedTypesTests/XPCSharedTypesTests.swift
@@ -1,6 +1,0 @@
-import Testing
-@testable import XPCSharedTypes
-
-@Test func example() async throws {
-    // Write your test here and use APIs like `#expect(...)` to check expected conditions.
-}

--- a/src/libxpc/MacOSX/XPCSharedTypes/Tests/XPCSharedTypesTests/XPCSharedTypesTests.swift
+++ b/src/libxpc/MacOSX/XPCSharedTypes/Tests/XPCSharedTypesTests/XPCSharedTypesTests.swift
@@ -1,0 +1,6 @@
+import Testing
+@testable import XPCSharedTypes
+
+@Test func example() async throws {
+    // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+}


### PR DESCRIPTION
### Abstract

To be able to exchange objects via XPC between processes, a simple library with exchange objects that implement `NSSecureCoding` can be useful.

### Details

This will be written and tested in Swift.

Objects in here will also provide a view and init with the JSON format the kext uses for the sake of use simplicity.

This library will also be tested with standard issue SPM test target.