### PR TITLE
feat: XPC GUI comm jobs 7

### DIFF
--- a/src/front/macOS/kDrive.xcodeproj/project.pbxproj
+++ b/src/front/macOS/kDrive.xcodeproj/project.pbxproj
@@ -121,6 +121,7 @@
 				Cache/Observation/ObservableCoherentCacheTests.swift,
 				Cache/Observation/ObservableData.swift,
 				Cache/Observation/ObservedAccountTests.swift,
+				Cache/Observation/ObservedDriveTests.swift,
 				Cache/Observation/ObservedUserTests.swift,
 				Parsing/Base64CodedTests.swift,
 				Parsing/CallbackMessageTests.swift,

--- a/src/front/macOS/kDrive.xcodeproj/project.pbxproj
+++ b/src/front/macOS/kDrive.xcodeproj/project.pbxproj
@@ -122,6 +122,7 @@
 				Cache/Observation/ObservableData.swift,
 				Cache/Observation/ObservedAccountTests.swift,
 				Cache/Observation/ObservedDriveTests.swift,
+				Cache/Observation/ObservedSynchroTests.swift,
 				Cache/Observation/ObservedUserTests.swift,
 				Parsing/Base64CodedTests.swift,
 				Parsing/CallbackMessageTests.swift,

--- a/src/front/macOS/kDrive/UI/Controllers/MainWindow/Onboarding/Login/LoginViewModel.swift
+++ b/src/front/macOS/kDrive/UI/Controllers/MainWindow/Onboarding/Login/LoginViewModel.swift
@@ -79,7 +79,7 @@ extension LoginViewModel: InfomaniakLoginDelegate {
                 let userDbId = try await LoginJob().login(code: code, verifier: verifier)
 
                 @InjectService var coherentCacheObservable: CoherentCacheObservable
-                coherentCacheObservable.usersPublisher.userPublisher(for: userDbId)
+                coherentCacheObservable.usersPublisher.userPublisher(userDbId: userDbId)
                     .receiveOnMain(store: &bindStore) { [weak self] user in
                         self?.handleConnectedUser(user)
                     }

--- a/src/front/macOS/kDriveCore/Models/DTOs/Account.swift
+++ b/src/front/macOS/kDriveCore/Models/DTOs/Account.swift
@@ -24,6 +24,7 @@ public typealias UserAccounts = (userDbId: Int32, indexedAccounts: [Int32: Accou
 // TODO: Update to track userDbId in Account to match server type
 public struct Account: Identifiable, Hashable, Sendable {
     public let dbId: Int32
+    public let userDbId: Int32
     public var name: String
     public var drives: IndexedDrives
 
@@ -31,8 +32,9 @@ public struct Account: Identifiable, Hashable, Sendable {
         dbId
     }
 
-    public init(dbId: Int32, name: String, drives: [Int32: Drive]) {
+    public init(dbId: Int32, userDbId: Int32, name: String, drives: [Int32: Drive]) {
         self.dbId = dbId
+        self.userDbId = userDbId
         self.name = name
         self.drives = drives
     }

--- a/src/front/macOS/kDriveCore/ServerBridge/Cache/CoherentCache.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Cache/CoherentCache.swift
@@ -50,8 +50,8 @@ public protocol CoherentCache: Sendable {
 
     func getSynchro(synchroDbId: Int32, driveDbId: Int32, accountDbId: Int32, userDbId: Int32) async -> Synchro?
     func getSynchro(synchroDbId: Int32) async -> Synchro?
-    func addSynchro(_ synchro: Synchro, toDrive driveDbId: Int32, accountDbId: Int32, userDbId: Int32) async
-    func removeSynchro(synchroDbId: Int32, driveDbId: Int32, accountDbId: Int32, userDbId: Int32) async
+    func addSynchro(_ synchro: Synchro) async throws
+    func removeSynchro(synchroDbId: Int32, driveDbId: Int32) async throws
     func updateSynchro(_ synchro: Synchro) async throws
 
     // MARK: - Cleanup

--- a/src/front/macOS/kDriveCore/ServerBridge/Cache/CoherentCache.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Cache/CoherentCache.swift
@@ -42,7 +42,7 @@ public protocol CoherentCache: Sendable {
 
     func getDrive(driveDbId: Int32, accountDbId: Int32, userDbId: Int32) async -> Drive?
     func getDrive(driveDbId: Int32) async -> Drive?
-    func addDrive(_ drive: Drive, accountDbId: Int32) async
+    func addDrive(_ drive: Drive, accountDbId: Int32) async throws
     func removeDrive(driveDbId: Int32, accountDbId: Int32, userDbId: Int32) async
     func updateDrive(drive: Drive) async throws
 

--- a/src/front/macOS/kDriveCore/ServerBridge/Cache/CoherentCache.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Cache/CoherentCache.swift
@@ -42,7 +42,7 @@ public protocol CoherentCache: Sendable {
 
     func getDrive(driveDbId: Int32, accountDbId: Int32, userDbId: Int32) async -> Drive?
     func getDrive(driveDbId: Int32) async -> Drive?
-    func addDrive(_ drive: Drive, accountDbId: Int32, userDbId: Int32) async
+    func addDrive(_ drive: Drive, accountDbId: Int32) async
     func removeDrive(driveDbId: Int32, accountDbId: Int32, userDbId: Int32) async
     func updateDrive(drive: Drive) async throws
 

--- a/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedAccount.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedAccount.swift
@@ -57,16 +57,6 @@ public final class ObservedAccount: ObservableObject {
             }
     }
 
-    /// Async stream for testing
-    var receivedValues: AsyncStream<Account?> {
-        AsyncStream { continuation in
-            let c = $wrappedValue
-                .sink { value in continuation.yield(value) }
-
-            continuation.onTermination = { _ in c.cancel() }
-        }
-    }
-
     deinit { cancellable?.cancel() }
 
     public var projectedValue: ObservedAccount { self }

--- a/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedAccount.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedAccount.swift
@@ -20,6 +20,7 @@ import Combine
 import Foundation
 import InfomaniakDI
 
+@MainActor
 @propertyWrapper
 public final class ObservedAccount: ObservableObject {
     @Published public private(set) var wrappedValue: Account?
@@ -55,7 +56,7 @@ public final class ObservedAccount: ObservableObject {
                 self?.wrappedValue = account
             }
     }
-    
+
     /// Async stream for testing
     var receivedValues: AsyncStream<Account?> {
         AsyncStream { continuation in

--- a/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedAccount.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedAccount.swift
@@ -55,6 +55,16 @@ public final class ObservedAccount: ObservableObject {
                 self?.wrappedValue = account
             }
     }
+    
+    /// Async stream for testing
+    var receivedValues: AsyncStream<Account?> {
+        AsyncStream { continuation in
+            let c = $wrappedValue
+                .sink { value in continuation.yield(value) }
+
+            continuation.onTermination = { _ in c.cancel() }
+        }
+    }
 
     deinit { cancellable?.cancel() }
 

--- a/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedAccount.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedAccount.swift
@@ -62,24 +62,23 @@ public final class ObservedAccount: ObservableObject {
 }
 
 public extension AnyPublisher where Output == IndexedUsers, Failure == Never {
-    func accountPublisher(userDbId: Int32,
-                          accountDbId: Int32)
-        -> AnyPublisher<Account?, Never> {
+    func accountEventPublisher(
+        userDbId: Int32,
+        accountDbId: Int32
+    ) -> AnyPublisher<ObservationEvent<Account>, Never> {
         map { usersDict -> Account? in
             usersDict[userDbId]?.accounts[accountDbId]
         }
-        .scan((old: Account?.none, new: Account?.none)) { prev, newAccount in
-            (old: prev.new, new: newAccount)
+        .map { account in
+            account.map(ObservationEvent.update) ?? .removed
         }
-        .map { pair -> Account? in
-            guard pair.old != pair.new else { return nil }
-            return pair.new
-        }
-        .compactMap { $0 }
+        .removeDuplicates()
         .eraseToAnyPublisher()
     }
 
-    func accountPublisher(accountDbId: Int32) -> AnyPublisher<Account?, Never> {
+    func accountEventPublisher(
+        accountDbId: Int32
+    ) -> AnyPublisher<ObservationEvent<Account>, Never> {
         map { usersDict -> Account? in
             for user in usersDict.values {
                 if let account = user.accounts[accountDbId] {
@@ -88,14 +87,42 @@ public extension AnyPublisher where Output == IndexedUsers, Failure == Never {
             }
             return nil
         }
-        .scan((old: Account?.none, new: Account?.none)) { prev, newAccount in
-            (old: prev.new, new: newAccount)
+        .map { account in
+            account.map(ObservationEvent.update) ?? .removed
         }
-        .map { pair -> Account? in
-            guard pair.old != pair.new else { return nil }
-            return pair.new
-        }
-        .compactMap { $0 }
+        .removeDuplicates()
         .eraseToAnyPublisher()
+    }
+
+    func accountPublisher(
+        userDbId: Int32,
+        accountDbId: Int32
+    ) -> AnyPublisher<Account?, Never> {
+        accountEventPublisher(
+            userDbId: userDbId,
+            accountDbId: accountDbId
+        )
+        .map { event -> Account? in
+            switch event {
+            case let .update(account): return account
+            case .removed: return nil
+            }
+        }
+        .removeDuplicates()
+        .eraseToAnyPublisher()
+    }
+
+    func accountPublisher(
+        accountDbId: Int32
+    ) -> AnyPublisher<Account?, Never> {
+        accountEventPublisher(accountDbId: accountDbId)
+            .map { event -> Account? in
+                switch event {
+                case let .update(account): return account
+                case .removed: return nil
+                }
+            }
+            .removeDuplicates()
+            .eraseToAnyPublisher()
     }
 }

--- a/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedDrive.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedDrive.swift
@@ -61,6 +61,16 @@ public final class ObservedDrive: ObservableObject {
             }
     }
 
+    /// Async stream for testing
+    var receivedValues: AsyncStream<Drive?> {
+        AsyncStream { continuation in
+            let c = $wrappedValue
+                .sink { value in continuation.yield(value) }
+
+            continuation.onTermination = { _ in c.cancel() }
+        }
+    }
+
     deinit { cancellable?.cancel() }
 
     public var projectedValue: ObservedDrive { self }

--- a/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedDrive.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedDrive.swift
@@ -1,0 +1,112 @@
+/*
+ Infomaniak kDrive - Desktop
+ Copyright (C) 2023-2025 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Combine
+import Foundation
+import InfomaniakDI
+
+@propertyWrapper
+public final class ObservedDrive: ObservableObject {
+    @Published public private(set) var wrappedValue: Drive?
+    private var cancellable: AnyCancellable?
+
+    public init(
+        userDbId: Int32,
+        accountDbId: Int32,
+        driveDbId: Int32,
+        cacheObservation: CoherentCacheObservable? = nil
+    ) {
+        let cacheObservation =
+            cacheObservation ?? InjectService<CoherentCacheObservable>().wrappedValue
+
+        cancellable = cacheObservation.usersPublisher
+            .drivePublisher(
+                userDbId: userDbId,
+                accountDbId: accountDbId,
+                driveDbId: driveDbId
+            )
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] drive in
+                self?.wrappedValue = drive
+            }
+    }
+
+    public init(
+        driveDbId: Int32,
+        cacheObservation: CoherentCacheObservable? = nil
+    ) {
+        let cacheObservation =
+            cacheObservation ?? InjectService<CoherentCacheObservable>().wrappedValue
+
+        cancellable = cacheObservation.usersPublisher
+            .drivePublisher(driveDbId: driveDbId)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] drive in
+                self?.wrappedValue = drive
+            }
+    }
+
+    deinit { cancellable?.cancel() }
+
+    public var projectedValue: ObservedDrive { self }
+}
+
+public extension AnyPublisher where Output == IndexedUsers, Failure == Never {
+    func drivePublisher(
+        userDbId: Int32,
+        accountDbId: Int32,
+        driveDbId: Int32
+    ) -> AnyPublisher<Drive?, Never> {
+        map { usersDict -> Drive? in
+            usersDict[userDbId]?
+                .accounts[accountDbId]?
+                .drives[driveDbId]
+        }
+        .scan((old: Drive?.none, new: Drive?.none)) { prev, newDrive in
+            (old: prev.new, new: newDrive)
+        }
+        .map { pair -> Drive? in
+            guard pair.old != pair.new else { return nil }
+            return pair.new
+        }
+        .compactMap { $0 }
+        .eraseToAnyPublisher()
+    }
+
+    func drivePublisher(driveDbId: Int32) -> AnyPublisher<Drive?, Never> {
+        map { usersDict -> Drive? in
+            for user in usersDict.values {
+                for account in user.accounts.values {
+                    if let drive = account.drives[driveDbId] {
+                        return drive
+                    }
+                }
+            }
+            return nil
+        }
+        .scan((old: Drive?.none, new: Drive?.none)) { prev, newDrive in
+            (old: prev.new, new: newDrive)
+        }
+        .map { pair -> Drive? in
+            guard pair.old != pair.new else { return nil }
+            return pair.new
+        }
+        .compactMap { $0 }
+        .eraseToAnyPublisher()
+    }
+}

--- a/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedDrive.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedDrive.swift
@@ -62,16 +62,6 @@ public final class ObservedDrive: ObservableObject {
             }
     }
 
-    /// Async stream for testing
-    var receivedValues: AsyncStream<Drive?> {
-        AsyncStream { continuation in
-            let c = $wrappedValue
-                .sink { value in continuation.yield(value) }
-
-            continuation.onTermination = { _ in c.cancel() }
-        }
-    }
-
     deinit { cancellable?.cancel() }
 
     public var projectedValue: ObservedDrive { self }

--- a/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedDrive.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedDrive.swift
@@ -67,28 +67,25 @@ public final class ObservedDrive: ObservableObject {
 }
 
 public extension AnyPublisher where Output == IndexedUsers, Failure == Never {
-    func drivePublisher(
+    func driveEventPublisher(
         userDbId: Int32,
         accountDbId: Int32,
         driveDbId: Int32
-    ) -> AnyPublisher<Drive?, Never> {
+    ) -> AnyPublisher<ObservationEvent<Drive>, Never> {
         map { usersDict -> Drive? in
             usersDict[userDbId]?
                 .accounts[accountDbId]?
                 .drives[driveDbId]
         }
-        .scan((old: Drive?.none, new: Drive?.none)) { prev, newDrive in
-            (old: prev.new, new: newDrive)
+        .map { drive -> ObservationEvent<Drive> in
+            if let drive { return .update(drive) }
+            return .removed
         }
-        .map { pair -> Drive? in
-            guard pair.old != pair.new else { return nil }
-            return pair.new
-        }
-        .compactMap { $0 }
+        .removeDuplicates()
         .eraseToAnyPublisher()
     }
 
-    func drivePublisher(driveDbId: Int32) -> AnyPublisher<Drive?, Never> {
+    func driveEventPublisher(driveDbId: Int32) -> AnyPublisher<ObservationEvent<Drive>, Never> {
         map { usersDict -> Drive? in
             for user in usersDict.values {
                 for account in user.accounts.values {
@@ -99,14 +96,38 @@ public extension AnyPublisher where Output == IndexedUsers, Failure == Never {
             }
             return nil
         }
-        .scan((old: Drive?.none, new: Drive?.none)) { prev, newDrive in
-            (old: prev.new, new: newDrive)
+        .map { drive -> ObservationEvent<Drive> in
+            drive.map(ObservationEvent.update) ?? .removed
         }
-        .map { pair -> Drive? in
-            guard pair.old != pair.new else { return nil }
-            return pair.new
-        }
-        .compactMap { $0 }
+        .removeDuplicates()
         .eraseToAnyPublisher()
+    }
+
+    func drivePublisher(
+        userDbId: Int32,
+        accountDbId: Int32,
+        driveDbId: Int32
+    ) -> AnyPublisher<Drive?, Never> {
+        driveEventPublisher(userDbId: userDbId, accountDbId: accountDbId, driveDbId: driveDbId)
+            .map { event -> Drive? in
+                switch event {
+                case let .update(drive): return drive
+                case .removed: return nil
+                }
+            }
+            .removeDuplicates()
+            .eraseToAnyPublisher()
+    }
+
+    func drivePublisher(driveDbId: Int32) -> AnyPublisher<Drive?, Never> {
+        driveEventPublisher(driveDbId: driveDbId)
+            .map { event -> Drive? in
+                switch event {
+                case let .update(drive): return drive
+                case .removed: return nil
+                }
+            }
+            .removeDuplicates()
+            .eraseToAnyPublisher()
     }
 }

--- a/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedDrive.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedDrive.swift
@@ -20,6 +20,7 @@ import Combine
 import Foundation
 import InfomaniakDI
 
+@MainActor
 @propertyWrapper
 public final class ObservedDrive: ObservableObject {
     @Published public private(set) var wrappedValue: Drive?

--- a/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedSynchro.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedSynchro.swift
@@ -58,6 +58,16 @@ public final class ObservedSynchro: ObservableObject {
             }
     }
 
+    /// Async stream for testing
+    var receivedValues: AsyncStream<Synchro?> {
+        AsyncStream { continuation in
+            let c = $wrappedValue
+                .sink { value in continuation.yield(value) }
+
+            continuation.onTermination = { _ in c.cancel() }
+        }
+    }
+
     deinit { cancellable?.cancel() }
 
     public var projectedValue: ObservedSynchro { self }

--- a/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedSynchro.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedSynchro.swift
@@ -1,0 +1,143 @@
+/*
+ Infomaniak kDrive - Desktop
+ Copyright (C) 2023-2025 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Combine
+import Foundation
+import InfomaniakDI
+
+@propertyWrapper
+public final class ObservedSynchro: ObservableObject {
+    @Published public private(set) var wrappedValue: Synchro?
+    private var cancellable: AnyCancellable?
+
+    public init(
+        userDbId: Int32,
+        accountDbId: Int32,
+        driveDbId: Int32,
+        synchroDbId: Int32,
+        cacheObservation: CoherentCacheObservable? = nil
+    ) {
+        let cacheObservation =
+            cacheObservation ?? InjectService<CoherentCacheObservable>().wrappedValue
+
+        cancellable = cacheObservation.usersPublisher
+            .synchroPublisher(userDbId: userDbId, accountDbId: accountDbId, driveDbId: driveDbId, synchroDbId: synchroDbId)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] synchro in
+                self?.wrappedValue = synchro
+            }
+    }
+
+    public init(
+        synchroDbId: Int32,
+        cacheObservation: CoherentCacheObservable? = nil
+    ) {
+        let cacheObservation =
+            cacheObservation ?? InjectService<CoherentCacheObservable>().wrappedValue
+
+        cancellable = cacheObservation.usersPublisher
+            .synchroPublisher(dbId: synchroDbId)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] synchro in
+                self?.wrappedValue = synchro
+            }
+    }
+
+    deinit { cancellable?.cancel() }
+
+    public var projectedValue: ObservedSynchro { self }
+}
+
+public extension AnyPublisher where Output == [Int32: User], Failure == Never {
+    func synchroEventPublisher(
+        userDbId: Int32,
+        accountDbId: Int32,
+        driveDbId: Int32,
+        synchroDbId: Int32
+    ) -> AnyPublisher<ObservationEvent<Synchro>, Never> {
+        map { usersDict -> Synchro? in
+            usersDict[userDbId]?
+                .accounts[accountDbId]?
+                .drives[driveDbId]?
+                .synchros[synchroDbId]
+        }
+        .map { synchro in
+            synchro.map(ObservationEvent.update) ?? .removed
+        }
+        .removeDuplicates()
+        .eraseToAnyPublisher()
+    }
+
+    func synchroEventPublisher(
+        synchroDbId: Int32
+    ) -> AnyPublisher<ObservationEvent<Synchro>, Never> {
+        map { usersDict -> Synchro? in
+            for user in usersDict.values {
+                for account in user.accounts.values {
+                    for drive in account.drives.values {
+                        if let synchro = drive.synchros[synchroDbId] {
+                            return synchro
+                        }
+                    }
+                }
+            }
+            return nil
+        }
+        .map { synchro in
+            synchro.map(ObservationEvent.update) ?? .removed
+        }
+        .removeDuplicates()
+        .eraseToAnyPublisher()
+    }
+
+    func synchroPublisher(
+        userDbId: Int32,
+        accountDbId: Int32,
+        driveDbId: Int32,
+        synchroDbId: Int32
+    ) -> AnyPublisher<Synchro?, Never> {
+        synchroEventPublisher(
+            userDbId: userDbId,
+            accountDbId: accountDbId,
+            driveDbId: driveDbId,
+            synchroDbId: synchroDbId
+        )
+        .map { event -> Synchro? in
+            switch event {
+            case let .update(synchro): return synchro
+            case .removed: return nil
+            }
+        }
+        .removeDuplicates()
+        .eraseToAnyPublisher()
+    }
+
+    func synchroPublisher(
+        dbId synchroDbId: Int32
+    ) -> AnyPublisher<Synchro?, Never> {
+        synchroEventPublisher(synchroDbId: synchroDbId)
+            .map { event -> Synchro? in
+                switch event {
+                case let .update(synchro): return synchro
+                case .removed: return nil
+                }
+            }
+            .removeDuplicates()
+            .eraseToAnyPublisher()
+    }
+}

--- a/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedSynchro.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedSynchro.swift
@@ -59,16 +59,6 @@ public final class ObservedSynchro: ObservableObject {
             }
     }
 
-    /// Async stream for testing
-    var receivedValues: AsyncStream<Synchro?> {
-        AsyncStream { continuation in
-            let c = $wrappedValue
-                .sink { value in continuation.yield(value) }
-
-            continuation.onTermination = { _ in c.cancel() }
-        }
-    }
-
     deinit { cancellable?.cancel() }
 
     public var projectedValue: ObservedSynchro { self }

--- a/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedSynchro.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedSynchro.swift
@@ -20,6 +20,7 @@ import Combine
 import Foundation
 import InfomaniakDI
 
+@MainActor
 @propertyWrapper
 public final class ObservedSynchro: ObservableObject {
     @Published public private(set) var wrappedValue: Synchro?

--- a/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedUser.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedUser.swift
@@ -20,7 +20,6 @@ import Combine
 import Foundation
 import InfomaniakDI
 
-// TODO: Extend observation with deletion _after_ signals are created
 public enum ObservationEvent<Some: Equatable>: Equatable {
     case update(Some)
     case removed

--- a/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedUser.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedUser.swift
@@ -25,6 +25,7 @@ public enum ObservationEvent<Some: Equatable>: Equatable {
     case removed
 }
 
+@MainActor
 @propertyWrapper
 public final class ObservedUser: ObservableObject {
     @Published public private(set) var wrappedValue: User?

--- a/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedUser.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedUser.swift
@@ -41,6 +41,16 @@ public final class ObservedUser: ObservableObject {
             }
     }
 
+    /// Async stream for testing
+    var receivedValues: AsyncStream<User?> {
+        AsyncStream { continuation in
+            let c = $wrappedValue
+                .sink { value in continuation.yield(value) }
+
+            continuation.onTermination = { _ in c.cancel() }
+        }
+    }
+
     deinit { cancellable?.cancel() }
 
     public var projectedValue: ObservedUser { self }

--- a/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedUser.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedUser.swift
@@ -30,11 +30,11 @@ public final class ObservedUser: ObservableObject {
     @Published public private(set) var wrappedValue: User?
     private var cancellable: AnyCancellable?
 
-    public init(dbId: Int32, cacheObservation: CoherentCacheObservable? = nil) {
+    public init(userDbId: Int32, cacheObservation: CoherentCacheObservable? = nil) {
         let cacheObservation = cacheObservation ?? InjectService<CoherentCacheObservable>().wrappedValue
 
         cancellable = cacheObservation.usersPublisher
-            .userPublisher(for: dbId)
+            .userPublisher(userDbId: userDbId)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] user in
                 self?.wrappedValue = user
@@ -47,16 +47,26 @@ public final class ObservedUser: ObservableObject {
 }
 
 public extension AnyPublisher where Output == IndexedUsers, Failure == Never {
-    func userPublisher(for dbId: Int32) -> AnyPublisher<User?, Never> {
-        map { $0[dbId] }
-            .scan((old: User?.none, new: User?.none)) { prev, newUser in
-                (old: prev.new, new: newUser)
+    func userEventPublisher(userDbId: Int32) -> AnyPublisher<ObservationEvent<User>, Never> {
+        map { usersDict -> User? in
+            usersDict[userDbId]
+        }
+        .map { account in
+            account.map(ObservationEvent.update) ?? .removed
+        }
+        .removeDuplicates()
+        .eraseToAnyPublisher()
+    }
+
+    func userPublisher(userDbId: Int32) -> AnyPublisher<User?, Never> {
+        userEventPublisher(userDbId: userDbId)
+            .map { event -> User? in
+                switch event {
+                case let .update(user): return user
+                case .removed: return nil
+                }
             }
-            .map { pair -> User? in
-                guard pair.old != pair.new else { return nil }
-                return pair.new
-            }
-            .compactMap { $0 }
+            .removeDuplicates()
             .eraseToAnyPublisher()
     }
 }

--- a/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedUser.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedUser.swift
@@ -42,16 +42,6 @@ public final class ObservedUser: ObservableObject {
             }
     }
 
-    /// Async stream for testing
-    var receivedValues: AsyncStream<User?> {
-        AsyncStream { continuation in
-            let c = $wrappedValue
-                .sink { value in continuation.yield(value) }
-
-            continuation.onTermination = { _ in c.cancel() }
-        }
-    }
-
     deinit { cancellable?.cancel() }
 
     public var projectedValue: ObservedUser { self }

--- a/src/front/macOS/kDriveCore/ServerBridge/Cache/ServerCoherentCache.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Cache/ServerCoherentCache.swift
@@ -35,10 +35,12 @@ public actor ServerCoherentCache: CoherentCache, CoherentCacheObservable {
             .eraseToAnyPublisher()
     }
 
-    enum CacheError: Error {
+    public enum CacheError: Error {
         case userNotFound(_ dbId: Int32)
         case accountNotFound(_ dbId: Int32)
+        case accountNotFoundContainingDrive(_ driveDbId: Int32)
         case driveNotFound(_ dbId: Int32)
+        case synchroNotFound(_ dbId: Int32)
     }
 
     public init() {}
@@ -186,20 +188,21 @@ public actor ServerCoherentCache: CoherentCache, CoherentCacheObservable {
 
     public func updateDrive(drive: Drive) throws {
         let userDbId = drive.userDbId
-        let accountId = drive.accountId
+        let driveDbId = drive.driveDbId
 
         guard var user = users[userDbId] else {
             throw CacheError.userNotFound(userDbId)
         }
-        guard var account = user.accounts[accountId] else {
-            throw CacheError.accountNotFound(accountId)
+
+        guard var account = user.accounts.values.first(where: { $0.drives[driveDbId] != nil }) else {
+            throw CacheError.accountNotFoundContainingDrive(driveDbId)
         }
 
         var indexedDrives = account.drives
-        indexedDrives[drive.id] = drive
+        indexedDrives[driveDbId] = drive
 
         account.drives = indexedDrives
-        user.accounts[accountId] = account
+        user.accounts[account.dbId] = account
         users[userDbId] = user
 
         notifyUpdate()
@@ -228,32 +231,26 @@ public actor ServerCoherentCache: CoherentCache, CoherentCacheObservable {
         return nil
     }
 
-    public func addSynchro(_ synchro: Synchro, toDrive driveDbId: Int32, accountDbId: Int32, userDbId: Int32) {
-        guard var user = users[userDbId],
-              var account = user.accounts[accountDbId],
-              var drive = account.drives[driveDbId]
-        else { return }
+    public func addSynchro(_ synchro: Synchro) throws {
+        let driveDbId = synchro.driveDbId
+        guard var drive = getDrive(driveDbId: driveDbId) else {
+            throw CacheError.driveNotFound(driveDbId)
+        }
 
-        drive.synchros[synchro.id] = synchro
-        account.drives[driveDbId] = drive
-        user.accounts[accountDbId] = account
-        users[userDbId] = user
-
-        notifyUpdate()
+        drive.synchros[synchro.dbId] = synchro
+        try updateDrive(drive: drive) // does observation update
     }
 
-    public func removeSynchro(synchroDbId: Int32, driveDbId: Int32, accountDbId: Int32, userDbId: Int32) {
-        guard var user = users[userDbId],
-              var account = user.accounts[accountDbId],
-              var drive = account.drives[driveDbId]
-        else { return }
+    public func removeSynchro(synchroDbId: Int32, driveDbId: Int32) throws {
+        guard var drive = getDrive(driveDbId: driveDbId) else {
+            throw CacheError.driveNotFound(driveDbId)
+        }
 
-        drive.synchros.removeValue(forKey: synchroDbId)
-        account.drives[driveDbId] = drive
-        user.accounts[accountDbId] = account
-        users[userDbId] = user
+        guard let _ = drive.synchros.removeValue(forKey: synchroDbId) else {
+            throw CacheError.synchroNotFound(synchroDbId)
+        }
 
-        notifyUpdate()
+        try updateDrive(drive: drive) // does observation update
     }
 
     public func updateSynchro(_ synchro: Synchro) throws {
@@ -262,9 +259,7 @@ public actor ServerCoherentCache: CoherentCache, CoherentCacheObservable {
         }
 
         drive.synchros[synchro.dbId] = synchro
-        try updateDrive(drive: drive)
-
-        notifyUpdate()
+        try updateDrive(drive: drive) // does observation update
     }
 
     // MARK: - Observation

--- a/src/front/macOS/kDriveCore/ServerBridge/Cache/ServerCoherentCache.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Cache/ServerCoherentCache.swift
@@ -156,7 +156,8 @@ public actor ServerCoherentCache: CoherentCache, CoherentCacheObservable {
         return nil
     }
 
-    public func addDrive(_ drive: Drive, accountDbId: Int32, userDbId: Int32) {
+    public func addDrive(_ drive: Drive, accountDbId: Int32) {
+        let userDbId = drive.userDbId
         guard var user = users[userDbId],
               var account = user.accounts[accountDbId]
         else { return }

--- a/src/front/macOS/kDriveCore/ServerBridge/Cache/ServerCoherentCache.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Cache/ServerCoherentCache.swift
@@ -217,7 +217,6 @@ public actor ServerCoherentCache: CoherentCache, CoherentCacheObservable {
             .synchros[synchroDbId]
     }
 
-    // TODO: If synchro has driveDbId, reuse getDrive
     public func getSynchro(synchroDbId: Int32) -> Synchro? {
         for user in users.values {
             for account in user.accounts.values {
@@ -238,7 +237,7 @@ public actor ServerCoherentCache: CoherentCache, CoherentCacheObservable {
         }
 
         drive.synchros[synchro.dbId] = synchro
-        try updateDrive(drive: drive) // does observation update
+        try updateDrive(drive: drive)
     }
 
     public func removeSynchro(synchroDbId: Int32, driveDbId: Int32) throws {
@@ -246,11 +245,11 @@ public actor ServerCoherentCache: CoherentCache, CoherentCacheObservable {
             throw CacheError.driveNotFound(driveDbId)
         }
 
-        guard let _ = drive.synchros.removeValue(forKey: synchroDbId) else {
+        guard drive.synchros.removeValue(forKey: synchroDbId) != nil else {
             throw CacheError.synchroNotFound(synchroDbId)
         }
 
-        try updateDrive(drive: drive) // does observation update
+        try updateDrive(drive: drive)
     }
 
     public func updateSynchro(_ synchro: Synchro) throws {
@@ -259,7 +258,7 @@ public actor ServerCoherentCache: CoherentCache, CoherentCacheObservable {
         }
 
         drive.synchros[synchro.dbId] = synchro
-        try updateDrive(drive: drive) // does observation update
+        try updateDrive(drive: drive)
     }
 
     // MARK: - Observation

--- a/src/front/macOS/kDriveCore/ServerBridge/Cache/ServerCoherentCache.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Cache/ServerCoherentCache.swift
@@ -156,11 +156,14 @@ public actor ServerCoherentCache: CoherentCache, CoherentCacheObservable {
         return nil
     }
 
-    public func addDrive(_ drive: Drive, accountDbId: Int32) {
+    public func addDrive(_ drive: Drive, accountDbId: Int32) throws {
         let userDbId = drive.userDbId
-        guard var user = users[userDbId],
-              var account = user.accounts[accountDbId]
-        else { return }
+        guard var user = users[userDbId] else {
+            throw CacheError.userNotFound(userDbId)
+        }
+        guard var account = user.accounts[accountDbId] else {
+            throw CacheError.accountNotFound(accountDbId)
+        }
 
         account.drives[drive.id] = drive
         user.accounts[accountDbId] = account

--- a/src/front/macOS/kDriveCore/ServerBridge/Jobs/DTOs/AccountResponse.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Jobs/DTOs/AccountResponse.swift
@@ -28,6 +28,6 @@ public struct AccountInfoResponse: Codable, Sendable {
 
 extension AccountInfoResponse {
     var asAccount: Account {
-        Account(dbId: dbId, name: "", drives: [:])
+        Account(dbId: dbId, userDbId: userDbId, name: "", drives: [:])
     }
 }

--- a/src/front/macOS/kDriveTests/Cache/CoherentCacheTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/CoherentCacheTests.swift
@@ -52,12 +52,12 @@ enum CacheData {
     static let expectedAccountDbId = Int32.random(in: 0 ... 10000)
     static let expectedAccountName = "myAccount"
     static var expectedAccount = Account(
-        dbId: expectedAccountDbId, name: expectedAccountName, drives: [:]
+        dbId: expectedAccountDbId, userDbId: expectedUserDbId, name: expectedAccountName, drives: [:]
     )
 
     static let updatedAccountName = "myUpdatedAccount"
     static var updatedAccount = Account(
-        dbId: expectedAccountDbId, name: updatedAccountName, drives: [:]
+        dbId: expectedAccountDbId, userDbId: expectedUserDbId, name: updatedAccountName, drives: [:]
     )
 
     static let expectedDriveDbId = Int32.random(in: 0 ... 10000)
@@ -301,10 +301,7 @@ struct CoherentCacheSynchroTests {
         #expect(await cache.getDrive(driveDbId: CacheData.expectedDriveDbId) == CacheData.expectedDrive)
 
         // WHEN
-        await cache.addSynchro(CacheData.expectedSynchro,
-                               toDrive: CacheData.expectedDriveDbId,
-                               accountDbId: CacheData.expectedAccountDbId,
-                               userDbId: CacheData.expectedUserDbId)
+        try await cache.addSynchro(CacheData.expectedSynchro)
 
         // THEN
         #expect(await cache.getSynchro(synchroDbId: CacheData.expectedSynchroDbId) == CacheData.expectedSynchro)
@@ -326,18 +323,13 @@ struct CoherentCacheSynchroTests {
         #expect(await cache.getAccount(accountDbId: CacheData.expectedAccountDbId, userDbId: CacheData.expectedUserDbId) == CacheData.expectedAccount)
         try await cache.addDrive(CacheData.expectedDrive, accountDbId: CacheData.expectedAccountDbId)
         #expect(await cache.getDrive(driveDbId: CacheData.expectedDriveDbId) == CacheData.expectedDrive)
-        await cache.addSynchro(CacheData.expectedSynchro,
-                               toDrive: CacheData.expectedDriveDbId,
-                               accountDbId: CacheData.expectedAccountDbId,
-                               userDbId: CacheData.expectedUserDbId)
+        try await cache.addSynchro(CacheData.expectedSynchro)
         #expect(await cache.getSynchro(synchroDbId: CacheData.expectedSynchroDbId) == CacheData.expectedSynchro)
 
         // WHEN
-        await cache.removeSynchro(
+        try await cache.removeSynchro(
             synchroDbId: CacheData.expectedSynchroDbId,
-            driveDbId: CacheData.expectedDriveDbId,
-            accountDbId: CacheData.expectedAccountDbId,
-            userDbId: CacheData.expectedUserDbId
+            driveDbId: CacheData.expectedDriveDbId
         )
 
         // THEN
@@ -360,10 +352,7 @@ struct CoherentCacheSynchroTests {
         #expect(await cache.getAccount(accountDbId: CacheData.expectedAccountDbId, userDbId: CacheData.expectedUserDbId) == CacheData.expectedAccount)
         try await cache.addDrive(CacheData.expectedDrive, accountDbId: CacheData.expectedAccountDbId)
         #expect(await cache.getDrive(driveDbId: CacheData.expectedDriveDbId) == CacheData.expectedDrive)
-        await cache.addSynchro(CacheData.expectedSynchro,
-                               toDrive: CacheData.expectedDriveDbId,
-                               accountDbId: CacheData.expectedAccountDbId,
-                               userDbId: CacheData.expectedUserDbId)
+        try await cache.addSynchro(CacheData.expectedSynchro)
         #expect(await cache.getSynchro(synchroDbId: CacheData.expectedSynchroDbId) == CacheData.expectedSynchro)
 
         // WHEN

--- a/src/front/macOS/kDriveTests/Cache/CoherentCacheTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/CoherentCacheTests.swift
@@ -102,7 +102,8 @@ enum CacheData {
 }
 
 struct CoherentCacheUserTests {
-    @Test func getUserInCache() async throws {
+    @Test(.timeLimit(.minutes(1)))
+    func getUserInCache() async throws {
         // GIVEN
         let user = CacheData.expectedUser
         let cache = ServerCoherentCache()
@@ -116,7 +117,8 @@ struct CoherentCacheUserTests {
         #expect(await cache.getUser(dbId: CacheData.expectedUserDbId) == user)
     }
 
-    @Test func removeUserInCacheFromDbId() async throws {
+    @Test(.timeLimit(.minutes(1)))
+    func removeUserInCacheFromDbId() async throws {
         // GIVEN
         let user = CacheData.expectedUser
         let cache = ServerCoherentCache()
@@ -131,7 +133,8 @@ struct CoherentCacheUserTests {
         #expect(await cache.getUser(dbId: CacheData.expectedUserDbId) == nil)
     }
 
-    @Test func updateUserInCache() async throws {
+    @Test(.timeLimit(.minutes(1)))
+    func updateUserInCache() async throws {
         // GIVEN
         let user = CacheData.expectedUser
         let cache = ServerCoherentCache()
@@ -162,7 +165,8 @@ struct CoherentCacheUserTests {
 }
 
 struct CoherentCacheAccountTests {
-    @Test func getAccountInCache() async throws {
+    @Test(.timeLimit(.minutes(1)))
+    func getAccountInCache() async throws {
         // GIVEN
         let user = CacheData.expectedUser
         let cache = ServerCoherentCache()
@@ -178,7 +182,8 @@ struct CoherentCacheAccountTests {
         #expect(await cache.getAccount(accountDbId: CacheData.expectedAccountDbId) == CacheData.expectedAccount)
     }
 
-    @Test func removeAccountInCacheFromDbId() async throws {
+    @Test(.timeLimit(.minutes(1)))
+    func removeAccountInCacheFromDbId() async throws {
         // GIVEN
         let user = CacheData.expectedUser
         let cache = ServerCoherentCache()
@@ -197,7 +202,8 @@ struct CoherentCacheAccountTests {
         #expect(await cache.getUser(dbId: CacheData.expectedUserDbId) == CacheData.expectedUser)
     }
 
-    @Test func updateAccountInCache() async throws {
+    @Test(.timeLimit(.minutes(1)))
+    func updateAccountInCache() async throws {
         // GIVEN
         let user = CacheData.expectedUser
         let cache = ServerCoherentCache()
@@ -228,7 +234,8 @@ struct CoherentCacheAccountTests {
 }
 
 struct CoherentCacheDriveTests {
-    @Test func getDriveInCache() async throws {
+    @Test(.timeLimit(.minutes(1)))
+    func getDriveInCache() async throws {
         // GIVEN
         let user = CacheData.expectedUser
         let cache = ServerCoherentCache()
@@ -244,7 +251,8 @@ struct CoherentCacheDriveTests {
         #expect(await cache.getDrive(driveDbId: CacheData.expectedDriveDbId) == CacheData.expectedDrive)
     }
 
-    @Test func removeDriveInCacheFromDbId() async throws {
+    @Test(.timeLimit(.minutes(1)))
+    func removeDriveInCacheFromDbId() async throws {
         // GIVEN
         let user = CacheData.expectedUser
         let cache = ServerCoherentCache()
@@ -264,7 +272,8 @@ struct CoherentCacheDriveTests {
         #expect(await cache.getDrive(driveDbId: CacheData.expectedDriveDbId) == nil)
     }
 
-    @Test func updateDriveInCache() async throws {
+    @Test(.timeLimit(.minutes(1)))
+    func updateDriveInCache() async throws {
         // GIVEN
         let user = CacheData.expectedUser
         let cache = ServerCoherentCache()
@@ -289,7 +298,8 @@ struct CoherentCacheDriveTests {
 }
 
 struct CoherentCacheSynchroTests {
-    @Test func getSynchroInCache() async throws {
+    @Test(.timeLimit(.minutes(1)))
+    func getSynchroInCache() async throws {
         // GIVEN
         let user = CacheData.expectedUser
         let cache = ServerCoherentCache()
@@ -313,7 +323,8 @@ struct CoherentCacheSynchroTests {
         ) == CacheData.expectedSynchro)
     }
 
-    @Test func removeSynchroInCacheFromDbId() async throws {
+    @Test(.timeLimit(.minutes(1)))
+    func removeSynchroInCacheFromDbId() async throws {
         // GIVEN
         let user = CacheData.expectedUser
         let cache = ServerCoherentCache()
@@ -342,7 +353,8 @@ struct CoherentCacheSynchroTests {
         ) == nil)
     }
 
-    @Test func updateSynchroInCache() async throws {
+    @Test(.timeLimit(.minutes(1)))
+    func updateSynchroInCache() async throws {
         // GIVEN
         let user = CacheData.expectedUser
         let cache = ServerCoherentCache()

--- a/src/front/macOS/kDriveTests/Cache/CoherentCacheTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/CoherentCacheTests.swift
@@ -238,7 +238,7 @@ struct CoherentCacheDriveTests {
         #expect(await cache.getAccount(accountDbId: CacheData.expectedAccountDbId, userDbId: CacheData.expectedUserDbId) == CacheData.expectedAccount)
 
         // WHEN
-        await cache.addDrive(CacheData.expectedDrive, accountDbId: CacheData.expectedAccountDbId, userDbId: CacheData.expectedUserDbId)
+        await cache.addDrive(CacheData.expectedDrive, accountDbId: CacheData.expectedAccountDbId)
 
         // THEN
         #expect(await cache.getDrive(driveDbId: CacheData.expectedDriveDbId) == CacheData.expectedDrive)
@@ -252,7 +252,7 @@ struct CoherentCacheDriveTests {
         #expect(await cache.getUser(dbId: CacheData.expectedUserDbId) == user)
         await cache.addAccount(CacheData.expectedAccount, userDbId: CacheData.expectedUserDbId)
         #expect(await cache.getAccount(accountDbId: CacheData.expectedAccountDbId, userDbId: CacheData.expectedUserDbId) == CacheData.expectedAccount)
-        await cache.addDrive(CacheData.expectedDrive, accountDbId: CacheData.expectedAccountDbId, userDbId: CacheData.expectedUserDbId)
+        await cache.addDrive(CacheData.expectedDrive, accountDbId: CacheData.expectedAccountDbId)
         #expect(await cache.getDrive(driveDbId: CacheData.expectedDriveDbId) == CacheData.expectedDrive)
 
         // WHEN
@@ -272,7 +272,7 @@ struct CoherentCacheDriveTests {
         #expect(await cache.getUser(dbId: CacheData.expectedUserDbId) == user)
         await cache.addAccount(CacheData.expectedAccount, userDbId: CacheData.expectedUserDbId)
         #expect(await cache.getAccount(accountDbId: CacheData.expectedAccountDbId, userDbId: CacheData.expectedUserDbId) == CacheData.expectedAccount)
-        await cache.addDrive(CacheData.expectedDrive, accountDbId: CacheData.expectedAccountDbId, userDbId: CacheData.expectedUserDbId)
+        await cache.addDrive(CacheData.expectedDrive, accountDbId: CacheData.expectedAccountDbId)
         #expect(await cache.getDrive(driveDbId: CacheData.expectedDriveDbId) == CacheData.expectedDrive)
 
         // WHEN
@@ -297,7 +297,7 @@ struct CoherentCacheSynchroTests {
         #expect(await cache.getUser(dbId: CacheData.expectedUserDbId) == user)
         await cache.addAccount(CacheData.expectedAccount, userDbId: CacheData.expectedUserDbId)
         #expect(await cache.getAccount(accountDbId: CacheData.expectedAccountDbId, userDbId: CacheData.expectedUserDbId) == CacheData.expectedAccount)
-        await cache.addDrive(CacheData.expectedDrive, accountDbId: CacheData.expectedAccountDbId, userDbId: CacheData.expectedUserDbId)
+        await cache.addDrive(CacheData.expectedDrive, accountDbId: CacheData.expectedAccountDbId)
         #expect(await cache.getDrive(driveDbId: CacheData.expectedDriveDbId) == CacheData.expectedDrive)
 
         // WHEN
@@ -324,7 +324,7 @@ struct CoherentCacheSynchroTests {
         #expect(await cache.getUser(dbId: CacheData.expectedUserDbId) == user)
         await cache.addAccount(CacheData.expectedAccount, userDbId: CacheData.expectedUserDbId)
         #expect(await cache.getAccount(accountDbId: CacheData.expectedAccountDbId, userDbId: CacheData.expectedUserDbId) == CacheData.expectedAccount)
-        await cache.addDrive(CacheData.expectedDrive, accountDbId: CacheData.expectedAccountDbId, userDbId: CacheData.expectedUserDbId)
+        await cache.addDrive(CacheData.expectedDrive, accountDbId: CacheData.expectedAccountDbId)
         #expect(await cache.getDrive(driveDbId: CacheData.expectedDriveDbId) == CacheData.expectedDrive)
         await cache.addSynchro(CacheData.expectedSynchro,
                                toDrive: CacheData.expectedDriveDbId,
@@ -358,7 +358,7 @@ struct CoherentCacheSynchroTests {
         #expect(await cache.getUser(dbId: CacheData.expectedUserDbId) == user)
         await cache.addAccount(CacheData.expectedAccount, userDbId: CacheData.expectedUserDbId)
         #expect(await cache.getAccount(accountDbId: CacheData.expectedAccountDbId, userDbId: CacheData.expectedUserDbId) == CacheData.expectedAccount)
-        await cache.addDrive(CacheData.expectedDrive, accountDbId: CacheData.expectedAccountDbId, userDbId: CacheData.expectedUserDbId)
+        await cache.addDrive(CacheData.expectedDrive, accountDbId: CacheData.expectedAccountDbId)
         #expect(await cache.getDrive(driveDbId: CacheData.expectedDriveDbId) == CacheData.expectedDrive)
         await cache.addSynchro(CacheData.expectedSynchro,
                                toDrive: CacheData.expectedDriveDbId,

--- a/src/front/macOS/kDriveTests/Cache/CoherentCacheTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/CoherentCacheTests.swift
@@ -238,7 +238,7 @@ struct CoherentCacheDriveTests {
         #expect(await cache.getAccount(accountDbId: CacheData.expectedAccountDbId, userDbId: CacheData.expectedUserDbId) == CacheData.expectedAccount)
 
         // WHEN
-        await cache.addDrive(CacheData.expectedDrive, accountDbId: CacheData.expectedAccountDbId)
+        try await cache.addDrive(CacheData.expectedDrive, accountDbId: CacheData.expectedAccountDbId)
 
         // THEN
         #expect(await cache.getDrive(driveDbId: CacheData.expectedDriveDbId) == CacheData.expectedDrive)
@@ -252,7 +252,7 @@ struct CoherentCacheDriveTests {
         #expect(await cache.getUser(dbId: CacheData.expectedUserDbId) == user)
         await cache.addAccount(CacheData.expectedAccount, userDbId: CacheData.expectedUserDbId)
         #expect(await cache.getAccount(accountDbId: CacheData.expectedAccountDbId, userDbId: CacheData.expectedUserDbId) == CacheData.expectedAccount)
-        await cache.addDrive(CacheData.expectedDrive, accountDbId: CacheData.expectedAccountDbId)
+        try await cache.addDrive(CacheData.expectedDrive, accountDbId: CacheData.expectedAccountDbId)
         #expect(await cache.getDrive(driveDbId: CacheData.expectedDriveDbId) == CacheData.expectedDrive)
 
         // WHEN
@@ -272,7 +272,7 @@ struct CoherentCacheDriveTests {
         #expect(await cache.getUser(dbId: CacheData.expectedUserDbId) == user)
         await cache.addAccount(CacheData.expectedAccount, userDbId: CacheData.expectedUserDbId)
         #expect(await cache.getAccount(accountDbId: CacheData.expectedAccountDbId, userDbId: CacheData.expectedUserDbId) == CacheData.expectedAccount)
-        await cache.addDrive(CacheData.expectedDrive, accountDbId: CacheData.expectedAccountDbId)
+        try await cache.addDrive(CacheData.expectedDrive, accountDbId: CacheData.expectedAccountDbId)
         #expect(await cache.getDrive(driveDbId: CacheData.expectedDriveDbId) == CacheData.expectedDrive)
 
         // WHEN
@@ -297,7 +297,7 @@ struct CoherentCacheSynchroTests {
         #expect(await cache.getUser(dbId: CacheData.expectedUserDbId) == user)
         await cache.addAccount(CacheData.expectedAccount, userDbId: CacheData.expectedUserDbId)
         #expect(await cache.getAccount(accountDbId: CacheData.expectedAccountDbId, userDbId: CacheData.expectedUserDbId) == CacheData.expectedAccount)
-        await cache.addDrive(CacheData.expectedDrive, accountDbId: CacheData.expectedAccountDbId)
+        try await cache.addDrive(CacheData.expectedDrive, accountDbId: CacheData.expectedAccountDbId)
         #expect(await cache.getDrive(driveDbId: CacheData.expectedDriveDbId) == CacheData.expectedDrive)
 
         // WHEN
@@ -324,7 +324,7 @@ struct CoherentCacheSynchroTests {
         #expect(await cache.getUser(dbId: CacheData.expectedUserDbId) == user)
         await cache.addAccount(CacheData.expectedAccount, userDbId: CacheData.expectedUserDbId)
         #expect(await cache.getAccount(accountDbId: CacheData.expectedAccountDbId, userDbId: CacheData.expectedUserDbId) == CacheData.expectedAccount)
-        await cache.addDrive(CacheData.expectedDrive, accountDbId: CacheData.expectedAccountDbId)
+        try await cache.addDrive(CacheData.expectedDrive, accountDbId: CacheData.expectedAccountDbId)
         #expect(await cache.getDrive(driveDbId: CacheData.expectedDriveDbId) == CacheData.expectedDrive)
         await cache.addSynchro(CacheData.expectedSynchro,
                                toDrive: CacheData.expectedDriveDbId,
@@ -358,7 +358,7 @@ struct CoherentCacheSynchroTests {
         #expect(await cache.getUser(dbId: CacheData.expectedUserDbId) == user)
         await cache.addAccount(CacheData.expectedAccount, userDbId: CacheData.expectedUserDbId)
         #expect(await cache.getAccount(accountDbId: CacheData.expectedAccountDbId, userDbId: CacheData.expectedUserDbId) == CacheData.expectedAccount)
-        await cache.addDrive(CacheData.expectedDrive, accountDbId: CacheData.expectedAccountDbId)
+        try await cache.addDrive(CacheData.expectedDrive, accountDbId: CacheData.expectedAccountDbId)
         #expect(await cache.getDrive(driveDbId: CacheData.expectedDriveDbId) == CacheData.expectedDrive)
         await cache.addSynchro(CacheData.expectedSynchro,
                                toDrive: CacheData.expectedDriveDbId,

--- a/src/front/macOS/kDriveTests/Cache/Observation/ObservableData.swift
+++ b/src/front/macOS/kDriveTests/Cache/Observation/ObservableData.swift
@@ -42,7 +42,10 @@ public enum ObservableData {
                                     name: "The amazing UPDATED test Drive",
                                     color: HexColor(hex: "#0a0a0a"), synchros: [:])
 
-    static let expectedAccount = Account(dbId: expectedAccountDbId, name: "3", drives: [expectedDriveDbId: expectedDrive])
+    static let expectedAccount = Account(dbId: expectedAccountDbId, name: "Some account", drives: [expectedDriveDbId: expectedDrive])
+
+    static let updatedAccount = Account(dbId: expectedAccountDbId, name: "Some UPDATED account", drives: [expectedDriveDbId: updatedDrive])
+
     static let indexedAccounts: IndexedAccounts = [
         1: Account(dbId: 1, name: "1", drives: [:]),
         2: Account(dbId: 2, name: "2", drives: [:]),

--- a/src/front/macOS/kDriveTests/Cache/Observation/ObservableData.swift
+++ b/src/front/macOS/kDriveTests/Cache/Observation/ObservableData.swift
@@ -34,6 +34,14 @@ public enum ObservableData {
                                      name: "The amazing test Drive",
                                      color: HexColor(hex: "#ffffff"), synchros: [:])
 
+    static let updatedDrive = Drive(driveDbId: expectedDriveDbId,
+                                    driveId: expectedDriveId,
+                                    accountId: expectedAccountId,
+                                    userDbId: expectedUserDbId,
+                                    userId: expectedUserId,
+                                    name: "The amazing UPDATED test Drive",
+                                    color: HexColor(hex: "#0a0a0a"), synchros: [:])
+
     static let expectedAccount = Account(dbId: expectedAccountDbId, name: "3", drives: [expectedDriveDbId: expectedDrive])
     static let indexedAccounts: IndexedAccounts = [
         1: Account(dbId: 1, name: "1", drives: [:]),

--- a/src/front/macOS/kDriveTests/Cache/Observation/ObservableData.swift
+++ b/src/front/macOS/kDriveTests/Cache/Observation/ObservableData.swift
@@ -42,15 +42,21 @@ public enum ObservableData {
                                     name: "The amazing UPDATED test Drive",
                                     color: HexColor(hex: "#0a0a0a"), synchros: [:])
 
-    static let expectedAccount = Account(dbId: expectedAccountDbId, name: "Some account", drives: [expectedDriveDbId: expectedDrive])
+    static let expectedAccount = Account(dbId: expectedAccountDbId,
+                                         userDbId: expectedUserDbId,
+                                         name: "Some account",
+                                         drives: [expectedDriveDbId: expectedDrive])
 
-    static let updatedAccount = Account(dbId: expectedAccountDbId, name: "Some UPDATED account", drives: [expectedDriveDbId: updatedDrive])
+    static let updatedAccount = Account(dbId: expectedAccountDbId,
+                                        userDbId: expectedUserDbId,
+                                        name: "Some UPDATED account",
+                                        drives: [expectedDriveDbId: updatedDrive])
 
     static let indexedAccounts: IndexedAccounts = [
-        1: Account(dbId: 1, name: "1", drives: [:]),
-        2: Account(dbId: 2, name: "2", drives: [:]),
+        1: Account(dbId: 1, userDbId: expectedUserDbId, name: "1", drives: [:]),
+        2: Account(dbId: 2, userDbId: expectedUserDbId, name: "2", drives: [:]),
         expectedAccountDbId: expectedAccount,
-        4: Account(dbId: 4, name: "4", drives: [:])
+        4: Account(dbId: 4, userDbId: expectedUserDbId, name: "4", drives: [:])
     ]
 
     static let expectedUser = User(
@@ -88,4 +94,15 @@ public enum ObservableData {
         isConnected: true,
         isStaff: true
     )
+
+    static let expectedSynchroDbId = Int32.random(in: 0 ... 1000)
+    static let expectedSynchroPath = "/dev/null"
+    static let expectedSynchro = Synchro(dbId: expectedSynchroDbId,
+                                         driveDbId: expectedDriveDbId,
+                                         localPath: expectedSynchroPath)
+
+    static let updatedSynchroPath = "C:\\Windows\\System32"
+    static let updatedSynchro = Synchro(dbId: expectedSynchroDbId,
+                                        driveDbId: expectedDriveDbId,
+                                        localPath: updatedSynchroPath)
 }

--- a/src/front/macOS/kDriveTests/Cache/Observation/ObservableData.swift
+++ b/src/front/macOS/kDriveTests/Cache/Observation/ObservableData.swift
@@ -52,10 +52,35 @@ public enum ObservableData {
         expectedAccountDbId: expectedAccount,
         4: Account(dbId: 4, name: "4", drives: [:])
     ]
+
     static let expectedUser = User(
         dbId: expectedUserDbId,
         userId: expectedUserId,
         name: "appleseed",
+        email: "ja@apple.com",
+        accounts: [:],
+        availableDrives: [:],
+        avatar: Data(),
+        isConnected: true,
+        isStaff: false
+    )
+
+    static let expectedUserWithAccounts = User(
+        dbId: expectedUserDbId,
+        userId: expectedUserId,
+        name: "appleseed",
+        email: "ja@apple.com",
+        accounts: indexedAccounts,
+        availableDrives: [:],
+        avatar: Data(),
+        isConnected: true,
+        isStaff: false
+    )
+
+    static let updatedUser = User(
+        dbId: expectedUserDbId,
+        userId: expectedUserId,
+        name: "appleseed UPDATE",
         email: "ja@apple.com",
         accounts: indexedAccounts,
         availableDrives: [:],

--- a/src/front/macOS/kDriveTests/Cache/Observation/ObservedAccountTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/Observation/ObservedAccountTests.swift
@@ -19,19 +19,20 @@
 import Foundation
 @testable import InfomaniakDI
 @testable import kDriveCore
-import XCTest
+import Testing
 
-final class ObservedAccountTests_dbIdOnly: XCTestCase {
-    func testSetObservedAccount() async throws {
+@MainActor
+struct ObservedAccountTests_dbIdOnly {
+    @Test func setObservedAccount() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
-        XCTAssertNil(initialUser, "Cache should initially be empty")
+        #expect(initialUser == nil, "Cache should initially be empty")
 
         @ObservedAccount(accountDbId: ObservableData.expectedAccountDbId,
                          cacheObservation: cache) var observedAccount: Account?
         let receivedValues = $observedAccount.receivedValues // Start to save the received values
-        XCTAssertNil(observedAccount, "Account should initially be nil")
+        #expect(observedAccount == nil, "Account should initially be nil")
 
         // WHEN
         let expectedUser = ObservableData.expectedUserWithAccounts
@@ -39,26 +40,26 @@ final class ObservedAccountTests_dbIdOnly: XCTestCase {
 
         // THEN
         let lastReceivedObject = await receivedValues.first(where: { $0 != nil })
-        XCTAssertEqual(lastReceivedObject, ObservableData.expectedAccount)
+        #expect(lastReceivedObject == ObservableData.expectedAccount)
 
         let cachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
         let cachedAccount = await cache.getAccount(accountDbId: ObservableData.expectedAccountDbId, userDbId: ObservableData.expectedUserDbId)
 
-        XCTAssertEqual(cachedUser, expectedUser, "The cache user should have been updated")
-        XCTAssertEqual(cachedAccount, ObservableData.expectedAccount, "The cache account should have been updated")
-        XCTAssertEqual(observedAccount, ObservableData.expectedAccount, "The observed object should have been updated")
+        #expect(cachedUser == expectedUser, "The cache user should have been updated")
+        #expect(cachedAccount == ObservableData.expectedAccount, "The cache account should have been updated")
+        #expect(observedAccount == ObservableData.expectedAccount, "The observed object should have been updated")
     }
 
-    func testUpdateObservedAccount() async throws {
+    @Test func updateObservedAccount() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
-        XCTAssertNil(initialUser, "Cache should initially be empty")
+        #expect(initialUser == nil, "Cache should initially be empty")
 
         @ObservedAccount(accountDbId: ObservableData.expectedAccountDbId,
                          cacheObservation: cache) var observedAccount: Account?
         let receivedValues = $observedAccount.receivedValues
-        XCTAssertNil(observedAccount, "Account should initially be nil")
+        #expect(observedAccount == nil, "Account should initially be nil")
 
         let expectedUser = ObservableData.expectedUserWithAccounts
         await cache.addUser(expectedUser)
@@ -66,8 +67,8 @@ final class ObservedAccountTests_dbIdOnly: XCTestCase {
         let cachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
         let cachedAccount = await cache.getAccount(accountDbId: ObservableData.expectedAccountDbId, userDbId: ObservableData.expectedUserDbId)
 
-        XCTAssertEqual(cachedUser, expectedUser, "The cache user should have been updated")
-        XCTAssertEqual(cachedAccount, ObservableData.expectedAccount, "The cache account should have been updated")
+        #expect(cachedUser == expectedUser, "The cache user should have been updated")
+        #expect(cachedAccount == ObservableData.expectedAccount, "The cache account should have been updated")
 
         // WHEN
         try await cache.updateAccount(ObservableData.updatedAccount)
@@ -76,20 +77,20 @@ final class ObservedAccountTests_dbIdOnly: XCTestCase {
         _ = await receivedValues.dropFirst().first(where: { $0 != nil })
 
         let latestAccount = await cache.getAccount(accountDbId: ObservableData.expectedAccountDbId, userDbId: ObservableData.expectedUserDbId)
-        XCTAssertEqual(latestAccount, ObservableData.updatedAccount, "The cache account should have been updated again")
-        XCTAssertEqual(observedAccount, ObservableData.updatedAccount, "The observed object should have been updated again")
+        #expect(latestAccount == ObservableData.updatedAccount, "The cache account should have been updated again")
+        #expect(observedAccount == ObservableData.updatedAccount, "The observed object should have been updated again")
     }
 
-    func testDoubleUpdateObservedAccount() async throws {
+    @Test func doubleUpdateObservedAccount() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
-        XCTAssertNil(initialUser, "Cache should initially be empty")
+        #expect(initialUser == nil, "Cache should initially be empty")
 
         @ObservedAccount(accountDbId: ObservableData.expectedAccountDbId,
                          cacheObservation: cache) var observedAccount: Account?
         let receivedValues = $observedAccount.receivedValues
-        XCTAssertNil(observedAccount, "Account should initially be nil")
+        #expect(observedAccount == nil, "Account should initially be nil")
 
         let expectedUser = ObservableData.expectedUserWithAccounts
         await cache.addUser(expectedUser)
@@ -97,8 +98,8 @@ final class ObservedAccountTests_dbIdOnly: XCTestCase {
         let cachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
         let cachedAccount = await cache.getAccount(accountDbId: ObservableData.expectedAccountDbId, userDbId: ObservableData.expectedUserDbId)
 
-        XCTAssertEqual(cachedUser, expectedUser, "The cache user should have been updated")
-        XCTAssertEqual(cachedAccount, ObservableData.expectedAccount, "The cache account should have been updated")
+        #expect(cachedUser == expectedUser, "The cache user should have been updated")
+        #expect(cachedAccount == ObservableData.expectedAccount, "The cache account should have been updated")
 
         // WHEN
         try await cache.updateAccount(ObservableData.updatedAccount)
@@ -108,20 +109,20 @@ final class ObservedAccountTests_dbIdOnly: XCTestCase {
         _ = await receivedValues.dropFirst().dropFirst().first(where: { $0 != nil })
 
         let latestAccount = await cache.getAccount(accountDbId: ObservableData.expectedAccountDbId, userDbId: ObservableData.expectedUserDbId)
-        XCTAssertEqual(latestAccount, ObservableData.updatedAccount, "The cache account should have been updated again")
-        XCTAssertEqual(observedAccount, ObservableData.updatedAccount, "The observed object should have been updated again")
+        #expect(latestAccount == ObservableData.updatedAccount, "The cache account should have been updated again")
+        #expect(observedAccount == ObservableData.updatedAccount, "The observed object should have been updated again")
     }
 
-    func testDeleteObservedAccount() async throws {
+    @Test func deleteObservedAccount() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
-        XCTAssertNil(initialUser, "Cache should initially be empty")
+        #expect(initialUser == nil, "Cache should initially be empty")
 
         @ObservedAccount(accountDbId: ObservableData.expectedAccountDbId,
                          cacheObservation: cache) var observedAccount: Account?
         let receivedValues = $observedAccount.receivedValues
-        XCTAssertNil(observedAccount, "Account should initially be nil")
+        #expect(observedAccount == nil, "Account should initially be nil")
 
         let expectedUser = ObservableData.expectedUserWithAccounts
         await cache.addUser(expectedUser)
@@ -129,30 +130,31 @@ final class ObservedAccountTests_dbIdOnly: XCTestCase {
         let cachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
         let cachedAccount = await cache.getAccount(accountDbId: ObservableData.expectedAccountDbId, userDbId: ObservableData.expectedUserDbId)
 
-        XCTAssertEqual(cachedUser, expectedUser, "The cache user should have been updated")
-        XCTAssertEqual(cachedAccount, ObservableData.expectedAccount, "The cache account should have been updated")
+        #expect(cachedUser == expectedUser, "The cache user should have been updated")
+        #expect(cachedAccount == ObservableData.expectedAccount, "The cache account should have been updated")
 
         // WHEN
         await cache.removeAccount(accountDbId: ObservableData.expectedAccountDbId)
 
         // THEN
         _ = await receivedValues.dropFirst().first(where: { $0 == nil })
-        XCTAssertNil(observedAccount, "The observed object should be nil to reflect deletion")
+        #expect(observedAccount == nil, "The observed object should be nil to reflect deletion")
     }
 }
 
-final class ObservedAccountTests_allIds: XCTestCase {
-    func testSetObservedAccount() async throws {
+@MainActor
+struct ObservedAccountTests_allIds {
+    @Test func setObservedAccount() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
-        XCTAssertNil(initialUser, "Cache should initially be empty")
+        #expect(initialUser == nil, "Cache should initially be empty")
 
         @ObservedAccount(userDbId: ObservableData.expectedUserDbId,
                          accountDbId: ObservableData.expectedAccountDbId,
                          cacheObservation: cache) var observedAccount: Account?
         let receivedValues = $observedAccount.receivedValues
-        XCTAssertNil(observedAccount, "Account should initially be nil")
+        #expect(observedAccount == nil, "Account should initially be nil")
 
         // WHEN
         let expectedUser = ObservableData.expectedUserWithAccounts
@@ -160,26 +162,26 @@ final class ObservedAccountTests_allIds: XCTestCase {
 
         // THEN
         let lastReceivedObject = await receivedValues.first(where: { $0 != nil })
-        XCTAssertEqual(lastReceivedObject, ObservableData.expectedAccount)
+        #expect(lastReceivedObject == ObservableData.expectedAccount)
 
         let cachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
         let cachedAccount = await cache.getAccount(accountDbId: ObservableData.expectedAccountDbId, userDbId: ObservableData.expectedUserDbId)
-        XCTAssertEqual(cachedUser, expectedUser, "The cache user should have been updated")
-        XCTAssertEqual(cachedAccount, ObservableData.expectedAccount, "The cache account should have been updated")
-        XCTAssertEqual(observedAccount, ObservableData.expectedAccount, "The observed object should have been updated")
+        #expect(cachedUser == expectedUser, "The cache user should have been updated")
+        #expect(cachedAccount == ObservableData.expectedAccount, "The cache account should have been updated")
+        #expect(observedAccount == ObservableData.expectedAccount, "The observed object should have been updated")
     }
 
-    func testUpdateObservedAccount() async throws {
+    @Test func updateObservedAccount() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
-        XCTAssertNil(initialUser, "Cache should initially be empty")
+        #expect(initialUser == nil, "Cache should initially be empty")
 
         @ObservedAccount(userDbId: ObservableData.expectedUserDbId,
                          accountDbId: ObservableData.expectedAccountDbId,
                          cacheObservation: cache) var observedAccount: Account?
         let receivedValues = $observedAccount.receivedValues
-        XCTAssertNil(observedAccount, "Account should initially be nil")
+        #expect(observedAccount == nil, "Account should initially be nil")
 
         let expectedUser = ObservableData.expectedUserWithAccounts
         await cache.addUser(expectedUser)
@@ -187,8 +189,8 @@ final class ObservedAccountTests_allIds: XCTestCase {
         let cachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
         let cachedAccount = await cache.getAccount(accountDbId: ObservableData.expectedAccountDbId, userDbId: ObservableData.expectedUserDbId)
 
-        XCTAssertEqual(cachedUser, expectedUser, "The cache user should have been updated")
-        XCTAssertEqual(cachedAccount, ObservableData.expectedAccount, "The cache account should have been updated")
+        #expect(cachedUser == expectedUser, "The cache user should have been updated")
+        #expect(cachedAccount == ObservableData.expectedAccount, "The cache account should have been updated")
 
         // WHEN
         try await cache.updateAccount(ObservableData.updatedAccount)
@@ -197,21 +199,21 @@ final class ObservedAccountTests_allIds: XCTestCase {
         _ = await receivedValues.dropFirst().first(where: { $0 != nil })
 
         let latestAccount = await cache.getAccount(accountDbId: ObservableData.expectedAccountDbId, userDbId: ObservableData.expectedUserDbId)
-        XCTAssertEqual(latestAccount, ObservableData.updatedAccount, "The cache account should have been updated again")
-        XCTAssertEqual(observedAccount, ObservableData.updatedAccount, "The observed object should have been updated again")
+        #expect(latestAccount == ObservableData.updatedAccount, "The cache account should have been updated again")
+        #expect(observedAccount == ObservableData.updatedAccount, "The observed object should have been updated again")
     }
 
-    func testDoubleUpdateObservedAccount() async throws {
+    @Test func doubleUpdateObservedAccount() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
-        XCTAssertNil(initialUser, "Cache should initially be empty")
+        #expect(initialUser == nil, "Cache should initially be empty")
 
         @ObservedAccount(userDbId: ObservableData.expectedUserDbId,
                          accountDbId: ObservableData.expectedAccountDbId,
                          cacheObservation: cache) var observedAccount: Account?
         let receivedValues = $observedAccount.receivedValues
-        XCTAssertNil(observedAccount, "Account should initially be nil")
+        #expect(observedAccount == nil, "Account should initially be nil")
 
         let expectedUser = ObservableData.expectedUserWithAccounts
         await cache.addUser(expectedUser)
@@ -219,8 +221,8 @@ final class ObservedAccountTests_allIds: XCTestCase {
         let cachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
         let cachedAccount = await cache.getAccount(accountDbId: ObservableData.expectedAccountDbId, userDbId: ObservableData.expectedUserDbId)
 
-        XCTAssertEqual(cachedUser, expectedUser, "The cache user should have been updated")
-        XCTAssertEqual(cachedAccount, ObservableData.expectedAccount, "The cache account should have been updated")
+        #expect(cachedUser == expectedUser, "The cache user should have been updated")
+        #expect(cachedAccount == ObservableData.expectedAccount, "The cache account should have been updated")
 
         // WHEN
         try await cache.updateAccount(ObservableData.updatedAccount)
@@ -230,21 +232,21 @@ final class ObservedAccountTests_allIds: XCTestCase {
         _ = await receivedValues.dropFirst().dropFirst().first(where: { $0 != nil })
 
         let latestAccount = await cache.getAccount(accountDbId: ObservableData.expectedAccountDbId, userDbId: ObservableData.expectedUserDbId)
-        XCTAssertEqual(latestAccount, ObservableData.updatedAccount, "The cache account should have been updated again")
-        XCTAssertEqual(observedAccount, ObservableData.updatedAccount, "The observed object should have been updated again")
+        #expect(latestAccount == ObservableData.updatedAccount, "The cache account should have been updated again")
+        #expect(observedAccount == ObservableData.updatedAccount, "The observed object should have been updated again")
     }
 
-    func testDeleteObservedAccount() async throws {
+    @Test func deleteObservedAccount() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
-        XCTAssertNil(initialUser, "Cache should initially be empty")
+        #expect(initialUser == nil, "Cache should initially be empty")
 
         @ObservedAccount(userDbId: ObservableData.expectedUserDbId,
                          accountDbId: ObservableData.expectedAccountDbId,
                          cacheObservation: cache) var observedAccount: Account?
         let receivedValues = $observedAccount.receivedValues
-        XCTAssertNil(observedAccount, "Account should initially be nil")
+        #expect(observedAccount == nil, "Account should initially be nil")
 
         let expectedUser = ObservableData.expectedUserWithAccounts
         await cache.addUser(expectedUser)
@@ -252,8 +254,8 @@ final class ObservedAccountTests_allIds: XCTestCase {
         let cachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
         let cachedAccount = await cache.getAccount(accountDbId: ObservableData.expectedAccountDbId, userDbId: ObservableData.expectedUserDbId)
 
-        XCTAssertEqual(cachedUser, expectedUser, "The cache user should have been updated")
-        XCTAssertEqual(cachedAccount, ObservableData.expectedAccount, "The cache account should have been updated")
+        #expect(cachedUser == expectedUser, "The cache user should have been updated")
+        #expect(cachedAccount == ObservableData.expectedAccount, "The cache account should have been updated")
 
         // WHEN
         await cache.removeAccount(accountDbId: ObservableData.expectedAccountDbId)
@@ -261,6 +263,6 @@ final class ObservedAccountTests_allIds: XCTestCase {
         // THEN
         _ = await receivedValues.dropFirst().first(where: { $0 == nil })
 
-        XCTAssertNil(observedAccount, "The observed object should be nil to reflect deletion")
+        #expect(observedAccount == nil, "The observed object should be nil to reflect deletion")
     }
 }

--- a/src/front/macOS/kDriveTests/Cache/Observation/ObservedAccountTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/Observation/ObservedAccountTests.swift
@@ -23,7 +23,8 @@ import Testing
 
 @MainActor
 struct ObservedAccountTests_dbIdOnly {
-    @Test func setObservedAccount() async throws {
+    @Test(.timeLimit(.minutes(1)))
+    func setObservedAccount() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
@@ -50,7 +51,8 @@ struct ObservedAccountTests_dbIdOnly {
         #expect(observedAccount == ObservableData.expectedAccount, "The observed object should have been updated")
     }
 
-    @Test func updateObservedAccount() async throws {
+    @Test(.timeLimit(.minutes(1)))
+    func updateObservedAccount() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
@@ -81,7 +83,8 @@ struct ObservedAccountTests_dbIdOnly {
         #expect(observedAccount == ObservableData.updatedAccount, "The observed object should have been updated again")
     }
 
-    @Test func doubleUpdateObservedAccount() async throws {
+    @Test(.timeLimit(.minutes(1)))
+    func doubleUpdateObservedAccount() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
@@ -113,7 +116,8 @@ struct ObservedAccountTests_dbIdOnly {
         #expect(observedAccount == ObservableData.updatedAccount, "The observed object should have been updated again")
     }
 
-    @Test func deleteObservedAccount() async throws {
+    @Test(.timeLimit(.minutes(1)))
+    func deleteObservedAccount() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
@@ -144,7 +148,8 @@ struct ObservedAccountTests_dbIdOnly {
 
 @MainActor
 struct ObservedAccountTests_allIds {
-    @Test func setObservedAccount() async throws {
+    @Test(.timeLimit(.minutes(1)))
+    func setObservedAccount() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
@@ -171,7 +176,8 @@ struct ObservedAccountTests_allIds {
         #expect(observedAccount == ObservableData.expectedAccount, "The observed object should have been updated")
     }
 
-    @Test func updateObservedAccount() async throws {
+    @Test(.timeLimit(.minutes(1)))
+    func updateObservedAccount() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
@@ -203,7 +209,8 @@ struct ObservedAccountTests_allIds {
         #expect(observedAccount == ObservableData.updatedAccount, "The observed object should have been updated again")
     }
 
-    @Test func doubleUpdateObservedAccount() async throws {
+    @Test(.timeLimit(.minutes(1)))
+    func doubleUpdateObservedAccount() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
@@ -236,7 +243,8 @@ struct ObservedAccountTests_allIds {
         #expect(observedAccount == ObservableData.updatedAccount, "The observed object should have been updated again")
     }
 
-    @Test func deleteObservedAccount() async throws {
+    @Test(.timeLimit(.minutes(1)))
+    func deleteObservedAccount() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)

--- a/src/front/macOS/kDriveTests/Cache/Observation/ObservedAccountTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/Observation/ObservedAccountTests.swift
@@ -33,7 +33,7 @@ final class ObservedAccountTests_dbIdOnly: XCTestCase {
         XCTAssertNil(observedAccount, "Account should initially be nil")
 
         // WHEN
-        let expectedUser = ObservableData.expectedUser
+        let expectedUser = ObservableData.expectedUserWithAccounts
         await cache.addUser(expectedUser)
 
         // Give time for observation to propagate
@@ -58,7 +58,7 @@ final class ObservedAccountTests_dbIdOnly: XCTestCase {
                          cacheObservation: cache) var observedAccount: Account?
         XCTAssertNil(observedAccount, "Account should initially be nil")
 
-        let expectedUser = ObservableData.expectedUser
+        let expectedUser = ObservableData.expectedUserWithAccounts
         await cache.addUser(expectedUser)
 
         let cachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
@@ -89,7 +89,7 @@ final class ObservedAccountTests_dbIdOnly: XCTestCase {
                          cacheObservation: cache) var observedAccount: Account?
         XCTAssertNil(observedAccount, "Account should initially be nil")
 
-        let expectedUser = ObservableData.expectedUser
+        let expectedUser = ObservableData.expectedUserWithAccounts
         await cache.addUser(expectedUser)
 
         let cachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
@@ -121,7 +121,7 @@ final class ObservedAccountTests_dbIdOnly: XCTestCase {
                          cacheObservation: cache) var observedAccount: Account?
         XCTAssertNil(observedAccount, "Account should initially be nil")
 
-        let expectedUser = ObservableData.expectedUser
+        let expectedUser = ObservableData.expectedUserWithAccounts
         await cache.addUser(expectedUser)
 
         let cachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
@@ -154,7 +154,7 @@ final class ObservedAccountTests_allIds: XCTestCase {
         XCTAssertNil(observedAccount, "Account should initially be nil")
 
         // WHEN
-        let expectedUser = ObservableData.expectedUser
+        let expectedUser = ObservableData.expectedUserWithAccounts
         await cache.addUser(expectedUser)
 
         // Give time for observation to propagate
@@ -179,7 +179,7 @@ final class ObservedAccountTests_allIds: XCTestCase {
                          cacheObservation: cache) var observedAccount: Account?
         XCTAssertNil(observedAccount, "Account should initially be nil")
 
-        let expectedUser = ObservableData.expectedUser
+        let expectedUser = ObservableData.expectedUserWithAccounts
         await cache.addUser(expectedUser)
 
         let cachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
@@ -211,7 +211,7 @@ final class ObservedAccountTests_allIds: XCTestCase {
                          cacheObservation: cache) var observedAccount: Account?
         XCTAssertNil(observedAccount, "Account should initially be nil")
 
-        let expectedUser = ObservableData.expectedUser
+        let expectedUser = ObservableData.expectedUserWithAccounts
         await cache.addUser(expectedUser)
 
         let cachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
@@ -244,7 +244,7 @@ final class ObservedAccountTests_allIds: XCTestCase {
                          cacheObservation: cache) var observedAccount: Account?
         XCTAssertNil(observedAccount, "Account should initially be nil")
 
-        let expectedUser = ObservableData.expectedUser
+        let expectedUser = ObservableData.expectedUserWithAccounts
         await cache.addUser(expectedUser)
 
         let cachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)

--- a/src/front/macOS/kDriveTests/Cache/Observation/ObservedAccountTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/Observation/ObservedAccountTests.swift
@@ -78,7 +78,7 @@ final class ObservedAccountTests_dbIdOnly: XCTestCase {
         XCTAssertEqual(latestAccount, ObservableData.updatedAccount, "The cache account should have been updated again")
         XCTAssertEqual(observedAccount, ObservableData.updatedAccount, "The observed object should have been updated again")
     }
-    
+
     func testDoubleUpdateObservedAccount() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
@@ -199,7 +199,7 @@ final class ObservedAccountTests_allIds: XCTestCase {
         XCTAssertEqual(latestAccount, ObservableData.updatedAccount, "The cache account should have been updated again")
         XCTAssertEqual(observedAccount, ObservableData.updatedAccount, "The observed object should have been updated again")
     }
-    
+
     func testDoubleUpdateObservedAccount() async throws {
         // GIVEN
         let cache = ServerCoherentCache()

--- a/src/front/macOS/kDriveTests/Cache/Observation/ObservedAccountTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/Observation/ObservedAccountTests.swift
@@ -16,10 +16,22 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import Combine
 import Foundation
 @testable import InfomaniakDI
-@testable import kDriveCore
+import kDriveCore
 import Testing
+
+extension ObservedAccount {
+    var receivedValues: AsyncStream<Account?> {
+        AsyncStream { continuation in
+            let cancellable = $wrappedValue
+                .sink { value in continuation.yield(value) }
+
+            continuation.onTermination = { _ in cancellable.cancel() }
+        }
+    }
+}
 
 @MainActor
 struct ObservedAccountTests_dbIdOnly {

--- a/src/front/macOS/kDriveTests/Cache/Observation/ObservedAccountTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/Observation/ObservedAccountTests.swift
@@ -21,8 +21,128 @@ import Foundation
 import kDriveCore
 import XCTest
 
-final class ObservedAccountTests: XCTestCase {
-    func testSetGetAccountFromPropertyWrapper_userDbId_accountDbId() async throws {
+final class ObservedAccountTests_dbIdOnly: XCTestCase {
+    func testSetObservedAccount() async throws {
+        // GIVEN
+        let cache = ServerCoherentCache()
+        let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        XCTAssertNil(initialUser, "Cache should initially be empty")
+
+        @ObservedAccount(accountDbId: ObservableData.expectedAccountDbId,
+                         cacheObservation: cache) var observedAccount: Account?
+        XCTAssertNil(observedAccount, "Account should initially be nil")
+
+        // WHEN
+        let expectedUser = ObservableData.expectedUser
+        await cache.addUser(expectedUser)
+
+        // Give time for observation to propagate
+        try await Task.sleep(nanoseconds: 10_000_000_000)
+
+        // THEN
+        let cachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        let cachedAccount = await cache.getAccount(accountDbId: ObservableData.expectedAccountDbId, userDbId: ObservableData.expectedUserDbId)
+
+        XCTAssertEqual(cachedUser, expectedUser, "The cache user should have been updated")
+        XCTAssertEqual(cachedAccount, ObservableData.expectedAccount, "The cache account should have been updated")
+        XCTAssertEqual(observedAccount, ObservableData.expectedAccount, "The observed object should have been updated")
+    }
+
+    func testUpdateObservedAccount() async throws {
+        // GIVEN
+        let cache = ServerCoherentCache()
+        let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        XCTAssertNil(initialUser, "Cache should initially be empty")
+
+        @ObservedAccount(accountDbId: ObservableData.expectedAccountDbId,
+                         cacheObservation: cache) var observedAccount: Account?
+        XCTAssertNil(observedAccount, "Account should initially be nil")
+
+        let expectedUser = ObservableData.expectedUser
+        await cache.addUser(expectedUser)
+
+        let cachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        let cachedAccount = await cache.getAccount(accountDbId: ObservableData.expectedAccountDbId, userDbId: ObservableData.expectedUserDbId)
+
+        XCTAssertEqual(cachedUser, expectedUser, "The cache user should have been updated")
+        XCTAssertEqual(cachedAccount, ObservableData.expectedAccount, "The cache account should have been updated")
+
+        // WHEN
+        try await cache.updateAccount(ObservableData.updatedAccount)
+
+        // Give time for observation to propagate
+        try await Task.sleep(nanoseconds: 10_000_000_000)
+
+        // THEN
+        let latestAccount = await cache.getAccount(accountDbId: ObservableData.expectedAccountDbId, userDbId: ObservableData.expectedUserDbId)
+        XCTAssertEqual(latestAccount, ObservableData.updatedAccount, "The cache account should have been updated again")
+        XCTAssertEqual(observedAccount, ObservableData.updatedAccount, "The observed object should have been updated again")
+    }
+    
+    func testDoubleUpdateObservedAccount() async throws {
+        // GIVEN
+        let cache = ServerCoherentCache()
+        let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        XCTAssertNil(initialUser, "Cache should initially be empty")
+
+        @ObservedAccount(accountDbId: ObservableData.expectedAccountDbId,
+                         cacheObservation: cache) var observedAccount: Account?
+        XCTAssertNil(observedAccount, "Account should initially be nil")
+
+        let expectedUser = ObservableData.expectedUser
+        await cache.addUser(expectedUser)
+
+        let cachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        let cachedAccount = await cache.getAccount(accountDbId: ObservableData.expectedAccountDbId, userDbId: ObservableData.expectedUserDbId)
+
+        XCTAssertEqual(cachedUser, expectedUser, "The cache user should have been updated")
+        XCTAssertEqual(cachedAccount, ObservableData.expectedAccount, "The cache account should have been updated")
+
+        // WHEN
+        try await cache.updateAccount(ObservableData.updatedAccount)
+        try await cache.updateAccount(ObservableData.updatedAccount)
+
+        // Give time for observation to propagate
+        try await Task.sleep(nanoseconds: 10_000_000_000)
+
+        // THEN
+        let latestAccount = await cache.getAccount(accountDbId: ObservableData.expectedAccountDbId, userDbId: ObservableData.expectedUserDbId)
+        XCTAssertEqual(latestAccount, ObservableData.updatedAccount, "The cache account should have been updated again")
+        XCTAssertEqual(observedAccount, ObservableData.updatedAccount, "The observed object should have been updated again")
+    }
+
+    func testDeleteObservedAccount() async throws {
+        // GIVEN
+        let cache = ServerCoherentCache()
+        let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        XCTAssertNil(initialUser, "Cache should initially be empty")
+
+        @ObservedAccount(accountDbId: ObservableData.expectedAccountDbId,
+                         cacheObservation: cache) var observedAccount: Account?
+        XCTAssertNil(observedAccount, "Account should initially be nil")
+
+        let expectedUser = ObservableData.expectedUser
+        await cache.addUser(expectedUser)
+
+        let cachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        let cachedAccount = await cache.getAccount(accountDbId: ObservableData.expectedAccountDbId, userDbId: ObservableData.expectedUserDbId)
+
+        XCTAssertEqual(cachedUser, expectedUser, "The cache user should have been updated")
+        XCTAssertEqual(cachedAccount, ObservableData.expectedAccount, "The cache account should have been updated")
+
+        // WHEN
+        await cache.removeAccount(accountDbId: ObservableData.expectedAccountDbId)
+
+        // Give time for observation to propagate
+        try await Task.sleep(nanoseconds: 10_000_000_000)
+
+        // THEN
+        XCTAssertNil(observedAccount, "The observed object should be nil to reflect deletion")
+    }
+}
+
+final class ObservedAccountTests_allIds: XCTestCase {
+    func testSetObservedAccount() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
@@ -34,9 +154,8 @@ final class ObservedAccountTests: XCTestCase {
         XCTAssertNil(observedAccount, "Account should initially be nil")
 
         // WHEN
-        let user = ObservableData.expectedUser
-
-        await cache.addUser(user)
+        let expectedUser = ObservableData.expectedUser
+        await cache.addUser(expectedUser)
 
         // Give time for observation to propagate
         try await Task.sleep(nanoseconds: 10_000_000_000)
@@ -44,35 +163,103 @@ final class ObservedAccountTests: XCTestCase {
         // THEN
         let cachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
         let cachedAccount = await cache.getAccount(accountDbId: ObservableData.expectedAccountDbId, userDbId: ObservableData.expectedUserDbId)
-        XCTAssertEqual(cachedUser, user, "The cache user should have been updated")
+        XCTAssertEqual(cachedUser, expectedUser, "The cache user should have been updated")
         XCTAssertEqual(cachedAccount, ObservableData.expectedAccount, "The cache account should have been updated")
         XCTAssertEqual(observedAccount, ObservableData.expectedAccount, "The observed object should have been updated")
     }
 
-    func testSetGetAccountFromPropertyWrapper_accountDbId() async throws {
+    func testUpdateObservedAccount() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
         XCTAssertNil(initialUser, "Cache should initially be empty")
 
-        @ObservedAccount(accountDbId: ObservableData.expectedAccountDbId,
+        @ObservedAccount(userDbId: ObservableData.expectedUserDbId,
+                         accountDbId: ObservableData.expectedAccountDbId,
                          cacheObservation: cache) var observedAccount: Account?
         XCTAssertNil(observedAccount, "Account should initially be nil")
 
-        // WHEN
-        let user = ObservableData.expectedUser
+        let expectedUser = ObservableData.expectedUser
+        await cache.addUser(expectedUser)
 
-        await cache.addUser(user)
+        let cachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        let cachedAccount = await cache.getAccount(accountDbId: ObservableData.expectedAccountDbId, userDbId: ObservableData.expectedUserDbId)
+
+        XCTAssertEqual(cachedUser, expectedUser, "The cache user should have been updated")
+        XCTAssertEqual(cachedAccount, ObservableData.expectedAccount, "The cache account should have been updated")
+
+        // WHEN
+        try await cache.updateAccount(ObservableData.updatedAccount)
 
         // Give time for observation to propagate
         try await Task.sleep(nanoseconds: 10_000_000_000)
 
         // THEN
+        let latestAccount = await cache.getAccount(accountDbId: ObservableData.expectedAccountDbId, userDbId: ObservableData.expectedUserDbId)
+        XCTAssertEqual(latestAccount, ObservableData.updatedAccount, "The cache account should have been updated again")
+        XCTAssertEqual(observedAccount, ObservableData.updatedAccount, "The observed object should have been updated again")
+    }
+    
+    func testDoubleUpdateObservedAccount() async throws {
+        // GIVEN
+        let cache = ServerCoherentCache()
+        let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        XCTAssertNil(initialUser, "Cache should initially be empty")
+
+        @ObservedAccount(userDbId: ObservableData.expectedUserDbId,
+                         accountDbId: ObservableData.expectedAccountDbId,
+                         cacheObservation: cache) var observedAccount: Account?
+        XCTAssertNil(observedAccount, "Account should initially be nil")
+
+        let expectedUser = ObservableData.expectedUser
+        await cache.addUser(expectedUser)
+
         let cachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
         let cachedAccount = await cache.getAccount(accountDbId: ObservableData.expectedAccountDbId, userDbId: ObservableData.expectedUserDbId)
 
-        XCTAssertEqual(cachedUser, user, "The cache user should have been updated")
+        XCTAssertEqual(cachedUser, expectedUser, "The cache user should have been updated")
         XCTAssertEqual(cachedAccount, ObservableData.expectedAccount, "The cache account should have been updated")
-        XCTAssertEqual(observedAccount, ObservableData.expectedAccount, "The observed object should have been updated")
+
+        // WHEN
+        try await cache.updateAccount(ObservableData.updatedAccount)
+        try await cache.updateAccount(ObservableData.updatedAccount)
+
+        // Give time for observation to propagate
+        try await Task.sleep(nanoseconds: 10_000_000_000)
+
+        // THEN
+        let latestAccount = await cache.getAccount(accountDbId: ObservableData.expectedAccountDbId, userDbId: ObservableData.expectedUserDbId)
+        XCTAssertEqual(latestAccount, ObservableData.updatedAccount, "The cache account should have been updated again")
+        XCTAssertEqual(observedAccount, ObservableData.updatedAccount, "The observed object should have been updated again")
+    }
+
+    func testDeleteObservedAccount() async throws {
+        // GIVEN
+        let cache = ServerCoherentCache()
+        let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        XCTAssertNil(initialUser, "Cache should initially be empty")
+
+        @ObservedAccount(userDbId: ObservableData.expectedUserDbId,
+                         accountDbId: ObservableData.expectedAccountDbId,
+                         cacheObservation: cache) var observedAccount: Account?
+        XCTAssertNil(observedAccount, "Account should initially be nil")
+
+        let expectedUser = ObservableData.expectedUser
+        await cache.addUser(expectedUser)
+
+        let cachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        let cachedAccount = await cache.getAccount(accountDbId: ObservableData.expectedAccountDbId, userDbId: ObservableData.expectedUserDbId)
+
+        XCTAssertEqual(cachedUser, expectedUser, "The cache user should have been updated")
+        XCTAssertEqual(cachedAccount, ObservableData.expectedAccount, "The cache account should have been updated")
+
+        // WHEN
+        await cache.removeAccount(accountDbId: ObservableData.expectedAccountDbId)
+
+        // Give time for observation to propagate
+        try await Task.sleep(nanoseconds: 10_000_000_000)
+
+        // THEN
+        XCTAssertNil(observedAccount, "The observed object should be nil to reflect deletion")
     }
 }

--- a/src/front/macOS/kDriveTests/Cache/Observation/ObservedAccountTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/Observation/ObservedAccountTests.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 @testable import InfomaniakDI
-import kDriveCore
+@testable import kDriveCore
 import XCTest
 
 final class ObservedAccountTests_dbIdOnly: XCTestCase {
@@ -30,16 +30,17 @@ final class ObservedAccountTests_dbIdOnly: XCTestCase {
 
         @ObservedAccount(accountDbId: ObservableData.expectedAccountDbId,
                          cacheObservation: cache) var observedAccount: Account?
+        let receivedValues = $observedAccount.receivedValues // Start to save the received values
         XCTAssertNil(observedAccount, "Account should initially be nil")
 
         // WHEN
         let expectedUser = ObservableData.expectedUserWithAccounts
         await cache.addUser(expectedUser)
 
-        // Give time for observation to propagate
-        try await Task.sleep(nanoseconds: 10_000_000_000)
-
         // THEN
+        let lastReceivedObject = await receivedValues.first(where: { $0 != nil })
+        XCTAssertEqual(lastReceivedObject, ObservableData.expectedAccount)
+
         let cachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
         let cachedAccount = await cache.getAccount(accountDbId: ObservableData.expectedAccountDbId, userDbId: ObservableData.expectedUserDbId)
 
@@ -56,6 +57,7 @@ final class ObservedAccountTests_dbIdOnly: XCTestCase {
 
         @ObservedAccount(accountDbId: ObservableData.expectedAccountDbId,
                          cacheObservation: cache) var observedAccount: Account?
+        let receivedValues = $observedAccount.receivedValues
         XCTAssertNil(observedAccount, "Account should initially be nil")
 
         let expectedUser = ObservableData.expectedUserWithAccounts
@@ -70,10 +72,9 @@ final class ObservedAccountTests_dbIdOnly: XCTestCase {
         // WHEN
         try await cache.updateAccount(ObservableData.updatedAccount)
 
-        // Give time for observation to propagate
-        try await Task.sleep(nanoseconds: 10_000_000_000)
-
         // THEN
+        _ = await receivedValues.dropFirst().first(where: { $0 != nil })
+
         let latestAccount = await cache.getAccount(accountDbId: ObservableData.expectedAccountDbId, userDbId: ObservableData.expectedUserDbId)
         XCTAssertEqual(latestAccount, ObservableData.updatedAccount, "The cache account should have been updated again")
         XCTAssertEqual(observedAccount, ObservableData.updatedAccount, "The observed object should have been updated again")
@@ -87,6 +88,7 @@ final class ObservedAccountTests_dbIdOnly: XCTestCase {
 
         @ObservedAccount(accountDbId: ObservableData.expectedAccountDbId,
                          cacheObservation: cache) var observedAccount: Account?
+        let receivedValues = $observedAccount.receivedValues
         XCTAssertNil(observedAccount, "Account should initially be nil")
 
         let expectedUser = ObservableData.expectedUserWithAccounts
@@ -102,10 +104,9 @@ final class ObservedAccountTests_dbIdOnly: XCTestCase {
         try await cache.updateAccount(ObservableData.updatedAccount)
         try await cache.updateAccount(ObservableData.updatedAccount)
 
-        // Give time for observation to propagate
-        try await Task.sleep(nanoseconds: 10_000_000_000)
-
         // THEN
+        _ = await receivedValues.dropFirst().dropFirst().first(where: { $0 != nil })
+
         let latestAccount = await cache.getAccount(accountDbId: ObservableData.expectedAccountDbId, userDbId: ObservableData.expectedUserDbId)
         XCTAssertEqual(latestAccount, ObservableData.updatedAccount, "The cache account should have been updated again")
         XCTAssertEqual(observedAccount, ObservableData.updatedAccount, "The observed object should have been updated again")
@@ -119,6 +120,7 @@ final class ObservedAccountTests_dbIdOnly: XCTestCase {
 
         @ObservedAccount(accountDbId: ObservableData.expectedAccountDbId,
                          cacheObservation: cache) var observedAccount: Account?
+        let receivedValues = $observedAccount.receivedValues
         XCTAssertNil(observedAccount, "Account should initially be nil")
 
         let expectedUser = ObservableData.expectedUserWithAccounts
@@ -133,10 +135,8 @@ final class ObservedAccountTests_dbIdOnly: XCTestCase {
         // WHEN
         await cache.removeAccount(accountDbId: ObservableData.expectedAccountDbId)
 
-        // Give time for observation to propagate
-        try await Task.sleep(nanoseconds: 10_000_000_000)
-
         // THEN
+        _ = await receivedValues.dropFirst().first(where: { $0 == nil })
         XCTAssertNil(observedAccount, "The observed object should be nil to reflect deletion")
     }
 }
@@ -151,16 +151,17 @@ final class ObservedAccountTests_allIds: XCTestCase {
         @ObservedAccount(userDbId: ObservableData.expectedUserDbId,
                          accountDbId: ObservableData.expectedAccountDbId,
                          cacheObservation: cache) var observedAccount: Account?
+        let receivedValues = $observedAccount.receivedValues
         XCTAssertNil(observedAccount, "Account should initially be nil")
 
         // WHEN
         let expectedUser = ObservableData.expectedUserWithAccounts
         await cache.addUser(expectedUser)
 
-        // Give time for observation to propagate
-        try await Task.sleep(nanoseconds: 10_000_000_000)
-
         // THEN
+        let lastReceivedObject = await receivedValues.first(where: { $0 != nil })
+        XCTAssertEqual(lastReceivedObject, ObservableData.expectedAccount)
+
         let cachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
         let cachedAccount = await cache.getAccount(accountDbId: ObservableData.expectedAccountDbId, userDbId: ObservableData.expectedUserDbId)
         XCTAssertEqual(cachedUser, expectedUser, "The cache user should have been updated")
@@ -177,6 +178,7 @@ final class ObservedAccountTests_allIds: XCTestCase {
         @ObservedAccount(userDbId: ObservableData.expectedUserDbId,
                          accountDbId: ObservableData.expectedAccountDbId,
                          cacheObservation: cache) var observedAccount: Account?
+        let receivedValues = $observedAccount.receivedValues
         XCTAssertNil(observedAccount, "Account should initially be nil")
 
         let expectedUser = ObservableData.expectedUserWithAccounts
@@ -191,10 +193,9 @@ final class ObservedAccountTests_allIds: XCTestCase {
         // WHEN
         try await cache.updateAccount(ObservableData.updatedAccount)
 
-        // Give time for observation to propagate
-        try await Task.sleep(nanoseconds: 10_000_000_000)
-
         // THEN
+        _ = await receivedValues.dropFirst().first(where: { $0 != nil })
+
         let latestAccount = await cache.getAccount(accountDbId: ObservableData.expectedAccountDbId, userDbId: ObservableData.expectedUserDbId)
         XCTAssertEqual(latestAccount, ObservableData.updatedAccount, "The cache account should have been updated again")
         XCTAssertEqual(observedAccount, ObservableData.updatedAccount, "The observed object should have been updated again")
@@ -209,6 +210,7 @@ final class ObservedAccountTests_allIds: XCTestCase {
         @ObservedAccount(userDbId: ObservableData.expectedUserDbId,
                          accountDbId: ObservableData.expectedAccountDbId,
                          cacheObservation: cache) var observedAccount: Account?
+        let receivedValues = $observedAccount.receivedValues
         XCTAssertNil(observedAccount, "Account should initially be nil")
 
         let expectedUser = ObservableData.expectedUserWithAccounts
@@ -224,10 +226,9 @@ final class ObservedAccountTests_allIds: XCTestCase {
         try await cache.updateAccount(ObservableData.updatedAccount)
         try await cache.updateAccount(ObservableData.updatedAccount)
 
-        // Give time for observation to propagate
-        try await Task.sleep(nanoseconds: 10_000_000_000)
-
         // THEN
+        _ = await receivedValues.dropFirst().dropFirst().first(where: { $0 != nil })
+
         let latestAccount = await cache.getAccount(accountDbId: ObservableData.expectedAccountDbId, userDbId: ObservableData.expectedUserDbId)
         XCTAssertEqual(latestAccount, ObservableData.updatedAccount, "The cache account should have been updated again")
         XCTAssertEqual(observedAccount, ObservableData.updatedAccount, "The observed object should have been updated again")
@@ -242,6 +243,7 @@ final class ObservedAccountTests_allIds: XCTestCase {
         @ObservedAccount(userDbId: ObservableData.expectedUserDbId,
                          accountDbId: ObservableData.expectedAccountDbId,
                          cacheObservation: cache) var observedAccount: Account?
+        let receivedValues = $observedAccount.receivedValues
         XCTAssertNil(observedAccount, "Account should initially be nil")
 
         let expectedUser = ObservableData.expectedUserWithAccounts
@@ -256,10 +258,9 @@ final class ObservedAccountTests_allIds: XCTestCase {
         // WHEN
         await cache.removeAccount(accountDbId: ObservableData.expectedAccountDbId)
 
-        // Give time for observation to propagate
-        try await Task.sleep(nanoseconds: 10_000_000_000)
-
         // THEN
+        _ = await receivedValues.dropFirst().first(where: { $0 == nil })
+
         XCTAssertNil(observedAccount, "The observed object should be nil to reflect deletion")
     }
 }

--- a/src/front/macOS/kDriveTests/Cache/Observation/ObservedDriveTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/Observation/ObservedDriveTests.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 @testable import InfomaniakDI
-import kDriveCore
+@testable import kDriveCore
 import XCTest
 
 final class ObservedDriveTests_driveDbIdOnly: XCTestCase {
@@ -29,6 +29,7 @@ final class ObservedDriveTests_driveDbIdOnly: XCTestCase {
         XCTAssertNil(initialUser, "Cache should initially be empty")
 
         @ObservedDrive(driveDbId: ObservableData.expectedDriveDbId, cacheObservation: cache) var observedDrive: Drive?
+        let receivedValues = $observedDrive.receivedValues // Start to save the received values
         XCTAssertNil(observedDrive, "Drive should initially be nil")
 
         await cache.addUser(ObservableData.expectedUserWithAccounts)
@@ -37,10 +38,10 @@ final class ObservedDriveTests_driveDbIdOnly: XCTestCase {
         let expectedDrive = ObservableData.expectedDrive
         try await cache.addDrive(expectedDrive, accountDbId: ObservableData.expectedAccountDbId)
 
-        // Give time for observation to propagate
-        try await Task.sleep(nanoseconds: 10_000_000_000)
-
         // THEN
+        let lastReceivedObject = await receivedValues.first(where: { $0 != nil })
+        XCTAssertEqual(lastReceivedObject, expectedDrive)
+
         let cachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
         XCTAssertEqual(cachedDrive, expectedDrive, "The cache should have been updated")
         XCTAssertEqual(observedDrive, expectedDrive, "The observed object should have been updated")
@@ -53,6 +54,7 @@ final class ObservedDriveTests_driveDbIdOnly: XCTestCase {
         XCTAssertNil(initialUser, "Cache should initially be empty")
 
         @ObservedDrive(driveDbId: ObservableData.expectedDriveDbId, cacheObservation: cache) var observedDrive: Drive?
+        let receivedValues = $observedDrive.receivedValues
         XCTAssertNil(observedDrive, "Drive should initially be nil")
 
         await cache.addUser(ObservableData.expectedUserWithAccounts)
@@ -67,10 +69,9 @@ final class ObservedDriveTests_driveDbIdOnly: XCTestCase {
         let updatedDrive = ObservableData.updatedDrive
         try await cache.addDrive(updatedDrive, accountDbId: ObservableData.expectedAccountDbId)
 
-        // Give time for observation to propagate
-        try await Task.sleep(nanoseconds: 10_000_000_000)
-
         // THEN
+        _ = await receivedValues.dropFirst().first(where: { $0 != nil })
+
         let latestCachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
         XCTAssertEqual(latestCachedDrive, updatedDrive, "The cache should have been updated again")
         XCTAssertEqual(observedDrive, updatedDrive, "The observed object should have been updated again")
@@ -83,6 +84,7 @@ final class ObservedDriveTests_driveDbIdOnly: XCTestCase {
         XCTAssertNil(initialUser, "Cache should initially be empty")
 
         @ObservedDrive(driveDbId: ObservableData.expectedDriveDbId, cacheObservation: cache) var observedDrive: Drive?
+        let receivedValues = $observedDrive.receivedValues
         XCTAssertNil(observedDrive, "Drive should initially be nil")
 
         await cache.addUser(ObservableData.expectedUserWithAccounts)
@@ -98,10 +100,9 @@ final class ObservedDriveTests_driveDbIdOnly: XCTestCase {
                                 accountDbId: ObservableData.expectedAccountDbId,
                                 userDbId: ObservableData.expectedUserDbId)
 
-        // Give time for observation to propagate
-        try await Task.sleep(nanoseconds: 10_000_000_000)
-
         // THEN
+        _ = await receivedValues.dropFirst().first(where: { $0 == nil })
+
         XCTAssertNil(observedDrive, "The observed object should have been updated to nil to reflect deletion")
     }
 }
@@ -117,6 +118,7 @@ final class ObservedDriveTests_allIds: XCTestCase {
                        accountDbId: ObservableData.expectedAccountDbId,
                        driveDbId: ObservableData.expectedDriveDbId,
                        cacheObservation: cache) var observedDrive: Drive?
+        let receivedValues = $observedDrive.receivedValues
         XCTAssertNil(observedDrive, "Drive should initially be nil")
 
         await cache.addUser(ObservableData.expectedUserWithAccounts)
@@ -125,10 +127,10 @@ final class ObservedDriveTests_allIds: XCTestCase {
         let expectedDrive = ObservableData.expectedDrive
         try await cache.addDrive(expectedDrive, accountDbId: ObservableData.expectedAccountDbId)
 
-        // Give time for observation to propagate
-        try await Task.sleep(nanoseconds: 10_000_000_000)
-
         // THEN
+        let lastReceivedObject = await receivedValues.first(where: { $0 != nil })
+        XCTAssertEqual(lastReceivedObject, expectedDrive)
+
         let cachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
         XCTAssertEqual(cachedDrive, expectedDrive, "The cache should have been updated")
         XCTAssertEqual(observedDrive, expectedDrive, "The observed object should have been updated")
@@ -144,6 +146,7 @@ final class ObservedDriveTests_allIds: XCTestCase {
                        accountDbId: ObservableData.expectedAccountDbId,
                        driveDbId: ObservableData.expectedDriveDbId,
                        cacheObservation: cache) var observedDrive: Drive?
+        let receivedValues = $observedDrive.receivedValues
         XCTAssertNil(observedDrive, "Drive should initially be nil")
 
         await cache.addUser(ObservableData.expectedUserWithAccounts)
@@ -158,10 +161,9 @@ final class ObservedDriveTests_allIds: XCTestCase {
         let updatedDrive = ObservableData.updatedDrive
         try await cache.addDrive(updatedDrive, accountDbId: ObservableData.expectedAccountDbId)
 
-        // Give time for observation to propagate
-        try await Task.sleep(nanoseconds: 10_000_000_000)
-
         // THEN
+        _ = await receivedValues.dropFirst().first(where: { $0 != nil })
+
         let latestCachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
         XCTAssertEqual(latestCachedDrive, updatedDrive, "The cache should have been updated again")
         XCTAssertEqual(observedDrive, updatedDrive, "The observed object should have been updated again")
@@ -177,6 +179,7 @@ final class ObservedDriveTests_allIds: XCTestCase {
                        accountDbId: ObservableData.expectedAccountDbId,
                        driveDbId: ObservableData.expectedDriveDbId,
                        cacheObservation: cache) var observedDrive: Drive?
+        let receivedValues = $observedDrive.receivedValues
         XCTAssertNil(observedDrive, "Drive should initially be nil")
 
         await cache.addUser(ObservableData.expectedUserWithAccounts)
@@ -192,10 +195,9 @@ final class ObservedDriveTests_allIds: XCTestCase {
                                 accountDbId: ObservableData.expectedAccountDbId,
                                 userDbId: ObservableData.expectedUserDbId)
 
-        // Give time for observation to propagate
-        try await Task.sleep(nanoseconds: 10_000_000_000)
-
         // THEN
+        _ = await receivedValues.dropFirst().first(where: { $0 == nil })
+
         XCTAssertNil(observedDrive, "The observed object should have been updated to nil to reflect deletion")
     }
 }

--- a/src/front/macOS/kDriveTests/Cache/Observation/ObservedDriveTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/Observation/ObservedDriveTests.swift
@@ -31,7 +31,7 @@ final class ObservedDriveTests_driveDbIdOnly: XCTestCase {
         @ObservedDrive(driveDbId: ObservableData.expectedDriveDbId, cacheObservation: cache) var observedDrive: Drive?
         XCTAssertNil(observedDrive, "Drive should initially be nil")
 
-        await cache.addUser(ObservableData.expectedUser)
+        await cache.addUser(ObservableData.expectedUserWithAccounts)
 
         // WHEN
         let expectedDrive = ObservableData.expectedDrive
@@ -55,7 +55,7 @@ final class ObservedDriveTests_driveDbIdOnly: XCTestCase {
         @ObservedDrive(driveDbId: ObservableData.expectedDriveDbId, cacheObservation: cache) var observedDrive: Drive?
         XCTAssertNil(observedDrive, "Drive should initially be nil")
 
-        await cache.addUser(ObservableData.expectedUser)
+        await cache.addUser(ObservableData.expectedUserWithAccounts)
 
         let expectedDrive = ObservableData.expectedDrive
         try await cache.addDrive(expectedDrive, accountDbId: ObservableData.expectedAccountDbId)
@@ -85,7 +85,7 @@ final class ObservedDriveTests_driveDbIdOnly: XCTestCase {
         @ObservedDrive(driveDbId: ObservableData.expectedDriveDbId, cacheObservation: cache) var observedDrive: Drive?
         XCTAssertNil(observedDrive, "Drive should initially be nil")
 
-        await cache.addUser(ObservableData.expectedUser)
+        await cache.addUser(ObservableData.expectedUserWithAccounts)
 
         let expectedDrive = ObservableData.expectedDrive
         try await cache.addDrive(expectedDrive, accountDbId: ObservableData.expectedAccountDbId)
@@ -119,7 +119,7 @@ final class ObservedDriveTests_allIds: XCTestCase {
                        cacheObservation: cache) var observedDrive: Drive?
         XCTAssertNil(observedDrive, "Drive should initially be nil")
 
-        await cache.addUser(ObservableData.expectedUser)
+        await cache.addUser(ObservableData.expectedUserWithAccounts)
 
         // WHEN
         let expectedDrive = ObservableData.expectedDrive
@@ -146,7 +146,7 @@ final class ObservedDriveTests_allIds: XCTestCase {
                        cacheObservation: cache) var observedDrive: Drive?
         XCTAssertNil(observedDrive, "Drive should initially be nil")
 
-        await cache.addUser(ObservableData.expectedUser)
+        await cache.addUser(ObservableData.expectedUserWithAccounts)
 
         let expectedDrive = ObservableData.expectedDrive
         try await cache.addDrive(expectedDrive, accountDbId: ObservableData.expectedAccountDbId)
@@ -179,7 +179,7 @@ final class ObservedDriveTests_allIds: XCTestCase {
                        cacheObservation: cache) var observedDrive: Drive?
         XCTAssertNil(observedDrive, "Drive should initially be nil")
 
-        await cache.addUser(ObservableData.expectedUser)
+        await cache.addUser(ObservableData.expectedUserWithAccounts)
 
         let expectedDrive = ObservableData.expectedDrive
         try await cache.addDrive(expectedDrive, accountDbId: ObservableData.expectedAccountDbId)

--- a/src/front/macOS/kDriveTests/Cache/Observation/ObservedDriveTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/Observation/ObservedDriveTests.swift
@@ -19,18 +19,20 @@
 import Foundation
 @testable import InfomaniakDI
 @testable import kDriveCore
-import XCTest
+import Testing
 
-final class ObservedDriveTests_driveDbIdOnly: XCTestCase {
-    func testSetObservedDrive() async throws {
+@MainActor
+struct ObservedDriveTests_driveDbIdOnly {
+    @Test(.timeLimit(.minutes(1)))
+    func setObservedDrive() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
-        XCTAssertNil(initialUser, "Cache should initially be empty")
+        #expect(initialUser == nil, "Cache should initially be empty")
 
         @ObservedDrive(driveDbId: ObservableData.expectedDriveDbId, cacheObservation: cache) var observedDrive: Drive?
         let receivedValues = $observedDrive.receivedValues // Start to save the received values
-        XCTAssertNil(observedDrive, "Drive should initially be nil")
+        #expect(observedDrive == nil, "Drive should initially be nil")
 
         await cache.addUser(ObservableData.expectedUserWithAccounts)
 
@@ -40,22 +42,23 @@ final class ObservedDriveTests_driveDbIdOnly: XCTestCase {
 
         // THEN
         let lastReceivedObject = await receivedValues.first(where: { $0 != nil })
-        XCTAssertEqual(lastReceivedObject, expectedDrive)
+        #expect(lastReceivedObject == expectedDrive)
 
         let cachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
-        XCTAssertEqual(cachedDrive, expectedDrive, "The cache should have been updated")
-        XCTAssertEqual(observedDrive, expectedDrive, "The observed object should have been updated")
+        #expect(cachedDrive == expectedDrive, "The cache should have been updated")
+        #expect(observedDrive == expectedDrive, "The observed object should have been updated")
     }
 
-    func testUpdateObservedDrive() async throws {
+    @Test(.timeLimit(.minutes(1)))
+    func updateObservedDrive() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
-        XCTAssertNil(initialUser, "Cache should initially be empty")
+        #expect(initialUser == nil, "Cache should initially be empty")
 
         @ObservedDrive(driveDbId: ObservableData.expectedDriveDbId, cacheObservation: cache) var observedDrive: Drive?
         let receivedValues = $observedDrive.receivedValues
-        XCTAssertNil(observedDrive, "Drive should initially be nil")
+        #expect(observedDrive == nil, "Drive should initially be nil")
 
         await cache.addUser(ObservableData.expectedUserWithAccounts)
 
@@ -63,7 +66,7 @@ final class ObservedDriveTests_driveDbIdOnly: XCTestCase {
         try await cache.addDrive(expectedDrive, accountDbId: ObservableData.expectedAccountDbId)
 
         let cachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
-        XCTAssertEqual(cachedDrive, expectedDrive, "The cache should have been updated")
+        #expect(cachedDrive == expectedDrive, "The cache should have been updated")
 
         // WHEN
         let updatedDrive = ObservableData.updatedDrive
@@ -73,19 +76,20 @@ final class ObservedDriveTests_driveDbIdOnly: XCTestCase {
         _ = await receivedValues.dropFirst().first(where: { $0 != nil })
 
         let latestCachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
-        XCTAssertEqual(latestCachedDrive, updatedDrive, "The cache should have been updated again")
-        XCTAssertEqual(observedDrive, updatedDrive, "The observed object should have been updated again")
+        #expect(latestCachedDrive == updatedDrive, "The cache should have been updated again")
+        #expect(observedDrive == updatedDrive, "The observed object should have been updated again")
     }
 
-    func testRemoveObservedDrive() async throws {
+    @Test(.timeLimit(.minutes(1)))
+    func doubleUpdateObservedDrive() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
-        XCTAssertNil(initialUser, "Cache should initially be empty")
+        #expect(initialUser == nil, "Cache should initially be empty")
 
         @ObservedDrive(driveDbId: ObservableData.expectedDriveDbId, cacheObservation: cache) var observedDrive: Drive?
         let receivedValues = $observedDrive.receivedValues
-        XCTAssertNil(observedDrive, "Drive should initially be nil")
+        #expect(observedDrive == nil, "Drive should initially be nil")
 
         await cache.addUser(ObservableData.expectedUserWithAccounts)
 
@@ -93,7 +97,39 @@ final class ObservedDriveTests_driveDbIdOnly: XCTestCase {
         try await cache.addDrive(expectedDrive, accountDbId: ObservableData.expectedAccountDbId)
 
         let cachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
-        XCTAssertEqual(cachedDrive, expectedDrive, "The cache should have been updated")
+        #expect(cachedDrive == expectedDrive, "The cache should have been updated")
+
+        // WHEN
+        let updatedDrive = ObservableData.updatedDrive
+        try await cache.addDrive(updatedDrive, accountDbId: ObservableData.expectedAccountDbId)
+        try await cache.addDrive(updatedDrive, accountDbId: ObservableData.expectedAccountDbId)
+
+        // THEN
+        _ = await receivedValues.dropFirst().dropFirst().first(where: { $0 != nil })
+
+        let latestCachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
+        #expect(latestCachedDrive == updatedDrive, "The cache should have been updated again")
+        #expect(observedDrive == updatedDrive, "The observed object should have been updated again")
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func removeObservedDrive() async throws {
+        // GIVEN
+        let cache = ServerCoherentCache()
+        let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        #expect(initialUser == nil, "Cache should initially be empty")
+
+        @ObservedDrive(driveDbId: ObservableData.expectedDriveDbId, cacheObservation: cache) var observedDrive: Drive?
+        let receivedValues = $observedDrive.receivedValues
+        #expect(observedDrive == nil, "Drive should initially be nil")
+
+        await cache.addUser(ObservableData.expectedUserWithAccounts)
+
+        let expectedDrive = ObservableData.expectedDrive
+        try await cache.addDrive(expectedDrive, accountDbId: ObservableData.expectedAccountDbId)
+
+        let cachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
+        #expect(cachedDrive == expectedDrive, "The cache should have been updated")
 
         // WHEN
         await cache.removeDrive(driveDbId: ObservableData.expectedDrive.driveDbId,
@@ -103,23 +139,25 @@ final class ObservedDriveTests_driveDbIdOnly: XCTestCase {
         // THEN
         _ = await receivedValues.dropFirst().first(where: { $0 == nil })
 
-        XCTAssertNil(observedDrive, "The observed object should have been updated to nil to reflect deletion")
+        #expect(observedDrive == nil, "The observed object should have been updated to nil to reflect deletion")
     }
 }
 
-final class ObservedDriveTests_allIds: XCTestCase {
-    func testSetObservedDrive() async throws {
+@MainActor
+struct ObservedDriveTests_allIds {
+    @Test(.timeLimit(.minutes(1)))
+    func setObservedDrive() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
-        XCTAssertNil(initialUser, "Cache should initially be empty")
+        #expect(initialUser == nil, "Cache should initially be empty")
 
         @ObservedDrive(userDbId: ObservableData.expectedUserDbId,
                        accountDbId: ObservableData.expectedAccountDbId,
                        driveDbId: ObservableData.expectedDriveDbId,
                        cacheObservation: cache) var observedDrive: Drive?
         let receivedValues = $observedDrive.receivedValues
-        XCTAssertNil(observedDrive, "Drive should initially be nil")
+        #expect(observedDrive == nil, "Drive should initially be nil")
 
         await cache.addUser(ObservableData.expectedUserWithAccounts)
 
@@ -129,25 +167,26 @@ final class ObservedDriveTests_allIds: XCTestCase {
 
         // THEN
         let lastReceivedObject = await receivedValues.first(where: { $0 != nil })
-        XCTAssertEqual(lastReceivedObject, expectedDrive)
+        #expect(lastReceivedObject == expectedDrive)
 
         let cachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
-        XCTAssertEqual(cachedDrive, expectedDrive, "The cache should have been updated")
-        XCTAssertEqual(observedDrive, expectedDrive, "The observed object should have been updated")
+        #expect(cachedDrive == expectedDrive, "The cache should have been updated")
+        #expect(observedDrive == expectedDrive, "The observed object should have been updated")
     }
 
-    func testUpdateObservedDrive() async throws {
+    @Test(.timeLimit(.minutes(1)))
+    func updateObservedDrive() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
-        XCTAssertNil(initialUser, "Cache should initially be empty")
+        #expect(initialUser == nil, "Cache should initially be empty")
 
         @ObservedDrive(userDbId: ObservableData.expectedUserDbId,
                        accountDbId: ObservableData.expectedAccountDbId,
                        driveDbId: ObservableData.expectedDriveDbId,
                        cacheObservation: cache) var observedDrive: Drive?
         let receivedValues = $observedDrive.receivedValues
-        XCTAssertNil(observedDrive, "Drive should initially be nil")
+        #expect(observedDrive == nil, "Drive should initially be nil")
 
         await cache.addUser(ObservableData.expectedUserWithAccounts)
 
@@ -155,7 +194,7 @@ final class ObservedDriveTests_allIds: XCTestCase {
         try await cache.addDrive(expectedDrive, accountDbId: ObservableData.expectedAccountDbId)
 
         let cachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
-        XCTAssertEqual(cachedDrive, expectedDrive, "The cache should have been updated")
+        #expect(cachedDrive == expectedDrive, "The cache should have been updated")
 
         // WHEN
         let updatedDrive = ObservableData.updatedDrive
@@ -165,22 +204,23 @@ final class ObservedDriveTests_allIds: XCTestCase {
         _ = await receivedValues.dropFirst().first(where: { $0 != nil })
 
         let latestCachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
-        XCTAssertEqual(latestCachedDrive, updatedDrive, "The cache should have been updated again")
-        XCTAssertEqual(observedDrive, updatedDrive, "The observed object should have been updated again")
+        #expect(latestCachedDrive == updatedDrive, "The cache should have been updated again")
+        #expect(observedDrive == updatedDrive, "The observed object should have been updated again")
     }
 
-    func testRemoveObservedDrive() async throws {
+    @Test(.timeLimit(.minutes(1)))
+    func doubleUpdateObservedDrive() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
-        XCTAssertNil(initialUser, "Cache should initially be empty")
+        #expect(initialUser == nil, "Cache should initially be empty")
 
         @ObservedDrive(userDbId: ObservableData.expectedUserDbId,
                        accountDbId: ObservableData.expectedAccountDbId,
                        driveDbId: ObservableData.expectedDriveDbId,
                        cacheObservation: cache) var observedDrive: Drive?
         let receivedValues = $observedDrive.receivedValues
-        XCTAssertNil(observedDrive, "Drive should initially be nil")
+        #expect(observedDrive == nil, "Drive should initially be nil")
 
         await cache.addUser(ObservableData.expectedUserWithAccounts)
 
@@ -188,7 +228,42 @@ final class ObservedDriveTests_allIds: XCTestCase {
         try await cache.addDrive(expectedDrive, accountDbId: ObservableData.expectedAccountDbId)
 
         let cachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
-        XCTAssertEqual(cachedDrive, expectedDrive, "The cache should have been updated")
+        #expect(cachedDrive == expectedDrive, "The cache should have been updated")
+
+        // WHEN
+        let updatedDrive = ObservableData.updatedDrive
+        try await cache.addDrive(updatedDrive, accountDbId: ObservableData.expectedAccountDbId)
+        try await cache.addDrive(updatedDrive, accountDbId: ObservableData.expectedAccountDbId)
+
+        // THEN
+        _ = await receivedValues.dropFirst().dropFirst().first(where: { $0 != nil })
+
+        let latestCachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
+        #expect(latestCachedDrive == updatedDrive, "The cache should have been updated again")
+        #expect(observedDrive == updatedDrive, "The observed object should have been updated again")
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func removeObservedDrive() async throws {
+        // GIVEN
+        let cache = ServerCoherentCache()
+        let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        #expect(initialUser == nil, "Cache should initially be empty")
+
+        @ObservedDrive(userDbId: ObservableData.expectedUserDbId,
+                       accountDbId: ObservableData.expectedAccountDbId,
+                       driveDbId: ObservableData.expectedDriveDbId,
+                       cacheObservation: cache) var observedDrive: Drive?
+        let receivedValues = $observedDrive.receivedValues
+        #expect(observedDrive == nil, "Drive should initially be nil")
+
+        await cache.addUser(ObservableData.expectedUserWithAccounts)
+
+        let expectedDrive = ObservableData.expectedDrive
+        try await cache.addDrive(expectedDrive, accountDbId: ObservableData.expectedAccountDbId)
+
+        let cachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
+        #expect(cachedDrive == expectedDrive, "The cache should have been updated")
 
         // WHEN
         await cache.removeDrive(driveDbId: ObservableData.expectedDrive.driveDbId,
@@ -198,6 +273,6 @@ final class ObservedDriveTests_allIds: XCTestCase {
         // THEN
         _ = await receivedValues.dropFirst().first(where: { $0 == nil })
 
-        XCTAssertNil(observedDrive, "The observed object should have been updated to nil to reflect deletion")
+        #expect(observedDrive == nil, "The observed object should have been updated to nil to reflect deletion")
     }
 }

--- a/src/front/macOS/kDriveTests/Cache/Observation/ObservedDriveTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/Observation/ObservedDriveTests.swift
@@ -1,0 +1,201 @@
+/*
+ Infomaniak kDrive - Desktop
+ Copyright (C) 2023-2025 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+@testable import InfomaniakDI
+import kDriveCore
+import XCTest
+
+final class ObservedDriveTests_driveDbIdOnly: XCTestCase {
+    func testSetObservedDrive() async throws {
+        // GIVEN
+        let cache = ServerCoherentCache()
+        let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        XCTAssertNil(initialUser, "Cache should initially be empty")
+
+        @ObservedDrive(driveDbId: ObservableData.expectedDriveDbId, cacheObservation: cache) var observedDrive: Drive?
+        XCTAssertNil(observedDrive, "Drive should initially be nil")
+
+        await cache.addUser(ObservableData.expectedUser)
+
+        // WHEN
+        let expectedDrive = ObservableData.expectedDrive
+        try await cache.addDrive(expectedDrive, accountDbId: ObservableData.expectedAccountDbId)
+
+        // Give time for observation to propagate
+        try await Task.sleep(nanoseconds: 10_000_000_000)
+
+        // THEN
+        let cachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
+        XCTAssertEqual(cachedDrive, expectedDrive, "The cache should have been updated")
+        XCTAssertEqual(observedDrive, expectedDrive, "The observed object should have been updated")
+    }
+    
+    func testUpdateObservedDrive() async throws {
+        // GIVEN
+        let cache = ServerCoherentCache()
+        let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        XCTAssertNil(initialUser, "Cache should initially be empty")
+
+        @ObservedDrive(driveDbId: ObservableData.expectedDriveDbId, cacheObservation: cache) var observedDrive: Drive?
+        XCTAssertNil(observedDrive, "Drive should initially be nil")
+
+        await cache.addUser(ObservableData.expectedUser)
+
+        let expectedDrive = ObservableData.expectedDrive
+        try await cache.addDrive(expectedDrive, accountDbId: ObservableData.expectedAccountDbId)
+        
+        let cachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
+        XCTAssertEqual(cachedDrive, expectedDrive, "The cache should have been updated")
+        
+        // WHEN
+        let updatedDrive = ObservableData.updatedDrive
+        try await cache.addDrive(updatedDrive, accountDbId: ObservableData.expectedAccountDbId)
+
+        // Give time for observation to propagate
+        try await Task.sleep(nanoseconds: 10_000_000_000)
+
+        // THEN
+        let latestCachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
+        XCTAssertEqual(latestCachedDrive, updatedDrive, "The cache should have been updated again")
+        XCTAssertEqual(observedDrive, updatedDrive, "The observed object should have been updated again")
+    }
+
+    func testRemoveObservedDrive() async throws {
+        // GIVEN
+        let cache = ServerCoherentCache()
+        let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        XCTAssertNil(initialUser, "Cache should initially be empty")
+
+        @ObservedDrive(driveDbId: ObservableData.expectedDriveDbId, cacheObservation: cache) var observedDrive: Drive?
+        XCTAssertNil(observedDrive, "Drive should initially be nil")
+
+        await cache.addUser(ObservableData.expectedUser)
+
+        let expectedDrive = ObservableData.expectedDrive
+        try await cache.addDrive(expectedDrive, accountDbId: ObservableData.expectedAccountDbId)
+
+        let cachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
+        XCTAssertEqual(cachedDrive, expectedDrive, "The cache should have been updated")
+
+        // WHEN
+        await cache.removeDrive(driveDbId: ObservableData.expectedDrive.driveDbId,
+                                accountDbId: ObservableData.expectedAccountDbId,
+                                userDbId: ObservableData.expectedUserDbId)
+
+        // Give time for observation to propagate
+        try await Task.sleep(nanoseconds: 10_000_000_000)
+
+        // THEN
+        XCTAssertNil(observedDrive, "The observed object should have been updated to nil to reflect deletion")
+    }
+}
+
+final class ObservedDriveTests_allIds: XCTestCase {
+    func testSetObservedDrive() async throws {
+        // GIVEN
+        let cache = ServerCoherentCache()
+        let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        XCTAssertNil(initialUser, "Cache should initially be empty")
+
+        @ObservedDrive(userDbId: ObservableData.expectedUserDbId,
+                       accountDbId: ObservableData.expectedAccountDbId,
+                       driveDbId: ObservableData.expectedDriveDbId,
+                       cacheObservation: cache) var observedDrive: Drive?
+        XCTAssertNil(observedDrive, "Drive should initially be nil")
+
+        await cache.addUser(ObservableData.expectedUser)
+
+        // WHEN
+        let expectedDrive = ObservableData.expectedDrive
+        try await cache.addDrive(expectedDrive, accountDbId: ObservableData.expectedAccountDbId)
+
+        // Give time for observation to propagate
+        try await Task.sleep(nanoseconds: 10_000_000_000)
+
+        // THEN
+        let cachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
+        XCTAssertEqual(cachedDrive, expectedDrive, "The cache should have been updated")
+        XCTAssertEqual(observedDrive, expectedDrive, "The observed object should have been updated")
+    }
+
+    func testUpdateObservedDrive() async throws {
+        // GIVEN
+        let cache = ServerCoherentCache()
+        let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        XCTAssertNil(initialUser, "Cache should initially be empty")
+
+        @ObservedDrive(userDbId: ObservableData.expectedUserDbId,
+                       accountDbId: ObservableData.expectedAccountDbId,
+                       driveDbId: ObservableData.expectedDriveDbId,
+                       cacheObservation: cache) var observedDrive: Drive?
+        XCTAssertNil(observedDrive, "Drive should initially be nil")
+
+        await cache.addUser(ObservableData.expectedUser)
+
+        let expectedDrive = ObservableData.expectedDrive
+        try await cache.addDrive(expectedDrive, accountDbId: ObservableData.expectedAccountDbId)
+        
+        let cachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
+        XCTAssertEqual(cachedDrive, expectedDrive, "The cache should have been updated")
+        
+        // WHEN
+        let updatedDrive = ObservableData.updatedDrive
+        try await cache.addDrive(updatedDrive, accountDbId: ObservableData.expectedAccountDbId)
+
+        // Give time for observation to propagate
+        try await Task.sleep(nanoseconds: 10_000_000_000)
+
+        // THEN
+        let latestCachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
+        XCTAssertEqual(latestCachedDrive, updatedDrive, "The cache should have been updated again")
+        XCTAssertEqual(observedDrive, updatedDrive, "The observed object should have been updated again")
+    }
+
+    func testRemoveObservedDrive() async throws {
+        // GIVEN
+        let cache = ServerCoherentCache()
+        let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        XCTAssertNil(initialUser, "Cache should initially be empty")
+
+        @ObservedDrive(userDbId: ObservableData.expectedUserDbId,
+                       accountDbId: ObservableData.expectedAccountDbId,
+                       driveDbId: ObservableData.expectedDriveDbId,
+                       cacheObservation: cache) var observedDrive: Drive?
+        XCTAssertNil(observedDrive, "Drive should initially be nil")
+
+        await cache.addUser(ObservableData.expectedUser)
+
+        let expectedDrive = ObservableData.expectedDrive
+        try await cache.addDrive(expectedDrive, accountDbId: ObservableData.expectedAccountDbId)
+
+        let cachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
+        XCTAssertEqual(cachedDrive, expectedDrive, "The cache should have been updated")
+
+        // WHEN
+        await cache.removeDrive(driveDbId: ObservableData.expectedDrive.driveDbId,
+                                accountDbId: ObservableData.expectedAccountDbId,
+                                userDbId: ObservableData.expectedUserDbId)
+
+        // Give time for observation to propagate
+        try await Task.sleep(nanoseconds: 10_000_000_000)
+
+        // THEN
+        XCTAssertNil(observedDrive, "The observed object should have been updated to nil to reflect deletion")
+    }
+}

--- a/src/front/macOS/kDriveTests/Cache/Observation/ObservedDriveTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/Observation/ObservedDriveTests.swift
@@ -16,10 +16,22 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import Combine
 import Foundation
 @testable import InfomaniakDI
-@testable import kDriveCore
+import kDriveCore
 import Testing
+
+extension ObservedDrive {
+    var receivedValues: AsyncStream<Drive?> {
+        AsyncStream { continuation in
+            let cancellable = $wrappedValue
+                .sink { value in continuation.yield(value) }
+
+            continuation.onTermination = { _ in cancellable.cancel() }
+        }
+    }
+}
 
 @MainActor
 struct ObservedDriveTests_driveDbIdOnly {

--- a/src/front/macOS/kDriveTests/Cache/Observation/ObservedDriveTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/Observation/ObservedDriveTests.swift
@@ -45,7 +45,7 @@ final class ObservedDriveTests_driveDbIdOnly: XCTestCase {
         XCTAssertEqual(cachedDrive, expectedDrive, "The cache should have been updated")
         XCTAssertEqual(observedDrive, expectedDrive, "The observed object should have been updated")
     }
-    
+
     func testUpdateObservedDrive() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
@@ -59,10 +59,10 @@ final class ObservedDriveTests_driveDbIdOnly: XCTestCase {
 
         let expectedDrive = ObservableData.expectedDrive
         try await cache.addDrive(expectedDrive, accountDbId: ObservableData.expectedAccountDbId)
-        
+
         let cachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
         XCTAssertEqual(cachedDrive, expectedDrive, "The cache should have been updated")
-        
+
         // WHEN
         let updatedDrive = ObservableData.updatedDrive
         try await cache.addDrive(updatedDrive, accountDbId: ObservableData.expectedAccountDbId)
@@ -150,10 +150,10 @@ final class ObservedDriveTests_allIds: XCTestCase {
 
         let expectedDrive = ObservableData.expectedDrive
         try await cache.addDrive(expectedDrive, accountDbId: ObservableData.expectedAccountDbId)
-        
+
         let cachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
         XCTAssertEqual(cachedDrive, expectedDrive, "The cache should have been updated")
-        
+
         // WHEN
         let updatedDrive = ObservableData.updatedDrive
         try await cache.addDrive(updatedDrive, accountDbId: ObservableData.expectedAccountDbId)

--- a/src/front/macOS/kDriveTests/Cache/Observation/ObservedSynchroTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/Observation/ObservedSynchroTests.swift
@@ -16,10 +16,22 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import Combine
 import Foundation
 @testable import InfomaniakDI
 @testable import kDriveCore
 import Testing
+
+extension ObservedSynchro {
+    var receivedValues: AsyncStream<Synchro?> {
+        AsyncStream { continuation in
+            let cancellable = $wrappedValue
+                .sink { value in continuation.yield(value) }
+
+            continuation.onTermination = { _ in cancellable.cancel() }
+        }
+    }
+}
 
 @MainActor
 struct ObservedSynchroTests_dbIdOnly {

--- a/src/front/macOS/kDriveTests/Cache/Observation/ObservedSynchroTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/Observation/ObservedSynchroTests.swift
@@ -1,0 +1,368 @@
+/*
+ Infomaniak kDrive - Desktop
+ Copyright (C) 2023-2025 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+@testable import InfomaniakDI
+import kDriveCore
+import XCTest
+
+final class ObservedSynchroTests_dbIdOnly: XCTestCase {
+    func testSetObservedSynchro() async throws {
+        // GIVEN
+        let cache = ServerCoherentCache()
+        let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        XCTAssertNil(initialUser, "Cache should initially be empty")
+
+        @ObservedSynchro(synchroDbId: ObservableData.expectedSynchroDbId, cacheObservation: cache) var observedSynchro: Synchro?
+
+        XCTAssertNil(observedSynchro, "Synchro should initially be nil")
+        await cache.addUser(ObservableData.expectedUserWithAccounts)
+
+        let expectedDrive = ObservableData.expectedDrive
+        try await cache.addDrive(expectedDrive, accountDbId: ObservableData.expectedAccountDbId)
+
+        let cachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
+        XCTAssertEqual(cachedDrive, expectedDrive, "The cache should have been updated with a Drive")
+
+        // WHEN
+        let expectedSynchro = ObservableData.expectedSynchro
+        try await cache.addSynchro(expectedSynchro)
+
+        // Give time for observation to propagate
+        try await Task.sleep(nanoseconds: 10_000_000_000)
+
+        // THEN
+        let fetchedSynchro = await cache.getSynchro(synchroDbId: ObservableData.expectedSynchroDbId)
+        XCTAssertEqual(fetchedSynchro, ObservableData.expectedSynchro, "We should find the object in cache")
+        XCTAssertEqual(observedSynchro, ObservableData.expectedSynchro, "The observed object should have been updated")
+    }
+
+    func testSetObservedSynchro_driveDoesNotExists() async throws {
+        // GIVEN
+        let cache = ServerCoherentCache()
+        let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        XCTAssertNil(initialUser, "Cache should initially be empty")
+
+        @ObservedSynchro(synchroDbId: ObservableData.expectedSynchroDbId, cacheObservation: cache) var observedSynchro: Synchro?
+
+        XCTAssertNil(observedSynchro, "Synchro should initially be nil")
+
+        // WHEN
+        let expectedSynchro = ObservableData.expectedSynchro
+        do {
+            try await cache.addSynchro(expectedSynchro)
+            XCTFail("This should have thrown")
+        } catch ServerCoherentCache.CacheError.driveNotFound {
+            // cool story bro
+        } catch {
+            XCTFail("Unexpected error \(error)")
+        }
+    }
+
+    func testUpdateObservedSynchro() async throws {
+        // GIVEN
+        let cache = ServerCoherentCache()
+        let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        XCTAssertNil(initialUser, "Cache should initially be empty")
+
+        @ObservedSynchro(synchroDbId: ObservableData.expectedSynchroDbId, cacheObservation: cache) var observedSynchro: Synchro?
+
+        XCTAssertNil(observedSynchro, "Synchro should initially be nil")
+        await cache.addUser(ObservableData.expectedUserWithAccounts)
+
+        let expectedDrive = ObservableData.expectedDrive
+        try await cache.addDrive(expectedDrive, accountDbId: ObservableData.expectedAccountDbId)
+
+        let cachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
+        XCTAssertEqual(cachedDrive, expectedDrive, "The cache should have been updated with a Drive")
+
+        let expectedSynchro = ObservableData.expectedSynchro
+        try await cache.addSynchro(expectedSynchro)
+
+        let fetchedSynchro = await cache.getSynchro(synchroDbId: ObservableData.expectedSynchroDbId)
+        XCTAssertEqual(fetchedSynchro, ObservableData.expectedSynchro, "We should find the object in cache")
+
+        // WHEN
+        let updatedSynchro = ObservableData.updatedSynchro
+        try await cache.updateSynchro(updatedSynchro)
+
+        // Give time for observation to propagate
+        try await Task.sleep(nanoseconds: 10_000_000_000)
+
+        // THEN
+        let latestFetchedSynchro = await cache.getSynchro(synchroDbId: ObservableData.expectedSynchroDbId)
+        XCTAssertEqual(latestFetchedSynchro, ObservableData.updatedSynchro, "We should find the object in cache updated")
+        XCTAssertEqual(observedSynchro, ObservableData.updatedSynchro, "The observed object should have been updated again")
+    }
+
+    func testDoubleUpdateObservedSynchro() async throws {
+        // GIVEN
+        let cache = ServerCoherentCache()
+        let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        XCTAssertNil(initialUser, "Cache should initially be empty")
+
+        @ObservedSynchro(synchroDbId: ObservableData.expectedSynchroDbId, cacheObservation: cache) var observedSynchro: Synchro?
+
+        XCTAssertNil(observedSynchro, "Synchro should initially be nil")
+        await cache.addUser(ObservableData.expectedUserWithAccounts)
+
+        let expectedDrive = ObservableData.expectedDrive
+        try await cache.addDrive(expectedDrive, accountDbId: ObservableData.expectedAccountDbId)
+
+        let cachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
+        XCTAssertEqual(cachedDrive, expectedDrive, "The cache should have been updated with a Drive")
+
+        let expectedSynchro = ObservableData.expectedSynchro
+        try await cache.addSynchro(expectedSynchro)
+
+        let fetchedSynchro = await cache.getSynchro(synchroDbId: ObservableData.expectedSynchroDbId)
+        XCTAssertEqual(fetchedSynchro, ObservableData.expectedSynchro, "We should find the object in cache")
+
+        // WHEN
+        let updatedSynchro = ObservableData.updatedSynchro
+        try await cache.updateSynchro(updatedSynchro)
+        try await cache.updateSynchro(updatedSynchro)
+
+        // Give time for observation to propagate
+        try await Task.sleep(nanoseconds: 10_000_000_000)
+
+        // THEN
+        let latestFetchedSynchro = await cache.getSynchro(synchroDbId: ObservableData.expectedSynchroDbId)
+        XCTAssertEqual(latestFetchedSynchro, ObservableData.updatedSynchro, "We should find the object in cache updated")
+        XCTAssertEqual(observedSynchro, ObservableData.updatedSynchro, "The observed object should have been updated again")
+    }
+
+    func testDeleteObservedSynchro() async throws {
+        // GIVEN
+        let cache = ServerCoherentCache()
+        let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        XCTAssertNil(initialUser, "Cache should initially be empty")
+
+        @ObservedSynchro(synchroDbId: ObservableData.expectedSynchroDbId, cacheObservation: cache) var observedSynchro: Synchro?
+
+        XCTAssertNil(observedSynchro, "Synchro should initially be nil")
+        await cache.addUser(ObservableData.expectedUserWithAccounts)
+
+        let expectedDrive = ObservableData.expectedDrive
+        try await cache.addDrive(expectedDrive, accountDbId: ObservableData.expectedAccountDbId)
+
+        let cachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
+        XCTAssertEqual(cachedDrive, expectedDrive, "The cache should have been updated with a Drive")
+
+        let expectedSynchro = ObservableData.expectedSynchro
+        try await cache.addSynchro(expectedSynchro)
+
+        let fetchedSynchro = await cache.getSynchro(synchroDbId: ObservableData.expectedSynchroDbId)
+        XCTAssertEqual(fetchedSynchro, ObservableData.expectedSynchro, "We should find the object in cache")
+
+        // WHEN
+        try await cache.removeSynchro(synchroDbId: expectedSynchro.dbId,
+                                      driveDbId: expectedSynchro.driveDbId)
+
+        // Give time for observation to propagate
+        try await Task.sleep(nanoseconds: 10_000_000_000)
+
+        // THEN
+        let latestFetchedSynchro = await cache.getSynchro(synchroDbId: ObservableData.expectedSynchroDbId)
+        XCTAssertNil(latestFetchedSynchro, "Object should no longer be available in cache")
+        XCTAssertNil(observedSynchro, "Object should be nilified once it's removed from the cache")
+    }
+}
+
+final class ObservedSynchroTests_allIds: XCTestCase {
+    func testSetObservedSynchro() async throws {
+        // GIVEN
+        let cache = ServerCoherentCache()
+        let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        XCTAssertNil(initialUser, "Cache should initially be empty")
+
+        @ObservedSynchro(userDbId: ObservableData.expectedUserDbId,
+                         accountDbId: ObservableData.expectedAccountDbId,
+                         driveDbId: ObservableData.expectedDriveDbId,
+                         synchroDbId: ObservableData.expectedSynchroDbId,
+                         cacheObservation: cache) var observedSynchro: Synchro?
+
+        XCTAssertNil(observedSynchro, "Synchro should initially be nil")
+        await cache.addUser(ObservableData.expectedUserWithAccounts)
+
+        let expectedDrive = ObservableData.expectedDrive
+        try await cache.addDrive(expectedDrive, accountDbId: ObservableData.expectedAccountDbId)
+
+        let cachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
+        XCTAssertEqual(cachedDrive, expectedDrive, "The cache should have been updated with a Drive")
+
+        // WHEN
+        let expectedSynchro = ObservableData.expectedSynchro
+        try await cache.addSynchro(expectedSynchro)
+
+        // Give time for observation to propagate
+        try await Task.sleep(nanoseconds: 10_000_000_000)
+
+        // THEN
+        let fetchedSynchro = await cache.getSynchro(synchroDbId: ObservableData.expectedSynchroDbId)
+        XCTAssertEqual(fetchedSynchro, ObservableData.expectedSynchro, "We should find the object in cache")
+        XCTAssertEqual(observedSynchro, ObservableData.expectedSynchro, "The observed object should have been updated")
+    }
+
+    func testSetObservedSynchro_driveDoesNotExists() async throws {
+        // GIVEN
+        let cache = ServerCoherentCache()
+        let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        XCTAssertNil(initialUser, "Cache should initially be empty")
+
+        @ObservedSynchro(userDbId: ObservableData.expectedUserDbId,
+                         accountDbId: ObservableData.expectedAccountDbId,
+                         driveDbId: ObservableData.expectedDriveDbId,
+                         synchroDbId: ObservableData.expectedSynchroDbId,
+                         cacheObservation: cache) var observedSynchro: Synchro?
+
+        XCTAssertNil(observedSynchro, "Synchro should initially be nil")
+
+        // WHEN
+        let expectedSynchro = ObservableData.expectedSynchro
+        do {
+            try await cache.addSynchro(expectedSynchro)
+            XCTFail("This should have thrown")
+        } catch ServerCoherentCache.CacheError.driveNotFound {
+            // cool story bro
+        } catch {
+            XCTFail("Unexpected error \(error)")
+        }
+    }
+
+    func testUpdateObservedSynchro() async throws {
+        // GIVEN
+        let cache = ServerCoherentCache()
+        let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        XCTAssertNil(initialUser, "Cache should initially be empty")
+
+        @ObservedSynchro(userDbId: ObservableData.expectedUserDbId,
+                         accountDbId: ObservableData.expectedAccountDbId,
+                         driveDbId: ObservableData.expectedDriveDbId,
+                         synchroDbId: ObservableData.expectedSynchroDbId,
+                         cacheObservation: cache) var observedSynchro: Synchro?
+
+        XCTAssertNil(observedSynchro, "Synchro should initially be nil")
+        await cache.addUser(ObservableData.expectedUserWithAccounts)
+
+        let expectedDrive = ObservableData.expectedDrive
+        try await cache.addDrive(expectedDrive, accountDbId: ObservableData.expectedAccountDbId)
+
+        let cachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
+        XCTAssertEqual(cachedDrive, expectedDrive, "The cache should have been updated with a Drive")
+
+        let expectedSynchro = ObservableData.expectedSynchro
+        try await cache.addSynchro(expectedSynchro)
+
+        let fetchedSynchro = await cache.getSynchro(synchroDbId: ObservableData.expectedSynchroDbId)
+        XCTAssertEqual(fetchedSynchro, ObservableData.expectedSynchro, "We should find the object in cache")
+
+        // WHEN
+        let updatedSynchro = ObservableData.updatedSynchro
+        try await cache.updateSynchro(updatedSynchro)
+
+        // Give time for observation to propagate
+        try await Task.sleep(nanoseconds: 10_000_000_000)
+
+        // THEN
+        let latestFetchedSynchro = await cache.getSynchro(synchroDbId: ObservableData.expectedSynchroDbId)
+        XCTAssertEqual(latestFetchedSynchro, ObservableData.updatedSynchro, "We should find the object in cache updated")
+        XCTAssertEqual(observedSynchro, ObservableData.updatedSynchro, "The observed object should have been updated again")
+    }
+
+    func testDoubleUpdateObservedSynchro() async throws {
+        // GIVEN
+        let cache = ServerCoherentCache()
+        let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        XCTAssertNil(initialUser, "Cache should initially be empty")
+
+        @ObservedSynchro(userDbId: ObservableData.expectedUserDbId,
+                         accountDbId: ObservableData.expectedAccountDbId,
+                         driveDbId: ObservableData.expectedDriveDbId,
+                         synchroDbId: ObservableData.expectedSynchroDbId,
+                         cacheObservation: cache) var observedSynchro: Synchro?
+
+        XCTAssertNil(observedSynchro, "Synchro should initially be nil")
+        await cache.addUser(ObservableData.expectedUserWithAccounts)
+
+        let expectedDrive = ObservableData.expectedDrive
+        try await cache.addDrive(expectedDrive, accountDbId: ObservableData.expectedAccountDbId)
+
+        let cachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
+        XCTAssertEqual(cachedDrive, expectedDrive, "The cache should have been updated with a Drive")
+
+        let expectedSynchro = ObservableData.expectedSynchro
+        try await cache.addSynchro(expectedSynchro)
+
+        let fetchedSynchro = await cache.getSynchro(synchroDbId: ObservableData.expectedSynchroDbId)
+        XCTAssertEqual(fetchedSynchro, ObservableData.expectedSynchro, "We should find the object in cache")
+
+        // WHEN
+        let updatedSynchro = ObservableData.updatedSynchro
+        try await cache.updateSynchro(updatedSynchro)
+        try await cache.updateSynchro(updatedSynchro)
+
+        // Give time for observation to propagate
+        try await Task.sleep(nanoseconds: 10_000_000_000)
+
+        // THEN
+        let latestFetchedSynchro = await cache.getSynchro(synchroDbId: ObservableData.expectedSynchroDbId)
+        XCTAssertEqual(latestFetchedSynchro, ObservableData.updatedSynchro, "We should find the object in cache updated")
+        XCTAssertEqual(observedSynchro, ObservableData.updatedSynchro, "The observed object should have been updated again")
+    }
+
+    func testDeleteObservedSynchro() async throws {
+        // GIVEN
+        let cache = ServerCoherentCache()
+        let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        XCTAssertNil(initialUser, "Cache should initially be empty")
+
+        @ObservedSynchro(userDbId: ObservableData.expectedUserDbId,
+                         accountDbId: ObservableData.expectedAccountDbId,
+                         driveDbId: ObservableData.expectedDriveDbId,
+                         synchroDbId: ObservableData.expectedSynchroDbId,
+                         cacheObservation: cache) var observedSynchro: Synchro?
+
+        XCTAssertNil(observedSynchro, "Synchro should initially be nil")
+        await cache.addUser(ObservableData.expectedUserWithAccounts)
+
+        let expectedDrive = ObservableData.expectedDrive
+        try await cache.addDrive(expectedDrive, accountDbId: ObservableData.expectedAccountDbId)
+
+        let cachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
+        XCTAssertEqual(cachedDrive, expectedDrive, "The cache should have been updated with a Drive")
+
+        let expectedSynchro = ObservableData.expectedSynchro
+        try await cache.addSynchro(expectedSynchro)
+
+        let fetchedSynchro = await cache.getSynchro(synchroDbId: ObservableData.expectedSynchroDbId)
+        XCTAssertEqual(fetchedSynchro, ObservableData.expectedSynchro, "We should find the object in cache")
+
+        // WHEN
+        try await cache.removeSynchro(synchroDbId: expectedSynchro.dbId,
+                                      driveDbId: expectedSynchro.driveDbId)
+
+        // Give time for observation to propagate
+        try await Task.sleep(nanoseconds: 10_000_000_000)
+
+        // THEN
+        let latestFetchedSynchro = await cache.getSynchro(synchroDbId: ObservableData.expectedSynchroDbId)
+        XCTAssertNil(latestFetchedSynchro, "Object should no longer be available in cache")
+        XCTAssertNil(observedSynchro, "Object should be nilified once it's removed from the cache")
+    }
+}

--- a/src/front/macOS/kDriveTests/Cache/Observation/ObservedSynchroTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/Observation/ObservedSynchroTests.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 @testable import InfomaniakDI
-import kDriveCore
+@testable import kDriveCore
 import XCTest
 
 final class ObservedSynchroTests_dbIdOnly: XCTestCase {
@@ -29,6 +29,7 @@ final class ObservedSynchroTests_dbIdOnly: XCTestCase {
         XCTAssertNil(initialUser, "Cache should initially be empty")
 
         @ObservedSynchro(synchroDbId: ObservableData.expectedSynchroDbId, cacheObservation: cache) var observedSynchro: Synchro?
+        let receivedValues = $observedSynchro.receivedValues // Start to save the received values
 
         XCTAssertNil(observedSynchro, "Synchro should initially be nil")
         await cache.addUser(ObservableData.expectedUserWithAccounts)
@@ -43,10 +44,9 @@ final class ObservedSynchroTests_dbIdOnly: XCTestCase {
         let expectedSynchro = ObservableData.expectedSynchro
         try await cache.addSynchro(expectedSynchro)
 
-        // Give time for observation to propagate
-        try await Task.sleep(nanoseconds: 10_000_000_000)
-
         // THEN
+        _ = await receivedValues.first(where: { $0 != nil })
+
         let fetchedSynchro = await cache.getSynchro(synchroDbId: ObservableData.expectedSynchroDbId)
         XCTAssertEqual(fetchedSynchro, ObservableData.expectedSynchro, "We should find the object in cache")
         XCTAssertEqual(observedSynchro, ObservableData.expectedSynchro, "The observed object should have been updated")
@@ -81,6 +81,7 @@ final class ObservedSynchroTests_dbIdOnly: XCTestCase {
         XCTAssertNil(initialUser, "Cache should initially be empty")
 
         @ObservedSynchro(synchroDbId: ObservableData.expectedSynchroDbId, cacheObservation: cache) var observedSynchro: Synchro?
+        let receivedValues = $observedSynchro.receivedValues
 
         XCTAssertNil(observedSynchro, "Synchro should initially be nil")
         await cache.addUser(ObservableData.expectedUserWithAccounts)
@@ -101,10 +102,9 @@ final class ObservedSynchroTests_dbIdOnly: XCTestCase {
         let updatedSynchro = ObservableData.updatedSynchro
         try await cache.updateSynchro(updatedSynchro)
 
-        // Give time for observation to propagate
-        try await Task.sleep(nanoseconds: 10_000_000_000)
-
         // THEN
+        _ = await receivedValues.dropFirst().first(where: { $0 != nil })
+
         let latestFetchedSynchro = await cache.getSynchro(synchroDbId: ObservableData.expectedSynchroDbId)
         XCTAssertEqual(latestFetchedSynchro, ObservableData.updatedSynchro, "We should find the object in cache updated")
         XCTAssertEqual(observedSynchro, ObservableData.updatedSynchro, "The observed object should have been updated again")
@@ -117,6 +117,7 @@ final class ObservedSynchroTests_dbIdOnly: XCTestCase {
         XCTAssertNil(initialUser, "Cache should initially be empty")
 
         @ObservedSynchro(synchroDbId: ObservableData.expectedSynchroDbId, cacheObservation: cache) var observedSynchro: Synchro?
+        let receivedValues = $observedSynchro.receivedValues
 
         XCTAssertNil(observedSynchro, "Synchro should initially be nil")
         await cache.addUser(ObservableData.expectedUserWithAccounts)
@@ -138,10 +139,9 @@ final class ObservedSynchroTests_dbIdOnly: XCTestCase {
         try await cache.updateSynchro(updatedSynchro)
         try await cache.updateSynchro(updatedSynchro)
 
-        // Give time for observation to propagate
-        try await Task.sleep(nanoseconds: 10_000_000_000)
-
         // THEN
+        _ = await receivedValues.dropFirst().dropFirst().dropFirst().first(where: { $0 != nil })
+
         let latestFetchedSynchro = await cache.getSynchro(synchroDbId: ObservableData.expectedSynchroDbId)
         XCTAssertEqual(latestFetchedSynchro, ObservableData.updatedSynchro, "We should find the object in cache updated")
         XCTAssertEqual(observedSynchro, ObservableData.updatedSynchro, "The observed object should have been updated again")
@@ -154,6 +154,7 @@ final class ObservedSynchroTests_dbIdOnly: XCTestCase {
         XCTAssertNil(initialUser, "Cache should initially be empty")
 
         @ObservedSynchro(synchroDbId: ObservableData.expectedSynchroDbId, cacheObservation: cache) var observedSynchro: Synchro?
+        let receivedValues = $observedSynchro.receivedValues
 
         XCTAssertNil(observedSynchro, "Synchro should initially be nil")
         await cache.addUser(ObservableData.expectedUserWithAccounts)
@@ -174,10 +175,9 @@ final class ObservedSynchroTests_dbIdOnly: XCTestCase {
         try await cache.removeSynchro(synchroDbId: expectedSynchro.dbId,
                                       driveDbId: expectedSynchro.driveDbId)
 
-        // Give time for observation to propagate
-        try await Task.sleep(nanoseconds: 10_000_000_000)
-
         // THEN
+        _ = await receivedValues.dropFirst().first(where: { $0 == nil })
+
         let latestFetchedSynchro = await cache.getSynchro(synchroDbId: ObservableData.expectedSynchroDbId)
         XCTAssertNil(latestFetchedSynchro, "Object should no longer be available in cache")
         XCTAssertNil(observedSynchro, "Object should be nilified once it's removed from the cache")
@@ -196,6 +196,7 @@ final class ObservedSynchroTests_allIds: XCTestCase {
                          driveDbId: ObservableData.expectedDriveDbId,
                          synchroDbId: ObservableData.expectedSynchroDbId,
                          cacheObservation: cache) var observedSynchro: Synchro?
+        let receivedValues = $observedSynchro.receivedValues
 
         XCTAssertNil(observedSynchro, "Synchro should initially be nil")
         await cache.addUser(ObservableData.expectedUserWithAccounts)
@@ -210,10 +211,9 @@ final class ObservedSynchroTests_allIds: XCTestCase {
         let expectedSynchro = ObservableData.expectedSynchro
         try await cache.addSynchro(expectedSynchro)
 
-        // Give time for observation to propagate
-        try await Task.sleep(nanoseconds: 10_000_000_000)
-
         // THEN
+        _ = await receivedValues.first(where: { $0 != nil })
+
         let fetchedSynchro = await cache.getSynchro(synchroDbId: ObservableData.expectedSynchroDbId)
         XCTAssertEqual(fetchedSynchro, ObservableData.expectedSynchro, "We should find the object in cache")
         XCTAssertEqual(observedSynchro, ObservableData.expectedSynchro, "The observed object should have been updated")
@@ -256,6 +256,7 @@ final class ObservedSynchroTests_allIds: XCTestCase {
                          driveDbId: ObservableData.expectedDriveDbId,
                          synchroDbId: ObservableData.expectedSynchroDbId,
                          cacheObservation: cache) var observedSynchro: Synchro?
+        let receivedValues = $observedSynchro.receivedValues
 
         XCTAssertNil(observedSynchro, "Synchro should initially be nil")
         await cache.addUser(ObservableData.expectedUserWithAccounts)
@@ -276,10 +277,9 @@ final class ObservedSynchroTests_allIds: XCTestCase {
         let updatedSynchro = ObservableData.updatedSynchro
         try await cache.updateSynchro(updatedSynchro)
 
-        // Give time for observation to propagate
-        try await Task.sleep(nanoseconds: 10_000_000_000)
-
         // THEN
+        _ = await receivedValues.dropFirst().first(where: { $0 != nil })
+
         let latestFetchedSynchro = await cache.getSynchro(synchroDbId: ObservableData.expectedSynchroDbId)
         XCTAssertEqual(latestFetchedSynchro, ObservableData.updatedSynchro, "We should find the object in cache updated")
         XCTAssertEqual(observedSynchro, ObservableData.updatedSynchro, "The observed object should have been updated again")
@@ -296,6 +296,7 @@ final class ObservedSynchroTests_allIds: XCTestCase {
                          driveDbId: ObservableData.expectedDriveDbId,
                          synchroDbId: ObservableData.expectedSynchroDbId,
                          cacheObservation: cache) var observedSynchro: Synchro?
+        let receivedValues = $observedSynchro.receivedValues
 
         XCTAssertNil(observedSynchro, "Synchro should initially be nil")
         await cache.addUser(ObservableData.expectedUserWithAccounts)
@@ -317,10 +318,9 @@ final class ObservedSynchroTests_allIds: XCTestCase {
         try await cache.updateSynchro(updatedSynchro)
         try await cache.updateSynchro(updatedSynchro)
 
-        // Give time for observation to propagate
-        try await Task.sleep(nanoseconds: 10_000_000_000)
-
         // THEN
+        _ = await receivedValues.dropFirst().dropFirst().first(where: { $0 != nil })
+
         let latestFetchedSynchro = await cache.getSynchro(synchroDbId: ObservableData.expectedSynchroDbId)
         XCTAssertEqual(latestFetchedSynchro, ObservableData.updatedSynchro, "We should find the object in cache updated")
         XCTAssertEqual(observedSynchro, ObservableData.updatedSynchro, "The observed object should have been updated again")
@@ -337,6 +337,7 @@ final class ObservedSynchroTests_allIds: XCTestCase {
                          driveDbId: ObservableData.expectedDriveDbId,
                          synchroDbId: ObservableData.expectedSynchroDbId,
                          cacheObservation: cache) var observedSynchro: Synchro?
+        let receivedValues = $observedSynchro.receivedValues
 
         XCTAssertNil(observedSynchro, "Synchro should initially be nil")
         await cache.addUser(ObservableData.expectedUserWithAccounts)
@@ -357,10 +358,9 @@ final class ObservedSynchroTests_allIds: XCTestCase {
         try await cache.removeSynchro(synchroDbId: expectedSynchro.dbId,
                                       driveDbId: expectedSynchro.driveDbId)
 
-        // Give time for observation to propagate
-        try await Task.sleep(nanoseconds: 10_000_000_000)
-
         // THEN
+        _ = await receivedValues.dropFirst().first(where: { $0 == nil })
+
         let latestFetchedSynchro = await cache.getSynchro(synchroDbId: ObservableData.expectedSynchroDbId)
         XCTAssertNil(latestFetchedSynchro, "Object should no longer be available in cache")
         XCTAssertNil(observedSynchro, "Object should be nilified once it's removed from the cache")

--- a/src/front/macOS/kDriveTests/Cache/Observation/ObservedSynchroTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/Observation/ObservedSynchroTests.swift
@@ -19,26 +19,28 @@
 import Foundation
 @testable import InfomaniakDI
 @testable import kDriveCore
-import XCTest
+import Testing
 
-final class ObservedSynchroTests_dbIdOnly: XCTestCase {
-    func testSetObservedSynchro() async throws {
+@MainActor
+struct ObservedSynchroTests_dbIdOnly {
+    @Test(.timeLimit(.minutes(1)))
+    func setObservedSynchro() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
-        XCTAssertNil(initialUser, "Cache should initially be empty")
+        #expect(initialUser == nil, "Cache should initially be empty")
 
         @ObservedSynchro(synchroDbId: ObservableData.expectedSynchroDbId, cacheObservation: cache) var observedSynchro: Synchro?
         let receivedValues = $observedSynchro.receivedValues // Start to save the received values
 
-        XCTAssertNil(observedSynchro, "Synchro should initially be nil")
+        #expect(observedSynchro == nil, "Synchro should initially be nil")
         await cache.addUser(ObservableData.expectedUserWithAccounts)
 
         let expectedDrive = ObservableData.expectedDrive
         try await cache.addDrive(expectedDrive, accountDbId: ObservableData.expectedAccountDbId)
 
         let cachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
-        XCTAssertEqual(cachedDrive, expectedDrive, "The cache should have been updated with a Drive")
+        #expect(cachedDrive == expectedDrive, "The cache should have been updated with a Drive")
 
         // WHEN
         let expectedSynchro = ObservableData.expectedSynchro
@@ -48,55 +50,57 @@ final class ObservedSynchroTests_dbIdOnly: XCTestCase {
         _ = await receivedValues.first(where: { $0 != nil })
 
         let fetchedSynchro = await cache.getSynchro(synchroDbId: ObservableData.expectedSynchroDbId)
-        XCTAssertEqual(fetchedSynchro, ObservableData.expectedSynchro, "We should find the object in cache")
-        XCTAssertEqual(observedSynchro, ObservableData.expectedSynchro, "The observed object should have been updated")
+        #expect(fetchedSynchro == ObservableData.expectedSynchro, "We should find the object in cache")
+        #expect(observedSynchro == ObservableData.expectedSynchro, "The observed object should have been updated")
     }
 
-    func testSetObservedSynchro_driveDoesNotExists() async throws {
+    @Test(.timeLimit(.minutes(1)))
+    func setObservedSynchro_driveDoesNotExists() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
-        XCTAssertNil(initialUser, "Cache should initially be empty")
+        #expect(initialUser == nil, "Cache should initially be empty")
 
         @ObservedSynchro(synchroDbId: ObservableData.expectedSynchroDbId, cacheObservation: cache) var observedSynchro: Synchro?
 
-        XCTAssertNil(observedSynchro, "Synchro should initially be nil")
+        #expect(observedSynchro == nil, "Synchro should initially be nil")
 
         // WHEN
         let expectedSynchro = ObservableData.expectedSynchro
         do {
             try await cache.addSynchro(expectedSynchro)
-            XCTFail("This should have thrown")
+            Issue.record("This should have thrown")
         } catch ServerCoherentCache.CacheError.driveNotFound {
             // cool story bro
         } catch {
-            XCTFail("Unexpected error \(error)")
+            Issue.record("Unexpected error \(error)")
         }
     }
 
-    func testUpdateObservedSynchro() async throws {
+    @Test(.timeLimit(.minutes(1)))
+    func updateObservedSynchro() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
-        XCTAssertNil(initialUser, "Cache should initially be empty")
+        #expect(initialUser == nil, "Cache should initially be empty")
 
         @ObservedSynchro(synchroDbId: ObservableData.expectedSynchroDbId, cacheObservation: cache) var observedSynchro: Synchro?
         let receivedValues = $observedSynchro.receivedValues
 
-        XCTAssertNil(observedSynchro, "Synchro should initially be nil")
+        #expect(observedSynchro == nil, "Synchro should initially be nil")
         await cache.addUser(ObservableData.expectedUserWithAccounts)
 
         let expectedDrive = ObservableData.expectedDrive
         try await cache.addDrive(expectedDrive, accountDbId: ObservableData.expectedAccountDbId)
 
         let cachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
-        XCTAssertEqual(cachedDrive, expectedDrive, "The cache should have been updated with a Drive")
+        #expect(cachedDrive == expectedDrive, "The cache should have been updated with a Drive")
 
         let expectedSynchro = ObservableData.expectedSynchro
         try await cache.addSynchro(expectedSynchro)
 
         let fetchedSynchro = await cache.getSynchro(synchroDbId: ObservableData.expectedSynchroDbId)
-        XCTAssertEqual(fetchedSynchro, ObservableData.expectedSynchro, "We should find the object in cache")
+        #expect(fetchedSynchro == ObservableData.expectedSynchro, "We should find the object in cache")
 
         // WHEN
         let updatedSynchro = ObservableData.updatedSynchro
@@ -106,33 +110,34 @@ final class ObservedSynchroTests_dbIdOnly: XCTestCase {
         _ = await receivedValues.dropFirst().first(where: { $0 != nil })
 
         let latestFetchedSynchro = await cache.getSynchro(synchroDbId: ObservableData.expectedSynchroDbId)
-        XCTAssertEqual(latestFetchedSynchro, ObservableData.updatedSynchro, "We should find the object in cache updated")
-        XCTAssertEqual(observedSynchro, ObservableData.updatedSynchro, "The observed object should have been updated again")
+        #expect(latestFetchedSynchro == ObservableData.updatedSynchro, "We should find the object in cache updated")
+        #expect(observedSynchro == ObservableData.updatedSynchro, "The observed object should have been updated again")
     }
 
-    func testDoubleUpdateObservedSynchro() async throws {
+    @Test(.timeLimit(.minutes(1)))
+    func doubleUpdateObservedSynchro() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
-        XCTAssertNil(initialUser, "Cache should initially be empty")
+        #expect(initialUser == nil, "Cache should initially be empty")
 
         @ObservedSynchro(synchroDbId: ObservableData.expectedSynchroDbId, cacheObservation: cache) var observedSynchro: Synchro?
         let receivedValues = $observedSynchro.receivedValues
 
-        XCTAssertNil(observedSynchro, "Synchro should initially be nil")
+        #expect(observedSynchro == nil, "Synchro should initially be nil")
         await cache.addUser(ObservableData.expectedUserWithAccounts)
 
         let expectedDrive = ObservableData.expectedDrive
         try await cache.addDrive(expectedDrive, accountDbId: ObservableData.expectedAccountDbId)
 
         let cachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
-        XCTAssertEqual(cachedDrive, expectedDrive, "The cache should have been updated with a Drive")
+        #expect(cachedDrive == expectedDrive, "The cache should have been updated with a Drive")
 
         let expectedSynchro = ObservableData.expectedSynchro
         try await cache.addSynchro(expectedSynchro)
 
         let fetchedSynchro = await cache.getSynchro(synchroDbId: ObservableData.expectedSynchroDbId)
-        XCTAssertEqual(fetchedSynchro, ObservableData.expectedSynchro, "We should find the object in cache")
+        #expect(fetchedSynchro == ObservableData.expectedSynchro, "We should find the object in cache")
 
         // WHEN
         let updatedSynchro = ObservableData.updatedSynchro
@@ -143,33 +148,34 @@ final class ObservedSynchroTests_dbIdOnly: XCTestCase {
         _ = await receivedValues.dropFirst().dropFirst().dropFirst().first(where: { $0 != nil })
 
         let latestFetchedSynchro = await cache.getSynchro(synchroDbId: ObservableData.expectedSynchroDbId)
-        XCTAssertEqual(latestFetchedSynchro, ObservableData.updatedSynchro, "We should find the object in cache updated")
-        XCTAssertEqual(observedSynchro, ObservableData.updatedSynchro, "The observed object should have been updated again")
+        #expect(latestFetchedSynchro == ObservableData.updatedSynchro, "We should find the object in cache updated")
+        #expect(observedSynchro == ObservableData.updatedSynchro, "The observed object should have been updated again")
     }
 
-    func testDeleteObservedSynchro() async throws {
+    @Test(.timeLimit(.minutes(1)))
+    func deleteObservedSynchro() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
-        XCTAssertNil(initialUser, "Cache should initially be empty")
+        #expect(initialUser == nil, "Cache should initially be empty")
 
         @ObservedSynchro(synchroDbId: ObservableData.expectedSynchroDbId, cacheObservation: cache) var observedSynchro: Synchro?
         let receivedValues = $observedSynchro.receivedValues
 
-        XCTAssertNil(observedSynchro, "Synchro should initially be nil")
+        #expect(observedSynchro == nil, "Synchro should initially be nil")
         await cache.addUser(ObservableData.expectedUserWithAccounts)
 
         let expectedDrive = ObservableData.expectedDrive
         try await cache.addDrive(expectedDrive, accountDbId: ObservableData.expectedAccountDbId)
 
         let cachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
-        XCTAssertEqual(cachedDrive, expectedDrive, "The cache should have been updated with a Drive")
+        #expect(cachedDrive == expectedDrive, "The cache should have been updated with a Drive")
 
         let expectedSynchro = ObservableData.expectedSynchro
         try await cache.addSynchro(expectedSynchro)
 
         let fetchedSynchro = await cache.getSynchro(synchroDbId: ObservableData.expectedSynchroDbId)
-        XCTAssertEqual(fetchedSynchro, ObservableData.expectedSynchro, "We should find the object in cache")
+        #expect(fetchedSynchro == ObservableData.expectedSynchro, "We should find the object in cache")
 
         // WHEN
         try await cache.removeSynchro(synchroDbId: expectedSynchro.dbId,
@@ -179,17 +185,19 @@ final class ObservedSynchroTests_dbIdOnly: XCTestCase {
         _ = await receivedValues.dropFirst().first(where: { $0 == nil })
 
         let latestFetchedSynchro = await cache.getSynchro(synchroDbId: ObservableData.expectedSynchroDbId)
-        XCTAssertNil(latestFetchedSynchro, "Object should no longer be available in cache")
-        XCTAssertNil(observedSynchro, "Object should be nilified once it's removed from the cache")
+        #expect(latestFetchedSynchro == nil, "Object should no longer be available in cache")
+        #expect(observedSynchro == nil, "Object should be nilified once it's removed from the cache")
     }
 }
 
-final class ObservedSynchroTests_allIds: XCTestCase {
-    func testSetObservedSynchro() async throws {
+@MainActor
+struct ObservedSynchroTests_allIds {
+    @Test(.timeLimit(.minutes(1)))
+    func setObservedSynchro() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
-        XCTAssertNil(initialUser, "Cache should initially be empty")
+        #expect(initialUser == nil, "Cache should initially be empty")
 
         @ObservedSynchro(userDbId: ObservableData.expectedUserDbId,
                          accountDbId: ObservableData.expectedAccountDbId,
@@ -198,14 +206,14 @@ final class ObservedSynchroTests_allIds: XCTestCase {
                          cacheObservation: cache) var observedSynchro: Synchro?
         let receivedValues = $observedSynchro.receivedValues
 
-        XCTAssertNil(observedSynchro, "Synchro should initially be nil")
+        #expect(observedSynchro == nil, "Synchro should initially be nil")
         await cache.addUser(ObservableData.expectedUserWithAccounts)
 
         let expectedDrive = ObservableData.expectedDrive
         try await cache.addDrive(expectedDrive, accountDbId: ObservableData.expectedAccountDbId)
 
         let cachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
-        XCTAssertEqual(cachedDrive, expectedDrive, "The cache should have been updated with a Drive")
+        #expect(cachedDrive == expectedDrive, "The cache should have been updated with a Drive")
 
         // WHEN
         let expectedSynchro = ObservableData.expectedSynchro
@@ -215,15 +223,16 @@ final class ObservedSynchroTests_allIds: XCTestCase {
         _ = await receivedValues.first(where: { $0 != nil })
 
         let fetchedSynchro = await cache.getSynchro(synchroDbId: ObservableData.expectedSynchroDbId)
-        XCTAssertEqual(fetchedSynchro, ObservableData.expectedSynchro, "We should find the object in cache")
-        XCTAssertEqual(observedSynchro, ObservableData.expectedSynchro, "The observed object should have been updated")
+        #expect(fetchedSynchro == ObservableData.expectedSynchro, "We should find the object in cache")
+        #expect(observedSynchro == ObservableData.expectedSynchro, "The observed object should have been updated")
     }
 
-    func testSetObservedSynchro_driveDoesNotExists() async throws {
+    @Test(.timeLimit(.minutes(1)))
+    func setObservedSynchro_driveDoesNotExists() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
-        XCTAssertNil(initialUser, "Cache should initially be empty")
+        #expect(initialUser == nil, "Cache should initially be empty")
 
         @ObservedSynchro(userDbId: ObservableData.expectedUserDbId,
                          accountDbId: ObservableData.expectedAccountDbId,
@@ -231,25 +240,26 @@ final class ObservedSynchroTests_allIds: XCTestCase {
                          synchroDbId: ObservableData.expectedSynchroDbId,
                          cacheObservation: cache) var observedSynchro: Synchro?
 
-        XCTAssertNil(observedSynchro, "Synchro should initially be nil")
+        #expect(observedSynchro == nil, "Synchro should initially be nil")
 
         // WHEN
         let expectedSynchro = ObservableData.expectedSynchro
         do {
             try await cache.addSynchro(expectedSynchro)
-            XCTFail("This should have thrown")
+            Issue.record("This should have thrown")
         } catch ServerCoherentCache.CacheError.driveNotFound {
             // cool story bro
         } catch {
-            XCTFail("Unexpected error \(error)")
+            Issue.record("Unexpected error \(error)")
         }
     }
 
-    func testUpdateObservedSynchro() async throws {
+    @Test(.timeLimit(.minutes(1)))
+    func updateObservedSynchro() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
-        XCTAssertNil(initialUser, "Cache should initially be empty")
+        #expect(initialUser == nil, "Cache should initially be empty")
 
         @ObservedSynchro(userDbId: ObservableData.expectedUserDbId,
                          accountDbId: ObservableData.expectedAccountDbId,
@@ -258,20 +268,20 @@ final class ObservedSynchroTests_allIds: XCTestCase {
                          cacheObservation: cache) var observedSynchro: Synchro?
         let receivedValues = $observedSynchro.receivedValues
 
-        XCTAssertNil(observedSynchro, "Synchro should initially be nil")
+        #expect(observedSynchro == nil, "Synchro should initially be nil")
         await cache.addUser(ObservableData.expectedUserWithAccounts)
 
         let expectedDrive = ObservableData.expectedDrive
         try await cache.addDrive(expectedDrive, accountDbId: ObservableData.expectedAccountDbId)
 
         let cachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
-        XCTAssertEqual(cachedDrive, expectedDrive, "The cache should have been updated with a Drive")
+        #expect(cachedDrive == expectedDrive, "The cache should have been updated with a Drive")
 
         let expectedSynchro = ObservableData.expectedSynchro
         try await cache.addSynchro(expectedSynchro)
 
         let fetchedSynchro = await cache.getSynchro(synchroDbId: ObservableData.expectedSynchroDbId)
-        XCTAssertEqual(fetchedSynchro, ObservableData.expectedSynchro, "We should find the object in cache")
+        #expect(fetchedSynchro == ObservableData.expectedSynchro, "We should find the object in cache")
 
         // WHEN
         let updatedSynchro = ObservableData.updatedSynchro
@@ -281,15 +291,16 @@ final class ObservedSynchroTests_allIds: XCTestCase {
         _ = await receivedValues.dropFirst().first(where: { $0 != nil })
 
         let latestFetchedSynchro = await cache.getSynchro(synchroDbId: ObservableData.expectedSynchroDbId)
-        XCTAssertEqual(latestFetchedSynchro, ObservableData.updatedSynchro, "We should find the object in cache updated")
-        XCTAssertEqual(observedSynchro, ObservableData.updatedSynchro, "The observed object should have been updated again")
+        #expect(latestFetchedSynchro == ObservableData.updatedSynchro, "We should find the object in cache updated")
+        #expect(observedSynchro == ObservableData.updatedSynchro, "The observed object should have been updated again")
     }
 
-    func testDoubleUpdateObservedSynchro() async throws {
+    @Test(.timeLimit(.minutes(1)))
+    func doubleUpdateObservedSynchro() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
-        XCTAssertNil(initialUser, "Cache should initially be empty")
+        #expect(initialUser == nil, "Cache should initially be empty")
 
         @ObservedSynchro(userDbId: ObservableData.expectedUserDbId,
                          accountDbId: ObservableData.expectedAccountDbId,
@@ -298,20 +309,20 @@ final class ObservedSynchroTests_allIds: XCTestCase {
                          cacheObservation: cache) var observedSynchro: Synchro?
         let receivedValues = $observedSynchro.receivedValues
 
-        XCTAssertNil(observedSynchro, "Synchro should initially be nil")
+        #expect(observedSynchro == nil, "Synchro should initially be nil")
         await cache.addUser(ObservableData.expectedUserWithAccounts)
 
         let expectedDrive = ObservableData.expectedDrive
         try await cache.addDrive(expectedDrive, accountDbId: ObservableData.expectedAccountDbId)
 
         let cachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
-        XCTAssertEqual(cachedDrive, expectedDrive, "The cache should have been updated with a Drive")
+        #expect(cachedDrive == expectedDrive, "The cache should have been updated with a Drive")
 
         let expectedSynchro = ObservableData.expectedSynchro
         try await cache.addSynchro(expectedSynchro)
 
         let fetchedSynchro = await cache.getSynchro(synchroDbId: ObservableData.expectedSynchroDbId)
-        XCTAssertEqual(fetchedSynchro, ObservableData.expectedSynchro, "We should find the object in cache")
+        #expect(fetchedSynchro == ObservableData.expectedSynchro, "We should find the object in cache")
 
         // WHEN
         let updatedSynchro = ObservableData.updatedSynchro
@@ -322,15 +333,16 @@ final class ObservedSynchroTests_allIds: XCTestCase {
         _ = await receivedValues.dropFirst().dropFirst().first(where: { $0 != nil })
 
         let latestFetchedSynchro = await cache.getSynchro(synchroDbId: ObservableData.expectedSynchroDbId)
-        XCTAssertEqual(latestFetchedSynchro, ObservableData.updatedSynchro, "We should find the object in cache updated")
-        XCTAssertEqual(observedSynchro, ObservableData.updatedSynchro, "The observed object should have been updated again")
+        #expect(latestFetchedSynchro == ObservableData.updatedSynchro, "We should find the object in cache updated")
+        #expect(observedSynchro == ObservableData.updatedSynchro, "The observed object should have been updated again")
     }
 
-    func testDeleteObservedSynchro() async throws {
+    @Test(.timeLimit(.minutes(1)))
+    func deleteObservedSynchro() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
-        XCTAssertNil(initialUser, "Cache should initially be empty")
+        #expect(initialUser == nil, "Cache should initially be empty")
 
         @ObservedSynchro(userDbId: ObservableData.expectedUserDbId,
                          accountDbId: ObservableData.expectedAccountDbId,
@@ -339,20 +351,20 @@ final class ObservedSynchroTests_allIds: XCTestCase {
                          cacheObservation: cache) var observedSynchro: Synchro?
         let receivedValues = $observedSynchro.receivedValues
 
-        XCTAssertNil(observedSynchro, "Synchro should initially be nil")
+        #expect(observedSynchro == nil, "Synchro should initially be nil")
         await cache.addUser(ObservableData.expectedUserWithAccounts)
 
         let expectedDrive = ObservableData.expectedDrive
         try await cache.addDrive(expectedDrive, accountDbId: ObservableData.expectedAccountDbId)
 
         let cachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
-        XCTAssertEqual(cachedDrive, expectedDrive, "The cache should have been updated with a Drive")
+        #expect(cachedDrive == expectedDrive, "The cache should have been updated with a Drive")
 
         let expectedSynchro = ObservableData.expectedSynchro
         try await cache.addSynchro(expectedSynchro)
 
         let fetchedSynchro = await cache.getSynchro(synchroDbId: ObservableData.expectedSynchroDbId)
-        XCTAssertEqual(fetchedSynchro, ObservableData.expectedSynchro, "We should find the object in cache")
+        #expect(fetchedSynchro == ObservableData.expectedSynchro, "We should find the object in cache")
 
         // WHEN
         try await cache.removeSynchro(synchroDbId: expectedSynchro.dbId,
@@ -362,7 +374,7 @@ final class ObservedSynchroTests_allIds: XCTestCase {
         _ = await receivedValues.dropFirst().first(where: { $0 == nil })
 
         let latestFetchedSynchro = await cache.getSynchro(synchroDbId: ObservableData.expectedSynchroDbId)
-        XCTAssertNil(latestFetchedSynchro, "Object should no longer be available in cache")
-        XCTAssertNil(observedSynchro, "Object should be nilified once it's removed from the cache")
+        #expect(latestFetchedSynchro == nil, "Object should no longer be available in cache")
+        #expect(observedSynchro == nil, "Object should be nilified once it's removed from the cache")
     }
 }

--- a/src/front/macOS/kDriveTests/Cache/Observation/ObservedUserTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/Observation/ObservedUserTests.swift
@@ -23,7 +23,8 @@ import Testing
 
 @MainActor
 struct ObservedUserTests {
-    @Test func setObservedUser() async throws {
+    @Test(.timeLimit(.minutes(1)))
+    func setObservedUser() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
@@ -46,7 +47,8 @@ struct ObservedUserTests {
         #expect(observedUser == expectedUser, "The observed object should have been updated")
     }
 
-    @Test func updateObservedUser() async throws {
+    @Test(.timeLimit(.minutes(1)))
+    func updateObservedUser() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
@@ -74,7 +76,8 @@ struct ObservedUserTests {
         #expect(observedUser == updatedUser, "The observed object should be up to date")
     }
 
-    @Test func updateObservedUserTwice() async throws {
+    @Test(.timeLimit(.minutes(1)))
+    func updateObservedUserTwice() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
@@ -103,7 +106,8 @@ struct ObservedUserTests {
         #expect(observedUser == updatedUser, "The observed object should be up to date")
     }
 
-    @Test func removeObservedUser() async throws {
+    @Test(.timeLimit(.minutes(1)))
+    func removeObservedUser() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)

--- a/src/front/macOS/kDriveTests/Cache/Observation/ObservedUserTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/Observation/ObservedUserTests.swift
@@ -70,7 +70,7 @@ final class ObservedUserTests: XCTestCase {
         let latestCachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
         XCTAssertEqual(latestCachedUser, updatedUser, "The observed object should have been updated again")
     }
-    
+
     func testUpdateObservedUserTwice() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
@@ -98,7 +98,7 @@ final class ObservedUserTests: XCTestCase {
         let latestCachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
         XCTAssertEqual(latestCachedUser, updatedUser, "The observed object should have been updated again")
     }
-    
+
     func testRemoveObservedUser() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
@@ -113,10 +113,10 @@ final class ObservedUserTests: XCTestCase {
 
         let cachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
         XCTAssertEqual(cachedUser, expectedUser, "The cache should have been updated")
-        
+
         // WHEN
         await cache.removeUser(dbId: ObservableData.expectedUserDbId)
-        
+
         // Give time for observation to propagate
         try await Task.sleep(nanoseconds: 10_000_000_000)
 

--- a/src/front/macOS/kDriveTests/Cache/Observation/ObservedUserTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/Observation/ObservedUserTests.swift
@@ -75,39 +75,9 @@ struct ObservedUserTests {
         #expect(latestCachedUser == updatedUser, "The object should be in cache")
         #expect(observedUser == updatedUser, "The observed object should be up to date")
     }
-    
+
     @Test(.timeLimit(.minutes(1)))
     func doubleUpdateObservedUser() async throws {
-        // GIVEN
-        let cache = ServerCoherentCache()
-        let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
-        #expect(initialUser == nil, "Cache should initially be empty")
-
-        @ObservedUser(userDbId: ObservableData.expectedUserDbId, cacheObservation: cache) var observedUser: User?
-        let receivedValues = $observedUser.receivedValues
-        #expect(observedUser == nil, "User should initially be nil")
-
-        let expectedUser = ObservableData.expectedUser
-        await cache.addUser(expectedUser)
-
-        let cachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
-        #expect(cachedUser == expectedUser, "The cache should have been updated")
-
-        // WHEN
-        let updatedUser = ObservableData.updatedUser
-        await cache.addUser(updatedUser)
-        await cache.addUser(updatedUser)
-
-        // THEN
-        _ = await receivedValues.dropFirst().dropFirst().first(where: { $0 != nil })
-
-        let latestCachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
-        #expect(latestCachedUser == updatedUser, "The object should be in cache")
-        #expect(observedUser == updatedUser, "The observed object should be up to date")
-    }
-
-    @Test(.timeLimit(.minutes(1)))
-    func updateObservedUserTwice() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)

--- a/src/front/macOS/kDriveTests/Cache/Observation/ObservedUserTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/Observation/ObservedUserTests.swift
@@ -28,7 +28,7 @@ final class ObservedUserTests: XCTestCase {
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
         XCTAssertNil(initialUser, "Cache should initially be empty")
 
-        @ObservedUser(dbId: ObservableData.expectedUserDbId, cacheObservation: cache) var observedUser: User?
+        @ObservedUser(userDbId: ObservableData.expectedUserDbId, cacheObservation: cache) var observedUser: User?
         XCTAssertNil(observedUser, "User should initially be nil")
 
         // WHEN
@@ -50,7 +50,7 @@ final class ObservedUserTests: XCTestCase {
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
         XCTAssertNil(initialUser, "Cache should initially be empty")
 
-        @ObservedUser(dbId: ObservableData.expectedUserDbId, cacheObservation: cache) var observedUser: User?
+        @ObservedUser(userDbId: ObservableData.expectedUserDbId, cacheObservation: cache) var observedUser: User?
         XCTAssertNil(observedUser, "User should initially be nil")
 
         let expectedUser = ObservableData.expectedUser
@@ -68,7 +68,8 @@ final class ObservedUserTests: XCTestCase {
 
         // THEN
         let latestCachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
-        XCTAssertEqual(latestCachedUser, updatedUser, "The observed object should have been updated again")
+        XCTAssertEqual(latestCachedUser, updatedUser, "The object should be in cache")
+        XCTAssertEqual(observedUser, updatedUser, "The observed object should be up to date")
     }
 
     func testUpdateObservedUserTwice() async throws {
@@ -77,7 +78,7 @@ final class ObservedUserTests: XCTestCase {
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
         XCTAssertNil(initialUser, "Cache should initially be empty")
 
-        @ObservedUser(dbId: ObservableData.expectedUserDbId, cacheObservation: cache) var observedUser: User?
+        @ObservedUser(userDbId: ObservableData.expectedUserDbId, cacheObservation: cache) var observedUser: User?
         XCTAssertNil(observedUser, "User should initially be nil")
 
         let expectedUser = ObservableData.expectedUser
@@ -96,7 +97,8 @@ final class ObservedUserTests: XCTestCase {
 
         // THEN
         let latestCachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
-        XCTAssertEqual(latestCachedUser, updatedUser, "The observed object should have been updated again")
+        XCTAssertEqual(latestCachedUser, updatedUser, "The object should no longer be in cache")
+        XCTAssertEqual(observedUser, updatedUser, "The observed object should be up to date")
     }
 
     func testRemoveObservedUser() async throws {
@@ -105,7 +107,7 @@ final class ObservedUserTests: XCTestCase {
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
         XCTAssertNil(initialUser, "Cache should initially be empty")
 
-        @ObservedUser(dbId: ObservableData.expectedUserDbId, cacheObservation: cache) var observedUser: User?
+        @ObservedUser(userDbId: ObservableData.expectedUserDbId, cacheObservation: cache) var observedUser: User?
         XCTAssertNil(observedUser, "User should initially be nil")
 
         let expectedUser = ObservableData.expectedUser
@@ -122,6 +124,7 @@ final class ObservedUserTests: XCTestCase {
 
         // THEN
         let latestCachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
-        XCTAssertNil(latestCachedUser, "The observed object should be nil since the cache entry was deleted")
+        XCTAssertNil(latestCachedUser, "The object should no longer be in cache")
+        XCTAssertNil(observedUser, "The observed object should be nil since the cache entry was deleted")
     }
 }

--- a/src/front/macOS/kDriveTests/Cache/Observation/ObservedUserTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/Observation/ObservedUserTests.swift
@@ -16,10 +16,22 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import Combine
 import Foundation
 @testable import InfomaniakDI
-@testable import kDriveCore
+import kDriveCore
 import Testing
+
+extension ObservedUser {
+    var receivedValues: AsyncStream<User?> {
+        AsyncStream { continuation in
+            let cancellable = $wrappedValue
+                .sink { value in continuation.yield(value) }
+
+            continuation.onTermination = { _ in cancellable.cancel() }
+        }
+    }
+}
 
 @MainActor
 struct ObservedUserTests {

--- a/src/front/macOS/kDriveTests/Cache/Observation/ObservedUserTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/Observation/ObservedUserTests.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 @testable import InfomaniakDI
-import kDriveCore
+@testable import kDriveCore
 import XCTest
 
 final class ObservedUserTests: XCTestCase {
@@ -29,16 +29,17 @@ final class ObservedUserTests: XCTestCase {
         XCTAssertNil(initialUser, "Cache should initially be empty")
 
         @ObservedUser(userDbId: ObservableData.expectedUserDbId, cacheObservation: cache) var observedUser: User?
+        let receivedValues = $observedUser.receivedValues // Start to save the received values
         XCTAssertNil(observedUser, "User should initially be nil")
 
         // WHEN
         let expectedUser = ObservableData.expectedUserWithAccounts
         await cache.addUser(expectedUser)
 
-        // Give time for observation to propagate
-        try await Task.sleep(nanoseconds: 10_000_000_000)
-
         // THEN
+        let lastReceivedObject = await receivedValues.first(where: { $0 != nil })
+        XCTAssertEqual(lastReceivedObject, expectedUser, "The object should be a received event")
+
         let cachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
         XCTAssertEqual(cachedUser, expectedUser, "The cache should have been updated")
         XCTAssertEqual(observedUser, expectedUser, "The observed object should have been updated")
@@ -51,6 +52,7 @@ final class ObservedUserTests: XCTestCase {
         XCTAssertNil(initialUser, "Cache should initially be empty")
 
         @ObservedUser(userDbId: ObservableData.expectedUserDbId, cacheObservation: cache) var observedUser: User?
+        let receivedValues = $observedUser.receivedValues
         XCTAssertNil(observedUser, "User should initially be nil")
 
         let expectedUser = ObservableData.expectedUser
@@ -63,10 +65,9 @@ final class ObservedUserTests: XCTestCase {
         let updatedUser = ObservableData.updatedUser
         await cache.addUser(updatedUser)
 
-        // Give time for observation to propagate
-        try await Task.sleep(nanoseconds: 10_000_000_000)
-
         // THEN
+        _ = await receivedValues.dropFirst().first(where: { $0 != nil })
+
         let latestCachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
         XCTAssertEqual(latestCachedUser, updatedUser, "The object should be in cache")
         XCTAssertEqual(observedUser, updatedUser, "The observed object should be up to date")
@@ -79,6 +80,7 @@ final class ObservedUserTests: XCTestCase {
         XCTAssertNil(initialUser, "Cache should initially be empty")
 
         @ObservedUser(userDbId: ObservableData.expectedUserDbId, cacheObservation: cache) var observedUser: User?
+        let receivedValues = $observedUser.receivedValues
         XCTAssertNil(observedUser, "User should initially be nil")
 
         let expectedUser = ObservableData.expectedUser
@@ -92,10 +94,9 @@ final class ObservedUserTests: XCTestCase {
         await cache.addUser(updatedUser)
         await cache.addUser(updatedUser)
 
-        // Give time for observation to propagate
-        try await Task.sleep(nanoseconds: 10_000_000_000)
-
         // THEN
+        _ = await receivedValues.dropFirst().dropFirst().first(where: { $0 != nil })
+
         let latestCachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
         XCTAssertEqual(latestCachedUser, updatedUser, "The object should no longer be in cache")
         XCTAssertEqual(observedUser, updatedUser, "The observed object should be up to date")
@@ -108,6 +109,7 @@ final class ObservedUserTests: XCTestCase {
         XCTAssertNil(initialUser, "Cache should initially be empty")
 
         @ObservedUser(userDbId: ObservableData.expectedUserDbId, cacheObservation: cache) var observedUser: User?
+        let receivedValues = $observedUser.receivedValues
         XCTAssertNil(observedUser, "User should initially be nil")
 
         let expectedUser = ObservableData.expectedUser
@@ -119,10 +121,9 @@ final class ObservedUserTests: XCTestCase {
         // WHEN
         await cache.removeUser(dbId: ObservableData.expectedUserDbId)
 
-        // Give time for observation to propagate
-        try await Task.sleep(nanoseconds: 10_000_000_000)
-
         // THEN
+        _ = await receivedValues.first(where: { $0 == nil })
+
         let latestCachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
         XCTAssertNil(latestCachedUser, "The object should no longer be in cache")
         XCTAssertNil(observedUser, "The observed object should be nil since the cache entry was deleted")

--- a/src/front/macOS/kDriveTests/Cache/Observation/ObservedUserTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/Observation/ObservedUserTests.swift
@@ -19,18 +19,19 @@
 import Foundation
 @testable import InfomaniakDI
 @testable import kDriveCore
-import XCTest
+import Testing
 
-final class ObservedUserTests: XCTestCase {
-    func testSetObservedUser() async throws {
+@MainActor
+struct ObservedUserTests {
+    @Test func setObservedUser() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
-        XCTAssertNil(initialUser, "Cache should initially be empty")
+        #expect(initialUser == nil, "Cache should initially be empty")
 
         @ObservedUser(userDbId: ObservableData.expectedUserDbId, cacheObservation: cache) var observedUser: User?
         let receivedValues = $observedUser.receivedValues // Start to save the received values
-        XCTAssertNil(observedUser, "User should initially be nil")
+        #expect(observedUser == nil, "User should initially be nil")
 
         // WHEN
         let expectedUser = ObservableData.expectedUserWithAccounts
@@ -38,28 +39,28 @@ final class ObservedUserTests: XCTestCase {
 
         // THEN
         let lastReceivedObject = await receivedValues.first(where: { $0 != nil })
-        XCTAssertEqual(lastReceivedObject, expectedUser, "The object should be a received event")
+        #expect(lastReceivedObject == expectedUser, "The object should be a received event")
 
         let cachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
-        XCTAssertEqual(cachedUser, expectedUser, "The cache should have been updated")
-        XCTAssertEqual(observedUser, expectedUser, "The observed object should have been updated")
+        #expect(cachedUser == expectedUser, "The cache should have been updated")
+        #expect(observedUser == expectedUser, "The observed object should have been updated")
     }
 
-    func testUpdateObservedUser() async throws {
+    @Test func updateObservedUser() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
-        XCTAssertNil(initialUser, "Cache should initially be empty")
+        #expect(initialUser == nil, "Cache should initially be empty")
 
         @ObservedUser(userDbId: ObservableData.expectedUserDbId, cacheObservation: cache) var observedUser: User?
         let receivedValues = $observedUser.receivedValues
-        XCTAssertNil(observedUser, "User should initially be nil")
+        #expect(observedUser == nil, "User should initially be nil")
 
         let expectedUser = ObservableData.expectedUser
         await cache.addUser(expectedUser)
 
         let cachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
-        XCTAssertEqual(cachedUser, expectedUser, "The cache should have been updated")
+        #expect(cachedUser == expectedUser, "The cache should have been updated")
 
         // WHEN
         let updatedUser = ObservableData.updatedUser
@@ -69,25 +70,25 @@ final class ObservedUserTests: XCTestCase {
         _ = await receivedValues.dropFirst().first(where: { $0 != nil })
 
         let latestCachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
-        XCTAssertEqual(latestCachedUser, updatedUser, "The object should be in cache")
-        XCTAssertEqual(observedUser, updatedUser, "The observed object should be up to date")
+        #expect(latestCachedUser == updatedUser, "The object should be in cache")
+        #expect(observedUser == updatedUser, "The observed object should be up to date")
     }
 
-    func testUpdateObservedUserTwice() async throws {
+    @Test func updateObservedUserTwice() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
-        XCTAssertNil(initialUser, "Cache should initially be empty")
+        #expect(initialUser == nil, "Cache should initially be empty")
 
         @ObservedUser(userDbId: ObservableData.expectedUserDbId, cacheObservation: cache) var observedUser: User?
         let receivedValues = $observedUser.receivedValues
-        XCTAssertNil(observedUser, "User should initially be nil")
+        #expect(observedUser == nil, "User should initially be nil")
 
         let expectedUser = ObservableData.expectedUser
         await cache.addUser(expectedUser)
 
         let cachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
-        XCTAssertEqual(cachedUser, expectedUser, "The cache should have been updated")
+        #expect(cachedUser == expectedUser, "The cache should have been updated")
 
         // WHEN
         let updatedUser = ObservableData.updatedUser
@@ -98,34 +99,34 @@ final class ObservedUserTests: XCTestCase {
         _ = await receivedValues.dropFirst().dropFirst().first(where: { $0 != nil })
 
         let latestCachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
-        XCTAssertEqual(latestCachedUser, updatedUser, "The object should no longer be in cache")
-        XCTAssertEqual(observedUser, updatedUser, "The observed object should be up to date")
+        #expect(latestCachedUser == updatedUser, "The object should no longer be in cache")
+        #expect(observedUser == updatedUser, "The observed object should be up to date")
     }
 
-    func testRemoveObservedUser() async throws {
+    @Test func removeObservedUser() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
-        XCTAssertNil(initialUser, "Cache should initially be empty")
+        #expect(initialUser == nil, "Cache should initially be empty")
 
         @ObservedUser(userDbId: ObservableData.expectedUserDbId, cacheObservation: cache) var observedUser: User?
         let receivedValues = $observedUser.receivedValues
-        XCTAssertNil(observedUser, "User should initially be nil")
+        #expect(observedUser == nil, "User should initially be nil")
 
         let expectedUser = ObservableData.expectedUser
         await cache.addUser(expectedUser)
 
         let cachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
-        XCTAssertEqual(cachedUser, expectedUser, "The cache should have been updated")
+        #expect(cachedUser == expectedUser, "The cache should have been updated")
 
         // WHEN
         await cache.removeUser(dbId: ObservableData.expectedUserDbId)
 
         // THEN
-        _ = await receivedValues.first(where: { $0 == nil })
+        _ = await receivedValues.dropFirst().first(where: { $0 == nil })
 
         let latestCachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
-        XCTAssertNil(latestCachedUser, "The object should no longer be in cache")
-        XCTAssertNil(observedUser, "The observed object should be nil since the cache entry was deleted")
+        #expect(latestCachedUser == nil, "The object should no longer be in cache")
+        #expect(observedUser == nil, "The observed object should be nil since the cache entry was deleted")
     }
 }

--- a/src/front/macOS/kDriveTests/Cache/Observation/ObservedUserTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/Observation/ObservedUserTests.swift
@@ -75,6 +75,36 @@ struct ObservedUserTests {
         #expect(latestCachedUser == updatedUser, "The object should be in cache")
         #expect(observedUser == updatedUser, "The observed object should be up to date")
     }
+    
+    @Test(.timeLimit(.minutes(1)))
+    func doubleUpdateObservedUser() async throws {
+        // GIVEN
+        let cache = ServerCoherentCache()
+        let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        #expect(initialUser == nil, "Cache should initially be empty")
+
+        @ObservedUser(userDbId: ObservableData.expectedUserDbId, cacheObservation: cache) var observedUser: User?
+        let receivedValues = $observedUser.receivedValues
+        #expect(observedUser == nil, "User should initially be nil")
+
+        let expectedUser = ObservableData.expectedUser
+        await cache.addUser(expectedUser)
+
+        let cachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        #expect(cachedUser == expectedUser, "The cache should have been updated")
+
+        // WHEN
+        let updatedUser = ObservableData.updatedUser
+        await cache.addUser(updatedUser)
+        await cache.addUser(updatedUser)
+
+        // THEN
+        _ = await receivedValues.dropFirst().dropFirst().first(where: { $0 != nil })
+
+        let latestCachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        #expect(latestCachedUser == updatedUser, "The object should be in cache")
+        #expect(observedUser == updatedUser, "The observed object should be up to date")
+    }
 
     @Test(.timeLimit(.minutes(1)))
     func updateObservedUserTwice() async throws {

--- a/src/front/macOS/kDriveTests/Cache/Observation/ObservedUserTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/Observation/ObservedUserTests.swift
@@ -22,7 +22,7 @@ import kDriveCore
 import XCTest
 
 final class ObservedUserTests: XCTestCase {
-    func testSetGetUserFromPropertyWrapper() async throws {
+    func testSetObservedUser() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
         let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
@@ -32,7 +32,7 @@ final class ObservedUserTests: XCTestCase {
         XCTAssertNil(observedUser, "User should initially be nil")
 
         // WHEN
-        let expectedUser = ObservableData.expectedUser
+        let expectedUser = ObservableData.expectedUserWithAccounts
         await cache.addUser(expectedUser)
 
         // Give time for observation to propagate
@@ -42,5 +42,86 @@ final class ObservedUserTests: XCTestCase {
         let cachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
         XCTAssertEqual(cachedUser, expectedUser, "The cache should have been updated")
         XCTAssertEqual(observedUser, expectedUser, "The observed object should have been updated")
+    }
+
+    func testUpdateObservedUser() async throws {
+        // GIVEN
+        let cache = ServerCoherentCache()
+        let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        XCTAssertNil(initialUser, "Cache should initially be empty")
+
+        @ObservedUser(dbId: ObservableData.expectedUserDbId, cacheObservation: cache) var observedUser: User?
+        XCTAssertNil(observedUser, "User should initially be nil")
+
+        let expectedUser = ObservableData.expectedUser
+        await cache.addUser(expectedUser)
+
+        let cachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        XCTAssertEqual(cachedUser, expectedUser, "The cache should have been updated")
+
+        // WHEN
+        let updatedUser = ObservableData.updatedUser
+        await cache.addUser(updatedUser)
+
+        // Give time for observation to propagate
+        try await Task.sleep(nanoseconds: 10_000_000_000)
+
+        // THEN
+        let latestCachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        XCTAssertEqual(latestCachedUser, updatedUser, "The observed object should have been updated again")
+    }
+    
+    func testUpdateObservedUserTwice() async throws {
+        // GIVEN
+        let cache = ServerCoherentCache()
+        let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        XCTAssertNil(initialUser, "Cache should initially be empty")
+
+        @ObservedUser(dbId: ObservableData.expectedUserDbId, cacheObservation: cache) var observedUser: User?
+        XCTAssertNil(observedUser, "User should initially be nil")
+
+        let expectedUser = ObservableData.expectedUser
+        await cache.addUser(expectedUser)
+
+        let cachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        XCTAssertEqual(cachedUser, expectedUser, "The cache should have been updated")
+
+        // WHEN
+        let updatedUser = ObservableData.updatedUser
+        await cache.addUser(updatedUser)
+        await cache.addUser(updatedUser)
+
+        // Give time for observation to propagate
+        try await Task.sleep(nanoseconds: 10_000_000_000)
+
+        // THEN
+        let latestCachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        XCTAssertEqual(latestCachedUser, updatedUser, "The observed object should have been updated again")
+    }
+    
+    func testRemoveObservedUser() async throws {
+        // GIVEN
+        let cache = ServerCoherentCache()
+        let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        XCTAssertNil(initialUser, "Cache should initially be empty")
+
+        @ObservedUser(dbId: ObservableData.expectedUserDbId, cacheObservation: cache) var observedUser: User?
+        XCTAssertNil(observedUser, "User should initially be nil")
+
+        let expectedUser = ObservableData.expectedUser
+        await cache.addUser(expectedUser)
+
+        let cachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        XCTAssertEqual(cachedUser, expectedUser, "The cache should have been updated")
+        
+        // WHEN
+        await cache.removeUser(dbId: ObservableData.expectedUserDbId)
+        
+        // Give time for observation to propagate
+        try await Task.sleep(nanoseconds: 10_000_000_000)
+
+        // THEN
+        let latestCachedUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        XCTAssertNil(latestCachedUser, "The observed object should be nil since the cache entry was deleted")
     }
 }


### PR DESCRIPTION
### Abstract

This PR aims to finish observation of the server cache.
Observation is now also fully tested

Note that now observation can send nil value if the object is removed.
You can guard on your observation to make sure it will not nilify your local values.

### Note

Depends on https://github.com/Infomaniak/desktop-kDrive/pull/1220