### PR TITLE
feat(macOS UI): Open authentication webpage

### DIFF
--- a/src/front/macOS/kDrive.xcodeproj/project.pbxproj
+++ b/src/front/macOS/kDrive.xcodeproj/project.pbxproj
@@ -15,8 +15,8 @@
 		F96700A52E95352C00EDD4D7 /* kDriveResources.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F967009E2E95352C00EDD4D7 /* kDriveResources.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F96701502E953CF600EDD4D7 /* kDriveResources.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F967009E2E95352C00EDD4D7 /* kDriveResources.framework */; };
 		F967FC8C2E8BC9FE00EDD4D7 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = F967FC8B2E8BC9FE00EDD4D7 /* Lottie */; };
+		F97269782E98F1CE002EA08D /* InfomaniakLogin in Frameworks */ = {isa = PBXBuildFile; productRef = F97269772E98F1CE002EA08D /* InfomaniakLogin */; };
 		F97805BE2E97E3AF00BC146C /* InfomaniakDI in Frameworks */ = {isa = PBXBuildFile; productRef = F97805BD2E97E3AF00BC146C /* InfomaniakDI */; };
-		F97805C12E97E3C500BC146C /* InfomaniakLogin in Frameworks */ = {isa = PBXBuildFile; productRef = F97805C02E97E3C500BC146C /* InfomaniakLogin */; };
 		F97805C32E97E3F900BC146C /* InfomaniakDI in Frameworks */ = {isa = PBXBuildFile; productRef = F97805C22E97E3F900BC146C /* InfomaniakDI */; };
 		F9ACC5382E5DF50F0081E80B /* swiftgen.yml in Resources */ = {isa = PBXBuildFile; fileRef = F9ACC5372E5DF50B0081E80B /* swiftgen.yml */; };
 /* End PBXBuildFile section */
@@ -49,6 +49,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = F967009D2E95352C00EDD4D7;
 			remoteInfo = kDriveResources;
+		};
+		F97269752E98EFAF002EA08D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 37A1C41E2E546A5200596DBB /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F97269622E98EC15002EA08D;
+			remoteInfo = kDriveLogin;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -136,9 +143,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				F97805BE2E97E3AF00BC146C /* InfomaniakDI in Frameworks */,
-				F97805C12E97E3C500BC146C /* InfomaniakLogin in Frameworks */,
 				37A1C4602E546CB700596DBB /* kDriveCore.framework in Frameworks */,
 				F96700A42E95352C00EDD4D7 /* kDriveResources.framework in Frameworks */,
+				F97269782E98F1CE002EA08D /* InfomaniakLogin in Frameworks */,
 				37A1C4452E546A9600596DBB /* kDriveCoreUI.framework in Frameworks */,
 				F967FC8C2E8BC9FE00EDD4D7 /* Lottie in Frameworks */,
 			);
@@ -244,6 +251,7 @@
 				37A1C4442E546A9600596DBB /* PBXTargetDependency */,
 				37A1C45F2E546CB700596DBB /* PBXTargetDependency */,
 				F96700A32E95352C00EDD4D7 /* PBXTargetDependency */,
+				F97269762E98EFAF002EA08D /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				37A1C4282E546A5200596DBB /* kDrive */,
@@ -252,7 +260,7 @@
 			packageProductDependencies = (
 				F967FC8B2E8BC9FE00EDD4D7 /* Lottie */,
 				F97805BD2E97E3AF00BC146C /* InfomaniakDI */,
-				F97805C02E97E3C500BC146C /* InfomaniakLogin */,
+				F97269772E98F1CE002EA08D /* InfomaniakLogin */,
 			);
 			productName = kDrive;
 			productReference = 37A1C4262E546A5200596DBB /* kDrive.app */;
@@ -492,6 +500,10 @@
 			target = F967009D2E95352C00EDD4D7 /* kDriveResources */;
 			targetProxy = F96701522E953CF600EDD4D7 /* PBXContainerItemProxy */;
 		};
+		F97269762E98EFAF002EA08D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			targetProxy = F97269752E98EFAF002EA08D /* PBXContainerItemProxy */;
+		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
@@ -649,7 +661,7 @@
 				SWIFT_DEFAULT_ACTOR_ISOLATION = nonisolated;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
-				SWIFT_VERSION = 6.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -685,7 +697,7 @@
 				SWIFT_DEFAULT_ACTOR_ISOLATION = nonisolated;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
-				SWIFT_VERSION = 6.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -723,7 +735,7 @@
 				SWIFT_INSTALL_MODULE = YES;
 				SWIFT_INSTALL_OBJC_HEADER = NO;
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
-				SWIFT_VERSION = 6.0;
+				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -763,7 +775,7 @@
 				SWIFT_INSTALL_MODULE = YES;
 				SWIFT_INSTALL_OBJC_HEADER = NO;
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
-				SWIFT_VERSION = 6.0;
+				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -802,7 +814,7 @@
 				SWIFT_INSTALL_MODULE = YES;
 				SWIFT_INSTALL_OBJC_HEADER = NO;
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
-				SWIFT_VERSION = 6.0;
+				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -841,7 +853,7 @@
 				SWIFT_INSTALL_MODULE = YES;
 				SWIFT_INSTALL_OBJC_HEADER = NO;
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
-				SWIFT_VERSION = 6.0;
+				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -996,8 +1008,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Infomaniak/ios-login.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 7.3.1;
+				branch = "chore/swift-5.10";
+				kind = branch;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -1008,15 +1020,15 @@
 			package = F967FC8A2E8BC9FE00EDD4D7 /* XCRemoteSwiftPackageReference "lottie-spm" */;
 			productName = Lottie;
 		};
