### PR TITLE
fix: linux release note name does not show the architecture

### DIFF
--- a/infomaniak-build-tools/upload-release-to-kDrive.ps1
+++ b/infomaniak-build-tools/upload-release-to-kDrive.ps1
@@ -61,14 +61,14 @@ $languages = @(
     "it"
 )
 
-foreach ($language in $languages)
+$simplifiedOs = $os
+if ($simplifiedOs -eq "linux-arm" -Or $simplifiedOs -eq "linux-amd") {
+    $simplifiedOs = "linux"
+}
+
+foreach ($lang in $languages)
 {
-    $lang = $language
-    if ($os -eq "linux-arm" -Or $os -eq "linux-amd") {
-        $lang "linux"
-    }
-    
-    $fileName = "kDrive-$versionNumber-$os-$lang.html"
+    $fileName = "kDrive-$versionNumber-$simplifiedOs-$lang.html"
     $filePath = ".\release_notes\kDrive-$versionNumber\$fileName"
     if (-not (Test-Path $filePath)) {
         Write-Host "❌ File $filePath does not exist, aborting upload." -f Red

--- a/infomaniak-build-tools/upload-release-to-kDrive.ps1
+++ b/infomaniak-build-tools/upload-release-to-kDrive.ps1
@@ -61,8 +61,13 @@ $languages = @(
     "it"
 )
 
-foreach ($lang in $languages)
+foreach ($language in $languages)
 {
+    $lang = $language
+    if ($os -eq "linux-arm" -Or $os -eq "linux-amd") {
+        $lang "linux"
+    }
+    
     $fileName = "kDrive-$versionNumber-$os-$lang.html"
     $filePath = ".\release_notes\kDrive-$versionNumber\$fileName"
     if (-not (Test-Path $filePath)) {


### PR DESCRIPTION
The release note names do not contain the architecture. This PR fix the upload script.