### PR TITLE
Handle files finishing with a point or space on Windows

### DIFF
--- a/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
@@ -269,8 +269,9 @@ ExitInfo LocalFileSystemObserverWorker::changesDetected(
                 // happens for instance if a file is deleted while another file with the same path is created shortly
                 // afterward. Typically, editors of the MS suite (xlsx, docx) or Adobe suite (pdf) perform a
                 // Delete-followed-by-Create operation during a single edit.
-                NodeId itemId = _liveSnapshot.itemId(relativePath);
-                if (!itemId.empty() && _liveSnapshot.removeItem(itemId)) {
+                const NodeId itemId = _liveSnapshot.itemId(relativePath);
+                if (itemId.empty()) continue;
+                if (_liveSnapshot.removeItem(itemId)) {
                     LOGW_SYNCPAL_DEBUG(_logger, L"Item removed from local snapshot: " << Utility::formatSyncPath(absolutePath)
                                                                                       << L" (" << CommonUtility::s2ws(itemId)
                                                                                       << L")");

--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
@@ -279,31 +279,38 @@ ExitCode UpdateTreeWorker::handleCreateOperationsWithSamePath() {
         }
 
         FSOpPtr createOp;
-        _operationSet->getOp(createOpId, createOp);
+        (void) _operationSet->getOp(createOpId, createOp);
 
-        std::pair<FSOpPtrMap::iterator, bool> insertionResult;
+        bool insertionFailedBecausePathExist = false;
+        SyncPath path;
         switch (createOp->objectType()) {
             case NodeType::File: {
-                SyncPath normalizedPath;
-                if (!Utility::normalizedSyncPath(createOp->path(), normalizedPath)) {
-                    normalizedPath = createOp->path();
+                if (!Utility::normalizedSyncPath(createOp->path(), path)) {
+                    path = createOp->path();
                     LOGW_SYNCPAL_WARN(_logger, L"Failed to normalize: " << Utility::formatSyncPath(createOp->path()));
                 }
-                insertionResult = _createFileOperationSet.try_emplace(normalizedPath, createOp);
+                if (!_createFileOperationSet.try_emplace(path, createOp).second) {
+                    insertionFailedBecausePathExist =
+                            _createFileOperationSet.contains(path); // The insertion might have fail because of unsupported
+                                                                    // character (e.g.: name finishing by a space or .)
+                }
                 break;
             }
             case NodeType::Directory:
-                insertionResult = createDirectoryOperationSet.try_emplace(createOp->path(), createOp);
+                if (!createDirectoryOperationSet.try_emplace(createOp->path(), createOp).second) {
+                    insertionFailedBecausePathExist =
+                            createDirectoryOperationSet.contains(path); // The insertion might have fail because of unsupported
+                                                                        // character (e.g.: name finishing by a space or .)
+                }
                 break;
             default:
                 break;
         }
 
-        if (!insertionResult.second) {
+        if (insertionFailedBecausePathExist) {
             // Failed to insert Create operation. A full rebuild of the snapshot is required.
             // The following issue has been identified: the operating system missed a delete operation, in which case a
             // liveSnapshot rebuild is both required and sufficient.
-
             LOGW_SYNCPAL_WARN(_logger, _side << L" update tree: Operation Create already exists on item with "
                                              << Utility::formatSyncPath(createOp->path()) << L", ID: "
                                              << CommonUtility::s2ws(createOp->nodeId()) << L", type " << createOp->objectType()

--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
@@ -290,24 +290,24 @@ ExitCode UpdateTreeWorker::handleCreateOperationsWithSamePath() {
                     LOGW_SYNCPAL_WARN(_logger, L"Failed to normalize: " << Utility::formatSyncPath(createOp->path()));
                 }
                 if (!_createFileOperationSet.try_emplace(path, createOp).second) {
-                    insertionFailedBecausePathExist =
-                            _createFileOperationSet.contains(path); // The insertion might have failed because of unsupported
-                                                                    // characters in `path` (e.g.: a file name finishing by a space or a dot).
+                    insertionFailedBecausePathExists = _createFileOperationSet.contains(
+                            path); // The insertion might have failed because of unsupported
+                                   // characters in `path` (e.g.: a file name finishing by a space or a dot).
                 }
                 break;
             }
             case NodeType::Directory:
                 if (!createDirectoryOperationSet.try_emplace(createOp->path(), createOp).second) {
-                    insertionFailedBecausePathExist =
-                            createDirectoryOperationSet.contains(path); // The insertion might have failed because of unsupported
-                                                                        // characters (e.g.: a folder name finishing by a space or a dot).
+                    insertionFailedBecausePathExists = createDirectoryOperationSet.contains(
+                            path); // The insertion might have failed because of unsupported
+                                   // characters (e.g.: a folder name finishing by a space or a dot).
                 }
                 break;
             default:
                 break;
         }
 
-        if (insertionFailedBecausePathExist) {
+        if (insertionFailedBecausePathExists) {
             // Failed to insert Create operation. A full rebuild of the snapshot is required.
             // The following issue has been identified: the operating system missed a delete operation, in which case a
             // liveSnapshot rebuild is both required and sufficient.

--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
@@ -281,7 +281,7 @@ ExitCode UpdateTreeWorker::handleCreateOperationsWithSamePath() {
         FSOpPtr createOp;
         (void) _operationSet->getOp(createOpId, createOp);
 
-        bool insertionFailedBecausePathExist = false;
+        bool insertionFailedBecausePathExists = false;
         SyncPath path;
         switch (createOp->objectType()) {
             case NodeType::File: {
@@ -291,16 +291,16 @@ ExitCode UpdateTreeWorker::handleCreateOperationsWithSamePath() {
                 }
                 if (!_createFileOperationSet.try_emplace(path, createOp).second) {
                     insertionFailedBecausePathExist =
-                            _createFileOperationSet.contains(path); // The insertion might have fail because of unsupported
-                                                                    // character (e.g.: name finishing by a space or .)
+                            _createFileOperationSet.contains(path); // The insertion might have failed because of unsupported
+                                                                    // characters in `path` (e.g.: a file name finishing by a space or a dot).
                 }
                 break;
             }
             case NodeType::Directory:
                 if (!createDirectoryOperationSet.try_emplace(createOp->path(), createOp).second) {
                     insertionFailedBecausePathExist =
-                            createDirectoryOperationSet.contains(path); // The insertion might have fail because of unsupported
-                                                                        // character (e.g.: name finishing by a space or .)
+                            createDirectoryOperationSet.contains(path); // The insertion might have failed because of unsupported
+                                                                        // characters (e.g.: a folder name finishing by a space or a dot).
                 }
                 break;
             default:


### PR DESCRIPTION
Some clients have files finishing by a '.' or a space on the local Windows file system, which is normally forbidden by the OS.
This creates a sync loop because the path could not be inserted in `_createFileOperationSet` in `UpdateTreeWorker`, leading to the reconstruction of the local snapshot and the restart of the sync.

The fix consists in rebuilding the snapshot in the case a of failed insertion in the map, but only if the path exists in it. If the path does not exist in the map, we simply continue the synchronization and the items ending with `.` or a space will be simply ignored because they will not appear in the `UpdateTree`.

It is hard to create a dedicated unit test because this is a situation that is difficult to reproduce locally.