### PR TITLE
feat(ui): improve about section and license display

### DIFF
--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/LicensesHyperlink.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/LicensesHyperlink.xaml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StackPanel x:Class="Infomaniak.kDrive.CustomControls.LicensesHyperlink"
+            xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+            xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+            xmlns:local="using:Infomaniak.kDrive.CustomControls"
+            xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+            xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+            xmlns:viewmodels="using:Infomaniak.kDrive.ViewModels"
+            xmlns:converters="using:Infomaniak.kDrive.Converters"
+            mc:Ignorable="d">
+
+    <TextBlock x:Name="ExpandedTextBox" />
+    <HyperlinkButton x:Uid="CC_LicensesHyperLink_HyperLinkButton" />
+</StackPanel>

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/LicensesHyperlink.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/LicensesHyperlink.xaml.cs
@@ -1,0 +1,48 @@
+using Infomaniak.kDrive.ViewModels;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using System;
+namespace Infomaniak.kDrive.CustomControls
+{
+    public sealed partial class LicensesHyperlink : StackPanel
+    {
+        public LicensesHyperlink()
+        {
+            InitializeComponent();
+        }
+
+        public AppVersion? DisplayedVersion
+        {
+            get => (AppVersion?)GetValue(DisplayedVersionProperty);
+            set => SetValue(DisplayedVersionProperty, value);
+
+        }
+
+        public static readonly DependencyProperty DisplayedVersionProperty =
+         DependencyProperty.Register(
+             nameof(DisplayedVersion),
+             typeof(AppVersion),
+             typeof(UpdateExpander),
+             new PropertyMetadata(null, OnDisplayedVersionChanged));
+
+        private static void OnDisplayedVersionChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if(d is not LicensesHyperlink control)
+            {
+                Logger.Log(Logger.Level.Warning, "DependencyObject is not of type LicensesHyperlink, this is unexpected.");
+                return;
+            }
+            control.Refresh();
+        }
+
+        public void Refresh()
+        {
+            if (DisplayedVersion is null)
+            {
+                Logger.Log(Logger.Level.Warning, "DisplayedVersion is null, this is unexpected.");
+                return;
+            }
+            ExpandedTextBox.Text = Utility.GetLocalizedString("CC_LicensesHyperLink_Text/TextTemplate", DisplayedVersion.Tag, DisplayedVersion.BuildVersion, DateTime.Now.Year);
+        }
+    }
+}

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/SyncActivityTable.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/SyncActivityTable.xaml
@@ -72,25 +72,25 @@
                                Style="{StaticResource Infomaniak.Style.TextBlock.Body}"
                                VerticalAlignment="Center"
                                Padding="{StaticResource Infomaniak.Style.Thickness.Left.S}"
-                               Foreground="{ThemeResource TextFillColorDisabled}" />
+                               Foreground="{ThemeResource TextFillColorSecondary}" />
                     <TextBlock x:Uid="CC_SyncActivityTable_Header_LastLocation"
                                Style="{StaticResource Infomaniak.Style.TextBlock.Body}"
                                Grid.Column="1"
                                VerticalAlignment="Center"
                                Padding="{StaticResource Infomaniak.Style.Thickness.Left.S}"
-                               Foreground="{ThemeResource TextFillColorDisabled}" />
+                               Foreground="{ThemeResource TextFillColorSecondary}" />
 
                     <TextBlock x:Uid="CC_SyncActivityTable_Header_Size"
                                Style="{StaticResource Infomaniak.Style.TextBlock.Body}"
                                Grid.Column="2"
                                VerticalAlignment="Center"
-                               Foreground="{ThemeResource TextFillColorDisabled}" />
+                               Foreground="{ThemeResource TextFillColorSecondary}" />
 
                     <TextBlock x:Uid="CC_SyncActivityTable_Header_State"
                                Style="{StaticResource Infomaniak.Style.TextBlock.Body}"
                                Grid.Column="3"
                                VerticalAlignment="Center"
