### PR TITLE
feat(settings): add language card and update auto-update

### DIFF
--- a/src/gui4/windows/kDrive client/kDrive client/Pages/SettingsPage.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/SettingsPage.xaml
@@ -61,8 +61,8 @@
 
                     <!-- General - Auto Update -->
                     <toolKit:SettingsCard x:Uid="Page_SettingsPage_AutoUpdate"
-                                          Visibility="Visible">
-                        <!-- TODO: Make it visible once auto-update is implemented on the server side (see: UpdateManager.ChangeAutoUpdate) -->
+                                          IsEnabled="False">
+                        <!-- TODO: Make it enabled once auto-update is implemented on the server side (see: UpdateManager.ChangeAutoUpdate) -->
                         <toolKit:SettingsCard.HeaderIcon>
                             <controls:SvgIcon UriString="{StaticResource Infomaniak.DS.Icons.Arrows.arrows-loop-automatic}"
                                               Height="32"
@@ -72,6 +72,20 @@
                                       Toggled="AutoUpdateToggleSwitch_Toggled" />
                     </toolKit:SettingsCard>
 
+                    <!-- General - Language -->
+                    <toolKit:SettingsCard x:Uid="Page_SettingsPage_Language"
+                                          IsEnabled="False">
+                        <toolKit:SettingsCard.HeaderIcon>
+                            <controls:SvgIcon  UriString="{StaticResource Infomaniak.DS.Icons.Communication.translate}"
+                                               Height="32"
+                                               Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
+                        </toolKit:SettingsCard.HeaderIcon>
+                        <ComboBox SelectedIndex="0">
+                            <ComboBoxItem x:Uid="Page_SettingsPage_Language_ComboBox_Default" />
+                            <!-- TODO: Add language options here (Not needed for beta release)-->
+                        </ComboBox>
+                    </toolKit:SettingsCard>
+                    
                     <!-- General - Beta -->
                     <toolKit:SettingsCard Description="kDrive Beta est disponible."
                                           Header="Version Beta">
@@ -88,21 +102,7 @@
                         </ComboBox>
                     </toolKit:SettingsCard>
 
-                    <!-- General - Language -->
-                    <toolKit:SettingsCard Header="Langue">
-                        <toolKit:SettingsCard.HeaderIcon>
-                            <controls:SvgIcon  UriString="{StaticResource Infomaniak.DS.Icons.Communication.translate}"
-                                               Height="32"
-                                               Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
-                        </toolKit:SettingsCard.HeaderIcon>
-                        <ComboBox SelectedIndex="0">
-                            <ComboBoxItem>Français</ComboBoxItem>
-                            <ComboBoxItem>Anglais</ComboBoxItem>
-                            <ComboBoxItem>Allemand</ComboBoxItem>
-                            <ComboBoxItem>Espagnol</ComboBoxItem>
-                            <ComboBoxItem>Italien</ComboBoxItem>
-                        </ComboBox>
-                    </toolKit:SettingsCard>
+                   
 
                     <!-- General - Auto start -->
                     <toolKit:SettingsCard Header="Ouvrir kDrive au démarrage de l’ordinateur">

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/de-DE/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/de-DE/Resources.resw
@@ -496,4 +496,10 @@
   <data name="CC_UpdateExpander_ChangeLogHyperLink.Content" xml:space="preserve">
     <value />
   </data>
+  <data name="Page_SettingsPage_Language.Header" type="System.Resources.ResXNullRef, System.Windows.Forms">
+    <value />
+  </data>
+  <data name="Page_SettingsPage_Language_ComboBox_default.Content" type="System.Resources.ResXNullRef, System.Windows.Forms">
+    <value />
+  </data>
 </root>

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/en-US/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/en-US/Resources.resw
@@ -496,4 +496,10 @@
   <data name="CC_UpdateExpander_ChangeLogHyperLink.Content" xml:space="preserve">
     <value />
   </data>
+  <data name="Page_SettingsPage_Language.Header" type="System.Resources.ResXNullRef, System.Windows.Forms">
+    <value />
+  </data>
+  <data name="Page_SettingsPage_Language_ComboBox_default.Content" type="System.Resources.ResXNullRef, System.Windows.Forms">
+    <value />
+  </data>
 </root>

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/es-ES/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/es-ES/Resources.resw
@@ -496,4 +496,10 @@
   <data name="CC_UpdateExpander_ChangeLogHyperLink.Content" xml:space="preserve">
     <value />
   </data>
+  <data name="Page_SettingsPage_Language.Header" type="System.Resources.ResXNullRef, System.Windows.Forms">
+    <value />
+  </data>
+  <data name="Page_SettingsPage_Language_ComboBox_default.Content" type="System.Resources.ResXNullRef, System.Windows.Forms">
+    <value />
+  </data>
 </root>

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/fr-FR/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/fr-FR/Resources.resw
@@ -533,4 +533,10 @@ Version {0} (build {1}), compilée le {2}
   <data name="CC_UpdateExpander_ChangeLogHyperLink.Content" xml:space="preserve">
     <value>Notes de mise à jour</value>
   </data>
+  <data name="Page_SettingsPage_Language.Header" xml:space="preserve">
+    <value>Langue</value>
+  </data>
+  <data name="Page_SettingsPage_Language_ComboBox_default.Content" xml:space="preserve">
+    <value>Default</value>
+  </data>
 </root>

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/it-IT/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/it-IT/Resources.resw
@@ -496,4 +496,10 @@
   <data name="CC_UpdateExpander_ChangeLogHyperLink.Content" xml:space="preserve">
     <value />
   </data>
+  <data name="Page_SettingsPage_Language.Header" type="System.Resources.ResXNullRef, System.Windows.Forms">
+    <value />
+  </data>
+  <data name="Page_SettingsPage_Language_ComboBox_default.Content" type="System.Resources.ResXNullRef, System.Windows.Forms">
+    <value />
+  </data>
 </root>

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/Settings/UpdateManager.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/Settings/UpdateManager.cs
@@ -9,7 +9,7 @@ namespace Infomaniak.kDrive.ViewModels
 {
     public class UpdateManager : UISafeObservableObject
     {
-        private bool _autoUpdateEnabled = true;
+        private bool _autoUpdateEnabled = false;
         private VersionChannel _currentChannel = VersionChannel.Beta;
         private AppVersion? _updateData;
 


### PR DESCRIPTION
Added a new "Language" settings card (currently disabled) with a placeholder dropdown for future language options. Updated the "Auto Update" card to be disabled by default. Removed the old language card implementation.Updated resources for new settings. Changed default auto-update behavior to disabled in UpdateManager.