### PR TITLE
WinUI3 Settings page simplify combobox

### DIFF
--- a/src/gui4/windows/kDrive client/kDrive client/Pages/SettingsPage.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/SettingsPage.xaml
@@ -113,7 +113,8 @@
                                                Height="32"
                                                Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
                         </toolKit:SettingsCard.HeaderIcon>
-                        <ComboBox SelectedIndex="0"
+                        <ComboBox SelectedValuePath="Tag"
+                                  SelectedValue="{x:Bind ViewModel.Settings.NotificationsDisabled, Converter={StaticResource ToStringConverter}, Mode=OneWay}"
                                   SelectionChanged="NotificationsCombobox_SelectionChanged"
                                   x:Name="NotificationsComboBox">
                             <ComboBoxItem x:Uid="Page_SettingsPage_Notifications_ComboBox_Never"

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/SettingsPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/SettingsPage.xaml.cs
@@ -40,21 +40,7 @@ namespace Infomaniak.kDrive.Pages
         {
             Logger.Log(Logger.Level.Info, "Navigated to SettingsPage - Initializing SettingsPage components");
             InitializeComponent();
-            RegisterPropertyChangedHandlers();
-
             Logger.Log(Logger.Level.Debug, "SettingsPage components initialized");
-        }
-
-        private void RegisterPropertyChangedHandlers()
-        {
-            ViewModel.Settings.PropertyChanged += Settings_PropertyChanged;
-            Utility.SetEnumComboBoxSelection(NotificationsComboBox, ViewModel.Settings.NotificationsDisabled);
-        }
-
-        private void Settings_PropertyChanged(object? sender, PropertyChangedEventArgs e)
-        {
-            if (e.PropertyName == nameof(ViewModel.Settings.NotificationsDisabled))
-                Utility.SetEnumComboBoxSelection(NotificationsComboBox, ViewModel.Settings.NotificationsDisabled);
         }
 
         private void CreateAccountButton_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
**depends on #1170** 

This pull request updates how the notification settings are bound and handled in the `SettingsPage` of the kDrive client. The main change is moving from manual property change handling to direct data binding for the notifications setting, simplifying the code and improving maintainability.

**UI Binding Improvements:**

* The `ComboBox` in `SettingsPage.xaml` now uses `SelectedValuePath="Tag"` and binds `SelectedValue` directly to `ViewModel.Settings.NotificationsDisabled`, with a converter for type conversion, enabling one-way data binding.

**Code Cleanup and Simplification:**

* Removed the `RegisterPropertyChangedHandlers` method and the associated `Settings_PropertyChanged` event handler from `SettingsPage.xaml.cs`, eliminating manual synchronization logic between the view model and the UI.