### PR TITLE
feat(Settings page Winui): Merge update related components.

### DIFF
--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/UpdateExpander.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/UpdateExpander.xaml
@@ -27,7 +27,7 @@
 
     <Button x:Uid="CC_UpdateExpander_UpdateButton"
             Style="{ThemeResource AccentButtonStyle}"
-            Visibility="{x:Bind Settings.UpdateManager.AvailableUpdate, Converter={StaticResource IsNullToBoolOrVisibilityConverter}, ConverterParameter='Inverted=True', Mode=OneWay}"
+            Visibility="{x:Bind ViewModel.Settings.UpdateManager.AvailableUpdate, Converter={StaticResource IsNullToBoolOrVisibilityConverter}, ConverterParameter='Inverted=True', Mode=OneWay}"
             Click="UpdateButton_Click" />
 
     <toolKit:SettingsExpander.Items>
@@ -49,6 +49,35 @@
                 <HyperlinkButton x:Uid="CC_UpdateExpander_ChangeLogHyperLink"
                                  NavigateUri="{x:Bind DisplayedVersion.ChangeLogUrl, Mode=OneWay}" />
             </StackPanel>
+        </toolKit:SettingsCard>
+
+        <toolKit:SettingsCard x:Uid="Page_SettingsPage_AutoUpdate"
+                              IsEnabled="False"
+                              Background="{ThemeResource LayerFillColorDefault}">
+            <!-- TODO: Make it enabled once auto-update is implemented on the server side (see: UpdateManager.ChangeAutoUpdate) -->
+            <toolKit:SettingsCard.HeaderIcon>
+                <local:SvgIcon UriString="{StaticResource Infomaniak.DS.Icons.Arrows.arrows-loop-automatic}"
+                               Height="32"
+                               Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
+            </toolKit:SettingsCard.HeaderIcon>
+            <ToggleSwitch IsOn="{x:Bind ViewModel.Settings.UpdateManager.AutoUpdateEnabled, Mode=OneWay}"
+                          Toggled="AutoUpdateToggleSwitch_Toggled" />
+        </toolKit:SettingsCard>
+
+        <toolKit:SettingsCard x:Uid="Page_SettingsPage_Beta_Expander"
+                              Background="{ThemeResource LayerFillColorDefault}">
+            <ComboBox x:Name="UpdateChannelComboBox"
+                      SelectionChanged="UpdateChannel_SelectionChanged">
+                <ComboBoxItem Tag="Prod"
+                              x:Uid="Page_SettingsPage_Beta_ComboBox_Stable" />
+                <ComboBoxItem Tag="Beta"
+                              x:Uid="Page_SettingsPage_Beta_ComboBox_Beta" />
+                <ComboBoxItem Tag="Internal"
+                              x:Name="UpdateChannelComboBox_Internal"
+                              x:Uid="Page_SettingsPage_Beta_ComboBox_Internal"
+                              Foreground="{ThemeResource SystemErrorTextColor}"
+                              Visibility="Collapsed" />
+            </ComboBox>
         </toolKit:SettingsCard>
     </toolKit:SettingsExpander.Items>
 </toolKit:SettingsExpander>

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/UpdateExpander.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/UpdateExpander.xaml.cs
@@ -1,27 +1,50 @@
 using CommunityToolkit.WinUI.Controls;
+using Infomaniak.kDrive.Types;
 using Infomaniak.kDrive.ViewModels;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using System;
