### PR TITLE
Fix(msi): Add missing step in msi cleanup step

### DIFF
--- a/installer/windows/kDriveInstaller/CleanUpAppData.ps1
+++ b/installer/windows/kDriveInstaller/CleanUpAppData.ps1
@@ -1,5 +1,5 @@
 ﻿# We should clean up parameters files before uninstalling the extension because removing the LiteSync leads to deletion of all the dehydrated placeholders.
-# In the case the uninstallation of the LiteSync failed but the dehydrated placeholders have been deleted, we do not want to have valid synchronization set up because it will propagate all the DELETE opearations on the server.
+# In the case the uninstallation of the LiteSync failed but the dehydrated placeholders have been deleted, we do not want to have valid synchronization set up because it will propagate all the DELETE operations on the server.
 
 # Clean kDrive folders for all users
 $profiles = Get-ChildItem "C:\Users" -Directory -ErrorAction SilentlyContinue
@@ -18,26 +18,27 @@ foreach ($profile in $profiles) {
     foreach ($path in $pathsToDelete) {
         if (Test-Path $path) {
             Write-Host "Deleting $path"
-            try {
-                Remove-Item $path -Recurse -Force -ErrorAction SilentlyContinue
-                Write-Host " → Deleted" -ForegroundColor Green
-            }
-            catch {
-                Write-Warning " → Failed to delete $path : $_"
-            }
+            Remove-Item $path -Recurse -Force -ErrorAction SilentlyContinue
         }
     }
 }
 
 # Remove shortcuts
 ## Start menu shortcut
-Remove-Item "%ProgramData%\Microsoft\Windows\Start Menu\Programs\kDrive.lnk"
-Remove-Item "%AppData%\Microsoft\Windows\Start Menu\Programs\kDrive.lnk"
-## Desktop shortcut
+Write-Host "Removing shortcuts..."
 $DesktopPath = [Environment]::GetFolderPath("Desktop")
-Remove-Item "$DesktopPath\kDrive.lnk" -Force -ErrorAction SilentlyContinue
-## Quick Launch shortcut
-Remove-Item $quickLaunchPath\${APPLICATION_NAME}.lnk -Force -ErrorAction SilentlyContinue
+$pathsToDelete = @(
+    "$env:ProgramData\Microsoft\Windows\Start Menu\Programs\kDrive.lnk",
+    "$env:APPDATA\Microsoft\Windows\Start Menu\Programs\kDrive.lnk",
+    "$DesktopPath\kDrive.lnk"
+)
+
+foreach ($path in $pathsToDelete) {
+    if (Test-Path $path) {
+        Write-Host "Deleting $path"
+        Remove-Item $path -Force -ErrorAction SilentlyContinue
+    }
+}
 
 # Remove credentials
 $CredentialsToDelete = 'com.infomaniak.drive.desktopclient*'

--- a/installer/windows/kDriveInstaller/CleanUpAppData.ps1
+++ b/installer/windows/kDriveInstaller/CleanUpAppData.ps1
@@ -2,7 +2,7 @@
 # In the case the uninstallation of the LiteSync failed but the dehydrated placeholders have been deleted, we do not want to have valid synchronization set up because it will propagate all the DELETE operations on the server.
 
 # Clean kDrive folders for all users
