### PR TITLE
Fix crash on showing context menu

### DIFF
--- a/src/libcommonserver/utility/utility_win.cpp
+++ b/src/libcommonserver/utility/utility_win.cpp
@@ -637,7 +637,7 @@ bool Utility::registryWalkSubKeys(HKEY hRootKey, const std::wstring &subKey,
     HKEY hKey;
     REGSAM sam = KEY_READ | KEY_WOW64_64KEY;
     LONG result = RegOpenKeyEx(hRootKey, subKey.c_str(), 0, sam, &hKey);
-    LOG_IF_FAIL(Log::instance()->getLogger(), result == ERROR_INVALID_FUNCTION)
+    LOG_IF_FAIL(Log::instance()->getLogger(), result == ERROR_SUCCESS)
     if (result != ERROR_SUCCESS) return false;
 
     DWORD maxSubKeyNameSize;

--- a/src/server/comm/extensionjob.cpp
+++ b/src/server/comm/extensionjob.cpp
@@ -220,7 +220,7 @@ void ExtensionJob::commandGetMenuItems(const CommString &argument, std::shared_p
 
 void ExtensionJob::commandCopyPublicLink(const CommString &argument, std::shared_ptr<AbstractCommChannel>) {
     const auto fileData = FileData::get(argument);
-    if (!fileData.syncDbId) return;
+    if (!fileData.isValid()) return;
 
     const auto syncPalMapIt = retrieveSyncPalMapIt(fileData.syncDbId);
     if (syncPalMapIt == _commManager->syncPalMap().end()) return;
@@ -275,7 +275,7 @@ void ExtensionJob::commandMakeAvailableLocallyDirect(const CommString &argument,
         SyncPath filePath(filePathStr);
 #endif
         auto fileData = FileData::get(filePath);
-        if (!fileData.syncDbId) {
+        if (!fileData.isValid()) {
             LOGW_WARN(Log::instance()->getLogger(), L"No file data - " << Utility::formatSyncPath(filePath));
             continue;
         }
@@ -470,6 +470,11 @@ void ExtensionJob::commandGetAllMenuItems(const CommString &argument, std::share
     // Some options only show for single files
     if (argumentList.size() == 1) {
         FileData fileData = FileData::get(argumentList[0]);
+        if (!fileData.isValid()) {
+            (void) channel->sendMessage(response);
+            return;
+        }
+
         NodeId nodeId;
         ExitCode exitCode = syncPalMapIt->second->fileRemoteIdFromLocalPath(fileData.relativePath, nodeId);
         if (exitCode != ExitCode::Ok) {
@@ -501,6 +506,7 @@ void ExtensionJob::commandGetAllMenuItems(const CommString &argument, std::share
         for (const auto &filePathStr: argumentList) {
             SyncPath filePath(filePathStr);
             auto fileData = FileData::get(filePath);
+            if (!fileData.isValid()) break;
             if (syncPalMapIt->second->isDownloadOngoing(fileData.relativePath)) {
                 canCancelHydration = true;
                 break;
@@ -553,7 +559,7 @@ void ExtensionJob::commandGetThumbnail(const CommString &argument, std::shared_p
     }
 
     FileData fileData = FileData::get(filePath);
-    if (!fileData.syncDbId) {
+    if (!fileData.isValid()) {
         LOGW_WARN(Log::instance()->getLogger(),
                   L"The file is not in a synchonized folder - " << Utility::formatSyncPath(filePath));
         return;
@@ -768,6 +774,10 @@ void ExtensionJob::executeCommand(const CommString &commandLineStr, std::shared_
 void ExtensionJob::manageActionsOnSingleFile(std::shared_ptr<AbstractCommChannel> channel, const std::vector<CommString> &files,
                                              SyncPalMap::const_iterator syncPalMapIt, VfsMap::const_iterator vfsMapIt,
                                              const Sync &sync) {
+    if (files.size() != 1) {
+        return;
+    }
+
     bool exists = false;
     IoError ioError = IoError::Success;
     if (!IoHelper::checkIfPathExists(files[0], exists, ioError) || !exists) {
@@ -775,7 +785,7 @@ void ExtensionJob::manageActionsOnSingleFile(std::shared_ptr<AbstractCommChannel
     }
 
     FileData fileData = FileData::get(files[0]);
-    if (fileData.localPath.empty()) {
+    if (!fileData.isValid()) {
         return;
     }
     bool isExcluded = vfsMapIt->second->isExcluded(fileData.localPath);
@@ -832,7 +842,9 @@ void ExtensionJob::fetchPrivateLinkUrlHelper(const SyncPath &localFile,
 
     if (syncPalMapIt == _commManager->syncPalMap().end()) return;
 
-    FileData fileData = FileData::get(localFile);
+    const FileData fileData = FileData::get(localFile);
+    if (!fileData.isValid()) return;
+
     NodeId itemId;
     if (syncPalMapIt->second->fileRemoteIdFromLocalPath(fileData.relativePath, itemId) != ExitCode::Ok) {
         LOGW_WARN(Log::instance()->getLogger(), L"Error in SyncPal::itemId - " << Utility::formatSyncPath(localFile));
@@ -848,7 +860,7 @@ bool ExtensionJob::syncFileStatus(const FileData &fileData, SyncFileStatus &stat
     vfsStatus.isPlaceholder = false;
     vfsStatus.isHydrated = false;
 
-    if (!fileData.syncDbId) return false;
+    if (!fileData.isValid()) return false;
 
     const auto syncPalMapIt = retrieveSyncPalMapIt(fileData.syncDbId);
     if (syncPalMapIt == _commManager->syncPalMap().end()) return false;
@@ -1120,16 +1132,17 @@ void ExtensionJob::buildAndSendMenuItemMessage(std::shared_ptr<AbstractCommChann
 void ExtensionJob::processFileList(const std::vector<CommString> &inFileList, std::vector<SyncPath> &outFileList) {
     // Process all files
     for (const auto &path: inFileList) {
-        FileData fileData = FileData::get(path);
-        if (fileData.virtualFileMode == VirtualFileMode::Mac) {
-            QFileInfo info(CommonUtility::commString2QStr(path));
+        const FileData fileData = FileData::get(path);
+        if (fileData.isValid() && fileData.virtualFileMode == VirtualFileMode::Mac) {
+            const QFileInfo info(CommonUtility::commString2QStr(path));
             if (info.isDir()) {
                 const QFileInfoList infoList =
                         QDir(CommonUtility::commString2QStr(path)).entryInfoList(QDir::Dirs | QDir::Files | QDir::NoDotAndDotDot);
                 std::vector<CommString> fileList;
                 for (const auto &tmpInfo: qAsConst(infoList)) {
-                    SyncPath tmpPath(QStr2Path(tmpInfo.filePath()));
+                    const SyncPath tmpPath(QStr2Path(tmpInfo.filePath()));
                     FileData tmpFileData = FileData::get(tmpPath);
+                    if (!tmpFileData.isValid()) continue;
 
                     auto status = SyncFileStatus::Unknown;
                     if (VfsStatus vfsStatus; !syncFileStatus(tmpFileData, status, vfsStatus)) {
@@ -1231,7 +1244,7 @@ FileData FileData::get(const SyncPath &path) {
         } else {
             LOGW_WARN(Log::instance()->getLogger(), L"Error in Utility::longpath - " << Utility::formatSyncPath(path));
         }
-        return FileData();
+        return {};
     }
 #else
     SyncPath tmpPath(path);

--- a/src/server/comm/extensionjob.cpp
+++ b/src/server/comm/extensionjob.cpp
@@ -153,11 +153,8 @@ void ExtensionJob::commandGetMenuItems(const CommString &argument, std::shared_p
         if (vfsMapIt == _commManager->vfsMap().end()) return;
     }
 
-    // Some options only show for single files
-    bool isSingleFile = false;
     if (files.size() == 1) {
         manageActionsOnSingleFile(channel, files, syncPalMapIt, vfsMapIt, sync);
-        isSingleFile = QFileInfo(CommonUtility::commString2QStr(files[0])).isFile();
     }
 
 #if defined(KD_MACOS)
@@ -171,9 +168,13 @@ void ExtensionJob::commandGetMenuItems(const CommString &argument, std::shared_p
         }
     }
 
+
     // File availability actions
     if (sync.dbId() && sync.virtualFileMode() != VirtualFileMode::Off && vfsMapIt->second->showPinStateActions()) {
         LOG_IF_FAIL(Log::instance()->getLogger(), !files.empty());
+
+        bool isSingleFile = files.size() == 1 && QFileInfo(CommonUtility::commString2QStr(files[0])).isFile();
+        ;
 
         bool canHydrate = true;
         bool canDehydrate = true;
@@ -206,12 +207,6 @@ void ExtensionJob::commandGetMenuItems(const CommString &argument, std::shared_p
         };
 
         makePinContextMenu(canHydrate, canDehydrate, canCancelDehydration, canCancelHydration);
-    }
-#elif defined(KD_WINDOWS)
-    // Some options only show for single files
-    bool isSingleFile = false;
-    if (files.size() == 1) {
-        manageActionsOnSingleFile(channel, files, syncPalMapIt, vfsMapIt, sync);
     }
 #endif
 

--- a/src/server/comm/extensionjob.cpp
+++ b/src/server/comm/extensionjob.cpp
@@ -153,6 +153,13 @@ void ExtensionJob::commandGetMenuItems(const CommString &argument, std::shared_p
         if (vfsMapIt == _commManager->vfsMap().end()) return;
     }
 
+    // Some options only show for single files
+    bool isSingleFile = false;
+    if (files.size() == 1) {
+        manageActionsOnSingleFile(channel, files, syncPalMapIt, vfsMapIt, sync);
+        isSingleFile = QFileInfo(CommonUtility::commString2QStr(files[0])).isFile();
+    }
+
 #if defined(KD_MACOS)
     // Manage dehydration cancellation
     bool canCancelDehydration = false;
@@ -167,14 +174,6 @@ void ExtensionJob::commandGetMenuItems(const CommString &argument, std::shared_p
     // File availability actions
     if (sync.dbId() && sync.virtualFileMode() != VirtualFileMode::Off && vfsMapIt->second->showPinStateActions()) {
         LOG_IF_FAIL(Log::instance()->getLogger(), !files.empty());
-
-        // Some options only show for single files
-        bool isSingleFile = false;
-        if (files.size() == 1) {
-            manageActionsOnSingleFile(channel, files, syncPalMapIt, vfsMapIt, sync);
-
-            isSingleFile = QFileInfo(CommonUtility::commString2QStr(files[0])).isFile();
-        }
 
         bool canHydrate = true;
         bool canDehydrate = true;

--- a/src/server/comm/extensionjob.h
+++ b/src/server/comm/extensionjob.h
@@ -31,6 +31,8 @@ struct FileData {
         static FileData get(const SyncPath &path);
         FileData parentFolder() const;
 
+        bool isValid() const { return syncDbId != 0; }
+
         // Absolute path of the file locally
         SyncPath localPath;
 


### PR DESCRIPTION
The value return by `FileData::get()` should always be checked.

Depends on 1133