### PR TITLE
fix: fix rm command

### DIFF
--- a/.github/actions/build_macos/action.yml
+++ b/.github/actions/build_macos/action.yml
@@ -269,6 +269,6 @@ runs:
         if: ${{ steps.build.outcome == 'success' && inputs.release_build == 'true' }}
 
       - name: Clean-up generated code
-        run : rm -rf build-macos
+        run : rm -rf build-macos/
         shell: bash
 


### PR DESCRIPTION
This error was visible during clean-up phase on macOS:
`Run rm -rf build-macos
rm: build-macos/client/install/notarization: Directory not empty
rm: build-macos/client/install: Directory not empty
rm: build-macos/client: Directory not empty
rm: build-macos: Directory not empty
Error: Process completed with exit code 1.`