### PR TITLE
Feat(settings): add auto-update toggle functionality

### DIFF
--- a/src/gui4/windows/kDrive client/kDrive client/Pages/SettingsPage.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/SettingsPage.xaml
@@ -56,17 +56,20 @@
                 <StackPanel Spacing="{StaticResource Infomaniak.Style.Spacing.XS}">
                     <TextBlock x:Uid="Page_SettingsPage_Global"
                                Style="{StaticResource Infomaniak.Style.TextBlock.Subtitle}" />
-
                     <!-- General - Update -->
                     <controls:UpdateExpander Settings="{x:Bind ViewModel.Settings, Mode=OneWay}" />
 
-                    <toolKit:SettingsCard x:Uid="Page_SettingsPage_AutoUpdate">
+                    <!-- General - Auto Update -->
+                    <toolKit:SettingsCard x:Uid="Page_SettingsPage_AutoUpdate"
+                                          Visibility="Visible">
+                        <!-- TODO: Make it visible once auto-update is implemented on the server side (see: UpdateManager.ChangeAutoUpdate) -->
                         <toolKit:SettingsCard.HeaderIcon>
                             <controls:SvgIcon UriString="{StaticResource Infomaniak.DS.Icons.Arrows.arrows-loop-automatic}"
                                               Height="32"
                                               Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
                         </toolKit:SettingsCard.HeaderIcon>
-                        <ToggleSwitch IsOn="{x:Bind ViewModel.Settings.UpdateManager.AutoUpdateEnabled, Mode=TwoWay}" />
+                        <ToggleSwitch IsOn="{x:Bind ViewModel.Settings.UpdateManager.AutoUpdateEnabled, Mode=OneWay}"
+                                      Toggled="AutoUpdateToggleSwitch_Toggled" />
                     </toolKit:SettingsCard>
 
                     <!-- General - Beta -->

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/SettingsPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/SettingsPage.xaml.cs
@@ -70,6 +70,20 @@ namespace Infomaniak.kDrive.Pages
             (App.Current as App)?.StartOnboarding();
         }
 
+        
+
+        private void SetSelectedChannel(VersionChannel channel)
+        {
+            foreach (var item in UpdateChannel.Items)
+            {
+                if (item is ComboBoxItem comboBoxItem && comboBoxItem.Tag is string tagString && Enum.TryParse<VersionChannel>(tagString, out VersionChannel itemChannel) && itemChannel == channel)
+                {
+                    UpdateChannel.SelectedItem = comboBoxItem;
+                    return;
+                }
+            }
+        }
+
         private async void UpdateChannel_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             if (sender is ComboBox comboBox && comboBox.SelectedItem is ComboBoxItem selectedItem)
@@ -87,15 +101,11 @@ namespace Infomaniak.kDrive.Pages
             }
         }
 
-        private void SetSelectedChannel(VersionChannel channel)
+        private async void AutoUpdateToggleSwitch_Toggled(object sender, RoutedEventArgs e)
         {
-            foreach (var item in UpdateChannel.Items)
+            if (sender is ToggleSwitch toggleSwitch)
             {
-                if (item is ComboBoxItem comboBoxItem && comboBoxItem.Tag is string tagString && Enum.TryParse<VersionChannel>(tagString, out VersionChannel itemChannel) && itemChannel == channel)
-                {
-                    UpdateChannel.SelectedItem = comboBoxItem;
-                    return;
-                }
+                await ViewModel.Settings.UpdateManager.ChangeAutoUpdate(toggleSwitch.IsOn);
             }
         }
     }

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/Settings/UpdateManager.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/Settings/UpdateManager.cs
@@ -40,5 +40,11 @@ namespace Infomaniak.kDrive.ViewModels
         {
             await App.ServiceProvider.GetRequiredService<IServerCommService>().ChangeUpdaterChannel(newChannel, CancellationToken.None);
         }
+
+        public async Task ChangeAutoUpdate(bool activated)
+        {
+            AutoUpdateEnabled = activated; // TODO: Replace with server logic once auto-update is supported by the server
+            await Task.CompletedTask;
+        }
     }
 }


### PR DESCRIPTION
Introduce a new SettingsCard for managing auto-update settings.
- Added `AutoUpdateToggleSwitch_Toggled` event handler in `SettingsPage.xaml.cs`.
- Added `ChangeAutoUpdate` method in `UpdateManager.cs` to handle toggle logic.
- Updated ToggleSwitch binding mode to `OneWay`.

The server-side logic for auto-update will be implemented later.

<img width="497" height="218" alt="image" src="https://github.com/user-attachments/assets/671d4c23-b2dd-45ea-a774-614217e9ef93" />
