### PR TITLE
fix: remove \n from the regex pattern

### DIFF
--- a/src/libsyncengine/requests/exclusiontemplatecache.cpp
+++ b/src/libsyncengine/requests/exclusiontemplatecache.cpp
@@ -78,8 +78,15 @@ void ExclusionTemplateCache::populateUndeletedExclusionTemplates() {
 }
 
 void ExclusionTemplateCache::updateRegexPatterns() {
+#ifdef KD_WINDOWS
+    // Adding character '\n' to the regex pattern produce an infinite loop inside method 'std::regex_match'. Therefor, we removed
+    // in Windows only because character '\n' is forbidden on Windows anyway.
+    static const std::string anyCharacter =
+            ".*?"; // The question mark `?` is used for lazy matching, i.e. it matches as few characters as possible.
+#else
     static const std::string anyCharacter =
             "(.|\n)*?"; // The question mark `?` is used for lazy matching, i.e. it matches as few characters as possible.
+#endif
 
     const std::scoped_lock<std::mutex> lock(_mutex);
     _regexPatterns.clear();

--- a/test/libsyncengine/requests/testexclusiontemplatecache.cpp
+++ b/test/libsyncengine/requests/testexclusiontemplatecache.cpp
@@ -72,7 +72,7 @@ static const std::vector<std::string> acceptedFiles = {"~test",
                                                     "System test Volume Information",
                                                     "رتجمع ثامر ورفاقه أمام باب المدرسة سيذهبون في رحلة إلى إسبانيا قال لهم "
                                                     "مرافقهم راقبوا أمتعتكم ولا تعبثوا بأثاث الحافلة قضوا هناك أياما ممتعة "
-                                                    "زاروا فيها مدنا كثيرة" // Long name in arabic used to generate infinite in the std::regex_match on Windows
+                                                    "زاروا فيها مدنا كثيرة" // Long name in arabic used to generate infinite loop in the std::regex_match on Windows
 #else
                                                     "test.fuse_hidden"
                                                     "test.gnucash.test.tmp-test"

--- a/test/libsyncengine/requests/testexclusiontemplatecache.cpp
+++ b/test/libsyncengine/requests/testexclusiontemplatecache.cpp
@@ -43,7 +43,9 @@ static const std::vector<std::string> rejectedFiles = {
         "testfile_conflict_test_20220913_130102_abcdefghij.txt",
         "_conflict___",
         "testfile_blacklisted_20220913_130102_abcdefghij.txt",
+#if !defined(KD_WINDOWS)
         "A\n_blacklisted_20240824_081432_s2L5tFynHP_blacklisted_20240824_180957.eml",
+#endif
 #if defined(KD_MACOS)
         ".DS_Store",
 #elif defined(KD_WINDOWS)
@@ -65,12 +67,15 @@ static const std::vector<std::string> acceptedFiles = {"~test",
                                                        "test.apdisk",
                                                        "test_Icon\rtest"
 #elif defined(KD_WINDOWS)
-                                                       "test.testkate-swp",
-                                                       "system volume information",
-                                                       "System test Volume Information"
+                                                    "test.testkate-swp",
+                                                    "system volume information",
+                                                    "System test Volume Information",
+                                                    "رتجمع ثامر ورفاقه أمام باب المدرسة سيذهبون في رحلة إلى إسبانيا قال لهم "
+                                                    "مرافقهم راقبوا أمتعتكم ولا تعبثوا بأثاث الحافلة قضوا هناك أياما ممتعة "
+                                                    "زاروا فيها مدنا كثيرة" // Long name in arabic used to generate infinite in the std::regex_match on Windows
 #else
-                                                       "test.fuse_hidden"
-                                                       "test.gnucash.test.tmp-test"
+                                                    "test.fuse_hidden"
+                                                    "test.gnucash.test.tmp-test"
 #endif
 };
 


### PR DESCRIPTION
The character `\n` is making the method `std::regex_match` to loop indefinitely on long file name without special characters (such as arabic or chinese).
The character `\n` was added as part of this PR: https://github.com/Infomaniak/desktop-kDrive/pull/986. However, since `\n` is a forbidden character on Windows, the regex pattern has been simplified for Windows only.