### PR TITLE
WinUI3 Settings page Send log

### DIFF
--- a/src/gui4/windows/kDrive client/kDrive client/Pages/SettingsPage.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/SettingsPage.xaml
@@ -68,6 +68,7 @@
         </Grid.RowDefinitions>
 
         <TextBlock Grid.Row="0"
+                   x:Uid="Page_SettingsPage_Title"
                    Text="Paramètres"
                    Style="{StaticResource Infomaniak.Style.TextBlock.Title}" />
 
@@ -469,6 +470,66 @@
                             </toolKit:SettingsCard>
                         </toolKit:SettingsExpander.Items>
                     </toolKit:SettingsExpander>
+
+                    <!-- Advanced - Send log -->
+                    <toolKit:SettingsCard Header="Support infomaniak">
+                        <toolKit:SettingsCard.HeaderIcon>
+                            <controls:SvgIcon UriString="{StaticResource Infomaniak.DS.Icons.Devices.headphones}"
+                                              Height="32"
+                                              Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
+                        </toolKit:SettingsCard.HeaderIcon>
+                        <StackPanel Orientation="Horizontal"
+                                    Spacing="{StaticResource Infomaniak.Style.Spacing.XS}">
+                            <controls:SvgIcon UriString="{StaticResource Infomaniak.DS.Icons.Actions.circle-check}"
+                                              Height="16"
+                                              Foreground="{ThemeResource SystemFillColorSuccess}">
+                                <ToolTipService.ToolTip>
+                                    <ToolTip Content="Votre dossier de logs a été partagé avec succés le xxxxxx à xxhxx et xxs." />
+                                    <!-- TODO: Replace with actual values once linked to the server -->
+                                </ToolTipService.ToolTip>
+                            </controls:SvgIcon>
+                            <controls:SvgIcon UriString="{StaticResource Infomaniak.DS.Icons.Actions.triangle-alert}"
+                                              Height="16"
+                                              Foreground="{ThemeResource SystemErrorTextColor}">
+                                <ToolTipService.ToolTip>
+                                    <ToolTip Content="L'envoi de votre dossier de logs a échoué. Veuillez réessayer." />
+                                </ToolTipService.ToolTip>
+                            </controls:SvgIcon>
+                            <ProgressRing x:Name="SendLogsProgressRing"
+                                          Height="16"
+                                          Width="Auto"
+                                          IsIndeterminate="False"
+                                          Visibility="Collapsed" />
+                            <Button x:Name="SendLogButton"
+                                    Style="{StaticResource AccentButtonStyle}"
+                                    Click="SendLogButton_Click">
+                                <Grid>
+                                    <TextBlock Text="Envoyer le dossier de débogage" />
+                                </Grid>
+                            </Button>
+                            <Button x:Name="CancelSendLogButton"
+                                    Content="Annuler"
+                                    Click="CancelSendLogButton_Click" />
+                            <ContentDialog x:Name="SendLogDialog"
+                                           Title="Envoyer le dossier de débogage au support Infomaniak"
+                                           PrimaryButtonText="Envoyer"
+                                           CloseButtonText="Annuler"
+                                           DefaultButton="Primary">
+
+                                <ContentDialog.Content>
+                                    <StackPanel Spacing="12">
+                                        <TextBlock Text="Le dossier complet est volumineux.Pour accélérer l’envoi, nous vous recommandons de n’envoyer que la dernière session kDrive."
+                                                   TextWrapping="WrapWholeWords"
+                                                   TextAlignment="Justify"
+                                                   Margin="0,0,0,8" />
+                                        <CheckBox Content="Envoyer uniquement la dernière session"
+                                                  IsChecked="True" />
+                                    </StackPanel>
+                                </ContentDialog.Content>
+                            </ContentDialog>
+                        </StackPanel>
+
+                    </toolKit:SettingsCard>
                 </StackPanel>
 
                 <!-- About kDrive -->

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/SettingsPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/SettingsPage.xaml.cs
@@ -324,7 +324,7 @@ namespace Infomaniak.kDrive.Pages
             bool toggleIsOn = toggleSwitch?.IsOn ?? false;
 
             if (ViewModel.Settings.LogLevel == Logger.Level.None && !toggleIsOn) return; // No change needed
-            if(ViewModel.Settings.LogLevel != Logger.Level.None && toggleIsOn) return; // No change needed
+            if (ViewModel.Settings.LogLevel != Logger.Level.None && toggleIsOn) return; // No change needed
 
             LogSettingsExpander.IsEnabled = false;
             await ViewModel.Settings.ChangeLogLevel(toggleIsOn ? Logger.Level.Debug : Logger.Level.None);
@@ -338,7 +338,7 @@ namespace Infomaniak.kDrive.Pages
             if (toggleSwitch is null)
                 Logger.Log(Logger.Level.Error, "sender is not a ToggleSwitch");
 
-            if(ViewModel.Settings.PurgeOldLogs == toggleSwitch?.IsOn) return; // No change needed
+            if (ViewModel.Settings.PurgeOldLogs == toggleSwitch?.IsOn) return; // No change needed
             LogSettingsExpander.IsEnabled = false;
             await ViewModel.Settings.ChangePurgeOldLog(toggleSwitch?.IsOn ?? false);
             LogSettingsExpander.IsEnabled = true;