+using System.ComponentModel;
+using System.Linq;
 namespace Infomaniak.kDrive.CustomControls
 {
     public sealed partial class UpdateExpander : SettingsExpander
     {
+        private AppModel _viewModel = App.ServiceProvider.GetRequiredService<AppModel>();
+        public AppModel ViewModel => _viewModel;
+
         public UpdateExpander()
         {
             InitializeComponent();
+            RegisterPropertyChangedHandlers();
         }
 
-        public static readonly DependencyProperty SettingsProperty =
-         DependencyProperty.Register(
-             nameof(Settings),
-             typeof(Settings),
-             typeof(UpdateExpander),
-             new PropertyMetadata(null, OnSettingsPropertyChanged));
-
-        public Settings? Settings
+        ~UpdateExpander()
         {
-            get => (Settings?)GetValue(SettingsProperty);
-            set => SetValue(SettingsProperty, value);
+            UnregisterPropertyChangedHandlers();
+        }
+
+        private void RegisterPropertyChangedHandlers()
+        {
+            ViewModel.Settings.UpdateManager.PropertyChanged += OnSettingsPropertyChanged;
+            ViewModel.Settings.PropertyChanged += OnSettingsPropertyChanged;
+            OnSettingsPropertyChanged(null, null);
+        }
+
+        private void UnregisterPropertyChangedHandlers()
+        {
+            ViewModel.Settings.UpdateManager.PropertyChanged -= OnSettingsPropertyChanged;
+            ViewModel.Settings.PropertyChanged -= OnSettingsPropertyChanged;
+        }
+
+        private void OnSettingsPropertyChanged(object? sender, PropertyChangedEventArgs? e)
+        {
+            if (e is null || e.PropertyName == nameof(ViewModel.Settings.UpdateManager.CurrentChannel))
+                Utility.SetEnumComboBoxSelection(UpdateChannelComboBox, ViewModel.Settings.UpdateManager.CurrentChannel);
+
+            if (e is null || e.PropertyName == nameof(UpdateManager.AvailableUpdate) || e.PropertyName == nameof(Settings.AppVersion))
+                Refresh();
         }
 
         // The version to display in the expander either the current app version or the available update version
@@ -30,7 +53,7 @@ namespace Infomaniak.kDrive.CustomControls
              nameof(DisplayedVersion),
              typeof(AppVersion),
              typeof(UpdateExpander),
-             new PropertyMetadata(null, OnSettingsPropertyChanged));
+             new PropertyMetadata(null));
 
         public AppVersion? DisplayedVersion
         {
@@ -39,68 +62,52 @@ namespace Infomaniak.kDrive.CustomControls
 
         }
 
