### PR TITLE
Node id exists on both replica

### DIFF
--- a/src/libsyncengine/propagation/operation_sorter/operationsorterworker.cpp
+++ b/src/libsyncengine/propagation/operation_sorter/operationsorterworker.cpp
@@ -292,8 +292,8 @@ SyncOpPtr OperationSorterWorker::getAncestorOpWithHighestIndex(const std::unorde
     std::shared_ptr<const Node> ancestorNode = node->parentNode();
     depth = ancestorNode ? 1 : 0;
 
-    while (ancestorNode && ancestorNode != _syncPal->updateTree(ancestorNode->side())->rootNode()) {
-        for (const auto parentOpIdList = _syncPal->_syncOps->getOpIdsFromNodeId(*ancestorNode->id());
+    while (ancestorNode && ancestorNode != _syncPal->updateTree(node->side())->rootNode()) {
+        for (const auto parentOpIdList = _syncPal->_syncOps->getOpIdsFromNodeId(*ancestorNode->id(), node->side());
              const auto &parentOpId: parentOpIdList) {
             const auto parentOp = _syncPal->_syncOps->getOp(parentOpId);
             if (parentOp->type() != OperationType::Create) {
@@ -402,7 +402,7 @@ std::optional<SyncOperationList> OperationSorterWorker::fixImpossibleFirstMoveOp
     int32_t lowestIndex = INT32_MAX;
     SyncOpPtr selectedOp = nullptr;
     for (const auto &n: moveDirectoryList) {
-        for (const auto opIds = _syncPal->_syncOps->getOpIdsFromNodeId(*n->id()); const auto opId: opIds) {
+        for (const auto opIds = _syncPal->_syncOps->getOpIdsFromNodeId(*n->id(), n->side()); const auto opId: opIds) {
             const auto op = _syncPal->_syncOps->getOp(opId);
             LOG_IF_FAIL(op)
             if (op->type() != OperationType::Move) {

--- a/src/libsyncengine/reconciliation/syncoperation.cpp
+++ b/src/libsyncengine/reconciliation/syncoperation.cpp
@@ -76,7 +76,7 @@ bool SyncOperationList::pushOp(SyncOpPtr op) {
     const auto [it, inserted] = _allOps.try_emplace(op->id(), op);
     if (!inserted) return false;
     _opSortedList.push_back(op->id());
-    _opListByType[op->type()].insert(op->id());
+    (void) _opListByType[op->type()].insert(op->id());
     _node2op[*op->affectedNode()->id()].push_back(op->id());
     return true;
 }

--- a/src/libsyncengine/reconciliation/syncoperation.cpp
+++ b/src/libsyncengine/reconciliation/syncoperation.cpp
@@ -62,6 +62,16 @@ SyncOpPtr SyncOperationList::getOp(const UniqueId id) {
     return opIt == _allOps.end() ? nullptr : opIt->second;
 }
 
+std::list<UniqueId> SyncOperationList::getOpIdsFromNodeId(const NodeId &nodeId, const ReplicaSide side) {
+    std::list<UniqueId> opList;
+    for (const auto opId: _node2op[nodeId]) {
+        const auto op = _allOps[opId];
+        // Keep the op only if its source side is the same as `side`.
+        if (op && otherSide(op->targetSide()) == side) opList.push_back(opId);
+    }
+    return opList;
+}
+
 bool SyncOperationList::pushOp(SyncOpPtr op) {
     const auto [it, inserted] = _allOps.try_emplace(op->id(), op);
     if (!inserted) return false;

--- a/src/libsyncengine/reconciliation/syncoperation.h
+++ b/src/libsyncengine/reconciliation/syncoperation.h
@@ -158,7 +158,7 @@ class SyncOperationList : public SharedObject {
         std::unordered_map<UniqueId, SyncOpPtr> _allOps;
         std::list<UniqueId> _opSortedList;
         std::unordered_map<OperationType, std::unordered_set<UniqueId>> _opListByType;
-        std::unordered_map<NodeId, std::list<UniqueId>> _node2op;
+        std::unordered_map<NodeId, std::list<UniqueId>, StringHashFunction, std::equal_to<>> _node2op;
 
         friend class TestOperationSorterWorker;
         friend class TestOperationGeneratorWorker;

--- a/src/libsyncengine/reconciliation/syncoperation.h
+++ b/src/libsyncengine/reconciliation/syncoperation.h
@@ -134,8 +134,8 @@ class SyncOperationList : public SharedObject {
         [[nodiscard]] const std::list<UniqueId> &opSortedList() const { return _opSortedList; }
         const std::unordered_set<UniqueId> &opListIdByType(const OperationType type) { return _opListByType[type]; }
         /**
-         * @brief Get the list of operation IDs related to the given node. The side must be provided as well in the case where the
-         * same ID would exist both on local and on remote replica.
+         * @brief Get the list of operation IDs related to the given node. The side must also be provided to handle cases where the 
+         *  same ID exists on both the local and remote replicas.
          * @param nodeId The ID of the object whose operations we want to retrieve.
          * @param side The side of the object designated by `nodeId`.
          * @return A list of operation IDs.

--- a/src/libsyncengine/reconciliation/syncoperation.h
+++ b/src/libsyncengine/reconciliation/syncoperation.h
@@ -133,7 +133,14 @@ class SyncOperationList : public SharedObject {
         SyncOpPtr getOp(UniqueId id);
         [[nodiscard]] const std::list<UniqueId> &opSortedList() const { return _opSortedList; }
         const std::unordered_set<UniqueId> &opListIdByType(const OperationType type) { return _opListByType[type]; }
-        const std::list<UniqueId> &getOpIdsFromNodeId(const NodeId &nodeId) { return _node2op[nodeId]; }
+        /**
+         * @brief Get the list of operation IDs related to the given node. The side must be provided as well in the case where the
+         * same ID would exist both on local and on remote replica.
+         * @param nodeId The ID of the object whose operations we want to retrieve.
+         * @param side The side of the object designated by `nodeId`.
+         * @return A list of operation IDs.
+         */
+        std::list<UniqueId> getOpIdsFromNodeId(const NodeId &nodeId, const ReplicaSide side);
         [[nodiscard]] const std::unordered_map<UniqueId, SyncOpPtr> &allOps() const { return _allOps; }
 
         bool pushOp(SyncOpPtr op);

--- a/test/libsyncengine/propagation/operation_sorter/testoperationsorterworker.cpp
+++ b/test/libsyncengine/propagation/operation_sorter/testoperationsorterworker.cpp
@@ -430,6 +430,63 @@ void TestOperationSorterWorker::testFixCreateBeforeCreateComplexOrdering() {
     }
 }
 
+void TestOperationSorterWorker::testFixCreateBeforeCreateSameIdOnBothSide() {
+    // Initial remote situation:
+    // .
+    // ├── A (a)
+    // │   └── AA (aa)
+    // │       └── AAA (aaa)
+    const auto nodeA = std::make_shared<Node>(std::nullopt, ReplicaSide::Remote, Str("A"), NodeType::Directory,
+                                              OperationType::Create, "a", testhelpers::defaultTime, testhelpers::defaultTime,
+                                              testhelpers::defaultDirSize, _syncPal->updateTree(ReplicaSide::Remote)->rootNode());
+    (void) _syncPal->updateTree(ReplicaSide::Remote)->rootNode()->insertChildren(nodeA);
+    _syncPal->updateTree(ReplicaSide::Remote)->insertNode(nodeA);
+    const auto opA = generateSyncOperation(OperationType::Create, nodeA);
+
+    const auto nodeAA =
+            std::make_shared<Node>(std::nullopt, ReplicaSide::Remote, Str("AA"), NodeType::Directory, OperationType::Create, "aa",
+                                   testhelpers::defaultTime, testhelpers::defaultTime, testhelpers::defaultDirSize, nodeA);
+    (void) nodeA->insertChildren(nodeAA);
+    _syncPal->updateTree(ReplicaSide::Remote)->insertNode(nodeAA);
+    const auto opAA = generateSyncOperation(OperationType::Create, nodeAA);
+
+    const auto nodeAAA =
+            std::make_shared<Node>(std::nullopt, ReplicaSide::Remote, Str("AAA"), NodeType::File, OperationType::Create, "aaa",
+                                   testhelpers::defaultTime, testhelpers::defaultTime, testhelpers::defaultDirSize, nodeAA);
+    (void) nodeAA->insertChildren(nodeAAA);
+    _syncPal->updateTree(ReplicaSide::Remote)->insertNode(nodeAAA);
+    const auto opAAA = generateSyncOperation(OperationType::Create, nodeAAA);
+
+    // Initial local situation :
+    // .
+    // └── B (b)
+    //     └── BA (aa)
+    const auto nodeB = std::make_shared<Node>(std::nullopt, ReplicaSide::Local, Str("B"), NodeType::Directory,
+                                              OperationType::Create, "b", testhelpers::defaultTime, testhelpers::defaultTime,
+                                              testhelpers::defaultDirSize, _syncPal->updateTree(ReplicaSide::Local)->rootNode());
+    (void) _syncPal->updateTree(ReplicaSide::Local)->rootNode()->insertChildren(nodeB);
+    _syncPal->updateTree(ReplicaSide::Local)->insertNode(nodeB);
+    const auto opB = generateSyncOperation(OperationType::Create, nodeB);
+
+    const auto nodeBA =
+            std::make_shared<Node>(std::nullopt, ReplicaSide::Local, Str("BA"), NodeType::File, OperationType::Create, "aa",
+                                   testhelpers::defaultTime, testhelpers::defaultTime, testhelpers::defaultDirSize, nodeB);
+    (void) nodeB->insertChildren(nodeBA);
+    _syncPal->updateTree(ReplicaSide::Local)->insertNode(nodeBA);
+    const auto opBA = generateSyncOperation(OperationType::Create, nodeBA);
+
+    _syncPal->syncOps()->clear();
+
+    (void) _syncPal->syncOps()->pushOp(opA);
+    (void) _syncPal->syncOps()->pushOp(opAA);
+    (void) _syncPal->syncOps()->pushOp(opAAA);
+    (void) _syncPal->syncOps()->pushOp(opB);
+    (void) _syncPal->syncOps()->pushOp(opBA);
+
+    _syncPal->_operationsSorterWorker->fixCreateBeforeCreate();
+
+    CPPUNIT_ASSERT(!_syncPal->_operationsSorterWorker->hasOrderChanged());
+}
 
 // edit before move, e.g. user moves an object "a" to "b" and then edit it.
 void TestOperationSorterWorker::testFixEditBeforeMove() {

--- a/test/libsyncengine/propagation/operation_sorter/testoperationsorterworker.h
+++ b/test/libsyncengine/propagation/operation_sorter/testoperationsorterworker.h
@@ -36,6 +36,7 @@ class TestOperationSorterWorker final : public CppUnit::TestFixture, public Test
         CPPUNIT_TEST(testFixMoveBeforeMoveOccupied);
         CPPUNIT_TEST(testFixCreateBeforeCreate);
         CPPUNIT_TEST(testFixCreateBeforeCreateComplexOrdering);
+        CPPUNIT_TEST(testFixCreateBeforeCreateSameIdOnBothSide);
         CPPUNIT_TEST(testFixEditBeforeMove);
         CPPUNIT_TEST(testFixEditBeforeMove2);
         CPPUNIT_TEST(testFixMoveBeforeMoveParentChildFlip);
@@ -63,6 +64,7 @@ class TestOperationSorterWorker final : public CppUnit::TestFixture, public Test
         void testFixMoveBeforeMoveOccupied();
         void testFixCreateBeforeCreate();
         void testFixCreateBeforeCreateComplexOrdering();
+        void testFixCreateBeforeCreateSameIdOnBothSide();
 
         void testFixEditBeforeMove();
         void testFixEditBeforeMove2();


### PR DESCRIPTION
In the rare cases where a same node ID exist on both replica, the sequence of operations could be altered in a way that makes it impossible to propagate them. Especially, an operation on a child item could be executed before creating its parent folder, leading the sync to fail.

The correction involve checking that the operation list retrieve from a node ID contains only operation for a given replica side.