-                               Foreground="{ThemeResource TextFillColorDisabled}" />
+                               Foreground="{ThemeResource TextFillColorSecondary}" />
 
                 </Grid>
             </ListView.Header>
@@ -196,7 +196,7 @@
                                               VerticalAlignment="Center"
                                               HorizontalAlignment="Left"
                                               UriString="{x:Bind Direction, Converter={StaticResource SyncActivityDirectionToIconConverter}, Mode=OneWay}"
-                                              Foreground="{ThemeResource TextFillColorDisabledBrush}">
+                                              Foreground="{ThemeResource TextFillColorSecondaryBrush}">
                                 <ToolTipService.ToolTip>
                                     <ToolTip Content="{x:Bind Direction, Converter={StaticResource SyncDirectionToToolTipConverter}, Mode=OneWay}" />
                                 </ToolTipService.ToolTip>

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/SyncSelector.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/SyncSelector.xaml
@@ -42,7 +42,7 @@
                                Style="{StaticResource Infomaniak.Style.TextBlock.Body}" />
                     <TextBlock Text="{Binding Drive.Name}"
                                Style="{StaticResource Infomaniak.Style.TextBlock.Caption}"
-                               Foreground="{ThemeResource TextFillColorDisabledBrush}" />
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                 </StackPanel>
             </StackPanel>
         </DataTemplate>

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/UpdateExpander.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/UpdateExpander.xaml
@@ -31,15 +31,28 @@
             Click="UpdateButton_Click" />
 
     <toolKit:SettingsExpander.Items>
+        <toolKit:SettingsCard Background="{ThemeResource LayerFillColorDefault}">
+            <toolKit:SettingsCard.Header>
+                <TextBlock  Style="{StaticResource Infomaniak.Style.TextBlock.Body}">
+                    <Run Text="kDrive" />
+                    <Run Text="{x:Bind DisplayedVersion.Tag , Mode=OneWay}" />
+                </TextBlock>
+            </toolKit:SettingsCard.Header>
+            <toolKit:SettingsCard.Description>
+                <StackPanel Spacing="{StaticResource Infomaniak.Style.Spacing.S}">
+                    <TextBlock x:Uid="CC_UpdateExpander_UpdateAvailable_UpdateDetails"
+                               Visibility="{x:Bind ViewModel.Settings.UpdateManager.AvailableUpdate, Converter={StaticResource IsNullToBoolOrVisibilityConverter}, ConverterParameter='Inverted=True', Mode=OneWay}" />
+                    <local:LicensesHyperlink DisplayedVersion="{x:Bind DisplayedVersion, Mode=OneWay}" />
+                </StackPanel>
+            </toolKit:SettingsCard.Description>
+            <HyperlinkButton x:Uid="
+                           CC_UpdateExpander_ChangeLogHyperLink"
+                             NavigateUri="{x:Bind DisplayedVersion.ChangeLogUrl, Mode=OneWay}" />
+        </toolKit:SettingsCard>
         <toolKit:SettingsCard x:Uid="Page_SettingsPage_AutoUpdate"
                               IsEnabled="False"
                               Background="{ThemeResource LayerFillColorDefault}">
             <!-- TODO: Make it enabled once auto-update is implemented on the server side (see: UpdateManager.ChangeAutoUpdate) -->
-            <toolKit:SettingsCard.HeaderIcon>
-                <local:SvgIcon UriString="{StaticResource Infomaniak.DS.Icons.Arrows.arrows-loop-automatic}"
-                               Height="32"
-                               Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
-            </toolKit:SettingsCard.HeaderIcon>
             <ToggleSwitch IsOn="{x:Bind ViewModel.Settings.UpdateManager.AutoUpdateEnabled, Mode=OneWay}"
                           Toggled="AutoUpdateToggleSwitch_Toggled" />
         </toolKit:SettingsCard>
