### PR TITLE
feat(trayicon): use neutral icon as initial state

### DIFF
--- a/src/gui4/windows/kDrive client/kDrive client/TrayIcon/TrayIconManager.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/TrayIcon/TrayIconManager.cs
@@ -66,7 +66,7 @@ namespace Infomaniak.kDrive.TrayIcon
                 _trayIcon.ForceCreate();
 
                 // Set initial icon
-                SetIcon_ok();
+                SetIcon_neutral();
             }
             else
             {
@@ -129,7 +129,7 @@ namespace Infomaniak.kDrive.TrayIcon
             (Application.Current as App)?.CurrentWindow?.Activate();
             await App.ServiceProvider.GetRequiredService<IServerCommService>().ActivateLoadInfo(CancellationToken.None);
 
-            SetIcon_ok();
+            SetIcon_neutral();
         }
 
         private void ExitApplicationCommand_ExecuteRequested(object? sender, ExecuteRequestedEventArgs args)


### PR DESCRIPTION
Replaced SetIcon_ok() with SetIcon_neutral() for tray icon initialization and activation. The tray icon now displays a neutral state at startup and when activated, instead of the previous "ok" state. This will be updated once the new icons are available and the icon-update logic has been implemented.