### PR TITLE
Fix unskip version

### DIFF
--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -63,7 +63,7 @@
 #include "server/comm/guijobs/signalaccountaddedjob.h"
 #include "server/comm/guijobs/signaluseraddedjob.h"
 #include "server/comm/guijobs/signaluserupdatedjob.h"
-#include "server/comm/guijobs/signaluserremovedjob.h" 
+#include "server/comm/guijobs/signaluserremovedjob.h"
 #include "server/comm/guijobs/signalaccountremovedjob.h"
 #include "server/comm/guijobs/signaldriveaddedjob.h"
 #include "server/comm/guijobs/signaldriveremovedjob.h"
@@ -4106,7 +4106,7 @@ void AppServer::addError(const Error &error) {
         }
         if (!toBeRemovedErrorIds.empty()) sendErrorsCleared(error.syncDbId());
     } else if (error.exitCode() == ExitCode::UpdateRequired) {
-        AbstractUpdater::unskipVersion();
+        _updateManager.get()->updater()->unskipVersion();
     }
 
     if (!ServerRequests::isAutoResolvedError(error) && !errorAlreadyExists) {

--- a/src/server/updater/abstractupdater.h
+++ b/src/server/updater/abstractupdater.h
@@ -63,7 +63,7 @@ class AbstractUpdater {
         void setStateChangeCallback(const std::function<void(UpdateState)> &stateChangeCallback);
 
         static void skipVersion(const std::string &skippedVersion);
-        static void unskipVersion();
+        virtual void unskipVersion();
         [[nodiscard]] static bool isVersionSkipped(const std::string &version);
 
         void setCurrentChannel(const VersionChannel currentChannel) { _currentChannel = currentChannel; }

--- a/src/server/updater/sparkleupdater.h
+++ b/src/server/updater/sparkleupdater.h
@@ -32,7 +32,7 @@ class SparkleUpdater final : public AbstractUpdater {
         void setQuitCallback(const std::function<void()> &quitCallback) override;
         void startInstaller() override;
 
-        static void unskipVersion();
+        void unskipVersion() override;
 
     private:
         void reset(const std::string &url = "");

--- a/src/server/updater/updatemanager.cpp
+++ b/src/server/updater/updatemanager.cpp
@@ -63,7 +63,7 @@ void UpdateManager::startInstaller() const {
     LOG_DEBUG(Log::instance()->getLogger(), "startInstaller called!");
 
     // Cleanup skipped version
-    AbstractUpdater::unskipVersion();
+    _updater->unskipVersion();
 
     _updater->startInstaller();
 }


### PR DESCRIPTION
Skipping a version should only deactivate the popup offering to install new version. However, clicking on the update button should "unskip" the version and allow the user to install the update anyway. This last part is broken since version 3.7.7