@@ -58,25 +71,6 @@
                               Foreground="{ThemeResource SystemErrorTextColor}"
                               Visibility="Collapsed" />
             </ComboBox>
-        </toolKit:SettingsCard>
-        <toolKit:SettingsCard Background="{ThemeResource LayerFillColorDefault}">
-            <toolKit:SettingsCard.Header>
-                <TextBlock  Style="{StaticResource Infomaniak.Style.TextBlock.Body}">
-                <Run Text="kDrive" />
-                <Run Text="{x:Bind DisplayedVersion.Tag , Mode=OneWay}" />
-                </TextBlock>
-            </toolKit:SettingsCard.Header>
-            <toolKit:SettingsCard.Description>
-                <StackPanel>
-                    <TextBlock x:Name="ExpandedTextBox" />
-                    <HyperlinkButton x:Uid="CC_UpdateExpander_LicensesHyperLink"
-                                     NavigateUri="https://github.com/Infomaniak/desktop-kDrive?tab=GPL-3.0-1-ov-file" />
-                </StackPanel>
-            </toolKit:SettingsCard.Description>
-            <StackPanel Orientation="Horizontal">
-                <HyperlinkButton x:Uid="CC_UpdateExpander_ChangeLogHyperLink"
-                                 NavigateUri="{x:Bind DisplayedVersion.ChangeLogUrl, Mode=OneWay}" />
-            </StackPanel>
         </toolKit:SettingsCard>
     </toolKit:SettingsExpander.Items>
 </toolKit:SettingsExpander>

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/UpdateExpander.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/UpdateExpander.xaml.cs
@@ -73,13 +73,11 @@ namespace Infomaniak.kDrive.CustomControls
             if (ViewModel.Settings.UpdateManager.AvailableUpdate is AppVersion updateVersion)
             {
                 this.Description = Utility.GetLocalizedString("CC_UpdateExpander_UpdateAvailable_Description/TextTemplate", updateVersion.Tag);
-                ExpandedTextBox.Text = Utility.GetLocalizedString("CC_UpdateExpander_UpdateAvailable_UpdateDetails/TextTemplate", updateVersion.Tag, updateVersion.BuildVersion, updateVersion.PrettyBuildDate, updateVersion.BuildDate.Year);
                 DisplayedVersion = updateVersion;
             }
             else if (ViewModel.Settings.AppVersion is AppVersion AppVersionInfo)
             {
                 this.Description = Utility.GetLocalizedString("CC_UpdateExpander_UpToDate_Description/Text");
-                ExpandedTextBox.Text = Utility.GetLocalizedString("CC_UpdateExpander_UpToDate_UpdateDetails/TextTemplate", AppVersionInfo.Tag, AppVersionInfo.BuildVersion, AppVersionInfo.PrettyBuildDate, AppVersionInfo.BuildDate.Year);
                 DisplayedVersion = AppVersionInfo;
             }
             // check if any of the users is staff to show the internal update channel combobox

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/SettingsPage.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/SettingsPage.xaml
@@ -44,7 +44,7 @@
             <TextBlock x:Uid="Page_SettingsPage_Drive_Configured"
                        VerticalAlignment="Center"
                        Style="{StaticResource Infomaniak.Style.TextBlock.Caption}"
-                       Foreground="{ThemeResource TextFillColorDisabled}" />
+                       Foreground="{ThemeResource TextFillColorSecondary}" />
 
         </DataTemplate>
         <DataTemplate x:Key="UnconfiguredDriveTemplate"
@@ -52,7 +52,7 @@
             <TextBlock x:Uid="Page_SettingsPage_Drive_Unconfigured"
                        VerticalAlignment="Center"
                        Style="{StaticResource Infomaniak.Style.TextBlock.Caption}"
-                       Foreground="{ThemeResource TextFillColorDisabled}" />
+                       Foreground="{ThemeResource TextFillColorSecondary}" />
         </DataTemplate>
         <local:DriveDataTemplateSelector x:Key="DriveDataTemplateSelector"
                                          ConfiguredTemplate="{StaticResource ConfiguredDriveTemplate}"