-        private static void OnSettingsPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-        {
-            if (d is UpdateExpander updateExpander)
-            {
-                if (e.OldValue is Settings oldSettings)
-                {
-                    updateExpander.UnregisterSettingsEventsHandlers(oldSettings);
-                }
-
-                if (e.NewValue is Settings newSettings)
-                {
-                    updateExpander.RegisterSettingsEventsHandlers(newSettings);
-                }
-                updateExpander.Refresh();
-            }
-        }
-
-        private void RegisterSettingsEventsHandlers(Settings settings)
-        {
-            settings.UpdateManager.PropertyChanged += OnSettingsPropertyChanged;
-            settings.PropertyChanged += OnSettingsPropertyChanged;
-        }
-
-        private void UnregisterSettingsEventsHandlers(Settings settings)
-        {
-            settings.UpdateManager.PropertyChanged -= OnSettingsPropertyChanged;
-            settings.PropertyChanged -= OnSettingsPropertyChanged;
-        }
-
-        private void OnSettingsPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
-        {
-            if (e.PropertyName == nameof(UpdateManager.AvailableUpdate) || e.PropertyName == nameof(Settings.AppVersion))
-            {
-                Refresh();
-            }
-        }
-
         public void Refresh()
         {
-            if (Settings is null)
+            if (ViewModel.Settings is null)
             {
                 Logger.Log(Logger.Level.Warning, "Settings is null, this is unexpected.");
                 return;
             }
 
-            if (Settings.UpdateManager.AvailableUpdate is AppVersion updateVersion)
+            if (ViewModel.Settings.UpdateManager.AvailableUpdate is AppVersion updateVersion)
             {
                 this.Description = Utility.GetLocalizedString("CC_UpdateExpander_UpdateAvailable_Description/TextTemplate", updateVersion.Tag);
                 ExpandedTextBox.Text = Utility.GetLocalizedString("CC_UpdateExpander_UpdateAvailable_UpdateDetails/TextTemplate", updateVersion.Tag, updateVersion.BuildVersion, updateVersion.PrettyBuildDate, updateVersion.BuildDate.Year);
                 DisplayedVersion = updateVersion;
             }
-            else if (Settings.AppVersion is AppVersion AppVersionInfo)
+            else if (ViewModel.Settings.AppVersion is AppVersion AppVersionInfo)
             {
                 this.Description = Utility.GetLocalizedString("CC_UpdateExpander_UpToDate_Description/Text");
                 ExpandedTextBox.Text = Utility.GetLocalizedString("CC_UpdateExpander_UpToDate_UpdateDetails/TextTemplate", AppVersionInfo.Tag, AppVersionInfo.BuildVersion, AppVersionInfo.PrettyBuildDate, AppVersionInfo.BuildDate.Year);
                 DisplayedVersion = AppVersionInfo;
             }
+            // check if any of the users is staff to show the internal update channel combobox
+            bool staffUserExists = App.ServiceProvider.GetRequiredService<AppModel>().Users.Any(user => user.IsStaff && user.IsConnected);
+            UpdateChannelComboBox_Internal.Visibility = staffUserExists ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        private async void UpdateChannel_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (!IsLoaded) return;
+            if (sender is ComboBox comboBox && comboBox.SelectedItem is ComboBoxItem selectedItem)
+            {
+                string? channelString = selectedItem.Tag as string;
+                if (Enum.TryParse<VersionChannel>(channelString, out VersionChannel selectedChannel))
+                {
+                    await ViewModel.Settings.UpdateManager.ChangeChannel(selectedChannel);
+                    Logger.Log(Logger.Level.Info, $"Update channel changed to {selectedChannel}");
+                }
+                else
+                {
+                    Logger.Log(Logger.Level.Error, $"Invalid update channel selected: {channelString}");
+                }
+            }
         }
 
         private async void UpdateButton_Click(object sender, RoutedEventArgs e)
         {
-            if (Settings is null)
+            if (ViewModel.Settings is null)
             {
                 Logger.Log(Logger.Level.Error, "Settings is null, cannot start update process.");
                 return;
@@ -113,7 +120,7 @@ namespace Infomaniak.kDrive.CustomControls
                 Logger.Log(Logger.Level.Info, "User clicked on Update button, starting update process.");
             }
 
-            if (!await Settings.UpdateManager.StartUpdate())
+            if (!await ViewModel.Settings.UpdateManager.StartUpdate())
             {
                 Logger.Log(Logger.Level.Error, "Update process failed to start.");
             }
@@ -121,6 +128,23 @@ namespace Infomaniak.kDrive.CustomControls
             if (btn is not null)
             {
                 btn.IsEnabled = true;
+            }
+        }
+
+        private async void AutoUpdateToggleSwitch_Toggled(object sender, RoutedEventArgs e)
+        {
+            if (!IsLoaded) return;
+            if (sender is ToggleSwitch toggleSwitch)
+            {
+                toggleSwitch.IsEnabled = false;
+                if (ViewModel.Settings is null || ViewModel.Settings.UpdateManager is null)
+                {
+                    Logger.Log(Logger.Level.Error, "Settings or UpdateManager is null, cannot change auto-update setting.");
+                    toggleSwitch.IsEnabled = true;
+                    return;
+                }
+                await ViewModel.Settings.UpdateManager.ChangeAutoUpdate(toggleSwitch.IsOn);
+                toggleSwitch.IsEnabled = true;
             }
         }
     }

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/SettingsPage.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/SettingsPage.xaml
@@ -77,20 +77,7 @@
                     <TextBlock x:Uid="Page_SettingsPage_Global"
                                Style="{StaticResource Infomaniak.Style.TextBlock.Subtitle}" />
                     <!-- General - Update -->
-                    <controls:UpdateExpander Settings="{x:Bind ViewModel.Settings, Mode=OneWay}" />
-
-                    <!-- General - Auto Update -->
-                    <toolKit:SettingsCard x:Uid="Page_SettingsPage_AutoUpdate"
-                                          IsEnabled="False">
-                        <!-- TODO: Make it enabled once auto-update is implemented on the server side (see: UpdateManager.ChangeAutoUpdate) -->
-                        <toolKit:SettingsCard.HeaderIcon>
-                            <controls:SvgIcon UriString="{StaticResource Infomaniak.DS.Icons.Arrows.arrows-loop-automatic}"
-                                              Height="32"
-                                              Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
-                        </toolKit:SettingsCard.HeaderIcon>
-                        <ToggleSwitch IsOn="{x:Bind ViewModel.Settings.UpdateManager.AutoUpdateEnabled, Mode=OneWay}"
-                                      Toggled="AutoUpdateToggleSwitch_Toggled" />
-                    </toolKit:SettingsCard>
+                    <controls:UpdateExpander />
 
                     <!-- General - Language -->
                     <toolKit:SettingsCard x:Uid="Page_SettingsPage_Language"
