### PR TITLE
Filter out empty node ID

### DIFF
--- a/src/libsyncengine/db/syncdb.cpp
+++ b/src/libsyncengine/db/syncdb.cpp
@@ -1791,9 +1791,9 @@ bool SyncDb::deleteSyncNode(const NodeId &nodeId, bool &found) {
     return true;
 }
 
-bool SyncDb::updateAllSyncNodes(SyncNodeType type, const NodeSet &nodeIdSet) {
+bool SyncDb::updateAllSyncNodes(const SyncNodeType type, const NodeSet &nodeIdSet) {
     const std::scoped_lock lock(_mutex);
-    int errId;
+    int errId = 0;
     std::string error;
 
     startTransaction();
@@ -1809,6 +1809,7 @@ bool SyncDb::updateAllSyncNodes(SyncNodeType type, const NodeSet &nodeIdSet) {
 
     // Insert new SyncNodes
     for (const NodeId &nodeId: nodeIdSet) {
+        if (nodeId.empty()) continue;
         LOG_IF_FAIL(queryResetAndClearBindings(INSERT_SYNC_NODE_REQUEST_ID));
         LOG_IF_FAIL(queryBindValue(INSERT_SYNC_NODE_REQUEST_ID, 1, nodeId));
         LOG_IF_FAIL(queryBindValue(INSERT_SYNC_NODE_REQUEST_ID, 2, toInt(type)));
@@ -1824,12 +1825,12 @@ bool SyncDb::updateAllSyncNodes(SyncNodeType type, const NodeSet &nodeIdSet) {
     return true;
 }
 
-bool SyncDb::selectAllSyncNodes(SyncNodeType type, NodeSet &nodeIdSet) {
+bool SyncDb::selectAllSyncNodes(const SyncNodeType type, NodeSet &nodeIdSet) {
     const std::scoped_lock lock(_mutex);
 
     LOG_IF_FAIL(queryResetAndClearBindings(SELECT_ALL_SYNC_NODE_REQUEST_ID));
     LOG_IF_FAIL(queryBindValue(SELECT_ALL_SYNC_NODE_REQUEST_ID, 1, toInt(type)));
-    bool found;
+    bool found = false;
     for (;;) {
         if (!queryNext(SELECT_ALL_SYNC_NODE_REQUEST_ID, found)) {
             LOG_WARN(_logger, "Error getting query result: " << SELECT_ALL_SYNC_NODE_REQUEST_ID);
@@ -1841,6 +1842,7 @@ bool SyncDb::selectAllSyncNodes(SyncNodeType type, NodeSet &nodeIdSet) {
 
         NodeId nodeId;
         LOG_IF_FAIL(queryStringValue(SELECT_ALL_SYNC_NODE_REQUEST_ID, 0, nodeId));
+        if (nodeId.empty()) continue;
 
         nodeIdSet.insert(nodeId);
     }

--- a/src/libsyncengine/jobs/network/kDrive_API/listing/abstractlistingjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/listing/abstractlistingjob.cpp
@@ -36,6 +36,7 @@ ExitInfo AbstractListingJob::setData() {
         Poco::JSON::Object json;
         Poco::JSON::Array withoutIdsArray;
         for (const auto &id: _blacklist) {
+            if (id.empty()) continue;
             (void) withoutIdsArray.add(id);
         }
         (void) json.set("without_ids", withoutIdsArray);


### PR DESCRIPTION
Empty node IDs should never be sent in the `without_ids` body parameter