### PR TITLE
chore(CI): Remove kDrive desktop CI run on Review requested

### DIFF
--- a/.github/workflows/kdrive-desktop-ci.yml
+++ b/.github/workflows/kdrive-desktop-ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches-ignore:
         - 'release/**'
-    types: [synchronize, review_requested, opened]
+    types: [synchronize, opened]
 
 concurrency:
   group: kDrive-desktop-ci-${{ github.head_ref }}


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow configuration. The change removes the `review_requested` event type from the list of pull request events that trigger the workflow, so the CI workflow will no longer run when a review is requested on a pull request.