### PR TITLE
Update release notes and fix translation script

### DIFF
--- a/infomaniak-build-tools/translate_release_notes.py
+++ b/infomaniak-build-tools/translate_release_notes.py
@@ -89,25 +89,33 @@ os_list = [
     'linux',
     'macos'
 ]
+os_keys = [
+    '$windows',
+    '$linux',
+    '$macos'
+]
 
 def split_os(lang, fullName):
     lang_ext = lang.lower()
 
+    count = 0;
     for os_name in os_list:
         os_ext = os_name.lower()
+        os_key = os_keys[count]
+        count += 1
         shutil.copyfile(f"{fullName}-{lang_ext}.html", f"{fullName}-{os_ext}-{lang_ext}.html")
         with open(f"{fullName}-{os_ext}-{lang_ext}.html", "r") as f:
             lines = f.readlines()
         with open(f"{fullName}-{os_ext}-{lang_ext}.html", "w") as f:
             for line in lines:
                 lowered = line.lower()
-                if any(os_note in lowered for os_note in os_list):
-                    if (f"<li>{os_name} -" in lowered):
-                        f.write(f"\t\t<li>{line[line.find('-') + 2:]}")
+                if any(key in lowered for key in os_keys):
+                    if os_key in lowered:
+                        f.write(f"\t\t<li>{line[line.find(f"{os_key}") + len(f"{os_key}"):]}")
                 else:
                     f.write(line)
 
-        prettify_html(f"{fullName}-{os_ext}-{lang_ext}.html") 
+        prettify_html(f"{fullName}-{os_ext}-{lang_ext}.html")
         
 
 print(f"Generating Release Notes for kDrive-{args.version}")

--- a/release_notes/kDrive-3.8.1/kDrive-3.8.1-linux-de.html
+++ b/release_notes/kDrive-3.8.1/kDrive-3.8.1-linux-de.html
@@ -28,7 +28,7 @@
   </h2>
   <ul>
    <li>
-    Spezielle Ordner ("Common documents" and "Shared") wurden schreibgesch&uuml;tzt, um die Zugriffsrechte von kDrive bestm&ouml;glich zu replizieren.
+    Spezielle Ordner (&bdquo;Gemeinsame Dokumente” und &bdquo;Freigegeben”) wurden schreibgesch&uuml;tzt, um die Zugriffsrechte von kDrive bestm&ouml;glich zu replizieren.
    </li>
   </ul>
   <h2>

--- a/release_notes/kDrive-3.8.1/kDrive-3.8.1-linux-en.html
+++ b/release_notes/kDrive-3.8.1/kDrive-3.8.1-linux-en.html
@@ -46,6 +46,9 @@
    <li>
     Fixed various bugs and crashes.
    </li>
+   <li>
+    Fixed synchronizations error following many move operations performed on the drive.
+   </li>
   </ul>
  </body>
 </html>

--- a/release_notes/kDrive-3.8.1/kDrive-3.8.1-linux-es.html
+++ b/release_notes/kDrive-3.8.1/kDrive-3.8.1-linux-es.html
@@ -28,7 +28,7 @@
   </h2>
   <ul>
    <li>
-    Las carpetas especiales ("Common documents" and "Shared") ahora son de solo lectura para replicar mejor los derechos de acceso de kDrive.
+    Las carpetas especiales («Documentos comunes» y «Compartidos») ahora son de solo lectura para replicar mejor los derechos de acceso de kDrive.
    </li>
   </ul>
   <h2>

--- a/release_notes/kDrive-3.8.1/kDrive-3.8.1-linux-fr.html
+++ b/release_notes/kDrive-3.8.1/kDrive-3.8.1-linux-fr.html
@@ -28,7 +28,7 @@
   </h2>
   <ul>
    <li>
-    Rendre les dossiers sp&eacute;ciaux ("Common documents" and "Shared") accessibles en lecture seule afin de reproduire au mieux les droits d'acc&egrave;s kDrive.
+    Rendre les dossiers sp&eacute;ciaux (« Documents communs » et « Partag&eacute;s ») accessibles en lecture seule afin de reproduire au mieux les droits d'acc&egrave;s kDrive.
    </li>
   </ul>
   <h2>

--- a/release_notes/kDrive-3.8.1/kDrive-3.8.1-linux-it.html
+++ b/release_notes/kDrive-3.8.1/kDrive-3.8.1-linux-it.html
@@ -28,7 +28,7 @@
   </h2>
   <ul>
    <li>
-    Le cartelle speciali ("Common documents" and "Shared") sono ora di sola lettura per replicare al meglio i diritti di accesso di kDrive.
+    Le cartelle speciali ("Documenti comuni" e "Condivisi") sono ora di sola lettura per replicare al meglio i diritti di accesso di kDrive.
    </li>
   </ul>
   <h2>

--- a/release_notes/kDrive-3.8.1/kDrive-3.8.1-macos-de.html
+++ b/release_notes/kDrive-3.8.1/kDrive-3.8.1-macos-de.html
@@ -28,7 +28,7 @@
   </h2>
   <ul>
    <li>
