### PR TITLE
Windows - Add -UpdateEnvironment parameter to build_dependencies.ps1

### DIFF
--- a/infomaniak-build-tools/conan/build_dependencies.ps1
+++ b/infomaniak-build-tools/conan/build_dependencies.ps1
@@ -58,7 +58,10 @@ param(
     [string]$OutputDir,
 
     [Parameter(Mandatory = $false, HelpMessage = "Use the 'infomaniak_release' Conan profile.")]
-    [switch]$MakeRelease
+    [switch]$MakeRelease,
+
+    [Parameter(Mandatory = $false, HelpMessage = "Update environment variables after installation.")]
+    [switch]$UpdateEnvironment
 )
 
 function Show-Help { Write-Host "Usage: $($MyInvocation.MyCommand.Name) [-Help] [Debug|Release|RelWithDebInfo] [-CI] [-OutputDir <path>] [-MakeRelease]" ; exit 0 }
@@ -207,6 +210,39 @@ if ($LASTEXITCODE -ne 0) {
 }
 
 Log "Conan dependencies successfully installed in: $OutputDir"
+
+# Update user environment variables if requested (programs will need to be restarted to see the changes)
+if ($UpdateEnvironment) {
+    Log "Removing previous conan path in user Path environment variable..."
+    $currentUserPath = [System.Environment]::GetEnvironmentVariable("Path", "User")
+    $newUserPath = ($currentUserPath -split ';' | Where-Object { $_ -notlike "*\.conan2\*" }) -join ';'
+
+    Log "Adding new conan path to user Path environment variable..."
+    $allowedNames = @("build", "bin")
+
+    $conanRoot = Join-Path $env:USERPROFILE ".conan2\p"
+        $conanBinPaths = Get-ChildItem -Path $conanRoot -Recurse -Include *.exe, *.dll | ForEach-Object { $_.Directory.FullName } | Sort-Object -Unique
+
+    # Get matching directories
+    $conanBinPaths = Get-ChildItem -Path $conanRoot -Recurse -Include *.exe, *.dll | Sort-Object -Unique | Where-Object {
+        $current = $_.Directory.Name
+        $parent = $_.Directory.Parent.Name
+        $grandparent = $_.Directory.Parent.Parent.Name
+        $allowedNames -contains $current -or
+        $allowedNames -contains $parent -or
+        $allowedNames -contains $grandparent
+    } | ForEach-Object { $_.Directory.FullName } | Sort-Object -Unique
+
+    foreach ($path in $conanBinPaths) {
+        if (-not ($newUserPath -split ';' | Where-Object { $_ -eq $path })) {
+            Log "Adding '$path' to user Path."
+            $newUserPath += ";$path"
+        }
+    }
+   [System.Environment]::SetEnvironmentVariable("Path", $newUserPath, "User")
+   Log "New user Path set to: $newUserPath"
+   Log "User Path environment variable updated. Please restart your programs to apply the changes."
+}
 
 if ($CI)  {
     # Exit the python virtual environment.


### PR DESCRIPTION
### ✨ Add optional `-UpdateEnvironment` parameter to update user environment variables after Conan installation (build_dependencies.ps1)

This PR introduces a new optional `-UpdateEnvironment` flag that updates the user's environment variables after installing Conan.

#### ✅ Key changes

* Added support for `-UpdateEnvironment` parameter
* Automatically cleans and updates the **user `Path`** variable
* Detects and adds the relevant Conan `build` / `bin` paths so debug builds can locate the generated DLLs

#### 🛠 Why this change?

Until now, in development environments we had to manually locate the Conan-built DLLs and copy/paste them into our build folder.

This workflow was error-prone and time-consuming.
With this change, the appropriate Conan output directories are added to the user `Path`, allowing the debug application to automatically resolve these binaries.

#### 🚀 Result

* No more manual DLL hunting
* Cleaner and faster local development workflow
* Environment can be updated automatically when needed