### PR TITLE
Restart login item agent on first launch after update

### DIFF
--- a/src/libcommonserver/db/db.cpp
+++ b/src/libcommonserver/db/db.cpp
@@ -101,9 +101,7 @@ Db::Db(const std::filesystem::path &dbPath) :
     _logger(Log::instance()->getLogger()),
     _sqliteDb(new SqliteDb()),
     _dbPath(dbPath),
-    _transaction(false),
-    _journalMode(defaultJournalMode(dbPath.string())),
-    _fromVersion(std::string()) {}
+    _journalMode(defaultJournalMode(dbPath.string())) {}
 
 Db::~Db() {
     close();

--- a/src/libcommonserver/db/db.h
+++ b/src/libcommonserver/db/db.h
@@ -78,6 +78,8 @@ class COMMONSERVER_EXPORT Db {
         bool tableExists(const std::string &tableName, bool &exist);
         bool columnExists(const std::string &tableName, const std::string &columnName, bool &exist);
 
+        [[nodiscard]] bool versionUpdated() const { return _versionUpdated; }
+
     protected:
         void startTransaction();
         void commitTransaction();
@@ -97,9 +99,10 @@ class COMMONSERVER_EXPORT Db {
         std::shared_ptr<SqliteDb> _sqliteDb;
         std::filesystem::path _dbPath;
         mutable std::recursive_mutex _mutex;
-        int _transaction;
+        int _transaction{0};
         std::string _journalMode;
         std::string _fromVersion;
+        bool _versionUpdated{false};
 
     private:
         bool insertVersion(const std::string &version);

--- a/src/libcommonserver/utility/utility.h
+++ b/src/libcommonserver/utility/utility.h
@@ -114,6 +114,7 @@ struct COMMONSERVER_EXPORT Utility {
 #if defined(KD_MACOS)
         static bool preventSleeping(bool enable);
         static void restartFinderExtension();
+        static void restartLoginItemAgent();
 #endif
         static bool getLinuxDesktopType(std::string &currentDesktop);
 

--- a/src/libcommonserver/utility/utility_mac.mm
+++ b/src/libcommonserver/utility/utility_mac.mm
@@ -29,6 +29,7 @@
 #include <log4cplus/loggingmacros.h>
 
 #import <AppKit/NSApplication.h>
+#import <AppKit/NSRunningApplication.h>
 #import <IOKit/pwr_mgt/IOPMLib.h>
 
 namespace KDC {
@@ -80,15 +81,18 @@ bool Utility::preventSleeping(bool enable) {
     return (ret == kIOReturnSuccess);
 }
 
+void runKillCommand(pid_t pid) {
+    NSString *killCommand = [NSString stringWithFormat:@"kill -9 %d", pid];
+    LOG_DEBUG(Log::instance()->getLogger(), "Running kill command: " << killCommand.UTF8String);
+    system(killCommand.UTF8String);
+}
+
 void Utility::restartFinderExtension() {
     NSString *bundleID = NSBundle.mainBundle.bundleIdentifier;
-    NSString *extBundleID = [NSString stringWithFormat:@"%@.Extension", bundleID];
-    NSArray<NSRunningApplication *> *apps = [NSRunningApplication runningApplicationsWithBundleIdentifier:extBundleID];
-    for (NSRunningApplication *app: apps) {
-        NSString *killCommand = [NSString stringWithFormat:@"kill -9 %d", app.processIdentifier];
-        LOG_DEBUG(Log::instance()->getLogger(), "Running kill Finder Extension command: " << killCommand.UTF8String);
-        system(killCommand.UTF8String);
-    }
+    NSString *processName = [NSString stringWithFormat:@"%@.Extension", bundleID];
+    NSArray<NSRunningApplication *> *apps = [NSRunningApplication runningApplicationsWithBundleIdentifier:processName];
+    LOG_DEBUG(Log::instance()->getLogger(), "Killing Finder Extension");
+    for (NSRunningApplication *app: apps) runKillCommand(app.processIdentifier);
 
     // Before macOS 15.0, and when other Finder extension (e.g. Goggle Drive) were installed,
     // it was needed to got to "System Settings -> Privacy & Security -> Extensions -> Added Extensions"
@@ -96,16 +100,60 @@ void Utility::restartFinderExtension() {
     // in Finder.
     // The commands below aims to simulate this manipulation.
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t) (0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-      NSString *runCommand = [NSString stringWithFormat:@"pluginkit -e ignore -i %@", extBundleID];
+      NSString *runCommand = [NSString stringWithFormat:@"pluginkit -e ignore -i %@", processName];
       LOG_DEBUG(Log::instance()->getLogger(), "Running ignore Finder Extension command: " << runCommand.UTF8String);
       system(runCommand.UTF8String);
     });
 
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t) (1.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-      NSString *runCommand = [NSString stringWithFormat:@"pluginkit -e use -i %@", extBundleID];
+      NSString *runCommand = [NSString stringWithFormat:@"pluginkit -e use -i %@", processName];
       LOG_DEBUG(Log::instance()->getLogger(), "Running use Finder Extension command: " << runCommand.UTF8String);
       system(runCommand.UTF8String);
     });
+}
+
+NSArray *getPIDsForProcessName(NSString *processName) {
+    NSTask *task = [[NSTask alloc] init];
+    [task setLaunchPath:@"/bin/ps"];
+    [task setArguments:@[ @"-axo", @"pid,comm" ]];
+
+    NSPipe *pipe = [NSPipe pipe];
+    [task setStandardOutput:pipe];
+    [task launch];
+
+    NSData *data = [[pipe fileHandleForReading] readDataToEndOfFile];
+    NSString *output = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+
+    NSMutableArray *pids = [NSMutableArray array];
+    NSArray *lines = [output componentsSeparatedByCharactersInSet:[NSCharacterSet newlineCharacterSet]];
+
+    for (NSString *line in lines) {
+        if ([line rangeOfString:processName].location != NSNotFound && ![line rangeOfString:@"grep"].location != NSNotFound) {
+            // Extraire le PID (premier champ)
+            NSArray *fields = [line componentsSeparatedByCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+            for (NSString *field in fields) {
+                if (!field || [field length] == 0 || [field isEqualToString:processName]) continue;
+                pid_t pid = [field intValue];
+                if (pid > 0) {
+                    [pids addObject:@(pid)];
+                }
+            }
+        }
+    }
+
+    return pids;
+}
+
+void Utility::restartLoginItemAgent() {
+    LOG_DEBUG(Log::instance()->getLogger(), "Killing Login Item Agent");
+    NSString *bundleID = NSBundle.mainBundle.bundleIdentifier;
+    NSString *processName =
+            [NSString stringWithFormat:@"%@%@.LoginItemAgent", [NSString stringWithUTF8String:TEAM_IDENTIFIER_PREFIX], bundleID];
+    NSMutableArray *pids = getPIDsForProcessName(processName);
+    for (NSNumber *pidNumber: pids) {
+        pid_t pid = [pidNumber longValue];
+        runKillCommand(pid);
+    }
 }
 
 bool Utility::hasLaunchOnStartup(const std::string &) {

--- a/src/libcommonserver/utility/utility_mac.mm
+++ b/src/libcommonserver/utility/utility_mac.mm
@@ -129,7 +129,6 @@ NSArray *getPIDsForProcessName(NSString *processName) {
 
     for (NSString *line in lines) {
         if ([line rangeOfString:processName].location != NSNotFound && ![line rangeOfString:@"grep"].location != NSNotFound) {
-            // Extraire le PID (premier champ)
             NSArray *fields = [line componentsSeparatedByCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
             for (NSString *field in fields) {
                 if (!field || [field length] == 0 || [field isEqualToString:processName]) continue;
@@ -150,7 +149,9 @@ void Utility::restartLoginItemAgent() {
     NSString *processName =
             [NSString stringWithFormat:@"%@%@.LoginItemAgent", [NSString stringWithUTF8String:TEAM_IDENTIFIER_PREFIX], bundleID];
     NSMutableArray *pids = getPIDsForProcessName(processName);
-    for (NSNumber *pidNumber: pids) {
+    assert(pids.count <= 1);
+    if (pids.count == 1) {
+        NSNumber *pidNumber = [pids objectAtIndex:0];
         pid_t pid = [pidNumber longValue];
         runKillCommand(pid);
     }

--- a/src/libparms/db/parmsdb.cpp
+++ b/src/libparms/db/parmsdb.cpp
@@ -1129,6 +1129,7 @@ bool ParmsDb::upgrade(const std::string &fromVersion, const std::string &toVersi
     }
 
     if (CommonUtility::isVersionLower(fromVersion, toVersion)) {
+        _versionUpdated = true;
         LOG_INFO(_logger, "Upgrade " << dbType() << " DB from " << fromVersion << " to " << toVersion);
         if (!insertUserTemplateNormalizations(fromVersion)) {
             LOG_WARN(_logger, "Insertion of the normalizations of user exclusion file patterns has failed.");

--- a/src/libsyncengine/db/syncdb.cpp
+++ b/src/libsyncengine/db/syncdb.cpp
@@ -449,6 +449,7 @@ bool SyncDb::prepare() {
 bool SyncDb::upgrade(const std::string &fromVersion, const std::string &toVersion) {
     if (!CommonUtility::isVersionLower(fromVersion, toVersion)) return true;
 
+    _versionUpdated = true;
     LOG_INFO(_logger, "Upgrade " << dbType() << " DB from " << fromVersion << " to " << toVersion);
 
     const std::string dbFromVersionNumber = CommonUtility::dbVersionNumber(fromVersion);

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -418,6 +418,10 @@ void AppServer::init() {
         return;
     }
 
+#if defined(KD_MACOS)
+    if (ParmsDb::instance()->versionUpdated()) Utility::restartLoginItemAgent();
+#endif
+
     // Start syncs
     QTimer::singleShot(0, [=, this]() { startSyncsAndRetryOnError(); });
 


### PR DESCRIPTION
After a change of communication protocol with the login item agent (after an update for example), it is necessary to restart the login item agent to apply the changes.
This PR aims at killing the login item agent on launch if a change in app version has been detected.