### PR TITLE
Fix infinite loop during upload

### DIFF
--- a/src/libsyncengine/jobs/network/kDrive_API/upload/upload_session/abstractuploadsession.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/upload/upload_session/abstractuploadsession.cpp
@@ -388,7 +388,7 @@ ExitInfo AbstractUploadSession::sendChunks() {
         if (_jobExecutionError) {
             // Job execution issue
             // exitCode & exitCause are those of the chunk that has failed
-            return exitInfo;
+            return _chunkJobExitInfo;
         }
         if (readError) {
             // Read file issue

--- a/src/libsyncengine/jobs/network/kDrive_API/upload/upload_session/abstractuploadsession.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/upload/upload_session/abstractuploadsession.cpp
@@ -124,9 +124,10 @@ void AbstractUploadSession::uploadChunkCallback(const UniqueId jobId) {
     const std::scoped_lock lock(_mutex);
     const auto jobInfo = _ongoingChunkJobs.extract(jobId);
     if (!jobInfo.empty() && jobInfo.mapped()) {
-        if (jobInfo.mapped()->hasHttpError() || jobInfo.mapped()->exitInfo().code() != ExitCode::Ok) {
+        if (jobInfo.mapped()->hasHttpError() || !jobInfo.mapped()->exitInfo()) {
             LOGW_WARN(_logger, L"Failed to upload chunk " << jobId << L" of file " << Path2WStr(_filePath.filename()));
             _jobExecutionError = true;
+            _chunkJobExitInfo = jobInfo.mapped()->exitInfo();
         }
 
         _threadCounter--;
@@ -273,7 +274,6 @@ ExitInfo AbstractUploadSession::sendChunks() {
         return ExitCode::SystemError;
     }
 
-    ExitInfo exitInfo;
     for (uint64_t chunkNb = 1; chunkNb <= _totalChunks; chunkNb++) {
         if (isAborted() || _jobExecutionError) {
             LOG_DEBUG(_logger, "Request " << jobId() << ": aborted");
@@ -346,7 +346,8 @@ ExitInfo AbstractUploadSession::sendChunks() {
         } else {
             LOG_INFO(_logger, "Session " << _sessionToken << ", thread " << chunkJob->jobId() << " start.");
 
-            if (exitInfo = chunkJob->runSynchronously(); exitInfo.code() != ExitCode::Ok || chunkJob->hasHttpError()) {
+            _chunkJobExitInfo = chunkJob->runSynchronously();
+            if (!_chunkJobExitInfo || chunkJob->hasHttpError()) {
                 LOGW_WARN(_logger, L"Failed to upload chunk " << chunkNb << L" of file " << Path2WStr(_filePath.filename()));
                 _jobExecutionError = true;
                 break;

--- a/src/libsyncengine/jobs/network/kDrive_API/upload/upload_session/abstractuploadsession.h
+++ b/src/libsyncengine/jobs/network/kDrive_API/upload/upload_session/abstractuploadsession.h
@@ -94,6 +94,7 @@ class AbstractUploadSession : public SyncJob {
         bool _sessionStarted = false;
         bool _sessionCancelled = false;
         bool _jobExecutionError = false;
+        ExitInfo _chunkJobExitInfo;
 
         std::string _sessionToken;
 

--- a/src/libsyncengine/syncpal/isyncworker.cpp
+++ b/src/libsyncengine/syncpal/isyncworker.cpp
@@ -100,9 +100,15 @@ void ISyncWorker::sleepUntilStartDelay(bool &awakenByStop) {
     }
 }
 
-void ISyncWorker::setDone(ExitCode exitCode) {
+void ISyncWorker::setDone(const ExitCode exitCode) {
     std::stringstream logStream;
     logStream << "Worker " << _name << " has finished with code=" << exitCode << " cause=" << _exitCause;
+
+    if (exitCode == ExitCode::Unknown) { // Workers should never exit with an "Unknown" exit code.
+        LOG_ERROR(_logger, "Worker " << _name << " exited with Unknown exit code.");
+        assert(false);
+        sentry::Handler::captureMessage(sentry::Level::Warning, "Unknown exit code", "Worker exited with Unknown exit code.");
+    }
 
     if (exitCode == ExitCode::Ok) {
         LOG_SYNCPAL_DEBUG(_logger, logStream.str());


### PR DESCRIPTION
If a network connection is lost during an upload session, the upload session job, and therefore the Executor worker, exited with exit code `Unknown`. This had for effect to loop indefinitely inside `SyncPalWorker::execute()`, waiting for the exit code to be something different from `Unknown`.
This PR fixes the `ExitInfo` returned by the `AbstractUploadSession` job and add some checks to make sure no workers exit `ExitCode::Unknown` anymore.