### PR TITLE
Fix the extended tests workflow

### DIFF
--- a/.github/workflows/build-and-run-extended-tests.yml
+++ b/.github/workflows/build-and-run-extended-tests.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Build kDrive desktop
         run: |
           call "C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Auxiliary/Build/vcvars64.bat"
-          powershell ./infomaniak-build-tools/windows/build-drive.ps1 -ci -coverage
+          powershell ./infomaniak-build-tools/windows/build-drive.ps1 -ci -coverage -unitTests
         shell: cmd
 
       - name: Execute tests

--- a/infomaniak-build-tools/windows/build-drive.ps1
+++ b/infomaniak-build-tools/windows/build-drive.ps1
@@ -46,7 +46,7 @@ Param(
     # Coverage: Flag to enable or disable the code coverage computation
     [switch] $coverage,
 
-    # Coverage: Flag to enable or disable the build of unit tests
+    # Unit tests: Flag to enable or disable the build of unit tests
     [switch] $unitTests,
 
     # Help: Displays the help message and exits


### PR DESCRIPTION
The tests were not running anymore in the "extended tests" workflow for Windows.
This was due to a missing build flag.