### PR TITLE
WinUI3 settings page sync rules

### DIFF
--- a/src/gui4/windows/kDrive client/kDrive client/Pages/SettingsPage.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/SettingsPage.xaml
@@ -289,12 +289,13 @@
 
                 <!-- Advanced -->
                 <StackPanel Spacing="{StaticResource Infomaniak.Style.Spacing.XS}">
-                    <TextBlock Text="Avancé"
+                    <TextBlock x:Uid="Page_SettingsPage_Advanced"
                                Style="{StaticResource Infomaniak.Style.TextBlock.Subtitle}" />
 
                     <!-- Advanced - Sync rules -->
-                    <toolKit:SettingsCard Header="Règles de synchronisation"
-                                          IsClickEnabled="True">
+                    <toolKit:SettingsCard x:Uid="Page_SettingsPage_SyncRules"
+                                          IsClickEnabled="True"
+                                          Click="SyncRulesCard_Clicked">
                         <toolKit:SettingsCard.HeaderIcon>
                             <controls:SvgIcon UriString="{StaticResource Infomaniak.DS.Icons.Edition.list-bullets}"
                                               Height="32"

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/SettingsPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/SettingsPage.xaml.cs
@@ -249,15 +249,23 @@ namespace Infomaniak.kDrive.Pages
             if (drive is Drive)
             {
                 Logger.Log(Logger.Level.Info, $"ManageDriveButton clicked for configured drive {drive.Name}, going to mange page");
+                // TODO: Implement navigation to Manage Drive Page
             }
             else if (drive is DriveAvailable)
             {
                 Logger.Log(Logger.Level.Info, $"ManageDriveButton clicked for unconfigured drive {drive.Name}, going to onboarding page");
+                // TODO: Implement navigation to Onboarding Page
             }
             else
             {
                 Logger.Log(Logger.Level.Error, "ManageDriveButton clicked but Tag is not a valid IDrive");
             }
+        }
+
+        private void SyncRulesCard_Clicked(object sender, RoutedEventArgs e)
+        {
+            Logger.Log(Logger.Level.Info, "Navigating to Sync Rules Page from Settings Page");
+            // TODO: Implement navigation to Sync Rules Page
         }
     }
 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/de-DE/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/de-DE/Resources.resw
@@ -508,6 +508,9 @@
   <data name="Page_SettingsPage_Accounts.Text" type="System.Resources.ResXNullRef, System.Windows.Forms">
     <value />
   </data>
+  <data name="Page_SettingsPage_Advanced.Text" type="System.Resources.ResXNullRef, System.Windows.Forms">
+    <value />
+  </data>
   <data name="Page_SettingsPage_RemoveAccount_Dialog.Title" type="System.Resources.ResXNullRef, System.Windows.Forms">
     <value />
   </data>
@@ -515,6 +518,12 @@
     <value />
   </data>
   <data name="Page_SettingsPage_RemoveAccount.Header" type="System.Resources.ResXNullRef, System.Windows.Forms">
+    <value />
+  </data>
+  <data name="Page_SettingsPage_SyncRules.Header" type="System.Resources.ResXNullRef, System.Windows.Forms">
+    <value />
+  </data>
+  <data name="Page_SettingsPage_SyncRules.Description" type="System.Resources.ResXNullRef, System.Windows.Forms">
     <value />
   </data>
   <data name="Page_SettingsPage_RemoveAccount_Dialog.SecondaryButtonText" type="System.Resources.ResXNullRef, System.Windows.Forms">

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/en-US/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/en-US/Resources.resw
@@ -508,6 +508,9 @@
   <data name="Page_SettingsPage_Accounts.Text" type="System.Resources.ResXNullRef, System.Windows.Forms">
     <value />
   </data>
+  <data name="Page_SettingsPage_Advanced.Text" type="System.Resources.ResXNullRef, System.Windows.Forms">
+    <value />
+  </data>
   <data name="Page_SettingsPage_RemoveAccount_Dialog.Title" type="System.Resources.ResXNullRef, System.Windows.Forms">
     <value />
   </data>
@@ -515,6 +518,12 @@
     <value />
   </data>
   <data name="Page_SettingsPage_RemoveAccount.Header" type="System.Resources.ResXNullRef, System.Windows.Forms">
