### PR TITLE
fix(parmsdb): bind filter param only when needed

### DIFF
--- a/src/libparms/db/parmsdb.cpp
+++ b/src/libparms/db/parmsdb.cpp
@@ -2960,7 +2960,9 @@ bool ParmsDb::selectConflicts(int syncDbId, ConflictType filter, std::vector<Err
 
     LOG_IF_FAIL(queryResetAndClearBindings(requestId));
     LOG_IF_FAIL(queryBindValue(requestId, 1, syncDbId));
-    if (filter != ConflictType::None) LOG_IF_FAIL(queryBindValue(requestId, 2, std::to_string(toInt(filter))));
+    if (filter != ConflictType::None) {
+        LOG_IF_FAIL(queryBindValue(requestId, 2, std::to_string(toInt(filter))));
+    }
 
     bool found = false;
     for (;;) {

--- a/src/libparms/db/parmsdb.cpp
+++ b/src/libparms/db/parmsdb.cpp
@@ -2960,7 +2960,7 @@ bool ParmsDb::selectConflicts(int syncDbId, ConflictType filter, std::vector<Err
 
     LOG_IF_FAIL(queryResetAndClearBindings(requestId));
     LOG_IF_FAIL(queryBindValue(requestId, 1, syncDbId));
-    LOG_IF_FAIL(queryBindValue(requestId, 2, std::to_string(toInt(filter))));
+    if (filter != ConflictType::None) LOG_IF_FAIL(queryBindValue(requestId, 2, std::to_string(toInt(filter))));
 
     bool found = false;
     for (;;) {


### PR DESCRIPTION
Previously, the filter parameter was always bound to the SQL query, even when no filter was applied. Now, the filter value is only bound if it is different from "None", preventing LOG_IF_FAIL false positive