### PR TITLE
feat: Mac GUI first Signal support

### DIFF
--- a/src/front/macOS/kDriveCore/Models/DTOs/Synchro.swift
+++ b/src/front/macOS/kDriveCore/Models/DTOs/Synchro.swift
@@ -28,4 +28,9 @@ public struct Synchro: Identifiable, Hashable, Sendable {
     public let dbId: Int32
     public let driveDbId: Int32
     public let localPath: String
+
+    public let targetPath: String
+    public let targetNodeId: String
+    public let supportVfs: Bool
+    public let virtualFileMode: KDC.VirtualFileMode
 }

--- a/src/front/macOS/kDriveCore/ServerBridge/Cache/CoherentCache.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Cache/CoherentCache.swift
@@ -44,6 +44,7 @@ public protocol CoherentCache: Sendable {
     func getDrive(driveDbId: Int32) async -> Drive?
     func addDrive(_ drive: Drive, accountDbId: Int32) async throws
     func removeDrive(driveDbId: Int32, accountDbId: Int32, userDbId: Int32) async
+    func removeDrive(driveDbId: Int32) async throws
     func updateDrive(drive: Drive) async throws
 
     // MARK: - Synchro

--- a/src/front/macOS/kDriveCore/ServerBridge/Cache/ServerCoherentCache.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Cache/ServerCoherentCache.swift
@@ -184,6 +184,21 @@ public actor ServerCoherentCache: CoherentCache, CoherentCacheObservable {
         notifyUpdate()
     }
 
+    public func removeDrive(driveDbId: Int32) throws {
+        for user in users.values {
+            for var account in user.accounts.values {
+                guard account.drives.removeValue(forKey: driveDbId) != nil else {
+                    continue
+                }
+
+                try updateAccount(account)
+                return
+            }
+        }
+
+        throw CacheError.driveNotFound(driveDbId)
+    }
+
     public func updateDrive(drive: Drive) throws {
         let accountDbId = drive.accountDbId
         guard var account = getAccount(accountDbId: accountDbId) else {

--- a/src/front/macOS/kDriveCore/ServerBridge/Jobs/DTOs/SyncList.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Jobs/DTOs/SyncList.swift
@@ -69,12 +69,12 @@ public struct NewSyncQuery: Codable, Sendable {
         self.accountId = accountId
         self.driveId = driveId
 
-        self._localFolderPath = Base64CodedString(wrappedValue: metadata.localFolderPath)
-        self._serverFolderPath = Base64CodedString(wrappedValue: metadata.serverFolderPath)
-        self._serverFolderNodeId = Base64CodedString(wrappedValue: metadata.serverFolderNodeId)
-        self.liteSync = metadata.liteSync
-        self._blackList = Base64CodedStrings(wrappedValue: metadata.blackList)
-        self._whiteList = Base64CodedStrings(wrappedValue: metadata.whiteList)
+        _localFolderPath = Base64CodedString(wrappedValue: metadata.localFolderPath)
+        _serverFolderPath = Base64CodedString(wrappedValue: metadata.serverFolderPath)
+        _serverFolderNodeId = Base64CodedString(wrappedValue: metadata.serverFolderNodeId)
+        liteSync = metadata.liteSync
+        _blackList = Base64CodedStrings(wrappedValue: metadata.blackList)
+        _whiteList = Base64CodedStrings(wrappedValue: metadata.whiteList)
     }
 }
 
@@ -90,17 +90,23 @@ public struct NewSyncQueryAlternate: Codable, Sendable {
     init(driveDbId: Int32, metadata: NewSyncMetadata) {
         self.driveDbId = driveDbId
 
-        self._localFolderPath = Base64CodedString(wrappedValue: metadata.localFolderPath)
-        self._serverFolderPath = Base64CodedString(wrappedValue: metadata.serverFolderPath)
-        self._serverFolderNodeId = Base64CodedString(wrappedValue: metadata.serverFolderNodeId)
-        self.liteSync = metadata.liteSync
-        self._blackList = Base64CodedStrings(wrappedValue: metadata.blackList)
-        self._whiteList = Base64CodedStrings(wrappedValue: metadata.whiteList)
+        _localFolderPath = Base64CodedString(wrappedValue: metadata.localFolderPath)
+        _serverFolderPath = Base64CodedString(wrappedValue: metadata.serverFolderPath)
+        _serverFolderNodeId = Base64CodedString(wrappedValue: metadata.serverFolderNodeId)
+        liteSync = metadata.liteSync
+        _blackList = Base64CodedStrings(wrappedValue: metadata.blackList)
+        _whiteList = Base64CodedStrings(wrappedValue: metadata.whiteList)
     }
 }
 
 extension SyncInfo {
     var asSynchro: Synchro {
-        Synchro(dbId: dbId, driveDbId: driveDbId, localPath: localPath)
+        Synchro(dbId: dbId,
+                driveDbId: driveDbId,
+                localPath: localPath,
+                targetPath: targetPath,
+                targetNodeId: targetNodeId,
+                supportVfs: supportVfs,
+                virtualFileMode: virtualFileMode)
     }
 }

--- a/src/front/macOS/kDriveCore/ServerBridge/Jobs/DTOs/SyncList.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Jobs/DTOs/SyncList.swift
@@ -47,7 +47,6 @@ public struct SyncInfo: Codable, Sendable {
     public let dbId: Int32
     public let driveDbId: Int32
     @Base64CodedString public var localPath: String
-    @Base64CodedString public var navigationPaneClsid: String
     public let supportVfs: Bool
     @Base64CodedString public var targetNodeId: String
     @Base64CodedString public var targetPath: String

--- a/src/front/macOS/kDriveCore/ServerBridge/Signal/DTOs/AccountInfoSignal.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Signal/DTOs/AccountInfoSignal.swift
@@ -1,0 +1,31 @@
+/*
+ Infomaniak kDrive - Desktop
+ Copyright (C) 2023-2025 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+
+struct AccountInfoSignal: Codable, Sendable {
+    let dbId: Int32
+    let userDbId: Int32
+    let accountId: Int32
+}
+
+extension AccountInfoSignal {
+    var asAccount: Account {
+        Account(dbId: dbId, userDbId: userDbId, name: "", drives: [:])
+    }
+}

--- a/src/front/macOS/kDriveCore/ServerBridge/Signal/DTOs/AccountInfoSignal.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Signal/DTOs/AccountInfoSignal.swift
@@ -29,3 +29,7 @@ extension AccountInfoSignal {
         Account(dbId: dbId, userDbId: userDbId, name: "", drives: [:])
     }
 }
+
+struct AccountRemoveSignal: Codable, Sendable {
+    let accountDbId: Int32
+}

--- a/src/front/macOS/kDriveCore/ServerBridge/Signal/DTOs/DriveInfoSignal.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Signal/DTOs/DriveInfoSignal.swift
@@ -1,0 +1,50 @@
+/*
+ Infomaniak kDrive - Desktop
+ Copyright (C) 2023-2025 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+
+struct DriveInfoSignal: Codable, Sendable {
+    let dbId: Int32
+    let id: Int32
+    let accountDbId: Int32
+    @Base64CodedString var name: String
+    @Base64CodedColor var color: HexColor
+    let notifications: Bool
+    let admin: Bool
+    let maintenance: Bool
+    let locked: Bool
+    let accessDenied: Bool
+}
+
+extension DriveInfoSignal {
+    func asDrive(accountId: Int32, userDbId: Int32, synchros: IndexedSynchros = [:]) -> Drive {
+        Drive(driveDbId: dbId,
+              driveId: id,
+              accountDbId: accountDbId,
+              accountId: accountId,
+              userDbId: userDbId,
+              name: name,
+              color: color,
+              accessDenied: accessDenied,
+              admin: admin,
+              locked: locked,
+              maintenance: maintenance,
+              notifications: notifications,
+              synchros: [:])
+    }
+}

--- a/src/front/macOS/kDriveCore/ServerBridge/Signal/DTOs/DriveInfoSignal.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Signal/DTOs/DriveInfoSignal.swift
@@ -52,4 +52,3 @@ extension DriveInfoSignal {
 struct DriveRemoveSignal: Codable, Sendable {
     let driveDbId: Int32
 }
-

--- a/src/front/macOS/kDriveCore/ServerBridge/Signal/DTOs/DriveInfoSignal.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Signal/DTOs/DriveInfoSignal.swift
@@ -48,3 +48,8 @@ extension DriveInfoSignal {
               synchros: [:])
     }
 }
+
+struct DriveRemoveSignal: Codable, Sendable {
+    let driveDbId: Int32
+}
+

--- a/src/front/macOS/kDriveCore/ServerBridge/Signal/DTOs/SyncInfoSignal.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Signal/DTOs/SyncInfoSignal.swift
@@ -1,0 +1,41 @@
+/*
+ Infomaniak kDrive - Desktop
+ Copyright (C) 2023-2025 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+
+struct SyncInfoSignal: Codable, Sendable {
+    let dbId: Int32
+    let driveDbId: Int32
+    @Base64CodedString var localPath: String
+    @Base64CodedString var targetPath: String
+    @Base64CodedString var targetNodeId: String
+    let supportVfs: Bool
+    let virtualFileMode: KDC.VirtualFileMode
+}
+
+extension SyncInfoSignal {
+    var asSynchro: Synchro {
+        Synchro(dbId: dbId,
+                driveDbId: driveDbId,
+                localPath: localPath,
+                targetPath: targetPath,
+                targetNodeId: targetNodeId,
+                supportVfs: supportVfs,
+                virtualFileMode: virtualFileMode)
+    }
+}

--- a/src/front/macOS/kDriveCore/ServerBridge/Signal/XPCSignalHandler.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Signal/XPCSignalHandler.swift
@@ -85,12 +85,15 @@ struct XPCSignalHandler: XPCSignalHandlerProtocol {
         case .ACCOUNT_REMOVED:
             try await handleAccountRemoved(signal)
 
-        case .DRIVE_UPDATED:
-            try await handleDriveUpdated(signal)
-
         case .DRIVE_ADDED:
             IKLogger.xpc.log("[KD] TODO - DRIVE_ADDED not available")
             throw SignalError.unsupported(signalNum)
+
+        case .DRIVE_UPDATED:
+            try await handleDriveUpdated(signal)
+
+        case .DRIVE_REMOVED:
+            try await handleDriveRemoved(signal)
 
         default:
             throw SignalError.unsupported(signalNum)
@@ -133,6 +136,15 @@ struct XPCSignalHandler: XPCSignalHandlerProtocol {
         }
 
         try await coherentCache.updateDriveSignal(driveInfo)
+    }
+
+    private func handleDriveRemoved(_ signal: Data) async throws {
+        guard let driveInfoSignal = try? decoder.decode(SignalMessage<DriveRemoveSignal>.self, from: signal),
+              let driveDbId = driveInfoSignal.body?.driveDbId else {
+            throw SignalError.unableToGetDriveDbIdFromSignal
+        }
+
+        try await coherentCache.removeDrive(driveDbId: driveDbId)
     }
 }
 

--- a/src/front/macOS/kDriveCore/ServerBridge/Signal/XPCSignalHandler.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Signal/XPCSignalHandler.swift
@@ -69,7 +69,10 @@ struct XPCSignalHandler: XPCSignalHandlerProtocol {
         case .ACCOUNT_REMOVED:
             await handleAccountRemoved(signal)
 
-        case .DRIVE_ADDED, .DRIVE_UPDATED:
+        case .DRIVE_UPDATED:
+            await handleDriveUpdated(signal)
+
+        case .DRIVE_ADDED:
             IKLogger.xpc.log("[KD] TODO - drive signal")
 
         default:
@@ -107,5 +110,32 @@ struct XPCSignalHandler: XPCSignalHandlerProtocol {
         }
 
         await coherentCache.removeAccount(accountDbId: accountDbId)
+    }
+
+    private func handleDriveUpdated(_ signal: Data) async {
+        guard let driveInfoSignal = try? decoder.decode(SignalMessage<DriveInfoSignal>.self, from: signal),
+              let driveInfo = driveInfoSignal.body else {
+            IKLogger.xpc.error("[KD] Unable to get driveInfo from signal")
+            return
+        }
+
+        try? await coherentCache.updateDriveSignal(driveInfo)
+    }
+}
+
+extension CoherentCache {
+    func updateDriveSignal(_ driveSignal: DriveInfoSignal) async throws {
+        let accountDbId = driveSignal.accountDbId
+        guard var account = await getAccount(accountDbId: accountDbId) else {
+            throw ServerCoherentCache.CacheError.accountNotFound(accountDbId)
+        }
+
+        let existingDrive = account.drives[driveSignal.dbId]
+        let updatedDrive = driveSignal.asDrive(accountId: account.id,
+                                               userDbId: account.userDbId,
+                                               synchros: existingDrive?.synchros ?? [:])
+        account.drives[driveSignal.dbId] = updatedDrive
+
+        try await updateAccount(account)
     }
 }

--- a/src/front/macOS/kDriveCore/ServerBridge/Signal/XPCSignalHandler.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Signal/XPCSignalHandler.swift
@@ -27,27 +27,39 @@ struct XPCSignalHandler: XPCSignalHandlerProtocol {
     let decoder = JSONDecoder()
     @LazyInjectService var coherentCache: CoherentCache
 
+    enum SignalError: Error {
+        case nilData
+        case unableToParseMetadata(_ signal: String)
+        case serverError(_ code: KDC.ExitCode?, _ cause: KDC.ExitCause?)
+        case unableToGetUserFromSignal
+        case unableToGetAccountFromSignal
+        case unableToGetAccountDbIdFromSignal
+        case unsupported(_ num: SignalNum)
+    }
+
     func handleServerSignal(_ signal: Data?) {
         Task {
-            await handleServerSignal(signal)
+            do {
+                try await handleServerSignal(signal)
+            } catch {
+                IKLogger.xpc.error("[KD] signal error :\(error)")
+                // TODO: Sentry
+            }
         }
     }
 
-    private func handleServerSignal(_ signal: Data?) async {
+    private func handleServerSignal(_ signal: Data?) async throws {
         guard let signal else {
-            IKLogger.xpc.error("[KD] recv sendSignal with nil data")
-            return
+            throw SignalError.nilData
         }
 
         guard let signalMetadata = try? decoder.decode(SignalMetadata.self, from: signal) else {
-            let output = String(data: signal, encoding: .utf8)
-            IKLogger.xpc.error("[KD] recv unable to parse signal \(String(describing: output))")
-            return
+            let output = String(data: signal, encoding: .utf8) ?? ""
+            throw SignalError.unableToParseMetadata(output)
         }
 
         guard signalMetadata.code == nil, signalMetadata.cause == nil else {
-            IKLogger.xpc.error("[KD] recv error code:\(String(describing: signalMetadata.code)) cause:\(String(describing: signalMetadata.cause))")
-            return
+            throw SignalError.serverError(signalMetadata.code, signalMetadata.cause)
         }
 
         let signalNum = signalMetadata.num
@@ -55,71 +67,71 @@ struct XPCSignalHandler: XPCSignalHandlerProtocol {
 
         switch signalNum {
         case .USER_ADDED:
-            await handleUserAdded(signal)
+            try await handleUserAdded(signal)
 
         case .USER_UPDATED:
             IKLogger.xpc.error("[KD] TODO - USER_UPDATED not available")
+            throw SignalError.unsupported(signalNum)
 
         case .ACCOUNT_ADDED:
-            await handleAccountAdded(signal)
+            try await handleAccountAdded(signal)
 
         case .ACCOUNT_UPDATED:
             IKLogger.xpc.error("[KD] TODO - ACCOUNT_UPDATED not available")
+            throw SignalError.unsupported(signalNum)
 
         case .ACCOUNT_REMOVED:
-            await handleAccountRemoved(signal)
+            try await handleAccountRemoved(signal)
 
         case .DRIVE_UPDATED:
-            await handleDriveUpdated(signal)
+            try await handleDriveUpdated(signal)
 
         case .DRIVE_ADDED:
-            IKLogger.xpc.log("[KD] TODO - drive signal")
+            IKLogger.xpc.log("[KD] TODO - DRIVE_ADDED not available")
+            throw SignalError.unsupported(signalNum)
 
         default:
-            IKLogger.xpc.error("[KD] recv error code:\(String(describing: signalMetadata.code)) cause:\(String(describing: signalMetadata.cause))")
+            throw SignalError.unsupported(signalNum)
         }
     }
 
     // MARK: - Specific signal handling
 
-    private func handleUserAdded(_ signal: Data) async {
+    private func handleUserAdded(_ signal: Data) async throws {
         guard let userInfoSignal = try? decoder.decode(SignalMessage<UserInfoSignal>.self, from: signal),
               let user = userInfoSignal.body?.asUser else {
-            IKLogger.xpc.error("[KD] Unable to get user from signal")
-            return
+            throw SignalError.unableToGetUserFromSignal
         }
 
         await coherentCache.updateUser(user)
     }
 
-    private func handleAccountAdded(_ signal: Data) async {
+    private func handleAccountAdded(_ signal: Data) async throws {
         guard let accountInfoSignal = try? decoder.decode(SignalMessage<AccountInfoSignal>.self, from: signal),
               let accountInfo = accountInfoSignal.body else {
-            IKLogger.xpc.error("[KD] Unable to get account from signal")
-            return
+            throw SignalError.unableToGetAccountFromSignal
         }
 
         await coherentCache.addAccount(accountInfo.asAccount, userDbId: accountInfo.userDbId)
     }
 
-    private func handleAccountRemoved(_ signal: Data) async {
+    private func handleAccountRemoved(_ signal: Data) async throws {
         guard let accountInfoSignal = try? decoder.decode(SignalMessage<AccountRemoveSignal>.self, from: signal),
               let accountDbId = accountInfoSignal.body?.accountDbId else {
-            IKLogger.xpc.error("[KD] Unable to get accountDbId from signal")
-            return
+            throw SignalError.unableToGetAccountDbIdFromSignal
         }
 
         await coherentCache.removeAccount(accountDbId: accountDbId)
     }
 
-    private func handleDriveUpdated(_ signal: Data) async {
+    private func handleDriveUpdated(_ signal: Data) async throws {
         guard let driveInfoSignal = try? decoder.decode(SignalMessage<DriveInfoSignal>.self, from: signal),
               let driveInfo = driveInfoSignal.body else {
             IKLogger.xpc.error("[KD] Unable to get driveInfo from signal")
             return
         }
 
-        try? await coherentCache.updateDriveSignal(driveInfo)
+        try await coherentCache.updateDriveSignal(driveInfo)
     }
 }
 

--- a/src/front/macOS/kDriveCore/ServerBridge/Signal/XPCSignalHandler.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Signal/XPCSignalHandler.swift
@@ -81,4 +81,17 @@ struct XPCSignalHandler: XPCSignalHandlerProtocol {
             await coherentCache.updateUser(user)
         }
     }
+
+    private func handleAccountAdded(_ signal: Data) {
+        guard let accountInfoSignal = try? decoder.decode(SignalMessage<AccountInfoSignal>.self, from: signal),
+              let accountInfo = accountInfoSignal.body else {
+            IKLogger.xpc.error("[KD] Unable to get account from signal")
+            return
+        }
+
+        Task {
+            @InjectService var coherentCache: CoherentCache
+            await coherentCache.addAccount(accountInfo.asAccount, userDbId: accountInfo.userDbId)
+        }
+    }
 }

--- a/src/front/macOS/kDriveCore/ServerBridge/Signal/XPCSignalHandler.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Signal/XPCSignalHandler.swift
@@ -25,8 +25,15 @@ public protocol XPCSignalHandlerProtocol {
 
 struct XPCSignalHandler: XPCSignalHandlerProtocol {
     let decoder = JSONDecoder()
+    @LazyInjectService var coherentCache: CoherentCache
 
     func handleServerSignal(_ signal: Data?) {
+        Task {
+            await handleServerSignal(signal)
+        }
+    }
+
+    private func handleServerSignal(_ signal: Data?) async {
         guard let signal else {
             IKLogger.xpc.error("[KD] recv sendSignal with nil data")
             return
@@ -48,13 +55,13 @@ struct XPCSignalHandler: XPCSignalHandlerProtocol {
 
         switch signalNum {
         case .USER_ADDED:
-            handleUserAdded(signal)
+            await handleUserAdded(signal)
 
         case .USER_UPDATED:
             IKLogger.xpc.error("[KD] TODO - USER_UPDATED not available")
 
         case .ACCOUNT_ADDED:
-            handleAccountAdded(signal)
+            await handleAccountAdded(signal)
 
         case .ACCOUNT_UPDATED:
             IKLogger.xpc.error("[KD] TODO - ACCOUNT_UPDATED not available")
@@ -69,29 +76,23 @@ struct XPCSignalHandler: XPCSignalHandlerProtocol {
 
     // MARK: - Specific signal handling
 
-    private func handleUserAdded(_ signal: Data) {
+    private func handleUserAdded(_ signal: Data) async {
         guard let userInfoSignal = try? decoder.decode(SignalMessage<UserInfoSignal>.self, from: signal),
               let user = userInfoSignal.body?.asUser else {
             IKLogger.xpc.error("[KD] Unable to get user from signal")
             return
         }
 
-        Task {
-            @InjectService var coherentCache: CoherentCache
-            await coherentCache.updateUser(user)
-        }
+        await coherentCache.updateUser(user)
     }
 
-    private func handleAccountAdded(_ signal: Data) {
+    private func handleAccountAdded(_ signal: Data) async {
         guard let accountInfoSignal = try? decoder.decode(SignalMessage<AccountInfoSignal>.self, from: signal),
               let accountInfo = accountInfoSignal.body else {
             IKLogger.xpc.error("[KD] Unable to get account from signal")
             return
         }
 
-        Task {
-            @InjectService var coherentCache: CoherentCache
-            await coherentCache.addAccount(accountInfo.asAccount, userDbId: accountInfo.userDbId)
-        }
+        await coherentCache.addAccount(accountInfo.asAccount, userDbId: accountInfo.userDbId)
     }
 }

--- a/src/front/macOS/kDriveCore/ServerBridge/Signal/XPCSignalHandler.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Signal/XPCSignalHandler.swift
@@ -66,6 +66,9 @@ struct XPCSignalHandler: XPCSignalHandlerProtocol {
         case .ACCOUNT_UPDATED:
             IKLogger.xpc.error("[KD] TODO - ACCOUNT_UPDATED not available")
 
+        case .ACCOUNT_REMOVED:
+            await handleAccountRemoved(signal)
+
         case .DRIVE_ADDED, .DRIVE_UPDATED:
             IKLogger.xpc.log("[KD] TODO - drive signal")
 
@@ -94,5 +97,15 @@ struct XPCSignalHandler: XPCSignalHandlerProtocol {
         }
 
         await coherentCache.addAccount(accountInfo.asAccount, userDbId: accountInfo.userDbId)
+    }
+
+    private func handleAccountRemoved(_ signal: Data) async {
+        guard let accountInfoSignal = try? decoder.decode(SignalMessage<AccountRemoveSignal>.self, from: signal),
+              let accountDbId = accountInfoSignal.body?.accountDbId else {
+            IKLogger.xpc.error("[KD] Unable to get accountDbId from signal")
+            return
+        }
+
+        await coherentCache.removeAccount(accountDbId: accountDbId)
     }
 }

--- a/src/front/macOS/kDriveCore/ServerBridge/Signal/XPCSignalHandler.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Signal/XPCSignalHandler.swift
@@ -34,6 +34,8 @@ struct XPCSignalHandler: XPCSignalHandlerProtocol {
         case unableToGetUserFromSignal
         case unableToGetAccountFromSignal
         case unableToGetAccountDbIdFromSignal
+        case unableToGetDriveFromSignal
+        case unableToGetDriveDbIdFromSignal
         case unsupported(_ num: SignalNum)
     }
 
@@ -127,8 +129,7 @@ struct XPCSignalHandler: XPCSignalHandlerProtocol {
     private func handleDriveUpdated(_ signal: Data) async throws {
         guard let driveInfoSignal = try? decoder.decode(SignalMessage<DriveInfoSignal>.self, from: signal),
               let driveInfo = driveInfoSignal.body else {
-            IKLogger.xpc.error("[KD] Unable to get driveInfo from signal")
-            return
+            throw SignalError.unableToGetDriveFromSignal
         }
 
         try await coherentCache.updateDriveSignal(driveInfo)

--- a/src/front/macOS/kDriveCore/ServerBridge/Signal/XPCSignalHandler.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Signal/XPCSignalHandler.swift
@@ -20,20 +20,20 @@ import Foundation
 import InfomaniakDI
 
 public protocol XPCSignalHandlerProtocol {
-    func handleServerSignal(_ msg: Data?)
+    func handleServerSignal(_ signal: Data?)
 }
 
 struct XPCSignalHandler: XPCSignalHandlerProtocol {
     let decoder = JSONDecoder()
 
-    public func handleServerSignal(_ msg: Data?) {
-        guard let msg else {
+    func handleServerSignal(_ signal: Data?) {
+        guard let signal else {
             IKLogger.xpc.error("[KD] recv sendSignal with nil data")
             return
         }
 
-        guard let signalMetadata = try? decoder.decode(SignalMetadata.self, from: msg) else {
-            let output = String(data: msg, encoding: .utf8)
+        guard let signalMetadata = try? decoder.decode(SignalMetadata.self, from: signal) else {
+            let output = String(data: signal, encoding: .utf8)
             IKLogger.xpc.error("[KD] recv unable to parse signal \(String(describing: output))")
             return
         }
@@ -47,26 +47,38 @@ struct XPCSignalHandler: XPCSignalHandlerProtocol {
         IKLogger.xpc.log("[KD] recv signal: \(signalNum)")
 
         switch signalNum {
-        case .USER_UPDATED, .USER_ADDED:
-            guard let userInfoSignal = try? decoder.decode(SignalMessage<UserInfoSignal>.self, from: msg),
-                  let user = userInfoSignal.body?.asUser else {
-                IKLogger.xpc.error("[KD] Unable to get user from signal")
-                return
-            }
+        case .USER_ADDED:
+            handleUserAdded(signal)
 
-            Task {
-                @InjectService var coherentCache: CoherentCache
-                await coherentCache.updateUser(user)
-            }
+        case .USER_UPDATED:
+            IKLogger.xpc.error("[KD] TODO - USER_UPDATED not available")
 
-        case .ACCOUNT_ADDED, .ACCOUNT_UPDATED:
-            IKLogger.xpc.log("[KD] TODO - account signal")
+        case .ACCOUNT_ADDED:
+            handleAccountAdded(signal)
+
+        case .ACCOUNT_UPDATED:
+            IKLogger.xpc.error("[KD] TODO - ACCOUNT_UPDATED not available")
 
         case .DRIVE_ADDED, .DRIVE_UPDATED:
             IKLogger.xpc.log("[KD] TODO - drive signal")
 
         default:
             IKLogger.xpc.error("[KD] recv error code:\(String(describing: signalMetadata.code)) cause:\(String(describing: signalMetadata.cause))")
+        }
+    }
+
+    // MARK: - Specific signal handling
+
+    private func handleUserAdded(_ signal: Data) {
+        guard let userInfoSignal = try? decoder.decode(SignalMessage<UserInfoSignal>.self, from: signal),
+              let user = userInfoSignal.body?.asUser else {
+            IKLogger.xpc.error("[KD] Unable to get user from signal")
+            return
+        }
+
+        Task {
+            @InjectService var coherentCache: CoherentCache
+            await coherentCache.updateUser(user)
         }
     }
 }

--- a/src/front/macOS/kDriveCore/ServerBridge/Signal/XPCSignalHandler.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Signal/XPCSignalHandler.swift
@@ -36,6 +36,7 @@ struct XPCSignalHandler: XPCSignalHandlerProtocol {
         case unableToGetAccountDbIdFromSignal
         case unableToGetDriveFromSignal
         case unableToGetDriveDbIdFromSignal
+        case unableToGetSyncFromSignal
         case unsupported(_ num: SignalNum)
     }
 
@@ -95,12 +96,17 @@ struct XPCSignalHandler: XPCSignalHandlerProtocol {
         case .DRIVE_REMOVED:
             try await handleDriveRemoved(signal)
 
+        case .SYNC_ADDED:
+            try await handleSyncAdded(signal)
+
         default:
             throw SignalError.unsupported(signalNum)
         }
     }
 
     // MARK: - Specific signal handling
+
+    // MARK: User
 
     private func handleUserAdded(_ signal: Data) async throws {
         guard let userInfoSignal = try? decoder.decode(SignalMessage<UserInfoSignal>.self, from: signal),
@@ -110,6 +116,8 @@ struct XPCSignalHandler: XPCSignalHandlerProtocol {
 
         await coherentCache.updateUser(user)
     }
+
+    // MARK: Account
 
     private func handleAccountAdded(_ signal: Data) async throws {
         guard let accountInfoSignal = try? decoder.decode(SignalMessage<AccountInfoSignal>.self, from: signal),
@@ -129,6 +137,8 @@ struct XPCSignalHandler: XPCSignalHandlerProtocol {
         await coherentCache.removeAccount(accountDbId: accountDbId)
     }
 
+    // MARK: Drive
+
     private func handleDriveUpdated(_ signal: Data) async throws {
         guard let driveInfoSignal = try? decoder.decode(SignalMessage<DriveInfoSignal>.self, from: signal),
               let driveInfo = driveInfoSignal.body else {
@@ -145,6 +155,17 @@ struct XPCSignalHandler: XPCSignalHandlerProtocol {
         }
 
         try await coherentCache.removeDrive(driveDbId: driveDbId)
+    }
+
+    // MARK: Synchro
+
+    private func handleSyncAdded(_ signal: Data) async throws {
+        guard let syncInfoSignal = try? decoder.decode(SignalMessage<SyncInfoSignal>.self, from: signal),
+              let syncInfo = syncInfoSignal.body else {
+            throw SignalError.unableToGetSyncFromSignal
+        }
+
+        try await coherentCache.addSynchro(syncInfo.asSynchro)
     }
 }
 

--- a/src/front/macOS/kDriveCore/ServerBridge/XPC/XPCQueryFetcher.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/XPC/XPCQueryFetcher.swift
@@ -43,7 +43,7 @@ struct XPCQueryFetcher: XPCQueryFetcherProtocol {
         }
 
         do {
-            IKLogger.data.log("recv raw: \(String(data: replyData, encoding: .utf8))")
+            //IKLogger.data.log("recv raw: \(String(data: replyData, encoding: .utf8))")
             let decodedMessage = try decoder.decode(Response.self, from: replyData)
             IKLogger.data.log("recv callback: \(String(describing: decodedMessage))")
             return decodedMessage

--- a/src/front/macOS/kDriveTests/Cache/CoherentCacheTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/CoherentCacheTests.swift
@@ -94,14 +94,27 @@ enum CacheData {
 
     static let expectedSynchroDbId = Int32.random(in: 0 ... 10000)
     static let expectedSynchroLocalPath = "/dev/null"
-    static let expectedSynchro = Synchro(
-        dbId: expectedSynchroDbId, driveDbId: expectedDriveDbId, localPath: expectedSynchroLocalPath
-    )
+    static let expectedSynchroPath = "/dev/null"
+    static let expectedTargetPath = "dev/bin"
+    static let expectedTargetNodeId = UUID().uuidString
+    static let expectedSupportVFS = true
+    static let expectedVirtualFileMode = KDC.VirtualFileMode.Mac
+    static let expectedSynchro = Synchro(dbId: expectedSynchroDbId,
+                                         driveDbId: expectedDriveDbId,
+                                         localPath: expectedSynchroLocalPath,
+                                         targetPath: expectedTargetPath,
+                                         targetNodeId: expectedTargetNodeId,
+                                         supportVfs: expectedSupportVFS,
+                                         virtualFileMode: expectedVirtualFileMode)
 
     static let updatedSynchroLocalPath = "C:/Windows/System32"
-    static let updatedSynchro = Synchro(
-        dbId: expectedSynchroDbId, driveDbId: expectedDriveDbId, localPath: updatedSynchroLocalPath
-    )
+    static let updatedSynchro = Synchro(dbId: expectedSynchroDbId,
+                                        driveDbId: expectedDriveDbId,
+                                        localPath: updatedSynchroLocalPath,
+                                        targetPath: expectedTargetPath,
+                                        targetNodeId: expectedTargetNodeId,
+                                        supportVfs: expectedSupportVFS,
+                                        virtualFileMode: expectedVirtualFileMode)
 }
 
 struct CoherentCacheUserTests {

--- a/src/front/macOS/kDriveTests/Cache/Observation/ObservableData.swift
+++ b/src/front/macOS/kDriveTests/Cache/Observation/ObservableData.swift
@@ -62,16 +62,16 @@ public enum ObservableData {
                                           color: HexColor(hex: "#ffffff"), synchros: [:])
 
     static let expectedDriveResponse = DriveResponse(driveDbId: expectedDriveDbId,
-                                                 driveId: expectedDriveId,
-                                                 accountDbId: expectedAccountDbId,
-                                                 color: HexColor(hex: "#ffffff")!,
-                                                 name: "The amazing test Drive",
-                                                 accessDenied: false,
-                                                 admin: true,
-                                                 locked: false,
-                                                 maintenance: false,
-                                                 notifications: true)
-    
+                                                     driveId: expectedDriveId,
+                                                     accountDbId: expectedAccountDbId,
+                                                     color: HexColor(hex: "#ffffff")!,
+                                                     name: "The amazing test Drive",
+                                                     accessDenied: false,
+                                                     admin: true,
+                                                     locked: false,
+                                                     maintenance: false,
+                                                     notifications: true)
+
     static let updatedDrive = Drive.some(driveDbId: expectedDriveDbId,
                                          driveId: expectedDriveId,
                                          accountDbId: expectedAccountDbId,
@@ -136,12 +136,24 @@ public enum ObservableData {
 
     static let expectedSynchroDbId = Int32.random(in: 0 ... 1000)
     static let expectedSynchroPath = "/dev/null"
+    static let expectedTargetPath = "dev/bin"
+    static let expectedTargetNodeId = UUID().uuidString
+    static let expectedSupportVFS = true
+    static let expectedVirtualFileMode = KDC.VirtualFileMode.Mac
     static let expectedSynchro = Synchro(dbId: expectedSynchroDbId,
                                          driveDbId: expectedDriveDbId,
-                                         localPath: expectedSynchroPath)
+                                         localPath: expectedSynchroPath,
+                                         targetPath: expectedTargetPath,
+                                         targetNodeId: expectedTargetNodeId,
+                                         supportVfs: expectedSupportVFS,
+                                         virtualFileMode: expectedVirtualFileMode)
 
     static let updatedSynchroPath = "C:\\Windows\\System32"
     static let updatedSynchro = Synchro(dbId: expectedSynchroDbId,
                                         driveDbId: expectedDriveDbId,
-                                        localPath: updatedSynchroPath)
+                                        localPath: updatedSynchroPath,
+                                        targetPath: expectedTargetPath,
+                                        targetNodeId: expectedTargetNodeId,
+                                        supportVfs: expectedSupportVFS,
+                                        virtualFileMode: expectedVirtualFileMode)
 }

--- a/src/front/macOS/kDriveTests/Cache/Observation/ObservedDriveTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/Observation/ObservedDriveTests.swift
@@ -177,6 +177,34 @@ struct ObservedDriveTests_driveDbIdOnly {
 
         #expect(observedDrive == nil, "The observed object should have been updated to nil to reflect deletion")
     }
+
+    @Test(.timeLimit(.minutes(1)))
+    func removeObservedDriveDbId() async throws {
+        // GIVEN
+        let cache = ServerCoherentCache()
+        let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        #expect(initialUser == nil, "Cache should initially be empty")
+
+        @ObservedDrive(driveDbId: ObservableData.expectedDriveDbId, cacheObservation: cache) var observedDrive: Drive?
+        let receivedValues = $observedDrive.receivedValues
+        #expect(observedDrive == nil, "Drive should initially be nil")
+
+        await cache.addUser(ObservableData.expectedUserWithAccounts)
+
+        let expectedDrive = ObservableData.expectedDrive
+        try await cache.addDrive(expectedDrive, accountDbId: ObservableData.expectedAccountDbId)
+
+        let cachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
+        #expect(cachedDrive == expectedDrive, "The cache should have been updated")
+
+        // WHEN
+        try await cache.removeDrive(driveDbId: ObservableData.expectedDrive.driveDbId)
+
+        // THEN
+        _ = await receivedValues.dropFirst().first(where: { $0 == nil })
+
+        #expect(observedDrive == nil, "The observed object should have been updated to nil to reflect deletion")
+    }
 }
 
 @MainActor
@@ -332,6 +360,37 @@ struct ObservedDriveTests_allIds {
         await cache.removeDrive(driveDbId: ObservableData.expectedDrive.driveDbId,
                                 accountDbId: ObservableData.expectedAccountDbId,
                                 userDbId: ObservableData.expectedUserDbId)
+
+        // THEN
+        _ = await receivedValues.dropFirst().first(where: { $0 == nil })
+
+        #expect(observedDrive == nil, "The observed object should have been updated to nil to reflect deletion")
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func removeObservedDriveDbId() async throws {
+        // GIVEN
+        let cache = ServerCoherentCache()
+        let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        #expect(initialUser == nil, "Cache should initially be empty")
+
+        @ObservedDrive(userDbId: ObservableData.expectedUserDbId,
+                       accountDbId: ObservableData.expectedAccountDbId,
+                       driveDbId: ObservableData.expectedDriveDbId,
+                       cacheObservation: cache) var observedDrive: Drive?
+        let receivedValues = $observedDrive.receivedValues
+        #expect(observedDrive == nil, "Drive should initially be nil")
+
+        await cache.addUser(ObservableData.expectedUserWithAccounts)
+
+        let expectedDrive = ObservableData.expectedDrive
+        try await cache.addDrive(expectedDrive, accountDbId: ObservableData.expectedAccountDbId)
+
+        let cachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
+        #expect(cachedDrive == expectedDrive, "The cache should have been updated")
+
+        // WHEN
+        try await cache.removeDrive(driveDbId: ObservableData.expectedDrive.driveDbId)
 
         // THEN
         _ = await receivedValues.dropFirst().first(where: { $0 == nil })


### PR DESCRIPTION
#### Abstract

Implementation of some signals: 

- USER_ADDED
- ACCOUNT_ADDED
- ACCOUNT_REMOVED
- DRIVE_UPDATED
- DRIVE_REMOVED
- SYNC_ADDED

Next signals in a following PR 

- USER_UPDATED
- ACCOUNT_UPDATED
- DRIVE_ADDED

#### Misc

depends on https://github.com/Infomaniak/desktop-kDrive/pull/1271