-    Spezielle Ordner ("Common documents" and "Shared") wurden schreibgesch&uuml;tzt, um die Zugriffsrechte von kDrive bestm&ouml;glich zu replizieren.
+    Spezielle Ordner (&bdquo;Gemeinsame Dokumente” und &bdquo;Freigegeben”) wurden schreibgesch&uuml;tzt, um die Zugriffsrechte von kDrive bestm&ouml;glich zu replizieren.
    </li>
   </ul>
   <h2>
@@ -48,6 +48,9 @@
    </li>
    <li>
     Synchronisierungsfehler nach vielen Verschiebevorg&auml;ngen auf dem Laufwerk behoben.
+   </li>
+   <li>
+    Miniaturansichten wurden behoben.
    </li>
   </ul>
  </body>

--- a/release_notes/kDrive-3.8.1/kDrive-3.8.1-macos-en.html
+++ b/release_notes/kDrive-3.8.1/kDrive-3.8.1-macos-en.html
@@ -47,6 +47,9 @@
     Fixed various bugs and crashes.
    </li>
    <li>
+    Fixed synchronizations error following many move operations performed on the drive.
+   </li>
+   <li>
     Fixed thumbnails.
    </li>
   </ul>

--- a/release_notes/kDrive-3.8.1/kDrive-3.8.1-macos-es.html
+++ b/release_notes/kDrive-3.8.1/kDrive-3.8.1-macos-es.html
@@ -28,7 +28,7 @@
   </h2>
   <ul>
    <li>
-    Las carpetas especiales ("Common documents" and "Shared") ahora son de solo lectura para replicar mejor los derechos de acceso de kDrive.
+    Las carpetas especiales («Documentos comunes» y «Compartidos») ahora son de solo lectura para replicar mejor los derechos de acceso de kDrive.
    </li>
   </ul>
   <h2>
@@ -48,6 +48,9 @@
    </li>
    <li>
     Se ha corregido el error de sincronizaci&oacute;n tras realizar numerosas operaciones de traslado en la unidad.
+   </li>
+   <li>
+    Se han corregido las miniaturas.
    </li>
   </ul>
  </body>

--- a/release_notes/kDrive-3.8.1/kDrive-3.8.1-macos-fr.html
+++ b/release_notes/kDrive-3.8.1/kDrive-3.8.1-macos-fr.html
@@ -28,7 +28,7 @@
   </h2>
   <ul>
    <li>
-    Rendre les dossiers sp&eacute;ciaux ("Common documents" and "Shared") accessibles en lecture seule afin de reproduire au mieux les droits d'acc&egrave;s kDrive.
+    Rendre les dossiers sp&eacute;ciaux (« Documents communs » et « Partag&eacute;s ») accessibles en lecture seule afin de reproduire au mieux les droits d'acc&egrave;s kDrive.
    </li>
   </ul>
   <h2>

--- a/release_notes/kDrive-3.8.1/kDrive-3.8.1-macos-it.html
+++ b/release_notes/kDrive-3.8.1/kDrive-3.8.1-macos-it.html
@@ -28,7 +28,7 @@
   </h2>
   <ul>
    <li>
-    Le cartelle speciali ("Common documents" and "Shared") sono ora di sola lettura per replicare al meglio i diritti di accesso di kDrive.
+    Le cartelle speciali ("Documenti comuni" e "Condivisi") sono ora di sola lettura per replicare al meglio i diritti di accesso di kDrive.
    </li>
   </ul>
   <h2>

--- a/release_notes/kDrive-3.8.1/kDrive-3.8.1-win-de.html
+++ b/release_notes/kDrive-3.8.1/kDrive-3.8.1-win-de.html
@@ -28,7 +28,7 @@
   </h2>
   <ul>
    <li>
-    Spezielle Ordner ("Common documents" and "Shared") wurden schreibgesch&uuml;tzt, um die Zugriffsrechte von kDrive bestm&ouml;glich zu replizieren.
+    Spezielle Ordner (&bdquo;Gemeinsame Dokumente” und &bdquo;Freigegeben”) wurden schreibgesch&uuml;tzt, um die Zugriffsrechte von kDrive bestm&ouml;glich zu replizieren.
    </li>
   </ul>
   <h2>
@@ -48,6 +48,12 @@
    </li>
    <li>
     Synchronisierungsfehler nach vielen Verschiebevorg&auml;ngen auf dem Laufwerk behoben.
+   </li>
+   <li>
+    Problem beim Update aufgrund einer Verbindungsunterbrechung w&auml;hrend des Downloads des Installationsprogramms behoben.
+   </li>
+   <li>
+    Ignoriert Objekte, deren Namen mit einem Punkt oder Leerzeichen enden.
    </li>
   </ul>
  </body>

--- a/release_notes/kDrive-3.8.1/kDrive-3.8.1-win-en.html
+++ b/release_notes/kDrive-3.8.1/kDrive-3.8.1-win-en.html
@@ -47,7 +47,13 @@
     Fixed various bugs and crashes.
    </li>
    <li>