@@ -170,32 +157,6 @@
                         </toolKit:SettingsCard.Description>
 
                     </toolKit:SettingsCard>
-
-                    <!-- General - Beta -->
-                    <toolKit:SettingsExpander x:Uid="Page_SettingsPage_Beta">
-                        <toolKit:SettingsExpander.HeaderIcon>
-                            <controls:SvgIcon UriString="{StaticResource Infomaniak.DS.Icons.Miscellaneous.rocket}"
-                                              Height="32"
-                                              Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
-                        </toolKit:SettingsExpander.HeaderIcon>
-
-                        <toolKit:SettingsExpander.Items>
-                            <toolKit:SettingsCard x:Uid="Page_SettingsPage_Beta_Expander">
-                                <ComboBox x:Name="UpdateChannelComboBox"
-                                          SelectionChanged="UpdateChannel_SelectionChanged">
-                                    <ComboBoxItem Tag="Prod"
-                                                  x:Uid="Page_SettingsPage_Beta_ComboBox_Stable" />
-                                    <ComboBoxItem Tag="Beta"
-                                                  x:Uid="Page_SettingsPage_Beta_ComboBox_Beta" />
-                                    <ComboBoxItem Tag="Internal"
-                                                  x:Name="UpdateChannelComboBox_Internal"
-                                                  x:Uid="Page_SettingsPage_Beta_ComboBox_Internal"
-                                                  Foreground="{ThemeResource SystemErrorTextColor}"
-                                                  Visibility="Collapsed" />
-                                </ComboBox>
-                            </toolKit:SettingsCard>
-                        </toolKit:SettingsExpander.Items>
-                    </toolKit:SettingsExpander>
                 </StackPanel>
 
                 <!-- Account -->

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/SettingsPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/SettingsPage.xaml.cs
@@ -40,80 +40,25 @@ namespace Infomaniak.kDrive.Pages
             Logger.Log(Logger.Level.Info, "Navigated to SettingsPage - Initializing SettingsPage components");
             InitializeComponent();
             RegisterPropertyChangedHandlers();
-            Loaded += onPageLoaded;
 
             Logger.Log(Logger.Level.Debug, "SettingsPage components initialized");
-        }
-        ~SettingsPage()
-        {
-            UnregisterPropertyChangedHandlers();
-        }
-
-        void onPageLoaded(object sender, RoutedEventArgs e)
-        {
-            // check if any of the users is staff to show the internal update channel combobox
-            bool staffUserExists = ViewModel.Users.Any(user => user.IsStaff && user.IsConnected);
-            UpdateChannelComboBox_Internal.Visibility = staffUserExists ? Visibility.Visible : Visibility.Collapsed;
         }
 
         private void RegisterPropertyChangedHandlers()
         {
             ViewModel.Settings.PropertyChanged += Settings_PropertyChanged;
-            SetEnumComboBoxSelection(NotificationsComboBox, ViewModel.Settings.NotificationsDisabled);
-
-            ViewModel.Settings.UpdateManager.PropertyChanged += UpdateManager_PropertyChanged;
-            SetEnumComboBoxSelection(UpdateChannelComboBox, ViewModel.Settings.UpdateManager.CurrentChannel);
+            Utility.SetEnumComboBoxSelection(NotificationsComboBox, ViewModel.Settings.NotificationsDisabled);
         }
 
         private void Settings_PropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             if (e.PropertyName == nameof(ViewModel.Settings.NotificationsDisabled))
