### PR TITLE
fix(http-error-401): stop the synchronization after three consecutive HTTP 401 errors caused by a request with token

### DIFF
--- a/src/libsyncengine/jobs/network/abstracttokennetworkjob.cpp
+++ b/src/libsyncengine/jobs/network/abstracttokennetworkjob.cpp
@@ -135,17 +135,14 @@ ExitInfo AbstractTokenNetworkJob::handleUnauthorizedResponse() {
         if (const auto exitInfo = refreshToken(); !exitInfo) {
             LOG_WARN(_logger, "Refresh token failed");
             disableRetry();
-            return {ExitCode::InvalidToken, ExitCause::LoginError};
+            return ExitCode::InvalidToken;
         }
 
         LOG_DEBUG(_logger, "Refresh token succeeded");
         return ExitCode::TokenRefreshed;
     }
 
-    if (_trials > 2) {
-        disableRetry();
-        return {ExitCode::InvalidToken, ExitCause::LoginError};
-    }
+    if (_trials > 2) disableRetry();
 
     return ExitCode::InvalidToken;
 }

--- a/src/libsyncengine/syncpal/syncpalworker.cpp
+++ b/src/libsyncengine/syncpal/syncpalworker.cpp
@@ -74,8 +74,10 @@ bool shouldBeStopped(const std::shared_ptr<ISyncWorker> w1, const std::shared_pt
             (w1 && w1->exitCode() == ExitCode::UpdateRequired) || (w2 && w2->exitCode() == ExitCode::UpdateRequired);
     const auto invalidSyncError =
             (w1 && w1->exitCode() == ExitCode::InvalidSync) || (w2 && w2->exitCode() == ExitCode::InvalidSync);
+    const auto invalidToken =
+            (w1 && w1->exitCode() == ExitCode::InvalidToken) || (w2 && w2->exitCode() == ExitCode::InvalidToken);
 
-    return dbError || systemError || updateRequired || invalidSyncError;
+    return dbError || systemError || updateRequired || invalidSyncError || invalidToken;
 }
 
 } // namespace


### PR DESCRIPTION
The proposed changes ensure that the synchronization stops after three consecutive HTTP 401 errors received as response status of a request requiring a token (i.e., the request job derives from `AbstractNetworkTokenJob` which includes the recurrent listing requests).

Under the aforementioned circumstances, the user is prompted by the GUI to login anew.