@@ -217,7 +217,7 @@
                                                            Style="{StaticResource Infomaniak.Style.TextBlock.Body}" />
                                                 <TextBlock Text="{x:Bind Email, Mode=OneWay}"
                                                            Style="{StaticResource Infomaniak.Style.TextBlock.Caption}"
-                                                           Foreground="{ThemeResource TextFillColorDisabled}" />
+                                                           Foreground="{ThemeResource TextFillColorSecondary}" />
                                             </StackPanel>
                                         </StackPanel>
                                     </toolKit:SettingsExpander.Header>
@@ -528,41 +528,24 @@
                         </StackPanel>
 
                     </toolKit:SettingsCard>
-                </StackPanel>
-
-                <!-- About kDrive -->
-                <StackPanel Spacing="{StaticResource Infomaniak.Style.Spacing.XS}">
-                    <TextBlock Text="Avancé"
-                               Style="{StaticResource Infomaniak.Style.TextBlock.Subtitle}" />
 
                     <!-- About - Privacy -->
-                    <toolKit:SettingsExpander Header="Version et informations légales">
+                    <toolKit:SettingsExpander Header="À propos de kDrive">
                         <toolKit:SettingsExpander.HeaderIcon>
-                            <controls:SvgIcon UriString="{StaticResource Infomaniak.DS.Icons.Books.book}"
+                            <controls:SvgIcon UriString="{StaticResource Infomaniak.Custom.Icons.drive-custom}"
                                               Height="32"
                                               Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
                         </toolKit:SettingsExpander.HeaderIcon>
                         <toolKit:SettingsExpander.Items>
                             <!-- General -->
                             <toolKit:SettingsCard Header="kDrive"
-                                                  Background="{ThemeResource LayerFillColorDefault}"
-                                                  Foreground="{ThemeResource TextFillColorDisabled}">
-                                <TextBlock Style="{StaticResource Infomaniak.Style.TextBlock.Body}"
-                                           TextWrapping="WrapWholeWords"
-                                           Text="Swiss Made cloud, open source et hébergé exclusivement en Suisse dans nos datacenters certifiés ISO (sécurité et environnement). kDrive allie transparence, souveraineté et respect de la vie privée." />
-                            </toolKit:SettingsCard>
-                            <toolKit:SettingsCard Header="kDrive"
-                                                  Background="{ThemeResource LayerFillColorDefault}"
-                                                  Foreground="{ThemeResource TextFillColorDisabled}">
-                                <toolKit:SettingsCard.HeaderIcon>
-                                    <controls:SvgIcon UriString="{StaticResource Infomaniak.DS.Icons.Arrows.arrow-loop}"
-                                                      Height="32"
-                                                      Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
-                                </toolKit:SettingsCard.HeaderIcon>
-
-                                <TextBlock Style="{StaticResource Infomaniak.Style.TextBlock.Body}"
-                                           TextWrapping="WrapWholeWords"
-                                           Text="Version 3.7.3 (build 20250728), compilée le 28 juillet 2025 © 2019–2025 Infomaniak Network SA — Licence LGPL v3 — Sources Git" />
+                                                  Background="{ThemeResource LayerFillColorDefault}">
+                                <toolKit:SettingsCard.Description>
+                                    <StackPanel Spacing="{StaticResource Infomaniak.Style.Spacing.S}">
+                                        <TextBlock Text="Développé et hébergé exclusivement en Suisse, kDrive assure une protection totale de vos données, sans revente ni espionnage, dans des centres certifiés ISO, avec chiffrement et sauvegarde sur plusieurs supports." />
+                                        <controls:LicensesHyperlink DisplayedVersion="{x:Bind ViewModel.Settings.AppVersion, Mode=OneWay}" />
+                                    </StackPanel>
+                                </toolKit:SettingsCard.Description>
                             </toolKit:SettingsCard>
                         </toolKit:SettingsExpander.Items>
                     </toolKit:SettingsExpander>

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/StoragePage.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/StoragePage.xaml
@@ -98,13 +98,13 @@
                                                 Color3="#E0E0E0" />
                 <Grid>
                     <TextBlock Style="{StaticResource Infomaniak.Style.TextBlock.Caption}"