-                SetEnumComboBoxSelection(NotificationsComboBox, ViewModel.Settings.NotificationsDisabled);
-        }
-
-        private void UpdateManager_PropertyChanged(object? sender, PropertyChangedEventArgs e)
-        {
-            if (e.PropertyName == nameof(ViewModel.Settings.UpdateManager.CurrentChannel))
-                SetEnumComboBoxSelection(UpdateChannelComboBox, ViewModel.Settings.UpdateManager.CurrentChannel);
-
-        }
-        private void UnregisterPropertyChangedHandlers()
-        {
-            ViewModel.Settings.UpdateManager.PropertyChanged -= UpdateManager_PropertyChanged;
+                Utility.SetEnumComboBoxSelection(NotificationsComboBox, ViewModel.Settings.NotificationsDisabled);
         }
 
         private void CreateAccountButton_Click(object sender, RoutedEventArgs e)
         {
             (App.Current as App)?.StartOnboarding();
-        }
-
-        private async void UpdateChannel_SelectionChanged(object sender, SelectionChangedEventArgs e)
-        {
-            if (!IsLoaded) return;
-            if (sender is ComboBox comboBox && comboBox.SelectedItem is ComboBoxItem selectedItem)
-            {
-                string? channelString = selectedItem.Tag as string;
-                if (Enum.TryParse<VersionChannel>(channelString, out VersionChannel selectedChannel))
-                {
-                    await ViewModel.Settings.UpdateManager.ChangeChannel(selectedChannel);
-                    Logger.Log(Logger.Level.Info, $"Update channel changed to {selectedChannel}");
-                }
-                else
-                {
-                    Logger.Log(Logger.Level.Error, $"Invalid update channel selected: {channelString}");
-                }
-            }
-        }
-
-        private async void AutoUpdateToggleSwitch_Toggled(object sender, RoutedEventArgs e)
-        {
-            if (!IsLoaded) return;
-            if (sender is ToggleSwitch toggleSwitch)
-            {
-                toggleSwitch.IsEnabled = false;
-                await ViewModel.Settings.UpdateManager.ChangeAutoUpdate(toggleSwitch.IsOn);
-                toggleSwitch.IsEnabled = true;
-            }
         }
 
         private async void AutoStartToggleSwitch_Toggled(object sender, RoutedEventArgs e)
@@ -127,17 +72,6 @@ namespace Infomaniak.kDrive.Pages
             }
         }
 
-        private void SetEnumComboBoxSelection<TEnum>(ComboBox comboBox, TEnum value) where TEnum : struct, Enum
-        {
-            foreach (var item in comboBox.Items)
-            {
-                if (item is ComboBoxItem comboBoxItem && comboBoxItem.Tag is string tagString && Enum.TryParse<TEnum>(tagString, out TEnum itemValue) && itemValue.Equals(value))
-                {
-                    comboBox.SelectedItem = comboBoxItem;
-                    return;
-                }
-            }
-        }
         private async void NotificationsCombobox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             if (!IsLoaded) return;

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -247,37 +247,61 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 Logger.Log(Logger.Level.Error, $"User not found for DriveAvailable with dbID {userDbId}.");
                 return;
             }
-            await Utility.RunOnUIThread(() =>
+
+            // We don't clear and re-add all items to avoid UI flickering
+            // Build sets for fast lookup
+            var newIds = driveAvailableInfoList.Select(d => d.DriveId).ToHashSet();
+            var existingIds = user.DrivesAvailable.Select(d => d.DriveId).ToHashSet();
+
+            // Add new drives
+            foreach (var info in driveAvailableInfoList)
             {
-                // We don't clear and re-add all items to avoid UI flickering
-                // Build sets for fast lookup
-                var newIds = driveAvailableInfoList.Select(d => d.DriveId).ToHashSet();
-                var existingIds = user.DrivesAvailable.Select(d => d.DriveId).ToHashSet();
-
-                // Add new drives
-                foreach (var info in driveAvailableInfoList)
+                if (!existingIds.Contains(info.DriveId ?? -1))
                 {
-                    if (!existingIds.Contains(info.DriveId ?? -1))
-                    {
-                        var drive = new DriveAvailable();
-                        CommStruct.ConversionHelper.copyToDriveAvailable(info, drive);
-                        user.DrivesAvailable.Add(drive);
-                    }
+                    var drive = new DriveAvailable();
+                    CommStruct.ConversionHelper.copyToDriveAvailable(info, drive);
+                    await Utility.RunOnUIThread(() => { user.DrivesAvailable.Add(drive); });
                 }
-
-                // Remove drives no longer available
-                foreach (var existingId in existingIds)
+                else
                 {
-                    if (!newIds.Contains(existingId))
+                    // Check if any of the properties have changed, if yes remove and re-add to trigger UI update
+                    var existingDrive = user.DrivesAvailable.FirstOrDefault(d => d.DriveId == info.DriveId);
+                    if (existingDrive != null)
                     {
-                        var driveToRemove = user.DrivesAvailable.FirstOrDefault(d => d.DriveId == existingId);
-                        if (driveToRemove != null)
+                        var tempDrive = new DriveAvailable();
+                        CommStruct.ConversionHelper.copyToDriveAvailable(info, tempDrive);
+                        // compare properties individually
+                        foreach (var prop in typeof(DriveAvailable).GetProperties())
                         {
-                            user.DrivesAvailable.Remove(driveToRemove);
+                            var existingValue = prop.GetValue(existingDrive);
+                            var newValue = prop.GetValue(tempDrive);
+                            if (!Equals(existingValue, newValue))
+                            {
+                                await Utility.RunOnUIThread(() => {
+                                    user.DrivesAvailable.Remove(existingDrive);
+                                    user.DrivesAvailable.Add(tempDrive); 
+                                });
+                                break;
+                            }
                         }
                     }
                 }
-            });
+            }
+
+
+            // Remove drives no longer available
+            foreach (var existingId in existingIds)
+            {
+                if (!newIds.Contains(existingId))
+                {
+                    var driveToRemove = user.DrivesAvailable.FirstOrDefault(d => d.DriveId == existingId);
+                    if (driveToRemove != null)
+                    {
+                        await Utility.RunOnUIThread(() => { user.DrivesAvailable.Remove(driveToRemove); });
+                    }
+                }
+            }
+
         }
 
 