@@ -377,6 +377,38 @@ namespace Infomaniak.kDrive.Pages
             }
             if (control is not null)
                 control.IsEnabled = true;
+        }
+
+        bool _logUploadCancelled = false;
+        private async void SendLogButton_Click(object sender, RoutedEventArgs e)
+        {
+            var result = await SendLogDialog.ShowAsync();
+            if (result != ContentDialogResult.Primary) return;
+
+            // !!! Simulate log upload progress
+            // TODO: Implement actual log upload once linked with the server side
+
+            _logUploadCancelled = false;
+            SendLogsProgressRing.Value = 0;
+            SendLogsProgressRing.Visibility = Visibility.Visible;
+            SendLogButton.IsEnabled = false;
+            CancelSendLogButton.Visibility = Visibility.Visible;
+            while (SendLogsProgressRing.Value < 100 && !_logUploadCancelled)
+            {
+                await Task.Delay(Random.Shared.Next(200, 800));
+                SendLogsProgressRing.Value += Random.Shared.Next(1, 20);
+            }
+            SendLogsProgressRing.Value = 100;
+            await Task.Delay(500);
+            SendLogsProgressRing.Visibility = Visibility.Collapsed;
+            SendLogButton.IsEnabled = true;
+            CancelSendLogButton.Visibility = Visibility.Collapsed;
+            _logUploadCancelled = false;
+        }
+
+        private void CancelSendLogButton_Click(object sender, RoutedEventArgs e)
+        {
+            _logUploadCancelled = true;
         }
     }
 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/de-DE/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/de-DE/Resources.resw
@@ -490,6 +490,9 @@
   <data name="Page_SettingsPage_Language.Header" type="System.Resources.ResXNullRef, System.Windows.Forms">
     <value />
   </data>
+  <data name="Page_SettingsPage_Title.Text" type="System.Resources.ResXNullRef, System.Windows.Forms">
+    <value />
+  </data>
   <data name="Page_SettingsPage_Accounts.Text" type="System.Resources.ResXNullRef, System.Windows.Forms">
     <value />
   </data>

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/en-US/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/en-US/Resources.resw
@@ -490,6 +490,9 @@
   <data name="Page_SettingsPage_Language.Header" type="System.Resources.ResXNullRef, System.Windows.Forms">
     <value />
   </data>
+  <data name="Page_SettingsPage_Title.Text" type="System.Resources.ResXNullRef, System.Windows.Forms">
+    <value />
+  </data>
   <data name="Page_SettingsPage_Accounts.Text" type="System.Resources.ResXNullRef, System.Windows.Forms">
     <value />
   </data>

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/es-ES/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/es-ES/Resources.resw
@@ -490,6 +490,9 @@
   <data name="Page_SettingsPage_Language.Header" type="System.Resources.ResXNullRef, System.Windows.Forms">
     <value />
   </data>
+  <data name="Page_SettingsPage_Title.Text" type="System.Resources.ResXNullRef, System.Windows.Forms">
+    <value />
+  </data>
   <data name="Page_SettingsPage_Accounts.Text" type="System.Resources.ResXNullRef, System.Windows.Forms">
     <value />
   </data>

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/fr-FR/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/fr-FR/Resources.resw
@@ -527,6 +527,9 @@ Version {0} (build {1}), compilée le {2}
   <data name="Page_SettingsPage_Language.Header" xml:space="preserve">
     <value>Langue</value>
   </data>
+  <data name="Page_SettingsPage_Title.Text" xml:space="preserve">
+    <value>Paramètres</value>
+  </data>
   <data name="Page_SettingsPage_Accounts.Text" xml:space="preserve">
     <value>Comptes</value>
   </data>

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/it-IT/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/it-IT/Resources.resw
@@ -490,6 +490,9 @@
   <data name="Page_SettingsPage_Language.Header" type="System.Resources.ResXNullRef, System.Windows.Forms">
     <value />
   </data>
+  <data name="Page_SettingsPage_Title.Text" type="System.Resources.ResXNullRef, System.Windows.Forms">
+    <value />
+  </data>
   <data name="Page_SettingsPage_Accounts.Text" type="System.Resources.ResXNullRef, System.Windows.Forms">
     <value />
   </data>


### PR DESCRIPTION
###  Add "Send Log" Feature to settings (UI Only)
**depends on #1174** 

This pull request introduces a new **"Send Log"** feature on the **Settings** page, allowing users to send their debug log folder to Infomaniak Support.

It adds new **UI components** for managing log uploads, including:

* 📤 Upload progress indication
* ❌ Upload cancellation
* ✅ Feedback on success or failure

---

### 🧩 Implementation Details

This PR **only implements the UI and mock behavior**.
Localization and actual server integration (to perform real log uploads) will be added in a **future PR**, once the backend endpoint is ready.

---

🎥 **Demo:**

https://github.com/user-attachments/assets/00d84c04-22f5-4f84-8a8b-43401303dd9b