### PR TITLE
feat: add node management gui jobs

### DIFF
--- a/src/gui/drivepreferenceswidget.cpp
+++ b/src/gui/drivepreferenceswidget.cpp
@@ -1117,8 +1117,6 @@ void DrivePreferencesWidget::onValidateUpdate(int syncDbId) {
         return;
     }
 
-    GuiRequests::propagateSyncListChange(syncDbId, true);
-
     // Hide update widget
     if (auto *itemWidget = (FolderItemWidget *) sender(); itemWidget) {
         itemWidget->setUpdateWidgetVisible(false);

--- a/src/gui/guirequests.cpp
+++ b/src/gui/guirequests.cpp
@@ -672,24 +672,6 @@ ExitCode GuiRequests::deleteSync(const int syncDbId) {
     return exitCode;
 }
 
-ExitCode GuiRequests::propagateSyncListChange(const int syncDbId, const bool restartSync) {
-    QByteArray params;
-    QDataStream paramsStream(&params, QIODevice::WriteOnly);
-    paramsStream << syncDbId;
-    paramsStream << restartSync;
-
-    QByteArray results;
-    if (!CommClient::instance()->execute(RequestNum::SYNC_PROPAGATE_SYNCLIST_CHANGE, params, results)) {
-        return ExitCode::SystemError;
-    }
-
-    auto exitCode = ExitCode::Unknown;
-    QDataStream resultStream(&results, QIODevice::ReadOnly);
-    resultStream >> exitCode;
-
-    return exitCode;
-}
-
 ExitCode GuiRequests::bestAvailableVfsMode(VirtualFileMode &mode) {
     QByteArray results;
     if (!CommClient::instance()->execute(RequestNum::UTILITY_BESTVFSAVAILABLEMODE, {}, results)) {

--- a/src/gui/guirequests.h
+++ b/src/gui/guirequests.h
@@ -113,7 +113,6 @@ struct GuiRequests {
         static ExitCode searchItemInDrive(int driveDbId, const QString &searchString, QList<SearchInfo> &list, bool &hasMore,
                                           QString &cursor); // !!! Use COMM_LONG_TIMEOUT !!!
         static ExitCode deleteSync(int syncDbId); // Asynchronous because it can be time consuming
-        static ExitCode propagateSyncListChange(int syncDbId, bool restartSync);
         static ExitCode bestAvailableVfsMode(VirtualFileMode &mode);
         static ExitCode propagateExcludeListChange(); // !!! Use COMM_LONG_TIMEOUT !!!
         static ExitCode hasSystemLaunchOnStartup(bool &enabled);

--- a/src/libcommon/comm.h
+++ b/src/libcommon/comm.h
@@ -69,7 +69,6 @@ enum class RequestNum {
     SYNC_ASKFORSTATUS,
     SYNC_SETSUPPORTSVIRTUALFILES,
     SYNC_SETROOTPINSTATE,
-    SYNC_PROPAGATE_SYNCLIST_CHANGE,
     SYNCNODE_LIST,
     SYNCNODE_SETLIST,
     NODE_PATH,
@@ -169,8 +168,6 @@ inline std::string toString(RequestNum e) {
             return "SYNC_SETSUPPORTSVIRTUALFILES";
         case RequestNum::SYNC_SETROOTPINSTATE:
             return "SYNC_SETROOTPINSTATE";
-        case RequestNum::SYNC_PROPAGATE_SYNCLIST_CHANGE:
-            return "SYNC_PROPAGATE_SYNCLIST_CHANGE";
         case RequestNum::SYNCNODE_LIST:
             return "SYNCNODE_LIST";
         case RequestNum::SYNCNODE_SETLIST:

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -72,6 +72,11 @@ set(server_SRCS
     comm/guijobs/syncdeletejob.h comm/guijobs/syncdeletejob.cpp
     comm/guijobs/syncgetpubliclinkurljob.h comm/guijobs/syncgetpubliclinkurljob.cpp
     comm/guijobs/syncgetprivatelinkurljob.h comm/guijobs/syncgetprivatelinkurljob.cpp
+    comm/guijobs/nodesubfoldersjob.h comm/guijobs/nodesubfoldersjob.cpp
+    comm/guijobs/nodefoldersizejob.h comm/guijobs/nodefoldersizejob.cpp
+    comm/guijobs/nodeinfojob.h comm/guijobs/nodeinfojob.cpp
+    comm/guijobs/syncnodelistjob.h comm/guijobs/syncnodelistjob.cpp
+    comm/guijobs/syncnodesetlistjob.h comm/guijobs/syncnodesetlistjob.cpp
     comm/guijobs/signaluseraddedjob.h comm/guijobs/signaluseraddedjob.cpp
     comm/guijobs/signaluserupdatedjob.h comm/guijobs/signaluserupdatedjob.cpp
     comm/guijobs/signaluserremovedjob.h comm/guijobs/signaluserremovedjob.cpp

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -1521,7 +1521,7 @@ void AppServer::onRequestReceived(int id, RequestNum num, const QByteArray &para
             }
             exitCode = syncPalMapIt->second->syncListUpdated(true);
             if (exitCode != ExitCode::Ok) {
-                LOG_WARN(_logger, "Error in SyncPal::setSyncIdSet: code=" << exitCode);
+                LOG_WARN(_logger, "Error in SyncPal::syncListUpdated: code=" << exitCode);
                 addError(Error(ERR_ID, exitCode, ExitCause::Unknown));
             }
             resultStream << toInt(exitCode);

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -63,7 +63,7 @@
 #include "server/comm/guijobs/signalaccountaddedjob.h"
 #include "server/comm/guijobs/signaluseraddedjob.h"
 #include "server/comm/guijobs/signaluserupdatedjob.h"
-#include "server/comm/guijobs/signaluserremovedjob.h" 
+#include "server/comm/guijobs/signaluserremovedjob.h"
 #include "server/comm/guijobs/signalaccountremovedjob.h"
 #include "server/comm/guijobs/signaldriveaddedjob.h"
 #include "server/comm/guijobs/signaldriveremovedjob.h"
@@ -1519,7 +1519,11 @@ void AppServer::onRequestReceived(int id, RequestNum num, const QByteArray &para
                 LOG_WARN(_logger, "Error in SyncPal::setSyncIdSet: code=" << exitCode);
                 addError(Error(ERR_ID, exitCode, ExitCause::Unknown));
             }
-
+            exitCode = syncPalMapIt->second->syncListUpdated(true);
+            if (exitCode != ExitCode::Ok) {
+                LOG_WARN(_logger, "Error in SyncPal::setSyncIdSet: code=" << exitCode);
+                addError(Error(ERR_ID, exitCode, ExitCause::Unknown));
+            }
             resultStream << toInt(exitCode);
             break;
         }
@@ -1634,7 +1638,7 @@ void AppServer::onRequestReceived(int id, RequestNum num, const QByteArray &para
             paramsStream >> driveId;
             paramsStream >> nodeId;
 
-            std::thread getFolderSize(ServerRequests::getFolderSize, userDbId, driveId, nodeId.toStdString(),
+            std::thread getFolderSize(ServerRequests::getFolderSizeWithCallback, userDbId, driveId, nodeId.toStdString(),
                                       std::bind_front(&AppServer::sendGetFolderSizeCompleted, this));
             getFolderSize.detach();
 
@@ -2133,35 +2137,6 @@ void AppServer::onRequestReceived(int id, RequestNum num, const QByteArray &para
                 resultStream << toInt(exitInfo.code());
                 break;
             }
-            resultStream << ExitCode::Ok;
-            break;
-        }
-        case RequestNum::SYNC_PROPAGATE_SYNCLIST_CHANGE: {
-            int syncDbId;
-            bool restartSync;
-            QDataStream paramsStream(params);
-            paramsStream >> syncDbId;
-            paramsStream >> restartSync;
-
-            const std::scoped_lock lock(syncPalMapMutex);
-            auto syncPalMapIt = syncPalMap.find(syncDbId);
-            if (syncPalMapIt == syncPalMap.end()) {
-                LOG_WARN(_logger, "SyncPal not found in syncPalMap for syncDbId=" << syncDbId);
-                resultStream << ExitCode::DataError;
-                break;
-            }
-            if (!syncPalMapIt->second) {
-                LOG_WARN(_logger, "SyncPal not set in syncPalMap for syncDbId=" << syncDbId);
-                resultStream << ExitCode::DataError;
-                break;
-            }
-
-            if (const auto exitCode = syncPalMapIt->second->syncListUpdated(restartSync); exitCode != ExitCode::Ok) {
-                LOG_WARN(_logger, "Error in SyncPal::syncListUpdated for syncDbId=" << syncDbId);
-                resultStream << exitCode;
-                break;
-            }
-
             resultStream << ExitCode::Ok;
             break;
         }
@@ -2996,10 +2971,10 @@ ExitInfo AppServer::processMigratedSyncOnceConnected(int userDbId, int driveId, 
             }
 
             if (!nodeId.isEmpty() && migrationSelectiveSync.type() == SyncNodeType::BlackList) {
-                    blackList << nodeId;
-                }
+                blackList << nodeId;
             }
         }
+    }
 
     return ExitCode::Ok;
 }
@@ -3573,7 +3548,7 @@ ExitInfo AppServer::initSyncPal(const Sync &sync, const NodeSet &blackList, bool
                 return exitInfo;
             }
         }
-            }
+    }
 
 #if defined(KD_WINDOWS) || defined(KD_MACOS)
     if (firstInit) {

--- a/src/server/comm/guijobs/abstractsyncaddjob.cpp
+++ b/src/server/comm/guijobs/abstractsyncaddjob.cpp
@@ -66,7 +66,6 @@ ExitInfo AbstractSyncAddJob::deserializeInputParms() {
 }
 
 ExitInfo AbstractSyncAddJob::serializeOutputParms() {
-    // Output parameters serialization
     writeParamValue(outParamsSyncInfo, _syncInfo, info2DynamicVar<SyncInfo>);
 
     return ExitCode::Ok;

--- a/src/server/comm/guijobs/abstractsyncaddjob.cpp
+++ b/src/server/comm/guijobs/abstractsyncaddjob.cpp
@@ -58,7 +58,7 @@ ExitInfo AbstractSyncAddJob::deserializeInputParms() {
         readParamValue(inParamsLiteSync, _liteSync);
         readParamValues(inParamsBlackList, _blackList);
     } catch (const std::exception &e) {
-        LOG_WARN(_logger, "Exception in AbstractGuiJob::readParamValue: error=" << e.what());
+        LOG_WARN(_logger, "Exception in AbstractSyncAddJob::readParamValue: error=" << e.what());
         return ExitCode::LogicError;
     }
 

--- a/src/server/comm/guijobs/accountinfolistjob.cpp
+++ b/src/server/comm/guijobs/accountinfolistjob.cpp
@@ -38,7 +38,6 @@ ExitInfo AccountInfoListJob::deserializeInputParms() {
 }
 
 ExitInfo AccountInfoListJob::serializeOutputParms() {
-    // Output parameters serialization
     writeParamValues(outParamsAccountInfoList, _accountInfoList, info2DynamicVar<AccountInfo>);
 
     return ExitCode::Ok;

--- a/src/server/comm/guijobs/drivedeletejob.cpp
+++ b/src/server/comm/guijobs/drivedeletejob.cpp
@@ -38,7 +38,7 @@ ExitInfo DriveDeleteJob::deserializeInputParms() {
     try {
         readParamValue(inParamsDriveDbId, _driveDbId);
     } catch (const std::exception &e) {
-        LOG_WARN(_logger, "Exception in AbstractGuiJob::readParamValue: error=" << e.what());
+        LOG_WARN(_logger, "Exception in DriveDeleteJob::readParamValue: error=" << e.what());
         return ExitCode::LogicError;
     }
 

--- a/src/server/comm/guijobs/driveinfolistjob.cpp
+++ b/src/server/comm/guijobs/driveinfolistjob.cpp
@@ -38,7 +38,6 @@ ExitInfo DriveInfoListJob::deserializeInputParms() {
 }
 
 ExitInfo DriveInfoListJob::serializeOutputParms() {
-    // Output parameters serialization
     writeParamValues(outParamsDriveInfoList, _driveInfoList, info2DynamicVar<DriveInfo>);
 
     return ExitCode::Ok;

--- a/src/server/comm/guijobs/drivesearchjob.cpp
+++ b/src/server/comm/guijobs/drivesearchjob.cpp
@@ -53,7 +53,6 @@ ExitInfo DriveSearchJob::deserializeInputParms() {
 }
 
 ExitInfo DriveSearchJob::serializeOutputParms() {
-    // Output parameters serialization
     writeParamValues(outParamsSearchInfoList, _searchInfoList, info2DynamicVar<SearchInfo>);
     writeParamValue(outParamsHasMore, _hasMore);
 

--- a/src/server/comm/guijobs/drivesearchjob.cpp
+++ b/src/server/comm/guijobs/drivesearchjob.cpp
@@ -45,7 +45,7 @@ ExitInfo DriveSearchJob::deserializeInputParms() {
         readParamValue(inParamsDriveDbId, _driveDbId);
         readParamValue(inParamsSearchString, _searchString);
     } catch (const std::exception &e) {
-        LOG_WARN(_logger, "Exception in AbstractGuiJob::readParamValue: error=" << e.what());
+        LOG_WARN(_logger, "Exception in DriveSearchJob::readParamValue: error=" << e.what());
         return ExitCode::LogicError;
     }
 

--- a/src/server/comm/guijobs/driveupdatejob.cpp
+++ b/src/server/comm/guijobs/driveupdatejob.cpp
@@ -46,7 +46,7 @@ ExitInfo DriveUpdateJob::deserializeInputParms() {
     try {
         readParamValue(inParamsDriveInfo, _driveInfo, dynamicVar2driveInfo);
     } catch (const std::exception &e) {
-        LOG_WARN(_logger, "Exception in AbstractGuiJob::readParamValue: error=" << e.what());
+        LOG_WARN(_logger, "Exception in DriveUpdateJob::readParamValue: error=" << e.what());
         return ExitCode::LogicError;
     }
 

--- a/src/server/comm/guijobs/guijobfactory.cpp
+++ b/src/server/comm/guijobs/guijobfactory.cpp
@@ -37,6 +37,11 @@
 #include "syncstartafterloginjob.h"
 #include "syncdeletejob.h"
 #include "syncgetpubliclinkurljob.h"
+#include "nodesubfoldersjob.h"
+#include "nodefoldersizejob.h"
+#include "syncnodelistjob.h"
+#include "syncnodesetlistjob.h"
+#include "nodeinfojob.h"
 #include "syncgetprivatelinkurljob.h"
 
 namespace KDC {
@@ -61,6 +66,11 @@ GuiJobFactory::GuiJobFactory() {
                 {RequestNum::SYNC_START_AFTER_LOGIN, makeShared<SyncStartAfterLoginJob>},
                 {RequestNum::SYNC_DELETE, makeShared<SyncDeleteJob>},
                 {RequestNum::SYNC_GETPUBLICLINKURL, makeShared<SyncGetPublicLinkUrlJob>},
+                {RequestNum::NODE_SUBFOLDERS, makeShared<NodeSubFoldersJob>},
+                {RequestNum::NODE_FOLDER_SIZE, makeShared<NodeFolderSizeJob>},
+                {RequestNum::SYNCNODE_LIST, makeShared<SyncNodeListJob>},
+                {RequestNum::SYNCNODE_SETLIST, makeShared<SyncNodeSetListJob>},
+                {RequestNum::NODE_INFO, makeShared<NodeInfoJob>},
                 {RequestNum::SYNC_GETPRIVATELINKURL, makeShared<SyncGetPrivateLinkUrlJob>}};
 }
 

--- a/src/server/comm/guijobs/loginrequesttokenjob.cpp
+++ b/src/server/comm/guijobs/loginrequesttokenjob.cpp
@@ -57,7 +57,6 @@ ExitInfo LoginRequestTokenJob::deserializeInputParms() {
 }
 
 ExitInfo LoginRequestTokenJob::serializeOutputParms() {
-    // Output parameters serialization
     if (_error.empty()) {
         writeParamValue(outParamsUserDbId, _userDbId);
     } else {

--- a/src/server/comm/guijobs/loginrequesttokenjob.cpp
+++ b/src/server/comm/guijobs/loginrequesttokenjob.cpp
@@ -49,7 +49,7 @@ ExitInfo LoginRequestTokenJob::deserializeInputParms() {
         readParamValue(inParamsCode, _code);
         readParamValue(inParamsCodeVerifier, _codeVerifier);
     } catch (const std::exception &e) {
-        LOG_WARN(_logger, "Exception in AbstractGuiJob::readParamValue: error=" << e.what());
+        LOG_WARN(_logger, "Exception in LoginRequestTokenJob::readParamValue: error=" << e.what());
         return ExitCode::LogicError;
     }
 

--- a/src/server/comm/guijobs/nodefoldersizejob.cpp
+++ b/src/server/comm/guijobs/nodefoldersizejob.cpp
@@ -46,7 +46,7 @@ ExitInfo NodeFolderSizeJob::deserializeInputParms() {
         readParamValue(inParamsDriveId, _driveId);
         readParamValue(inParamsNodeId, _nodeId);
     } catch (const std::exception &e) {
-        LOG_WARN(_logger, "Exception in AbstractGuiJob::readParamValue: error=" << e.what());
+        LOG_WARN(_logger, "Exception in NodeFolderSizeJob::readParamValue: error=" << e.what());
         return ExitCode::LogicError;
     }
 

--- a/src/server/comm/guijobs/nodefoldersizejob.cpp
+++ b/src/server/comm/guijobs/nodefoldersizejob.cpp
@@ -54,7 +54,6 @@ ExitInfo NodeFolderSizeJob::deserializeInputParms() {
 }
 
 ExitInfo NodeFolderSizeJob::serializeOutputParms() {
-    // Output parameters serialization
     writeParamValue(outParamsFolderSize, _folderSize);
     return ExitCode::Ok;
 }

--- a/src/server/comm/guijobs/nodefoldersizejob.cpp
+++ b/src/server/comm/guijobs/nodefoldersizejob.cpp
@@ -1,0 +1,66 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "nodefoldersizejob.h"
+#include "appserver.h"
+#include "requests/serverrequests.h"
+#include "server/comm/guijobmanager.h"
+#include "libcommon/utility/utility.h"
+#include "libcommon/comm.h"
+#include "libcommonserver/log/log.h"
+
+// Input parameters keys
+static const auto inParamsUserDbId = "userDbId";
+static const auto inParamsDriveId = "driveId";
+static const auto inParamsNodeId = "nodeId";
+
+// Output parameters keys
+static const auto outParamsFolderSize = "folderSize";
+
+namespace KDC {
+
+NodeFolderSizeJob::NodeFolderSizeJob(std::shared_ptr<CommManager> commManager, int requestId, const Poco::DynamicStruct &inParams,
+                                     std::shared_ptr<AbstractCommChannel> channel) :
+    AbstractGuiJob(commManager, requestId, inParams, channel) {
+    _requestNum = RequestNum::NODE_FOLDER_SIZE;
+}
+
+ExitInfo NodeFolderSizeJob::deserializeInputParms() {
+    try {
+        readParamValue(inParamsUserDbId, _userDbId);
+        readParamValue(inParamsDriveId, _driveId);
+        readParamValue(inParamsNodeId, _nodeId);
+    } catch (const std::exception &e) {
+        LOG_WARN(_logger, "Exception in AbstractGuiJob::readParamValue: error=" << e.what());
+        return ExitCode::LogicError;
+    }
+
+    return ExitCode::Ok;
+}
+
+ExitInfo NodeFolderSizeJob::serializeOutputParms() {
+    // Output parameters serialization
+    writeParamValue(outParamsFolderSize, _folderSize);
+    return ExitCode::Ok;
+}
+
+ExitInfo NodeFolderSizeJob::process() {
+    return ServerRequests::getFolderSize(_userDbId, _driveId, _nodeId, _folderSize);
+}
+
+} // namespace KDC

--- a/src/server/comm/guijobs/nodefoldersizejob.h
+++ b/src/server/comm/guijobs/nodefoldersizejob.h
@@ -1,0 +1,47 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "server/comm/guijobs/abstractguijob.h"
+#include "libcommon/info/nodeinfo.h"
+namespace KDC {
+
+class NodeFolderSizeJob : public AbstractGuiJob {
+    public:
+        NodeFolderSizeJob(std::shared_ptr<CommManager> commManager, int requestId, const Poco::DynamicStruct &inParams,
+                    std::shared_ptr<AbstractCommChannel> channel);
+
+    private:
+        // Input parameters
+        int _userDbId = 0;
+        int _driveId = 0;
+        NodeId _nodeId;
+        bool _withPath = false;
+
+        // Output parameters
+        int64_t _folderSize = 0;
+
+        ExitInfo deserializeInputParms() override;
+        ExitInfo serializeOutputParms() override;
+        ExitInfo process() override;
+
+        friend class TestGuiCommChannel;
+};
+
+} // namespace KDC

--- a/src/server/comm/guijobs/nodefoldersizejob.h
+++ b/src/server/comm/guijobs/nodefoldersizejob.h
@@ -32,7 +32,6 @@ class NodeFolderSizeJob : public AbstractGuiJob {
         int _userDbId = 0;
         int _driveId = 0;
         NodeId _nodeId;
-        bool _withPath = false;
 
         // Output parameters
         int64_t _folderSize = 0;

--- a/src/server/comm/guijobs/nodeinfojob.cpp
+++ b/src/server/comm/guijobs/nodeinfojob.cpp
@@ -24,7 +24,7 @@
 #include "libcommon/comm.h"
 #include "libcommonserver/log/log.h"
 
-// Input parameters keys
+ // Input parameters keys
 static const auto inParamsUserDbId = "userDbId";
 static const auto inParamsDriveId = "driveId";
 static const auto inParamsNodeId = "nodeId";
@@ -56,12 +56,7 @@ ExitInfo NodeInfoJob::deserializeInputParms() {
 }
 
 ExitInfo NodeInfoJob::serializeOutputParms() {
-    std::function<Poco::Dynamic::Var(const NodeInfo &)> nodeInfo2DynamicVar = [](const NodeInfo &value) {
-        Poco::DynamicStruct structValue;
-        value.toDynamicStruct(structValue);
-        return structValue;
-    };
-    writeParamValue(outParamsNodeInfo, _nodeInfo, nodeInfo2DynamicVar);
+    writeParamValue(outParamsNodeInfo, _nodeInfo, info2DynamicVar<NodeInfo>);
 
     return ExitCode::Ok;
 }

--- a/src/server/comm/guijobs/nodeinfojob.cpp
+++ b/src/server/comm/guijobs/nodeinfojob.cpp
@@ -48,7 +48,7 @@ ExitInfo NodeInfoJob::deserializeInputParms() {
         readParamValue(inParamsNodeId, _nodeId);
         readParamValue(inParamsWithPath, _withPath);
     } catch (const std::exception &e) {
-        LOG_WARN(_logger, "Exception in AbstractGuiJob::readParamValue: error=" << e.what());
+        LOG_WARN(_logger, "Exception in NodeInfoJob::readParamValue: error=" << e.what());
         return ExitCode::LogicError;
     }
 

--- a/src/server/comm/guijobs/nodeinfojob.cpp
+++ b/src/server/comm/guijobs/nodeinfojob.cpp
@@ -24,7 +24,7 @@
 #include "libcommon/comm.h"
 #include "libcommonserver/log/log.h"
 
- // Input parameters keys
+// Input parameters keys
 static const auto inParamsUserDbId = "userDbId";
 static const auto inParamsDriveId = "driveId";
 static const auto inParamsNodeId = "nodeId";
@@ -62,7 +62,11 @@ ExitInfo NodeInfoJob::serializeOutputParms() {
 }
 
 ExitInfo NodeInfoJob::process() {
-    return ServerRequests::getNodeInfo(_userDbId, _driveId, _nodeId, _nodeInfo, _withPath);
+    if (ExitInfo exitInfo = ServerRequests::getNodeInfo(_userDbId, _driveId, _nodeId, _nodeInfo, _withPath); !exitInfo) {
+        LOG_WARN(_logger, "Error in Requests::getNodeInfo");
+        AppServer::addError(Error(ERR_ID, exitInfo.code(), exitInfo.cause()));
+        return exitInfo;
+    }
+    return ExitCode::Ok;
 }
-
 } // namespace KDC

--- a/src/server/comm/guijobs/nodeinfojob.cpp
+++ b/src/server/comm/guijobs/nodeinfojob.cpp
@@ -56,7 +56,6 @@ ExitInfo NodeInfoJob::deserializeInputParms() {
 }
 
 ExitInfo NodeInfoJob::serializeOutputParms() {
-    // Output parameters serialization
     std::function<Poco::Dynamic::Var(const NodeInfo &)> nodeInfo2DynamicVar = [](const NodeInfo &value) {
         Poco::DynamicStruct structValue;
         value.toDynamicStruct(structValue);

--- a/src/server/comm/guijobs/nodeinfojob.cpp
+++ b/src/server/comm/guijobs/nodeinfojob.cpp
@@ -1,0 +1,74 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "nodeinfojob.h"
+#include "appserver.h"
+#include "requests/serverrequests.h"
+#include "server/comm/guijobmanager.h"
+#include "libcommon/utility/utility.h"
+#include "libcommon/comm.h"
+#include "libcommonserver/log/log.h"
+
+// Input parameters keys
+static const auto inParamsUserDbId = "userDbId";
+static const auto inParamsDriveId = "driveId";
+static const auto inParamsNodeId = "nodeId";
+static const auto inParamsWithPath = "withPath";
+
+// Output parameters keys
+static const auto outParamsNodeInfo = "nodeInfo";
+
+namespace KDC {
+
+NodeInfoJob::NodeInfoJob(std::shared_ptr<CommManager> commManager, int requestId, const Poco::DynamicStruct &inParams,
+                         std::shared_ptr<AbstractCommChannel> channel) :
+    AbstractGuiJob(commManager, requestId, inParams, channel) {
+    _requestNum = RequestNum::NODE_INFO;
+}
+
+ExitInfo NodeInfoJob::deserializeInputParms() {
+    try {
+        readParamValue(inParamsUserDbId, _userDbId);
+        readParamValue(inParamsDriveId, _driveId);
+        readParamValue(inParamsNodeId, _nodeId);
+        readParamValue(inParamsWithPath, _withPath);
+    } catch (const std::exception &e) {
+        LOG_WARN(_logger, "Exception in AbstractGuiJob::readParamValue: error=" << e.what());
+        return ExitCode::LogicError;
+    }
+
+    return ExitCode::Ok;
+}
+
+ExitInfo NodeInfoJob::serializeOutputParms() {
+    // Output parameters serialization
+    std::function<Poco::Dynamic::Var(const NodeInfo &)> nodeInfo2DynamicVar = [](const NodeInfo &value) {
+        Poco::DynamicStruct structValue;
+        value.toDynamicStruct(structValue);
+        return structValue;
+    };
+    writeParamValue(outParamsNodeInfo, _nodeInfo, nodeInfo2DynamicVar);
+
+    return ExitCode::Ok;
+}
+
+ExitInfo NodeInfoJob::process() {
+    return ServerRequests::getNodeInfo(_userDbId, _driveId, _nodeId, _nodeInfo, _withPath);
+}
+
+} // namespace KDC

--- a/src/server/comm/guijobs/nodeinfojob.h
+++ b/src/server/comm/guijobs/nodeinfojob.h
@@ -1,0 +1,47 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "server/comm/guijobs/abstractguijob.h"
+#include "libcommon/info/nodeinfo.h"
+namespace KDC {
+
+class NodeInfoJob : public AbstractGuiJob {
+    public:
+        NodeInfoJob(std::shared_ptr<CommManager> commManager, int requestId, const Poco::DynamicStruct &inParams,
+                    std::shared_ptr<AbstractCommChannel> channel);
+
+    private:
+        // Input parameters
+        int _userDbId = 0;
+        int _driveId = 0;
+        NodeId _nodeId;
+        bool _withPath = false;
+
+        // Output parameters
+        NodeInfo _nodeInfo;
+
+        ExitInfo deserializeInputParms() override;
+        ExitInfo serializeOutputParms() override;
+        ExitInfo process() override;
+
+        friend class TestGuiCommChannel;
+};
+
+} // namespace KDC

--- a/src/server/comm/guijobs/nodesubfoldersjob.cpp
+++ b/src/server/comm/guijobs/nodesubfoldersjob.cpp
@@ -61,7 +61,13 @@ ExitInfo NodeSubFoldersJob::serializeOutputParms() {
 }
 
 ExitInfo NodeSubFoldersJob::process() {
-    return ServerRequests::getSubFolders(_userDbId, _driveId, _nodeId, _nodeSubFolderInfoList, _withPath);
+
+    if (const auto exitInfo = ServerRequests::getSubFolders(_userDbId, _driveId, _nodeId, _nodeSubFolderInfoList, _withPath); !exitInfo) {
+        LOG_WARN(_logger, "Error in Requests::getSubFolders");
+        AppServer::addError(Error(ERR_ID, exitInfo.code(), exitInfo.cause()));
+        return exitInfo;
+    }
+    return ExitCode::Ok;
 }
 
 } // namespace KDC

--- a/src/server/comm/guijobs/nodesubfoldersjob.cpp
+++ b/src/server/comm/guijobs/nodesubfoldersjob.cpp
@@ -48,7 +48,7 @@ ExitInfo NodeSubFoldersJob::deserializeInputParms() {
         readParamValue(inParamsNodeId, _nodeId);
         readParamValue(inParamsWithPath, _withPath);
     } catch (const std::exception &e) {
-        LOG_WARN(_logger, "Exception in AbstractGuiJob::readParamValue: error=" << e.what());
+        LOG_WARN(_logger, "Exception in NodeSubFoldersJob::readParamValue: error=" << e.what());
         return ExitCode::LogicError;
     }
 

--- a/src/server/comm/guijobs/nodesubfoldersjob.cpp
+++ b/src/server/comm/guijobs/nodesubfoldersjob.cpp
@@ -24,7 +24,7 @@
 #include "libcommon/comm.h"
 #include "libcommonserver/log/log.h"
 
-// Input parameters keys
+        // Input parameters keys
 static const auto inParamsUserDbId = "userDbId";
 static const auto inParamsDriveId = "driveId";
 static const auto inParamsNodeId = "nodeId";
@@ -56,13 +56,7 @@ ExitInfo NodeSubFoldersJob::deserializeInputParms() {
 }
 
 ExitInfo NodeSubFoldersJob::serializeOutputParms() {
-    std::function<Poco::Dynamic::Var(const NodeInfo &)> nodeInfo2DynamicVar = [](const NodeInfo &value) {
-        Poco::DynamicStruct structValue;
-        value.toDynamicStruct(structValue);
-        return structValue;
-    };
-    writeParamValues(outParamsNodeSubFolderInfoList, _nodeSubFolderInfoList, nodeInfo2DynamicVar);
-
+    writeParamValues(outParamsNodeSubFolderInfoList, _nodeSubFolderInfoList, info2DynamicVar<NodeInfo>);
     return ExitCode::Ok;
 }
 

--- a/src/server/comm/guijobs/nodesubfoldersjob.cpp
+++ b/src/server/comm/guijobs/nodesubfoldersjob.cpp
@@ -56,7 +56,6 @@ ExitInfo NodeSubFoldersJob::deserializeInputParms() {
 }
 
 ExitInfo NodeSubFoldersJob::serializeOutputParms() {
-    // Output parameters serialization
     std::function<Poco::Dynamic::Var(const NodeInfo &)> nodeInfo2DynamicVar = [](const NodeInfo &value) {
         Poco::DynamicStruct structValue;
         value.toDynamicStruct(structValue);

--- a/src/server/comm/guijobs/nodesubfoldersjob.cpp
+++ b/src/server/comm/guijobs/nodesubfoldersjob.cpp
@@ -1,0 +1,74 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "nodesubfoldersjob.h"
+#include "appserver.h"
+#include "requests/serverrequests.h"
+#include "server/comm/guijobmanager.h"
+#include "libcommon/utility/utility.h"
+#include "libcommon/comm.h"
+#include "libcommonserver/log/log.h"
+
+// Input parameters keys
+static const auto inParamsUserDbId = "userDbId";
+static const auto inParamsDriveId = "driveId";
+static const auto inParamsNodeId = "nodeId";
+static const auto inParamsWithPath = "withPath";
+
+// Output parameters keys
+static const auto outParamsNodeSubFolderInfoList = "nodeSubFolderInfoList";
+
+namespace KDC {
+
+NodeSubFoldersJob::NodeSubFoldersJob(std::shared_ptr<CommManager> commManager, int requestId, const Poco::DynamicStruct &inParams,
+                                     std::shared_ptr<AbstractCommChannel> channel) :
+    AbstractGuiJob(commManager, requestId, inParams, channel) {
+    _requestNum = RequestNum::NODE_SUBFOLDERS;
+}
+
+ExitInfo NodeSubFoldersJob::deserializeInputParms() {
+    try {
+        readParamValue(inParamsUserDbId, _userDbId);
+        readParamValue(inParamsDriveId, _driveId);
+        readParamValue(inParamsNodeId, _nodeId);
+        readParamValue(inParamsWithPath, _withPath);
+    } catch (const std::exception &e) {
+        LOG_WARN(_logger, "Exception in AbstractGuiJob::readParamValue: error=" << e.what());
+        return ExitCode::LogicError;
+    }
+
+    return ExitCode::Ok;
+}
+
+ExitInfo NodeSubFoldersJob::serializeOutputParms() {
+    // Output parameters serialization
+    std::function<Poco::Dynamic::Var(const NodeInfo &)> nodeInfo2DynamicVar = [](const NodeInfo &value) {
+        Poco::DynamicStruct structValue;
+        value.toDynamicStruct(structValue);
+        return structValue;
+    };
+    writeParamValues(outParamsNodeSubFolderInfoList, _nodeSubFolderInfoList, nodeInfo2DynamicVar);
+
+    return ExitCode::Ok;
+}
+
+ExitInfo NodeSubFoldersJob::process() {
+    return ServerRequests::getSubFolders(_userDbId, _driveId, _nodeId, _nodeSubFolderInfoList, _withPath);
+}
+
+} // namespace KDC

--- a/src/server/comm/guijobs/nodesubfoldersjob.h
+++ b/src/server/comm/guijobs/nodesubfoldersjob.h
@@ -1,0 +1,47 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "server/comm/guijobs/abstractguijob.h"
+#include "libcommon/info/nodeinfo.h"
+namespace KDC {
+
+class NodeSubFoldersJob : public AbstractGuiJob {
+    public:
+        NodeSubFoldersJob(std::shared_ptr<CommManager> commManager, int requestId, const Poco::DynamicStruct &inParams,
+                    std::shared_ptr<AbstractCommChannel> channel);
+
+    private:
+        // Input parameters
+        int _userDbId = 0;
+        int _driveId = 0;
+        NodeId _nodeId;
+        bool _withPath = false;
+
+        // Output parameters
+        std::vector<NodeInfo> _nodeSubFolderInfoList;
+
+        ExitInfo deserializeInputParms() override;
+        ExitInfo serializeOutputParms() override;
+        ExitInfo process() override;
+
+        friend class TestGuiCommChannel;
+};
+
+} // namespace KDC

--- a/src/server/comm/guijobs/signalaccountaddedjob.cpp
+++ b/src/server/comm/guijobs/signalaccountaddedjob.cpp
@@ -31,7 +31,6 @@ SignalAccountAddedJob::SignalAccountAddedJob(const AccountInfo &accountInfo) :
 }
 
 ExitInfo SignalAccountAddedJob::serializeOutputParms() {
-    // Output parameters serialization
     writeParamValue(outParamsAccountInfo, _accountInfo, info2DynamicVar<AccountInfo>);
     return ExitCode::Ok;
 }

--- a/src/server/comm/guijobs/signalaccountremovedjob.cpp
+++ b/src/server/comm/guijobs/signalaccountremovedjob.cpp
@@ -31,7 +31,6 @@ SignalAccountRemovedJob::SignalAccountRemovedJob(int accountDbId) :
 }
 
 ExitInfo SignalAccountRemovedJob::serializeOutputParms() {
-    // Output parameters serialization
     writeParamValue(outParamsAccountDbId, _accountDbId);
     return ExitCode::Ok;
 }

--- a/src/server/comm/guijobs/signaldriveaddedjob.cpp
+++ b/src/server/comm/guijobs/signaldriveaddedjob.cpp
@@ -31,7 +31,6 @@ SignalDriveAddedJob::SignalDriveAddedJob(const DriveInfo &driveInfo) :
 }
 
 ExitInfo SignalDriveAddedJob::serializeOutputParms() {
-    // Output parameters serialization
     writeParamValue(outParamsDriveInfo, _driveInfo, info2DynamicVar<DriveInfo>);
     return ExitCode::Ok;
 }

--- a/src/server/comm/guijobs/signaldriveremovedjob.cpp
+++ b/src/server/comm/guijobs/signaldriveremovedjob.cpp
@@ -31,7 +31,6 @@ SignalDriveRemovedJob::SignalDriveRemovedJob(int driveDbId) :
 }
 
 ExitInfo SignalDriveRemovedJob::serializeOutputParms() {
-    // Output parameters serialization
     writeParamValue(outParamsDriveDbId, _driveDbId);
     return ExitCode::Ok;
 }

--- a/src/server/comm/guijobs/signalsyncaddedjob.cpp
+++ b/src/server/comm/guijobs/signalsyncaddedjob.cpp
@@ -31,7 +31,6 @@ SignalSyncAddedJob::SignalSyncAddedJob(const SyncInfo &syncInfo) :
 }
 
 ExitInfo SignalSyncAddedJob::serializeOutputParms() {
-    // Output parameters serialization
     writeParamValue(outParamsSyncInfo, _syncInfo, info2DynamicVar<SyncInfo>);
     return ExitCode::Ok;
 }

--- a/src/server/comm/guijobs/signalsynccompleteditem.cpp
+++ b/src/server/comm/guijobs/signalsynccompleteditem.cpp
@@ -33,7 +33,6 @@ SignalSyncCompletedItem::SignalSyncCompletedItem(int syncDbId, const SyncFileIte
 }
 
 ExitInfo SignalSyncCompletedItem::serializeOutputParms() {
-    // Output parameters serialization
     writeParamValue(outParamsSyncDbId, _syncDbId);
     writeParamValue(outParamsItemInfo, _itemInfo, info2DynamicVar<SyncFileItemInfo>);
     return ExitCode::Ok;

--- a/src/server/comm/guijobs/signalsyncprogressinfo.cpp
+++ b/src/server/comm/guijobs/signalsyncprogressinfo.cpp
@@ -38,7 +38,6 @@ SignalSyncProgressInfo::SignalSyncProgressInfo(int syncDbId, SyncStatus syncStat
 }
 
 ExitInfo SignalSyncProgressInfo::serializeOutputParms() {
-    // Output parameters serialization
     writeParamValue(outParamsSyncDbId, _syncDbId);
     writeParamValue(outParamsSyncstatus, _syncStatus);
     writeParamValue(outParamsSyncStep, _syncStep);

--- a/src/server/comm/guijobs/signalsyncremovedjob.cpp
+++ b/src/server/comm/guijobs/signalsyncremovedjob.cpp
@@ -31,7 +31,6 @@ SignalSyncRemovedJob::SignalSyncRemovedJob(int syncDbId) :
 }
 
 ExitInfo SignalSyncRemovedJob::serializeOutputParms() {
-    // Output parameters serialization
     writeParamValue(outParamsSyncDbId, _syncDbId);
     return ExitCode::Ok;
 }

--- a/src/server/comm/guijobs/signaluseraddedjob.cpp
+++ b/src/server/comm/guijobs/signaluseraddedjob.cpp
@@ -31,7 +31,6 @@ SignalUserAddedJob::SignalUserAddedJob(const UserInfo &userInfo) :
 }
 
 ExitInfo SignalUserAddedJob::serializeOutputParms() {
-    // Output parameters serialization
     writeParamValue(outParamsUserInfo, _userInfo, info2DynamicVar<UserInfo>);
     return ExitCode::Ok;
 }

--- a/src/server/comm/guijobs/signaluserremovedjob.cpp
+++ b/src/server/comm/guijobs/signaluserremovedjob.cpp
@@ -31,7 +31,6 @@ SignalUserRemovedJob::SignalUserRemovedJob(int userDbId) :
 }
 
 ExitInfo SignalUserRemovedJob::serializeOutputParms() {
-    // Output parameters serialization
     writeParamValue(outParamsUserDbId, _userDbId);
     return ExitCode::Ok;
 }

--- a/src/server/comm/guijobs/signaluserupdatedjob.cpp
+++ b/src/server/comm/guijobs/signaluserupdatedjob.cpp
@@ -31,7 +31,6 @@ SignalUserUpdatedJob::SignalUserUpdatedJob(const UserInfo &userInfo) :
 }
 
 ExitInfo SignalUserUpdatedJob::serializeOutputParms() {
-    // Output parameters serialization
     writeParamValue(outParamsUserInfo, _userInfo, info2DynamicVar<UserInfo>);
     return ExitCode::Ok;
 }

--- a/src/server/comm/guijobs/syncadd2job.cpp
+++ b/src/server/comm/guijobs/syncadd2job.cpp
@@ -43,7 +43,7 @@ ExitInfo SyncAdd2Job::deserializeInputParms() {
     try {
         readParamValue(inParamsDriveDbId, _driveDbId);
     } catch (const std::exception &e) {
-        LOG_WARN(_logger, "Exception in AbstractGuiJob::readParamValue: error=" << e.what());
+        LOG_WARN(_logger, "Exception in SyncAdd2Job::readParamValue: error=" << e.what());
         return ExitCode::LogicError;
     }
 

--- a/src/server/comm/guijobs/syncaddjob.cpp
+++ b/src/server/comm/guijobs/syncaddjob.cpp
@@ -47,7 +47,7 @@ ExitInfo SyncAddJob::deserializeInputParms() {
         readParamValue(inParamsAccountId, _accountId);
         readParamValue(inParamsDriveId, _driveId);
     } catch (const std::exception &e) {
-        LOG_WARN(_logger, "Exception in AbstractGuiJob::readParamValue: error=" << e.what());
+        LOG_WARN(_logger, "Exception in SyncAddJob::readParamValue: error=" << e.what());
         return ExitCode::LogicError;
     }
 

--- a/src/server/comm/guijobs/syncdeletejob.cpp
+++ b/src/server/comm/guijobs/syncdeletejob.cpp
@@ -38,7 +38,7 @@ ExitInfo SyncDeleteJob::deserializeInputParms() {
     try {
         readParamValue(inParamsSyncDbId, _syncDbId);
     } catch (const std::exception &e) {
-        LOG_WARN(_logger, "Exception in AbstractGuiJob::readParamValue: error=" << e.what());
+        LOG_WARN(_logger, "Exception in SyncDeleteJob::readParamValue: error=" << e.what());
         return ExitCode::LogicError;
     }
 

--- a/src/server/comm/guijobs/syncgetprivatelinkurljob.cpp
+++ b/src/server/comm/guijobs/syncgetprivatelinkurljob.cpp
@@ -46,7 +46,7 @@ ExitInfo SyncGetPrivateLinkUrlJob::deserializeInputParms() {
         readParamValue(inParamsDriveDbId, _driveDbId);
         readParamValue(inParamsFileId, _fileId);
     } catch (const std::exception &e) {
-        LOG_WARN(_logger, "Exception in AbstractGuiJob::readParamValue: error=" << e.what());
+        LOG_WARN(_logger, "Exception in SyncGetPrivateLinkUrlJob::readParamValue: error=" << e.what());
         return ExitCode::LogicError;
     }
 

--- a/src/server/comm/guijobs/syncgetpubliclinkurljob.cpp
+++ b/src/server/comm/guijobs/syncgetpubliclinkurljob.cpp
@@ -54,7 +54,6 @@ ExitInfo SyncGetPublicLinkUrlJob::deserializeInputParms() {
 }
 
 ExitInfo SyncGetPublicLinkUrlJob::serializeOutputParms() {
-    // Output parameters serialization
     writeParamValue(outParamsLinkUrl, _linkUrl);
 
     return ExitCode::Ok;

--- a/src/server/comm/guijobs/syncgetpubliclinkurljob.cpp
+++ b/src/server/comm/guijobs/syncgetpubliclinkurljob.cpp
@@ -46,7 +46,7 @@ ExitInfo SyncGetPublicLinkUrlJob::deserializeInputParms() {
         readParamValue(inParamsDriveDbId, _driveDbId);
         readParamValue(inParamsNodeId, _nodeId);
     } catch (const std::exception &e) {
-        LOG_WARN(_logger, "Exception in AbstractGuiJob::readParamValue: error=" << e.what());
+        LOG_WARN(_logger, "Exception in SyncGetPublicLinkUrlJob::readParamValue: error=" << e.what());
         return ExitCode::LogicError;
     }
 

--- a/src/server/comm/guijobs/syncinfolistjob.cpp
+++ b/src/server/comm/guijobs/syncinfolistjob.cpp
@@ -38,7 +38,6 @@ ExitInfo SyncInfoListJob::deserializeInputParms() {
 }
 
 ExitInfo SyncInfoListJob::serializeOutputParms() {
-    // Output parameters serialization
     writeParamValues(outParamsSyncInfoList, _syncInfoList, info2DynamicVar<SyncInfo>);
 
     return ExitCode::Ok;

--- a/src/server/comm/guijobs/syncnodelistjob.cpp
+++ b/src/server/comm/guijobs/syncnodelistjob.cpp
@@ -67,6 +67,8 @@ ExitInfo SyncNodeListJob::process() {
 
     NodeSet nodeIdSet;
     if (ExitInfo exitInfo = it->second->syncIdSet(_syncNodeType, nodeIdSet); !exitInfo) {
+        LOG_WARN(_logger, "Error in SyncPal::setSyncIdSet: " << exitInfo);
+        AppServer::addError(Error(ERR_ID, exitInfo.code(), exitInfo.cause()));
         return exitInfo;
     }
     _nodeIdList.assign(nodeIdSet.begin(), nodeIdSet.end());

--- a/src/server/comm/guijobs/syncnodelistjob.cpp
+++ b/src/server/comm/guijobs/syncnodelistjob.cpp
@@ -44,7 +44,7 @@ ExitInfo SyncNodeListJob::deserializeInputParms() {
         readParamValue(inParamsSyncDbId, _syncDbId);
         readParamValue(inParamsSyncNodeType, _syncNodeType);
     } catch (const std::exception &e) {
-        LOG_WARN(_logger, "Exception in AbstractGuiJob::readParamValue: error=" << e.what());
+        LOG_WARN(_logger, "Exception in SyncNodeListJob::readParamValue: error=" << e.what());
         return ExitCode::LogicError;
     }
 

--- a/src/server/comm/guijobs/syncnodelistjob.cpp
+++ b/src/server/comm/guijobs/syncnodelistjob.cpp
@@ -52,9 +52,7 @@ ExitInfo SyncNodeListJob::deserializeInputParms() {
 }
 
 ExitInfo SyncNodeListJob::serializeOutputParms() {
-    // Output parameters serialization
     writeParamValues(outParamsNodeIdList, _nodeIdList);
-
     return ExitCode::Ok;
 }
 

--- a/src/server/comm/guijobs/syncnodelistjob.cpp
+++ b/src/server/comm/guijobs/syncnodelistjob.cpp
@@ -1,0 +1,78 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "syncnodelistjob.h"
+#include "appserver.h"
+#include "requests/serverrequests.h"
+#include "server/comm/guijobmanager.h"
+#include "libcommon/utility/utility.h"
+#include "libcommon/comm.h"
+#include "libcommonserver/log/log.h"
+
+// Input parameters keys
+static const auto inParamsSyncDbId = "syncDbId";
+static const auto inParamsSyncNodeType = "syncNodeType";
+
+// Output parameters keys
+static const auto outParamsNodeIdList = "nodeIdList";
+
+namespace KDC {
+
+SyncNodeListJob::SyncNodeListJob(std::shared_ptr<CommManager> commManager, int requestId, const Poco::DynamicStruct &inParams,
+                                 std::shared_ptr<AbstractCommChannel> channel) :
+    AbstractGuiJob(commManager, requestId, inParams, channel) {
+    _requestNum = RequestNum::SYNCNODE_LIST;
+}
+
+ExitInfo SyncNodeListJob::deserializeInputParms() {
+    try {
+        readParamValue(inParamsSyncDbId, _syncDbId);
+        readParamValue(inParamsSyncNodeType, _syncNodeType);
+    } catch (const std::exception &e) {
+        LOG_WARN(_logger, "Exception in AbstractGuiJob::readParamValue: error=" << e.what());
+        return ExitCode::LogicError;
+    }
+
+    return ExitCode::Ok;
+}
+
+ExitInfo SyncNodeListJob::serializeOutputParms() {
+    // Output parameters serialization
+    writeParamValues(outParamsNodeIdList, _nodeIdList);
+
+    return ExitCode::Ok;
+}
+
+ExitInfo SyncNodeListJob::process() {
+    std::scoped_lock lock(_commManager->appServer().syncPalMapMutex);
+    auto &syncPalMap = _commManager->appServer().syncPalMap;
+    auto it = syncPalMap.find(_syncDbId);
+    if (it == syncPalMap.end()) {
+        LOG_WARN(_logger, "SyncNodeListJob::process: SyncPal not found for syncDbId=" << _syncDbId);
+        return ExitCode::DataError;
+    }
+
+    NodeSet nodeIdSet;
+    if (ExitInfo exitInfo = it->second->syncIdSet(_syncNodeType, nodeIdSet); !exitInfo) {
+        return exitInfo;
+    }
+    _nodeIdList.assign(nodeIdSet.begin(), nodeIdSet.end());
+    return ExitCode::Ok;
+}
+
+} // namespace KDC

--- a/src/server/comm/guijobs/syncnodelistjob.h
+++ b/src/server/comm/guijobs/syncnodelistjob.h
@@ -1,0 +1,44 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "server/comm/guijobs/abstractguijob.h"
+namespace KDC {
+
+class SyncNodeListJob : public AbstractGuiJob {
+    public:
+        SyncNodeListJob(std::shared_ptr<CommManager> commManager, int requestId, const Poco::DynamicStruct &inParams,
+                    std::shared_ptr<AbstractCommChannel> channel);
+
+    private:
+        // Input parameters
+        int _syncDbId = 0;
+        SyncNodeType _syncNodeType = SyncNodeType::Undefined;
+
+        // Output parameters
+        std::vector<NodeId> _nodeIdList;
+
+        ExitInfo deserializeInputParms() override;
+        ExitInfo serializeOutputParms() override;
+        ExitInfo process() override;
+
+        friend class TestGuiCommChannel;
+};
+
+} // namespace KDC

--- a/src/server/comm/guijobs/syncnodesetlistjob.cpp
+++ b/src/server/comm/guijobs/syncnodesetlistjob.cpp
@@ -43,7 +43,7 @@ ExitInfo SyncNodeSetListJob::deserializeInputParms() {
         readParamValue(inParamsSyncNodeType, _syncNodeType);
         readParamValues(inParamsNodeIdList, _nodeIdList);
     } catch (const std::exception &e) {
-        LOG_WARN(_logger, "Exception in AbstractGuiJob::readParamValue: error=" << e.what());
+        LOG_WARN(_logger, "Exception in SyncNodeSetListJob::readParamValue: error=" << e.what());
         return ExitCode::LogicError;
     }
 

--- a/src/server/comm/guijobs/syncnodesetlistjob.cpp
+++ b/src/server/comm/guijobs/syncnodesetlistjob.cpp
@@ -34,7 +34,7 @@ namespace KDC {
 SyncNodeSetListJob::SyncNodeSetListJob(std::shared_ptr<CommManager> commManager, int requestId,
                                        const Poco::DynamicStruct &inParams, std::shared_ptr<AbstractCommChannel> channel) :
     AbstractGuiJob(commManager, requestId, inParams, channel) {
-    _requestNum = RequestNum::SYNCNODE_LIST;
+    _requestNum = RequestNum::SYNCNODE_SETLIST;
 }
 
 ExitInfo SyncNodeSetListJob::deserializeInputParms() {

--- a/src/server/comm/guijobs/syncnodesetlistjob.cpp
+++ b/src/server/comm/guijobs/syncnodesetlistjob.cpp
@@ -1,0 +1,72 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "syncnodesetlistjob.h"
+#include "appserver.h"
+#include "requests/serverrequests.h"
+#include "server/comm/guijobmanager.h"
+#include "libcommon/utility/utility.h"
+#include "libcommon/comm.h"
+#include "libcommonserver/log/log.h"
+
+// Input parameters keys
+static const auto inParamsSyncDbId = "syncDbId";
+static const auto inParamsSyncNodeType = "syncNodeType";
+static const auto inParamsNodeIdList = "nodeIdList";
+
+namespace KDC {
+
+SyncNodeSetListJob::SyncNodeSetListJob(std::shared_ptr<CommManager> commManager, int requestId,
+                                       const Poco::DynamicStruct &inParams, std::shared_ptr<AbstractCommChannel> channel) :
+    AbstractGuiJob(commManager, requestId, inParams, channel) {
+    _requestNum = RequestNum::SYNCNODE_LIST;
+}
+
+ExitInfo SyncNodeSetListJob::deserializeInputParms() {
+    try {
+        readParamValue(inParamsSyncDbId, _syncDbId);
+        readParamValue(inParamsSyncNodeType, _syncNodeType);
+        readParamValues(inParamsNodeIdList, _nodeIdList);
+    } catch (const std::exception &e) {
+        LOG_WARN(_logger, "Exception in AbstractGuiJob::readParamValue: error=" << e.what());
+        return ExitCode::LogicError;
+    }
+
+    return ExitCode::Ok;
+}
+
+ExitInfo SyncNodeSetListJob::process() {
+    std::scoped_lock lock(_commManager->appServer().syncPalMapMutex);
+    auto &syncPalMap = _commManager->appServer().syncPalMap;
+    auto it = syncPalMap.find(_syncDbId);
+    if (it == syncPalMap.end()) {
+        LOG_WARN(_logger, "SyncNodeSetListJob::process: SyncPal not found for syncDbId=" << _syncDbId);
+        return ExitCode::DataError;
+    }
+
+    NodeSet nodeIdSet;
+    nodeIdSet.insert(_nodeIdList.begin(), _nodeIdList.end());
+    if (ExitInfo exitInfo = it->second->setSyncIdSet(_syncNodeType, nodeIdSet); !exitInfo) {
+        LOG_WARN(_logger, "SyncNodeSetListJob::process: setSyncIdSet failed for syncDbId=" << _syncDbId
+                                                                                           << ", syncNodeType=" << _syncNodeType);
+        return exitInfo;
+    }
+    return it->second->syncListUpdated(it->second->isRunning());
+}
+
+} // namespace KDC

--- a/src/server/comm/guijobs/syncnodesetlistjob.cpp
+++ b/src/server/comm/guijobs/syncnodesetlistjob.cpp
@@ -64,9 +64,16 @@ ExitInfo SyncNodeSetListJob::process() {
     if (ExitInfo exitInfo = it->second->setSyncIdSet(_syncNodeType, nodeIdSet); !exitInfo) {
         LOG_WARN(_logger, "SyncNodeSetListJob::process: setSyncIdSet failed for syncDbId=" << _syncDbId
                                                                                            << ", syncNodeType=" << _syncNodeType);
+        AppServer::addError(Error(ERR_ID, exitInfo.code(), exitInfo.cause()));
         return exitInfo;
     }
-    return it->second->syncListUpdated(it->second->isRunning());
-}
 
+    if (ExitInfo exitInfo = it->second->syncListUpdated(it->second->isRunning()); !exitInfo) {
+        LOG_WARN(_logger, "SyncNodeSetListJob::process: syncListUpdated failed for syncDbId=" << _syncDbId << ", syncNodeType="
+                                                                                              << _syncNodeType);
+        AppServer::addError(Error(ERR_ID, exitInfo.code(), exitInfo.cause()));
+        return exitInfo;
+    }
+    return ExitCode::Ok;
+}
 } // namespace KDC

--- a/src/server/comm/guijobs/syncnodesetlistjob.h
+++ b/src/server/comm/guijobs/syncnodesetlistjob.h
@@ -33,7 +33,7 @@ class SyncNodeSetListJob : public AbstractGuiJob {
         std::vector<NodeId> _nodeIdList;
 
         ExitInfo deserializeInputParms() override;
-        ExitInfo serializeOutputParms() { return ExitCode::Ok; }
+        ExitInfo serializeOutputParms() override { return ExitCode::Ok; }
         ExitInfo process() override;
 
         friend class TestGuiCommChannel;

--- a/src/server/comm/guijobs/syncnodesetlistjob.h
+++ b/src/server/comm/guijobs/syncnodesetlistjob.h
@@ -1,0 +1,42 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "server/comm/guijobs/abstractguijob.h"
+namespace KDC {
+
+class SyncNodeSetListJob : public AbstractGuiJob {
+    public:
+        SyncNodeSetListJob(std::shared_ptr<CommManager> commManager, int requestId, const Poco::DynamicStruct &inParams,
+                    std::shared_ptr<AbstractCommChannel> channel);
+
+    private:
+        // Input parameters
+        int _syncDbId = 0;
+        SyncNodeType _syncNodeType = SyncNodeType::Undefined;
+        std::vector<NodeId> _nodeIdList;
+
+        ExitInfo deserializeInputParms() override;
+        ExitInfo serializeOutputParms() { return ExitCode::Ok; }
+        ExitInfo process() override;
+
+        friend class TestGuiCommChannel;
+};
+
+} // namespace KDC

--- a/src/server/comm/guijobs/syncstartafterloginjob.cpp
+++ b/src/server/comm/guijobs/syncstartafterloginjob.cpp
@@ -40,7 +40,7 @@ ExitInfo SyncStartAfterLoginJob::deserializeInputParms() {
     try {
         readParamValue(inParamsUserDbId, _userDbId);
     } catch (const std::exception &e) {
-        LOG_WARN(_logger, "Exception in AbstractGuiJob::readParamValue: error=" << e.what());
+        LOG_WARN(_logger, "Exception in SyncStartAfterLoginJob::readParamValue: error=" << e.what());
         return ExitCode::LogicError;
     }
 

--- a/src/server/comm/guijobs/syncstartjob.cpp
+++ b/src/server/comm/guijobs/syncstartjob.cpp
@@ -39,7 +39,7 @@ ExitInfo SyncStartJob::deserializeInputParms() {
     try {
         readParamValue(inParamsSyncDbId, _syncDbId);
     } catch (const std::exception &e) {
-        LOG_WARN(_logger, "Exception in AbstractGuiJob::readParamValue: error=" << e.what());
+        LOG_WARN(_logger, "Exception in SyncStartJob::readParamValue: error=" << e.what());
         return ExitCode::LogicError;
     }
 

--- a/src/server/comm/guijobs/syncstatusjob.cpp
+++ b/src/server/comm/guijobs/syncstatusjob.cpp
@@ -42,7 +42,7 @@ ExitInfo SyncStatusJob::deserializeInputParms() {
     try {
         readParamValue(inParamsSyncDbId, _syncDbId);
     } catch (const std::exception &e) {
-        LOG_WARN(_logger, "Exception in AbstractGuiJob::readParamValue: error=" << e.what());
+        LOG_WARN(_logger, "Exception in SyncStatusJob::readParamValue: error=" << e.what());
         return ExitCode::LogicError;
     }
 

--- a/src/server/comm/guijobs/syncstatusjob.cpp
+++ b/src/server/comm/guijobs/syncstatusjob.cpp
@@ -50,7 +50,6 @@ ExitInfo SyncStatusJob::deserializeInputParms() {
 }
 
 ExitInfo SyncStatusJob::serializeOutputParms() {
-    // Output parameters serialization
     writeParamValue(outParamsSyncStatus, _syncStatus);
 
     return ExitCode::Ok;

--- a/src/server/comm/guijobs/syncstopjob.cpp
+++ b/src/server/comm/guijobs/syncstopjob.cpp
@@ -39,7 +39,7 @@ ExitInfo SyncStopJob::deserializeInputParms() {
     try {
         readParamValue(inParamsSyncDbId, _syncDbId);
     } catch (const std::exception &e) {
-        LOG_WARN(_logger, "Exception in AbstractGuiJob::readParamValue: error=" << e.what());
+        LOG_WARN(_logger, "Exception in SyncStopJob::readParamValue: error=" << e.what());
         return ExitCode::LogicError;
     }
 

--- a/src/server/comm/guijobs/useravailabledrivesjob.cpp
+++ b/src/server/comm/guijobs/useravailabledrivesjob.cpp
@@ -50,7 +50,6 @@ ExitInfo UserAvailableDrivesJob::deserializeInputParms() {
 }
 
 ExitInfo UserAvailableDrivesJob::serializeOutputParms() {
-    // Output parameters serialization
     std::function<Poco::Dynamic::Var(const DriveAvailableInfo &)> driveAvailableInfo2DynamicVar =
             [](const DriveAvailableInfo &value) {
                 Poco::DynamicStruct structValue;

--- a/src/server/comm/guijobs/useravailabledrivesjob.cpp
+++ b/src/server/comm/guijobs/useravailabledrivesjob.cpp
@@ -50,13 +50,7 @@ ExitInfo UserAvailableDrivesJob::deserializeInputParms() {
 }
 
 ExitInfo UserAvailableDrivesJob::serializeOutputParms() {
-    std::function<Poco::Dynamic::Var(const DriveAvailableInfo &)> driveAvailableInfo2DynamicVar =
-            [](const DriveAvailableInfo &value) {
-                Poco::DynamicStruct structValue;
-                value.toDynamicStruct(structValue);
-                return structValue;
-            };
-    writeParamValues(outParamsDriveAvailableInfoList, _driveAvailableInfoList, driveAvailableInfo2DynamicVar);
+    writeParamValues(outParamsDriveAvailableInfoList, _driveAvailableInfoList, info2DynamicVar<DriveAvailableInfo>);
 
     return ExitCode::Ok;
 }

--- a/src/server/comm/guijobs/useravailabledrivesjob.cpp
+++ b/src/server/comm/guijobs/useravailabledrivesjob.cpp
@@ -42,7 +42,7 @@ ExitInfo UserAvailableDrivesJob::deserializeInputParms() {
     try {
         readParamValue(inParamsUserDbId, _userDbId);
     } catch (const std::exception &e) {
-        LOG_WARN(_logger, "Exception in AbstractGuiJob::readParamValue: error=" << e.what());
+        LOG_WARN(_logger, "Exception in UserAvailableDrivesJob::readParamValue: error=" << e.what());
         return ExitCode::LogicError;
     }
 

--- a/src/server/comm/guijobs/userdbidlistjob.cpp
+++ b/src/server/comm/guijobs/userdbidlistjob.cpp
@@ -38,7 +38,6 @@ ExitInfo UserDbIdListJob::deserializeInputParms() {
 }
 
 ExitInfo UserDbIdListJob::serializeOutputParms() {
-    // Output parameters serialization
     writeParamValue(outParamsUserDbIdList, _userDbIdList);
 
     return ExitCode::Ok;

--- a/src/server/comm/guijobs/userdeletejob.cpp
+++ b/src/server/comm/guijobs/userdeletejob.cpp
@@ -40,7 +40,7 @@ ExitInfo UserDeleteJob::deserializeInputParms() {
     try {
         readParamValue(inParamsUserDbId, _userDbId);
     } catch (const std::exception &e) {
-        LOG_WARN(_logger, "Exception in AbstractGuiJob::readParamValue: error=" << e.what());
+        LOG_WARN(_logger, "Exception in UserDeleteJob::readParamValue: error=" << e.what());
         return ExitCode::LogicError;
     }
 

--- a/src/server/comm/guijobs/userinfolistjob.cpp
+++ b/src/server/comm/guijobs/userinfolistjob.cpp
@@ -38,7 +38,6 @@ ExitInfo UserInfoListJob::deserializeInputParms() {
 }
 
 ExitInfo UserInfoListJob::serializeOutputParms() {
-    // Output parameters serialization
     writeParamValues(outParamsUserInfoList, _userInfoList, info2DynamicVar<UserInfo>);
 
     return ExitCode::Ok;

--- a/src/server/requests/serverrequests.cpp
+++ b/src/server/requests/serverrequests.cpp
@@ -815,17 +815,17 @@ ExitInfo ServerRequests::getSubFolders(const int userDbId, const int driveId, co
                 job = std::make_shared<GetFileListJob>(userDbId, driveId, nodeId, page, true);
             } catch (const std::exception &e) {
                 LOG_WARN(Log::instance()->getLogger(), "Error in GetFileListJob::GetFileListJob for userDbId="
-                                                               << userDbId << " driveId=" << driveId
-                                                               << " nodeId=" << nodeId << " error=" << e.what());
+                                                               << userDbId << " driveId=" << driveId << " nodeId=" << nodeId
+                                                               << " error=" << e.what());
                 return AbstractTokenNetworkJob::exception2ExitCode(e);
             }
         }
 
         job->setWithPath(withPath);
         if (const auto exitInfo = job->runSynchronously(); !exitInfo) {
-            LOG_WARN(Log::instance()->getLogger(), "Error in GetFileListJob::runSynchronously for userDbId="
-                                                           << userDbId << " driveId=" << driveId
-                                                           << " nodeId=" << nodeId << " error=" << exitInfo);
+            LOG_WARN(Log::instance()->getLogger(),
+                     "Error in GetFileListJob::runSynchronously for userDbId=" << userDbId << " driveId=" << driveId
+                                                                               << " nodeId=" << nodeId << " error=" << exitInfo);
             return exitInfo;
         }
 
@@ -1320,10 +1320,9 @@ ExitCode ServerRequests::getPublicLinkUrl(int driveDbId, const NodeId &nodeId, s
 }
 
 ExitInfo ServerRequests::getFolderSizeWithCallback(int userDbId, int driveId, const NodeId &nodeId,
-                                       std::function<void(const QString &, qint64)> callback) {
-
+                                                   std::function<void(const QString &, qint64)> callback) {
     int64_t result = 0;
-    if (ExitInfo exitInfo =ServerRequests::getFolderSize(userDbId, driveId, nodeId, result); !exitInfo) {
+    if (ExitInfo exitInfo = ServerRequests::getFolderSize(userDbId, driveId, nodeId, result); !exitInfo) {
         return exitInfo;
     }
 

--- a/src/server/requests/serverrequests.cpp
+++ b/src/server/requests/serverrequests.cpp
@@ -390,6 +390,9 @@ ExitCode ServerRequests::requestToken(const QString &code, const QString &codeVe
     return requestToken(QStr2Str(code), QStr2Str(codeVerifier), userInfo, userCreated, error, errorDescr);
 }
 
+ExitInfo ServerRequests::getNodeInfo(int userDbId, int driveId, const std::string &nodeId, NodeInfo &nodeInfo, bool withPath) {
+    return getNodeInfo(userDbId, driveId, QString::fromStdString(nodeId), nodeInfo, withPath);
+}
 ExitInfo ServerRequests::getNodeInfo(int userDbId, int driveId, const QString &nodeId, NodeInfo &nodeInfo,
                                      bool withPath /*= false*/) {
     std::shared_ptr<GetFileInfoJob> job;
@@ -780,12 +783,26 @@ ExitCode ServerRequests::addSync(int driveDbId, const QString &localFolderPath, 
 
 ExitInfo ServerRequests::getSubFolders(const int userDbId, const int driveId, const QString &nodeId, QList<NodeInfo> &list,
                                        const bool withPath /*= false*/) {
+    std::vector<NodeInfo> stdVector;
+    const ExitInfo exitInfo = getSubFolders(userDbId, driveId, nodeId.toStdString(), stdVector, withPath);
+    if (!exitInfo) {
+        return exitInfo;
+    }
+    list.clear();
+    for (const NodeInfo &nodeInfo: stdVector) {
+        list.push_back(nodeInfo);
+    }
+    return ExitCode::Ok;
+}
+
+ExitInfo ServerRequests::getSubFolders(const int userDbId, const int driveId, const NodeId &nodeId, std::vector<NodeInfo> &list,
+                                       const bool withPath /*= false*/) {
     list.clear();
     uint64_t page = 1;
     uint64_t totalPages = 0;
     do {
         std::shared_ptr<GetRootFileListJob> job = nullptr;
-        if (nodeId.isEmpty()) {
+        if (nodeId.empty()) {
             try {
                 job = std::make_shared<GetRootFileListJob>(userDbId, driveId, page, true);
             } catch (const std::exception &e) {
@@ -795,11 +812,11 @@ ExitInfo ServerRequests::getSubFolders(const int userDbId, const int driveId, co
             }
         } else {
             try {
-                job = std::make_shared<GetFileListJob>(userDbId, driveId, nodeId.toStdString(), page, true);
+                job = std::make_shared<GetFileListJob>(userDbId, driveId, nodeId, page, true);
             } catch (const std::exception &e) {
                 LOG_WARN(Log::instance()->getLogger(), "Error in GetFileListJob::GetFileListJob for userDbId="
                                                                << userDbId << " driveId=" << driveId
-                                                               << " nodeId=" << nodeId.toStdString() << " error=" << e.what());
+                                                               << " nodeId=" << nodeId << " error=" << e.what());
                 return AbstractTokenNetworkJob::exception2ExitCode(e);
             }
         }
@@ -808,7 +825,7 @@ ExitInfo ServerRequests::getSubFolders(const int userDbId, const int driveId, co
         if (const auto exitInfo = job->runSynchronously(); !exitInfo) {
             LOG_WARN(Log::instance()->getLogger(), "Error in GetFileListJob::runSynchronously for userDbId="
                                                            << userDbId << " driveId=" << driveId
-                                                           << " nodeId=" << nodeId.toStdString() << " error=" << exitInfo);
+                                                           << " nodeId=" << nodeId << " error=" << exitInfo);
             return exitInfo;
         }
 
@@ -870,7 +887,7 @@ ExitInfo ServerRequests::getSubFolders(const int userDbId, const int driveId, co
             NodeInfo nodeInfo(QString::fromStdString(nodeId2), SyncName2QStr(name),
                               -1, // Size is not set here as it can be very long to evaluate
                               parentId.c_str(), modTime, SyncName2QStr(path));
-            list << nodeInfo;
+            list.push_back(nodeInfo);
         }
 
         page++;
@@ -1302,8 +1319,19 @@ ExitCode ServerRequests::getPublicLinkUrl(int driveDbId, const NodeId &nodeId, s
     return ExitCode::Ok;
 }
 
-ExitInfo ServerRequests::getFolderSize(int userDbId, int driveId, const NodeId &nodeId,
+ExitInfo ServerRequests::getFolderSizeWithCallback(int userDbId, int driveId, const NodeId &nodeId,
                                        std::function<void(const QString &, qint64)> callback) {
+
+    int64_t result = 0;
+    if (ExitInfo exitInfo =ServerRequests::getFolderSize(userDbId, driveId, nodeId, result); !exitInfo) {
+        return exitInfo;
+    }
+
+    callback(QString::fromStdString(nodeId), result);
+    return ExitCode::Ok;
+}
+
+ExitInfo ServerRequests::getFolderSize(int userDbId, int driveId, const NodeId &nodeId, int64_t &result) {
     if (nodeId.empty()) {
         LOG_WARN(Log::instance()->getLogger(), "Node ID is empty");
         return ExitCode::DataError;
@@ -1343,12 +1371,9 @@ ExitInfo ServerRequests::getFolderSize(int userDbId, int driveId, const NodeId &
         return ExitCode::BackError;
     }
 
-    qint64 size = 0;
-    if (!JsonParserUtility::extractValue(dataObj, sizeKey, size)) {
+    if (!JsonParserUtility::extractValue(dataObj, sizeKey, result)) {
         return ExitCode::BackError;
     }
-
-    callback(QString::fromStdString(nodeId), size);
 
     return ExitCode::Ok;
 }

--- a/src/server/requests/serverrequests.cpp
+++ b/src/server/requests/serverrequests.cpp
@@ -90,13 +90,13 @@ ExitCode ServerRequests::getUserInfoList(QList<UserInfo> &list) {
 }
 
 ExitCode ServerRequests::getUserInfoList(std::vector<UserInfo> &list) {
+    list.clear();
     std::vector<User> userList;
     if (!ParmsDb::instance()->selectAllUsers(userList)) {
         LOG_WARN(Log::instance()->getLogger(), "Error in ParmsDb::selectAllUsers");
         return ExitCode::DbError;
     }
 
-    list.clear();
     for (const User &user: userList) {
         UserInfo userInfo;
         userToUserInfo(user, userInfo);

--- a/src/server/requests/serverrequests.h
+++ b/src/server/requests/serverrequests.h
@@ -106,13 +106,17 @@ struct SYNCENGINE_EXPORT ServerRequests {
         static ExitCode addSync(int driveDbId, const QString &localFolderPath, const QString &serverFolderPath,
                                 const QString &serverFolderNodeId, bool liteSync, bool showInNavigationPane, SyncInfo &syncInfo);
         static ExitInfo getNodeInfo(int userDbId, int driveId, const QString &nodeId, NodeInfo &nodeInfo, bool withPath = false);
+        static ExitInfo getNodeInfo(int userDbId, int driveId, const std::string &nodeId, NodeInfo &nodeInfo, bool withPath = false);
         static ExitInfo getSubFolders(int userDbId, int driveId, const QString &nodeId, QList<NodeInfo> &list,
+                                      bool withPath = false); // TODO: Delete after switching to the new comm layer
+        static ExitInfo getSubFolders(int userDbId, int driveId, const NodeId &nodeId, std::vector<NodeInfo> &list,
                                       bool withPath = false);
         static ExitInfo getSubFolders(int driveDbId, const QString &nodeId, QList<NodeInfo> &list, bool withPath = false);
         static ExitCode createDir(int driveDbId, const QString &parentNodeId, const QString &dirName, QString &newNodeId);
         static ExitCode getPublicLinkUrl(int driveDbId, const NodeId &nodeId, std::string &linkUrl);
-        static ExitInfo getFolderSize(int userDbId, int driveId, const NodeId &nodeId,
+        static ExitInfo getFolderSizeWithCallback(int userDbId, int driveId, const NodeId &nodeId,
                                       std::function<void(const QString &, qint64)> callback);
+        static ExitInfo getFolderSize(int userDbId, int driveId, const NodeId &nodeId, int64_t& result);
         static ExitCode getNodeIdByPath(int userDbId, int driveId, const SyncPath &path, QString &nodeId);
         static ExitInfo getPathByNodeId(int userDbId, int driveId, const QString &nodeId, QString &path);
 

--- a/test/server/CMakeLists.txt
+++ b/test/server/CMakeLists.txt
@@ -52,6 +52,11 @@ set(server_SRCS
     ${server_srcs_path}/comm/guijobs/syncdeletejob.h ${server_srcs_path}/comm/guijobs/syncdeletejob.cpp
     ${server_srcs_path}/comm/guijobs/syncgetpubliclinkurljob.h ${server_srcs_path}/comm/guijobs/syncgetpubliclinkurljob.cpp
     ${server_srcs_path}/comm/guijobs/syncgetprivatelinkurljob.h ${server_srcs_path}/comm/guijobs/syncgetprivatelinkurljob.cpp
+    ${server_srcs_path}/comm/guijobs/nodesubfoldersjob.h ${server_srcs_path}/comm/guijobs/nodesubfoldersjob.cpp
+    ${server_srcs_path}/comm/guijobs/nodefoldersizejob.h ${server_srcs_path}/comm/guijobs/nodefoldersizejob.cpp
+    ${server_srcs_path}/comm/guijobs/syncnodelistjob.h ${server_srcs_path}/comm/guijobs/syncnodelistjob.cpp
+    ${server_srcs_path}/comm/guijobs/syncnodesetlistjob.h ${server_srcs_path}/comm/guijobs/syncnodesetlistjob.cpp
+    ${server_srcs_path}/comm/guijobs/nodeinfojob.h ${server_srcs_path}/comm/guijobs/nodeinfojob.cpp
     ${server_srcs_path}/comm/guijobs/signaluseraddedjob.h ${server_srcs_path}/comm/guijobs/signaluseraddedjob.cpp
     ${server_srcs_path}/comm/guijobs/signaluserupdatedjob.h ${server_srcs_path}/comm/guijobs/signaluserupdatedjob.cpp
     ${server_srcs_path}/comm/guijobs/signaluserremovedjob.h ${server_srcs_path}/comm/guijobs/signaluserremovedjob.cpp

--- a/test/server/comm/testguicommchannel.h
+++ b/test/server/comm/testguicommchannel.h
@@ -96,6 +96,12 @@ class TestGuiCommChannel : public CppUnit::TestFixture, public TestBase {
         void testSyncDeleteJob();
         void testSyncGetPublicLinkUrlJob();
         void testSyncGetPrivateLinkUrlJob();
+        void testNodeSubFolderJob();
+        void testNodeFolderSizeJob();
+        void testSyncNodeListJob();
+        void testSyncNodeSetListJob();
+        void testNodeInfoJob();
+
 
     private:
         GuiJobFactory _guiJobFactory;


### PR DESCRIPTION
**depend on #1212** 
This commit introduces several new jobs for enhanced node management:
- Added `NodeFolderSizeJob`, `NodeInfoJob`, `NodeSubFoldersJob`, `SyncNodeListJob`, and `SyncNodeSetListJob` for operations like folder size calculation, node info retrieval, and sync list updates.
- Integrated these jobs into `GuiJobFactory`.

Refactored `ServerRequests` to support these jobs:
- Added methods like `getNodeInfo`, `getSubFolders`, and `getFolderSize`.

Removed deprecated `propagateSyncListChange` logic:
- Deleted the method from `GuiRequests` and its references in `AppServer`.

Updated `CMakeLists.txt` to include new job files.

Added unit tests for the new jobs:
- Tests include `testNodeSubFolderJob`, `testNodeFolderSizeJob`, `testSyncNodeListJob`, `testSyncNodeSetListJob`, and `testNodeInfoJob`.

Performed code cleanup and optimizations:
- Replaced `QList` with `std::vector` for better performance.
- Improved thread safety with `std::scoped_lock`.