### PR TITLE
Split the upload of installers by OS when build release packages

### DIFF
--- a/.github/workflows/kdrive-desktop-release.yml
+++ b/.github/workflows/kdrive-desktop-release.yml
@@ -189,7 +189,7 @@ jobs:
           merge-multiple: true
 
       - name: Upload debug files and installers/appimage to kDrive
-        run: powershell ./infomaniak-build-tools/upload-release-to-kDrive.ps1 -version "${{ steps.get-version.outputs.kDrive_version }}"
+        run: powershell ./infomaniak-build-tools/upload-release-to-kDrive.ps1 -version "${{ steps.get-version.outputs.kDrive_version }}" -os "win"
 
       - name: Download sentry-cli and login
         run: |
@@ -230,7 +230,7 @@ jobs:
           merge-multiple: true
 
       - name: Upload debug files and installers/appimage to kDrive
-        run: powershell ./infomaniak-build-tools/upload-release-to-kDrive.ps1 -version "${{ steps.get-version.outputs.kDrive_version }}"
+        run: powershell ./infomaniak-build-tools/upload-release-to-kDrive.ps1 -version "${{ steps.get-version.outputs.kDrive_version }}" -os "linux-amd"
 
       - name: Download sentry-cli and login
         run: |
@@ -271,7 +271,7 @@ jobs:
           merge-multiple: true
 
       - name: Upload debug files and installers/appimage to kDrive
-        run: powershell ./infomaniak-build-tools/upload-release-to-kDrive.ps1 -version "${{ steps.get-version.outputs.kDrive_version }}"
+        run: powershell ./infomaniak-build-tools/upload-release-to-kDrive.ps1 -version "${{ steps.get-version.outputs.kDrive_version }}" -os "linux-arm"
 
       - name: Download sentry-cli and login
         run: |
@@ -312,7 +312,7 @@ jobs:
           merge-multiple: true
 
       - name: Upload debug files and installers/appimage to kDrive
-        run: powershell ./infomaniak-build-tools/upload-release-to-kDrive.ps1 -version "${{ steps.get-version.outputs.kDrive_version }}"
+        run: powershell ./infomaniak-build-tools/upload-release-to-kDrive.ps1 -version "${{ steps.get-version.outputs.kDrive_version }}" -os "mac"
 
       - name: Download sentry-cli and login
         run: |

--- a/.github/workflows/kdrive-desktop-release.yml
+++ b/.github/workflows/kdrive-desktop-release.yml
@@ -312,7 +312,7 @@ jobs:
           merge-multiple: true
 
       - name: Upload debug files and installers/appimage to kDrive
-        run: powershell ./infomaniak-build-tools/upload-release-to-kDrive.ps1 -version "${{ steps.get-version.outputs.kDrive_version }}" -os "mac"
+        run: powershell ./infomaniak-build-tools/upload-release-to-kDrive.ps1 -version "${{ steps.get-version.outputs.kDrive_version }}" -os "macos"
 
       - name: Download sentry-cli and login
         run: |

--- a/.github/workflows/kdrive-desktop-release.yml
+++ b/.github/workflows/kdrive-desktop-release.yml
@@ -164,8 +164,8 @@ jobs:
           release_build_altool_username: ${{ secrets.ALTOOL_USERNAME }}
 
 # Upload the installer and sentry artifacts
-  upload-to-kDrive-and-sentry:
-    needs: [build-Linux-amd, build-Linux-arm, build-Windows, build-MacOS]
+  upload-to-kDrive-and-sentry-Windows:
+    needs: [build-Windows]
     runs-on: [self-hosted, Windows, desktop-kdrive-with-gui] # Could be runing on any windows runner, but we use 'desktop-kdrive-with-gui' to avoid monopolizing the runners that are used for the CI builds.
     env:
         KDRIVE_TOKEN: ${{ secrets.KDRIVE_TOKEN }}
@@ -188,27 +188,6 @@ jobs:
           pattern: win-release-artifacts-*
           merge-multiple: true
 
-      - name: Download macOS artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: build-macos
-          pattern: macos-release-artifacts-*
-          merge-multiple: true
-
-      - name: Download Linux ARM64 artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: build-linux-arm64
-          pattern: linux-release-artifacts-*-arm64
-          merge-multiple: true
-
-      - name: Download Linux AMD64 artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: build-linux-amd64
-          pattern: linux-release-artifacts-*-amd64
-          merge-multiple: true
-
       - name: Upload debug files and installers/appimage to kDrive
         run: powershell ./infomaniak-build-tools/upload-release-to-kDrive.ps1 -version "${{ steps.get-version.outputs.kDrive_version }}"
 
@@ -226,12 +205,119 @@ jobs:
           .\sentry-cli.exe debug-files upload --project kdrive-client --type sourcebundle .\build-windows\kDrive_client.src.zip
         shell: powershell
 
+  upload-to-kDrive-and-sentry-Linux-amd:
+    needs: [build-Linux-amd]
+    runs-on: [self-hosted, Windows, desktop-kdrive-with-gui] # Could be runing on any windows runner, but we use 'desktop-kdrive-with-gui' to avoid monopolizing the runners that are used for the CI builds.
+    env:
+        KDRIVE_TOKEN: ${{ secrets.KDRIVE_TOKEN }}
+        KDRIVE_ID: ${{ secrets.KDRIVE_ID }}
+        KDRIVE_DIR_ID: ${{ secrets.KDRIVE_DIR_ID }}
+    steps:
+      - name: Checkout the PR
+        uses: actions/checkout@v4.1.1
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Get kDrive version
+        id: get-version
+        uses: ./.github/actions/get_version
+
+      - name: Download Linux AMD64 artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: build-linux-amd64
+          pattern: linux-release-artifacts-*-amd64
+          merge-multiple: true
+
+      - name: Upload debug files and installers/appimage to kDrive
+        run: powershell ./infomaniak-build-tools/upload-release-to-kDrive.ps1 -version "${{ steps.get-version.outputs.kDrive_version }}"
+
+      - name: Download sentry-cli and login
+        run: |
+          Invoke-WebRequest -Uri https://github.com/getsentry/sentry-cli/releases/download/2.46.0/sentry-cli-Windows-x86_64.exe -OutFile sentry-cli.exe
+          .\sentry-cli.exe login --auth-token ${{ secrets.SENTRY_AUTH_TOKEN }}
+        shell: powershell
+
       - name: Upload sentry artifacts - Linux
         run: |
           .\sentry-cli.exe debug-files upload --project kdrive-server .\build-linux\kDrive.dbg
           .\sentry-cli.exe debug-files upload --project kdrive-client .\build-linux\kDrive_client.dbg
           .\sentry-cli.exe debug-files upload --project kdrive-server --type sourcebundle .\build-linux\kDrive.src.zip
           .\sentry-cli.exe debug-files upload --project kdrive-client --type sourcebundle .\build-linux\kDrive_client.src.zip
+        shell: powershell
+
+  upload-to-kDrive-and-sentry-Linux-arm:
+    needs: [build-Linux-arm]
+    runs-on: [self-hosted, Windows, desktop-kdrive-with-gui] # Could be runing on any windows runner, but we use 'desktop-kdrive-with-gui' to avoid monopolizing the runners that are used for the CI builds.
+    env:
+        KDRIVE_TOKEN: ${{ secrets.KDRIVE_TOKEN }}
+        KDRIVE_ID: ${{ secrets.KDRIVE_ID }}
+        KDRIVE_DIR_ID: ${{ secrets.KDRIVE_DIR_ID }}
+    steps:
+      - name: Checkout the PR
+        uses: actions/checkout@v4.1.1
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Get kDrive version
+        id: get-version
+        uses: ./.github/actions/get_version
+
+      - name: Download Linux ARM64 artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: build-linux-arm64
+          pattern: linux-release-artifacts-*-arm64
+          merge-multiple: true
+
+      - name: Upload debug files and installers/appimage to kDrive
+        run: powershell ./infomaniak-build-tools/upload-release-to-kDrive.ps1 -version "${{ steps.get-version.outputs.kDrive_version }}"
+
+      - name: Download sentry-cli and login
+        run: |
+          Invoke-WebRequest -Uri https://github.com/getsentry/sentry-cli/releases/download/2.46.0/sentry-cli-Windows-x86_64.exe -OutFile sentry-cli.exe
+          .\sentry-cli.exe login --auth-token ${{ secrets.SENTRY_AUTH_TOKEN }}
+        shell: powershell
+
+      - name: Upload sentry artifacts - Linux
+        run: |
+          .\sentry-cli.exe debug-files upload --project kdrive-server .\build-linux\kDrive.dbg
+          .\sentry-cli.exe debug-files upload --project kdrive-client .\build-linux\kDrive_client.dbg
+          .\sentry-cli.exe debug-files upload --project kdrive-server --type sourcebundle .\build-linux\kDrive.src.zip
+          .\sentry-cli.exe debug-files upload --project kdrive-client --type sourcebundle .\build-linux\kDrive_client.src.zip
+        shell: powershell
+
+  upload-to-kDrive-and-sentry-macOS:
+    needs: [build-MacOS]
+    runs-on: [self-hosted, Windows, desktop-kdrive-with-gui] # Could be runing on any windows runner, but we use 'desktop-kdrive-with-gui' to avoid monopolizing the runners that are used for the CI builds.
+    env:
+        KDRIVE_TOKEN: ${{ secrets.KDRIVE_TOKEN }}
+        KDRIVE_ID: ${{ secrets.KDRIVE_ID }}
+        KDRIVE_DIR_ID: ${{ secrets.KDRIVE_DIR_ID }}
+    steps:
+      - name: Checkout the PR
+        uses: actions/checkout@v4.1.1
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Get kDrive version
+        id: get-version
+        uses: ./.github/actions/get_version
+
+      - name: Download macOS artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: build-macos
+          pattern: macos-release-artifacts-*
+          merge-multiple: true
+
+      - name: Upload debug files and installers/appimage to kDrive
+        run: powershell ./infomaniak-build-tools/upload-release-to-kDrive.ps1 -version "${{ steps.get-version.outputs.kDrive_version }}"
+
+      - name: Download sentry-cli and login
+        run: |
+          Invoke-WebRequest -Uri https://github.com/getsentry/sentry-cli/releases/download/2.46.0/sentry-cli-Windows-x86_64.exe -OutFile sentry-cli.exe
+          .\sentry-cli.exe login --auth-token ${{ secrets.SENTRY_AUTH_TOKEN }}
         shell: powershell
 
       - name: Upload sentry artifacts - macOS

--- a/.github/workflows/kdrive-desktop-release.yml
+++ b/.github/workflows/kdrive-desktop-release.yml
@@ -207,7 +207,7 @@ jobs:
 
   upload-to-kDrive-and-sentry-Linux-amd:
     needs: [build-Linux-amd]
-    runs-on: [self-hosted, Windows, desktop-kdrive-with-gui] # Could be runing on any windows runner, but we use 'desktop-kdrive-with-gui' to avoid monopolizing the runners that are used for the CI builds.
+    runs-on: [self-hosted, Windows, desktop-kdrive-with-gui] # Could be running on any windows runner, but we use 'desktop-kdrive-with-gui' to avoid monopolizing the runners that are used for the CI builds.
     env:
         KDRIVE_TOKEN: ${{ secrets.KDRIVE_TOKEN }}
         KDRIVE_ID: ${{ secrets.KDRIVE_ID }}
@@ -248,7 +248,7 @@ jobs:
 
   upload-to-kDrive-and-sentry-Linux-arm:
     needs: [build-Linux-arm]
-    runs-on: [self-hosted, Windows, desktop-kdrive-with-gui] # Could be runing on any windows runner, but we use 'desktop-kdrive-with-gui' to avoid monopolizing the runners that are used for the CI builds.
+    runs-on: [self-hosted, Windows, desktop-kdrive-with-gui] # Could be running on any windows runner, but we use 'desktop-kdrive-with-gui' to avoid monopolizing the runners that are used for the CI builds.
     env:
         KDRIVE_TOKEN: ${{ secrets.KDRIVE_TOKEN }}
         KDRIVE_ID: ${{ secrets.KDRIVE_ID }}
@@ -289,7 +289,7 @@ jobs:
 
   upload-to-kDrive-and-sentry-macOS:
     needs: [build-MacOS]
-    runs-on: [self-hosted, Windows, desktop-kdrive-with-gui] # Could be runing on any windows runner, but we use 'desktop-kdrive-with-gui' to avoid monopolizing the runners that are used for the CI builds.
+    runs-on: [self-hosted, Windows, desktop-kdrive-with-gui] # Could be running on any windows runner, but we use 'desktop-kdrive-with-gui' to avoid monopolizing the runners that are used for the CI builds.
     env:
         KDRIVE_TOKEN: ${{ secrets.KDRIVE_TOKEN }}
         KDRIVE_ID: ${{ secrets.KDRIVE_ID }}

--- a/infomaniak-build-tools/upload-release-to-kDrive.ps1
+++ b/infomaniak-build-tools/upload-release-to-kDrive.ps1
@@ -19,7 +19,7 @@ param (
     [Parameter(Mandatory = $true)]
     [string]$version,
 
-    [ValidateSet('win', 'mac', 'linux-arm', 'linux-amd')]
+    [ValidateSet('win', 'macos', 'linux-arm', 'linux-amd')]
     [string] $os
 )
 
@@ -160,7 +160,7 @@ if ($os -eq "win") {
     Write-Host " - Windows Files - \n"
 }
 
