### PR TITLE
Chore add automatic tagging

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,8 +2,8 @@
 
 WinUI:
   - changed-files:
-   - any-glob-to-any-file: 'src/gui4/windows/**'
-
+    - any-glob-to-any-file: 'src/gui4/windows/**'
+    
 macOS UI:
  - changed-files:
-  - any-glob-to-any-file: 'src/front/macOS/**'
+   - any-glob-to-any-file: 'src/front/macOS/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,9 @@
+# Labeler configuration for PR file path rules
+
+WinUI:
+  - changed-files:
+   - any-glob-to-any-file: 'src/gui4/windows/**'
+
+macOS UI:
+ - changed-files:
+  - any-glob-to-any-file: 'src/front/macOS/**'

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,66 @@
+﻿name: PR Auto Labeler
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  path-labels:
+    runs-on: self-hosted
+    steps:
+      - name: Apply path-based labels
+        uses: actions/labeler@v6
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml
+
+  quick-fix-label:
+    runs-on: self-hosted
+    steps:
+      - name: Check total changed lines and add quick fix label
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const prNumber = context.payload.pull_request.number;
+
+            // List files in PR
+            const files = await github.paginate(
+              github.rest.pulls.listFiles,
+              {
+                owner,
+                repo,
+                pull_number: prNumber,
+                per_page: 100,
+              }
+            );
+
+            // Sum additions + deletions
+            const changed = files.reduce(
+              (sum, f) => sum + (f.additions || 0) + (f.deletions || 0),
+              0
+            );
+
+            core.info(`Total changed lines: ${changed}`);
+
+            if (changed < 4) {
+              try {
+                await github.rest.issues.addLabels({
+                  owner,
+                  repo,
+                  issue_number: prNumber,
+                  labels: ["quick fix 🚀"],
+                });
+                core.info('Added "quick fix 🚀" label.');
+              } catch (e) {
+                core.warning(`Failed to add label: ${e.message}`);
+              }
+            } else {
+              core.info("Change exceeds quick fix threshold; not labeling.");
+            }

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -49,7 +49,7 @@ jobs:
 
             core.info(`Total changed lines: ${changed}`);
 
-            if (changed < 4) {
+            if (changed <= 20) {
               try {
                 await github.rest.issues.addLabels({
                   owner,


### PR DESCRIPTION
This pull request introduces automated labeling for pull requests based on file paths and the size of changes.
**GitHub Automation and Labeling:**

* Added `.github/labeler.yml` to define rules for automatically applying labels (`WinUI`, `macOS UI`) to PRs based on changed file paths.
* Added `.github/workflows/pr-labeler.yml` workflow to automatically apply labels using the defined rules and to add a "quick fix 🚀" label to PRs with fewer than 4 changed lines.