### PR TITLE
fix: never remove CLSID from DB

### DIFF
--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -2559,11 +2559,11 @@ ExitCode AppServer::migrateConfiguration(bool &proxyNotSupported) {
 
     MigrationParams mp = MigrationParams();
     std::vector<std::pair<migrateptr, std::string>> migrateArr = {
-        {&MigrationParams::migrateGeneralParams, "migrateGeneralParams"},
-        {&MigrationParams::migrateAccountsParams, "migrateAccountsParams"},
-        {&MigrationParams::migrateTemplateExclusion, "migrateFileExclusion"},
+            {&MigrationParams::migrateGeneralParams, "migrateGeneralParams"},
+            {&MigrationParams::migrateAccountsParams, "migrateAccountsParams"},
+            {&MigrationParams::migrateTemplateExclusion, "migrateFileExclusion"},
 #if defined(KD_MACOS)
-        {&MigrationParams::migrateAppExclusion, "migrateAppExclusion"},
+            {&MigrationParams::migrateAppExclusion, "migrateAppExclusion"},
 #endif
     };
 
@@ -2843,6 +2843,14 @@ ExitInfo AppServer::startSyncs(User &user) {
 
             for (Sync &sync: syncList) {
                 QSet<QString> blackList;
+                bool syncUpdated = false;
+
+                // Make sure we have valid CLSID
+                if (sync.navigationPaneClsid().empty()) {
+                    sync.setNavigationPaneClsid(QUuid::createUuid().toString().toStdString());
+                    syncUpdated = true;
+                }
+
                 if (user.toMigrate()) {
                     if (!user.keychainKey().empty()) {
                         // End migration once connected
@@ -2856,24 +2864,24 @@ ExitInfo AppServer::startSyncs(User &user) {
                             mainExitInfo.merge(exitInfo, {ExitCode::SystemError});
                             continue;
                         }
-
-                        if (syncUpdated) {
-                            // Update sync
-                            bool found = false;
-                            if (!ParmsDb::instance()->updateSync(sync, found)) {
-                                LOG_WARN(_logger, "Error in ParmsDb::updateSync");
-                                return {ExitCode::DbError, ExitCause::DbAccessError};
-                            }
-                            if (!found) {
-                                LOG_WARN(_logger, "Sync not found in sync table for syncDbId=" << sync.dbId());
-                                return {ExitCode::DataError, ExitCause::DbEntryNotFound};
-                            }
-
-                            SyncInfo syncInfo;
-                            ServerRequests::syncToSyncInfo(sync, syncInfo);
-                            sendSyncUpdated(syncInfo);
-                        }
                     }
+                }
+
+                if (syncUpdated) {
+                    // Update sync
+                    bool found = false;
+                    if (!ParmsDb::instance()->updateSync(sync, found)) {
+                        LOG_WARN(_logger, "Error in ParmsDb::updateSync");
+                        return {ExitCode::DbError, ExitCause::DbAccessError};
+                    }
+                    if (!found) {
+                        LOG_WARN(_logger, "Sync not found in sync table for syncDbId=" << sync.dbId());
+                        return {ExitCode::DataError, ExitCause::DbEntryNotFound};
+                    }
+
+                    SyncInfo syncInfo;
+                    ServerRequests::syncToSyncInfo(sync, syncInfo);
+                    sendSyncUpdated(syncInfo);
                 }
 
                 // Clear old errors for this sync
@@ -3756,28 +3764,24 @@ ExitInfo AppServer::createAndStartVfs(const Sync &sync) noexcept {
 
 #if defined(KD_WINDOWS)
     // Save sync
-    Sync tmpSync(sync);
-    tmpSync.setNavigationPaneClsid(vfsMapIt->second->namespaceCLSID());
-
-    if (tmpSync.virtualFileMode() == KDC::VirtualFileMode::Win) {
-        Utility::setFolderPinState(CommonUtility::s2ws(tmpSync.navigationPaneClsid()),
+    if (sync.virtualFileMode() == KDC::VirtualFileMode::Win) {
+        Utility::setFolderPinState(CommonUtility::s2ws(vfsMapIt->second->namespaceCLSID()),
                                    _navigationPaneHelper->showInExplorerNavigationPane());
     } else {
-        if (tmpSync.navigationPaneClsid().empty()) {
-            tmpSync.setNavigationPaneClsid(QUuid::createUuid().toString().toStdString());
-            vfsMapIt->second->setNamespaceCLSID(tmpSync.navigationPaneClsid());
+        if (vfsMapIt->second->namespaceCLSID().empty()) {
+            vfsMapIt->second->setNamespaceCLSID(sync.navigationPaneClsid());
         }
         Utility::addLegacySyncRootKeys(CommonUtility::s2ws(sync.navigationPaneClsid()), sync.localPath(),
                                        _navigationPaneHelper->showInExplorerNavigationPane());
     }
 
     bool found = false;
-    if (!ParmsDb::instance()->updateSync(tmpSync, found)) {
+    if (!ParmsDb::instance()->updateSync(sync, found)) {
         LOG_WARN(_logger, "Error in ParmsDb::updateSync");
         return {ExitCode::DbError, ExitCause::DbAccessError};
     }
     if (!found) {
-        LOG_WARN(_logger, "Sync not found in sync table for syncDbId=" << tmpSync.dbId());
+        LOG_WARN(_logger, "Sync not found in sync table for syncDbId=" << sync.dbId());
         return {ExitCode::DataError, ExitCause::DbEntryNotFound};
     }
 #endif
@@ -3867,16 +3871,10 @@ ExitInfo AppServer::setSupportsVirtualFiles(int syncDbId, bool value) {
 
 #if defined(KD_WINDOWS)
         if (newMode == VirtualFileMode::Win) {
-            // Remove legacy sync root keys
             Utility::removeLegacySyncRootKeys(CommonUtility::s2ws(sync.navigationPaneClsid()));
-            sync.setNavigationPaneClsid(std::string());
         } else if (sync.virtualFileMode() == VirtualFileMode::Win) {
-            // Add legacy sync root keys
-            bool show = _navigationPaneHelper->showInExplorerNavigationPane();
-            if (sync.navigationPaneClsid().empty()) {
-                sync.setNavigationPaneClsid(QUuid::createUuid().toString().toStdString());
-            }
-            Utility::addLegacySyncRootKeys(CommonUtility::s2ws(sync.navigationPaneClsid()), sync.localPath(), show);
+            Utility::addLegacySyncRootKeys(CommonUtility::s2ws(sync.navigationPaneClsid()), sync.localPath(),
+                                           _navigationPaneHelper->showInExplorerNavigationPane());
         }
 #endif
 

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -2854,7 +2854,6 @@ ExitInfo AppServer::startSyncs(User &user) {
                 if (user.toMigrate()) {
                     if (!user.keychainKey().empty()) {
                         // End migration once connected
-                        bool syncUpdated = false;
                         if (const auto exitInfo =
                                     processMigratedSyncOnceConnected(user.dbId(), drive.driveId(), sync, blackList, syncUpdated);
                             !exitInfo) {

--- a/src/server/navigationpanehelper.cpp
+++ b/src/server/navigationpanehelper.cpp
@@ -95,9 +95,6 @@ void NavigationPaneHelper::updateCloudStorageRegistry() {
 
     for (KDC::Sync &sync: syncList) {
         if (sync.virtualFileMode() != KDC::VirtualFileMode::Win) {
-            if (sync.navigationPaneClsid().empty()) {
-                sync.setNavigationPaneClsid(QUuid::createUuid().toString().toStdString());
-            }
             Utility::addLegacySyncRootKeys(CommonUtility::s2ws(sync.navigationPaneClsid()), sync.localPath(),
                                            _showInExplorerNavigationPane);
         }

--- a/src/server/requests/serverrequests.cpp
+++ b/src/server/requests/serverrequests.cpp
@@ -726,9 +726,7 @@ ExitCode ServerRequests::addSync(int driveDbId, const SyncPath &localFolderPath,
 
     QUuid navigationPaneClsid;
 #ifdef Q_OS_WIN
-    if (showInNavigationPane) {
-        navigationPaneClsid = QUuid::createUuid();
-    }
+    navigationPaneClsid = QUuid::createUuid();
 #endif
 
     Sync sync;
@@ -761,7 +759,7 @@ ExitCode ServerRequests::addSync(int driveDbId, const SyncPath &localFolderPath,
     sync.setDbPath(std::filesystem::path());
     sync.setHasFullyCompleted(false);
     sync.setNavigationPaneClsid(navigationPaneClsid.toString().toStdString());
-    if (ExitCode exitCode = createSync(sync, syncInfo); exitCode != ExitCode::Ok) {
+    if (const auto exitCode = createSync(sync, syncInfo); exitCode != ExitCode::Ok) {
         LOG_WARN(Log::instance()->getLogger(), "Error in createSync");
         return exitCode;
     }


### PR DESCRIPTION
The shortcuts pointing to synchronized file were broken after restarting the app or hiding the Quick Access shortcut to the sync folder.
The fix consists of setting the CLSID once when creating the sync and never removing it from DB nor registry.