-if ($os -eq "mac") {
+if ($os -eq "macos") {
     Write-Host " - macOS Files - " # macOS
     $macos_files = @(
         "$app.pkg",

--- a/infomaniak-build-tools/upload-release-to-kDrive.ps1
+++ b/infomaniak-build-tools/upload-release-to-kDrive.ps1
@@ -17,7 +17,10 @@
 #>
 param (
     [Parameter(Mandatory = $true)]
-    [string]$version
+    [string]$version,
+
+    [ValidateSet('win', 'mac', 'linux-arm', 'linux-amd')]
+    [string] $os
 )
 
 if (-not $env:KDRIVE_TOKEN) {
@@ -53,12 +56,6 @@ $headers = @{
 }
 
 # upload release notes
-$os_s = @(
-    "linux",
-    "macos",
-    "win"
-)
-
 $languages = @(
     "de",
     "en",
@@ -67,8 +64,7 @@ $languages = @(
     "it"
 )
 
-foreach ($os in $os_s)
-{
+if ($os -ne "linux-arm") {  # Do not upload linux release notes twice
     foreach ($lang in $languages)
     {
         $fileName = "kDrive-$versionNumber-$os-$lang.html"
@@ -150,48 +146,57 @@ function Upload-FilesToKDrive {
     }
     Pop-Location
 }
-Write-Host " - Windows Files - " # Windows
-$win_files = @(
-    "$app.exe",
-    "kDrive.pdb",
-    "kDrive_client.pdb",
-    "kDrive.src.zip",
-    "kDrive_client.src.zip"
-)
-Upload-FilesToKDrive -directory build-windows -files $win_files -targetSubDir "windows"
-Write-Host " - Windows Files - \n"
 
-Write-Host " - macOS Files - " # macOS
-$macos_files = @(
-    "$app.pkg",
-    "$app.zip", # Sparkle zip
-    "update-macos-$version.xml", # Sparkle update xml
-    "kDrive.dSYM",
-    "kDrive_client.dSYM",
-    "kDrive.src.zip",
-    "kDrive_client.src.zip"
-)
-Upload-FilesToKDrive -directory build-macos -files $macos_files -targetSubDir "macos"
-Write-Host " - macOS Files - \n"
+if ($os -eq "win") {
+    Write-Host " - Windows Files - " # Windows
+    $win_files = @(
+        "$app.exe",
+        "kDrive.pdb",
+        "kDrive_client.pdb",
+        "kDrive.src.zip",
+        "kDrive_client.src.zip"
+    )
+    Upload-FilesToKDrive -directory build-windows -files $win_files -targetSubDir "windows"
+    Write-Host " - Windows Files - \n"
+}
 
-Write-Host " - Linux AMD64 Files - " # Linux AMD
-$linux_amd_files = @(
-    "$app-amd64.AppImage",
-    "kDrive.dbg",
-    "kDrive_client.dbg",
-    "kDrive.src.zip",
-    "kDrive_client.src.zip"
-)
-Upload-FilesToKDrive -directory build-linux-amd64 -files $linux_amd_files -targetSubDir "linux-amd"
-Write-Host " - Linux AMD64 Files - \n"
+if ($os -eq "mac") {
+    Write-Host " - macOS Files - " # macOS
+    $macos_files = @(
+        "$app.pkg",
+        "$app.zip", # Sparkle zip
+        "update-macos-$version.xml", # Sparkle update xml
+        "kDrive.dSYM",
+        "kDrive_client.dSYM",
+        "kDrive.src.zip",
+        "kDrive_client.src.zip"
+    )
+    Upload-FilesToKDrive -directory build-macos -files $macos_files -targetSubDir "macos"
+    Write-Host " - macOS Files - \n"
+}
 
-Write-Host " - Linux ARM64 Files - " # Linux ARM
-$linux_arm_files = @(
-    "$app-arm64.AppImage",
-    "kDrive.dbg",
-    "kDrive_client.dbg",
-    "kDrive.src.zip",
-    "kDrive_client.src.zip"
-)
-Upload-FilesToKDrive -directory build-linux-arm64 -files $linux_arm_files -targetSubDir "linux-arm"
-Write-Host " - Linux ARM64 Files - \n"
+if ($os -eq "linux-amd") {
+    Write-Host " - Linux AMD64 Files - " # Linux AMD
+    $linux_amd_files = @(
+        "$app-amd64.AppImage",
+        "kDrive.dbg",
+        "kDrive_client.dbg",
+        "kDrive.src.zip",
+        "kDrive_client.src.zip"
+    )
+    Upload-FilesToKDrive -directory build-linux-amd64 -files $linux_amd_files -targetSubDir "linux-amd"
+    Write-Host " - Linux AMD64 Files - \n"
+}
+
+if ($os -eq "linux-arm") {
+    Write-Host " - Linux ARM64 Files - " # Linux ARM
+    $linux_arm_files = @(
+        "$app-arm64.AppImage",
+        "kDrive.dbg",
+        "kDrive_client.dbg",
+        "kDrive.src.zip",
+        "kDrive_client.src.zip"
+    )
+    Upload-FilesToKDrive -directory build-linux-arm64 -files $linux_arm_files -targetSubDir "linux-arm"
+    Write-Host " - Linux ARM64 Files - \n"
+}

--- a/infomaniak-build-tools/upload-release-to-kDrive.ps1
+++ b/infomaniak-build-tools/upload-release-to-kDrive.ps1
@@ -64,29 +64,27 @@ $languages = @(
     "it"
 )
 
-if ($os -ne "linux-arm") {  # Do not upload linux release notes twice
-    foreach ($lang in $languages)
-    {
-        $fileName = "kDrive-$versionNumber-$os-$lang.html"
-        $filePath = ".\release_notes\kDrive-$versionNumber\$fileName"
-        if (-not (Test-Path $filePath)) {
-            Write-Host "❌ File $filePath does not exist, aborting upload." -f Red
-            exit 1
-        }
-
-        $size = (Get-ChildItem $filePath | % {[int]($_.length)})
-        if ($size -eq 0) {
-            Write-Host "Unable to get file size for $filePath, aborting upload." -f Red
-            Pop-Location
-            exit 1
-        }
-
-        $uri = "https://api.infomaniak.com/3/drive/$env:KDRIVE_ID/upload?directory_id=$env:KDRIVE_DIR_ID&total_size=$size&file_name=$fileName&directory_path=$versionNumber/$date/release-notes&conflict=version"
-        Write-Host "uploading $filePath to kDrive at $uri"
-        $result = Invoke-RestMethod -Method "POST" -Uri $uri -Header $headers -ContentType 'application/octet-stream' -InFile $filePath
-        Write-Host "Uploaded $filePath to kDrive successfully. $result" -f Green
-        Sleep(5)
+foreach ($lang in $languages)
+{
+    $fileName = "kDrive-$versionNumber-$os-$lang.html"
+    $filePath = ".\release_notes\kDrive-$versionNumber\$fileName"
+    if (-not (Test-Path $filePath)) {
+        Write-Host "❌ File $filePath does not exist, aborting upload." -f Red
+        exit 1
     }
+
+    $size = (Get-ChildItem $filePath | % {[int]($_.length)})
+    if ($size -eq 0) {
+        Write-Host "Unable to get file size for $filePath, aborting upload." -f Red
+        Pop-Location
+        exit 1
+    }
+
+    $uri = "https://api.infomaniak.com/3/drive/$env:KDRIVE_ID/upload?directory_id=$env:KDRIVE_DIR_ID&total_size=$size&file_name=$fileName&directory_path=$versionNumber/$date/release-notes&conflict=version"
+    Write-Host "uploading $filePath to kDrive at $uri"
+    $result = Invoke-RestMethod -Method "POST" -Uri $uri -Header $headers -ContentType 'application/octet-stream' -InFile $filePath
+    Write-Host "Uploaded $filePath to kDrive successfully. $result" -f Green
+    Sleep(5)
 }
 
 function Upload-FilesToKDrive {

--- a/translations/client_de.ts
+++ b/translations/client_de.ts
@@ -208,12 +208,12 @@ Bitte wählen Sie einen anderen Ordner. Wenn Sie fortfahren, wird Lite Sync deak
 <context>
     <name>KDC::AddDriveLoginWidget</name>
     <message>
-        <location filename="../src/gui/adddriveloginwidget.cpp" line="92"/>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
         <source>Token request failed: %1 - %2</source>
         <translation>Token-Anfrage fehlgeschlagen: %1 - %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/adddriveloginwidget.cpp" line="106"/>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="99"/>
         <source>Login failed: %1 - %2</source>
         <translation>Login fehlgeschlagen: %1 - %2</translation>
     </message>
@@ -284,8 +284,13 @@ Bitte wählen Sie einen anderen Ordner. Wenn Sie fortfahren, wird Lite Sync deak
 </context>
 <context>
     <name>KDC::AppServer</name>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="1497"/>
+        <source>Share link copied to clipboard</source>
+        <translation>Link zum Teilen in die Zwischenablage kopiert</translation>
+    </message>
     <message numerus="yes">
-        <location filename="../src/server/appserver.cpp" line="3328"/>
+        <location filename="../src/server/appserver.cpp" line="3445"/>
         <source>%1 and %n other file(s) have been removed.</source>
         <translation>
             <numerusform>%1 und %n andere Datei(en) wurde(n) gelöscht.</numerusform>
@@ -293,13 +298,13 @@ Bitte wählen Sie einen anderen Ordner. Wenn Sie fortfahren, wird Lite Sync deak
         </translation>
     </message>
     <message>
-        <location filename="../src/server/appserver.cpp" line="3330"/>
+        <location filename="../src/server/appserver.cpp" line="3447"/>
         <source>%1 has been removed.</source>
         <comment>%1 names a file.</comment>
         <translation>%1 wurde gelöscht.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/server/appserver.cpp" line="3335"/>
+        <location filename="../src/server/appserver.cpp" line="3452"/>
         <source>%1 and %n other file(s) have been added.</source>
         <translation>
             <numerusform>%1 und %n andere Datei(en) wurde(n) hinzugefügt.</numerusform>
@@ -307,13 +312,13 @@ Bitte wählen Sie einen anderen Ordner. Wenn Sie fortfahren, wird Lite Sync deak
         </translation>
     </message>
     <message>
-        <location filename="../src/server/appserver.cpp" line="3337"/>
+        <location filename="../src/server/appserver.cpp" line="3454"/>
         <source>%1 has been added.</source>
         <comment>%1 names a file.</comment>
         <translation>%1 wurde hinzugefügt.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/server/appserver.cpp" line="3342"/>
+        <location filename="../src/server/appserver.cpp" line="3459"/>
         <source>%1 and %n other file(s) have been updated.</source>
         <translation>
             <numerusform>%1 und %n andere Datei(en) wurde(n) aktualisiert.</numerusform>
@@ -321,13 +326,13 @@ Bitte wählen Sie einen anderen Ordner. Wenn Sie fortfahren, wird Lite Sync deak
         </translation>
     </message>
     <message>
-        <location filename="../src/server/appserver.cpp" line="3344"/>
+        <location filename="../src/server/appserver.cpp" line="3461"/>
         <source>%1 has been updated.</source>
         <comment>%1 names a file.</comment>
         <translation>%1 wurde aktualisiert.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/server/appserver.cpp" line="3349"/>
+        <location filename="../src/server/appserver.cpp" line="3466"/>
         <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
         <translation>
             <numerusform>%1 wurde zu %2 verschoben und %n andere Datei(en) wurde(n) verschoben.</numerusform>
@@ -335,17 +340,17 @@ Bitte wählen Sie einen anderen Ordner. Wenn Sie fortfahren, wird Lite Sync deak
         </translation>
     </message>
     <message>
-        <location filename="../src/server/appserver.cpp" line="3352"/>
+        <location filename="../src/server/appserver.cpp" line="3469"/>
         <source>%1 has been moved to %2.</source>
         <translation>%1 wurde zu %2 verschoben.</translation>
     </message>
     <message>
-        <location filename="../src/server/appserver.cpp" line="3360"/>
+        <location filename="../src/server/appserver.cpp" line="3477"/>
         <source>Sync Activity</source>
         <translation>Synchronisierungsaktivität</translation>
     </message>
     <message>
-        <location filename="../src/server/appserver.cpp" line="4266"/>
+        <location filename="../src/server/appserver.cpp" line="4379"/>
         <source>A new folder larger than %1 MB has been added in the drive %2, you must validate its synchronization: %3.
 </source>
         <translation>Ein neuer Ordner mit einer Grösse von mehr als %1 MB wurde zum Laufwerk %2 hinzugefügt, Sie müssen die Synchronisierung überprüfen: %3.
@@ -471,17 +476,17 @@ Wählen Sie diejenigen aus, die Sie synchronisieren möchten:</translation>
         <translation>Es wurden keine Synchronisierungsordner konfiguriert.</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1428"/>
+        <location filename="../src/gui/clientgui.cpp" line="1417"/>
         <source>Synthesis</source>
         <translation>Synthese</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1429"/>
+        <location filename="../src/gui/clientgui.cpp" line="1418"/>
         <source>Preferences</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1430"/>
+        <location filename="../src/gui/clientgui.cpp" line="1419"/>
         <source>Quit</source>
         <translation>Beenden</translation>
     </message>
@@ -526,22 +531,22 @@ Wählen Sie diejenigen aus, die Sie synchronisieren möchten:</translation>
         <translation>%1 (Synchronisierung wurde angehalten)</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1263"/>
+        <location filename="../src/gui/clientgui.cpp" line="1252"/>
         <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
         <translation>Möchten Sie die Synchronisierungen des Kontos &lt;i&gt;%1&lt;/i&gt; wirklich entfernen?&lt;br&gt;&lt;b&gt;Hinweis:&lt;/b&gt; Dadurch werden &lt;b&gt;keine&lt;/b&gt; Dateien gelöscht.</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1267"/>
+        <location filename="../src/gui/clientgui.cpp" line="1256"/>
         <source>REMOVE ALL SYNCHRONIZATIONS</source>
         <translation>ALLE SYNC. ENTFERNEN</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1268"/>
+        <location filename="../src/gui/clientgui.cpp" line="1257"/>
         <source>CANCEL</source>
         <translation>ABBRECHEN</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1596"/>
+        <location filename="../src/gui/clientgui.cpp" line="1585"/>
         <source>Failed to start synchronizations!</source>
         <translation>Synchronisierungen konnten nicht gestartet werden!</translation>
     </message>
@@ -564,12 +569,6 @@ Wählen Sie diejenigen aus, die Sie synchronisieren möchten:</translation>
         <location filename="../src/gui/clientgui.cpp" line="255"/>
         <source>Synchronization is paused</source>
         <translation>Synchronisierung wird angehalten</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="876"/>
-        <location filename="../src/gui/clientgui.cpp" line="924"/>
-        <source>The shared link has been copied to the clipboard.</source>
-        <translation>Der freigegebene Link wurde in die Zwischenablage kopiert.</translation>
     </message>
 </context>
 <context>
@@ -945,145 +944,160 @@ Wählen Sie diejenigen aus, die Sie synchronisieren möchten:</translation>
 <context>
     <name>KDC::DrivePreferencesWidget</name>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1258"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1310"/>
         <source>Folders</source>
         <translation>Ordner</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1260"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1312"/>
         <source>Notifications</source>
         <translation>Benachrichtigungen</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1263"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1315"/>
         <source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
         <translation>Es wird eine Benachrichtigung angezeigt, sobald ein neuer Ordner synchronisiert oder geändert wurde</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1264"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1316"/>
         <source>Connected with</source>
         <translation>Verbunden mit</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1070"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1133"/>
         <source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
         <translation>Wollen Sie die Synchronisierung des Ordners &lt;i&gt;%1&lt;/i&gt;wirklich beenden?&lt;br&gt;&lt;b&gt;Hinweis:&lt;/b&gt; Hierdurch werden &lt;b&gt;keine&lt;/b&gt; Dateien gelöscht.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="128"/>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1257"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="129"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1309"/>
         <source>Some folders were not synchronized because they are too large.</source>
         <translation>Einige Ordner wurden nicht synchronisiert, da sie zu gross sind.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="400"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="397"/>
         <source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
         <translation>Dieser Vorgang kann je nach Größe des Ordners zwischen einigen Sekunden und einigen Minuten dauern.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="404"/>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="436"/>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1075"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="401"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="432"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1138"/>
         <source>CANCEL</source>
         <translation>ABBRECHEN</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="803"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="802"/>
         <source>New local folder synchronization failed!</source>
         <translation>Neue Synchronisierung des lokalen Ordners fehlgeschlagen!</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="979"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="977"/>
         <source>Lite Sync activation failed.</source>
         <translation>Lite Sync-Aktivierung fehlgeschlagen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="997"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="995"/>
         <source>Lite Sync deactivation failed.</source>
         <translation>Lite Sync-Deaktivierung fehlgeschlagen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1074"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1137"/>
         <source>REMOVE FOLDER SYNC CONNECTION</source>
         <translation>VERBINDUNG FÜR ORDNERSYNC. ENTFERNEN</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1142"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1200"/>
         <source>An error occurred while loading the list of subfolders.</source>
         <translation>Beim Laden der Liste der Unterordner ist ein Fehler aufgetreten.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1261"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1313"/>
         <source>Enable the notifications for this kDrive</source>
         <translation>Benachrichtigungen für diesen kDrive aktivieren</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="403"/>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="435"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="400"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="431"/>
         <source>CONFIRM</source>
         <translation>BESTÄTIGEN</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="118"/>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1256"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="119"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1308"/>
         <source>Synchronization errors and information.</source>
         <translation>Synchronisierungsfehler und Informationen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="147"/>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1259"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="153"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1311"/>
         <source>Synchronize a local folder</source>
         <translation>Lokalen Ordner synchronisieren</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="399"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="396"/>
         <source>Do you really want to turn on Lite Sync?</source>
         <translation>Wollen Sie Lite Sync wirklich einschalten?</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="427"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="423"/>
         <source>Do you really want to turn off Lite Sync?</source>
         <translation>Wollen Sie Lite Sync wirklich ausschalten?</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="429"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="425"/>
         <source>You don&apos;t have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
         <translation>Sie haben nicht genug Speicherplatz, um alle Dateien auf Ihrem kDrive (%1 fehlt) zu synchronisieren. Wenn Sie Lite Sync ausschalten, müssen Sie die auf Ihrem Rechner zu synchronisierenden Ordner auswählen. Bis dahin wird die Synchronisierung Ihres kDrive ausgesetzt.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="433"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="429"/>
         <source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
         <translation>Wenn Sie Lite Sync deaktivieren, werden alle Dateien auf Ihren Computer heruntergeladen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="666"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="680"/>
         <source>Failed to create new synchronization</source>
         <translation>Neue Synchronisierung konnte nicht erstellt werden</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="975"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="973"/>
         <source>Lite Sync activated.</source>
         <translation>Lite Sync aktiviert.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="993"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="991"/>
         <source>Lite Sync deactivated.</source>
         <translation>Lite Sync ist deaktiviert.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1056"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1053"/>
         <source>This drive is being deleted.</source>
         <translation>Dieses Laufwerk wird gelöscht.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1097"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1114"/>
+        <source>Impossible to open item %1</source>
+        <translation>Element %1 kann nicht geöffnet werden</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1159"/>
         <source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
         <translation>Die Synchronisierung des Ordners &lt;i&gt;%1&lt;/i&gt; konnte nicht beendet werden.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1265"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1317"/>
         <source>Remove all synchronizations</source>
         <translation>Entfernen Sie alle Synchronisierungen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1318"/>
+        <source>Search in your kDrive</source>
+        <translation>Suchen Sie in Ihrem kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1319"/>
+        <source>Search</source>
+        <translation>Suche</translation>
     </message>
 </context>
 <context>
@@ -1609,7 +1623,7 @@ Bitte verwenden Sie den folgenden Link, um die Protokolle an den Support zu send
         <location filename="../src/gui/parametersdialog.cpp" line="428"/>
         <location filename="../src/gui/parametersdialog.cpp" line="488"/>
         <location filename="../src/gui/parametersdialog.cpp" line="528"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="541"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="542"/>
         <source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
         <translation>Ein technischer Fehler ist aufgetreten (Fehler %1).&lt;br&gt;Bitte leeren Sie den Verlauf und kontaktieren Sie unser Support-Team, falls der Fehler weiterhin besteht.</translation>
     </message>
@@ -1687,7 +1701,7 @@ Bitte verwenden Sie den folgenden Link, um die Protokolle an den Support zu send
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="423"/>
         <source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
-        <translation type="unfinished">Eine Datei oder ein Ordner in Ihrem Synchronisationsordner scheint beschädigt zu sein.&lt;br&gt;Die Synchronisation wurde gestoppt.</translation>
+        <translation>Eine Datei oder ein Ordner in Ihrem Synchronisationsordner scheint beschädigt zu sein.&lt;br&gt;Die Synchronisation wurde gestoppt.</translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="437"/>
@@ -1755,22 +1769,22 @@ Bitte verwenden Sie den folgenden Link, um die Protokolle an den Support zu send
         <translation>Beim Zugriff auf die Synchronisierungsdatenbank ist ein Fehler aufgetreten (Fehler %1). Die &lt;br/&gt;Synchronisierung wurde angehalten.</translation>
     </message>
     <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="545"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="546"/>
         <source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
         <translation>Es ist ein Anmeldeproblem aufgetreten (Fehler %1).&lt;br&gt;Token ungültig oder widerrufen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="550"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="551"/>
         <source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
         <translation>Verschachtelte Synchronisierungen sind verboten (Fehler %1).&lt;br&gt;Sie sollten nur Synchronisierungen behalten, deren Ordner nicht verschachtelt sind.</translation>
     </message>
     <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="554"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="555"/>
         <source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
         <translation>Der Synchronisationsordner auf dem entfernten kDrive existiert nicht mehr oder ist nicht mehr zugänglich (Fehler %1).&lt;br&gt;Sie müssen ihn wiederherstellen oder ihm wieder Zugriffsrechte geben oder die Synchronisation löschen/neu erstellen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="561"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="562"/>
         <source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
         <translation>Fehler beim Parsen des Dateinamens (Fehler %1).&lt;br&gt;Sonderzeichen wie doppelte Anführungszeichen, umgekehrte Schrägstriche oder Zeilenumbrüche können zu Parsingfehlern führen.</translation>
     </message>
@@ -2309,42 +2323,6 @@ Bitte verwenden Sie den folgenden Link, um die Protokolle an den Support zu send
     </message>
 </context>
 <context>
-    <name>KDC::SocketApi</name>
-    <message>
-        <location filename="../src/server/socketapi.cpp" line="815"/>
-        <location filename="../src/server/socketapi.cpp" line="1022"/>
-        <location filename="../src/server/socketapi.cpp" line="1074"/>
-        <source>Copy private share link</source>
-        <translation>Link zur privaten Freigabe kopieren</translation>
-    </message>
-    <message>
-        <location filename="../src/server/socketapi.cpp" line="1001"/>
-        <location filename="../src/server/socketapi.cpp" line="1058"/>
-        <source>Resharing this file is not allowed</source>
-        <translation>Die erneute Freigabe dieser Datei ist nicht erlaubt</translation>
-    </message>
-    <message>
-        <location filename="../src/server/socketapi.cpp" line="1002"/>
-        <location filename="../src/server/socketapi.cpp" line="1059"/>
-        <source>Resharing this folder is not allowed</source>
-        <translation>Die erneute Freigabe dieses Ordners ist nicht erlaubt</translation>
-    </message>
-    <message>
-        <location filename="../src/server/socketapi.cpp" line="1013"/>
-        <location filename="../src/server/socketapi.cpp" line="1017"/>
-        <location filename="../src/server/socketapi.cpp" line="1068"/>
-        <location filename="../src/server/socketapi.cpp" line="1070"/>
-        <source>Copy public share link</source>
-        <translation>Öffentlichen Freigabelink kopieren</translation>
-    </message>
-    <message>
-        <location filename="../src/server/socketapi.cpp" line="1211"/>
-        <location filename="../src/server/socketapi.cpp" line="1279"/>
-        <source>Open in browser</source>
-        <translation>Im Browser öffnen</translation>
-    </message>
-</context>
-<context>
     <name>KDC::StatusBarWidget</name>
     <message>
         <location filename="../src/gui/statusbarwidget.cpp" line="178"/>
@@ -2382,6 +2360,11 @@ Bitte verwenden Sie den folgenden Link, um die Protokolle an den Support zu send
 <context>
     <name>KDC::SynchronizedItemWidget</name>
     <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
+        <source>Copy share link</source>
+        <translation>Link zur Freigabe kopieren</translation>
+    </message>
+    <message>
         <location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
         <source>Display on kdrive.infomaniak.com</source>
         <translation>Anzeigen auf kdrive.infomaniak.com</translation>
@@ -2405,11 +2388,6 @@ Bitte verwenden Sie den folgenden Link, um die Protokolle an den Support zu send
         <location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
         <source>Add to favorites</source>
         <translation>Zu Favoriten hinzufügen</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
-        <source>Copy sharing link</source>
-        <translation>Freigabelink kopieren</translation>
     </message>
 </context>
 <context>
@@ -2536,23 +2514,23 @@ Bitte verwenden Sie den folgenden Link, um die Protokolle an den Support zu send
 <context>
     <name>KDC::SynthesisPopover</name>
     <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1176"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1171"/>
         <source>Update kDrive App</source>
         <translation>Aktualisieren Sie die kDrive-App</translation>
     </message>
     <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1177"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1172"/>
         <source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
         <translation>Diese kDrive-App-Version wird nicht mehr unterstützt. Um auf die neuesten Funktionen und Verbesserungen zuzugreifen, aktualisieren Sie bitte.</translation>
     </message>
     <message>
         <location filename="../src/gui/synthesispopover.cpp" line="966"/>
-        <location filename="../src/gui/synthesispopover.cpp" line="1179"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1174"/>
         <source>Update</source>
         <translation>Aktualisieren</translation>
     </message>
     <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1181"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1176"/>
         <source>Please download the latest version on the website.</source>
         <translation>Bitte laden Sie die neueste Version auf der Website herunter.</translation>
     </message>
@@ -2577,7 +2555,7 @@ Bitte verwenden Sie den folgenden Link, um die Protokolle an den Support zu send
         <translation>Nicht verfügbar</translation>
     </message>
     <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1194"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1189"/>
         <source>You can synchronize files &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;from your computer&lt;/a&gt; or on &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
         <translation>Sie können Dateien &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;von Ihrem Computer&lt;/a&gt; oder von &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt; synchronisieren.</translation>
     </message>
@@ -2598,27 +2576,27 @@ Bitte verwenden Sie den folgenden Link, um die Protokolle an den Support zu send
     </message>
     <message>
         <location filename="../src/gui/synthesispopover.cpp" line="1123"/>
-        <location filename="../src/gui/synthesispopover.cpp" line="1175"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1170"/>
         <source>Not implemented!</source>
         <translation>Nicht implementiert!</translation>
     </message>
     <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1187"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1182"/>
         <source>No synchronized folder for this Drive!</source>
         <translation>Kein synchronisierter Ordner für diesen kDrive!</translation>
     </message>
     <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1190"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1185"/>
         <source>No kDrive configured!</source>
         <translation>Kein kDrive eingerichtet!</translation>
     </message>
     <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1156"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1151"/>
         <source>Unable to open link %1.</source>
         <translation>Link %1 kann nicht geöffnet werden.</translation>
     </message>
     <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1168"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1163"/>
         <source>Invalid link %1.</source>
         <translation>Ungültiger Link %1.</translation>
     </message>
@@ -2675,87 +2653,92 @@ Bitte verwenden Sie den folgenden Link, um die Protokolle an den Support zu send
 <context>
     <name>KDC::VersionWidget</name>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="270"/>
+        <location filename="../src/gui/versionwidget.cpp" line="295"/>
         <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</source>
         <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="157"/>
+        <location filename="../src/gui/versionwidget.cpp" line="169"/>
         <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Show release note&lt;/a&gt;</source>
         <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Versionshinweis anzeigen&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="160"/>
+        <location filename="../src/gui/versionwidget.cpp" line="172"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="161"/>
+        <location filename="../src/gui/versionwidget.cpp" line="173"/>
         <source>UPDATE</source>
         <translation>AKTUALISIEREN</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="176"/>
+        <location filename="../src/gui/versionwidget.cpp" line="197"/>
         <source>%1 is up to date!</source>
         <translation>%1 ist auf dem neuesten Stand!</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="180"/>
+        <location filename="../src/gui/versionwidget.cpp" line="201"/>
         <source>Checking update on server...</source>
         <translation>Überprüfe Update auf dem Server...</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="184"/>
+        <location filename="../src/gui/versionwidget.cpp" line="205"/>
         <source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;here&lt;/a&gt;.</source>
         <translation>Ein Update ist verfügbar: %1.&lt;br&gt;Bitte laden Sie es &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;hier&lt;/a&gt; herunter.</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="191"/>
+        <location filename="../src/gui/versionwidget.cpp" line="212"/>
         <source>An update is available: %1</source>
         <translation>Ein Update ist verfügbar: %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="197"/>
+        <location filename="../src/gui/versionwidget.cpp" line="218"/>
         <source>Downloading %1. Please wait...</source>
         <translation>Herunterladen von %1. Bitte warten…</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="202"/>
+        <location filename="../src/gui/versionwidget.cpp" line="223"/>
         <source>Could not check for new updates.</source>
         <translation>Es konnte nicht nach neuen Updates gesucht werden.</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="206"/>
+        <location filename="../src/gui/versionwidget.cpp" line="227"/>
         <source>An error occurred during update.</source>
         <translation>Während der Aktualisierung ist ein Fehler aufgetreten.</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="210"/>
+        <location filename="../src/gui/versionwidget.cpp" line="231"/>
         <source>Could not download update.</source>
         <translation>Das Update konnte nicht heruntergeladen werden.</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="226"/>
+        <location filename="../src/gui/versionwidget.cpp" line="235"/>
+        <source>Update disabled.</source>
+        <translation>Update deaktiviert.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="251"/>
         <source>Beta program</source>
         <translation>Beta-Programm</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="227"/>
+        <location filename="../src/gui/versionwidget.cpp" line="252"/>
         <source>Get early access to new versions of the application</source>
         <translation>Frühzeitiger Zugang zu neuen Versionen der Anwendung</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="231"/>
+        <location filename="../src/gui/versionwidget.cpp" line="256"/>
         <source>Join</source>
         <translation>Beitreten</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="234"/>
+        <location filename="../src/gui/versionwidget.cpp" line="259"/>
         <source>Modify</source>
         <translation>Ändern Sie</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="234"/>
+        <location filename="../src/gui/versionwidget.cpp" line="259"/>
         <source>Quit</source>
         <translation>Beenden</translation>
     </message>
@@ -2773,47 +2756,47 @@ Bitte verwenden Sie den folgenden Link, um die Protokolle an den Support zu send
         <translation>Einstellungen können nicht gespeichert werden!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="340"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="355"/>
         <source>The parent folder is a sync folder or contained in one</source>
         <translation>Der übergeordnete Ordner ist ein Sync-Ordner oder befindet sich in einem / einer</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="361"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="376"/>
         <source>Can&apos;t find a valid path</source>
         <translation>Kann keinen gültigen Pfad finden</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="1839"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="1862"/>
         <source>No valid folder selected!</source>
         <translation>Kein gültiger Ordner ausgewählt!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="1850"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="1873"/>
         <source>The selected path does not exist!</source>
         <translation>Der ausgewählte Pfad existiert nicht!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="1855"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="1878"/>
         <source>The selected path is not a folder!</source>
         <translation>Der ausgewählte Pfad ist kein Ordner!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="1860"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="1883"/>
         <source>You have no permission to write to the selected folder!</source>
         <translation>Sie haben keine Schreibberechtigung für den ausgewählten Ordner!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="1890"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="1913"/>
         <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
         <translation>Der lokale Ordner %1 enthält einen bereits synchronisierten Ordner. Bitte wählen Sie einen anderen!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="1898"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="1921"/>
         <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
         <translation>Der lokale Ordner %1 befindet sich in einem bereits synchronisierten Ordner. Bitte wählen Sie einen anderen!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="1908"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="1931"/>
         <source>The local folder %1 is already synced on the same drive. Please pick another one!</source>
         <translation>Der lokale Ordner %1 ist bereits auf demselben Drive synchronisiert. Bitte wählen Sie einen anderen!</translation>
     </message>
@@ -2837,11 +2820,56 @@ Bitte verwenden Sie den folgenden Link, um die Protokolle an den Support zu send
         <source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
         <translation>Lite Sync ist deaktiviert. Die kDrive-Dateien nutzen den Speicherplatz Ihres Computers.</translation>
     </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1167"/>
+        <source>Make available locally</source>
+        <translation>Lokal verfügbar machen</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1171"/>
+        <source>Free up local space</source>
+        <translation>Lokalen Speicherplatz freigeben</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1175"/>
+        <source>Cancel free up local space</source>
+        <translation>Lokalen Speicherplatz freigeben abbrechen</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1179"/>
+        <source>Cancel make available locally</source>
+        <translation>Lokal verfügbar machen abbrechen</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1183"/>
+        <source>Resharing this file is not allowed</source>
+        <translation>Die erneute Freigabe dieser Datei ist nicht erlaubt</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1184"/>
+        <source>Resharing this folder is not allowed</source>
+        <translation>Die erneute Freigabe dieses Ordners ist nicht erlaubt</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1188"/>
+        <source>Copy public share link</source>
+        <translation>Öffentlichen Freigabelink kopieren</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1192"/>
+        <source>Copy private share link</source>
+        <translation>Link zur privaten Freigabe kopieren</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1196"/>
+        <source>Open in browser</source>
+        <translation>Im Browser öffnen</translation>
+    </message>
 </context>
 <context>
     <name>SharedTools::QtSingleApplication</name>
     <message>
-        <location filename="../src/server/appserver.cpp" line="102"/>
+        <location filename="../src/server/appserver.cpp" line="106"/>
         <source>kDrive application will close due to a fatal error.</source>
         <translation>Die kDrive-Anwendung wird aufgrund eines schwerwiegenden Fehlers geschlossen.</translation>
     </message>
@@ -2933,27 +2961,6 @@ Bitte verwenden Sie den folgenden Link, um die Protokolle an den Support zu send
 <context>
     <name>utility</name>
     <message>
-        <location filename="../src/server/socketapi.cpp" line="1362"/>
-        <source>Make available locally</source>
-        <translation>Lokal verfügbar machen</translation>
-    </message>
-    <message>
-        <location filename="../src/server/socketapi.cpp" line="1370"/>
-        <source>Cancel free up local space</source>
-        <translation>Lokalen Speicherplatz freigeben abbrechen</translation>
-    </message>
-    <message>
-        <location filename="../src/server/socketapi.cpp" line="1375"/>
-        <location filename="../src/server/socketapi.cpp" line="1377"/>
-        <source>Cancel make available locally</source>
-        <translation>Lokal verfügbar machen abbrechen</translation>
-    </message>
-    <message>
-        <location filename="../src/server/socketapi.cpp" line="1366"/>
-        <source>Free up local space</source>
-        <translation>Lokalen Speicherplatz freigeben</translation>
-    </message>
-    <message>
         <location filename="../src/gui/guiutility.cpp" line="79"/>
         <source>Could not open browser</source>
         <translation>Konnte Browser nicht öffnen</translation>
@@ -3036,6 +3043,11 @@ Sie können eines über die kDrive-Einstellungen hinzufügen.</translation>
         <location filename="../src/gui/guiutility.cpp" line="596"/>
         <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
         <translation>Der Ordner &lt;b&gt;%1&lt;/b&gt; kann nicht als Synchronisationsordner ausgewählt werden. Bitte wählen Sie einen anderen Ordner. Vorgeschlagener Ordner: &lt;b&gt;%2&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="638"/>
+        <source>You cannot exclude more than 1000 folders. Please uncheck higher-level folders.</source>
+        <translation>Sie können nicht mehr als 1000 Verzeichnisse ausschließen. Bitte heben Sie die Markierung von übergeordneten Ordnern auf.</translation>
     </message>
     <message>
         <location filename="../src/gui/guiutility.cpp" line="347"/>

--- a/translations/client_es.ts
+++ b/translations/client_es.ts
@@ -208,12 +208,12 @@ Seleccione otra carpeta. Si continúa, Lite Sync se deshabilitará.&lt;br&gt;
 <context>
     <name>KDC::AddDriveLoginWidget</name>
     <message>
-        <location filename="../src/gui/adddriveloginwidget.cpp" line="92"/>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
         <source>Token request failed: %1 - %2</source>
         <translation>Error al solicitar el token: %1 – %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/adddriveloginwidget.cpp" line="106"/>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="99"/>
         <source>Login failed: %1 - %2</source>
         <translation>Inicio de sesión fallido: %1 – %2</translation>
     </message>
@@ -284,8 +284,13 @@ Seleccione otra carpeta. Si continúa, Lite Sync se deshabilitará.&lt;br&gt;
 </context>
 <context>
     <name>KDC::AppServer</name>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="1497"/>
+        <source>Share link copied to clipboard</source>
+        <translation>Enlace compartido copiado al portapapeles</translation>
+    </message>
     <message numerus="yes">
-        <location filename="../src/server/appserver.cpp" line="3328"/>
+        <location filename="../src/server/appserver.cpp" line="3445"/>
         <source>%1 and %n other file(s) have been removed.</source>
         <translation>
             <numerusform>%1 y otros %n archivo(s) han sido borrados.</numerusform>
@@ -293,13 +298,13 @@ Seleccione otra carpeta. Si continúa, Lite Sync se deshabilitará.&lt;br&gt;
         </translation>
     </message>
     <message>
-        <location filename="../src/server/appserver.cpp" line="3330"/>
+        <location filename="../src/server/appserver.cpp" line="3447"/>
         <source>%1 has been removed.</source>
         <comment>%1 names a file.</comment>
         <translation>%1 ha sido eliminado.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/server/appserver.cpp" line="3335"/>
+        <location filename="../src/server/appserver.cpp" line="3452"/>
         <source>%1 and %n other file(s) have been added.</source>
         <translation>
             <numerusform>%1 y % otros archivo(s) han sido añadidos.</numerusform>
@@ -307,13 +312,13 @@ Seleccione otra carpeta. Si continúa, Lite Sync se deshabilitará.&lt;br&gt;
         </translation>
     </message>
     <message>
-        <location filename="../src/server/appserver.cpp" line="3337"/>
+        <location filename="../src/server/appserver.cpp" line="3454"/>
         <source>%1 has been added.</source>
         <comment>%1 names a file.</comment>
         <translation>%1 ha sido añadido.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/server/appserver.cpp" line="3342"/>
+        <location filename="../src/server/appserver.cpp" line="3459"/>
         <source>%1 and %n other file(s) have been updated.</source>
         <translation>
             <numerusform>%1 y otros %n archivo(s) han sido actualizados.</numerusform>
@@ -321,13 +326,13 @@ Seleccione otra carpeta. Si continúa, Lite Sync se deshabilitará.&lt;br&gt;
         </translation>
     </message>
     <message>
-        <location filename="../src/server/appserver.cpp" line="3344"/>
+        <location filename="../src/server/appserver.cpp" line="3461"/>
         <source>%1 has been updated.</source>
         <comment>%1 names a file.</comment>
         <translation>%1 ha sido actualizado.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/server/appserver.cpp" line="3349"/>
+        <location filename="../src/server/appserver.cpp" line="3466"/>
         <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
         <translation>
             <numerusform>%1 ha sido movido a %2 y otros %n archivo(s) han sido movidos.</numerusform>
@@ -335,17 +340,17 @@ Seleccione otra carpeta. Si continúa, Lite Sync se deshabilitará.&lt;br&gt;
         </translation>
     </message>
     <message>
-        <location filename="../src/server/appserver.cpp" line="3352"/>
+        <location filename="../src/server/appserver.cpp" line="3469"/>
         <source>%1 has been moved to %2.</source>
         <translation>%1 ha sido movido a %2.</translation>
     </message>
     <message>
-        <location filename="../src/server/appserver.cpp" line="3360"/>
+        <location filename="../src/server/appserver.cpp" line="3477"/>
         <source>Sync Activity</source>
         <translation>Actividad de sincronización</translation>
     </message>
     <message>
-        <location filename="../src/server/appserver.cpp" line="4266"/>
+        <location filename="../src/server/appserver.cpp" line="4379"/>
         <source>A new folder larger than %1 MB has been added in the drive %2, you must validate its synchronization: %3.
 </source>
         <translation>Se ha añadido una nueva carpeta mayor a %1 MB en el drive %2, debes validar su sincronización: %3.
@@ -471,17 +476,17 @@ Selecciona los que quieras sincronizar:</translation>
         <translation>No hay carpetas de sincronización configuradas.</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1428"/>
+        <location filename="../src/gui/clientgui.cpp" line="1417"/>
         <source>Synthesis</source>
         <translation>Síntesis</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1429"/>
+        <location filename="../src/gui/clientgui.cpp" line="1418"/>
         <source>Preferences</source>
         <translation>Preferencias</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1430"/>
+        <location filename="../src/gui/clientgui.cpp" line="1419"/>
         <source>Quit</source>
         <translation>Salir</translation>
     </message>
@@ -526,22 +531,22 @@ Selecciona los que quieras sincronizar:</translation>
         <translation>%1 (sincronización en pausa)</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1263"/>
+        <location filename="../src/gui/clientgui.cpp" line="1252"/>
         <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
         <translation>¿Realmente desea eliminar las sincronizaciones de la cuenta &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Nota:&lt;/b&gt; Esto &lt;b&gt;no&lt;/b&gt; eliminará ningún archivo.</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1267"/>
+        <location filename="../src/gui/clientgui.cpp" line="1256"/>
         <source>REMOVE ALL SYNCHRONIZATIONS</source>
         <translation>ELIMINAR TODAS LAS SINC.</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1268"/>
+        <location filename="../src/gui/clientgui.cpp" line="1257"/>
         <source>CANCEL</source>
         <translation>CANCELAR</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1596"/>
+        <location filename="../src/gui/clientgui.cpp" line="1585"/>
         <source>Failed to start synchronizations!</source>
         <translation>¡Error al iniciar las sincronizaciones!</translation>
     </message>
@@ -564,12 +569,6 @@ Selecciona los que quieras sincronizar:</translation>
         <location filename="../src/gui/clientgui.cpp" line="255"/>
         <source>Synchronization is paused</source>
         <translation>La sincronización está en pausa</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="876"/>
-        <location filename="../src/gui/clientgui.cpp" line="924"/>
-        <source>The shared link has been copied to the clipboard.</source>
-        <translation>El enlace compartido se ha copiado en el portapapeles.</translation>
     </message>
 </context>
 <context>
@@ -943,145 +942,160 @@ Selecciona los que quieras sincronizar:</translation>
 <context>
     <name>KDC::DrivePreferencesWidget</name>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1258"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1310"/>
         <source>Folders</source>
         <translation>Carpetas</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1260"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1312"/>
         <source>Notifications</source>
         <translation>Notificaciones</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1263"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1315"/>
         <source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
         <translation>Se mostrará una notificación en cuanto se haya sincronizado o modificado una nueva carpeta</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1264"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1316"/>
         <source>Connected with</source>
         <translation>Conectado con</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1070"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1133"/>
         <source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
         <translation>¿Estás seguro de que deseas dejar de sincronizar la carpeta &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Nota:&lt;/b&gt; Esto &lt;b&gt;no&lt;/b&gt; eliminará ningún archivo.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="128"/>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1257"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="129"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1309"/>
         <source>Some folders were not synchronized because they are too large.</source>
         <translation>Algunas carpetas no fueron sincronizadas por ser demasiado grandes.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="400"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="397"/>
         <source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
         <translation>Esta operación puede durar de unos segundos a unos minutos en función del tamaño de la carpeta.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="404"/>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="436"/>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1075"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="401"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="432"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1138"/>
         <source>CANCEL</source>
         <translation>CANCELAR</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="803"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="802"/>
         <source>New local folder synchronization failed!</source>
         <translation>¡Error al sincronizar las nuevas carpetas locales!</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="979"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="977"/>
         <source>Lite Sync activation failed.</source>
         <translation>Error en la activación de Lite Sync.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="997"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="995"/>
         <source>Lite Sync deactivation failed.</source>
         <translation>Ha fallado la desactivación de Lite Sync.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1074"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1137"/>
         <source>REMOVE FOLDER SYNC CONNECTION</source>
         <translation>ELIMINAR CONEXIÓN DE SINCRONIZACIÓN DE CARPETAS</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1142"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1200"/>
         <source>An error occurred while loading the list of subfolders.</source>
         <translation>Se produjo un error al cargar la lista de subcarpetas.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1261"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1313"/>
         <source>Enable the notifications for this kDrive</source>
         <translation>Habilitar las notificaciones para este kDrive</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="403"/>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="435"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="400"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="431"/>
         <source>CONFIRM</source>
         <translation>CONFIRMAR</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="118"/>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1256"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="119"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1308"/>
         <source>Synchronization errors and information.</source>
         <translation>Errores de sincronización e información.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="147"/>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1259"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="153"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1311"/>
         <source>Synchronize a local folder</source>
         <translation>Sincronizar una carpeta local</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="399"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="396"/>
         <source>Do you really want to turn on Lite Sync?</source>
         <translation>¿Estás seguro de que deseas activar Lite Sync?</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="427"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="423"/>
         <source>Do you really want to turn off Lite Sync?</source>
         <translation>¿Estás seguro de que deseas desactivar Lite Sync?</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="429"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="425"/>
         <source>You don&apos;t have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
         <translation>No tienes suficiente espacio para sincronizar todos los archivos en el kDrive (falta %1). Si se desactiva Lite Sync, habrá que elegir qué carpetas se sincronizan en el ordenador. Mientras tanto, se detendrá la sincronización de tu kDrive.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="433"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="429"/>
         <source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
         <translation>Si desactivas Lite Sync, todos los archivos se descargarán en tu ordenador.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="666"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="680"/>
         <source>Failed to create new synchronization</source>
         <translation>No se pudo crear la nueva sincronización</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="975"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="973"/>
         <source>Lite Sync activated.</source>
         <translation>Lite Sync activado.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="993"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="991"/>
         <source>Lite Sync deactivated.</source>
         <translation>Lite Sync desactivado.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1056"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1053"/>
         <source>This drive is being deleted.</source>
         <translation>Esta unidad se está eliminando.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1097"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1114"/>
+        <source>Impossible to open item %1</source>
+        <translation>Imposible abrir el elemento %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1159"/>
         <source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
         <translation>No se pudo detener la sincronización de la carpeta &lt;i&gt;%1&lt;/i&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1265"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1317"/>
         <source>Remove all synchronizations</source>
         <translation>Eliminar todas las sincronizaciones</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1318"/>
+        <source>Search in your kDrive</source>
+        <translation>Busca en tu kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1319"/>
+        <source>Search</source>
+        <translation>Buscar en</translation>
     </message>
 </context>
 <context>
@@ -1607,7 +1621,7 @@ Por favor, utilice el siguiente enlace para enviar los registros al soporte: &lt
         <location filename="../src/gui/parametersdialog.cpp" line="428"/>
         <location filename="../src/gui/parametersdialog.cpp" line="488"/>
         <location filename="../src/gui/parametersdialog.cpp" line="528"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="541"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="542"/>
         <source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
         <translation>Se ha producido un error técnico (error %1).&lt;br&gt;Vacíe el historial y, si el error persiste, póngase en contacto con nuestro equipo de soporte.</translation>
     </message>
@@ -1685,7 +1699,7 @@ Por favor, utilice el siguiente enlace para enviar los registros al soporte: &lt
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="423"/>
         <source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
-        <translation type="unfinished">Un archivo o carpeta dentro su carpeta de sincronización parece estar corrupto.&lt;br&gt;La sincronización se ha detenido.</translation>
+        <translation>Un archivo o carpeta dentro su carpeta de sincronización parece estar corrupto.&lt;br&gt;La sincronización se ha detenido.</translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="437"/>
@@ -1753,22 +1767,22 @@ Por favor, utilice el siguiente enlace para enviar los registros al soporte: &lt
         <translation>Se ha producido un error al acceder a la base de datos de sincronización (error %1).&lt;br&gt;La sincronización se ha detenido.</translation>
     </message>
     <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="545"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="546"/>
         <source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
         <translation>Se ha producido un problema de inicio de sesión (error %1).&lt;br&gt;Token no válido o revocado.</translation>
     </message>
     <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="550"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="551"/>
         <source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
         <translation>Las sincronizaciones anidadas están prohibidas (error %1).&lt;br&gt;Solo debes conservar las sincronizaciones cuyas carpetas no estén anidadas.</translation>
     </message>
     <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="554"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="555"/>
         <source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
         <translation>La carpeta de sincronización en el kDrive remoto ya no existe o ya no es accesible (error %1).&lt;br&gt;Debe restaurarla o devolverle los derechos de acceso o eliminar/recrear la sincronización.</translation>
     </message>
     <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="561"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="562"/>
         <source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
         <translation>Error de análisis del nombre de archivo (error %1).&lt;br&gt;Los caracteres especiales como comillas dobles, barras invertidas o retornos de línea pueden provocar errores de análisis.</translation>
     </message>
@@ -2307,42 +2321,6 @@ Por favor, utilice el siguiente enlace para enviar los registros al soporte: &lt
     </message>
 </context>
 <context>
-    <name>KDC::SocketApi</name>
-    <message>
-        <location filename="../src/server/socketapi.cpp" line="815"/>
-        <location filename="../src/server/socketapi.cpp" line="1022"/>
-        <location filename="../src/server/socketapi.cpp" line="1074"/>
-        <source>Copy private share link</source>
-        <translation>Copiar enlace para compartir privado</translation>
-    </message>
-    <message>
-        <location filename="../src/server/socketapi.cpp" line="1001"/>
-        <location filename="../src/server/socketapi.cpp" line="1058"/>
-        <source>Resharing this file is not allowed</source>
-        <translation>No está permitido volver a compartir este archivo</translation>
-    </message>
-    <message>
-        <location filename="../src/server/socketapi.cpp" line="1002"/>
-        <location filename="../src/server/socketapi.cpp" line="1059"/>
-        <source>Resharing this folder is not allowed</source>
-        <translation>No está permitido volver a compartir esta carpeta</translation>
-    </message>
-    <message>
-        <location filename="../src/server/socketapi.cpp" line="1013"/>
-        <location filename="../src/server/socketapi.cpp" line="1017"/>
-        <location filename="../src/server/socketapi.cpp" line="1068"/>
-        <location filename="../src/server/socketapi.cpp" line="1070"/>
-        <source>Copy public share link</source>
-        <translation>Copiar enlace para compartir públicamente</translation>
-    </message>
-    <message>
-        <location filename="../src/server/socketapi.cpp" line="1211"/>
-        <location filename="../src/server/socketapi.cpp" line="1279"/>
-        <source>Open in browser</source>
-        <translation>Abrir en navegador</translation>
-    </message>
-</context>
-<context>
     <name>KDC::StatusBarWidget</name>
     <message>
         <location filename="../src/gui/statusbarwidget.cpp" line="178"/>
@@ -2380,6 +2358,11 @@ Por favor, utilice el siguiente enlace para enviar los registros al soporte: &lt
 <context>
     <name>KDC::SynchronizedItemWidget</name>
     <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
+        <source>Copy share link</source>
+        <translation>Copiar enlace compartido</translation>
+    </message>
+    <message>
         <location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
         <source>Display on kdrive.infomaniak.com</source>
         <translation>Mostrar en kdrive.infomaniak.com</translation>
@@ -2403,11 +2386,6 @@ Por favor, utilice el siguiente enlace para enviar los registros al soporte: &lt
         <location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
         <source>Add to favorites</source>
         <translation>Añadir a favoritos</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
-        <source>Copy sharing link</source>
-        <translation>Copiar enlace para compartir</translation>
     </message>
 </context>
 <context>
@@ -2534,23 +2512,23 @@ Por favor, utilice el siguiente enlace para enviar los registros al soporte: &lt
 <context>
     <name>KDC::SynthesisPopover</name>
     <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1176"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1171"/>
         <source>Update kDrive App</source>
         <translation>Actualizar la aplicación kDrive</translation>
     </message>
     <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1177"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1172"/>
         <source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
         <translation>Esta versión de la aplicación kDrive ya no es compatible. Para acceder a las últimas funciones y mejoras, actualice.</translation>
     </message>
     <message>
         <location filename="../src/gui/synthesispopover.cpp" line="966"/>
-        <location filename="../src/gui/synthesispopover.cpp" line="1179"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1174"/>
         <source>Update</source>
         <translation>Actualizar</translation>
     </message>
     <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1181"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1176"/>
         <source>Please download the latest version on the website.</source>
         <translation>Descargue la última versión del sitio web.</translation>
     </message>
@@ -2575,7 +2553,7 @@ Por favor, utilice el siguiente enlace para enviar los registros al soporte: &lt
         <translation>Indisponible</translation>
     </message>
     <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1194"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1189"/>
         <source>You can synchronize files &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;from your computer&lt;/a&gt; or on &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
         <translation>Puedes sincronizar archivos &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;desde tu ordenador&lt;/a&gt; o en &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
     </message>
@@ -2596,27 +2574,27 @@ Por favor, utilice el siguiente enlace para enviar los registros al soporte: &lt
     </message>
     <message>
         <location filename="../src/gui/synthesispopover.cpp" line="1123"/>
-        <location filename="../src/gui/synthesispopover.cpp" line="1175"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1170"/>
         <source>Not implemented!</source>
         <translation>¡No implementado!</translation>
     </message>
     <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1187"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1182"/>
         <source>No synchronized folder for this Drive!</source>
         <translation>¡No hay ninguna carpeta sincronizada para este Drive!</translation>
     </message>
     <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1190"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1185"/>
         <source>No kDrive configured!</source>
         <translation>¡No hay ningún kDrive configurado!</translation>
     </message>
     <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1156"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1151"/>
         <source>Unable to open link %1.</source>
         <translation>No se puede abrir el enlace %1.</translation>
     </message>
     <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1168"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1163"/>
         <source>Invalid link %1.</source>
         <translation>Enlace %1 no válido.</translation>
     </message>
@@ -2673,87 +2651,92 @@ Por favor, utilice el siguiente enlace para enviar los registros al soporte: &lt
 <context>
     <name>KDC::VersionWidget</name>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="270"/>
+        <location filename="../src/gui/versionwidget.cpp" line="295"/>
         <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</source>
         <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="157"/>
+        <location filename="../src/gui/versionwidget.cpp" line="169"/>
         <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Show release note&lt;/a&gt;</source>
         <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Mostrar nota de lanzamiento&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="160"/>
+        <location filename="../src/gui/versionwidget.cpp" line="172"/>
         <source>Version</source>
         <translation>Versión</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="161"/>
+        <location filename="../src/gui/versionwidget.cpp" line="173"/>
         <source>UPDATE</source>
         <translation>ACTUALIZAR</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="176"/>
+        <location filename="../src/gui/versionwidget.cpp" line="197"/>
         <source>%1 is up to date!</source>
         <translation>¡%1 está actualizado!</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="180"/>
+        <location filename="../src/gui/versionwidget.cpp" line="201"/>
         <source>Checking update on server...</source>
         <translation>Comprobando actualización en servidor...</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="184"/>
+        <location filename="../src/gui/versionwidget.cpp" line="205"/>
         <source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;here&lt;/a&gt;.</source>
         <translation>Hay una actualización disponible: %1. Descárgala &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;aquí&lt;/a&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="191"/>
+        <location filename="../src/gui/versionwidget.cpp" line="212"/>
         <source>An update is available: %1</source>
         <translation>Hay disponible una actualización: %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="197"/>
+        <location filename="../src/gui/versionwidget.cpp" line="218"/>
         <source>Downloading %1. Please wait...</source>
         <translation>Descargando %1. Espera...</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="202"/>
+        <location filename="../src/gui/versionwidget.cpp" line="223"/>
         <source>Could not check for new updates.</source>
         <translation>No se puede comprobar si hay actualizaciones.</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="206"/>
+        <location filename="../src/gui/versionwidget.cpp" line="227"/>
         <source>An error occurred during update.</source>
         <translation>Se ha producido un error durante la actualización.</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="210"/>
+        <location filename="../src/gui/versionwidget.cpp" line="231"/>
         <source>Could not download update.</source>
         <translation>No se ha podido descargar la actualización.</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="226"/>
+        <location filename="../src/gui/versionwidget.cpp" line="235"/>
+        <source>Update disabled.</source>
+        <translation>Actualización desactivada.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="251"/>
         <source>Beta program</source>
         <translation>Programa Beta</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="227"/>
+        <location filename="../src/gui/versionwidget.cpp" line="252"/>
         <source>Get early access to new versions of the application</source>
         <translation>Obtenga acceso anticipado a las nuevas versiones de la aplicación</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="231"/>
+        <location filename="../src/gui/versionwidget.cpp" line="256"/>
         <source>Join</source>
         <translation>Contacto</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="234"/>
+        <location filename="../src/gui/versionwidget.cpp" line="259"/>
         <source>Modify</source>
         <translation>Modifique</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="234"/>
+        <location filename="../src/gui/versionwidget.cpp" line="259"/>
         <source>Quit</source>
         <translation>Salir</translation>
     </message>
@@ -2771,47 +2754,47 @@ Por favor, utilice el siguiente enlace para enviar los registros al soporte: &lt
         <translation>¡No se pueden guardar los parámetros!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="340"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="355"/>
         <source>The parent folder is a sync folder or contained in one</source>
         <translation>La carpeta principal es una carpeta de sincronización o está contenida en una</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="361"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="376"/>
         <source>Can&apos;t find a valid path</source>
         <translation>No se puede encontrar una ruta válida</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="1839"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="1862"/>
         <source>No valid folder selected!</source>
         <translation>¡No se ha seleccionado una carpeta válida!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="1850"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="1873"/>
         <source>The selected path does not exist!</source>
         <translation>¡La ruta seleccionada no existe!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="1855"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="1878"/>
         <source>The selected path is not a folder!</source>
         <translation>¡La ruta seleccionada no es una carpeta!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="1860"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="1883"/>
         <source>You have no permission to write to the selected folder!</source>
         <translation>¡No tienes permiso para escribir en la carpeta seleccionada!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="1890"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="1913"/>
         <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
         <translation>La carpeta local %1 contiene una carpeta ya sincronizada.¡Elige otra!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="1898"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="1921"/>
         <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
         <translation>La carpeta local %1 está contenida en una carpeta ya sincronizada.¡Elige otra!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="1908"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="1931"/>
         <source>The local folder %1 is already synced on the same drive. Please pick another one!</source>
         <translation>La carpeta local %1 ya está sincronizada en el mismo drive.¡Elige otra!</translation>
     </message>
@@ -2835,11 +2818,56 @@ Por favor, utilice el siguiente enlace para enviar los registros al soporte: &lt
         <source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
         <translation>Lite Sync está desactivado. Los archivos de kDrive utilizan el espacio de almacenamiento de tu ordenador.</translation>
     </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1167"/>
+        <source>Make available locally</source>
+        <translation>Poner a disposición localmente</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1171"/>
+        <source>Free up local space</source>
+        <translation>Liberar espacio local</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1175"/>
+        <source>Cancel free up local space</source>
+        <translation>Cancelar liberar espacio local</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1179"/>
+        <source>Cancel make available locally</source>
+        <translation>Cancelar disponible localmente</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1183"/>
+        <source>Resharing this file is not allowed</source>
+        <translation>No está permitido volver a compartir este archivo</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1184"/>
+        <source>Resharing this folder is not allowed</source>
+        <translation>No está permitido volver a compartir esta carpeta</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1188"/>
+        <source>Copy public share link</source>
+        <translation>Copiar enlace para compartir públicamente</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1192"/>
+        <source>Copy private share link</source>
+        <translation>Copiar enlace para compartir privado</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1196"/>
+        <source>Open in browser</source>
+        <translation>Abrir en navegador</translation>
+    </message>
 </context>
 <context>
     <name>SharedTools::QtSingleApplication</name>
     <message>
-        <location filename="../src/server/appserver.cpp" line="102"/>
+        <location filename="../src/server/appserver.cpp" line="106"/>
         <source>kDrive application will close due to a fatal error.</source>
         <translation>La aplicación kDrive se cerrará debido a un error fatal.</translation>
     </message>
@@ -2931,27 +2959,6 @@ Por favor, utilice el siguiente enlace para enviar los registros al soporte: &lt
 <context>
     <name>utility</name>
     <message>
-        <location filename="../src/server/socketapi.cpp" line="1362"/>
-        <source>Make available locally</source>
-        <translation>Poner a disposición localmente</translation>
-    </message>
-    <message>
-        <location filename="../src/server/socketapi.cpp" line="1370"/>
-        <source>Cancel free up local space</source>
-        <translation>Cancelar liberar espacio local</translation>
-    </message>
-    <message>
-        <location filename="../src/server/socketapi.cpp" line="1375"/>
-        <location filename="../src/server/socketapi.cpp" line="1377"/>
-        <source>Cancel make available locally</source>
-        <translation>Cancelar disponible localmente</translation>
-    </message>
-    <message>
-        <location filename="../src/server/socketapi.cpp" line="1366"/>
-        <source>Free up local space</source>
-        <translation>Liberar espacio local</translation>
-    </message>
-    <message>
         <location filename="../src/gui/guiutility.cpp" line="79"/>
         <source>Could not open browser</source>
         <translation>No se puede abrir el navegador</translation>
@@ -3034,6 +3041,11 @@ quedan %3...</translation>
         <location filename="../src/gui/guiutility.cpp" line="596"/>
         <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
         <translation>La carpeta &lt;b&gt;%1&lt;/b&gt; no puede seleccionarse como carpeta de sincronización. Por favor, seleccione otra carpeta. Carpeta sugerida: &lt;b&gt;%2&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="638"/>
+        <source>You cannot exclude more than 1000 folders. Please uncheck higher-level folders.</source>
+        <translation>No puede excluir más de 1000 carpetas. Desmarque las carpetas de nivel superior.</translation>
     </message>
     <message>
         <location filename="../src/gui/guiutility.cpp" line="347"/>

--- a/translations/client_fr.ts
+++ b/translations/client_fr.ts
@@ -208,12 +208,12 @@ Veuillez sélectionner un autre dossier. Si vous continuez, Lite Sync sera désa
 <context>
     <name>KDC::AddDriveLoginWidget</name>
     <message>
-        <location filename="../src/gui/adddriveloginwidget.cpp" line="92"/>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
         <source>Token request failed: %1 - %2</source>
         <translation>Échec de la demande de jeton&#xa0;: %1 - %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/adddriveloginwidget.cpp" line="106"/>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="99"/>
         <source>Login failed: %1 - %2</source>
         <translation>La connexion a échoué&#xa0;: %1 - %2</translation>
     </message>
@@ -284,8 +284,13 @@ Veuillez sélectionner un autre dossier. Si vous continuez, Lite Sync sera désa
 </context>
 <context>
     <name>KDC::AppServer</name>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="1497"/>
+        <source>Share link copied to clipboard</source>
+        <translation>Lien partagé copié dans le presse-papiers</translation>
+    </message>
     <message numerus="yes">
-        <location filename="../src/server/appserver.cpp" line="3328"/>
+        <location filename="../src/server/appserver.cpp" line="3445"/>
         <source>%1 and %n other file(s) have been removed.</source>
         <translation>
             <numerusform>%1 a été supprimé.</numerusform>
@@ -293,13 +298,13 @@ Veuillez sélectionner un autre dossier. Si vous continuez, Lite Sync sera désa
         </translation>
     </message>
     <message>
-        <location filename="../src/server/appserver.cpp" line="3330"/>
+        <location filename="../src/server/appserver.cpp" line="3447"/>
         <source>%1 has been removed.</source>
         <comment>%1 names a file.</comment>
         <translation>%1 a été supprimé.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/server/appserver.cpp" line="3335"/>
+        <location filename="../src/server/appserver.cpp" line="3452"/>
         <source>%1 and %n other file(s) have been added.</source>
         <translation>
             <numerusform>%1 et %n autre(s) fichier(s) ont été ajouté(s).</numerusform>
@@ -307,13 +312,13 @@ Veuillez sélectionner un autre dossier. Si vous continuez, Lite Sync sera désa
         </translation>
     </message>
     <message>
-        <location filename="../src/server/appserver.cpp" line="3337"/>
+        <location filename="../src/server/appserver.cpp" line="3454"/>
         <source>%1 has been added.</source>
         <comment>%1 names a file.</comment>
         <translation>%1 a été ajouté.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/server/appserver.cpp" line="3342"/>
+        <location filename="../src/server/appserver.cpp" line="3459"/>
         <source>%1 and %n other file(s) have been updated.</source>
         <translation>
             <numerusform>%1 a été mis à jour.</numerusform>
@@ -321,13 +326,13 @@ Veuillez sélectionner un autre dossier. Si vous continuez, Lite Sync sera désa
         </translation>
     </message>
     <message>
-        <location filename="../src/server/appserver.cpp" line="3344"/>
+        <location filename="../src/server/appserver.cpp" line="3461"/>
         <source>%1 has been updated.</source>
         <comment>%1 names a file.</comment>
         <translation>%1 a été mis à jour.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/server/appserver.cpp" line="3349"/>
+        <location filename="../src/server/appserver.cpp" line="3466"/>
         <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
         <translation>
             <numerusform>%1 a été déplacé vers %2.</numerusform>
@@ -335,17 +340,17 @@ Veuillez sélectionner un autre dossier. Si vous continuez, Lite Sync sera désa
         </translation>
     </message>
     <message>
-        <location filename="../src/server/appserver.cpp" line="3352"/>
+        <location filename="../src/server/appserver.cpp" line="3469"/>
         <source>%1 has been moved to %2.</source>
         <translation>%1 a été déplacé vers %2.</translation>
     </message>
     <message>
-        <location filename="../src/server/appserver.cpp" line="3360"/>
+        <location filename="../src/server/appserver.cpp" line="3477"/>
         <source>Sync Activity</source>
         <translation>Activité de synchronisation</translation>
     </message>
     <message>
-        <location filename="../src/server/appserver.cpp" line="4266"/>
+        <location filename="../src/server/appserver.cpp" line="4379"/>
         <source>A new folder larger than %1 MB has been added in the drive %2, you must validate its synchronization: %3.
 </source>
         <translation>Un nouveau dossier supérieur à %1 Mo a été ajouté dans le lecteur %2, vous devez valider sa synchronisation: %3.</translation>
@@ -475,18 +480,18 @@ Sélectionnez ceux que vous souhaitez synchroniser:</translation>
         <translation>Aucun dossier à synchroniser n&apos;est configuré.</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1428"/>
+        <location filename="../src/gui/clientgui.cpp" line="1417"/>
         <source>Synthesis</source>
         <translation>Synthèse</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1429"/>
+        <location filename="../src/gui/clientgui.cpp" line="1418"/>
         <source>Preferences</source>
         <translatorcomment>Préférences</translatorcomment>
         <translation>Préférences</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1430"/>
+        <location filename="../src/gui/clientgui.cpp" line="1419"/>
         <source>Quit</source>
         <translation>Quitter</translation>
     </message>
@@ -531,22 +536,22 @@ Sélectionnez ceux que vous souhaitez synchroniser:</translation>
         <translation>%1 (Synchronisation en pause)</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1263"/>
+        <location filename="../src/gui/clientgui.cpp" line="1252"/>
         <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
         <translation>Voulez-vous vraiment supprimer les synchronisations du compte &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Remarque&#xa0;:&lt;/b&gt; Cela &lt;b&gt;ne&lt;/b&gt; supprimera aucun fichier.</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1267"/>
+        <location filename="../src/gui/clientgui.cpp" line="1256"/>
         <source>REMOVE ALL SYNCHRONIZATIONS</source>
         <translation>SUPPRIMER TOUTES LES SYNC</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1268"/>
+        <location filename="../src/gui/clientgui.cpp" line="1257"/>
         <source>CANCEL</source>
         <translation>ANNULER</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1596"/>
+        <location filename="../src/gui/clientgui.cpp" line="1585"/>
         <source>Failed to start synchronizations!</source>
         <translation>Échec du démarrage des synchronisations&#xa0;!</translation>
     </message>
@@ -564,12 +569,6 @@ Sélectionnez ceux que vous souhaitez synchroniser:</translation>
         <location filename="../src/gui/clientgui.cpp" line="255"/>
         <source>Synchronization is paused</source>
         <translation>La synchronisation est en pause</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="876"/>
-        <location filename="../src/gui/clientgui.cpp" line="924"/>
-        <source>The shared link has been copied to the clipboard.</source>
-        <translation>Le lien partagé a été copié dans le presse-papier.</translation>
     </message>
 </context>
 <context>
@@ -943,145 +942,160 @@ Sélectionnez ceux que vous souhaitez synchroniser:</translation>
 <context>
     <name>KDC::DrivePreferencesWidget</name>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1258"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1310"/>
         <source>Folders</source>
         <translation>Dossiers</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1260"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1312"/>
         <source>Notifications</source>
         <translation>Notifications</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1263"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1315"/>
         <source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
         <translation>Une notification sera affichée dès qu’un nouveau dossier aura été synchronisé ou modifié</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1264"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1316"/>
         <source>Connected with</source>
         <translation>Connecté avec</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1070"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1133"/>
         <source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
         <translation>Voulez-vous vraiment arrêter de synchroniser le dossier &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note :&lt;/b&gt; &lt;/b&gt;Aucun&lt;/b&gt; fichier ne sera supprimé.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="128"/>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1257"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="129"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1309"/>
         <source>Some folders were not synchronized because they are too large.</source>
         <translation>Certains dossiers n&apos;ont pas été synchronisés parce qu’ils sont trop volumineux.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="400"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="397"/>
         <source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
         <translation>Cette opération peut prendre de quelques secondes à quelques minutes en fonction de la taille du dossier.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="404"/>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="436"/>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1075"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="401"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="432"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1138"/>
         <source>CANCEL</source>
         <translation>ANNULER</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="803"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="802"/>
         <source>New local folder synchronization failed!</source>
         <translation>La synchronisation du nouveau dossier local a échoué!</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="979"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="977"/>
         <source>Lite Sync activation failed.</source>
         <translation>L&apos;activation de la Lite Sync a échoué.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="997"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="995"/>
         <source>Lite Sync deactivation failed.</source>
         <translation>La désactivation de la Lite Sync a échoué.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1074"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1137"/>
         <source>REMOVE FOLDER SYNC CONNECTION</source>
         <translation>SUPPRIMER LA SYNC. DU DOSSIER</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1142"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1200"/>
         <source>An error occurred while loading the list of subfolders.</source>
         <translation>Une erreur s&apos;est produite lors du chargement de la liste des sous-dossiers.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1261"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1313"/>
         <source>Enable the notifications for this kDrive</source>
         <translation>Activer les notifications pour ce kDrive</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="403"/>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="435"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="400"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="431"/>
         <source>CONFIRM</source>
         <translation>CONFIRMER</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="118"/>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1256"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="119"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1308"/>
         <source>Synchronization errors and information.</source>
         <translation>Erreurs et informations de synchronisation.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="147"/>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1259"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="153"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1311"/>
         <source>Synchronize a local folder</source>
         <translation>Synchroniser un dossier local</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="399"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="396"/>
         <source>Do you really want to turn on Lite Sync?</source>
         <translation>Voulez-vous vraiment activer la Lite Sync?</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="427"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="423"/>
         <source>Do you really want to turn off Lite Sync?</source>
         <translation>Voulez vous vraiment désactiver la Lite Sync?</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="429"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="425"/>
         <source>You don&apos;t have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
         <translation>Vous n&apos;avez pas assez de place pour synchroniser tous les fichiers sur votre kDrive (manque %1). Si vous désactivez la Lite Sync, vous devrez sélectionner les dossiers à synchroniser sur votre ordinateur. Dans un premier temps, la synchronisation de votre kDrive sera mise en pause.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="433"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="429"/>
         <source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
         <translation>Si vous désactivez la Lite Sync, tous les fichiers seront téléchargés sur votre ordinateur.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="666"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="680"/>
         <source>Failed to create new synchronization</source>
         <translation>Impossible de créer une nouvelle synchronisation</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="975"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="973"/>
         <source>Lite Sync activated.</source>
         <translation>Lite Sync activée.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="993"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="991"/>
         <source>Lite Sync deactivated.</source>
         <translation>Lite Sync désactivée.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1056"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1053"/>
         <source>This drive is being deleted.</source>
         <translation>Ce lecteur est en cours de suppression.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1097"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1114"/>
+        <source>Impossible to open item %1</source>
+        <translation>Impossible d&apos;ouvrir l&apos;élément %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1159"/>
         <source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
         <translation>Échec de l&apos;arrêt de la synchronisation du dossier &lt;i&gt;%1&lt;/i&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1265"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1317"/>
         <source>Remove all synchronizations</source>
         <translation>Supprimer toutes les synchronisations</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1318"/>
+        <source>Search in your kDrive</source>
+        <translation>Rechercher dans votre kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1319"/>
+        <source>Search</source>
+        <translation>Rechercher</translation>
     </message>
 </context>
 <context>
@@ -1607,7 +1621,7 @@ Veuillez utiliser le lien suivant pour envoyer les logs au support: &lt;a style=
         <location filename="../src/gui/parametersdialog.cpp" line="428"/>
         <location filename="../src/gui/parametersdialog.cpp" line="488"/>
         <location filename="../src/gui/parametersdialog.cpp" line="528"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="541"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="542"/>
         <source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
         <translation>Une erreur technique s&apos;est produite (erreur %1).&lt;br&gt;Veuillez vider l&apos;historique et si l&apos;erreur persiste, contactez notre équipe d&apos;assistance.</translation>
     </message>
@@ -1753,22 +1767,22 @@ Veuillez utiliser le lien suivant pour envoyer les logs au support: &lt;a style=
         <translation>Une erreur d&apos;accès à la base de données de synchronisation s&apos;est produite (erreur %1).&lt;br&gt;La synchronisation a été arrêtée.</translation>
     </message>
     <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="545"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="546"/>
         <source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
         <translation>Un problème de connexion est survenu (erreur %1).&lt;br&gt;Jeton invalide ou révoqué.</translation>
     </message>
     <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="550"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="551"/>
         <source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
         <translation>Les synchronisations imbriquées sont interdites (erreur %1).&lt;br&gt;Vous ne devez conserver que les synchronisations dont les dossiers ne sont pas imbriqués.</translation>
     </message>
     <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="554"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="555"/>
         <source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
         <translation>Le dossier de synchronisation sur le kDrive distant n&apos;existe plus ou n&apos;est plus accessible (erreur %1).&lt;br&gt;Vous devez le restaurer ou lui redonner des droits d&apos;accès ou supprimer/recréer la synchronisation.</translation>
     </message>
     <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="561"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="562"/>
         <source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
         <translation>Erreur d&apos;analyse du nom de fichier (erreur %1).&lt;br&gt;Les caractères spéciaux tels que les guillemets doubles, les barres obliques inverses ou les retours de ligne peuvent provoquer des échecs d&apos;analyse.</translation>
     </message>
@@ -2307,42 +2321,6 @@ Veuillez utiliser le lien suivant pour envoyer les logs au support: &lt;a style=
     </message>
 </context>
 <context>
-    <name>KDC::SocketApi</name>
-    <message>
-        <location filename="../src/server/socketapi.cpp" line="815"/>
-        <location filename="../src/server/socketapi.cpp" line="1022"/>
-        <location filename="../src/server/socketapi.cpp" line="1074"/>
-        <source>Copy private share link</source>
-        <translation>Copier le lien de partage privé</translation>
-    </message>
-    <message>
-        <location filename="../src/server/socketapi.cpp" line="1001"/>
-        <location filename="../src/server/socketapi.cpp" line="1058"/>
-        <source>Resharing this file is not allowed</source>
-        <translation>Le partage de ce fichier n&apos;est pas autorisé</translation>
-    </message>
-    <message>
-        <location filename="../src/server/socketapi.cpp" line="1002"/>
-        <location filename="../src/server/socketapi.cpp" line="1059"/>
-        <source>Resharing this folder is not allowed</source>
-        <translation>Le partage de ce dossier n&apos;est pas autorisé</translation>
-    </message>
-    <message>
-        <location filename="../src/server/socketapi.cpp" line="1013"/>
-        <location filename="../src/server/socketapi.cpp" line="1017"/>
-        <location filename="../src/server/socketapi.cpp" line="1068"/>
-        <location filename="../src/server/socketapi.cpp" line="1070"/>
-        <source>Copy public share link</source>
-        <translation>Copier le lien de partage public</translation>
-    </message>
-    <message>
-        <location filename="../src/server/socketapi.cpp" line="1211"/>
-        <location filename="../src/server/socketapi.cpp" line="1279"/>
-        <source>Open in browser</source>
-        <translation>Ouvrir dans le navigateur web</translation>
-    </message>
-</context>
-<context>
     <name>KDC::StatusBarWidget</name>
     <message>
         <location filename="../src/gui/statusbarwidget.cpp" line="178"/>
@@ -2380,6 +2358,11 @@ Veuillez utiliser le lien suivant pour envoyer les logs au support: &lt;a style=
 <context>
     <name>KDC::SynchronizedItemWidget</name>
     <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
+        <source>Copy share link</source>
+        <translation>Copier le lien de partage</translation>
+    </message>
+    <message>
         <location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
         <source>Display on kdrive.infomaniak.com</source>
         <translation>Afficher sur kdrive.infomaniak.com</translation>
@@ -2403,11 +2386,6 @@ Veuillez utiliser le lien suivant pour envoyer les logs au support: &lt;a style=
         <location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
         <source>Add to favorites</source>
         <translation>Ajouter aux favoris</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
-        <source>Copy sharing link</source>
-        <translation>Copier le lien de partage</translation>
     </message>
 </context>
 <context>
@@ -2534,23 +2512,23 @@ Veuillez utiliser le lien suivant pour envoyer les logs au support: &lt;a style=
 <context>
     <name>KDC::SynthesisPopover</name>
     <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1176"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1171"/>
         <source>Update kDrive App</source>
         <translation>Mettre à jour l&apos;application kDrive</translation>
     </message>
     <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1177"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1172"/>
         <source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
         <translation>Cette version de l&apos;application kDrive n&apos;est plus prise en charge. Pour accéder aux dernières fonctionnalités et améliorations, veuillez mettre à jour.</translation>
     </message>
     <message>
         <location filename="../src/gui/synthesispopover.cpp" line="966"/>
-        <location filename="../src/gui/synthesispopover.cpp" line="1179"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1174"/>
         <source>Update</source>
         <translation>Mise à jour</translation>
     </message>
     <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1181"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1176"/>
         <source>Please download the latest version on the website.</source>
         <translation>Veuillez télécharger la dernière version sur le site Web.</translation>
     </message>
@@ -2575,7 +2553,7 @@ Veuillez utiliser le lien suivant pour envoyer les logs au support: &lt;a style=
         <translation>Indisponible</translation>
     </message>
     <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1194"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1189"/>
         <source>You can synchronize files &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;from your computer&lt;/a&gt; or on &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
         <translation>Vous pouvez synchroniser les fichiers &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;depuis votre ordinateur&lt;/a&gt; ou sur &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/ un&gt;.</translation>
     </message>
@@ -2596,27 +2574,27 @@ Veuillez utiliser le lien suivant pour envoyer les logs au support: &lt;a style=
     </message>
     <message>
         <location filename="../src/gui/synthesispopover.cpp" line="1123"/>
-        <location filename="../src/gui/synthesispopover.cpp" line="1175"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1170"/>
         <source>Not implemented!</source>
         <translation>Non implémenté&#xa0;!</translation>
     </message>
     <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1187"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1182"/>
         <source>No synchronized folder for this Drive!</source>
         <translation>Aucun fichier synchronisé pour ce kDrive&#xa0;!</translation>
     </message>
     <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1190"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1185"/>
         <source>No kDrive configured!</source>
         <translation>Aucun kDrive configuré !</translation>
     </message>
     <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1156"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1151"/>
         <source>Unable to open link %1.</source>
         <translation>Impossible d’ouvrir le lien %1.</translation>
     </message>
     <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1168"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1163"/>
         <source>Invalid link %1.</source>
         <translation>Lien %1 invalide.</translation>
     </message>
@@ -2673,87 +2651,92 @@ Veuillez utiliser le lien suivant pour envoyer les logs au support: &lt;a style=
 <context>
     <name>KDC::VersionWidget</name>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="270"/>
+        <location filename="../src/gui/versionwidget.cpp" line="295"/>
         <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</source>
         <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="157"/>
+        <location filename="../src/gui/versionwidget.cpp" line="169"/>
         <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Show release note&lt;/a&gt;</source>
         <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Afficher la note de version&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="160"/>
+        <location filename="../src/gui/versionwidget.cpp" line="172"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="161"/>
+        <location filename="../src/gui/versionwidget.cpp" line="173"/>
         <source>UPDATE</source>
         <translation>METTRE A JOUR</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="176"/>
+        <location filename="../src/gui/versionwidget.cpp" line="197"/>
         <source>%1 is up to date!</source>
         <translation>%1 est à jour !</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="180"/>
+        <location filename="../src/gui/versionwidget.cpp" line="201"/>
         <source>Checking update on server...</source>
         <translation>Vérification de la mise à jour sur le serveur...</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="184"/>
+        <location filename="../src/gui/versionwidget.cpp" line="205"/>
         <source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;here&lt;/a&gt;.</source>
         <translation>Une mise à jour est disponible&#xa0;: %1.&lt;br&gt;Veuillez la télécharger depuis &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;ici&lt;/a&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="191"/>
+        <location filename="../src/gui/versionwidget.cpp" line="212"/>
         <source>An update is available: %1</source>
         <translation>Une mise à jour est disponible: %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="197"/>
+        <location filename="../src/gui/versionwidget.cpp" line="218"/>
         <source>Downloading %1. Please wait...</source>
         <translation>Téléchargement %1 en cours. Veuillez patienter…</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="202"/>
+        <location filename="../src/gui/versionwidget.cpp" line="223"/>
         <source>Could not check for new updates.</source>
         <translation>Impossible de vérifier la présence de nouvelles mises à jour.</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="206"/>
+        <location filename="../src/gui/versionwidget.cpp" line="227"/>
         <source>An error occurred during update.</source>
         <translation>Une erreur s&apos;est produite lors de la mise à jour.</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="210"/>
+        <location filename="../src/gui/versionwidget.cpp" line="231"/>
         <source>Could not download update.</source>
         <translation>Impossible de télécharger la mise à jour.</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="226"/>
+        <location filename="../src/gui/versionwidget.cpp" line="235"/>
+        <source>Update disabled.</source>
+        <translation>Mise à jour désactivée.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="251"/>
         <source>Beta program</source>
         <translation>Programme bêta</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="227"/>
+        <location filename="../src/gui/versionwidget.cpp" line="252"/>
         <source>Get early access to new versions of the application</source>
         <translation>Bénéficier d&apos;un accès anticipé aux nouvelles versions de l&apos;application</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="231"/>
+        <location filename="../src/gui/versionwidget.cpp" line="256"/>
         <source>Join</source>
         <translation>Rejoindre</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="234"/>
+        <location filename="../src/gui/versionwidget.cpp" line="259"/>
         <source>Modify</source>
         <translation>Modifier</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="234"/>
+        <location filename="../src/gui/versionwidget.cpp" line="259"/>
         <source>Quit</source>
         <translation>Quitter</translation>
     </message>
@@ -2771,47 +2754,47 @@ Veuillez utiliser le lien suivant pour envoyer les logs au support: &lt;a style=
         <translation>Impossible d&apos;enregistrer les paramètres&#xa0;!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="340"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="355"/>
         <source>The parent folder is a sync folder or contained in one</source>
         <translation>Le dossier parent est un dossier de synchronisation ou contenu dans un</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="361"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="376"/>
         <source>Can&apos;t find a valid path</source>
         <translation>Impossible de trouver un chemin valide</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="1839"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="1862"/>
         <source>No valid folder selected!</source>
         <translation>Aucun dossier valable sélectionné!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="1850"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="1873"/>
         <source>The selected path does not exist!</source>
         <translation>Le chemin sélectionné n’existe pas!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="1855"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="1878"/>
         <source>The selected path is not a folder!</source>
         <translation>Le chemin sélectionné n&apos;est pas un dossier!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="1860"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="1883"/>
         <source>You have no permission to write to the selected folder!</source>
         <translation>Vous n&apos;avez pas la permission d&apos;écrire dans le dossier sélectionné!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="1890"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="1913"/>
         <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
         <translation>Le dossier local %1 contient un dossier déjà synchronisé. Veuillez en choisir un autre&#xa0;!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="1898"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="1921"/>
         <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
         <translation>Le dossier local %1 est contenu dans un dossier déjà synchronisé. Veuillez en choisir un autre&#xa0;!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="1908"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="1931"/>
         <source>The local folder %1 is already synced on the same drive. Please pick another one!</source>
         <translation>Le dossier local %1 est déjà synchronisé sur le même lecteur. Veuillez en choisir un autre&#xa0;!</translation>
     </message>
@@ -2835,11 +2818,56 @@ Veuillez utiliser le lien suivant pour envoyer les logs au support: &lt;a style=
         <source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
         <translation>La Lite sync est désactivée. Les fichiers kDrive utilisent l&apos;espace de stockage de votre ordinateur.</translation>
     </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1167"/>
+        <source>Make available locally</source>
+        <translation>Rendre disponible localement</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1171"/>
+        <source>Free up local space</source>
+        <translation>Libérer de l’espace local</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1175"/>
+        <source>Cancel free up local space</source>
+        <translation>Annuler libérer l&apos;espace local</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1179"/>
+        <source>Cancel make available locally</source>
+        <translation>Annuler rendre disponible localement</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1183"/>
+        <source>Resharing this file is not allowed</source>
+        <translation>Le partage de ce fichier n&apos;est pas autorisé</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1184"/>
+        <source>Resharing this folder is not allowed</source>
+        <translation>Le partage de ce dossier n&apos;est pas autorisé</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1188"/>
+        <source>Copy public share link</source>
+        <translation>Copier le lien de partage public</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1192"/>
+        <source>Copy private share link</source>
+        <translation>Copier le lien de partage privé</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1196"/>
+        <source>Open in browser</source>
+        <translation>Ouvrir dans le navigateur web</translation>
+    </message>
 </context>
 <context>
     <name>SharedTools::QtSingleApplication</name>
     <message>
-        <location filename="../src/server/appserver.cpp" line="102"/>
+        <location filename="../src/server/appserver.cpp" line="106"/>
         <source>kDrive application will close due to a fatal error.</source>
         <translation>L&apos;application kDrive se fermera en raison d&apos;une erreur fatale.</translation>
     </message>
@@ -3001,30 +3029,14 @@ Veuillez utiliser le lien suivant pour envoyer les logs au support: &lt;a style=
         <translation>Le dossier &lt;b&gt;%1&lt;/b&gt; ne peut pas être sélectionné comme dossier de synchronisation. Veuillez sélectionner un autre dossier. Dossier suggéré : &lt;b&gt;%2&lt;/b&gt;</translation>
     </message>
     <message>
+        <location filename="../src/gui/guiutility.cpp" line="638"/>
+        <source>You cannot exclude more than 1000 folders. Please uncheck higher-level folders.</source>
+        <translation>Vous ne pouvez pas exclure plus de 1000 dossiers. Veuillez décocher des dossiers de niveau supérieur.</translation>
+    </message>
+    <message>
         <location filename="../src/gui/guiutility.cpp" line="347"/>
         <source>Synchronization starting</source>
         <translation>Démarrage de la synchronisation</translation>
-    </message>
-    <message>
-        <location filename="../src/server/socketapi.cpp" line="1362"/>
-        <source>Make available locally</source>
-        <translation>Rendre disponible localement</translation>
-    </message>
-    <message>
-        <location filename="../src/server/socketapi.cpp" line="1366"/>
-        <source>Free up local space</source>
-        <translation>Libérer de l’espace local</translation>
-    </message>
-    <message>
-        <location filename="../src/server/socketapi.cpp" line="1370"/>
-        <source>Cancel free up local space</source>
-        <translation>Annuler libérer l&apos;espace local</translation>
-    </message>
-    <message>
-        <location filename="../src/server/socketapi.cpp" line="1375"/>
-        <location filename="../src/server/socketapi.cpp" line="1377"/>
-        <source>Cancel make available locally</source>
-        <translation>Annuler rendre disponible localement</translation>
     </message>
     <message>
         <location filename="../src/gui/guiutility.cpp" line="371"/>

--- a/translations/client_it.ts
+++ b/translations/client_it.ts
@@ -208,12 +208,12 @@ Seleziona un&apos;altra cartella. Se continui, Lite Sync verrà disabilitato.&lt
 <context>
     <name>KDC::AddDriveLoginWidget</name>
     <message>
-        <location filename="../src/gui/adddriveloginwidget.cpp" line="92"/>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
         <source>Token request failed: %1 - %2</source>
         <translation>Richiesta token non riuscita: %1 – %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/adddriveloginwidget.cpp" line="106"/>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="99"/>
         <source>Login failed: %1 - %2</source>
         <translation>Accesso non riuscito: %1 – %2</translation>
     </message>
@@ -284,8 +284,13 @@ Seleziona un&apos;altra cartella. Se continui, Lite Sync verrà disabilitato.&lt
 </context>
 <context>
     <name>KDC::AppServer</name>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="1497"/>
+        <source>Share link copied to clipboard</source>
+        <translation>Link condiviso copiato negli appunti</translation>
+    </message>
     <message numerus="yes">
-        <location filename="../src/server/appserver.cpp" line="3328"/>
+        <location filename="../src/server/appserver.cpp" line="3445"/>
         <source>%1 and %n other file(s) have been removed.</source>
         <translation>
             <numerusform>%1 e %n altri file sono stati rimossi.</numerusform>
@@ -293,13 +298,13 @@ Seleziona un&apos;altra cartella. Se continui, Lite Sync verrà disabilitato.&lt
         </translation>
     </message>
     <message>
-        <location filename="../src/server/appserver.cpp" line="3330"/>
+        <location filename="../src/server/appserver.cpp" line="3447"/>
         <source>%1 has been removed.</source>
         <comment>%1 names a file.</comment>
         <translation>%1 è stato rimosso.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/server/appserver.cpp" line="3335"/>
+        <location filename="../src/server/appserver.cpp" line="3452"/>
         <source>%1 and %n other file(s) have been added.</source>
         <translation>
             <numerusform>%1 e %n altri file sono stati aggiunti.</numerusform>
@@ -307,13 +312,13 @@ Seleziona un&apos;altra cartella. Se continui, Lite Sync verrà disabilitato.&lt
         </translation>
     </message>
     <message>
-        <location filename="../src/server/appserver.cpp" line="3337"/>
+        <location filename="../src/server/appserver.cpp" line="3454"/>
         <source>%1 has been added.</source>
         <comment>%1 names a file.</comment>
         <translation>%1 è stato aggiunto.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/server/appserver.cpp" line="3342"/>
+        <location filename="../src/server/appserver.cpp" line="3459"/>
         <source>%1 and %n other file(s) have been updated.</source>
         <translation>
             <numerusform>%1 e %n altri file sono stati aggiornati.</numerusform>
@@ -321,13 +326,13 @@ Seleziona un&apos;altra cartella. Se continui, Lite Sync verrà disabilitato.&lt
         </translation>
     </message>
     <message>
-        <location filename="../src/server/appserver.cpp" line="3344"/>
+        <location filename="../src/server/appserver.cpp" line="3461"/>
         <source>%1 has been updated.</source>
         <comment>%1 names a file.</comment>
         <translation>%1 è stato aggiornato.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/server/appserver.cpp" line="3349"/>
+        <location filename="../src/server/appserver.cpp" line="3466"/>
         <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
         <translation>
             <numerusform>%1 è stato spostato in %2 e %n altri file sono stati spostati.</numerusform>
@@ -335,17 +340,17 @@ Seleziona un&apos;altra cartella. Se continui, Lite Sync verrà disabilitato.&lt
         </translation>
     </message>
     <message>
-        <location filename="../src/server/appserver.cpp" line="3352"/>
+        <location filename="../src/server/appserver.cpp" line="3469"/>
         <source>%1 has been moved to %2.</source>
         <translation>%1 è stato spostato in %2.</translation>
     </message>
     <message>
-        <location filename="../src/server/appserver.cpp" line="3360"/>
+        <location filename="../src/server/appserver.cpp" line="3477"/>
         <source>Sync Activity</source>
         <translation>Sincronizza attività</translation>
     </message>
     <message>
-        <location filename="../src/server/appserver.cpp" line="4266"/>
+        <location filename="../src/server/appserver.cpp" line="4379"/>
         <source>A new folder larger than %1 MB has been added in the drive %2, you must validate its synchronization: %3.
 </source>
         <translation>È stata aggiunta una nuova cartella più grande di %1 MB nell&apos;unità %2, devi convalidarne la sincronizzazione: %3.
@@ -471,17 +476,17 @@ Seleziona quelli che desideri sincronizzare:</translation>
         <translation>Non è stata configurata alcuna cartella per la sincronizzazione.</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1428"/>
+        <location filename="../src/gui/clientgui.cpp" line="1417"/>
         <source>Synthesis</source>
         <translation>Sintesi</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1429"/>
+        <location filename="../src/gui/clientgui.cpp" line="1418"/>
         <source>Preferences</source>
         <translation>Preferenze</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1430"/>
+        <location filename="../src/gui/clientgui.cpp" line="1419"/>
         <source>Quit</source>
         <translation>Esci</translation>
     </message>
@@ -526,22 +531,22 @@ Seleziona quelli che desideri sincronizzare:</translation>
         <translation>%1 (Sincronizzazione sospesa)</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1263"/>
+        <location filename="../src/gui/clientgui.cpp" line="1252"/>
         <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
         <translation>Vuoi davvero rimuovere le sincronizzazioni dell&apos;account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Nota:&lt;/b&gt; questo &lt;b&gt;non&lt;/b&gt; eliminerà alcun file.</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1267"/>
+        <location filename="../src/gui/clientgui.cpp" line="1256"/>
         <source>REMOVE ALL SYNCHRONIZATIONS</source>
         <translation>RIMUOVERE TUTTE LE SINC</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1268"/>
+        <location filename="../src/gui/clientgui.cpp" line="1257"/>
         <source>CANCEL</source>
         <translation>ANNULLA</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1596"/>
+        <location filename="../src/gui/clientgui.cpp" line="1585"/>
         <source>Failed to start synchronizations!</source>
         <translation>Impossibile avviare la sincronizzazione!</translation>
     </message>
@@ -564,12 +569,6 @@ Seleziona quelli che desideri sincronizzare:</translation>
         <location filename="../src/gui/clientgui.cpp" line="255"/>
         <source>Synchronization is paused</source>
         <translation>Sincronizzazione sospesa</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="876"/>
-        <location filename="../src/gui/clientgui.cpp" line="924"/>
-        <source>The shared link has been copied to the clipboard.</source>
-        <translation>Il link condiviso è stato copiato negli appunti.</translation>
     </message>
 </context>
 <context>
@@ -943,145 +942,160 @@ Seleziona quelli che desideri sincronizzare:</translation>
 <context>
     <name>KDC::DrivePreferencesWidget</name>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1258"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1310"/>
         <source>Folders</source>
         <translation>Cartelle</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1260"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1312"/>
         <source>Notifications</source>
         <translation>Notifiche</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1263"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1315"/>
         <source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
         <translation>Verrà visualizzata una notifica appena una nuova cartella sarà sincronizzata o modificata</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1264"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1316"/>
         <source>Connected with</source>
         <translation>Connesso a</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1070"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1133"/>
         <source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
         <translation>Interrompere la sincronizzazione della cartella &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Nota:&lt;/b&gt; questa operazione &lt;b&gt;non&lt;/b&gt; eliminerà alcun file.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="128"/>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1257"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="129"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1309"/>
         <source>Some folders were not synchronized because they are too large.</source>
         <translation>Alcune cartelle non sono state sincronizzate perché sono troppo grandi.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="400"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="397"/>
         <source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
         <translation>Questa operazione può richiedere da pochi secondi a qualche minuto, a seconda delle dimensioni della cartella.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="404"/>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="436"/>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1075"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="401"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="432"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1138"/>
         <source>CANCEL</source>
         <translation>ANNULLA</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="803"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="802"/>
         <source>New local folder synchronization failed!</source>
         <translation>Nuova sincronizzazione delle cartelle locali non riuscita!</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="979"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="977"/>
         <source>Lite Sync activation failed.</source>
         <translation>Attivazione Lite Sync non riuscita.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="997"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="995"/>
         <source>Lite Sync deactivation failed.</source>
         <translation>Disattivazione Lite Sync non riuscita.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1074"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1137"/>
         <source>REMOVE FOLDER SYNC CONNECTION</source>
         <translation>RIMUOVI CONNESSIONE DI SINC. CARTELLE</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1142"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1200"/>
         <source>An error occurred while loading the list of subfolders.</source>
         <translation>Si è verificato un errore durante il caricamento dell&apos;elenco delle sottocartelle.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1261"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1313"/>
         <source>Enable the notifications for this kDrive</source>
         <translation>Abilita le notifiche per questo kDrive</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="403"/>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="435"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="400"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="431"/>
         <source>CONFIRM</source>
         <translation>CONFERMA</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="118"/>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1256"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="119"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1308"/>
         <source>Synchronization errors and information.</source>
         <translation>Errori di sincronizzazione e informazioni.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="147"/>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1259"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="153"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1311"/>
         <source>Synchronize a local folder</source>
         <translation>Sincronizza una cartella locale</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="399"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="396"/>
         <source>Do you really want to turn on Lite Sync?</source>
         <translation>Abilitare Lite Sync?</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="427"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="423"/>
         <source>Do you really want to turn off Lite Sync?</source>
         <translation>Disabilitare Lite Sync?</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="429"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="425"/>
         <source>You don&apos;t have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
         <translation>Non hai abbastanza spazio libero per sincronizzare tutti i file sul tuo kDrive (%1 mancanti). Se disabiliti Lite Sync dovrai scegliere quali cartelle sincronizzare sul tuo computer. Nel frattempo la sincronizzazione del tuo kDrive verrà sospesa.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="433"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="429"/>
         <source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
         <translation>Se si disattiva Lite Sync, tutti i file verranno scaricati sul computer.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="666"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="680"/>
         <source>Failed to create new synchronization</source>
         <translation>Creazione della nuova sincronizzazione non riuscita</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="975"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="973"/>
         <source>Lite Sync activated.</source>
         <translation>Sincronizzazione Lite attivata.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="993"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="991"/>
         <source>Lite Sync deactivated.</source>
         <translation>Lite Sync disattivato.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1056"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1053"/>
         <source>This drive is being deleted.</source>
         <translation>Questa unità è in fase di eliminazione.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1097"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1114"/>
+        <source>Impossible to open item %1</source>
+        <translation>Impossibile aprire l&apos;articolo %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1159"/>
         <source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
         <translation>Impossibile interrompere la sincronizzazione della cartella &lt;i&gt;%1&lt;/i&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1265"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1317"/>
         <source>Remove all synchronizations</source>
         <translation>Rimuovi tutte le sincronizzazioni</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1318"/>
+        <source>Search in your kDrive</source>
+        <translation>Cerca nel tuo kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1319"/>
+        <source>Search</source>
+        <translation>Ricerca</translation>
     </message>
 </context>
 <context>
@@ -1607,7 +1621,7 @@ Per favore, utilizza il seguente link per inviare i log al supporto: &lt;a style
         <location filename="../src/gui/parametersdialog.cpp" line="428"/>
         <location filename="../src/gui/parametersdialog.cpp" line="488"/>
         <location filename="../src/gui/parametersdialog.cpp" line="528"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="541"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="542"/>
         <source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
         <translation>Si è verificato un errore tecnico (errore %1).&lt;br&gt;Svuota la cronologia e, se l&apos;errore persiste, contatta il nostro team di supporto.</translation>
     </message>
@@ -1685,7 +1699,7 @@ Per favore, utilizza il seguente link per inviare i log al supporto: &lt;a style
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="423"/>
         <source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
-        <translation type="unfinished">Un file o una cartella all&apos;interno della cartella di sincronizzazione sembra essere corrotto.&lt;br&gt;La sincronizzazione è stata interrotta.</translation>
+        <translation>Un file o una cartella all&apos;interno della cartella di sincronizzazione sembra essere corrotto.&lt;br&gt;La sincronizzazione è stata interrotta.</translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="437"/>
@@ -1754,22 +1768,22 @@ Accedi alla versione web per verificare lo stato del tuo kDrive oppure contatta 
         <translation>Si è verificato un errore nell&apos;accedere al database di sincronizzazione (errore %1). &lt;br&gt;La sincronizzazione è stata interrotta.</translation>
     </message>
     <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="545"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="546"/>
         <source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
         <translation>Si è verificato un problema di accesso (errore %1).&lt;br&gt;Token non valido o revocato.</translation>
     </message>
     <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="550"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="551"/>
         <source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
         <translation>Le sincronizzazioni nidificate sono vietate (errore %1).&lt;br&gt;Conservare solo le sincronizzazioni le cui cartelle non sono nidificate.</translation>
     </message>
     <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="554"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="555"/>
         <source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
         <translation>La cartella di sincronizzazione sul kDrive remoto non esiste più o non è più accessibile (errore %1).&lt;br&gt;È necessario ripristinarla o ridarle i diritti di accesso o cancellare/ricreare la sincronizzazione.</translation>
     </message>
     <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="561"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="562"/>
         <source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
         <translation>Errore durante l&apos;analisi del nome file (errore %1).&lt;br&gt;Caratteri speciali come virgolette doppie, barre rovesciate o ritorni a capo possono causare errori di analisi.</translation>
     </message>
@@ -2308,42 +2322,6 @@ Accedi alla versione web per verificare lo stato del tuo kDrive oppure contatta 
     </message>
 </context>
 <context>
-    <name>KDC::SocketApi</name>
-    <message>
-        <location filename="../src/server/socketapi.cpp" line="815"/>
-        <location filename="../src/server/socketapi.cpp" line="1022"/>
-        <location filename="../src/server/socketapi.cpp" line="1074"/>
-        <source>Copy private share link</source>
-        <translation>Copia il collegamento di condivisione privata</translation>
-    </message>
-    <message>
-        <location filename="../src/server/socketapi.cpp" line="1001"/>
-        <location filename="../src/server/socketapi.cpp" line="1058"/>
-        <source>Resharing this file is not allowed</source>
-        <translation>Ricondivisione di questo file non consentita</translation>
-    </message>
-    <message>
-        <location filename="../src/server/socketapi.cpp" line="1002"/>
-        <location filename="../src/server/socketapi.cpp" line="1059"/>
-        <source>Resharing this folder is not allowed</source>
-        <translation>Ricondivisione di questa cartella non consentita</translation>
-    </message>
-    <message>
-        <location filename="../src/server/socketapi.cpp" line="1013"/>
-        <location filename="../src/server/socketapi.cpp" line="1017"/>
-        <location filename="../src/server/socketapi.cpp" line="1068"/>
-        <location filename="../src/server/socketapi.cpp" line="1070"/>
-        <source>Copy public share link</source>
-        <translation>Copia il collegamento di condivisione pubblica</translation>
-    </message>
-    <message>
-        <location filename="../src/server/socketapi.cpp" line="1211"/>
-        <location filename="../src/server/socketapi.cpp" line="1279"/>
-        <source>Open in browser</source>
-        <translation>Apri nel browser</translation>
-    </message>
-</context>
-<context>
     <name>KDC::StatusBarWidget</name>
     <message>
         <location filename="../src/gui/statusbarwidget.cpp" line="178"/>
@@ -2381,6 +2359,11 @@ Accedi alla versione web per verificare lo stato del tuo kDrive oppure contatta 
 <context>
     <name>KDC::SynchronizedItemWidget</name>
     <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
+        <source>Copy share link</source>
+        <translation>Copiare il link di condivisione</translation>
+    </message>
+    <message>
         <location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
         <source>Display on kdrive.infomaniak.com</source>
         <translation>Visualizzazione su kdrive.infomaniak.com</translation>
@@ -2404,11 +2387,6 @@ Accedi alla versione web per verificare lo stato del tuo kDrive oppure contatta 
         <location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
         <source>Add to favorites</source>
         <translation>Aggiungi ai preferiti</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
-        <source>Copy sharing link</source>
-        <translation>Copia il link di condivisione</translation>
     </message>
 </context>
 <context>
@@ -2535,23 +2513,23 @@ Accedi alla versione web per verificare lo stato del tuo kDrive oppure contatta 
 <context>
     <name>KDC::SynthesisPopover</name>
     <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1176"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1171"/>
         <source>Update kDrive App</source>
         <translation>Aggiorna l&apos;app kDrive</translation>
     </message>
     <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1177"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1172"/>
         <source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
         <translation>Questa versione dell&apos;app kDrive non è più supportata. Per accedere alle funzionalità e ai miglioramenti più recenti, aggiornare.</translation>
     </message>
     <message>
         <location filename="../src/gui/synthesispopover.cpp" line="966"/>
-        <location filename="../src/gui/synthesispopover.cpp" line="1179"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1174"/>
         <source>Update</source>
         <translation>Aggiornamento</translation>
     </message>
     <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1181"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1176"/>
         <source>Please download the latest version on the website.</source>
         <translation>Si prega di scaricare l&apos;ultima versione dal sito web.</translation>
     </message>
@@ -2576,7 +2554,7 @@ Accedi alla versione web per verificare lo stato del tuo kDrive oppure contatta 
         <translation>Non disponibile</translation>
     </message>
     <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1194"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1189"/>
         <source>You can synchronize files &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;from your computer&lt;/a&gt; or on &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
         <translation>Puoi sincronizzare i file &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;dal tuo computer&lt;/a&gt; o su &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
     </message>
@@ -2597,27 +2575,27 @@ Accedi alla versione web per verificare lo stato del tuo kDrive oppure contatta 
     </message>
     <message>
         <location filename="../src/gui/synthesispopover.cpp" line="1123"/>
-        <location filename="../src/gui/synthesispopover.cpp" line="1175"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1170"/>
         <source>Not implemented!</source>
         <translation>Non implementato!</translation>
     </message>
     <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1187"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1182"/>
         <source>No synchronized folder for this Drive!</source>
         <translation>Nessuna cartella sincronizzata per questo kDrive!</translation>
     </message>
     <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1190"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1185"/>
         <source>No kDrive configured!</source>
         <translation>Nessun kDrive configurato!</translation>
     </message>
     <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1156"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1151"/>
         <source>Unable to open link %1.</source>
         <translation>Impossibile aprire il link %1.</translation>
     </message>
     <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1168"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1163"/>
         <source>Invalid link %1.</source>
         <translation>Link %1 non valido.</translation>
     </message>
@@ -2674,87 +2652,92 @@ Accedi alla versione web per verificare lo stato del tuo kDrive oppure contatta 
 <context>
     <name>KDC::VersionWidget</name>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="270"/>
+        <location filename="../src/gui/versionwidget.cpp" line="295"/>
         <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</source>
         <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="157"/>
+        <location filename="../src/gui/versionwidget.cpp" line="169"/>
         <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Show release note&lt;/a&gt;</source>
         <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Mostra nota di rilascio&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="160"/>
+        <location filename="../src/gui/versionwidget.cpp" line="172"/>
         <source>Version</source>
         <translation>Versione</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="161"/>
+        <location filename="../src/gui/versionwidget.cpp" line="173"/>
         <source>UPDATE</source>
         <translation>AGGIORNAMENTO</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="176"/>
+        <location filename="../src/gui/versionwidget.cpp" line="197"/>
         <source>%1 is up to date!</source>
         <translation>%1 è aggiornato!</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="180"/>
+        <location filename="../src/gui/versionwidget.cpp" line="201"/>
         <source>Checking update on server...</source>
         <translation>Controllo dell&apos;aggiornamento sul server...</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="184"/>
+        <location filename="../src/gui/versionwidget.cpp" line="205"/>
         <source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;here&lt;/a&gt;.</source>
         <translation>È disponibile un aggiornamento: %1.&lt;br&gt;Scaricalo da &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;qui&lt;/a&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="191"/>
+        <location filename="../src/gui/versionwidget.cpp" line="212"/>
         <source>An update is available: %1</source>
         <translation>È disponibile un aggiornamento: %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="197"/>
+        <location filename="../src/gui/versionwidget.cpp" line="218"/>
         <source>Downloading %1. Please wait...</source>
         <translation>Download in corso %1. Attendere...</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="202"/>
+        <location filename="../src/gui/versionwidget.cpp" line="223"/>
         <source>Could not check for new updates.</source>
         <translation>Impossibile verificare la presenza di nuovi aggiornamenti.</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="206"/>
+        <location filename="../src/gui/versionwidget.cpp" line="227"/>
         <source>An error occurred during update.</source>
         <translation>Si è verificato un errore durante l&apos;aggiornamento.</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="210"/>
+        <location filename="../src/gui/versionwidget.cpp" line="231"/>
         <source>Could not download update.</source>
         <translation>Impossibile scaricare l&apos;aggiornamento.</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="226"/>
+        <location filename="../src/gui/versionwidget.cpp" line="235"/>
+        <source>Update disabled.</source>
+        <translation>Aggiornamento disabilitato.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="251"/>
         <source>Beta program</source>
         <translation>Beta program</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="227"/>
+        <location filename="../src/gui/versionwidget.cpp" line="252"/>
         <source>Get early access to new versions of the application</source>
         <translation>Ottenere l&apos;accesso anticipato alle nuove versioni dell&apos;applicazione</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="231"/>
+        <location filename="../src/gui/versionwidget.cpp" line="256"/>
         <source>Join</source>
         <translation>Contatto</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="234"/>
+        <location filename="../src/gui/versionwidget.cpp" line="259"/>
         <source>Modify</source>
         <translation>Modificare</translation>
     </message>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="234"/>
+        <location filename="../src/gui/versionwidget.cpp" line="259"/>
         <source>Quit</source>
         <translation>Esci</translation>
     </message>
@@ -2772,47 +2755,47 @@ Accedi alla versione web per verificare lo stato del tuo kDrive oppure contatta 
         <translation>Impossibile salvare i parametri!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="340"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="355"/>
         <source>The parent folder is a sync folder or contained in one</source>
         <translation>La cartella padre è una cartella di sincronizzazione o contenuta in un</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="361"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="376"/>
         <source>Can&apos;t find a valid path</source>
         <translation>Impossibile trovare un percorso valido</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="1839"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="1862"/>
         <source>No valid folder selected!</source>
         <translation>Nessuna cartella valida selezionata!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="1850"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="1873"/>
         <source>The selected path does not exist!</source>
         <translation>Il percorso selezionato non esiste!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="1855"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="1878"/>
         <source>The selected path is not a folder!</source>
         <translation>Il percorso selezionato non è una cartella!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="1860"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="1883"/>
         <source>You have no permission to write to the selected folder!</source>
         <translation>Non disponi dell&apos;autorizzazione di scrittura per la cartella selezionata!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="1890"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="1913"/>
         <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
         <translation>La cartella locale %1 contiene una cartella già sincronizzata. Scegline un&apos;altra!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="1898"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="1921"/>
         <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
         <translation>La cartella locale %1 è contenuta in una cartella già sincronizzata. Scegline un&apos;altra!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="1908"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="1931"/>
         <source>The local folder %1 is already synced on the same drive. Please pick another one!</source>
         <translation>La cartella locale %1 è già sincronizzata sulla stessa unità. Scegline un&apos;altra!</translation>
     </message>
@@ -2836,11 +2819,56 @@ Accedi alla versione web per verificare lo stato del tuo kDrive oppure contatta 
         <source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
         <translation>Lite sync è disabilitato. I file kDrive utilizzano lo spazio di archiviazione del tuo computer.</translation>
     </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1167"/>
+        <source>Make available locally</source>
+        <translation>Rendere disponibile localmente</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1171"/>
+        <source>Free up local space</source>
+        <translation>Libera spazio locale</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1175"/>
+        <source>Cancel free up local space</source>
+        <translation>Annulla liberazione di spazio locale</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1179"/>
+        <source>Cancel make available locally</source>
+        <translation>Annulla rendere disponibile localmente</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1183"/>
+        <source>Resharing this file is not allowed</source>
+        <translation>Ricondivisione di questo file non consentita</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1184"/>
+        <source>Resharing this folder is not allowed</source>
+        <translation>Ricondivisione di questa cartella non consentita</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1188"/>
+        <source>Copy public share link</source>
+        <translation>Copia il collegamento di condivisione pubblica</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1192"/>
+        <source>Copy private share link</source>
+        <translation>Copia il collegamento di condivisione privata</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1196"/>
+        <source>Open in browser</source>
+        <translation>Apri nel browser</translation>
+    </message>
 </context>
 <context>
     <name>SharedTools::QtSingleApplication</name>
     <message>
-        <location filename="../src/server/appserver.cpp" line="102"/>
+        <location filename="../src/server/appserver.cpp" line="106"/>
         <source>kDrive application will close due to a fatal error.</source>
         <translation>L&apos;applicazione kDrive si chiuderà a causa di un errore irreversibile.</translation>
     </message>
@@ -2933,27 +2961,6 @@ Accedi alla versione web per verificare lo stato del tuo kDrive oppure contatta 
 <context>
     <name>utility</name>
     <message>
-        <location filename="../src/server/socketapi.cpp" line="1362"/>
-        <source>Make available locally</source>
-        <translation>Rendere disponibile localmente</translation>
-    </message>
-    <message>
-        <location filename="../src/server/socketapi.cpp" line="1366"/>
-        <source>Free up local space</source>
-        <translation>Libera spazio locale</translation>
-    </message>
-    <message>
-        <location filename="../src/server/socketapi.cpp" line="1370"/>
-        <source>Cancel free up local space</source>
-        <translation>Annulla liberazione di spazio locale</translation>
-    </message>
-    <message>
-        <location filename="../src/server/socketapi.cpp" line="1375"/>
-        <location filename="../src/server/socketapi.cpp" line="1377"/>
-        <source>Cancel make available locally</source>
-        <translation>Annulla rendere disponibile localmente</translation>
-    </message>
-    <message>
         <location filename="../src/gui/guiutility.cpp" line="79"/>
         <source>Could not open browser</source>
         <translation>Impossibile aprire il browser</translation>
@@ -3036,6 +3043,11 @@ Puoi aggiungerne uno dalle impostazioni di kDrive.</translation>
         <location filename="../src/gui/guiutility.cpp" line="596"/>
         <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
         <translation>La cartella &lt;b&gt;%1&lt;/b&gt; non può essere selezionata come cartella di sincronizzazione. Selezionare un&apos;altra cartella. Cartella suggerita: &lt;b&gt;%2&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="638"/>
+        <source>You cannot exclude more than 1000 folders. Please uncheck higher-level folders.</source>
+        <translation>Non è possibile escludere più di 1000 cartelle. Deselezionare le cartelle di livello superiore.</translation>
     </message>
     <message>
         <location filename="../src/gui/guiutility.cpp" line="347"/>


### PR DESCRIPTION
For now, no packages are uploaded if at least 1 failed. This PR aims to upload anyway all the release artifacts that were successfully built.

Example of successful upload of macOS artifacts while builds for oother OSs failed: https://github.com/Infomaniak/desktop-kDrive/actions/runs/18721126616