### PR TITLE
Fix infinite loop due to permission holder

### DIFF
--- a/src/server/vfs/win/vfs_win.cpp
+++ b/src/server/vfs/win/vfs_win.cpp
@@ -538,7 +538,7 @@ ExitInfo VfsWin::setPinState(const SyncPath &relativePathStd, PinState state) {
             break;
     }
 
-    PermissionsHolder permsHolder(fullPath, logger());
+    const PermissionsHolder permsHolder(fullPath, logger());
     if (vfsSetPinState(fullPath.lexically_normal().native().c_str(), vfsState) != S_OK) {
         LOGW_WARN(logger(), L"Error in vfsSetPinState: " << Utility::formatSyncPath(fullPath));
         return handleVfsError(fullPath);
@@ -578,7 +578,6 @@ PinState VfsWin::pinState(const SyncPath &relativePathStd) {
 
 ExitInfo VfsWin::status(const SyncPath &filePath, VfsStatus &vfsStatus) {
     // Check if the file is a placeholder
-    PermissionsHolder permsHolder(filePath, logger());
     bool isDehydrated = false;
     if (vfsGetPlaceHolderStatus(filePath.lexically_normal().native().c_str(), &vfsStatus.isPlaceholder, &isDehydrated, nullptr) !=
         S_OK) {

--- a/version.json
+++ b/version.json
@@ -3,7 +3,7 @@
     "major": 3,
     "minor": 8,
     "patch": 1,
-    "build": 2,
+    "build": 3,
     "year": 2025
   }
 }


### PR DESCRIPTION
An infinite loop might occur because reading the vfs status of a file triggered an edit event. Then, in the local file system observer, when this event is processed, the vfs status is checked again, leading to the trigger of a new edit event.

This is because the `PermissionsHolder` set temporary full access to the file, which triggered the edit event.