### PR TITLE
[TRELLO-1132] Define the constants of the Windows installer project at build time

### DIFF
--- a/infomaniak-build-tools/windows/build-drive.ps1
+++ b/infomaniak-build-tools/windows/build-drive.ps1
@@ -593,12 +593,49 @@ function Create-Archive {
     Write-Host "Archive created."
 }
 
+function Get-Overlay-Guid {
+    param (
+        [string] $path,
+        [string] $keyType
+    )
+
+
+    $guid = (Select-String -Path "$path\extensions\windows\standard\KDOverlays\OverlayConstants.h" $keyType)
+    $guid = $guid.Substring(1) # Trim the initial 'L' character.
+
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+    return $guid
+}
+
 function Create-MSI-Package {
+    param (
+        [string] $path,
+        [string] $buildPath
+    )
+
     Write-Host "Creating MSI package ..."
 
-	$appName = Get-Package-Name $buildPath
+    $guid = Get-Overlay-Guid -Path $path -KeyType "OVERLAY_GUID_OK"
+    $definedConstants = "regKeyOkGUID=$guid;"
+
+    $guid = Get-Overlay-Guid -Path $path -KeyType "OVERLAY_GUID_ERROR"
+    $definedConstants += "regKeyErrorGUID=$guid;"
+
+    $guid = Get-Overlay-Guid -Path $path -KeyType "OVERLAY_GUID_SYNC"
+    $definedConstants += "regKeySyncGUID=$guid;"
+
+    $guid = Get-Overlay-Guid -Path $path -KeyType "OVERLAY_GUID_WARNING"
+    $definedConstants += "regKeyWarningGUID=$guid;"
+    
+    $definedConstants += "desktop-kDriveDir=" + "$path;"
+
+    $version = Get-Version -IncludeBuildVersion true
+    $definedConstants += "version=" + "$version;"
+
+    $appName = Get-Package-Name $buildPath
 	
-	dotnet build "$msiInstallerFolderPath/kDriveInstaller.sln" /p:Configuration="Release" /p:Platform="x64" /p:OutputName=$appName
+	dotnet build "$msiInstallerFolderPath/kDriveInstaller.sln" /p:Configuration="Release" /p:Platform="x64" /p:OutputName=$appName /p:DefineConstants=$definedConstants
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 	Move-Item -Path "$msiPackageFolderPath/$appName.msi" -Destination "$contentPath"
@@ -832,7 +869,7 @@ if (!$ci) {
 #################################################################################################
 
 if ($msi) {
-    Create-MSI-Package
+    Create-MSI-Package -Path $path -BuildPath $buildPath
     if ($LASTEXITCODE -ne 0) {
         Write-Host "MSI package creation failed ($LASTEXITCODE) . Aborting." -f Red
         exit $LASTEXITCODE

--- a/infomaniak-build-tools/windows/build-drive.ps1
+++ b/infomaniak-build-tools/windows/build-drive.ps1
@@ -593,49 +593,12 @@ function Create-Archive {
     Write-Host "Archive created."
 }
 
-function Get-Overlay-Guid {
-    param (
-        [string] $path,
-        [string] $keyType
-    )
-
-
-    $guid = (Select-String -Path "$path\extensions\windows\standard\KDOverlays\OverlayConstants.h" $keyType)
-    $guid = $guid.Substring(1) # Trim the initial 'L' character.
-
-    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-
-    return $guid
-}
-
 function Create-MSI-Package {
-    param (
-        [string] $path,
-        [string] $buildPath
-    )
-
     Write-Host "Creating MSI package ..."
 
-    $guid = Get-Overlay-Guid -Path $path -KeyType "OVERLAY_GUID_OK"
-    $definedConstants = "regKeyOkGUID=$guid;"
-
-    $guid = Get-Overlay-Guid -Path $path -KeyType "OVERLAY_GUID_ERROR"
-    $definedConstants += "regKeyErrorGUID=$guid;"
-
-    $guid = Get-Overlay-Guid -Path $path -KeyType "OVERLAY_GUID_SYNC"
-    $definedConstants += "regKeySyncGUID=$guid;"
-
-    $guid = Get-Overlay-Guid -Path $path -KeyType "OVERLAY_GUID_WARNING"
-    $definedConstants += "regKeyWarningGUID=$guid;"
-    
-    $definedConstants += "desktop-kDriveDir=" + "$path;"
-
-    $version = Get-Version -IncludeBuildVersion true
-    $definedConstants += "version=" + "$version;"
-
-    $appName = Get-Package-Name $buildPath
+	$appName = Get-Package-Name $buildPath
 	
-	dotnet build "$msiInstallerFolderPath/kDriveInstaller.sln" /p:Configuration="Release" /p:Platform="x64" /p:OutputName=$appName /p:DefineConstants=$definedConstants
+	dotnet build "$msiInstallerFolderPath/kDriveInstaller.sln" /p:Configuration="Release" /p:Platform="x64" /p:OutputName=$appName
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 	Move-Item -Path "$msiPackageFolderPath/$appName.msi" -Destination "$contentPath"
@@ -869,7 +832,7 @@ if (!$ci) {
 #################################################################################################
 
 if ($msi) {
-    Create-MSI-Package -Path $path -BuildPath $buildPath
+    Create-MSI-Package
     if ($LASTEXITCODE -ne 0) {
         Write-Host "MSI package creation failed ($LASTEXITCODE) . Aborting." -f Red
         exit $LASTEXITCODE

--- a/installer/windows/Bootstraper/fetchVersion.ps1
+++ b/installer/windows/Bootstraper/fetchVersion.ps1
@@ -28,12 +28,15 @@ function Get-Overlay-Guid {
         [string] $keyType
     )
 
-    $guid = (Select-String -Path "$path\extensions\windows\standard\KDOverlays\OverlayConstants.h" $keyType |  Select-Object -ExpandProperty Line)
-    $guid = $guid.Split(" ")[-1] # Extract last word.
-    $guid = $guid.Substring(1) # Trim the initial 'L' character.
-
-    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-
+    try {
+        $guid = (Select-String -Path "$path\extensions\windows\standard\KDOverlays\OverlayConstants.h" $keyType |  Select-Object -ExpandProperty Line)
+        $guid = $guid.Split(" ")[-1] # Extract last word.
+        $guid = $guid.Substring(2, $guid.length - 3) # Trim the initial 'L' character and the surrounding double quotes.
+    } catch {
+            Write-Error "Failed to retrieve overlay GUID for '$keyType' from OverlayConstants.h"
+            exit 1
+    }
+    
     return $guid
 }
 
@@ -45,19 +48,18 @@ function Update-Define-Constants {
     )
 
     $pattern = "$key=*"
-    $existing = $defineConstants | Where-Object { $_ -like $pattern }
+    $existing = $defineConstants.Value | Where-Object { $_ -like $pattern }
 
     if ($existing) {
         # Update existing constant
-        $constantIndex = [array]::IndexOf($defineConstants, $existing)
-        $defineConstants[$constantIndex] = "$key=$value"
+        $constantIndex = [array]::IndexOf($defineConstants.Value, $existing)
+        $defineConstants.Value[$constantIndex] = "$key=$value"
         Write-Host "Existing $key constant found. Updating to $value."
     } else {
         # Add new constant
         $defineConstants.Value += "$key=$value"
         Write-Host "No existing $key constant found. Adding $key=$value"
     }
-
 }
 
 
@@ -102,8 +104,6 @@ Update-Define-Constants -Key "regKeySyncGUID" -Value $guid -DefineConstants ([re
 
 $guid = Get-Overlay-Guid -Path $RepositoryRootPath -KeyType "OVERLAY_GUID_WARNING"
 Update-Define-Constants -Key "regKeyWarningGUID" -Value $guid -DefineConstants ([ref]$defineConstants)
-
-Write-Host $defineConstants
 
 # Save
 

--- a/installer/windows/Bootstraper/fetchVersion.ps1
+++ b/installer/windows/Bootstraper/fetchVersion.ps1
@@ -21,6 +21,46 @@ param(
     [string]$RepositoryRootPath
 )
 
+
+function Get-Overlay-Guid {
+    param (
+        [string] $path,
+        [string] $keyType
+    )
+
+    $guid = (Select-String -Path "$path\extensions\windows\standard\KDOverlays\OverlayConstants.h" $keyType |  Select-Object -ExpandProperty Line)
+    $guid = $guid.Split(" ")[-1] # Extract last word.
+    $guid = $guid.Substring(1) # Trim the initial 'L' character.
+
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+    return $guid
+}
+
+function Update-Define-Constants {
+    param (
+        [string] $key,
+        [string] $value,
+        [ref] $defineConstants
+    )
+
+    $pattern = "$key=*"
+    $existing = $defineConstants | Where-Object { $_ -like $pattern }
+
+    if ($existing) {
+        # Update existing constant
+        $constantIndex = [array]::IndexOf($defineConstants, $existing)
+        $defineConstants[$constantIndex] = "$key=$value"
+        Write-Host "Existing $key constant found. Updating to $value."
+    } else {
+        # Add new constant
+        $defineConstants.Value += "$key=$value"
+        Write-Host "No existing $key constant found. Adding $key=$value"
+    }
+
+}
+
+
 $versionString = ""
 $RepositoryRootPath = $RepositoryRootPath.Trim('"')
 . "$RepositoryRootPath\infomaniak-build-tools\version-helpers.ps1"
@@ -39,22 +79,33 @@ if (-Not (Test-Path $WixProjPath)) {
 $propertyGroupNode = $wixProjXml.Project.PropertyGroup | Where-Object { $_.DefineConstants } | Select-Object -First 1
 
 if (-not $propertyGroupNode) {
-    Write-Error "No <DefineConstants> found in wixproj — expected exactly one."
+    Write-Error "No <DefineConstants> found in wixproj. Expected exactly one."
     exit 1
 }
-$defineConstants = $propertyGroupNode.DefineConstants -split ';'
-$existingVersion = $defineConstants | Where-Object { $_ -like 'version=*' }
 
-if ($existingVersion) {
-    # Update existing Version constant
-    $versionConstantIndex = [array]::IndexOf($defineConstants, $existingVersion)
-    $defineConstants[$versionConstantIndex] = "version=$versionString"
-    Write-Host "Existing Version constant found. Updating to $versionString"
-} else {
-    # Add new Version constant
-    $defineConstants += "version=$versionString"
-    Write-Host "No existing Version constant found. Adding Version=$versionString"
-}
+$defineConstants = $propertyGroupNode.DefineConstants -split ';'
+
+# Version
+
+Update-Define-Constants -Key "version" -Value $versionString -DefineConstants ([ref]$defineConstants)
+
+# Overlay GUIDs 
+
+$guid = Get-Overlay-Guid -Path $RepositoryRootPath -KeyType "OVERLAY_GUID_OK"
+Update-Define-Constants -Key "regKeyOkGUID" -Value $guid -DefineConstants ([ref]$defineConstants)
+
+$guid = Get-Overlay-Guid -Path $RepositoryRootPath -KeyType "OVERLAY_GUID_ERROR"
+Update-Define-Constants -Key "regKeyErrorGUID" -Value $guid -DefineConstants ([ref]$defineConstants)
+
+$guid = Get-Overlay-Guid -Path $RepositoryRootPath -KeyType "OVERLAY_GUID_SYNC"
+Update-Define-Constants -Key "regKeySyncGUID" -Value $guid -DefineConstants ([ref]$defineConstants)
+
+$guid = Get-Overlay-Guid -Path $RepositoryRootPath -KeyType "OVERLAY_GUID_WARNING"
+Update-Define-Constants -Key "regKeyWarningGUID" -Value $guid -DefineConstants ([ref]$defineConstants)
+
+Write-Host $defineConstants
+
+# Save
 
 $propertyGroupNode.DefineConstants = ($defineConstants -join ';')
 Write-Host "Updated wixproj Version to $versionString"

--- a/installer/windows/kDriveInstaller/kDriveInstaller.wixproj
+++ b/installer/windows/kDriveInstaller/kDriveInstaller.wixproj
@@ -1,6 +1,6 @@
 <Project Sdk="WixToolset.Sdk/6.0.2">
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <DefineConstants>desktop-kDriveDir=$(SolutionDir)..\..\..;regKeyOkGUID={0960F090-F328-48A3-B746-276B1E3C3722};regKeyErrorGUID={0960F090-F328-48A3-B746-276B1E3C3722};regKeySyncGUID={0960F094-F328-48A3-B746-276B1E3C3722};regKeyWarningGUID={0960F096-F328-48A3-B746-276B1E3C3722};version=3.7.8.2</DefineConstants>
+    <DefineConstants>desktop-kDriveDir=$(SolutionDir)..\..\..</DefineConstants>
     <VerboseOutput>true</VerboseOutput>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <SuppressIces>ICE57;ICE61</SuppressIces>


### PR DESCRIPTION
The goal of this PR is to ensure that the file _"OverlayConstants.h"_ remains the only source of true regarding the values of the overlay GUI constants. Duplicate values have been removed from the Windows installer project. The overlay constants are now retrevied at the time of bootstrapping the Windows installer project.