+    <value />
+  </data>
+  <data name="Page_SettingsPage_SyncRules.Header" type="System.Resources.ResXNullRef, System.Windows.Forms">
+    <value />
+  </data>
+  <data name="Page_SettingsPage_SyncRules.Description" type="System.Resources.ResXNullRef, System.Windows.Forms">
     <value />
   </data>
   <data name="Page_SettingsPage_RemoveAccount_Dialog.SecondaryButtonText" type="System.Resources.ResXNullRef, System.Windows.Forms">

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/es-ES/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/es-ES/Resources.resw
@@ -508,6 +508,9 @@
   <data name="Page_SettingsPage_Accounts.Text" type="System.Resources.ResXNullRef, System.Windows.Forms">
     <value />
   </data>
+  <data name="Page_SettingsPage_Advanced.Text" type="System.Resources.ResXNullRef, System.Windows.Forms">
+    <value />
+  </data>
   <data name="Page_SettingsPage_RemoveAccount_Dialog.Title" type="System.Resources.ResXNullRef, System.Windows.Forms">
     <value />
   </data>
@@ -515,6 +518,12 @@
     <value />
   </data>
   <data name="Page_SettingsPage_RemoveAccount.Header" type="System.Resources.ResXNullRef, System.Windows.Forms">
+    <value />
+  </data>
+  <data name="Page_SettingsPage_SyncRules.Header" type="System.Resources.ResXNullRef, System.Windows.Forms">
+    <value />
+  </data>
+  <data name="Page_SettingsPage_SyncRules.Description" type="System.Resources.ResXNullRef, System.Windows.Forms">
     <value />
   </data>
   <data name="Page_SettingsPage_RemoveAccount_Dialog.SecondaryButtonText" type="System.Resources.ResXNullRef, System.Windows.Forms">

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/fr-FR/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/fr-FR/Resources.resw
@@ -545,6 +545,9 @@ Version {0} (build {1}), compilée le {2}
   <data name="Page_SettingsPage_Accounts.Text" xml:space="preserve">
     <value>Comptes</value>
   </data>
+  <data name="Page_SettingsPage_Advanced.Text" xml:space="preserve">
+    <value>Avancé</value>
+  </data>
   <data name="Page_SettingsPage_RemoveAccount_Dialog.Title" xml:space="preserve">
     <value>Déconnecter ce compte ?</value>
   </data>
@@ -554,6 +557,12 @@ Version {0} (build {1}), compilée le {2}
   </data>
   <data name="Page_SettingsPage_RemoveAccount.Header" xml:space="preserve">
     <value>Deconnecter ce compte</value>
+  </data>
+  <data name="Page_SettingsPage_SyncRules.Header" xml:space="preserve">
+    <value>Règles de synchronisation</value>
+  </data>
+  <data name="Page_SettingsPage_SyncRules.Description" xml:space="preserve">
+    <value>Évitez que certains fichiers soient copiés dans kDrive.</value>
   </data>
   <data name="Page_SettingsPage_RemoveAccount_Dialog.SecondaryButtonText" xml:space="preserve">
     <value>Deconnecter</value>

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/it-IT/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/it-IT/Resources.resw
@@ -508,6 +508,9 @@
   <data name="Page_SettingsPage_Accounts.Text" type="System.Resources.ResXNullRef, System.Windows.Forms">
     <value />
   </data>
+  <data name="Page_SettingsPage_Advanced.Text" type="System.Resources.ResXNullRef, System.Windows.Forms">
+    <value />
+  </data>
   <data name="Page_SettingsPage_RemoveAccount_Dialog.Title" type="System.Resources.ResXNullRef, System.Windows.Forms">
     <value />
   </data>
@@ -515,6 +518,12 @@
     <value />
   </data>
   <data name="Page_SettingsPage_RemoveAccount.Header" type="System.Resources.ResXNullRef, System.Windows.Forms">
+    <value />
+  </data>
+  <data name="Page_SettingsPage_SyncRules.Header" type="System.Resources.ResXNullRef, System.Windows.Forms">
+    <value />
+  </data>
+  <data name="Page_SettingsPage_SyncRules.Description" type="System.Resources.ResXNullRef, System.Windows.Forms">
     <value />
   </data>
   <data name="Page_SettingsPage_RemoveAccount_Dialog.SecondaryButtonText" type="System.Resources.ResXNullRef, System.Windows.Forms">


### PR DESCRIPTION
Added a new settings card in `SettingsPage.xaml` for configuring sync rules. The card includes a description, an icon, and a click event handler.

Added the `SyncRulesCard_Clicked` method in `SettingsPage.xaml.cs` to handle navigation to the sync rules page (TODO implementation pending).


<img width="899" height="277" alt="image" src="https://github.com/user-attachments/assets/d650c41b-0b84-4990-a4da-9b361837d8e1" />
