### PR TITLE
fix: improve URI handling and localization fallback

### DIFF
--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/KSuiteUpgradeBar.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/KSuiteUpgradeBar.xaml.cs
@@ -1,18 +1,5 @@
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
-using Microsoft.UI.Xaml.Data;
-using Microsoft.UI.Xaml.Input;
-using Microsoft.UI.Xaml.Media;
-using Microsoft.UI.Xaml.Navigation;
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
-using System.Windows.Automation.Peers;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
@@ -25,15 +12,11 @@ namespace Infomaniak.kDrive.CustomControls
         {
             InitializeComponent();
 
+            Uri? upgradekSuiteUri;
             // TODO: Fetch the type of the kSuite the user is using (my or pro)
-            //if (true /* Selected kSuite is "my"*/)
-            //{
-            UpgradeHyperLinkButton.NavigateUri = new Uri(Utility.GetLocalizedString("Global_UpgradeOfferMy_Url"));
-            //}
-            //else
-            //{
-            //  UpgradeHyperLinkButton.NavigateUri = new Uri(Utility.GetLocalizedString("Global_UpgradeOfferProUrl"));
-            //}
+            Uri.TryCreate(Utility.GetLocalizedString("Global_UpgradeOfferMy_Url"), UriKind.Absolute, out upgradekSuiteUri);
+            //Uri.TryCreate(Utility.GetLocalizedString("Global_UpgradeOfferProUrl"), UriKind.Absolute, out upgradekSuiteUri);
+            UpgradeHyperLinkButton.NavigateUri = upgradekSuiteUri;
         }
     }
 }

--- a/src/gui4/windows/kDrive client/kDrive client/Utility/Utility.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Utility/Utility.cs
@@ -295,7 +295,13 @@ namespace Infomaniak.kDrive
         public static string GetLocalizedString(string key, params object?[]? args)
         {
             var resourceLoader = Windows.ApplicationModel.Resources.ResourceLoader.GetForViewIndependentUse();
-            string localizedString = resourceLoader.GetString(key) ?? string.Empty;
+            string? localizedString = resourceLoader.GetString(key);
+
+            if(localizedString is null || localizedString.Length == 0)
+            {
+                Logger.Log(Logger.Level.Warning, $"Missing localization for key: {key} in current culture {System.Globalization.CultureInfo.CurrentUICulture.Name}");
+                localizedString = key; // Fallback to the key itself if not found
+            }
 
             // Replace literal \r\n with real newlines
             localizedString = localizedString.Replace("\\r\\n", Environment.NewLine);


### PR DESCRIPTION
Refactored KSuiteUpgradeBar to use Uri.TryCreate for safer URL assignment. Enhanced Utility.GetLocalizedString to log missing localization keys and fallback to the key itself if no localized string is found, aiding debugging and preventing empty strings.

depends on #1291 