### PR TITLE
fix(ui): set SyncSelector Visibility to OneWay binding

### DIFF
--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/AppNavigationView.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/AppNavigationView.xaml
@@ -23,7 +23,7 @@
     <NavigationView.PaneCustomContent>
         <controls:SyncSelector HorizontalAlignment="Stretch"
                                Margin="4,9,4,20"
-                               Visibility="{x:Bind IsPaneOpen, Converter={StaticResource BooleanToVisibilityConverter}}"
+                               Visibility="{x:Bind IsPaneOpen, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}"
                                IsEnabled="{x:Bind ViewModel.SelectedSync, Converter={StaticResource IsNullToBoolOrVisibilityConverter}, ConverterParameter='Inverted=True', Mode=OneWay}" />
     </NavigationView.PaneCustomContent>
 


### PR DESCRIPTION
Changed SyncSelector Visibility binding to Mode=OneWay to ensure it updates whe the source change (IsPaneOpen).