### PR TITLE
Handle 401 errors better

### DIFF
--- a/src/libcommon/keychainmanager/apitoken.cpp
+++ b/src/libcommon/keychainmanager/apitoken.cpp
@@ -76,6 +76,7 @@ std::string ApiToken::reconstructJsonString() const {
     obj.stringify(out);
     return out.str();
 }
+
 bool ApiToken::operator==(const ApiToken &other) const {
     return this->_accessToken == other._accessToken && this->_refreshToken == other._refreshToken &&
            this->_tokenType == other._tokenType && this->_expiresIn == other._expiresIn && this->_userId == other._userId &&

--- a/src/libcommon/keychainmanager/apitoken.h
+++ b/src/libcommon/keychainmanager/apitoken.h
@@ -38,9 +38,9 @@ class ApiToken {
         inline const std::string &tokenType() const { return _tokenType; }
         inline void setTokenType(const std::string &newTokenType) { _tokenType = newTokenType; }
         inline uint64_t expiresIn() const { return _expiresIn; }
-        inline void setExpiresIn(uint64_t newExpiresIn) { _expiresIn = newExpiresIn; }
+        inline void setExpiresIn(const uint64_t newExpiresIn) { _expiresIn = newExpiresIn; }
         inline int userId() const { return _userId; }
-        inline void setUserId(int newUserId) { _userId = newUserId; }
+        inline void setUserId(const int newUserId) { _userId = newUserId; }
         inline const std::string &scope() const { return _scope; }
         inline void setScope(const std::string &newScope) { _scope = newScope; }
 

--- a/src/libcommon/keychainmanager/keychainmanager.cpp
+++ b/src/libcommon/keychainmanager/keychainmanager.cpp
@@ -114,7 +114,7 @@ bool KeyChainManager::readApiToken(const std::string &keychainKey, ApiToken &api
     }
 
     std::string token;
-    bool returnValue = readDataFromKeystore(keychainKey, token, found);
+    const bool returnValue = readDataFromKeystore(keychainKey, token, found);
     if (returnValue && found) {
         apiToken = ApiToken(token);
     }
@@ -122,7 +122,7 @@ bool KeyChainManager::readApiToken(const std::string &keychainKey, ApiToken &api
     return returnValue;
 }
 
-bool KeyChainManager::deleteToken(const std::string &keychainKey) {
+bool KeyChainManager::deleteToken(const std::string &keychainKey) const {
     keychain::Error error{};
     keychain::deletePassword(PACKAGE, SERVICE, keychainKey, error);
     if (error) {

--- a/src/libcommon/keychainmanager/keychainmanager.h
+++ b/src/libcommon/keychainmanager/keychainmanager.h
@@ -41,7 +41,7 @@ class COMMON_EXPORT KeyChainManager : public QObject {
 
         bool writeToken(const std::string &keychainKey, const std::string &rawData);
         bool readApiToken(const std::string &keychainKey, ApiToken &apiToken, bool &found);
-        bool deleteToken(const std::string &keychainKey);
+        bool deleteToken(const std::string &keychainKey) const;
 
         bool readDataFromKeystore(const std::string &keychainKey, std::string &data, bool &found);
 

--- a/src/libsyncengine/jobs/network/abstracttokennetworkjob.cpp
+++ b/src/libsyncengine/jobs/network/abstracttokennetworkjob.cpp
@@ -39,8 +39,8 @@ namespace KDC {
 std::unordered_map<int, std::pair<std::shared_ptr<Login>, int>> AbstractTokenNetworkJob::_userToApiKeyMap;
 std::unordered_map<int, std::pair<int, int>> AbstractTokenNetworkJob::_driveToApiKeyMap;
 
-AbstractTokenNetworkJob::AbstractTokenNetworkJob(ApiType apiType, int userDbId, int userId, int driveDbId, int driveId,
-                                                 bool returnJson /*= true*/) :
+AbstractTokenNetworkJob::AbstractTokenNetworkJob(const ApiType apiType, const int userDbId, const int userId, const int driveDbId,
+                                                 const int driveId, const bool returnJson /*= true*/) :
     _apiType(apiType),
     _userDbId(userDbId),
     _userId(userId),
@@ -61,12 +61,12 @@ AbstractTokenNetworkJob::AbstractTokenNetworkJob(ApiType apiType, int userDbId, 
         throw std::runtime_error("Invalid parameters!");
     }
 
-    _token = loadToken();
+    _apiToken = loadApiToken();
 
-    addRawHeader("Authorization", "Bearer " + _token);
+    addRawHeader("Authorization", "Bearer " + _apiToken.accessToken());
 }
 
-AbstractTokenNetworkJob::AbstractTokenNetworkJob(ApiType apiType, bool returnJson /*= true*/) :
+AbstractTokenNetworkJob::AbstractTokenNetworkJob(const ApiType apiType, const bool returnJson /*= true*/) :
     AbstractTokenNetworkJob(apiType, 0, 0, 0, 0, returnJson) {}
 
 ExitCause AbstractTokenNetworkJob::getExitCause() const {
@@ -82,13 +82,12 @@ ExitCause AbstractTokenNetworkJob::getExitCause() const {
     return exitInfo().cause();
 }
 
-void AbstractTokenNetworkJob::updateLoginByUserDbId(const Login &login, int userDbId) {
-    auto it = _userToApiKeyMap.find(userDbId);
-    if (it != _userToApiKeyMap.end()) {
-        std::shared_ptr<Login> currentLogin = it->second.first;
+void AbstractTokenNetworkJob::updateLoginByUserDbId(const Login &login, const int userDbId) {
+    if (const auto it = _userToApiKeyMap.find(userDbId); it != _userToApiKeyMap.end()) {
+        const std::shared_ptr<Login> currentLogin = it->second.first;
         // get new credentials
-        ApiToken newApiToken = login.apiToken();
-        std::string newKeychainKey = login.keychainKey();
+        const ApiToken newApiToken = login.apiToken();
+        const std::string newKeychainKey = login.keychainKey();
         // set new credentials to Login class
         currentLogin->setApiToken(newApiToken);
         currentLogin->setKeychainKey(newKeychainKey);
@@ -123,11 +122,11 @@ std::string AbstractTokenNetworkJob::getSpecificUrl() {
 ExitInfo AbstractTokenNetworkJob::handleUnauthorizedResponse() {
     // There is no longer any refresh of the token since v3.5.6
     // This code is only used when updating from a version < v3.5.6
-    if (const auto token = loadToken(); token != _token) {
+    if (const auto apiToken = loadApiToken(); apiToken != _apiToken) {
         LOG_DEBUG(_logger, "Token refreshed by another request");
         _accessTokenAlreadyRefreshed = false;
-        _token = token;
-        addRawHeader("Authorization", "Bearer " + _token);
+        _apiToken = apiToken;
+        addRawHeader("Authorization", "Bearer " + _apiToken.accessToken());
         return ExitCode::TokenRefreshed;
     }
 
@@ -153,7 +152,8 @@ ExitInfo AbstractTokenNetworkJob::handleUnauthorizedResponse() {
     return ExitCode::InvalidToken;
 }
 
-void AbstractTokenNetworkJob::defaultBackErrorHandling(NetworkErrorCode errorCode, const Poco::URI &uri, ExitCause &exitCause) {
+void AbstractTokenNetworkJob::defaultBackErrorHandling(const NetworkErrorCode errorCode, const Poco::URI &uri,
+                                                       ExitCause &exitCause) {
     static const std::map<NetworkErrorCode, AbstractTokenNetworkJob::ExitHandler> errorCodeHandlingMap = {
             {NetworkErrorCode::ValidationFailed, ExitHandler{ExitCause::InvalidName, "Invalid file or directory name"}},
             {NetworkErrorCode::UploadNotTerminatedError, ExitHandler{ExitCause::UploadNotTerminated, "Upload not terminated"}},
@@ -199,8 +199,7 @@ ExitInfo AbstractTokenNetworkJob::handleError(const std::string &replyBody, cons
     Poco::JSON::Object::Ptr errorObjPtr = nullptr;
     if (!extractJsonError(replyBody, errorObjPtr)) return exitInfo;
 
-    const NetworkErrorCode errorCode = getNetworkErrorCode(_errorCode);
-    switch (errorCode) {
+    switch (const NetworkErrorCode errorCode = getNetworkErrorCode(_errorCode); errorCode) {
         case NetworkErrorCode::NotAuthorized: {
             if (!_accessTokenAlreadyRefreshed) {
                 LOG_DEBUG(_logger, "Request failed: " << Utility::formatRequest(uri, _errorCode, _errorDescr)
@@ -215,29 +214,28 @@ ExitInfo AbstractTokenNetworkJob::handleError(const std::string &replyBody, cons
                 LOG_DEBUG(_logger, "Refresh token succeeded");
                 return ExitCode::TokenRefreshed;
             }
-            return exitInfo;
+            break;
         }
-
         case NetworkErrorCode::ProductMaintenance:
         case NetworkErrorCode::DriveIsInMaintenanceError: {
             LOG_DEBUG(_logger, "Product in maintenance");
             disableRetry();
             if (const auto contextObj = errorObjPtr->getObject(contextKey); contextObj != nullptr) {
                 std::string context;
-                JsonParserUtility::extractValue(contextObj, reasonKey, context, false);
+                (void) JsonParserUtility::extractValue(contextObj, reasonKey, context, false);
                 if (getNetworkErrorReason(context) == NetworkErrorReason::NotRenew) {
                     exitInfo.setCause(ExitCause::DriveNotRenew);
                     return exitInfo;
                 }
             }
             exitInfo.setCause(ExitCause::DriveMaintenance);
-            return exitInfo;
+            break;
         }
         default:
             ExitCause exitCause = ExitCause::Unknown;
             defaultBackErrorHandling(errorCode, uri, exitCause);
             exitInfo.setCause(exitCause);
-            return exitInfo;
+            break;
     }
     return exitInfo;
 }
@@ -316,8 +314,8 @@ ExitInfo AbstractTokenNetworkJob::handleJsonResponse(const std::string &replyBod
     return ExitCode::Ok;
 }
 
-std::string AbstractTokenNetworkJob::loadToken() {
-    std::string token;
+ApiToken AbstractTokenNetworkJob::loadApiToken() {
+    ApiToken apiToken;
     if (_apiType == ApiType::Desktop) {
         // Fetch the drive identifier of the first available sync.
         std::vector<Sync> syncList;
@@ -423,7 +421,7 @@ std::string AbstractTokenNetworkJob::loadToken() {
             if (const auto it = _userToApiKeyMap.find(_userDbId); it != _userToApiKeyMap.end()) {
                 // userDbId found in User cache
                 _userId = it->second.second;
-                token = it->second.first->apiToken().accessToken();
+                apiToken = it->second.first->apiToken();
             } else {
                 assert(false);
                 const std::string err{"User cache not set for userDbId=" + std::to_string(_userDbId)};
@@ -437,7 +435,7 @@ std::string AbstractTokenNetworkJob::loadToken() {
             if (const auto it = _userToApiKeyMap.find(_userDbId); it != _userToApiKeyMap.end()) {
                 // userDbId found in User cache
                 _userId = it->second.second;
-                token = it->second.first->apiToken().accessToken();
+                apiToken = it->second.first->apiToken();
             } else {
                 // Get user
                 User user;
@@ -470,7 +468,7 @@ std::string AbstractTokenNetworkJob::loadToken() {
                 }
 
                 _userId = user.userId();
-                token = login->apiToken().accessToken();
+                apiToken = login->apiToken();
                 _userToApiKeyMap[_userDbId] = {login, _userId};
             }
             break;
@@ -480,7 +478,7 @@ std::string AbstractTokenNetworkJob::loadToken() {
             break;
     }
 
-    return token;
+    return apiToken;
 }
 
 std::string AbstractTokenNetworkJob::getContentType() {
@@ -526,29 +524,30 @@ ExitInfo AbstractTokenNetworkJob::refreshToken() {
         return exitInfo;
     }
 
-    _token = login->apiToken().accessToken();
-    addRawHeader("Authorization", "Bearer " + _token);
+    _apiToken = login->apiToken().accessToken();
+    addRawHeader("Authorization", "Bearer " + _apiToken.accessToken());
     return ExitCode::Ok;
 }
 
 long AbstractTokenNetworkJob::tokenUpdateDurationFromNow() {
-    auto it = _userToApiKeyMap.find(_userDbId);
-    if (it != _userToApiKeyMap.end()) {
-        // userDbId found in User cache
-        std::shared_ptr<Login> login = it->second.first;
-        return login->tokenUpdateDurationFromNow();
-    } else {
+    const auto it = _userToApiKeyMap.find(_userDbId);
+    if (it == _userToApiKeyMap.end()) {
         LOG_WARN(_logger, "User cache not set for userDbId=" << _userDbId);
         return 0;
     }
+    // userDbId found in User cache
+    const std::shared_ptr<Login> login = it->second.first;
+    return login->tokenUpdateDurationFromNow();
 }
 
 ExitCode AbstractTokenNetworkJob::exception2ExitCode(const std::exception &exc) {
     if (dynamic_cast<const AbstractTokenNetworkJob::DbError *>(&exc)) {
         return ExitCode::DbError;
-    } else if (dynamic_cast<const AbstractTokenNetworkJob::DataError *>(&exc)) {
+    }
+    if (dynamic_cast<const AbstractTokenNetworkJob::DataError *>(&exc)) {
         return ExitCode::DataError;
-    } else if (dynamic_cast<const AbstractTokenNetworkJob::TokenError *>(&exc)) {
+    }
+    if (dynamic_cast<const AbstractTokenNetworkJob::TokenError *>(&exc)) {
         return ExitCode::InvalidToken;
     }
 

--- a/src/libsyncengine/jobs/network/abstracttokennetworkjob.cpp
+++ b/src/libsyncengine/jobs/network/abstracttokennetworkjob.cpp
@@ -123,7 +123,7 @@ std::string AbstractTokenNetworkJob::getSpecificUrl() {
 ExitInfo AbstractTokenNetworkJob::handleUnauthorizedResponse() {
     // There is no longer any refresh of the token since v3.5.6
     // This code is only used when updating from a version < v3.5.6
-    if (std::string token = loadToken(); token != _token) {
+    if (const auto token = loadToken(); token != _token) {
         LOG_DEBUG(_logger, "Token refreshed by another request");
         _accessTokenAlreadyRefreshed = false;
         _token = token;
@@ -137,7 +137,6 @@ ExitInfo AbstractTokenNetworkJob::handleUnauthorizedResponse() {
             LOG_WARN(_logger, "Refresh token failed");
             disableRetry();
             return {ExitCode::InvalidToken, ExitCause::LoginError};
-            ;
         }
 
         LOG_DEBUG(_logger, "Refresh token succeeded");
@@ -324,14 +323,14 @@ std::string AbstractTokenNetworkJob::loadToken() {
         std::vector<Sync> syncList;
         if (!ParmsDb::instance()->selectAllSyncs(syncList)) {
             assert(false);
-            std::string err{"Error in ParmsDb::selectAllSyncs"};
+            const std::string err{"Error in ParmsDb::selectAllSyncs"};
             LOG_WARN(_logger, err);
             throw DbError(err);
         }
 
         if (syncList.empty()) {
             assert(false);
-            std::string err{"No sync found"};
+            const std::string err{"No sync found"};
             LOG_WARN(_logger, err);
             throw DataError(err);
         }
@@ -344,24 +343,23 @@ std::string AbstractTokenNetworkJob::loadToken() {
         case ApiType::Desktop:
         case ApiType::NotifyDrive: {
             if (_driveDbId) {
-                auto it = _driveToApiKeyMap.find(_driveDbId);
-                if (it != _driveToApiKeyMap.end()) {
+                if (const auto it = _driveToApiKeyMap.find(_driveDbId); it != _driveToApiKeyMap.end()) {
                     // driveDbId found in Drive cache
                     _userDbId = it->second.first;
                     _driveId = it->second.second;
                 } else {
                     // Get drive
                     Drive drive;
-                    bool found;
+                    bool found = false;
                     if (!ParmsDb::instance()->selectDrive(_driveDbId, drive, found)) {
                         assert(false);
-                        std::string err{"Error in ParmsDb::selectDrive"};
+                        const std::string err{"Error in ParmsDb::selectDrive"};
                         LOG_WARN(_logger, err);
                         throw DbError(err);
                     }
                     if (!found) {
                         assert(false);
-                        std::string err{"Drive not found for driveDbId=" + std::to_string(_driveDbId)};
+                        const std::string err{"Drive not found for driveDbId=" + std::to_string(_driveDbId)};
                         LOG_WARN(_logger, err);
                         throw DataError(err);
                     }
@@ -372,45 +370,45 @@ std::string AbstractTokenNetworkJob::loadToken() {
                     Account account;
                     if (!ParmsDb::instance()->selectAccount(drive.accountDbId(), account, found)) {
                         assert(false);
-                        std::string err{"Error in ParmsDb::selectAccount"};
+                        const std::string err{"Error in ParmsDb::selectAccount"};
                         LOG_WARN(_logger, err);
                         throw DbError(err);
                     }
                     if (!found) {
                         assert(false);
-                        std::string err{"Account not found for accountDbId=" + std::to_string(drive.accountDbId())};
+                        const std::string err{"Account not found for accountDbId=" + std::to_string(drive.accountDbId())};
                         LOG_WARN(_logger, err);
                         throw DataError(err);
                     }
 
                     _userDbId = account.userDbId();
 
-                    if (_userToApiKeyMap.find(_userDbId) == _userToApiKeyMap.end()) {
+                    if (!_userToApiKeyMap.contains(_userDbId)) {
                         // Get user
                         User user;
                         if (!ParmsDb::instance()->selectUser(_userDbId, user, found)) {
                             assert(false);
-                            std::string err{"Error in ParmsDb::selectUser"};
+                            const std::string err{"Error in ParmsDb::selectUser"};
                             LOG_WARN(_logger, err);
                             throw DbError(err);
                         }
                         if (!found) {
                             assert(false);
-                            std::string err{"User not found for userDbId=" + std::to_string(_userDbId)};
+                            const std::string err{"User not found for userDbId=" + std::to_string(_userDbId)};
                             LOG_WARN(_logger, err);
                             throw DataError(err);
                         }
 
                         if (user.keychainKey().empty()) {
-                            std::string err{"Access token is empty"};
+                            const std::string err{"Access token is empty"};
                             LOG_DEBUG(_logger, err);
                             throw TokenError(err);
                         }
 
                         // Read token form keystore
-                        std::shared_ptr<Login> login = std::shared_ptr<Login>(new Login(user.keychainKey()));
+                        auto login = std::make_shared<Login>(user.keychainKey());
                         if (!login->hasToken()) {
-                            std::string err{"Failed to retrieve access token"};
+                            const std::string err{"Failed to retrieve access token"};
                             LOG_WARN(_logger, err);
                             throw TokenError(err);
                         }
@@ -422,14 +420,13 @@ std::string AbstractTokenNetworkJob::loadToken() {
                 }
             }
 
-            auto it = _userToApiKeyMap.find(_userDbId);
-            if (it != _userToApiKeyMap.end()) {
+            if (const auto it = _userToApiKeyMap.find(_userDbId); it != _userToApiKeyMap.end()) {
                 // userDbId found in User cache
                 _userId = it->second.second;
                 token = it->second.first->apiToken().accessToken();
             } else {
                 assert(false);
-                std::string err{"User cache not set for userDbId=" + std::to_string(_userDbId)};
+                const std::string err{"User cache not set for userDbId=" + std::to_string(_userDbId)};
                 LOG_WARN(_logger, err);
                 throw std::runtime_error(err);
             }
@@ -437,8 +434,7 @@ std::string AbstractTokenNetworkJob::loadToken() {
         }
         case ApiType::Profile:
         case ApiType::DriveByUser: {
-            auto it = _userToApiKeyMap.find(_userDbId);
-            if (it != _userToApiKeyMap.end()) {
+            if (const auto it = _userToApiKeyMap.find(_userDbId); it != _userToApiKeyMap.end()) {
                 // userDbId found in User cache
                 _userId = it->second.second;
                 token = it->second.first->apiToken().accessToken();
@@ -448,27 +444,27 @@ std::string AbstractTokenNetworkJob::loadToken() {
                 bool found = false;
                 if (!ParmsDb::instance()->selectUser(_userDbId, user, found)) {
                     assert(false);
-                    std::string err{"Error in ParmsDb::selectUser"};
+                    const std::string err{"Error in ParmsDb::selectUser"};
                     LOG_WARN(_logger, err);
                     throw DbError(err);
                 }
                 if (!found) {
                     assert(false);
-                    std::string err{"User not found for userDbId=" + std::to_string(_userDbId)};
+                    const std::string err{"User not found for userDbId=" + std::to_string(_userDbId)};
                     LOG_WARN(_logger, err);
                     throw DataError(err);
                 }
 
                 if (user.keychainKey().empty()) {
-                    std::string err{"Access token is empty"};
+                    const std::string err{"Access token is empty"};
                     LOG_DEBUG(_logger, err);
                     throw TokenError(err);
                 }
 
                 // Read token form keystore
-                std::shared_ptr<Login> login = std::shared_ptr<Login>(new Login(user.keychainKey()));
+                auto login = std::make_shared<Login>(user.keychainKey());
                 if (!login->hasToken()) {
-                    std::string err{"Failed to retrieve access token"};
+                    const std::string err{"Failed to retrieve access token"};
                     LOG_WARN(_logger, err);
                     throw TokenError(err);
                 }
@@ -493,49 +489,45 @@ std::string AbstractTokenNetworkJob::getContentType() {
 
 ExitInfo AbstractTokenNetworkJob::refreshToken() {
     _accessTokenAlreadyRefreshed = true;
-
-    auto it = _userToApiKeyMap.find(_userDbId);
-    if (it != _userToApiKeyMap.end()) {
-        // userDbId found in User cache
-        std::shared_ptr<Login> login = it->second.first;
-        ExitInfo exitInfo = login->refreshToken();
-        if (!exitInfo) {
-            LOG_WARN(_logger, "Failed to refresh token: code=" << exitInfo << " login error=" << login->error()
-                                                               << " login error descr=" << login->errorDescr());
-            exitInfo.setCause(ExitCause::LoginError);
-
-            // Clear the keychain key
-            User user;
-            bool found = false;
-            if (!ParmsDb::instance()->selectUser(_userDbId, user, found)) {
-                LOG_WARN(_logger, "Error in ParmsDb::selectUser");
-                return ExitCode::DbError;
-            }
-            if (!found) {
-                LOG_WARN(_logger, "User not found for userDbId=" << _userDbId);
-                return {ExitCode::DataError, ExitCause::DbEntryNotFound};
-            }
-
-            KeyChainManager::instance()->deleteToken(user.keychainKey());
-
-            user.setKeychainKey(""); // Clear the keychainKey
-            ParmsDb::instance()->updateUser(user, found);
-            if (!found) {
-                LOG_WARN(_logger, "User not found for userDbId=" << _userDbId);
-                return {ExitCode::DataError, ExitCause::DbEntryNotFound};
-            }
-
-            return exitInfo;
-        }
-
-        _token = login->apiToken().accessToken();
-        addRawHeader("Authorization", "Bearer " + _token);
-        return ExitCode::Ok;
-    } else {
+    const auto it = _userToApiKeyMap.find(_userDbId);
+    if (it == _userToApiKeyMap.end()) {
         LOG_WARN(_logger, "User cache not set for userDbId=" << _userDbId);
         return {ExitCode::DataError, ExitCause::LoginError};
     }
 
+    // userDbId found in User cache
+    const std::shared_ptr<Login> login = it->second.first;
+    if (auto exitInfo = login->refreshToken(); !exitInfo) {
+        LOG_WARN(_logger, "Failed to refresh token: code=" << exitInfo << " login error=" << login->error()
+                                                           << " login error descr=" << login->errorDescr());
+        exitInfo.setCause(ExitCause::LoginError);
+
+        // Clear the keychain key
+        User user;
+        bool found = false;
+        if (!ParmsDb::instance()->selectUser(_userDbId, user, found)) {
+            LOG_WARN(_logger, "Error in ParmsDb::selectUser");
+            return ExitCode::DbError;
+        }
+        if (!found) {
+            LOG_WARN(_logger, "User not found for userDbId=" << _userDbId);
+            return {ExitCode::DataError, ExitCause::DbEntryNotFound};
+        }
+
+        (void) KeyChainManager::instance()->deleteToken(user.keychainKey());
+
+        user.setKeychainKey(""); // Clear the keychainKey
+        (void) ParmsDb::instance()->updateUser(user, found);
+        if (!found) {
+            LOG_WARN(_logger, "User not found for userDbId=" << _userDbId);
+            return {ExitCode::DataError, ExitCause::DbEntryNotFound};
+        }
+
+        return exitInfo;
+    }
+
+    _token = login->apiToken().accessToken();
+    addRawHeader("Authorization", "Bearer " + _token);
     return ExitCode::Ok;
 }
 

--- a/src/libsyncengine/jobs/network/abstracttokennetworkjob.cpp
+++ b/src/libsyncengine/jobs/network/abstracttokennetworkjob.cpp
@@ -130,7 +130,7 @@ ExitInfo AbstractTokenNetworkJob::handleUnauthorizedResponse() {
         return ExitCode::TokenRefreshed;
     }
 
-    if (!_accessTokenAlreadyRefreshed || tokenUpdateDurationFromNow() > TOKEN_LIFETIME) {
+    if (!_apiToken.refreshToken().empty() && (!_accessTokenAlreadyRefreshed || tokenUpdateDurationFromNow() > TOKEN_LIFETIME)) {
         // The token has not already been refreshed or was refreshed more than its lifetime ago
         if (const auto exitInfo = refreshToken(); !exitInfo) {
             LOG_WARN(_logger, "Refresh token failed");
@@ -141,8 +141,6 @@ ExitInfo AbstractTokenNetworkJob::handleUnauthorizedResponse() {
         LOG_DEBUG(_logger, "Refresh token succeeded");
         return ExitCode::TokenRefreshed;
     }
-
-    LOG_WARN(_logger, "Token already refreshed once");
 
     if (_trials > 2) {
         disableRetry();

--- a/src/libsyncengine/jobs/network/abstracttokennetworkjob.h
+++ b/src/libsyncengine/jobs/network/abstracttokennetworkjob.h
@@ -102,7 +102,7 @@ class AbstractTokenNetworkJob : public AbstractNetworkJob {
 
         bool _accessTokenAlreadyRefreshed = false;
 
-        ApiToken loadApiToken();
+        virtual ApiToken loadApiToken();
 
         std::string getUrl() override;
         ExitInfo handleUnauthorizedResponse();

--- a/src/libsyncengine/jobs/network/abstracttokennetworkjob.h
+++ b/src/libsyncengine/jobs/network/abstracttokennetworkjob.h
@@ -98,11 +98,11 @@ class AbstractTokenNetworkJob : public AbstractNetworkJob {
         int _driveDbId;
         int _driveId;
         bool _returnJson;
-        std::string _token;
+        ApiToken _apiToken;
 
         bool _accessTokenAlreadyRefreshed = false;
 
-        std::string loadToken();
+        ApiToken loadApiToken();
 
         std::string getUrl() override;
         ExitInfo handleUnauthorizedResponse();

--- a/src/libsyncengine/jobs/network/login/abstractloginjob.cpp
+++ b/src/libsyncengine/jobs/network/login/abstractloginjob.cpp
@@ -31,20 +31,6 @@ AbstractLoginJob::AbstractLoginJob() {
     _httpMethod = Poco::Net::HTTPRequest::HTTP_POST;
 }
 
-bool AbstractLoginJob::hasErrorApi(std::string *errorCode, std::string *errorDescr) {
-    if (getStatusCode() == Poco::Net::HTTPResponse::HTTP_OK) {
-        return false;
-    }
-
-    if (errorCode) {
-        *errorCode = _errorCode;
-        if (errorDescr) {
-            *errorDescr = _errorDescr;
-        }
-    }
-    return true;
-}
-
 std::string AbstractLoginJob::getSpecificUrl() {
     return "/token";
 }
@@ -81,8 +67,7 @@ ExitInfo AbstractLoginJob::handleError(const std::string &replyBody, const Poco:
     }
 
     ExitInfo exitInfo;
-    Poco::JSON::Object::Ptr errorObj = jsonError->getObject(errorKey);
-    if (errorObj) {
+    if (Poco::JSON::Object::Ptr errorObj = jsonError->getObject(errorKey); errorObj) {
         if (!JsonParserUtility::extractValue(errorObj, codeKey, _errorCode)) {
             return {};
         }

--- a/src/libsyncengine/jobs/network/login/abstractloginjob.h
+++ b/src/libsyncengine/jobs/network/login/abstractloginjob.h
@@ -29,8 +29,6 @@ class AbstractLoginJob : public AbstractNetworkJob {
 
         inline const ApiToken &apiToken() const { return _apiToken; }
 
-        bool hasErrorApi(std::string *errorCode = nullptr, std::string *errorDescr = nullptr);
-
     protected:
         ApiToken _apiToken;
 
@@ -41,9 +39,6 @@ class AbstractLoginJob : public AbstractNetworkJob {
 
         ExitInfo handleResponse(std::istream &inputStream) override;
         ExitInfo handleError(const std::string &replyBody, const Poco::URI &uri) override;
-
-        std::string _errorCode;
-        std::string _errorDescr;
 };
 
 } // namespace KDC

--- a/src/libsyncengine/jobs/network/login/gettokenjob.cpp
+++ b/src/libsyncengine/jobs/network/login/gettokenjob.cpp
@@ -24,7 +24,6 @@
 namespace KDC {
 
 GetTokenJob::GetTokenJob(const std::string &authorizationCode, const std::string &codeVerifier) :
-    AbstractLoginJob(),
     _authorizationCode(authorizationCode),
     _codeVerifier(codeVerifier) {
 #if defined(KD_MACOS)

--- a/src/libsyncengine/login/login.cpp
+++ b/src/libsyncengine/login/login.cpp
@@ -46,15 +46,12 @@ Login::Login(const std::string &keychainKey) :
     _info[_apiToken.userId()] = LoginInfo();
 }
 
-Login::~Login() {}
-
 ExitInfo Login::requestToken(const std::string &authorizationCode, const std::string &codeVerifier /*= ""*/) {
     LOG_DEBUG(_logger, "Start token request");
 
     try {
         GetTokenJob job(authorizationCode, codeVerifier);
-        const ExitCode exitCode = job.runSynchronously();
-        if (exitCode != ExitCode::Ok) {
+        if (const ExitCode exitCode = job.runSynchronously(); exitCode != ExitCode::Ok) {
             LOG_WARN(_logger, "Error in GetTokenJob::runSynchronously: code=" << exitCode);
             _error = std::string();
             _errorDescr = std::string();
@@ -62,13 +59,12 @@ ExitInfo Login::requestToken(const std::string &authorizationCode, const std::st
         }
 
         LOG_DEBUG(_logger, "job.runSynchronously() done");
-        std::string errorCode;
-        std::string errorDescr;
-        if (job.hasErrorApi(&errorCode, &errorDescr)) {
+        if (job.hasErrorApi()) {
             LOGW_WARN(_logger, L"Failed to retrieve authentification token. Error : "
-                                       << KDC::CommonUtility::s2ws(errorCode) << L" - " << KDC::CommonUtility::s2ws(errorDescr));
-            _error = errorCode;
-            _errorDescr = errorDescr;
+                                       << KDC::CommonUtility::s2ws(job.errorCode()) << L" - "
+                                       << KDC::CommonUtility::s2ws(job.errorDescr()));
+            _error = job.errorCode();
+            _errorDescr = job.errorDescr();
             return ExitCode::BackError;
         }
 
@@ -96,15 +92,13 @@ ExitInfo Login::refreshToken() {
 }
 
 long Login::tokenUpdateDurationFromNow() const {
-    auto it = _info.find(_apiToken.userId());
-    if (it != _info.end()) {
-        auto tokenLastUpdate = it->second._lastTokenUpdateTime;
-        auto now = std::chrono::steady_clock::now();
-        auto duration = std::chrono::duration_cast<std::chrono::seconds>(now - tokenLastUpdate);
-        return duration.count();
-    } else {
-        return 0;
-    }
+    const auto it = _info.find(_apiToken.userId());
+    if (it == _info.end()) return 0;
+
+    const auto tokenLastUpdate = it->second._lastTokenUpdateTime;
+    const auto now = std::chrono::steady_clock::now();
+    const auto duration = std::chrono::duration_cast<std::chrono::seconds>(now - tokenLastUpdate);
+    return duration.count();
 }
 
 ExitCode Login::refreshToken(const std::string &keychainKey, ApiToken &apiToken, std::string &error, std::string &errorDescr) {
@@ -135,14 +129,16 @@ ExitCode Login::refreshToken(const std::string &keychainKey, ApiToken &apiToken,
 
     try {
         RefreshTokenJob job(apiToken);
-        const ExitCode exitCode = job.runSynchronously();
-        if (exitCode != ExitCode::Ok) {
+        if (const ExitCode exitCode = job.runSynchronously(); exitCode != ExitCode::Ok) {
             LOG_WARN(Log::instance()->getLogger(), "Error in RefreshTokenJob::runSynchronously: code=" << exitCode);
-            job.hasErrorApi(&error, &errorDescr);
+            error = job.errorCode();
+            errorDescr = job.errorDescr();
             return exitCode;
         }
 
-        if (job.hasErrorApi(&error, &errorDescr)) {
+        if (job.hasErrorApi()) {
+            error = job.errorCode();
+            errorDescr = job.errorDescr();
             LOG_WARN(Log::instance()->getLogger(),
                      "Failed to retrieve authentication token. Error : " << error << " - " << errorDescr);
             return ExitCode::NetworkError;

--- a/src/libsyncengine/login/login.cpp
+++ b/src/libsyncengine/login/login.cpp
@@ -109,9 +109,9 @@ ExitCode Login::refreshToken(const std::string &keychainKey, ApiToken &apiToken,
         return ExitCode::InvalidToken;
     }
 
-    std::chrono::time_point<std::chrono::steady_clock> tokenLastUpdate = _info[apiToken.userId()]._lastTokenUpdateTime;
+    const std::chrono::time_point<std::chrono::steady_clock> tokenLastUpdate = _info[apiToken.userId()]._lastTokenUpdateTime;
 
-    const std::lock_guard<std::mutex> lock(_info[apiToken.userId()]._mutex);
+    const std::lock_guard lock(_info[apiToken.userId()]._mutex);
 
     if (_info[apiToken.userId()]._lastTokenUpdateTime > tokenLastUpdate) {
         LOG_INFO(Log::instance()->getLogger(), "Token already refreshed in another thread");

--- a/src/libsyncengine/login/login.h
+++ b/src/libsyncengine/login/login.h
@@ -38,8 +38,7 @@ class Login {
         };
 
         Login();
-        Login(const std::string &keychainKey);
-        virtual ~Login();
+        explicit Login(const std::string &keychainKey);
 
         /*
          * Retrieve the API tokens
@@ -51,9 +50,9 @@ class Login {
         long tokenUpdateDurationFromNow() const;
 
         inline const ApiToken &apiToken() const { return _apiToken; }
-        inline void setApiToken(ApiToken &apiToken) { _apiToken = apiToken; }
+        inline void setApiToken(const ApiToken &apiToken) { _apiToken = apiToken; }
         inline const std::string &keychainKey() const { return _keychainKey; }
-        inline void setKeychainKey(std::string &keychain) { _keychainKey = keychain; }
+        inline void setKeychainKey(const std::string &keychain) { _keychainKey = keychain; }
         inline bool hasError() const { return !_error.empty(); }
         inline void setError(const std::string &error) { _error = error; }
         inline std::string error() const { return _error; }

--- a/src/server/migration/migrationparams.cpp
+++ b/src/server/migration/migrationparams.cpp
@@ -762,21 +762,17 @@ ExitCode MigrationParams::getOldAppPwd(const std::string &keychainKey, std::stri
 
 ExitCode MigrationParams::getTokenFromAppPassword(const std::string &email, const std::string &appPassword, ApiToken &apiToken) {
     try {
-        std::string errorDescr, errorCode;
         GetTokenFromAppPasswordJob job(email, appPassword);
-        const ExitCode exitCode = job.runSynchronously();
-        if (exitCode != ExitCode::Ok) {
+        if (const ExitCode exitCode = job.runSynchronously(); exitCode != ExitCode::Ok) {
             LOG_WARN(_logger, "Error in GetTokenFromAppPasswordJob::runSynchronously: code=" << exitCode);
-            errorCode = std::string();
-            errorDescr = std::string();
             return exitCode;
         }
 
         LOG_DEBUG(_logger, "job.runSynchronously() done");
-        if (job.hasErrorApi(&errorCode, &errorDescr)) {
-            LOGW_WARN(_logger, L"Failed to retrieve authentification token. code=" << KDC::CommonUtility::s2ws(errorCode)
+        if (job.hasErrorApi()) {
+            LOGW_WARN(_logger, L"Failed to retrieve authentification token. code=" << KDC::CommonUtility::s2ws(job.errorCode())
                                                                                    << L" descr="
-                                                                                   << KDC::CommonUtility::s2ws(errorDescr));
+                                                                                   << KDC::CommonUtility::s2ws(job.errorDescr()));
             return ExitCode::BackError;
         }
 

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -92,12 +92,11 @@ void TestNetworkJobs::setUp() {
     const testhelpers::TestVariables testVariables;
 
     // Insert api token into keystore
-    ApiToken apiToken;
-    apiToken.setAccessToken(testVariables.apiToken);
+    _apiToken.setAccessToken(testVariables.apiToken);
 
     const std::string keychainKey("123");
     (void) KeyChainManager::instance(true);
-    (void) KeyChainManager::instance()->writeToken(keychainKey, apiToken.reconstructJsonString());
+    (void) KeyChainManager::instance()->writeToken(keychainKey, _apiToken.reconstructJsonString());
     // Create parmsDb
     (void) ParmsDb::instance(_localParmsDbTempDir.path() / MockDb::makeDbMockFileName(), KDRIVE_VERSION_STRING, true, true);
     ParametersCache::instance()->parameters().setExtendedLog(true);
@@ -1555,18 +1554,34 @@ bool TestNetworkJobs::createTestFiles() {
 void TestNetworkJobs::testGetInfoUserTrialsOn401Error() {
     class GetInfoUserJobMock final : public GetInfoUserJob {
         public:
-            explicit GetInfoUserJobMock(int32_t userDbId) :
-                GetInfoUserJob(userDbId) {};
+            explicit GetInfoUserJobMock(const int32_t userDbId, const ApiToken &apiToken) :
+                GetInfoUserJob(userDbId),
+                _apiToken(apiToken) {};
 
             [[nodiscard]] Poco::Net::HTTPResponse httpResponse() const override {
                 return Poco::Net::HTTPResponse(Poco::Net::HTTPResponse::HTTP_UNAUTHORIZED);
             }
+            ApiToken loadApiToken() override { return _apiToken; }
+
+        private:
+            ApiToken _apiToken;
     };
 
-    GetInfoUserJobMock job(_userDbId);
-    ExitCode exitCode = job.runSynchronously();
-    CPPUNIT_ASSERT_EQUAL(ExitCode::InvalidToken, exitCode);
-    CPPUNIT_ASSERT_EQUAL(0, job.trials());
+    // Without refresh token.
+    {
+        GetInfoUserJobMock job(_userDbId, _apiToken);
+        const auto exitInfo = job.runSynchronously();
+        CPPUNIT_ASSERT_EQUAL(ExitCode::InvalidToken, exitInfo.code());
+    }
+    // With refresh token
+    {
+        _apiToken.setRefreshToken("123");
+        GetInfoUserJobMock job(_userDbId, _apiToken);
+        (void) job.runSynchronously(); // Run once just to update the refresh token in cache.
+        const auto exitInfo = job.runSynchronously();
+        CPPUNIT_ASSERT_EQUAL(ExitCode::InvalidToken, exitInfo.code());
+        CPPUNIT_ASSERT_EQUAL(0, job.trials());
+    }
 }
 
 } // namespace KDC

--- a/test/libsyncengine/jobs/network/testnetworkjobs.h
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "testincludes.h"
+#include "keychainmanager/apitoken.h"
 #include "test_utility/localtemporarydirectory.h"
 
 #include "utility/types.h"
@@ -114,6 +115,7 @@ class TestNetworkJobs : public CppUnit::TestFixture, public TestBase {
         int _driveDbId = 0;
         int _userDbId = 0;
         NodeId _remoteDirId;
+        ApiToken _apiToken;
 
         SyncName _dummyFileName;
         SyncPath _dummyLocalFilePath;


### PR DESCRIPTION
In some cases, we could try to refresh the token even if we do not have a refresh token available anymore.
This PR aims to bypass the refresh token process if the refresh token is empty. In that case, the request is retried once more.