### PR TITLE
Fix update issue on Windows

### DIFF
--- a/src/libsyncengine/jobs/network/abstractnetworkjob.cpp
+++ b/src/libsyncengine/jobs/network/abstractnetworkjob.cpp
@@ -225,8 +225,8 @@ ExitInfo AbstractNetworkJob::runJob() noexcept {
 }
 
 bool AbstractNetworkJob::hasHttpError(std::string *errorCode /*= nullptr*/) const {
-    if (_httpResponse.getStatus() != Poco::Net::HTTPResponse::HTTP_OK) {
-        if (errorCode) *errorCode = std::to_string(_httpResponse.getStatus());
+    if (httpResponse().getStatus() != Poco::Net::HTTPResponse::HTTP_OK) {
+        if (errorCode) *errorCode = std::to_string(httpResponse().getStatus());
         return true;
     }
     return false;
@@ -405,10 +405,10 @@ ExitInfo AbstractNetworkJob::receiveResponse(const Poco::URI &uri) {
         return ExitCode::Ok;
     }
 
-    LOG_DEBUG(_logger, "Request " << jobId() << " finished with status: " << _httpResponse.getStatus() << " / "
-                                  << _httpResponse.getReason());
+    LOG_DEBUG(_logger, "Request " << jobId() << " finished with status: " << httpResponse().getStatus() << " / "
+                                  << httpResponse().getReason());
 
-    if (Utility::isError500(_httpResponse.getStatus())) {
+    if (Utility::isError500(httpResponse().getStatus())) {
         std::string replyBody;
         getStringFromStream(stream[0].get(), replyBody);
         LOG_WARN(_logger, "Reply " << jobId() << ": " << replyBody);
@@ -416,7 +416,7 @@ ExitInfo AbstractNetworkJob::receiveResponse(const Poco::URI &uri) {
         return {ExitCode::BackError, ExitCause::Http5xx};
     }
 
-    switch (_httpResponse.getStatus()) {
+    switch (httpResponse().getStatus()) {
         case Poco::Net::HTTPResponse::HTTP_OK: {
             try {
                 const std::scoped_lock<std::recursive_mutex> lock(_mutexSession);
@@ -489,7 +489,7 @@ ExitInfo AbstractNetworkJob::handleError(std::istream &inputStream, const Poco::
 }
 
 void AbstractNetworkJob::getStringFromStream(std::istream &inputStream, std::string &res) {
-    if (const std::string encoding = _httpResponse.get("content-encoding", ""); encoding == "gzip") {
+    if (const std::string encoding = httpResponse().get("content-encoding", ""); encoding == "gzip") {
         std::stringstream ss;
         unzip(inputStream, ss);
         res = ss.str();
@@ -502,7 +502,7 @@ void AbstractNetworkJob::getStringFromStream(std::istream &inputStream, std::str
 ExitInfo AbstractNetworkJob::followRedirect() {
     // Get redirection URL
     std::string redirectUrl;
-    redirectUrl = _httpResponse.get("Location", "");
+    redirectUrl = httpResponse().get("Location", "");
 
     if (redirectUrl.empty()) {
         LOG_WARN(_logger, "Request " << jobId() << ": Failed to retrieve redirection URL");
@@ -603,7 +603,7 @@ ExitInfo AbstractNetworkJob::extractJson(const std::string &replyBody, Poco::JSO
     } catch (const Poco::Exception &exc) {
         LOGW_WARN(_logger, L"Reply " << jobId() << L" received doesn't contain a valid JSON payload: "
                                      << CommonUtility::s2ws(exc.displayText()));
-        Utility::logGenericServerError(_logger, "Request error", replyBody, _httpResponse);
+        Utility::logGenericServerError(_logger, "Request error", replyBody, httpResponse());
         return {ExitCode::BackError, ExitCause::ApiErr};
     }
 

--- a/src/libsyncengine/jobs/network/abstractnetworkjob.h
+++ b/src/libsyncengine/jobs/network/abstractnetworkjob.h
@@ -42,9 +42,10 @@ class AbstractNetworkJob : public SyncJob {
 
         [[nodiscard]] bool hasHttpError(std::string *errorCode = nullptr) const;
         bool hasErrorApi() const;
-        [[nodiscard]] Poco::Net::HTTPResponse::HTTPStatus getStatusCode() const { return _resHttp.getStatus(); }
+        [[nodiscard]] Poco::Net::HTTPResponse::HTTPStatus getStatusCode() const { return _httpResponse.getStatus(); }
         void abort() override;
 
+        [[nodiscard]] Poco::Net::HTTPResponse httpResponse() const { return _httpResponse; }
         [[nodiscard]] std::string octetStreamRes() const { return _octetStreamRes; }
         Poco::JSON::Object::Ptr jsonRes() { return _jsonRes; }
 
@@ -81,7 +82,6 @@ class AbstractNetworkJob : public SyncJob {
         std::string _httpMethod;
         uint8_t _apiVersion{2};
         std::string _data;
-        Poco::Net::HTTPResponse _resHttp;
         int _customTimeout = 0;
         int32_t _trials = 2; // By default, try again once if exception is thrown
         std::string _errorCode;
@@ -117,6 +117,7 @@ class AbstractNetworkJob : public SyncJob {
         static Poco::Net::Context::Ptr _context;
         static TimeoutHelper _timeoutHelper;
 
+        Poco::Net::HTTPResponse _httpResponse;
         Poco::JSON::Object::Ptr _jsonRes{nullptr};
         std::string _octetStreamRes;
 

--- a/src/libsyncengine/jobs/network/abstractnetworkjob.h
+++ b/src/libsyncengine/jobs/network/abstractnetworkjob.h
@@ -45,7 +45,7 @@ class AbstractNetworkJob : public SyncJob {
         [[nodiscard]] Poco::Net::HTTPResponse::HTTPStatus getStatusCode() const { return _httpResponse.getStatus(); }
         void abort() override;
 
-        [[nodiscard]] Poco::Net::HTTPResponse httpResponse() const { return _httpResponse; }
+        [[nodiscard]] virtual Poco::Net::HTTPResponse httpResponse() const { return _httpResponse; }
         [[nodiscard]] std::string octetStreamRes() const { return _octetStreamRes; }
         Poco::JSON::Object::Ptr jsonRes() { return _jsonRes; }
 

--- a/src/libsyncengine/jobs/network/abstracttokennetworkjob.cpp
+++ b/src/libsyncengine/jobs/network/abstracttokennetworkjob.cpp
@@ -184,7 +184,7 @@ void AbstractTokenNetworkJob::defaultBackErrorHandling(NetworkErrorCode errorCod
 
 
 ExitInfo AbstractTokenNetworkJob::handleError(const std::string &replyBody, const Poco::URI &uri) {
-    switch (_resHttp.getStatus()) {
+    switch (httpResponse().getStatus()) {
         case Poco::Net::HTTPResponse::HTTP_UNAUTHORIZED:
             return handleUnauthorizedResponse();
         case Poco::Net::HTTPResponse::HTTP_NOT_FOUND: {

--- a/src/libsyncengine/jobs/network/directdownloadjob.cpp
+++ b/src/libsyncengine/jobs/network/directdownloadjob.cpp
@@ -28,11 +28,17 @@ namespace KDC {
 
 constexpr uint64_t bufferSize = 4096 * 1000; // 4MB     // TODO : this should be defined in a common parent class
 
-DirectDownloadJob::DirectDownloadJob(const SyncPath &destinationFile, const std::string &url, const bool headerOnly /*= false*/) :
+DirectDownloadJob::DirectDownloadJob(const std::string &url) :
+    _url(url) {
+    _httpMethod = Poco::Net::HTTPRequest::HTTP_HEAD;
+}
+
+DirectDownloadJob::DirectDownloadJob(const SyncPath &destinationFile, const std::string &url) :
     _destinationFile(destinationFile),
     _url(url) {
-    _httpMethod = headerOnly ? Poco::Net::HTTPRequest::HTTP_HEAD : Poco::Net::HTTPRequest::HTTP_GET;
+    _httpMethod = Poco::Net::HTTPRequest::HTTP_GET;
 }
+
 
 ExitInfo DirectDownloadJob::handleResponse(std::istream &is) {
     if (_httpMethod == Poco::Net::HTTPRequest::HTTP_HEAD) return ExitCode::Ok;

--- a/src/libsyncengine/jobs/network/directdownloadjob.cpp
+++ b/src/libsyncengine/jobs/network/directdownloadjob.cpp
@@ -26,7 +26,7 @@
 
 namespace KDC {
 
-#define BUF_SIZE 4096 * 1000 // 4MB     // TODO : this should be defined in a common parent class
+constexpr uint64_t bufferSize = 4096 * 1000; // 4MB     // TODO : this should be defined in a common parent class
 
 DirectDownloadJob::DirectDownloadJob(const SyncPath &destinationFile, const std::string &url) :
     _destinationFile(destinationFile),
@@ -42,63 +42,7 @@ ExitInfo DirectDownloadJob::handleResponse(std::istream &is) {
                 Utility::enoughSpace(_destinationFile) ? ExitCause::FileAccessError : ExitCause::NotEnoughDiskSpace};
     }
 
-    setProgress(0);
-    if (std::streamsize expectedSize = _resHttp.getContentLength();
-        expectedSize == Poco::Net::HTTPMessage::UNKNOWN_CONTENT_LENGTH || expectedSize > 0) {
-        std::unique_ptr<char[]> buffer(new char[BUF_SIZE]);
-        bool done = false;
-        while (!done) {
-            if (isAborted()) {
-                LOG_DEBUG(_logger, "Request " << jobId() << ": aborted");
-                break;
-            }
-
-            is.read(buffer.get(), BUF_SIZE);
-            if (is.bad() && !is.fail()) {
-                // Read/writing error and not logical error
-                LOG_WARN(_logger,
-                         "Request " << jobId() << ": error after reading " << getProgress() << " bytes from input stream");
-                break;
-            }
-
-            std::streamsize readSize = is.gcount();
-            addProgress(readSize);
-            LOG_DEBUG(_logger, "Request " << jobId() << ": " << getProgress() << " bytes read");
-            if (readSize > 0) {
-                output.write(buffer.get(), readSize);
-                if (output.bad()) {
-                    // Read/writing error or logical error
-                    LOG_WARN(_logger, "Request " << jobId() << ": error after writing " << getProgress() << " bytes to tmp file");
-                    break;
-                }
-                output.flush();
-                if (output.bad()) {
-                    // Read/writing error or logical error
-                    LOG_WARN(_logger,
-                             "Request " << jobId() << ": error after flushing " << getProgress() << " bytes to tmp file");
-                    break;
-                }
-            } else {
-                if (is.eof()) {
-                    // End of stream
-                    if (expectedSize == Poco::Net::HTTPMessage::UNKNOWN_CONTENT_LENGTH || getProgress() == expectedSize) {
-                        done = true;
-                    } else {
-                        // Expected size hasn't been read
-                        LOG_WARN(_logger,
-                                 "Request " << jobId() << ": eof after reading " << getProgress() << " bytes from input stream");
-                        break;
-                    }
-                } else {
-                    // Expected size hasn't been read
-                    LOG_WARN(_logger, "Request " << jobId() << ": nothing more to read but eof not reached");
-                    break;
-                }
-            }
-        }
-    } else {
-        LOG_WARN(_logger, "Reply " << jobId() << " is empty");
-    }
+    ExitInfo exitInfo = readFromStream(is, output);
 
     output.close();
     if (output.bad()) {
@@ -106,7 +50,7 @@ ExitInfo DirectDownloadJob::handleResponse(std::istream &is) {
         LOG_WARN(_logger, "Request " << jobId() << ": error after closing tmp file");
     }
 
-    return ExitCode::Ok;
+    return exitInfo;
 }
 
 ExitInfo DirectDownloadJob::handleError(const std::string &replyBody, const Poco::URI &uri) {
@@ -114,6 +58,62 @@ ExitInfo DirectDownloadJob::handleError(const std::string &replyBody, const Poco
     const auto errorCode = std::to_string(_resHttp.getStatus());
     LOG_WARN(_logger, "Download " << uri.toString() << " failed with error: " << errorCode << " - " << _resHttp.getReason());
     return {};
+}
+
+ExitInfo DirectDownloadJob::readFromStream(std::istream &is, std::ofstream &output) {
+    const auto expectedSize = _resHttp.getContentLength();
+    if (expectedSize != Poco::Net::HTTPMessage::UNKNOWN_CONTENT_LENGTH && expectedSize == 0) {
+        LOG_WARN(_logger, "Reply " << jobId() << " is empty");
+        return ExitCode::Ok;
+    }
+
+    setProgress(0);
+
+    const std::unique_ptr<char[]> buffer(new char[bufferSize]);
+    while (true) {
+        if (isAborted()) {
+            LOG_DEBUG(_logger, "Request " << jobId() << ": aborted");
+            return ExitCode::Ok;
+        }
+
+        (void) is.read(buffer.get(), bufferSize);
+        if (is.bad() && !is.fail()) {
+            // Read/writing error and not logical error
+            LOG_WARN(_logger, "Request " << jobId() << ": error after reading " << getProgress() << " bytes from input stream");
+            return ExitCode::SystemError;
+        }
+
+        const auto readSize = is.gcount();
+        addProgress(readSize);
+        LOG_DEBUG(_logger, "Request " << jobId() << ": " << getProgress() << " bytes read");
+        if (readSize > 0) {
+            (void) output.write(buffer.get(), readSize);
+            if (output.bad()) {
+                // Read/writing error or logical error
+                LOG_WARN(_logger, "Request " << jobId() << ": error after writing " << getProgress() << " bytes to tmp file");
+                return ExitCode::SystemError;
+            }
+            (void) output.flush();
+            if (output.bad()) {
+                // Read/writing error or logical error
+                LOG_WARN(_logger, "Request " << jobId() << ": error after flushing " << getProgress() << " bytes to tmp file");
+                return ExitCode::SystemError;
+            }
+        }
+
+        if (is.eof()) {
+            // End of stream
+            if (expectedSize == Poco::Net::HTTPMessage::UNKNOWN_CONTENT_LENGTH || getProgress() == expectedSize) {
+                return ExitCode::Ok;
+            }
+
+            // Expected size hasn't been read
+            LOG_WARN(_logger, "Request " << jobId() << ": eof after reading " << getProgress() << " bytes from input stream");
+            return ExitCode::SystemError;
+        }
+    }
+
+    return ExitCode::Ok;
 }
 
 } // namespace KDC

--- a/src/libsyncengine/jobs/network/directdownloadjob.h
+++ b/src/libsyncengine/jobs/network/directdownloadjob.h
@@ -36,6 +36,7 @@ class DirectDownloadJob final : public AbstractNetworkJob {
     private:
         ExitInfo handleResponse(std::istream &inputStream) override;
         ExitInfo handleError(const std::string &replyBody, const Poco::URI &uri) override;
+        ExitInfo readFromStream(std::istream &is, std::ofstream &output);
 
         const SyncPath _destinationFile;
         const std::string _url;

--- a/src/libsyncengine/jobs/network/directdownloadjob.h
+++ b/src/libsyncengine/jobs/network/directdownloadjob.h
@@ -25,7 +25,7 @@ namespace KDC {
 
 class DirectDownloadJob final : public AbstractNetworkJob {
     public:
-        DirectDownloadJob(const SyncPath &destinationFile, const std::string &url);
+        DirectDownloadJob(const SyncPath &destinationFile, const std::string &url, bool headerOnly = false);
 
         [[nodiscard]] const SyncPath &getDestinationFile() const { return _destinationFile; }
 

--- a/src/libsyncengine/jobs/network/directdownloadjob.h
+++ b/src/libsyncengine/jobs/network/directdownloadjob.h
@@ -25,7 +25,17 @@ namespace KDC {
 
 class DirectDownloadJob final : public AbstractNetworkJob {
     public:
-        DirectDownloadJob(const SyncPath &destinationFile, const std::string &url, bool headerOnly = false);
+        /**
+         * @brief Constructor used to retrieve only the headers.
+         * @param url The URL of the file to be downloaded.
+         */
+        DirectDownloadJob(const std::string &url);
+        /**
+         * @brief Constructor used to actually download the target file.
+         * @param destinationFile The local destination where the file will be downloaded.
+         * @param url The URL of the file to be downloaded.
+         */
+        DirectDownloadJob(const SyncPath &destinationFile, const std::string &url);
 
         [[nodiscard]] const SyncPath &getDestinationFile() const { return _destinationFile; }
 

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
@@ -181,7 +181,7 @@ ExitInfo DownloadJob::runJob() noexcept {
 ExitInfo DownloadJob::handleResponse(std::istream &is) {
     // Get Mime type
     std::string contentType;
-    contentType = _resHttp.get("Content-Type", "");
+    contentType = httpResponse().get("Content-Type", "");
 
     std::string mimeType;
     if (!contentType.empty()) {
@@ -256,9 +256,9 @@ ExitInfo DownloadJob::handleResponse(std::istream &is) {
                 // Download issue
                 return {ExitCode::BackError, ExitCause::InvalidSize};
             } else if (const std::streamsize neededPlace =
-                               _resHttp.getContentLength() == Poco::Net::HTTPMessage::UNKNOWN_CONTENT_LENGTH
+                               httpResponse().getContentLength() == Poco::Net::HTTPMessage::UNKNOWN_CONTENT_LENGTH
                                        ? BUF_SIZE
-                                       : (_resHttp.getContentLength() - getProgress());
+                                       : (httpResponse().getContentLength() - getProgress());
                        !hasEnoughPlace(_tmpPath, _localpath, neededPlace, _logger)) {
                 return {ExitCode::SystemError, ExitCause::NotEnoughDiskSpace};
             } else {
@@ -587,7 +587,7 @@ ExitInfo DownloadJob::createTmpFile(std::optional<std::reference_wrapper<std::is
 
     std::streamsize expectedSize = 0;
     if (istr) {
-        expectedSize = _resHttp.getContentLength();
+        expectedSize = httpResponse().getContentLength();
         setProgress(0);
         if (expectedSize != Poco::Net::HTTPMessage::UNKNOWN_CONTENT_LENGTH) {
             if (!hasEnoughPlace(_tmpPath, _localpath, expectedSize, _logger)) {

--- a/src/libsyncengine/jobs/network/kDrive_API/getfileinfojob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/getfileinfojob.cpp
@@ -86,7 +86,8 @@ ExitInfo GetFileInfoJob::handleResponse(std::istream &is) {
 
 ExitInfo GetFileInfoJob::handleError(const std::string &replyBody, const Poco::URI &uri) {
     using namespace Poco::Net;
-    if (_resHttp.getStatus() == HTTPResponse::HTTP_FORBIDDEN || _resHttp.getStatus() == HTTPResponse::HTTP_NOT_FOUND) {
+    if (httpResponse().getStatus() == HTTPResponse::HTTP_FORBIDDEN ||
+        httpResponse().getStatus() == HTTPResponse::HTTP_NOT_FOUND) {
         return ExitCode::Ok; // The file is not accessible or doesn't exist
     }
 

--- a/src/libsyncengine/jobs/network/kDrive_API/getinfodrivejob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/getinfodrivejob.cpp
@@ -33,8 +33,8 @@ GetInfoDriveJob::GetInfoDriveJob(int driveDbId) :
 }
 
 ExitInfo GetInfoDriveJob::handleError(const std::string &replyBody, const Poco::URI &uri) {
-    if (_resHttp.getStatus() == Poco::Net::HTTPResponse::HTTP_FORBIDDEN ||
-        _resHttp.getStatus() == Poco::Net::HTTPResponse::HTTP_NOT_FOUND) {
+    if (httpResponse().getStatus() == Poco::Net::HTTPResponse::HTTP_FORBIDDEN ||
+        httpResponse().getStatus() == Poco::Net::HTTPResponse::HTTP_NOT_FOUND) {
         // The drive is not accessible or doesn't exist
         return ExitCode::Ok;
     }

--- a/src/libsyncengine/jobs/network/kDrive_API/getsizejob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/getsizejob.cpp
@@ -54,7 +54,7 @@ ExitInfo GetSizeJob::handleResponse(std::istream &is) {
 }
 
 ExitInfo GetSizeJob::handleError(const std::string &replyBody, const Poco::URI &uri) {
-    if (_resHttp.getStatus() == Poco::Net::HTTPResponse::HTTP_FORBIDDEN) {
+    if (httpResponse().getStatus() == Poco::Net::HTTPResponse::HTTP_FORBIDDEN) {
         // Access to the directory is forbidden
         return ExitCode::Ok;
     }

--- a/src/libsyncengine/jobs/network/kDrive_API/listing/abstractlistingjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/listing/abstractlistingjob.cpp
@@ -48,7 +48,7 @@ ExitInfo AbstractListingJob::setData() {
 }
 
 ExitInfo AbstractListingJob::handleError(const std::string &replyBody, const Poco::URI &uri) {
-    if (_resHttp.getStatus() == Poco::Net::HTTPResponse::HTTP_FORBIDDEN) {
+    if (httpResponse().getStatus() == Poco::Net::HTTPResponse::HTTP_FORBIDDEN) {
         // Access to the directory is forbidden or it doesn't exist
         return {ExitCode::InvalidSync, ExitCause::SyncDirAccessError};
     }

--- a/src/libsyncengine/jobs/network/kDrive_API/listing/csvfullfilelistwithcursorjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/listing/csvfullfilelistwithcursorjob.cpp
@@ -47,7 +47,7 @@ bool CsvFullFileListWithCursorJob::getItem(SnapshotItem &item, bool &error, bool
 }
 
 std::string CsvFullFileListWithCursorJob::getCursor() {
-    return _resHttp.get("X-kDrive-Cursor", "");
+    return httpResponse().get("X-kDrive-Cursor", "");
 }
 
 std::string CsvFullFileListWithCursorJob::getSpecificUrl() {

--- a/src/libsyncengine/jobs/network/kDrive_API/upload/upload_session/uploadsessioncanceljob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/upload/upload_session/uploadsessioncanceljob.cpp
@@ -41,7 +41,7 @@ std::string UploadSessionCancelJob::getSpecificUrl() {
 }
 
 ExitInfo UploadSessionCancelJob::handleError(const std::string &replyBody, const Poco::URI &uri) {
-    if (_resHttp.getStatus() == Poco::Net::HTTPResponse::HTTP_BAD_REQUEST) {
+    if (httpResponse().getStatus() == Poco::Net::HTTPResponse::HTTP_BAD_REQUEST) {
         return ExitCode::BackError;
     }
 

--- a/src/libsyncengine/jobs/network/login/abstractloginjob.cpp
+++ b/src/libsyncengine/jobs/network/login/abstractloginjob.cpp
@@ -70,7 +70,7 @@ ExitInfo AbstractLoginJob::handleError(const std::string &replyBody, const Poco:
         jsonError = jsonParser.parse(replyBody).extract<Poco::JSON::Object::Ptr>();
     } catch (Poco::Exception &exc) {
         LOG_WARN(_logger, "Reply " << jobId() << " received doesn't contain a valid JSON error: " << exc.displayText());
-        Utility::logGenericServerError(_logger, "Login error", replyBody, _resHttp);
+        Utility::logGenericServerError(_logger, "Login error", replyBody, httpResponse());
         return {ExitCode::BackError, ExitCause::ApiErr};
     }
 

--- a/src/server/updater/abstractupdater.h
+++ b/src/server/updater/abstractupdater.h
@@ -31,7 +31,7 @@ class AbstractUpdater {
         AbstractUpdater();
         virtual ~AbstractUpdater() = default;
 
-        [[nodiscard]] const VersionInfo &versionInfo(const VersionChannel channel) const {
+        [[nodiscard]] virtual const VersionInfo &versionInfo(const VersionChannel channel) const {
             return _updateChecker->versionInfo(channel);
         }
         [[nodiscard]] const UpdateState &state() const { return _state; }

--- a/src/server/updater/updatechecker.cpp
+++ b/src/server/updater/updatechecker.cpp
@@ -57,12 +57,12 @@ class VersionInfoCmp {
         }
 };
 
-const VersionInfo &UpdateChecker::versionInfo(const VersionChannel choosedChannel) {
+const VersionInfo &UpdateChecker::versionInfo(const VersionChannel chosenChannel) {
     if (!_isVersionReceived) return _defaultVersionInfo;
     const VersionInfo &prodVersion = prodVersionInfo();
 
     // If the user wants only `Production` versions, just return the current `Production` version.
-    if (choosedChannel == VersionChannel::Prod) return prodVersion;
+    if (chosenChannel == VersionChannel::Prod) return prodVersion;
 
     // Otherwise, we need to check if there is not a newer version in other channels.
     const VersionInfo &betaVersion =
@@ -74,7 +74,7 @@ const VersionInfo &UpdateChecker::versionInfo(const VersionChannel choosedChanne
     sortedVersionList.insert(betaVersion);
     sortedVersionList.insert(internalVersion);
     for (const auto &versionInfo: sortedVersionList) {
-        if (versionInfo.get().channel <= choosedChannel) return versionInfo;
+        if (versionInfo.get().channel <= chosenChannel) return versionInfo;
     }
 
     return _defaultVersionInfo;

--- a/src/server/updater/updatechecker.h
+++ b/src/server/updater/updatechecker.h
@@ -43,11 +43,11 @@ class UpdateChecker {
          * to the selected distribution channel. That means if the `Beta` version is newer than the `Internal` version, the the
          * `Beta` version wins over the `Internal` one and must be proposed even if the user has selected the `Internal` channel.
          * The rule is the `Production` version wins over all others, the `Beta` verison wins over the `Internal` version.
-         * @param choosedChannel The selected distribution channel.
+         * @param chosenChannel The selected distribution channel.
          * @return A reference to the found `VersionInfo` object. If not found, return a reference to default constructed, invalid
          * `VersionInfo`object.
          */
-        const VersionInfo &versionInfo(VersionChannel choosedChannel);
+        const VersionInfo &versionInfo(VersionChannel chosenChannel);
 
         [[nodiscard]] const std::unordered_map<VersionChannel, VersionInfo> &versionsInfo() const { return _versionsInfo; }
         [[nodiscard]] bool isVersionReceived() const { return _isVersionReceived; }

--- a/src/server/updater/updatemanager.cpp
+++ b/src/server/updater/updatemanager.cpp
@@ -38,7 +38,7 @@ UpdateManager::UpdateManager(QObject *parent) :
 
     initUpdater();
 
-    connect(&_updateCheckTimer, &QTimer::timeout, this, &UpdateManager::slotTimerFired);
+    (void) connect(&_updateCheckTimer, &QTimer::timeout, this, &UpdateManager::slotTimerFired);
 
     static constexpr auto checkInterval = std::chrono::hours(1);
     _updateCheckTimer.start(std::chrono::milliseconds(checkInterval).count());
@@ -46,7 +46,7 @@ UpdateManager::UpdateManager(QObject *parent) :
     // Setup callback for update state change notification
     const std::function<void(UpdateState)> callback = std::bind_front(&UpdateManager::onUpdateStateChanged, this);
     _updater->setStateChangeCallback(callback);
-    connect(this, &UpdateManager::updateStateChanged, this, &UpdateManager::slotUpdateStateChanged, Qt::QueuedConnection);
+    (void) connect(this, &UpdateManager::updateStateChanged, this, &UpdateManager::slotUpdateStateChanged, Qt::QueuedConnection);
 
     // At startup, do a check in any case and setup distribution channel.
     QTimer::singleShot(3000, this, [this]() { setDistributionChannel(_currentChannel); });
@@ -54,7 +54,7 @@ UpdateManager::UpdateManager(QObject *parent) :
 
 void UpdateManager::setDistributionChannel(const VersionChannel channel) {
     _currentChannel = channel;
-    _updater->checkUpdateAvailable(channel);
+    (void) _updater->checkUpdateAvailable(channel);
     ParametersCache::instance()->parameters().setDistributionChannel(channel);
     ParametersCache::instance()->save();
 }
@@ -69,7 +69,7 @@ void UpdateManager::startInstaller() const {
 }
 
 void UpdateManager::slotTimerFired() const {
-    _updater->checkUpdateAvailable(_currentChannel);
+    (void) _updater->checkUpdateAvailable(_currentChannel);
 }
 
 void UpdateManager::slotUpdateStateChanged(const UpdateState newState) {
@@ -94,7 +94,7 @@ void UpdateManager::slotUpdateStateChanged(const UpdateState newState) {
         }
         case UpdateState::Ready: {
             if (AbstractUpdater::isVersionSkipped(_updater->versionInfo(_currentChannel).fullVersion())) break;
-                // The new version is ready to be installed
+            // The new version is ready to be installed
 #if defined(KD_WINDOWS)
             emit showUpdateDialog();
 #endif

--- a/src/server/updater/windowsupdater.cpp
+++ b/src/server/updater/windowsupdater.cpp
@@ -138,7 +138,7 @@ bool WindowsUpdater::getInstallerPath(SyncPath &path) const {
     return true;
 }
 
-std::streamsize WindowsUpdater::getExpectedInstallerSize(const SyncPath &destinationPath, const std::string &downloadUrl) {
+std::streamsize WindowsUpdater::getExpectedInstallerSize(const std::string &downloadUrl) {
     // Get the expected size of the installer.
     DirectDownloadJob job(downloadUrl);
     (void) job.runSynchronously();

--- a/src/server/updater/windowsupdater.h
+++ b/src/server/updater/windowsupdater.h
@@ -22,7 +22,7 @@
 
 namespace KDC {
 
-class WindowsUpdater final : public AbstractUpdater {
+class WindowsUpdater : public AbstractUpdater {
     public:
         void onUpdateFound() override;
         void startInstaller() override;
@@ -42,7 +42,14 @@ class WindowsUpdater final : public AbstractUpdater {
          * Build the destination path where the installer should be downloaded.
          * @return the absolute path to the installer file.
          */
-        [[nodiscard]] bool getInstallerPath(SyncPath &path) const;
+        [[nodiscard]] virtual bool getInstallerPath(SyncPath &path) const;
+
+        /**
+         * @brief Retrieve the size of a file from the content length header.
+         * @param downloadUrl The URL of the file to be downloaded.
+         * @return The expected size of the installer file to be downloaded.
+         */
+        virtual std::streamsize getExpectedInstallerSize(const std::string &downloadUrl);
 };
 
 } // namespace KDC

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -1560,12 +1560,9 @@ void TestNetworkJobs::testGetInfoUserTrialsOn401Error() {
             explicit GetInfoUserJobMock(int32_t userDbId) :
                 GetInfoUserJob(userDbId) {};
 
-        protected:
-            ExitInfo receiveResponseFromSession(StreamVector &stream) override {
-                AbstractNetworkJob::receiveResponseFromSession(stream);
-                httpResponse().setStatus("401");
-                return ExitCode::Ok;
-            };
+            [[nodiscard]] Poco::Net::HTTPResponse httpResponse() const override {
+                return Poco::Net::HTTPResponse(Poco::Net::HTTPResponse::HTTP_UNAUTHORIZED);
+            }
     };
 
     GetInfoUserJobMock job(_userDbId);

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -1563,7 +1563,7 @@ void TestNetworkJobs::testGetInfoUserTrialsOn401Error() {
         protected:
             ExitInfo receiveResponseFromSession(StreamVector &stream) override {
                 AbstractNetworkJob::receiveResponseFromSession(stream);
-                _resHttp.setStatus("401");
+                httpResponse().setStatus("401");
                 return ExitCode::Ok;
             };
     };

--- a/test/server/CMakeLists.txt
+++ b/test/server/CMakeLists.txt
@@ -116,6 +116,8 @@ set(testserver_SRCS
 if(APPLE)
     list(APPEND testserver_SRCS vfs/mac/testlitesynccommclient.h vfs/mac/testlitesynccommclient.cpp)
     list(APPEND testserver_SRCS vfs/mac/testvfsmac.h vfs/mac/testvfsmac.cpp)
+elseif(WIN32)
+    list(APPEND testserver_SRCS updater/testwindowsupdater.h updater/testwindowsupdater.cpp)
 endif()
 
 if(WIN32)

--- a/test/server/test.cpp
+++ b/test/server/test.cpp
@@ -25,6 +25,9 @@
 #endif
 #include "workers/testworkers.h"
 #include "updater/testabstractupdater.h"
+#if defined(KD_WINDOWS)
+#include "updater/testwindowsupdater.h"
+#endif
 #include "updater/testupdatechecker.h"
 #include "requests/testserverrequests.h"
 #include "appserver/testappserver.h"
@@ -41,6 +44,9 @@ CPPUNIT_TEST_SUITE_REGISTRATION(TestLiteSyncCommClient);
 CPPUNIT_TEST_SUITE_REGISTRATION(TestWorkers);
 CPPUNIT_TEST_SUITE_REGISTRATION(TestUpdateChecker);
 CPPUNIT_TEST_SUITE_REGISTRATION(TestAbstractUpdater);
+#if defined(KD_WINDOWS)
+CPPUNIT_TEST_SUITE_REGISTRATION(TestWindowsUpdater);
+#endif
 CPPUNIT_TEST_SUITE_REGISTRATION(TestServerRequests);
 CPPUNIT_TEST_SUITE_REGISTRATION(TestAppServer);
 CPPUNIT_TEST_SUITE_REGISTRATION(TestSocketComm);

--- a/test/server/updater/mockupdatechecker.h
+++ b/test/server/updater/mockupdatechecker.h
@@ -28,7 +28,7 @@ namespace KDC {
 class MockUpdateChecker : public UpdateChecker {
     public:
         using UpdateChecker::UpdateChecker;
-        void setUpdateShoudBeAvailable(const bool val) { _updateShouldBeAvailable = val; }
+        void setUpdateShouldBeAvailable(const bool val) { _updateShouldBeAvailable = val; }
         void setAllVersionInfo(const AllVersionsInfo &versionInfo) { _versionsInfo = versionInfo; }
 
     private:

--- a/test/server/updater/testupdatechecker.cpp
+++ b/test/server/updater/testupdatechecker.cpp
@@ -44,7 +44,7 @@ void TestUpdateChecker::testCheckUpdateAvailable() {
     {
         MockUpdateChecker testObj;
         UniqueId jobId = 0;
-        testObj.setUpdateShoudBeAvailable(true);
+        testObj.setUpdateShouldBeAvailable(true);
         testObj.checkUpdateAvailability(&jobId);
         while (!SyncJobManagerSingleton::instance()->isJobFinished(jobId)) Utility::msleep(10);
         CPPUNIT_ASSERT(testObj.versionInfo(VersionChannel::Beta).isValid());
@@ -54,7 +54,7 @@ void TestUpdateChecker::testCheckUpdateAvailable() {
     {
         MockUpdateChecker testObj;
         UniqueId jobId = 0;
-        testObj.setUpdateShoudBeAvailable(false);
+        testObj.setUpdateShouldBeAvailable(false);
         testObj.checkUpdateAvailability(&jobId);
         while (!SyncJobManagerSingleton::instance()->isJobFinished(jobId)) Utility::msleep(10);
         CPPUNIT_ASSERT(testObj.versionInfo(VersionChannel::Beta).isValid());

--- a/test/server/updater/testwindowsupdater.cpp
+++ b/test/server/updater/testwindowsupdater.cpp
@@ -76,21 +76,21 @@ void TestWindowsUpdater::testOnUpdateFound() {
     testObj.onUpdateFound();
     CPPUNIT_ASSERT_EQUAL(UpdateState::Downloading, testObj.state());
 
-    // Installer exist locally but is empty.
+    // Installer exists locally but is empty.
     testhelpers::generateTestFile(dummyInstallerPath);
 
     testObj.onUpdateFound();
     CPPUNIT_ASSERT_EQUAL(UpdateState::Downloading, testObj.state());
     CPPUNIT_ASSERT(std::filesystem::exists(dummyInstallerPath)); // Local file has been removed.
 
-    // Installer exist locally but incomplete.
+    // Installer exists locally but is incomplete.
     testhelpers::generateOrEditTestFile(dummyInstallerPath);
 
     testObj.onUpdateFound();
     CPPUNIT_ASSERT_EQUAL(UpdateState::Downloading, testObj.state());
     CPPUNIT_ASSERT(std::filesystem::exists(dummyInstallerPath)); // Local file has been removed.
 
-    // Installer exist locally and is valid.
+    // Installer exists locally and is valid.
     testhelpers::generateTestFile(dummyInstallerPath, 10);
 
     testObj.onUpdateFound();

--- a/test/server/updater/testwindowsupdater.cpp
+++ b/test/server/updater/testwindowsupdater.cpp
@@ -1,0 +1,75 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "testwindowsupdater.h"
+
+#include "io/iohelper.h"
+#include "test_utility/localtemporarydirectory.h"
+#include "test_utility/testhelpers.h"
+#include "updater/windowsupdater.h"
+
+namespace KDC {
+
+void TestWindowsUpdater::testOnUpdateFound() {
+    class WindowsUpdaterMock final : public WindowsUpdater {
+        public:
+            void setInstallerPath(const SyncPath &installerPath) { _installerPath = installerPath; }
+
+        private:
+            [[nodiscard]] bool getInstallerPath(SyncPath &path) const override {
+                path = _installerPath;
+                return true;
+            }
+
+            std::streamsize getExpectedInstallerSize([[maybe_unused]] const std::string &downloadUrl) override { return 10; }
+
+            SyncPath _installerPath;
+    };
+
+    LocalTemporaryDirectory tempDir("TestWindowsUpdater");
+    WindowsUpdaterMock testObj;
+    const auto dummyInstallerPath = tempDir.path() / "TestWindowsUpdater";
+    testObj.setInstallerPath(dummyInstallerPath);
+
+    // Installer is not yet downloaded.
+    testObj.onUpdateFound();
+    CPPUNIT_ASSERT_EQUAL(UpdateState::Downloading, testObj.state());
+
+    // Installer exist locally but is empty.
+    testhelpers::generateTestFile(dummyInstallerPath);
+
+    testObj.onUpdateFound();
+    CPPUNIT_ASSERT_EQUAL(UpdateState::Downloading, testObj.state());
+    CPPUNIT_ASSERT(!std::filesystem::exists(dummyInstallerPath)); // Local file has been removed.
+
+    // Installer exist locally but incomplete.
+    testhelpers::generateOrEditTestFile(dummyInstallerPath);
+
+    testObj.onUpdateFound();
+    CPPUNIT_ASSERT_EQUAL(UpdateState::Downloading, testObj.state());
+    CPPUNIT_ASSERT(!std::filesystem::exists(dummyInstallerPath)); // Local file has been removed.
+
+    // Installer exist locally and is valid.
+    testhelpers::generateTestFile(dummyInstallerPath, 10);
+
+    testObj.onUpdateFound();
+    CPPUNIT_ASSERT_EQUAL(UpdateState::Ready, testObj.state());
+    CPPUNIT_ASSERT(std::filesystem::exists(dummyInstallerPath));
+}
+
+} // namespace KDC

--- a/test/server/updater/testwindowsupdater.h
+++ b/test/server/updater/testwindowsupdater.h
@@ -1,0 +1,41 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "test_utility/testbase.h"
+
+#include <cppunit/TestFixture.h>
+#include <cppunit/extensions/HelperMacros.h>
+
+namespace KDC {
+
+class TestWindowsUpdater final : public CppUnit::TestFixture, public TestBase {
+        CPPUNIT_TEST_SUITE(TestWindowsUpdater);
+        CPPUNIT_TEST(testOnUpdateFound);
+        CPPUNIT_TEST_SUITE_END();
+
+    public:
+        void setUp() override;
+        void tearDown() override;
+
+    protected:
+        void testOnUpdateFound();
+};
+
+} // namespace KDC

--- a/test/server/updater/testwindowsupdater.h
+++ b/test/server/updater/testwindowsupdater.h
@@ -18,10 +18,7 @@
 
 #pragma once
 
-#include "test_utility/testbase.h"
-
-#include <cppunit/TestFixture.h>
-#include <cppunit/extensions/HelperMacros.h>
+#include "testincludes.h"
 
 namespace KDC {
 
@@ -34,7 +31,7 @@ class TestWindowsUpdater final : public CppUnit::TestFixture, public TestBase {
         void setUp() override;
         void tearDown() override;
 
-    protected:
+    private:
         void testOnUpdateFound();
 };
 

--- a/test/test_utility/testhelpers.cpp
+++ b/test/test_utility/testhelpers.cpp
@@ -54,7 +54,7 @@ SyncName makeNfcSyncName() {
 }
 
 void generateTestFile(const SyncPath &path, const uint64_t size /*= 0*/) {
-    std::ofstream testFile(path, std::ios::app);
+    std::ofstream testFile(path, std::ios_base::in | std::ios_base::trunc);
     if (size) {
         setTestFileSize(path, size);
     }
@@ -70,8 +70,7 @@ void generateOrEditTestFile(const SyncPath &path) {
 void setTestFileSize(const SyncPath &path, uint64_t size) {
     const std::string str{"0123456789"};
     std::ofstream ofs(path, std::ios_base::in | std::ios_base::trunc);
-    for (uint64_t i = 0;
-         i < static_cast<uint64_t>(round(static_cast<double>(size * 1000000) / static_cast<double>(str.length()))); i++) {
+    for (uint64_t i = 0; i < static_cast<uint64_t>(round(static_cast<double>(size) / static_cast<double>(str.length()))); i++) {
         ofs << str;
     }
 }
@@ -145,6 +144,18 @@ void createSymLinkLoop(const SyncPath &filepath1, const SyncPath &filepath2, con
 
     std::filesystem::current_path(currentPath);
     std::filesystem::rename(tempDir.path() / filepath1.filename(), filepath1);
+}
+
+void setupLogging() {
+    IoError ioError = IoError::Success;
+    SyncPath logDirPath;
+    if (!IoHelper::logDirectoryPath(logDirPath, ioError)) {}
+
+    // Setup log4cplus
+    const std::filesystem::path logFilePath = logDirPath / Utility::logFileNameWithTime();
+    if (!Log::instance(Path2WStr(logFilePath))) {
+        assert(false);
+    }
 }
 
 } // namespace KDC::testhelpers

--- a/test/test_utility/testhelpers.cpp
+++ b/test/test_utility/testhelpers.cpp
@@ -53,10 +53,27 @@ SyncName makeNfcSyncName() {
     return nfcNormalized;
 }
 
+void generateTestFile(const SyncPath &path, const uint64_t size /*= 0*/) {
+    std::ofstream testFile(path, std::ios::app);
+    if (size) {
+        setTestFileSize(path, size);
+    }
+    testFile.close();
+}
+
 void generateOrEditTestFile(const SyncPath &path) {
     std::ofstream testFile(path, std::ios::app);
     testFile << "test" << std::endl;
     testFile.close();
+}
+
+void setTestFileSize(const SyncPath &path, uint64_t size) {
+    const std::string str{"0123456789"};
+    std::ofstream ofs(path, std::ios_base::in | std::ios_base::trunc);
+    for (uint64_t i = 0;
+         i < static_cast<uint64_t>(round(static_cast<double>(size * 1000000) / static_cast<double>(str.length()))); i++) {
+        ofs << str;
+    }
 }
 
 void generateBigFiles(const SyncPath &dirPath, const uint16_t size, const uint16_t count) {

--- a/test/test_utility/testhelpers.cpp
+++ b/test/test_utility/testhelpers.cpp
@@ -18,6 +18,7 @@
 
 #include "testhelpers.h"
 #include "localtemporarydirectory.h"
+#include "io/iohelper.h"
 
 #include "libcommon/utility/utility.h"
 

--- a/test/test_utility/testhelpers.h
+++ b/test/test_utility/testhelpers.h
@@ -120,4 +120,6 @@ void setModificationDate(const SyncPath &path, const std::chrono::time_point<std
 // `filepath1` and `filepath2`.
 void createSymLinkLoop(const SyncPath &filepath1, const SyncPath &filepath2, const NodeType nodeType = NodeType::File);
 
+void setupLogging();
+
 } // namespace KDC::testhelpers

--- a/test/test_utility/testhelpers.h
+++ b/test/test_utility/testhelpers.h
@@ -98,7 +98,10 @@ struct RightsSet {
         bool execute;
 };
 
+void generateTestFile(const SyncPath &path, const uint64_t size = 0);
 void generateOrEditTestFile(const SyncPath &path);
+void setTestFileSize(const SyncPath &path, uint64_t size);
+
 /**
  * @brief Generate test files.
  * @param dirPath Directory in which the files will be created.


### PR DESCRIPTION
On Windows, if an installer was already existing in the temp directory but only partially downloaded, the update is impossible.
This PR aims at checking the expected size of the installer using a HEAD request and comparing it with the size of the local file (if it exists). If the sizes are the same, we skip the download step and offer immediately to install the update. Otherwise, the local file is removed and the remote one downloaded.