+    Fixed synchronizations error following many move operations performed on the drive.
+   </li>
+   <li>
     Fixed update issue due to a connection loss during installer download.
+   </li>
+   <li>
+    Ignores objects whose names end with a period or space.
    </li>
   </ul>
  </body>

--- a/release_notes/kDrive-3.8.1/kDrive-3.8.1-win-es.html
+++ b/release_notes/kDrive-3.8.1/kDrive-3.8.1-win-es.html
@@ -28,7 +28,7 @@
   </h2>
   <ul>
    <li>
-    Las carpetas especiales ("Common documents" and "Shared") ahora son de solo lectura para replicar mejor los derechos de acceso de kDrive.
+    Las carpetas especiales («Documentos comunes» y «Compartidos») ahora son de solo lectura para replicar mejor los derechos de acceso de kDrive.
    </li>
   </ul>
   <h2>
@@ -48,6 +48,12 @@
    </li>
    <li>
     Se ha corregido el error de sincronizaci&oacute;n tras realizar numerosas operaciones de traslado en la unidad.
+   </li>
+   <li>
+    Se ha corregido un problema de actualizaci&oacute;n debido a una p&eacute;rdida de conexi&oacute;n durante la descarga del instalador.
+   </li>
+   <li>
+    Ignora los objetos cuyos nombres terminan con un punto o un espacio.
    </li>
   </ul>
  </body>

--- a/release_notes/kDrive-3.8.1/kDrive-3.8.1-win-fr.html
+++ b/release_notes/kDrive-3.8.1/kDrive-3.8.1-win-fr.html
@@ -28,7 +28,7 @@
   </h2>
   <ul>
    <li>
-    Rendre les dossiers sp&eacute;ciaux ("Common documents" and "Shared") accessibles en lecture seule afin de reproduire au mieux les droits d'acc&egrave;s kDrive.
+    Rendre les dossiers sp&eacute;ciaux (« Documents communs » et « Partag&eacute;s ») accessibles en lecture seule afin de reproduire au mieux les droits d'acc&egrave;s kDrive.
    </li>
   </ul>
   <h2>
@@ -50,7 +50,10 @@
     Correction des erreurs de synchronisation apr&egrave;s de nombreuses op&eacute;rations de d&eacute;placement effectu&eacute;es sur le lecteur.
    </li>
    <li>
-    Probl&egrave;me de mise &agrave; jour dû &agrave; une perte de connexion pendant le t&eacute;l&eacute;chargement du programme d'installation corrig&eacute;.
+    Correction d'un probl&egrave;me de mise &agrave; jour dû &agrave; une perte de connexion pendant le t&eacute;l&eacute;chargement du programme d'installation.
+   </li>
+   <li>
+    Ignore les objets dont le nom se termine par un point ou un espace.
    </li>
   </ul>
  </body>

--- a/release_notes/kDrive-3.8.1/kDrive-3.8.1-win-it.html
+++ b/release_notes/kDrive-3.8.1/kDrive-3.8.1-win-it.html
@@ -28,7 +28,7 @@
   </h2>
   <ul>
    <li>
-    Le cartelle speciali ("Common documents" and "Shared") sono ora di sola lettura per replicare al meglio i diritti di accesso di kDrive.
+    Le cartelle speciali ("Documenti comuni" e "Condivisi") sono ora di sola lettura per replicare al meglio i diritti di accesso di kDrive.
    </li>
   </ul>
   <h2>
@@ -50,7 +50,10 @@
     Corretto l'errore di sincronizzazione che si verificava dopo numerose operazioni di spostamento eseguite sull'unit&agrave;.
    </li>
    <li>
-    Risolto il problema di aggiornamento dovuto a una perdita di connessione durante il download del programma di installazione.
+    Risolto il problema di aggiornamento dovuto alla perdita di connessione durante il download del programma di installazione.
+   </li>
+   <li>
+    Ignora gli oggetti i cui nomi terminano con un punto o uno spazio.
    </li>
   </ul>
  </body>

--- a/release_notes/kDrive-template.html
+++ b/release_notes/kDrive-template.html
@@ -32,8 +32,9 @@
         <li>Fixed upload issues on locked files.</li>
         <li>Fixed various bugs and crashes.</li>
         <li>Fixed synchronizations error following many move operations performed on the drive.</li>
-        <li>macos - Fixed thumbnails.</li>
-        <li>win - Fixed update issue due to a connection loss during installer download.</li>
+        <li>$macosFixed thumbnails.</li>
+        <li>$windowsFixed update issue due to a connection loss during installer download.</li>
+        <li>$windowsIgnores objects whose names end with a period or space.</li>
     </ul>
 </body>
 </html>

--- a/version.json
+++ b/version.json
@@ -3,7 +3,7 @@
     "major": 3,
     "minor": 8,
     "patch": 1,
-    "build": 3,
+    "build": 4,
     "year": 2025
   }
 }


### PR DESCRIPTION
The tag to decide if a line should be included in the release note according to the OS is changed in this PR. From now on, we use `$windows`, `$linux` or `$macos` at the beginning of the row without separator.