### PR TITLE
Check cycles only if no move operations

### DIFF
--- a/src/libsyncengine/propagation/operation_sorter/operationsorterworker.cpp
+++ b/src/libsyncengine/propagation/operation_sorter/operationsorterworker.cpp
@@ -69,12 +69,18 @@ void OperationSorterWorker::sortOperations() {
         fixEditBeforeMove();
         fixMoveBeforeMoveHierarchyFlip();
 
-        CycleFinder cycleFinder(_reorderings);
-        cycleFinder.findCompleteCycle();
-        if (cycleFinder.hasCompleteCycle()) {
-            completeCycle = cycleFinder.completeCycle();
-            cycleFound = true;
-            break;
+        // Cycles can occur only in presence of at least 1 Move operation.
+        if (!_syncPal->_syncOps->opListIdByType(OperationType::Move).empty() ||
+            !_syncPal->_syncOps->opListIdByType(OperationType::MoveEdit).empty() ||
+            !_syncPal->_syncOps->opListIdByType(OperationType::MoveOut).empty()) {
+            // Check for cycles.
+            CycleFinder cycleFinder(_reorderings);
+            cycleFinder.findCompleteCycle();
+            if (cycleFinder.hasCompleteCycle()) {
+                completeCycle = cycleFinder.completeCycle();
+                cycleFound = true;
+                break;
+            }
         }
     }
 

--- a/src/libsyncengine/propagation/operation_sorter/operationsorterworker.cpp
+++ b/src/libsyncengine/propagation/operation_sorter/operationsorterworker.cpp
@@ -48,6 +48,11 @@ void OperationSorterWorker::execute() {
     setDone(ExitCode::Ok);
 }
 
+bool hasMoveOperation(const std::shared_ptr<SyncOperationList> &syncOps) {
+    return !syncOps->opListIdByType(OperationType::Move).empty() || !syncOps->opListIdByType(OperationType::MoveEdit).empty() ||
+           !syncOps->opListIdByType(OperationType::MoveOut).empty();
+}
+
 void OperationSorterWorker::sortOperations() {
     _syncPal->_syncOps->startUpdate();
     SyncOperationList completeCycle;
@@ -70,9 +75,7 @@ void OperationSorterWorker::sortOperations() {
         fixMoveBeforeMoveHierarchyFlip();
 
         // Cycles can occur only in presence of at least 1 Move operation.
-        if (!_syncPal->_syncOps->opListIdByType(OperationType::Move).empty() ||
-            !_syncPal->_syncOps->opListIdByType(OperationType::MoveEdit).empty() ||
-            !_syncPal->_syncOps->opListIdByType(OperationType::MoveOut).empty()) {
+        if (hasMoveOperation(_syncPal->_syncOps)) {
             // Check for cycles.
             CycleFinder cycleFinder(_reorderings);
             cycleFinder.findCompleteCycle();

--- a/test/libsyncengine/integration/testintegration.cpp
+++ b/test/libsyncengine/integration/testintegration.cpp
@@ -240,6 +240,7 @@ void TestIntegration::inconsistencyTests() {
 void TestIntegration::testBreakCycle() {
     waitForSyncToBeIdle(SourceLocation::currentLoc());
 
+    // Setup initial situation
     _syncPal->pause(); // We need to pause the sync because the back might take some time to notify all the events.
     const RemoteTemporaryDirectory tmpRemoteDir(_driveDbId, _remoteSyncDir.id());
     NodeId nodeIdAA;
@@ -258,6 +259,7 @@ void TestIntegration::testBreakCycle() {
     _syncPal->unpause();
     waitForSyncToBeIdle(SourceLocation::currentLoc());
 
+    // Generate cycle
     _syncPal->pause(); // We need to pause the sync because the back might take some time to notify all the events.
     const auto pathAA = _syncPal->localPath() / tmpRemoteDir.name() / "A" / "AA";
     // Rename A/AA/AAA to A/AA/AAA2 on remote replica.


### PR DESCRIPTION
Cycles might occur only if at least 1 MOVE operation exists. Therefore, a simple optimization consists in **not** checking for cycles only if there are no move operations to propagate. This might considerably reduce the duration of the `OperationSorter` step for the very first synchronization of big drives.