-                               Foreground="{ThemeResource TextFillColorDisabled}">
+                               Foreground="{ThemeResource TextFillColorSecondary}">
                         <Run Text="{x:Bind PageViewModel.DiskUsedSize, Mode=OneWay, Converter={StaticResource BytesToHumanReadableStringConverter}}" />
                         <Run x:Uid="Page_StoragePage_Used" />
                     </TextBlock>
                     <TextBlock Style="{StaticResource Infomaniak.Style.TextBlock.Caption}"
                                HorizontalAlignment="Right"
-                               Foreground="{ThemeResource TextFillColorDisabled}">
+                               Foreground="{ThemeResource TextFillColorSecondary}">
                         <Run Text="{x:Bind PageViewModel.DiskFreeSize, Mode=OneWay, Converter={StaticResource BytesToHumanReadableStringConverter}}" />
                         <Run x:Uid="Page_StoragePage_Free" />
                     </TextBlock>
@@ -134,7 +134,7 @@
                                Text="{x:Bind PageViewModel.HydratedFileSize, Mode=OneWay, Converter={StaticResource BytesToHumanReadableStringConverter}}"
                                HorizontalAlignment="Right"
                                Style="{StaticResource Infomaniak.Style.TextBlock.BodySb}"
-                               Foreground="{ThemeResource AccentTextFillColorDisabled}" />
+                               Foreground="{ThemeResource AccentTextFillColorSecondaryBrush}" />
                 </Grid>
                 <Rectangle Height="1"
                            Fill="LightGray"
@@ -163,7 +163,7 @@
                                Text="{x:Bind PageViewModel.OtherFileSize, Mode=OneWay, Converter={StaticResource BytesToHumanReadableStringConverter}}"
                                HorizontalAlignment="Right"
                                Style="{StaticResource Infomaniak.Style.TextBlock.BodySb}"
-                               Foreground="{ThemeResource AccentTextFillColorDisabled}" />
+                               Foreground="{ThemeResource AccentTextFillColorSecondaryBrush}" />
                 </Grid>
                 <Rectangle Height="1"
                            Fill="LightGray"
@@ -191,7 +191,7 @@
                                Text="{x:Bind PageViewModel.DiskFreeSize, Mode=OneWay, Converter={StaticResource BytesToHumanReadableStringConverter}}"
                                HorizontalAlignment="Right"
                                Style="{StaticResource Infomaniak.Style.TextBlock.BodySb}"
-                               Foreground="{ThemeResource AccentTextFillColorDisabled}" />
+                               Foreground="{ThemeResource AccentTextFillColorSecondaryBrush}" />
                 </Grid>
             </StackPanel>
         </Grid>

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/de-DE/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/de-DE/Resources.resw
@@ -468,10 +468,10 @@
   <data name="CC_UpdateExpander_UpToDate_Description.Text" xml:space="preserve">
     <value />
   </data>
-  <data name="CC_UpdateExpander_UpdateAvailable_UpdateDetails.TextTemplate" xml:space="preserve">
+  <data name="CC_UpdateExpander_UpdateAvailable_UpdateDetails.Text" xml:space="preserve">
     <value />
   </data>
-  <data name="CC_UpdateExpander_UpToDate_UpdateDetails.TextTemplate" xml:space="preserve">
+  <data name="CC_LicensesHyperLink_Text.TextTemplate" xml:space="preserve">
     <value />
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
@@ -487,7 +487,10 @@
   <data name="Page_SettingsPage_Notifications.Header" type="System.Resources.ResXNullRef, System.Windows.Forms">
     <value />
   </data>