+		F97269772E98F1CE002EA08D /* InfomaniakLogin */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F97805BF2E97E3C500BC146C /* XCRemoteSwiftPackageReference "ios-login" */;
+			productName = InfomaniakLogin;
+		};
 		F97805BD2E97E3AF00BC146C /* InfomaniakDI */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = F97805BC2E97E3AF00BC146C /* XCRemoteSwiftPackageReference "ios-dependency-injection" */;
 			productName = InfomaniakDI;
-		};
-		F97805C02E97E3C500BC146C /* InfomaniakLogin */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = F97805BF2E97E3C500BC146C /* XCRemoteSwiftPackageReference "ios-login" */;
-			productName = InfomaniakLogin;
 		};
 		F97805C22E97E3F900BC146C /* InfomaniakDI */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/src/front/macOS/kDrive.xcodeproj/project.pbxproj
+++ b/src/front/macOS/kDrive.xcodeproj/project.pbxproj
@@ -11,11 +11,13 @@
 		37A1C4462E546A9600596DBB /* kDriveCoreUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 37A1C43F2E546A9600596DBB /* kDriveCoreUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		37A1C4602E546CB700596DBB /* kDriveCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 37A1C45A2E546CB600596DBB /* kDriveCore.framework */; };
 		37A1C4612E546CB700596DBB /* kDriveCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 37A1C45A2E546CB600596DBB /* kDriveCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		37A1C4712E54708F00596DBB /* InfomaniakDI in Frameworks */ = {isa = PBXBuildFile; productRef = 37A1C4702E54708F00596DBB /* InfomaniakDI */; };
 		F96700A42E95352C00EDD4D7 /* kDriveResources.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F967009E2E95352C00EDD4D7 /* kDriveResources.framework */; };
 		F96700A52E95352C00EDD4D7 /* kDriveResources.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F967009E2E95352C00EDD4D7 /* kDriveResources.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F96701502E953CF600EDD4D7 /* kDriveResources.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F967009E2E95352C00EDD4D7 /* kDriveResources.framework */; };
 		F967FC8C2E8BC9FE00EDD4D7 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = F967FC8B2E8BC9FE00EDD4D7 /* Lottie */; };
+		F97805BE2E97E3AF00BC146C /* InfomaniakDI in Frameworks */ = {isa = PBXBuildFile; productRef = F97805BD2E97E3AF00BC146C /* InfomaniakDI */; };
+		F97805C12E97E3C500BC146C /* InfomaniakLogin in Frameworks */ = {isa = PBXBuildFile; productRef = F97805C02E97E3C500BC146C /* InfomaniakLogin */; };
+		F97805C32E97E3F900BC146C /* InfomaniakDI in Frameworks */ = {isa = PBXBuildFile; productRef = F97805C22E97E3F900BC146C /* InfomaniakDI */; };
 		F9ACC5382E5DF50F0081E80B /* swiftgen.yml in Resources */ = {isa = PBXBuildFile; fileRef = F9ACC5372E5DF50B0081E80B /* swiftgen.yml */; };
 /* End PBXBuildFile section */
 
@@ -89,11 +91,21 @@
 			);
 			target = 37A1C43E2E546A9600596DBB /* kDriveCoreUI */;
 		};
+		F97805C62E97E4DF00BC146C /* Exceptions for "kDrive" folder in "kDrive" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Resources/Info.plist,
+			);
+			target = 37A1C4252E546A5200596DBB /* kDrive */;
+		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		37A1C4282E546A5200596DBB /* kDrive */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				F97805C62E97E4DF00BC146C /* Exceptions for "kDrive" folder in "kDrive" target */,
+			);
 			path = kDrive;
 			sourceTree = "<group>";
 		};
@@ -123,6 +135,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F97805BE2E97E3AF00BC146C /* InfomaniakDI in Frameworks */,
+				F97805C12E97E3C500BC146C /* InfomaniakLogin in Frameworks */,
 				37A1C4602E546CB700596DBB /* kDriveCore.framework in Frameworks */,
 				F96700A42E95352C00EDD4D7 /* kDriveResources.framework in Frameworks */,
 				37A1C4452E546A9600596DBB /* kDriveCoreUI.framework in Frameworks */,
@@ -142,7 +156,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				37A1C4712E54708F00596DBB /* InfomaniakDI in Frameworks */,
+				F97805C32E97E3F900BC146C /* InfomaniakDI in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -237,6 +251,8 @@
 			name = kDrive;
 			packageProductDependencies = (
 				F967FC8B2E8BC9FE00EDD4D7 /* Lottie */,
+				F97805BD2E97E3AF00BC146C /* InfomaniakDI */,
+				F97805C02E97E3C500BC146C /* InfomaniakLogin */,
 			);
 			productName = kDrive;
 			productReference = 37A1C4262E546A5200596DBB /* kDrive.app */;
@@ -284,7 +300,7 @@
 			);
 			name = kDriveCore;
 			packageProductDependencies = (
-				37A1C4702E54708F00596DBB /* InfomaniakDI */,
+				F97805C22E97E3F900BC146C /* InfomaniakDI */,
 			);
 			productName = kDriveCore;
 			productReference = 37A1C45A2E546CB600596DBB /* kDriveCore.framework */;
@@ -353,8 +369,9 @@
 			mainGroup = 37A1C41D2E546A5200596DBB;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				37A1C46F2E54708F00596DBB /* XCRemoteSwiftPackageReference "swift-dependency-injection" */,
 				F967FC8A2E8BC9FE00EDD4D7 /* XCRemoteSwiftPackageReference "lottie-spm" */,
