### PR TITLE
[TRELLO-1117] Fixes incorrect update of the folders excluded by the user via GUI

### DIFF
--- a/src/gui/drivepreferenceswidget.h
+++ b/src/gui/drivepreferenceswidget.h
@@ -97,7 +97,7 @@ class DrivePreferencesWidget : public LargeWidgetWithCustomToolTip {
         QLineEdit *_searchBox{nullptr};
         QPushButton *_searchButton{nullptr};
         QLabel *_searchProgressLabel{nullptr};
-        QListView *_searchResultView;
+        QListView *_searchResultView{nullptr};
         class SearchItemListModel : public QStringListModel {
             public:
                 void setSearchItems(const QList<SearchInfo> &data) {
@@ -108,7 +108,7 @@ class DrivePreferencesWidget : public LargeWidgetWithCustomToolTip {
                     }
                     setStringList(list);
                 };
-                NodeId id(int row) const {
+                [[nodiscard]] NodeId id(int row) const {
                     if (row > _data.count() - 1) return "0";
                     return _data[row].id();
                 }
@@ -133,12 +133,12 @@ class DrivePreferencesWidget : public LargeWidgetWithCustomToolTip {
         void resetFoldersBlocs();
         void updateFoldersBlocs();
         void refreshFoldersBlocs() const;
-        FolderTreeItemWidget *blocTreeItemWidget(PreferencesBlocWidget *folderBloc);
-        FolderItemWidget *blocItemWidget(PreferencesBlocWidget *folderBloc);
-        QFrame *blocSeparatorFrame(PreferencesBlocWidget *folderBloc);
+        static FolderTreeItemWidget *blocTreeItemWidget(PreferencesBlocWidget *folderBloc);
+        static FolderItemWidget *blocItemWidget(PreferencesBlocWidget const *folderBloc);
+        static QFrame *blocSeparatorFrame(PreferencesBlocWidget const *folderBloc);
         bool addSync(const QString &localFolderPath, bool liteSync, const QString &serverFolderPath,
-                     const QString &serverFolderNodeId, QSet<QString> blackSet, QSet<QString> whiteSet);
-        bool updateSelectiveSyncList(const QHash<int, QHash<const QString, bool>> &mapUndefinedFolders);
+                     const QString &serverFolderNodeId, const QSet<QString> &blackSet, const QSet<QString> &whiteSet);
+        static bool updateSelectiveSyncList(const QHash<int, QHash<const QString, bool>> &mapUndefinedFolders);
         void updateGuardedFoldersBlocs();
 
         void initializeSearchBloc();
@@ -155,8 +155,8 @@ class DrivePreferencesWidget : public LargeWidgetWithCustomToolTip {
         void onDisplayFolderDetail(int syncDbId, bool display);
         void onOpenFolder(const QString &filePath);
         void onSubfoldersLoaded(bool error, ExitCause exitCause, bool empty);
-        void onNeedToSave(bool isFolderItemBlackListed);
-        void onCancelUpdate(int syncDbId);
+        void onNeedToSave(bool isFolderItemBlackListed) const;
+        void onCancelUpdate(int syncDbId) const;
         void onValidateUpdate(int syncDbId);
         void onNewBigFolderDiscovered(int syncDbId, const QString &path);
         void onUndecidedListsCleared();

--- a/src/gui/foldertreeitemwidget.cpp
+++ b/src/gui/foldertreeitemwidget.cpp
@@ -157,18 +157,19 @@ ExitCode FolderTreeItemWidget::updateBlackUndecidedSet() {
     if (!_syncDbId) return ExitCode::Ok;
 
     bool userConnected = false;
-    if (auto userInfoIt = _gui->userInfoMap().find(_userDbId); userInfoIt != _gui->userInfoMap().end()) {
+    if (const auto userInfoIt = _gui->userInfoMap().find(_userDbId); userInfoIt != _gui->userInfoMap().end()) {
         userConnected = userInfoIt->second.connected();
     }
 
     if (!userConnected) return ExitCode::Ok;
 
-    if (auto exitCode = GuiRequests::getSyncIdSet(_syncDbId, SyncNodeType::BlackList, _oldBlackList); exitCode != ExitCode::Ok) {
+    if (const auto exitCode = GuiRequests::getSyncIdSet(_syncDbId, SyncNodeType::BlackList, _oldBlackList);
+        exitCode != ExitCode::Ok) {
         qCWarning(lcFolderTreeItemWidget()) << "Error in GuiRequests::getSyncIdSet with SyncNodeType::BlackList";
         return exitCode;
     }
 
-    if (auto exitCode = GuiRequests::getSyncIdSet(_syncDbId, SyncNodeType::UndecidedList, _oldUndecidedList);
+    if (const auto exitCode = GuiRequests::getSyncIdSet(_syncDbId, SyncNodeType::UndecidedList, _oldUndecidedList);
         exitCode != ExitCode::Ok) {
         qCWarning(lcFolderTreeItemWidget()) << "Error in GuiRequests::getSyncIdSet with SyncNodeType::UndecidedList";
         return exitCode;
@@ -637,7 +638,7 @@ void FolderTreeItemWidget::onSyncListRefreshed() {
     }
 }
 
-void FolderTreeItemWidget::onFolderSizeCompleted(const QString &nodeId, qint64 size) {
+void FolderTreeItemWidget::onFolderSizeCompleted(const QString &nodeId, const qint64 size) {
     const auto &subFoldersMapIt = _subFoldersMap.find(nodeId);
     if (subFoldersMapIt != _subFoldersMap.end()) {
         setItemSize(subFoldersMapIt.value(), size);

--- a/src/gui/foldertreeitemwidget.cpp
+++ b/src/gui/foldertreeitemwidget.cpp
@@ -266,9 +266,9 @@ void FolderTreeItemWidget::createBlackSet(const QTreeWidgetItem *parentItem, QSe
 
     switch (parentItem->checkState(TreeWidgetColumn::Folder)) {
         case Qt::Unchecked: {
+            (void) blackset.insert(parentNodeId);
             const QString path = getPath(parentNodeId);
             if (!path.isEmpty()) {
-                (void) blackset.insert(parentNodeId);
                 (void) _blacklistCache.emplace(parentNodeId, path);
             }
             removeChildNodeFromSet(path, blackset);

--- a/src/gui/foldertreeitemwidget.h
+++ b/src/gui/foldertreeitemwidget.h
@@ -43,7 +43,7 @@ class FolderTreeItemWidget : public QTreeWidget {
         void loadSubFolders();
         QSet<QString> createBlackSet();
         QSet<QString> createWhiteSet();
-        inline int syncDbId() { return _syncDbId; }
+        int syncDbId() const { return _syncDbId; }
         qint64 nodeSize(QTreeWidgetItem *item) const;
 
     signals:
@@ -56,26 +56,20 @@ class FolderTreeItemWidget : public QTreeWidget {
             Size
         };
 
-        enum Mode {
-            Creation = 0,
-            Update
-        };
-
         std::shared_ptr<ClientGui> _gui;
-        int _syncDbId;
-        int _userDbId;
-        int _driveId;
+        int _syncDbId{0};
+        int _userDbId{0};
+        int _driveId{0};
         QString _driveName;
         QColor _driveColor;
         QString _nodeId;
         bool _displayRoot;
-        Mode _mode;
         QSet<QString> _oldBlackList;
         QSet<QString> _oldUndecidedList;
         static const QColor _folderIconColor;
         static const QSize _folderIconSize;
         static const QColor _sizeTextColor;
-        bool _inserting;
+        bool _inserting{false};
         QHash<QString, QTreeWidgetItem *> _subFoldersMap;
         using GuiNodeId = QString;
         using GuiPath = QString;
@@ -86,10 +80,6 @@ class FolderTreeItemWidget : public QTreeWidget {
         // whitelisted during the latest synchronization.
         QSet<const QTreeWidgetItem *> _newlyBlackListedItems;
 
-        inline QColor folderIconColor() const { return _folderIconColor; }
-        inline QSize folderIconSize() const { return _folderIconSize; }
-        inline QColor sizeTextColor() const { return _sizeTextColor; }
-
         void initUI();
         QString iconPath(const QString &folderName);
         QColor iconColor(const QString &folderName);
@@ -97,7 +87,6 @@ class FolderTreeItemWidget : public QTreeWidget {
         void setFolderIcon(QTreeWidgetItem *item, const QString &folderName);
         void setSubFoldersIcon(QTreeWidgetItem *parent);
         QTreeWidgetItem *findFirstChild(QTreeWidgetItem *parent, const QString &text);
-        int getDriveId();
         void insertNode(QTreeWidgetItem *parent, const NodeInfo &nodeInfo);
         void updateDirectories(QTreeWidgetItem *item, const QString &nodeId, QList<NodeInfo> list);
         ExitCode updateBlackUndecidedSet();
@@ -129,7 +118,7 @@ class FolderTreeItemWidget : public QTreeWidget {
         void onItemExpanded(QTreeWidgetItem *item);
         void onItemChanged(QTreeWidgetItem *item, int col);
         void onSyncListRefreshed();
-        void onFolderSizeCompleted(QString nodeId, qint64 size);
+        void onFolderSizeCompleted(const QString &nodeId, qint64 size);
 };
 
 } // namespace KDC

--- a/src/gui/foldertreeitemwidget.h
+++ b/src/gui/foldertreeitemwidget.h
@@ -113,6 +113,10 @@ class FolderTreeItemWidget : public QTreeWidget {
         // depending on user actions (check or uncheck folder items).
         void updateNewlyBlackListedItems(const QTreeWidgetItem *item);
 
+        // Returns the relative path associated of the item identified with remote identifier `nodeId`
+        // Note: We first check the existence of the path in _blacklistCache first to avoid unnecessary HTTP GET requests.
+        QString getPath(const QString &nodeId);
+
 
     private slots:
         void onItemExpanded(QTreeWidgetItem *item);


### PR DESCRIPTION
Accessing non-existing items in the excluded folder paths cache had the side effect to remove folders that were purposely excluded by the user.