-  <data name="CC_UpdateExpander_LicensesHyperLink.Content" xml:space="preserve">
+  <data name="CC_LicensesHyperLink_HyperLinkButton.Content" xml:space="preserve">
+    <value />
+  </data>
+  <data name="CC_LicensesHyperLink_HyperLinkButton.NavigateUri" xml:space="preserve">
     <value />
   </data>
   <data name="CC_UpdateExpander_ChangeLogHyperLink.Content" xml:space="preserve">

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/en-US/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/en-US/Resources.resw
@@ -468,10 +468,10 @@
   <data name="CC_UpdateExpander_UpToDate_Description.Text" xml:space="preserve">
     <value />
   </data>
-  <data name="CC_UpdateExpander_UpdateAvailable_UpdateDetails.TextTemplate" xml:space="preserve">
+  <data name="CC_UpdateExpander_UpdateAvailable_UpdateDetails.Text" xml:space="preserve">
     <value />
   </data>
-  <data name="CC_UpdateExpander_UpToDate_UpdateDetails.TextTemplate" xml:space="preserve">
+  <data name="CC_LicensesHyperLink_Text.TextTemplate" xml:space="preserve">
     <value />
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
@@ -487,7 +487,10 @@
   <data name="Page_SettingsPage_Notifications.Header" type="System.Resources.ResXNullRef, System.Windows.Forms">
     <value />
   </data>
-  <data name="CC_UpdateExpander_LicensesHyperLink.Content" xml:space="preserve">
+  <data name="CC_LicensesHyperLink_HyperLinkButton.Content" xml:space="preserve">
+    <value />
+  </data>
+  <data name="CC_LicensesHyperLink_HyperLinkButton.NavigateUri" xml:space="preserve">
     <value />
   </data>
   <data name="CC_UpdateExpander_ChangeLogHyperLink.Content" xml:space="preserve">

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/es-ES/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/es-ES/Resources.resw
@@ -468,10 +468,10 @@
   <data name="CC_UpdateExpander_UpToDate_Description.Text" xml:space="preserve">
     <value />
   </data>
-  <data name="CC_UpdateExpander_UpdateAvailable_UpdateDetails.TextTemplate" xml:space="preserve">
+  <data name="CC_UpdateExpander_UpdateAvailable_UpdateDetails.Text" xml:space="preserve">
     <value />
   </data>
-  <data name="CC_UpdateExpander_UpToDate_UpdateDetails.TextTemplate" xml:space="preserve">
+  <data name="CC_LicensesHyperLink_Text.TextTemplate" xml:space="preserve">
     <value />
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
@@ -487,7 +487,10 @@
   <data name="Page_SettingsPage_Notifications.Header" type="System.Resources.ResXNullRef, System.Windows.Forms">
     <value />
   </data>
-  <data name="CC_UpdateExpander_LicensesHyperLink.Content" xml:space="preserve">
+  <data name="CC_LicensesHyperLink_HyperLinkButton.Content" xml:space="preserve">
+    <value />
+  </data>
+  <data name="CC_LicensesHyperLink_HyperLinkButton.NavigateUri" xml:space="preserve">
     <value />
   </data>
   <data name="CC_UpdateExpander_ChangeLogHyperLink.Content" xml:space="preserve">

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/fr-FR/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/fr-FR/Resources.resw
@@ -506,16 +506,13 @@ ou choisissez une offre adaptée à vos besoins.</value>
   <data name="CC_UpdateExpander_UpToDate_Description.Text" xml:space="preserve">
     <value>L’application est à jour</value>
   </data>