+				F97805BC2E97E3AF00BC146C /* XCRemoteSwiftPackageReference "ios-dependency-injection" */,
+				F97805BF2E97E3C500BC146C /* XCRemoteSwiftPackageReference "ios-login" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 37A1C4272E546A5200596DBB /* Products */;
@@ -850,6 +867,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MARKETING_VERSION = 1.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
@@ -888,6 +906,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MARKETING_VERSION = 1.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
@@ -957,14 +976,6 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		37A1C46F2E54708F00596DBB /* XCRemoteSwiftPackageReference "swift-dependency-injection" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/Infomaniak/swift-dependency-injection";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.0.4;
-			};
-		};
 		F967FC8A2E8BC9FE00EDD4D7 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/airbnb/lottie-spm.git";
@@ -973,18 +984,44 @@
 				minimumVersion = 4.5.2;
 			};
 		};
+		F97805BC2E97E3AF00BC146C /* XCRemoteSwiftPackageReference "ios-dependency-injection" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Infomaniak/ios-dependency-injection.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.0.4;
+			};
+		};
+		F97805BF2E97E3C500BC146C /* XCRemoteSwiftPackageReference "ios-login" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Infomaniak/ios-login.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 7.3.1;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		37A1C4702E54708F00596DBB /* InfomaniakDI */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 37A1C46F2E54708F00596DBB /* XCRemoteSwiftPackageReference "swift-dependency-injection" */;
-			productName = InfomaniakDI;
-		};
 		F967FC8B2E8BC9FE00EDD4D7 /* Lottie */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = F967FC8A2E8BC9FE00EDD4D7 /* XCRemoteSwiftPackageReference "lottie-spm" */;
 			productName = Lottie;
+		};
+		F97805BD2E97E3AF00BC146C /* InfomaniakDI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F97805BC2E97E3AF00BC146C /* XCRemoteSwiftPackageReference "ios-dependency-injection" */;
+			productName = InfomaniakDI;
+		};
+		F97805C02E97E3C500BC146C /* InfomaniakLogin */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F97805BF2E97E3C500BC146C /* XCRemoteSwiftPackageReference "ios-login" */;
+			productName = InfomaniakLogin;
+		};
+		F97805C22E97E3F900BC146C /* InfomaniakDI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F97805BC2E97E3AF00BC146C /* XCRemoteSwiftPackageReference "ios-dependency-injection" */;
+			productName = InfomaniakDI;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/src/front/macOS/kDrive/KDriveApp.swift
+++ b/src/front/macOS/kDrive/KDriveApp.swift
@@ -18,10 +18,16 @@
 
 import Cocoa
 
-let delegate = AppDelegate()
-NSApplication.shared.delegate = delegate
+@main
+struct KDriveApp {
+    @MainActor
+    static func main() async {
+        let delegate = AppDelegate()
+        NSApplication.shared.delegate = delegate
 
-let mainMenu = MainMenu()
-mainMenu.setAsAppMainMenu()
+        let mainMenu = MainMenu()
+        mainMenu.setAsAppMainMenu()
 
-NSApplication.shared.run()
+        NSApplication.shared.run()
+    }
+}

