### PR TITLE
fix: set ExitCause to apply appropriate error handling

### DIFF
--- a/src/libsyncengine/syncpal/syncpal.cpp
+++ b/src/libsyncengine/syncpal/syncpal.cpp
@@ -807,7 +807,7 @@ ExitInfo SyncPal::isRootFolderValid() {
     if (NodeId rootNodeId; IoHelper::getNodeId(localPath(), rootNodeId)) {
         if (rootNodeId.empty()) {
             LOGW_SYNCPAL_WARN(_logger, L"Unable to get root folder nodeId: " << Utility::formatSyncPath(localPath()));
-            return ExitCode::SystemError;
+            return {ExitCode::SystemError, ExitCause::SyncDirAccessError};
         }
 
         if (localNodeId().empty()) {
@@ -821,7 +821,7 @@ ExitInfo SyncPal::isRootFolderValid() {
         return localNodeId() == rootNodeId ? ExitInfo(ExitCode::Ok) : ExitInfo(ExitCode::DataError, ExitCause::SyncDirChanged);
     } else {
         LOGW_SYNCPAL_WARN(_logger, L"Error in IoHelper::getNodeId for root folder: " << Utility::formatSyncPath(localPath()));
-        return ExitCode::SystemError;
+        return {ExitCode::SystemError, ExitCause::SyncDirAccessError};
     }
 }
 

--- a/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
@@ -407,13 +407,15 @@ void LocalFileSystemObserverWorker::execute() {
             break;
         }
 
-        if (exitInfo = _syncPal->isRootFolderValid(); !exitInfo) {
+        exitInfo = _syncPal->isRootFolderValid();
+        if (!exitInfo) {
             LOG_SYNCPAL_WARN(_logger, "Error in isRootFolderValid: " << exitInfo);
             invalidateSnapshot();
             break;
         }
 
-        if (exitInfo = _folderWatcher->exitInfo(); !exitInfo) {
+        exitInfo = _folderWatcher->exitInfo();
+        if (!exitInfo) {
             LOG_SYNCPAL_WARN(_logger, "Error in FolderWatcher: " << _folderWatcher->exitInfo());
             tryToInvalidateSnapshot();
             break;
@@ -429,11 +431,12 @@ void LocalFileSystemObserverWorker::execute() {
 
         // Wait 1 sec after the last update
         if (_updating) {
-            auto diff_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() -
-                                                                                 _needUpdateTimerStart);
+            const auto diff_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() -
+                                                                                       _needUpdateTimerStart);
             if (diff_ms.count() > waitForUpdateDelay) {
                 // Check if root folder is still valid
-                if (exitInfo = _syncPal->isRootFolderValid(); !exitInfo) {
+                exitInfo = _syncPal->isRootFolderValid();
+                if (!exitInfo) {
                     LOG_SYNCPAL_WARN(_logger, "Error in isRootFolderValid: " << exitInfo);
                     invalidateSnapshot();
                     break;


### PR DESCRIPTION
If the external drive on which a sync is running is unmounted, the error retrieved from the `LocalFileSystemObserver` sets only the `ExitCode`, not the `ExitCause`. Therefore, the appropriate error handling logic (in this case pausing the sync and retrying every minute) cannot be applied, and the sync is completely stopped.