-  <data name="CC_UpdateExpander_UpdateAvailable_UpdateDetails.TextTemplate" xml:space="preserve">
-    <value>Cette mise à jour apporte des correctifs importants et des améliorations liées à  la sécurité, et est recommandée à tous les utilisateurs. 
-Version {0} (build {1}), compilée le {2}
-© 2019–{3} Infomaniak Network SA</value>
-    <comment>{0}: version tag ie 4.0.0; {1} version build ie 20252010; {2}: pretty date ie nov 28, 2025, {3}: current year: 2025</comment>
+  <data name="CC_UpdateExpander_UpdateAvailable_UpdateDetails.Text" xml:space="preserve">
+    <value>Cette mise à jour apporte des correctifs importants et des améliorations liées à  la sécurité, et est recommandée à tous les utilisateurs. </value>
   </data>
-  <data name="CC_UpdateExpander_UpToDate_UpdateDetails.TextTemplate" xml:space="preserve">
-    <value>Version {0} (build {1}), compilée le {2}
-© 2019–{3} Infomaniak Network SA</value>
-    <comment>{0}: version tag ie 4.0.0; {1} version build ie 20252010; {2}: pretty date ie nov 28, 2025, {3}: current year: 2025</comment>
+  <data name="CC_LicensesHyperLink_Text.TextTemplate" xml:space="preserve">
+    <value>Version {0} (build {1})
+© 2019–{2} Infomaniak Network SA</value>
+    <comment>{0}: version tag ie 4.0.0; {1} version build ie 0; {2}: current year: 2025</comment>
   </data>
   <data name="Page_SettingsPage_Global.Text" xml:space="preserve">
     <value>Général</value>
@@ -529,8 +526,11 @@ Version {0} (build {1}), compilée le {2}
   <data name="Page_SettingsPage_Notifications.Header" xml:space="preserve">
     <value>Désactiver les notifications</value>
   </data>
-  <data name="CC_UpdateExpander_LicensesHyperLink.Content" xml:space="preserve">
+  <data name="CC_LicensesHyperLink_HyperLinkButton.Content" xml:space="preserve">
     <value>Licence LGPL v3 - Sources Git</value>
+  </data>
+  <data name="CC_LicensesHyperLink_HyperLinkButton.NavigateUri" xml:space="preserve">
+    <value>https://github.com/Infomaniak/desktop-kDrive?tab=GPL-3.0-1-ov-file</value>
   </data>
   <data name="CC_UpdateExpander_ChangeLogHyperLink.Content" xml:space="preserve">
     <value>Notes de mise à jour</value>

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/it-IT/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/it-IT/Resources.resw
@@ -468,10 +468,10 @@
   <data name="CC_UpdateExpander_UpToDate_Description.Text" xml:space="preserve">
     <value />
   </data>
-  <data name="CC_UpdateExpander_UpdateAvailable_UpdateDetails.TextTemplate" xml:space="preserve">
+  <data name="CC_UpdateExpander_UpdateAvailable_UpdateDetails.Text" xml:space="preserve">
     <value />
   </data>
-  <data name="CC_UpdateExpander_UpToDate_UpdateDetails.TextTemplate" xml:space="preserve">
+  <data name="CC_LicensesHyperLink_Text.TextTemplate" xml:space="preserve">
     <value />
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
@@ -487,7 +487,10 @@
   <data name="Page_SettingsPage_Notifications.Header" type="System.Resources.ResXNullRef, System.Windows.Forms">
     <value />
   </data>
-  <data name="CC_UpdateExpander_LicensesHyperLink.Content" xml:space="preserve">
+  <data name="CC_LicensesHyperLink_HyperLinkButton.Content" xml:space="preserve">
+    <value />
+  </data>
+  <data name="CC_LicensesHyperLink_HyperLinkButton.NavigateUri" xml:space="preserve">
     <value />
   </data>
   <data name="CC_UpdateExpander_ChangeLogHyperLink.Content" xml:space="preserve">


### PR DESCRIPTION
Refactor "About kDrive" section for clarity and update icon. Replace disabled text color with secondary for better readability. Introduce reusable LicensesHyperlink control for version/license info. Simplify resource strings and separate license/version details. Move license/version logic to LicensesHyperlink control. Update icons and XAML structure for consistency and maintainability.