### PR TITLE
Crash serveur - UpdateChecker::versionInfoReceived 

### DIFF
--- a/src/server/updater/updatechecker.cpp
+++ b/src/server/updater/updatechecker.cpp
@@ -81,6 +81,8 @@ const VersionInfo &UpdateChecker::versionInfo(const VersionChannel chosenChannel
 }
 
 void UpdateChecker::versionInfoReceived(UniqueId jobId) {
+    // A mutex is needed because this function can be run multiple times simultaneously when the computer wakes from sleep.
+    const std::scoped_lock<std::mutex> lock(_mutex);
     _isVersionReceived = false;
     _versionsInfo.clear();
     LOG_INFO(Log::instance()->getLogger(), "App version info received");

--- a/src/server/updater/updatechecker.h
+++ b/src/server/updater/updatechecker.h
@@ -85,6 +85,7 @@ class UpdateChecker {
         const VersionInfo _defaultVersionInfo;
         AllVersionsInfo _versionsInfo;
         bool _isVersionReceived{false};
+        std::mutex _mutex;
 
         friend class MockUpdateChecker;
         friend class TestUpdateChecker;


### PR DESCRIPTION
`UpdateChecker::versionInfoReceived` can be run twice simultaneously, e.g. when the Mac wakes up from sleep.