-$profiles = Get-ChildItem "C:\Users" -Directory -ErrorAction SilentlyContinue
+$profiles = Get-ChildItem "C:\Users" -Directory -ErrorAction Continue
 
 foreach ($profile in $profiles) {
 
@@ -18,7 +18,7 @@ foreach ($profile in $profiles) {
     foreach ($path in $pathsToDelete) {
         if (Test-Path $path) {
             Write-Host "Deleting $path"
-            Remove-Item $path -Recurse -Force -ErrorAction SilentlyContinue
+            Remove-Item $path -Recurse -Force -ErrorAction Continue
         }
     }
 }
@@ -36,7 +36,7 @@ $pathsToDelete = @(
 foreach ($path in $pathsToDelete) {
     if (Test-Path $path) {
         Write-Host "Deleting $path"
-        Remove-Item $path -Force -ErrorAction SilentlyContinue
+        Remove-Item $path -Force -ErrorAction Continue
     }
 }
 
@@ -51,22 +51,15 @@ $syncRootRegPath = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Syn
 
 Write-Host "Scanning SyncRootManager registry entries..."
 
-Get-ChildItem $syncRootRegPath -ErrorAction SilentlyContinue | ForEach-Object {
+Get-ChildItem $syncRootRegPath -ErrorAction Continue | ForEach-Object {
     $key = $_
-    $props = Get-ItemProperty -Path $key.PSPath -ErrorAction SilentlyContinue
+    $props = Get-ItemProperty -Path $key.PSPath -ErrorAction Continue
     $defaultValue = $props.'(default)'
 
     if ($defaultValue -eq "kDrive") {
         $syncRootId = $key.PSChildName
         Write-Host "Deleting SyncRoot key: $syncRootId"
-
-        try {
-            Remove-Item -Path $key.PSPath -Recurse -Force -ErrorAction SilentlyContinue
-            Write-Host " → Deleted successfully" -ForegroundColor Green
-        }
-        catch {
-            Write-Warning " → Failed to delete $syncRootId : $_"
-        }
+        Remove-Item -Path $key.PSPath -Recurse -Force -ErrorAction Continue
     }
 }
 

--- a/installer/windows/kDriveInstaller/CleanUpAppData.ps1
+++ b/installer/windows/kDriveInstaller/CleanUpAppData.ps1
@@ -1,14 +1,33 @@
-# We should clean up parameters files before uninstalling the extension because removing the LiteSync leads to deletion of all the dehydrated placeholders.
+﻿# We should clean up parameters files before uninstalling the extension because removing the LiteSync leads to deletion of all the dehydrated placeholders.
 # In the case the uninstallation of the LiteSync failed but the dehydrated placeholders have been deleted, we do not want to have valid synchronization set up because it will propagate all the DELETE opearations on the server.
 
-# Remove DB folders
-Remove-Item "$env:LOCALAPPDATA\kDrive" -Recurse
+# Clean kDrive folders for all users
+$profiles = Get-ChildItem "C:\Users" -Directory -ErrorAction SilentlyContinue
 
-# Remove log folder
-Remove-Item "$env:TEMP\kDrive-logdir" -Recurse
+foreach ($profile in $profiles) {
 
-# Remove cache folder
-Remove-Item "$env:TEMP\kDrive-cache" -Recurse
+    $localAppData = Join-Path $profile.FullName "AppData\Local"
+    $tempFolder   = Join-Path $localAppData "Temp"
+
+    $pathsToDelete = @(
+        Join-Path $localAppData "kDrive"
+        Join-Path $tempFolder   "kDrive-logdir"
+        Join-Path $tempFolder   "kDrive-cache"
+    )
+
+    foreach ($path in $pathsToDelete) {
+        if (Test-Path $path) {
+            Write-Host "Deleting $path"
+            try {
+                Remove-Item $path -Recurse -Force -ErrorAction SilentlyContinue
+                Write-Host " → Deleted" -ForegroundColor Green
+            }
+            catch {
+                Write-Warning " → Failed to delete $path : $_"
+            }
+        }
+    }
+}
 
 # Remove shortcuts
 ## Start menu shortcut
@@ -16,14 +35,38 @@ Remove-Item "%ProgramData%\Microsoft\Windows\Start Menu\Programs\kDrive.lnk"
 Remove-Item "%AppData%\Microsoft\Windows\Start Menu\Programs\kDrive.lnk"
 ## Desktop shortcut
 $DesktopPath = [Environment]::GetFolderPath("Desktop")
-Remove-Item "$DesktopPath\kDrive.lnk"
+Remove-Item "$DesktopPath\kDrive.lnk" -Force -ErrorAction SilentlyContinue
 ## Quick Launch shortcut
-Remove-Item $quickLaunchPath\${APPLICATION_NAME}.lnk
+Remove-Item $quickLaunchPath\${APPLICATION_NAME}.lnk -Force -ErrorAction SilentlyContinue
 
 # Remove credentials
 $CredentialsToDelete = 'com.infomaniak.drive.desktopclient*'
 $Credentials = cmdkey.exe /list:($CredentialsToDelete) | Select-String -Pattern 'Target:*'
 $Credentials = $Credentials -replace ' ', '' -replace 'Target:', ''
 foreach ($Credential in $Credentials) {cmdkey.exe /delete $Credential | Out-Null}
+
+# Remove SyncRoot registration
+$syncRootRegPath = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\SyncRootManager"
+
+Write-Host "Scanning SyncRootManager registry entries..."
+
+Get-ChildItem $syncRootRegPath -ErrorAction SilentlyContinue | ForEach-Object {
+    $key = $_
+    $props = Get-ItemProperty -Path $key.PSPath -ErrorAction SilentlyContinue
+    $defaultValue = $props.'(default)'
+
+    if ($defaultValue -eq "kDrive") {
+        $syncRootId = $key.PSChildName
+        Write-Host "Deleting SyncRoot key: $syncRootId"
+
+        try {
+            Remove-Item -Path $key.PSPath -Recurse -Force -ErrorAction SilentlyContinue
+            Write-Host " → Deleted successfully" -ForegroundColor Green
+        }
+        catch {
+            Write-Warning " → Failed to delete $syncRootId : $_"
+        }
+    }
+}
 
 exit 0


### PR DESCRIPTION
Improved the cleanup script `CleanUpAppData.ps1` to ensure a more thorough removal of local data and configurations during the uninstallation of `kDrive`. Key changes include:
- Added support for cleaning `kDrive` folders across all user profiles.
- Introduced detailed logging for deleted paths and error handling.
- Forced deletion of shortcuts to avoid errors if files are missing.
- Implemented removal of `SyncRootManager` registry entries related to `kDrive`.