--- a/src/gui4/windows/kDrive client/kDrive client/Utility/Utility.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Utility/Utility.cs
@@ -4,6 +4,7 @@ using Infomaniak.kDrive.ViewModels;
 using Microsoft.UI;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
 using System;
 
 using System.Diagnostics;
@@ -312,6 +313,18 @@ namespace Infomaniak.kDrive
             }
 
             return localizedString;
+        }
+
+        public static void SetEnumComboBoxSelection<TEnum>(ComboBox comboBox, TEnum value) where TEnum : struct, Enum
+        {
+            foreach (var item in comboBox.Items)
+            {
+                if (item is ComboBoxItem comboBoxItem && comboBoxItem.Tag is string tagString && Enum.TryParse<TEnum>(tagString, out TEnum itemValue) && itemValue.Equals(value))
+                {
+                    comboBox.SelectedItem = comboBoxItem;
+                    return;
+                }
+            }
         }
     }
 }

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/User.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/User.cs
@@ -165,12 +165,6 @@ namespace Infomaniak.kDrive.ViewModels
          */
         private void MergeDrives()
         {
-            // Define drive Equal action based on DriveId and type
-            Func<IDrive, IDrive, bool> driveEqualAction = (d1, d2) =>
-            {
-                return d1.DriveId == d2.DriveId && d1.GetType() == d2.GetType();
-            };
-
             List<IDrive> drives = new();
             foreach (var drive in Drives)
                 drives.Add(drive);
@@ -182,12 +176,12 @@ namespace Infomaniak.kDrive.ViewModels
             for (int i = AllDrives.Count - 1; i >= 0; i--)
             {
                 var drive = AllDrives[i];
-                if (drives.FirstOrDefault(d => driveEqualAction(d, drive)) is null)
+                if (drives.FirstOrDefault(d => d == drive) is null)
                     AllDrives.RemoveAt(i);
             }
 
             foreach (var drive in drives)
-                if (AllDrives.FirstOrDefault(d => driveEqualAction(d, drive)) is null)
+                if (AllDrives.FirstOrDefault(d =>  d == drive) is null)
                     AllDrives.Add(drive);
         }
     }


### PR DESCRIPTION
<img width="1008" height="337" alt="image" src="https://github.com/user-attachments/assets/45c4088b-2dde-4850-80c4-0847a004f752" />

**depends on #1161** 

**Update Settings UI**

* Moved the auto-update toggle and update channel selection controls into the `UpdateExpander` control, consolidating all update-related settings in one place and removing their previous separate implementations from `SettingsPage.xaml`. 
* Refactored `UpdateExpander.xaml.cs` to use the `ViewModel` directly instead of a dependency property, and replaced property change event registration logic with a more robust handler registration/unregistration in the control's constructor and destructor. 
* Moved update channel selection and auto-update toggle event handlers from `SettingsPage.xaml.cs` into `UpdateExpander.xaml.cs`, ensuring all update-related actions are handled within the custom control.

**UI Update Reliability:**

* Improved drive availability updates by ensuring that UI changes are triggered only when drive properties actually change, reducing unnecessary UI flicker and making updates more efficient.