--- a/src/front/macOS/kDrive/UI/Controllers/MainWindow/Onboarding/OnboardingViewController.swift
+++ b/src/front/macOS/kDrive/UI/Controllers/MainWindow/Onboarding/OnboardingViewController.swift
@@ -39,6 +39,7 @@ final class OnboardingViewController: NSViewController {
         super.init(nibName: nil, bundle: nil)
     }
 
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/src/front/macOS/kDrive/UI/Controllers/MainWindow/Onboarding/OnboardingViewController.swift
+++ b/src/front/macOS/kDrive/UI/Controllers/MainWindow/Onboarding/OnboardingViewController.swift
@@ -84,7 +84,6 @@ final class OnboardingViewController: NSViewController {
     }
 
     private func bindViewModel() {
-        transition(toStep: viewModel.currentStep)
         viewModel.$currentStep.receive(on: DispatchQueue.main)
             .sink { [weak self] step in
                 self?.transition(toStep: step)

--- a/src/front/macOS/kDrive/UI/Controllers/MainWindow/Onboarding/OnboardingViewController.swift
+++ b/src/front/macOS/kDrive/UI/Controllers/MainWindow/Onboarding/OnboardingViewController.swift
@@ -59,7 +59,7 @@ final class OnboardingViewController: NSViewController {
     private func setupWindowAppearance() {
         guard let window = view.window else { return }
 
-        window.title = KDriveLocalizable.onboardingLoginTitle
+        window.title = KDriveLocalizable.onboardingWindowTitle
         window.titlebarAppearsTransparent = true
         window.isMovableByWindowBackground = false
     }
@@ -85,6 +85,7 @@ final class OnboardingViewController: NSViewController {
     }
 
     private func bindViewModel() {
+        transition(toStep: viewModel.currentStep)
         viewModel.$currentStep.receive(on: DispatchQueue.main)
             .sink { [weak self] step in
                 self?.transition(toStep: step)
@@ -104,14 +105,11 @@ final class OnboardingViewController: NSViewController {
         case .login:
             return LoginViewController(viewModel: viewModel)
         case .driveSelection:
-            print("Not Implemented Yet")
-            return NSViewController()
+            fatalError("Not Implemented Yet")
         case .permissions:
-            print("Not Implemented Yet")
-            return NSViewController()
+            fatalError("Not Implemented Yet")
         case .synchronisation:
-            print("Not Implemented Yet")
-            return NSViewController()
+            fatalError("Not Implemented Yet")
         }
     }
 

--- a/src/front/macOS/kDrive/UI/Controllers/MainWindow/Onboarding/OnboardingViewModel.swift
+++ b/src/front/macOS/kDrive/UI/Controllers/MainWindow/Onboarding/OnboardingViewModel.swift
@@ -53,13 +53,25 @@ final class OnboardingViewModel: ObservableObject {
     }
 }
 
+// MARK: - InfomaniakLoginDelegate
+
 extension OnboardingViewModel: InfomaniakLoginDelegate {
     func didCompleteLoginWith(code: String, verifier: String) {
         isShowingAuthenticationWindow = false
-        // TODO: get user token
+
+        // TODO: Server should code & verifier into a token
+        // TODO: Get user + drives
+
+        currentStep = .driveSelection
     }
 
     func didFailLoginWith(error: any Error) {
         isShowingAuthenticationWindow = false
+
+        guard (error as? ASWebAuthenticationSessionError)?.code != .canceledLogin else {
+            return
+        }
+
+        currentStep = .login(.fail)
     }
 }

--- a/src/front/macOS/kDrive/UI/Controllers/MainWindow/Onboarding/Steps/LoginViewController.swift
+++ b/src/front/macOS/kDrive/UI/Controllers/MainWindow/Onboarding/Steps/LoginViewController.swift
@@ -16,19 +16,16 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import AuthenticationServices
 import Cocoa
 import Combine
 import InfomaniakDI
 import InfomaniakLogin
 import kDriveCoreUI
+import kDriveLogin
 import kDriveResources
+import AuthenticationServices
 
-final class LoginViewController: OnboardingStepViewController, ASWebAuthenticationPresentationContextProviding {
-    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
-        return view.window!
-    }
-
+final class LoginViewController: OnboardingStepViewController {
     @LazyInjectService private var loginService: InfomaniakLoginable
 
     private let viewModel: OnboardingViewModel
@@ -92,10 +89,10 @@ final class LoginViewController: OnboardingStepViewController, ASWebAuthenticati
 
 extension LoginViewController: InfomaniakLoginDelegate {
     func didCompleteLoginWith(code: String, verifier: String) {
-        print("Success")
+        // TODO: Send code & verifier to server
     }
 
     func didFailLoginWith(error: any Error) {
-        print("Failure")
+        // TODO: Handle error
     }
 }

--- a/src/front/macOS/kDrive/UI/Controllers/MainWindow/Onboarding/Steps/LoginViewController.swift
+++ b/src/front/macOS/kDrive/UI/Controllers/MainWindow/Onboarding/Steps/LoginViewController.swift
@@ -64,7 +64,7 @@ final class LoginViewController: OnboardingStepViewController {
         case .success:
             fatalError("Not Implemented Yet")
         case .fail:
-            fatalError("Not Implemented Yet")
+            setupErrorView()
         }
     }
 
@@ -76,6 +76,11 @@ final class LoginViewController: OnboardingStepViewController {
         primaryButton.target = self
         primaryButton.action = #selector(openLoginWebView)
         secondaryButton.title = KDriveLocalizable.buttonCreateAccount
+    }
+
+    private func setupErrorView() {
+        titleLabel.stringValue = KDriveLocalizable.onboardingErrorTitle
+        descriptionLabel.stringValue = KDriveLocalizable.onboardingLoginErrorDescription
     }
 
     private func markButtonsAsLoading(_ isLoading: Bool) {

--- a/src/front/macOS/kDrive/UI/Controllers/MainWindow/Onboarding/Steps/LoginViewController.swift
+++ b/src/front/macOS/kDrive/UI/Controllers/MainWindow/Onboarding/Steps/LoginViewController.swift
@@ -16,13 +16,13 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import AuthenticationServices
 import Cocoa
 import Combine
 import InfomaniakLogin
 import kDriveCoreUI
 import kDriveLogin
 import kDriveResources
-import AuthenticationServices
 
 final class LoginViewController: OnboardingStepViewController {
     private let viewModel: OnboardingViewModel

--- a/src/front/macOS/kDrive/UI/Controllers/MainWindow/Onboarding/Steps/LoginViewController.swift
+++ b/src/front/macOS/kDrive/UI/Controllers/MainWindow/Onboarding/Steps/LoginViewController.swift
@@ -67,6 +67,9 @@ final class LoginViewController: OnboardingStepViewController {
         descriptionLabel.stringValue = KDriveLocalizable.onboardingLoginDescription
 
         primaryButton.title = KDriveLocalizable.buttonLogin
+        primaryButton.action = #selector(openLoginWebView)
         secondaryButton.title = KDriveLocalizable.buttonCreateAccount
     }
+
+    @objc private func openLoginWebView() {}
 }

--- a/src/front/macOS/kDrive/UI/Controllers/MainWindow/Onboarding/Steps/LoginViewController.swift
+++ b/src/front/macOS/kDrive/UI/Controllers/MainWindow/Onboarding/Steps/LoginViewController.swift
@@ -16,12 +16,9 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import AuthenticationServices
 import Cocoa
 import Combine
-import InfomaniakLogin
 import kDriveCoreUI
-import kDriveLogin
 import kDriveResources
 
 final class LoginViewController: OnboardingStepViewController {
@@ -44,24 +41,27 @@ final class LoginViewController: OnboardingStepViewController {
     }
 
     private func bindViewModel() {
+        transitionLogin(toStep: viewModel.currentStep)
         viewModel.$currentStep.receive(on: DispatchQueue.main).sink { [weak self] step in
-            self?.transitionContent(toStep: step)
+            self?.transitionLogin(toStep: step)
         }
         .store(in: &bindStore)
 
+        markButtonsAsLoading(viewModel.isShowingAuthenticationWindow)
         viewModel.$isShowingAuthenticationWindow.receive(on: DispatchQueue.main).sink { [weak self] isShowing in
             self?.markButtonsAsLoading(isShowing)
         }
         .store(in: &bindStore)
     }
 
-    private func transitionContent(toStep step: OnboardingStep) {
+    private func transitionLogin(toStep step: OnboardingStep) {
         guard case .login(let loginStep) = viewModel.currentStep else { return }
 
         switch loginStep {
         case .initial:
             setupInitialView()
         case .success:
+            // TODO: Check if this step is necessary once the server is implemented
             fatalError("Not Implemented Yet")
         case .fail:
             setupErrorView()

--- a/src/front/macOS/kDrive/UI/Controllers/MainWindow/Onboarding/Steps/OnboardingStepViewController.swift
+++ b/src/front/macOS/kDrive/UI/Controllers/MainWindow/Onboarding/Steps/OnboardingStepViewController.swift
@@ -21,8 +21,8 @@ import Combine
 import kDriveCoreUI
 
 open class OnboardingStepViewController: NSViewController {
-    private static let minContainerWidth: CGFloat = 200
-    private static let maxContainerWidth: CGFloat = 450
+    private static let minContainerWidth: CGFloat = 300
+    private static let maxContainerWidth: CGFloat = 500
 
     public let containerView = NSView()
     public let titleLabel = NSTextField(labelWithString: "")
@@ -48,6 +48,7 @@ open class OnboardingStepViewController: NSViewController {
         descriptionLabel.font = .preferredFont(forTextStyle: .body)
         descriptionLabel.lineBreakMode = .byWordWrapping
         descriptionLabel.textColor = .Tokens.Text.secondary
+        descriptionLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         containerView.addSubview(descriptionLabel)
 
         secondaryButton.translatesAutoresizingMaskIntoConstraints = false
@@ -58,15 +59,14 @@ open class OnboardingStepViewController: NSViewController {
         containerView.addSubview(primaryButton)
 
         NSLayoutConstraint.activate([
-            containerView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             containerView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
             containerView.widthAnchor.constraint(greaterThanOrEqualToConstant: Self.minContainerWidth),
             containerView.widthAnchor.constraint(lessThanOrEqualToConstant: Self.maxContainerWidth),
 
-            containerView.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor, constant: AppPadding.padding16),
-            view.trailingAnchor.constraint(greaterThanOrEqualTo: containerView.trailingAnchor, constant: AppPadding.padding16),
-            containerView.topAnchor.constraint(greaterThanOrEqualTo: view.topAnchor, constant: AppPadding.padding16),
-            view.bottomAnchor.constraint(greaterThanOrEqualTo: containerView.bottomAnchor, constant: AppPadding.padding16),
+            containerView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: AppPadding.padding64),
+            view.trailingAnchor.constraint(greaterThanOrEqualTo: containerView.trailingAnchor, constant: AppPadding.padding64),
+            containerView.topAnchor.constraint(greaterThanOrEqualTo: view.topAnchor, constant: AppPadding.padding32),
+            view.bottomAnchor.constraint(greaterThanOrEqualTo: containerView.bottomAnchor, constant: AppPadding.padding32),
 
             titleLabel.topAnchor.constraint(equalTo: containerView.topAnchor),
             titleLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),

--- a/src/front/macOS/kDrive/Utils/DriveTargetAssembly.swift
+++ b/src/front/macOS/kDrive/Utils/DriveTargetAssembly.swift
@@ -21,7 +21,7 @@ import InfomaniakDI
 import kDriveCore
 
 final class DriveTargetAssembly: TargetAssembly {
-    override class func getTargetServices() -> [Factory] {
+    override static func getTargetServices() -> [Factory] {
         return [
             Factory(type: WindowRouter.self) { _, _ in
                 MainWindowRouter()

--- a/src/front/macOS/kDrive/Utils/DriveTargetAssembly.swift
+++ b/src/front/macOS/kDrive/Utils/DriveTargetAssembly.swift
@@ -18,13 +18,22 @@
 
 import Cocoa
 import InfomaniakDI
+import InfomaniakLogin
 import kDriveCore
 
 final class DriveTargetAssembly: TargetAssembly {
+    static let loginConfig = InfomaniakLogin.Config(
+        clientId: "5EA39279-FF64-4BB8-A872-4A40B5786317",
+        redirectURI: "kdrive://auth-desktop"
+    )
+
     override static func getTargetServices() -> [Factory] {
         return [
             Factory(type: WindowRouter.self) { _, _ in
                 MainWindowRouter()
+            },
+            Factory(type: InfomaniakLoginable.self) { _, _ in
+                InfomaniakLogin(config: Self.loginConfig)
             }
         ]
     }

--- a/src/front/macOS/kDriveCoreUI/Tokens/AppPadding.swift
+++ b/src/front/macOS/kDriveCoreUI/Tokens/AppPadding.swift
@@ -19,6 +19,7 @@
 import Foundation
 
 public enum AppPadding {
+    public static let padding64: CGFloat = 64
     public static let padding48: CGFloat = 48
     public static let padding32: CGFloat = 32
     public static let padding16: CGFloat = 16

--- a/src/front/macOS/kDriveCoreUI/UI/Views/Buttons/BorderedProminentButton.swift
+++ b/src/front/macOS/kDriveCoreUI/UI/Views/Buttons/BorderedProminentButton.swift
@@ -38,7 +38,7 @@ public final class BorderedProminentButton: NSButton {
         super.init(coder: coder)
         setupColors()
     }
-
+    
     private func setupColors() {
         bezelColor = backgroundColor
         setupTitleColor()

--- a/src/front/macOS/kDriveCoreUI/UI/Views/Buttons/BorderedProminentButton.swift
+++ b/src/front/macOS/kDriveCoreUI/UI/Views/Buttons/BorderedProminentButton.swift
@@ -23,13 +23,13 @@ public final class BorderedProminentButton: NSButton {
     var backgroundColor = NSColor.Tokens.Action.primary
     var foregroundColor = NSColor.Tokens.Action.onPrimary
 
-    public override var title: String {
+    override public var title: String {
         didSet {
             setupTitleColor()
         }
     }
 
-    public override init(frame frameRect: NSRect) {
+    override public init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
         setupColors()
     }
@@ -38,7 +38,7 @@ public final class BorderedProminentButton: NSButton {
         super.init(coder: coder)
         setupColors()
     }
-    
+
     private func setupColors() {
         bezelColor = backgroundColor
         setupTitleColor()

--- a/src/front/macOS/kDriveCoreUI/UI/Views/SidebarTableCellView.swift
+++ b/src/front/macOS/kDriveCoreUI/UI/Views/SidebarTableCellView.swift
@@ -17,7 +17,6 @@
  */
 
 import Cocoa
-import kDriveCoreUI
 
 public final class SidebarTableCellView: NSTableCellView {
     public var badge: Int? {

--- a/src/front/macOS/kDriveResources/Generated/Strings+Generated.swift
+++ b/src/front/macOS/kDriveResources/Generated/Strings+Generated.swift
@@ -18,10 +18,16 @@ public enum KDriveLocalizable {
   public static let buttonOpenInBrowser = KDriveLocalizable.tr("Localizable", "buttonOpenInBrowser", fallback: "Open in browser")
   /// loco:68b04d5a63085b7ab90cea63
   public static let buttonOpenInFinder = KDriveLocalizable.tr("Localizable", "buttonOpenInFinder", fallback: "Open in Finder")
+  /// loco:68e8fa06c1b003290f0ccf42
+  public static let onboardingErrorTitle = KDriveLocalizable.tr("Localizable", "onboardingErrorTitle", fallback: "Erreur de connexion")
   /// loco:68e6739c8af12c42e80027c5
   public static let onboardingLoginDescription = KDriveLocalizable.tr("Localizable", "onboardingLoginDescription", fallback: "The fast, secure private cloud, hosted in Switzerland.\n\nLog in and keep your documents synchronized on all your devices.")
+  /// loco:68e8fa543a683192560af9e2
+  public static let onboardingLoginErrorDescription = KDriveLocalizable.tr("Localizable", "onboardingLoginErrorDescription", fallback: "Une erreur est survenue, veuillez réessayer.")
   /// loco:68e673754d80559c460bdf02
   public static let onboardingLoginTitle = KDriveLocalizable.tr("Localizable", "onboardingLoginTitle", fallback: "Welcome to kDrive!")
+  /// loco:68e8fa27d09187683c0679b2
+  public static let onboardingWindowTitle = KDriveLocalizable.tr("Localizable", "onboardingWindowTitle", fallback: "Bienvenue dans kDrive")
   /// loco:68cd386502633dee14000352
   public static let sidebarItemAccounts = KDriveLocalizable.tr("Localizable", "sidebarItemAccounts", fallback: "Accounts")
   /// loco:68cd389fcc36238762040074

--- a/src/front/macOS/kDriveResources/Localizable/de.lproj/Localizable.strings
+++ b/src/front/macOS/kDriveResources/Localizable/de.lproj/Localizable.strings
@@ -4,7 +4,7 @@
  * Locale: de, German
  * Tagged: macOS
  * Exported by: Valentin Perignon
- * Exported at: Wed, 08 Oct 2025 16:23:50 +0200
+ * Exported at: Fri, 10 Oct 2025 14:22:19 +0200
  */
 
 /* loco:68e673c48af12c42e80027c8 */
@@ -19,11 +19,20 @@
 /* loco:68b04d5a63085b7ab90cea63 */
 "buttonOpenInFinder" = "In Finder öffnen";
 
+/* loco:68e8fa06c1b003290f0ccf42 */
+"onboardingErrorTitle" = "Fehler bei der Verbindung";
+
 /* loco:68e6739c8af12c42e80027c5 */
 "onboardingLoginDescription" = "Die schnelle und sichere private Cloud, die in der Schweiz gehostet wird.\n\nMelden Sie sich an und halten Sie Ihre Dokumente auf all Ihren Geräten synchronisiert.";
 
+/* loco:68e8fa543a683192560af9e2 */
+"onboardingLoginErrorDescription" = "Une erreur est survenue, veuillez réessayer.";
+
 /* loco:68e673754d80559c460bdf02 */
 "onboardingLoginTitle" = "Willkommen bei kDrive!";
+
+/* loco:68e8fa27d09187683c0679b2 */
+"onboardingWindowTitle" = "Willkommen bei kDrive";
 
 /* loco:68cd386502633dee14000352 */
 "sidebarItemAccounts" = "Konten";

--- a/src/front/macOS/kDriveResources/Localizable/de.lproj/Localizable.strings
+++ b/src/front/macOS/kDriveResources/Localizable/de.lproj/Localizable.strings
@@ -4,7 +4,7 @@
  * Locale: de, German
  * Tagged: macOS
  * Exported by: Valentin Perignon
- * Exported at: Fri, 10 Oct 2025 14:22:19 +0200
+ * Exported at: Mon, 13 Oct 2025 08:40:02 +0200
  */
 
 /* loco:68e673c48af12c42e80027c8 */
@@ -20,13 +20,13 @@
 "buttonOpenInFinder" = "In Finder öffnen";
 
 /* loco:68e8fa06c1b003290f0ccf42 */
-"onboardingErrorTitle" = "Fehler bei der Verbindung";
+"onboardingErrorTitle" = "Verbindungsfehler";
 
 /* loco:68e6739c8af12c42e80027c5 */
 "onboardingLoginDescription" = "Die schnelle und sichere private Cloud, die in der Schweiz gehostet wird.\n\nMelden Sie sich an und halten Sie Ihre Dokumente auf all Ihren Geräten synchronisiert.";
 
 /* loco:68e8fa543a683192560af9e2 */
-"onboardingLoginErrorDescription" = "Une erreur est survenue, veuillez réessayer.";
+"onboardingLoginErrorDescription" = "Es ist ein Fehler aufgetreten, bitte versuchen Sie es erneut.";
 
 /* loco:68e673754d80559c460bdf02 */
 "onboardingLoginTitle" = "Willkommen bei kDrive!";

--- a/src/front/macOS/kDriveResources/Localizable/en.lproj/Localizable.strings
+++ b/src/front/macOS/kDriveResources/Localizable/en.lproj/Localizable.strings
@@ -4,7 +4,7 @@
  * Locale: en, English
  * Tagged: macOS
  * Exported by: Valentin Perignon
- * Exported at: Wed, 08 Oct 2025 16:23:50 +0200
+ * Exported at: Fri, 10 Oct 2025 14:22:19 +0200
  */
 
 /* loco:68e673c48af12c42e80027c8 */
@@ -19,11 +19,20 @@
 /* loco:68b04d5a63085b7ab90cea63 */
 "buttonOpenInFinder" = "Open in Finder";
 
+/* loco:68e8fa06c1b003290f0ccf42 */
+"onboardingErrorTitle" = "Erreur de connexion";
+
 /* loco:68e6739c8af12c42e80027c5 */
 "onboardingLoginDescription" = "The fast, secure private cloud, hosted in Switzerland.\n\nLog in and keep your documents synchronized on all your devices.";
 
+/* loco:68e8fa543a683192560af9e2 */
+"onboardingLoginErrorDescription" = "Une erreur est survenue, veuillez réessayer.";
+
 /* loco:68e673754d80559c460bdf02 */
 "onboardingLoginTitle" = "Welcome to kDrive!";
+
+/* loco:68e8fa27d09187683c0679b2 */
+"onboardingWindowTitle" = "Bienvenue dans kDrive";
 
 /* loco:68cd386502633dee14000352 */
 "sidebarItemAccounts" = "Accounts";

--- a/src/front/macOS/kDriveResources/Localizable/en.lproj/Localizable.strings
+++ b/src/front/macOS/kDriveResources/Localizable/en.lproj/Localizable.strings
@@ -4,7 +4,7 @@
  * Locale: en, English
  * Tagged: macOS
  * Exported by: Valentin Perignon
- * Exported at: Fri, 10 Oct 2025 14:22:19 +0200
+ * Exported at: Mon, 13 Oct 2025 08:40:02 +0200
  */
 
 /* loco:68e673c48af12c42e80027c8 */
@@ -20,19 +20,19 @@
 "buttonOpenInFinder" = "Open in Finder";
 
 /* loco:68e8fa06c1b003290f0ccf42 */
-"onboardingErrorTitle" = "Erreur de connexion";
+"onboardingErrorTitle" = "Connection error";
 
 /* loco:68e6739c8af12c42e80027c5 */
 "onboardingLoginDescription" = "The fast, secure private cloud, hosted in Switzerland.\n\nLog in and keep your documents synchronized on all your devices.";
 
 /* loco:68e8fa543a683192560af9e2 */
-"onboardingLoginErrorDescription" = "Une erreur est survenue, veuillez réessayer.";
+"onboardingLoginErrorDescription" = "An error has occurred, please try again.";
 
 /* loco:68e673754d80559c460bdf02 */
 "onboardingLoginTitle" = "Welcome to kDrive!";
 
 /* loco:68e8fa27d09187683c0679b2 */
-"onboardingWindowTitle" = "Bienvenue dans kDrive";
+"onboardingWindowTitle" = "Welcome to kDrive";
 
 /* loco:68cd386502633dee14000352 */
 "sidebarItemAccounts" = "Accounts";

--- a/src/front/macOS/kDriveResources/Localizable/es.lproj/Localizable.strings
+++ b/src/front/macOS/kDriveResources/Localizable/es.lproj/Localizable.strings
@@ -4,7 +4,7 @@
  * Locale: es, Spanish
  * Tagged: macOS
  * Exported by: Valentin Perignon
- * Exported at: Wed, 08 Oct 2025 16:23:50 +0200
+ * Exported at: Fri, 10 Oct 2025 14:22:19 +0200
  */
 
 /* loco:68e673c48af12c42e80027c8 */
@@ -19,11 +19,20 @@
 /* loco:68b04d5a63085b7ab90cea63 */
 "buttonOpenInFinder" = "Abrir en el Finder";
 
+/* loco:68e8fa06c1b003290f0ccf42 */
+"onboardingErrorTitle" = "Error de conexión";
+
 /* loco:68e6739c8af12c42e80027c5 */
 "onboardingLoginDescription" = "La nube privada, rápida y segura, alojada en Suiza.\n\nConéctate y mantén tus documentos sincronizados en todos tus dispositivos.";
 
+/* loco:68e8fa543a683192560af9e2 */
+"onboardingLoginErrorDescription" = "Se ha producido un error, vuelva a intentarlo.";
+
 /* loco:68e673754d80559c460bdf02 */
 "onboardingLoginTitle" = "¡Bienvenido a kDrive!";
+
+/* loco:68e8fa27d09187683c0679b2 */
+"onboardingWindowTitle" = "Bienvenido a kDrive";
 
 /* loco:68cd386502633dee14000352 */
 "sidebarItemAccounts" = "Cuentas";

--- a/src/front/macOS/kDriveResources/Localizable/es.lproj/Localizable.strings
+++ b/src/front/macOS/kDriveResources/Localizable/es.lproj/Localizable.strings
@@ -4,7 +4,7 @@
  * Locale: es, Spanish
  * Tagged: macOS
  * Exported by: Valentin Perignon
- * Exported at: Fri, 10 Oct 2025 14:22:19 +0200
+ * Exported at: Mon, 13 Oct 2025 08:40:02 +0200
  */
 
 /* loco:68e673c48af12c42e80027c8 */
@@ -26,7 +26,7 @@
 "onboardingLoginDescription" = "La nube privada, rápida y segura, alojada en Suiza.\n\nConéctate y mantén tus documentos sincronizados en todos tus dispositivos.";
 
 /* loco:68e8fa543a683192560af9e2 */
-"onboardingLoginErrorDescription" = "Se ha producido un error, vuelva a intentarlo.";
+"onboardingLoginErrorDescription" = "Se ha producido un error, inténtelo de nuevo.";
 
 /* loco:68e673754d80559c460bdf02 */
 "onboardingLoginTitle" = "¡Bienvenido a kDrive!";

--- a/src/front/macOS/kDriveResources/Localizable/fr.lproj/Localizable.strings
+++ b/src/front/macOS/kDriveResources/Localizable/fr.lproj/Localizable.strings
@@ -4,7 +4,7 @@
  * Locale: fr, French
  * Tagged: macOS
  * Exported by: Valentin Perignon
- * Exported at: Wed, 08 Oct 2025 16:23:50 +0200
+ * Exported at: Fri, 10 Oct 2025 14:22:19 +0200
  */
 
 /* loco:68e673c48af12c42e80027c8 */
@@ -19,11 +19,20 @@
 /* loco:68b04d5a63085b7ab90cea63 */
 "buttonOpenInFinder" = "Ouvrir dans Finder";
 
+/* loco:68e8fa06c1b003290f0ccf42 */
+"onboardingErrorTitle" = "Erreur de connexion";
+
 /* loco:68e6739c8af12c42e80027c5 */
 "onboardingLoginDescription" = "Le cloud privé, rapide et sécurisé, hébergé en Suisse.\n\nConnectez-vous et gardez vos documents synchronisés sur tous vos appareils.";
 
+/* loco:68e8fa543a683192560af9e2 */
+"onboardingLoginErrorDescription" = "Une erreur est survenue, veuillez réessayer.";
+
 /* loco:68e673754d80559c460bdf02 */
 "onboardingLoginTitle" = "Bienvenue dans kDrive !";
+
+/* loco:68e8fa27d09187683c0679b2 */
+"onboardingWindowTitle" = "Bienvenue dans kDrive";
 
 /* loco:68cd386502633dee14000352 */
 "sidebarItemAccounts" = "Comptes";

--- a/src/front/macOS/kDriveResources/Localizable/fr.lproj/Localizable.strings
+++ b/src/front/macOS/kDriveResources/Localizable/fr.lproj/Localizable.strings
@@ -4,7 +4,7 @@
  * Locale: fr, French
  * Tagged: macOS
  * Exported by: Valentin Perignon
- * Exported at: Fri, 10 Oct 2025 14:22:19 +0200
+ * Exported at: Mon, 13 Oct 2025 08:40:02 +0200
  */
 
 /* loco:68e673c48af12c42e80027c8 */

--- a/src/front/macOS/kDriveResources/Localizable/it.lproj/Localizable.strings
+++ b/src/front/macOS/kDriveResources/Localizable/it.lproj/Localizable.strings
@@ -4,7 +4,7 @@
  * Locale: it, Italian
  * Tagged: macOS
  * Exported by: Valentin Perignon
- * Exported at: Wed, 08 Oct 2025 16:23:50 +0200
+ * Exported at: Fri, 10 Oct 2025 14:22:19 +0200
  */
 
 /* loco:68e673c48af12c42e80027c8 */
@@ -19,11 +19,20 @@
 /* loco:68b04d5a63085b7ab90cea63 */
 "buttonOpenInFinder" = "Aprire nel Finder";
 
+/* loco:68e8fa06c1b003290f0ccf42 */
+"onboardingErrorTitle" = "Errore di connessione";
+
 /* loco:68e6739c8af12c42e80027c5 */
 "onboardingLoginDescription" = "Il cloud privato veloce e sicuro, ospitato in Svizzera.\n\nCollegatevi e mantenete i vostri documenti sincronizzati su tutti i vostri dispositivi.";
 
+/* loco:68e8fa543a683192560af9e2 */
+"onboardingLoginErrorDescription" = "È stato commesso un errore, quindi è necessario ripetere l'operazione.";
+
 /* loco:68e673754d80559c460bdf02 */
 "onboardingLoginTitle" = "Benvenuti su kDrive!";
+
+/* loco:68e8fa27d09187683c0679b2 */
+"onboardingWindowTitle" = "Benvenuti in kDrive";
 
 /* loco:68cd386502633dee14000352 */
 "sidebarItemAccounts" = "Conti";

--- a/src/front/macOS/kDriveResources/Localizable/it.lproj/Localizable.strings
+++ b/src/front/macOS/kDriveResources/Localizable/it.lproj/Localizable.strings
@@ -4,7 +4,7 @@
  * Locale: it, Italian
  * Tagged: macOS
  * Exported by: Valentin Perignon
- * Exported at: Fri, 10 Oct 2025 14:22:19 +0200
+ * Exported at: Mon, 13 Oct 2025 08:40:02 +0200
  */
 
 /* loco:68e673c48af12c42e80027c8 */
@@ -26,7 +26,7 @@
 "onboardingLoginDescription" = "Il cloud privato veloce e sicuro, ospitato in Svizzera.\n\nCollegatevi e mantenete i vostri documenti sincronizzati su tutti i vostri dispositivi.";
 
 /* loco:68e8fa543a683192560af9e2 */
-"onboardingLoginErrorDescription" = "È stato commesso un errore, quindi è necessario ripetere l'operazione.";
+"onboardingLoginErrorDescription" = "Si è verificato un errore, riprovare.";
 
 /* loco:68e673754d80559c460bdf02 */
 "onboardingLoginTitle" = "Benvenuti su kDrive!";


### PR DESCRIPTION
Open the browser with the Infomaniak Login page and transitions to the next step.

https://github.com/user-attachments/assets/1321211a-7a55-4bf2-84b9-49f2ddbc9137


`ASWebAuthenticationSession` crashes the app if we build with Swift 6.
While wanting for Apple to reply to a DTS, we must build the app with Swift 5.10 (including InfomaniakLogin library)