### PR TITLE
feat(ui): set title bar to use app default theme

### DIFF
--- a/src/gui4/windows/kDrive client/kDrive client/MainWindow.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/MainWindow.xaml.cs
@@ -41,6 +41,7 @@ namespace Infomaniak.kDrive
             this.SetTitleBar(AppTitleBar);
             Utility.SetWindowProperties(this, 900, 530, true);
             AppModel.UIThreadDispatcher = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread(); // Save the UI thread dispatcher for later use in view models
+            AppWindow.TitleBar.PreferredTheme = Microsoft.UI.Windowing.TitleBarTheme.UseDefaultAppMode;
         }
     }
 }

--- a/src/gui4/windows/kDrive client/kDrive client/OnBoardingWindow.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/OnBoardingWindow.xaml.cs
@@ -40,6 +40,7 @@ namespace Infomaniak.kDrive.OnBoarding
             this.ExtendsContentIntoTitleBar = true;  // enable custom titlebar
             this.SetTitleBar(AppTitleBar);
             Utility.SetWindowProperties(this, 850, 530, false);
+            AppWindow.TitleBar.PreferredTheme = Microsoft.UI.Windowing.TitleBarTheme.UseDefaultAppMode;
 
             if (ViewModel.Users.Any())
             {


### PR DESCRIPTION
Set AppWindow.TitleBar.PreferredTheme to UseDefaultAppMode in MainWindow and OnBoardingWindow to ensure the title bar matches the application's default theme for visual consistency. It was previously leading to mim/maximize anc close icon being almost invisble (dark on dark or light on light)