### PR TITLE
Do not merge 2 real nodes

### DIFF
--- a/src/gui/parametersdialog.cpp
+++ b/src/gui/parametersdialog.cpp
@@ -537,6 +537,7 @@ QString ParametersDialog::getSyncPalErrorText(const QString &fctCode, const Exit
             return getSyncPalBackErrorText(err, exitCause, userIsAdmin);
         case ExitCode::SystemError:
             return getSyncPalSystemErrorText(err, exitCause);
+        case ExitCode::InvalidOperation:
         case ExitCode::FatalError:
             return tr("A technical error has occurred (error %1).<br>"
                       "Please empty the history and if the error persists, contact our support team.")
@@ -568,7 +569,6 @@ QString ParametersDialog::getSyncPalErrorText(const QString &fctCode, const Exit
         case ExitCode::TokenRefreshed:
         case ExitCode::RateLimited:
         case ExitCode::OperationCanceled:
-        case ExitCode::InvalidOperation:
         case ExitCode::UpdateRequired:
         case ExitCode::LogUploadFailed:
         case ExitCode::UpdateFailed:

--- a/src/libcommon/utility/cstypes.h
+++ b/src/libcommon/utility/cstypes.h
@@ -131,6 +131,7 @@ enum class ExitCause {
     Http5xx,
     NotEnoughINotifyWatches,
     FileOrDirectoryCorrupted,
+    UpdateTreeIntegrityCheckFailed,
     EnumEnd
 };
 

--- a/src/libcommon/utility/types.cpp
+++ b/src/libcommon/utility/types.cpp
@@ -220,6 +220,8 @@ std::string toString(const ExitCause e) {
             return "NotEnoughINotifyWatches";
         case ExitCause::FileOrDirectoryCorrupted:
             return "FileOrDirectoryCorrupted";
+        case ExitCause::UpdateTreeIntegrityCheckFailed:
+            return "UpdateTreeIntegrityCheckFailed";
         default:
             return noConversionStr;
     }

--- a/src/libsyncengine/propagation/operation_sorter/operationsorterworker.cpp
+++ b/src/libsyncengine/propagation/operation_sorter/operationsorterworker.cpp
@@ -102,8 +102,11 @@ void OperationSorterWorker::fixDeleteBeforeMove() {
 
         const auto deleteNode = deleteOp->affectedNode();
         LOG_IF_FAIL(deleteNode)
+        const auto parentPath = deleteNode->parentNode()->hasChangeEvent(OperationType::Move)
+                                        ? deleteNode->parentNode()->moveOriginInfos().path()
+                                        : deleteNode->parentNode()->getPath();
         NodeId deleteNodeParentId;
-        if (!getIdFromDb(deleteNode->side(), deleteNode->getPath().parent_path(), deleteNodeParentId)) {
+        if (!getIdFromDb(deleteNode->side(), parentPath, deleteNodeParentId)) {
             continue;
         }
 
@@ -188,8 +191,11 @@ void OperationSorterWorker::fixDeleteBeforeCreate() {
 
         const auto deleteNode = deleteOp->affectedNode();
         LOG_IF_FAIL(deleteNode)
+        const auto parentPath = deleteNode->parentNode()->hasChangeEvent(OperationType::Move)
+                                        ? deleteNode->parentNode()->moveOriginInfos().path()
+                                        : deleteNode->parentNode()->getPath();
         NodeId deleteNodeParentId;
-        if (!getIdFromDb(deleteNode->side(), deleteNode->getPath().parent_path(), deleteNodeParentId)) {
+        if (!getIdFromDb(deleteNode->side(), parentPath, deleteNodeParentId)) {
             continue;
         }
 

--- a/src/libsyncengine/syncpal/syncpalworker.cpp
+++ b/src/libsyncengine/syncpal/syncpalworker.cpp
@@ -55,7 +55,9 @@ bool shouldBePaused(const std::shared_ptr<ISyncWorker> w1, const std::shared_ptr
     const auto syncDirNotAccessible =
             (w1 && w1->exitCode() == ExitCode::SystemError && w1->exitCause() == ExitCause::SyncDirAccessError) ||
             (w2 && w2->exitCode() == ExitCode::SystemError && w2->exitCause() == ExitCause::SyncDirAccessError);
-    return networkIssue || httpBlockingError || syncDirNotAccessible;
+    const auto invalidOperation =
+            (w1 && w1->exitCode() == ExitCode::InvalidOperation) || (w2 && w2->exitCode() == ExitCode::InvalidOperation);
+    return networkIssue || httpBlockingError || syncDirNotAccessible || invalidOperation;
 }
 
 bool shouldBeStoppedAndRestarted(const std::shared_ptr<ISyncWorker> w1, const std::shared_ptr<ISyncWorker> w2 = nullptr) {

--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
@@ -92,7 +92,8 @@ void UpdateTreeWorker::execute() {
     }
 
     if (exitCode == ExitCode::Ok && !integrityCheck()) {
-        exitCode = ExitCode::DataError;
+        exitCode = ExitCode::InvalidOperation;
+        setExitCause(ExitCause::UpdateTreeIntegrityCheckFailed);
     }
 
     if (exitCode == ExitCode::Ok) {
@@ -1154,28 +1155,47 @@ bool UpdateTreeWorker::mergingTempNodeToRealNode(std::shared_ptr<Node> tmpNode, 
     return true;
 }
 
+std::wstring logStr(const std::shared_ptr<Node> node) {
+    std::wstringstream logStream;
+    logStream << L" (node ID: '" << CommonUtility::s2ws(node->id().value_or("-1")) << L"', DB ID: '" << node->idb().value_or(-1)
+              << L"', " << Utility::formatSyncName(node->name()) << L")";
+    return logStream.str();
+}
+static const auto integrityCheckFailureMsg = L" update tree integrity check failed.";
+
 bool UpdateTreeWorker::integrityCheck() {
     // TODO : check if this does not slow the process too much
     LOGW_SYNCPAL_INFO(_logger, _side << L" update tree integrity check started");
     for (const auto &[_, node]: _updateTree->nodes()) {
         if (!node->id().has_value() || node->id() == NodeId{} || node->isTmp() ||
             CommonUtility::startsWith(*node->id(), "tmp_")) {
-            std::wstringstream logStream;
-            logStream << L", DB ID: '" << node->idb().value_or(-1) << L"', name: '" << SyncName2WStr(node->name()) << L"')";
-            const auto integrityCheckFailureMsg = L" update tree integrity check failed.";
-
             if (!node->id().has_value() || node->id() == NodeId{}) {
                 LOGW_SYNCPAL_WARN(_logger, _side << integrityCheckFailureMsg << L" Found a non-temporary node without ID: "
-                                                 << L" (node ID: ''" << logStream.str());
+                                                 << logStr(node));
             } else {
                 LOGW_SYNCPAL_WARN(_logger, _side << integrityCheckFailureMsg << L" A temporary node remains in the update tree: "
-                                                 << L" (node ID: '" << CommonUtility::s2ws(node->id().value_or(""))
-                                                 << logStream.str());
+                                                 << logStr(node));
             }
 
             sentry::Handler::captureMessage(sentry::Level::Warning, "UpdateTreeWorker::integrityCheck",
                                             "A node without a valid ID remains in the update tree");
 
+            return false;
+        }
+
+        if (!checkOperationTypes(node)) return false;
+    }
+    return true;
+}
+
+bool UpdateTreeWorker::checkOperationTypes(const std::shared_ptr<Node> node) {
+    for (const auto type: {OperationType::Create, OperationType::Delete}) {
+        if (node->hasChangeEvent(type) && (node->changeEvents() | type) != type) {
+            auto typeStr = type == OperationType::Create ? L"Create" : L"Delete";
+            LOGW_SYNCPAL_WARN(_logger, _side << integrityCheckFailureMsg << L" " << typeStr
+                                             << L"d node has associated operations other than " << typeStr << L" : "
+                                             << logStr(node));
+            sentry::Handler::captureMessage(sentry::Level::Warning, "UpdateTreeWorker::integrityCheck", "Bad operations types!");
             return false;
         }
     }

--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
@@ -207,53 +207,54 @@ ExitCode UpdateTreeWorker::step3DeleteDirectory() {
             }
 
             // Check if parentNode has got a child with the same name
-            std::shared_ptr<Node> newNode = parentNode->findChildren(deleteOp->path().filename(), deleteOp->nodeId());
-            if (newNode != nullptr) {
+            std::shared_ptr<Node> existingNode = parentNode->findChildren(deleteOp->path().filename(), deleteOp->nodeId());
+            if (existingNode && existingNode->isTmp()) {
                 // Node already exists, update it
-                newNode->setIdb(idb);
-                if (!_updateTree->updateNodeId(newNode, deleteOp->nodeId())) {
+                existingNode->setIdb(idb);
+                if (!_updateTree->updateNodeId(existingNode, deleteOp->nodeId())) {
                     LOGW_SYNCPAL_WARN(_logger, L"Error in UpdateTreeWorker::updateNodeId");
                     return ExitCode::DataError;
                 }
-                newNode->setCreatedAt(deleteOp->createdAt());
-                newNode->setModificationTime(deleteOp->lastModified());
-                newNode->setSize(deleteOp->size());
-                newNode->insertChangeEvent(OperationType::Delete);
-                newNode->setIsTmp(false);
-                _updateTree->nodes()[deleteOp->nodeId()] = newNode;
+                existingNode->setCreatedAt(deleteOp->createdAt());
+                existingNode->setModificationTime(deleteOp->lastModified());
+                existingNode->setSize(deleteOp->size());
+                existingNode->insertChangeEvent(OperationType::Delete);
+                existingNode->setIsTmp(false);
+                _updateTree->nodes()[deleteOp->nodeId()] = existingNode;
                 if (ParametersCache::isExtendedLogEnabled()) {
-                    LOGW_SYNCPAL_DEBUG(_logger,
-                                       _side << L" update tree: Node '" << SyncName2WStr(newNode->name()).c_str()
-                                             << L"' (node ID: '"
-                                             << CommonUtility::s2ws(newNode->id().has_value() ? *newNode->id() : NodeId()).c_str()
-                                             << L"', DB ID: '" << (newNode->idb().has_value() ? *newNode->idb() : -1)
-                                             << L"') updated. Operation DELETE inserted in change events.");
+                    LOGW_SYNCPAL_DEBUG(
+                            _logger,
+                            _side << L" update tree: Node '" << SyncName2WStr(existingNode->name()).c_str() << L"' (node ID: '"
+                                  << CommonUtility::s2ws(existingNode->id().has_value() ? *existingNode->id() : NodeId()).c_str()
+                                  << L"', DB ID: '" << (existingNode->idb().has_value() ? *existingNode->idb() : -1)
+                                  << L"') updated. Operation DELETE inserted in change events.");
                 }
             } else {
                 // create node
-                newNode = std::make_shared<Node>(idb, _side, deleteOp->path().filename().native(), deleteOp->objectType(),
-                                                 OperationType::Delete, deleteOp->nodeId(), deleteOp->createdAt(),
-                                                 deleteOp->lastModified(), deleteOp->size(), parentNode);
-                if (newNode == nullptr) {
+                existingNode = std::make_shared<Node>(idb, _side, deleteOp->path().filename().native(), deleteOp->objectType(),
+                                                      OperationType::Delete, deleteOp->nodeId(), deleteOp->createdAt(),
+                                                      deleteOp->lastModified(), deleteOp->size(), parentNode);
+                if (existingNode == nullptr) {
                     std::cout << "Failed to allocate memory" << std::endl;
                     LOG_SYNCPAL_ERROR(_logger, "Failed to allocate memory");
                     return ExitCode::SystemError;
                 }
 
-                if (!parentNode->insertChildren(newNode)) {
-                    LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node name=" << SyncName2WStr(newNode->name())
+                if (!parentNode->insertChildren(existingNode)) {
+                    LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node name=" << SyncName2WStr(existingNode->name())
                                                                                             << L" parent node name="
                                                                                             << SyncName2WStr(parentNode->name()));
                     return ExitCode::DataError;
                 }
 
-                _updateTree->nodes()[deleteOp->nodeId()] = newNode;
+                _updateTree->nodes()[deleteOp->nodeId()] = existingNode;
                 if (ParametersCache::isExtendedLogEnabled()) {
                     LOGW_SYNCPAL_DEBUG(
                             _logger,
-                            _side << L" update tree: Node '" << SyncName2WStr(newNode->name()) << L"' (node ID: '"
-                                  << CommonUtility::s2ws(newNode->id().has_value() ? *newNode->id() : NodeId()).c_str()
-                                  << L"', DB ID: '" << (newNode->idb().has_value() ? *newNode->idb() : -1) << L"', parent ID: '"
+                            _side << L" update tree: Node '" << SyncName2WStr(existingNode->name()) << L"' (node ID: '"
+                                  << CommonUtility::s2ws(existingNode->id().has_value() ? *existingNode->id() : NodeId()).c_str()
+                                  << L"', DB ID: '" << (existingNode->idb().has_value() ? *existingNode->idb() : -1)
+                                  << L"', parent ID: '"
                                   << CommonUtility::s2ws(parentNode->id().has_value() ? *parentNode->id() : NodeId()).c_str()
                                   << L"') inserted. Operation DELETE inserted in change events.");
                 }

--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.h
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.h
@@ -160,6 +160,7 @@ class UpdateTreeWorker : public ISyncWorker {
          * @return true if no temporary node is found
          */
         bool integrityCheck();
+        bool checkOperationTypes(const std::shared_ptr<Node> node);
 
         friend class TestUpdateTreeWorker;
 };

--- a/src/server/requests/serverrequests.cpp
+++ b/src/server/requests/serverrequests.cpp
@@ -932,6 +932,7 @@ bool ServerRequests::isDisplayableError(const Error &error) {
                     return false;
             }
         }
+        case ExitCode::InvalidOperation:
         case ExitCode::LogicError: {
             return true;
         }

--- a/test/libsyncengine/integration/testintegration.cpp
+++ b/test/libsyncengine/integration/testintegration.cpp
@@ -704,7 +704,7 @@ void TestIntegration::testDeleteAndMoveCase() {
         (void) jobBB.runSynchronously();
         nodeIdBB = jobBB.nodeId();
 
-        const auto filename = "test.txt";
+        const auto filename = Str("test.txt");
         nodeIdAAA = duplicateRemoteFile(_driveDbId, _testFileRemoteId, filename);
         moveRemoteFile(_driveDbId, nodeIdAAA, nodeIdAA);
         nodeIdBBB = duplicateRemoteFile(_driveDbId, _testFileRemoteId, filename);

--- a/test/libsyncengine/integration/testintegration.cpp
+++ b/test/libsyncengine/integration/testintegration.cpp
@@ -161,6 +161,7 @@ void TestIntegration::testAll() {
     testParentRename();
     testNegativeModificationTime();
     testDeleteAndRecreateBranch();
+    testDeleteAndMoveCase();
     testSymLinkWithTooManySymbolicLevels();
     testDirSymLinkWithTooManySymbolicLevels();
     testSynchronizationOfSymLinks();
@@ -647,7 +648,7 @@ void TestIntegration::testDeleteAndRecreateBranch() {
         moveRemoteFile(_driveDbId, nodeIdAAAA, tmpRemoteDir.id());
 
         // Delete A/AA
-        deleteRemoteFile(_driveDbId, nodeIdAA);
+        deleteRemoteItem(_driveDbId, nodeIdAA);
 
         // Create A/AA/AAA1
         CreateDirJob jobAA(nullptr, _driveDbId, nodeIdA, Str("AA"));
@@ -666,6 +667,82 @@ void TestIntegration::testDeleteAndRecreateBranch() {
     CPPUNIT_ASSERT(std::filesystem::exists(_syncPal->localPath() / tmpRemoteDir.name() / "A" / "AA" / "AAA1"));
 
     logStep("testDeleteAndRecreateBranch");
+}
+
+void TestIntegration::testDeleteAndMoveCase() {
+    waitForSyncToBeIdle(SourceLocation::currentLoc());
+
+    // Setup initial situation:
+    // .
+    // └── testDeleteAndMoveCase(m)
+    //     ├── A(a)
+    //     │   └── test(aa)
+    //     │       └── test.txt(aaa)
+    //     └── B(b)
+    //         └── test(bb)
+    //             └── test.txt(bbb)
+
+    _syncPal->pause(); // We need to pause the sync because the back might take some time to notify all the events.
+    const RemoteTemporaryDirectory tmpRemoteDir(_driveDbId, _remoteSyncDir.id(), "testDeleteAndMoveCase");
+    NodeId nodeIdA;
+    NodeId nodeIdAA;
+    NodeId nodeIdAAA;
+    NodeId nodeIdB;
+    NodeId nodeIdBB;
+    NodeId nodeIdBBB;
+    {
+        CreateDirJob jobA(nullptr, _driveDbId, tmpRemoteDir.id(), Str("A"));
+        (void) jobA.runSynchronously();
+        nodeIdA = jobA.nodeId();
+        CreateDirJob jobAA(nullptr, _driveDbId, jobA.nodeId(), Str("test"));
+        (void) jobAA.runSynchronously();
+        nodeIdAA = jobAA.nodeId();
+        CreateDirJob jobB(nullptr, _driveDbId, tmpRemoteDir.id(), Str("B"));
+        (void) jobB.runSynchronously();
+        nodeIdB = jobB.nodeId();
+        CreateDirJob jobBB(nullptr, _driveDbId, jobB.nodeId(), Str("test"));
+        (void) jobBB.runSynchronously();
+        nodeIdBB = jobBB.nodeId();
+
+        const auto filename = "test.txt";
+        nodeIdAAA = duplicateRemoteFile(_driveDbId, _testFileRemoteId, filename);
+        moveRemoteFile(_driveDbId, nodeIdAAA, nodeIdAA);
+        nodeIdBBB = duplicateRemoteFile(_driveDbId, _testFileRemoteId, filename);
+        moveRemoteFile(_driveDbId, nodeIdBBB, nodeIdBB);
+    }
+    _syncPal->_remoteFSObserverWorker->forceUpdate(); // Make sure that the remote change is detected immediately
+    _syncPal->unpause();
+    waitForSyncToBeIdle(SourceLocation::currentLoc());
+
+    _syncPal->pause();
+
+    // Generate final situation:
+    // .
+    // └── main_folder(m)
+    //     └── A2(a)
+    //         └── test(bb)
+    //             └── test.txt(bbb)
+
+    // Delete aa
+    deleteRemoteItem(_driveDbId, nodeIdAA);
+    // Rename a
+    (void) RenameJob(nullptr, _driveDbId, nodeIdA, Str("A2")).runSynchronously();
+    // Move bb
+    moveRemoteFile(_driveDbId, nodeIdBB, nodeIdA);
+    // Delete b
+    deleteRemoteItem(_driveDbId, nodeIdB);
+
+    _syncPal->unpause();
+    waitForSyncToBeIdle(SourceLocation::currentLoc());
+
+    CPPUNIT_ASSERT(_syncPal->updateTree(ReplicaSide::Remote)->exists(nodeIdA));
+    CPPUNIT_ASSERT(!_syncPal->updateTree(ReplicaSide::Remote)->exists(nodeIdAA));
+    CPPUNIT_ASSERT(!_syncPal->updateTree(ReplicaSide::Remote)->exists(nodeIdAAA));
+    CPPUNIT_ASSERT(!_syncPal->updateTree(ReplicaSide::Remote)->exists(nodeIdB));
+    CPPUNIT_ASSERT(_syncPal->updateTree(ReplicaSide::Remote)->exists(nodeIdBB));
+    CPPUNIT_ASSERT(_syncPal->updateTree(ReplicaSide::Remote)->exists(nodeIdBBB));
+
+    logStep("testDeleteAndMoveCase");
 }
 
 #if defined(KD_LINUX)
@@ -943,7 +1020,7 @@ NodeId TestIntegration::duplicateRemoteFile(const int driveDbId, const NodeId &i
     return job.nodeId();
 }
 
-void TestIntegration::deleteRemoteFile(const int driveDbId, const NodeId &id) const {
+void TestIntegration::deleteRemoteItem(const int driveDbId, const NodeId &id) const {
     DeleteJob job(driveDbId, id);
     job.setBypassCheck(true);
     (void) job.runSynchronously();

--- a/test/libsyncengine/integration/testintegration.h
+++ b/test/libsyncengine/integration/testintegration.h
@@ -82,6 +82,7 @@ class TestIntegration : public CppUnit::TestFixture, public TestBase {
         void testNegativeModificationTime();
 
         void testDeleteAndRecreateBranch();
+        void testDeleteAndMoveCase();
 
         void testSynchronizationOfSymLinks();
         void testSymLinkWithTooManySymbolicLevels();
@@ -133,7 +134,7 @@ class TestIntegration : public CppUnit::TestFixture, public TestBase {
         void moveRemoteFile(const int driveDbId, const NodeId &remoteFileId, const NodeId &destinationRemoteParentId,
                             const SyncName &name = {}) const;
         NodeId duplicateRemoteFile(const int driveDbId, const NodeId &id, const SyncName &newName) const;
-        void deleteRemoteFile(const int driveDbId, const NodeId &id) const;
+        void deleteRemoteItem(const int driveDbId, const NodeId &id) const;
         SyncPath findLocalFileByNamePrefix(const SyncPath &parentAbsolutePath, const SyncName &namePrefix) const;
 
         log4cplus::Logger _logger;

--- a/test/libsyncengine/integration/testintegration_conflicts.cpp
+++ b/test/libsyncengine/integration/testintegration_conflicts.cpp
@@ -319,7 +319,7 @@ void TestIntegration::testMoveDeleteConflict() {
         waitForSyncToBeIdle(SourceLocation::currentLoc());
 
         // Delete A on remote replica
-        deleteRemoteFile(_driveDbId, info.remoteNodeIdA);
+        deleteRemoteItem(_driveDbId, info.remoteNodeIdA);
 
         // Rename A to B on local replica
         const SyncPath localPathA = _syncPal->localPath() / tmpRemoteDir.name() / "A";
@@ -348,7 +348,7 @@ void TestIntegration::testMoveDeleteConflict() {
         waitForSyncToBeIdle(SourceLocation::currentLoc());
 
         // Delete A on remote replica
-        deleteRemoteFile(_driveDbId, info.remoteNodeIdA);
+        deleteRemoteItem(_driveDbId, info.remoteNodeIdA);
 
         // Rename A to B on local replica
         const SyncPath localPathA = _syncPal->localPath() / tmpRemoteDir.name() / "A";
@@ -383,7 +383,7 @@ void TestIntegration::testMoveDeleteConflict() {
         waitForSyncToBeIdle(SourceLocation::currentLoc());
 
         // Delete A on remote replica
-        deleteRemoteFile(_driveDbId, info.remoteNodeIdA);
+        deleteRemoteItem(_driveDbId, info.remoteNodeIdA);
 
         // Rename A to B on local replica
         const SyncPath localPathA = _syncPal->localPath() / tmpRemoteDir.name() / "A";
@@ -413,7 +413,7 @@ void TestIntegration::testMoveDeleteConflict() {
         waitForSyncToBeIdle(SourceLocation::currentLoc());
 
         // Delete A on remote replica
-        deleteRemoteFile(_driveDbId, info.remoteNodeIdA);
+        deleteRemoteItem(_driveDbId, info.remoteNodeIdA);
 
         // Rename A to B on local replica
         const SyncPath localPathA = _syncPal->localPath() / tmpRemoteDir.name() / "A";
@@ -442,7 +442,7 @@ void TestIntegration::testMoveDeleteConflict() {
         waitForSyncToBeIdle(SourceLocation::currentLoc());
 
         // Delete A on remote replica
-        deleteRemoteFile(_driveDbId, info.remoteNodeIdA);
+        deleteRemoteItem(_driveDbId, info.remoteNodeIdA);
 
         // Rename A/AB to A/AB2 on local replica
         const SyncPath localPathAB = _syncPal->localPath() / tmpRemoteDir.name() / "AB";
@@ -474,7 +474,7 @@ void TestIntegration::testMoveParentDeleteConflict() {
         waitForSyncToBeIdle(SourceLocation::currentLoc());
 
         // Delete A on remote replica
-        deleteRemoteFile(_driveDbId, info.remoteNodeIdA);
+        deleteRemoteItem(_driveDbId, info.remoteNodeIdA);
 
         // Move A/AA/AAA to A/AB/AAA on local replica
         const SyncPath localPathA = _syncPal->localPath() / tmpRemoteDir.name() / "A";
@@ -504,7 +504,7 @@ void TestIntegration::testMoveParentDeleteConflict() {
         (void) RenameJob(nullptr, _driveDbId, info.remoteNodeIdA, Str("A2")).runSynchronously();
 
         // Delete A/AB on remote replica
-        deleteRemoteFile(_driveDbId, info.remoteNodeIdAB);
+        deleteRemoteItem(_driveDbId, info.remoteNodeIdAB);
 
         // Move A/AA to A/AB/AA on local replica
         const SyncPath localPathA = _syncPal->localPath() / tmpRemoteDir.name() / "A";
@@ -543,7 +543,7 @@ void TestIntegration::testMoveParentDeleteConflict() {
         waitForSyncToBeIdle(SourceLocation::currentLoc());
 
         // Delete A/AB on remote replica
-        deleteRemoteFile(_driveDbId, info.remoteNodeIdAB);
+        deleteRemoteItem(_driveDbId, info.remoteNodeIdAB);
 
         // Edit A/AB/ABB on local replica
         const SyncPath localPathA = _syncPal->localPath() / tmpRemoteDir.name() / "A";
@@ -580,7 +580,7 @@ void TestIntegration::testCreateParentDeleteConflict() {
     waitForSyncToBeIdle(SourceLocation::currentLoc());
 
     // Delete AB on remote replica
-    deleteRemoteFile(_driveDbId, info.remoteNodeIdAB);
+    deleteRemoteItem(_driveDbId, info.remoteNodeIdAB);
 
     // Create A/AB/ABA on local replica
     const SyncPath localPathA = _syncPal->localPath() / tmpRemoteDir.name() / "A";

--- a/test/libsyncengine/update_detection/update_detector/testupdatetreeworker.cpp
+++ b/test/libsyncengine/update_detection/update_detector/testupdatetreeworker.cpp
@@ -1193,7 +1193,7 @@ void TestUpdateTreeWorker::testIntegrityCheck() {
     CPPUNIT_ASSERT(_localUpdateTreeWorker->integrityCheck());
     newNode->setChangeEvents(OperationType::Edit);
     CPPUNIT_ASSERT(_localUpdateTreeWorker->integrityCheck());
-    newNode->setMoveOriginInfos(testhelpers::dummyMoveOriginInfo);
+    newNode->setMoveOriginInfos(Node::MoveOriginInfos("/dummy", "1"));
     newNode->setChangeEvents(OperationType::Move);
     CPPUNIT_ASSERT(_localUpdateTreeWorker->integrityCheck());
     newNode->setChangeEvents(OperationType::Delete);

--- a/test/libsyncengine/update_detection/update_detector/testupdatetreeworker.cpp
+++ b/test/libsyncengine/update_detection/update_detector/testupdatetreeworker.cpp
@@ -1188,6 +1188,28 @@ void TestUpdateTreeWorker::testIntegrityCheck() {
 
     newNode->setId(NodeId{"123"});
     CPPUNIT_ASSERT(_localUpdateTreeWorker->integrityCheck());
+
+    newNode->setChangeEvents(OperationType::Create);
+    CPPUNIT_ASSERT(_localUpdateTreeWorker->integrityCheck());
+    newNode->setChangeEvents(OperationType::Edit);
+    CPPUNIT_ASSERT(_localUpdateTreeWorker->integrityCheck());
+    newNode->setMoveOriginInfos(testhelpers::dummyMoveOriginInfo);
+    newNode->setChangeEvents(OperationType::Move);
+    CPPUNIT_ASSERT(_localUpdateTreeWorker->integrityCheck());
+    newNode->setChangeEvents(OperationType::Delete);
+    CPPUNIT_ASSERT(_localUpdateTreeWorker->integrityCheck());
+    newNode->setChangeEvents(OperationType::Edit | OperationType::Move);
+    CPPUNIT_ASSERT(_localUpdateTreeWorker->integrityCheck());
+    newNode->setChangeEvents(OperationType::Create | OperationType::Move);
+    CPPUNIT_ASSERT(!_localUpdateTreeWorker->integrityCheck());
+    newNode->setChangeEvents(OperationType::Create | OperationType::Edit);
+    CPPUNIT_ASSERT(!_localUpdateTreeWorker->integrityCheck());
+    newNode->setChangeEvents(OperationType::Delete | OperationType::Move);
+    CPPUNIT_ASSERT(!_localUpdateTreeWorker->integrityCheck());
+    newNode->setChangeEvents(OperationType::Delete | OperationType::Edit);
+    CPPUNIT_ASSERT(!_localUpdateTreeWorker->integrityCheck());
+    newNode->setChangeEvents(OperationType::Delete | OperationType::Create);
+    CPPUNIT_ASSERT(!_localUpdateTreeWorker->integrityCheck());
 }
 
 } // namespace KDC

--- a/test/test_utility/testhelpers.h
+++ b/test/test_utility/testhelpers.h
@@ -21,7 +21,6 @@
 #include "libcommon/utility/utility.h"
 #include "libcommon/utility/types.h"
 #include "libcommonserver/utility/utility.h"
-#include "libsyncengine/update_detection/update_detector/node.h"
 #include "version.h"
 #include "io/filestat.h"
 
@@ -43,7 +42,6 @@ inline const SyncPath localTestDirPath() {
 const SyncTime defaultTime = std::time(nullptr);
 constexpr int64_t defaultFileSize = 123;
 constexpr int64_t defaultDirSize = 0;
-const Node::MoveOriginInfos dummyMoveOriginInfo = Node::MoveOriginInfos("/dummy", "1");
 
 SyncName makeNfdSyncName();
 SyncName makeNfcSyncName();

--- a/test/test_utility/testhelpers.h
+++ b/test/test_utility/testhelpers.h
@@ -21,6 +21,7 @@
 #include "libcommon/utility/utility.h"
 #include "libcommon/utility/types.h"
 #include "libcommonserver/utility/utility.h"
+#include "libsyncengine/update_detection/update_detector/node.h"
 #include "version.h"
 #include "io/filestat.h"
 
@@ -42,6 +43,7 @@ inline const SyncPath localTestDirPath() {
 const SyncTime defaultTime = std::time(nullptr);
 constexpr int64_t defaultFileSize = 123;
 constexpr int64_t defaultDirSize = 0;
+const Node::MoveOriginInfos dummyMoveOriginInfo = Node::MoveOriginInfos("/dummy", "1");
 
 SyncName makeNfdSyncName();
 SyncName makeNfcSyncName();


### PR DESCRIPTION
A client had a recurring error on step 3 (UpdateTreeWorker) in `updateNodeWithDb`. After analyzing his logs, we figured out that in some cases, 2 real nodes might be merged into 1 node (with both Move and Delete operations associated).

The fix is [here](https://github.com/Infomaniak/desktop-kDrive/pull/1110#discussion_r2438682342), where we previously did not check if a node was temporary before merging it with another real node.