### PR TITLE
fix: return a valid exit code

### DIFF
--- a/src/libsyncengine/jobs/network/kDrive_API/listing/csvfullfilelistwithcursorjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/listing/csvfullfilelistwithcursorjob.cpp
@@ -83,7 +83,7 @@ ExitInfo CsvFullFileListWithCursorJob::handleResponse(std::istream &is) {
     const auto length = _ss.tellg();
     if (length == 0) {
         LOG_ERROR(_logger, "Reply " << jobId() << " received with empty content.");
-        return {};
+        return {ExitCode::BackError, ExitCause::FullListParsingError};
     }
 
     _ss.seekg(0, std::ios_base::beg);

--- a/src/libsyncengine/syncpal/syncpalworker.cpp
+++ b/src/libsyncengine/syncpal/syncpalworker.cpp
@@ -49,9 +49,11 @@ bool shouldBePaused(const std::shared_ptr<ISyncWorker> w1, const std::shared_ptr
     const auto networkIssue =
             (w1 && w1->exitCode() == ExitCode::NetworkError) || (w2 && w2->exitCode() == ExitCode::NetworkError);
     const auto httpBlockingError = (w1 && w1->exitCode() == ExitCode::BackError &&
-                                    (w1->exitCause() == ExitCause::Http5xx || w1->exitCause() == ExitCause::HttpErr)) ||
+                                    (w1->exitCause() == ExitCause::Http5xx || w1->exitCause() == ExitCause::HttpErr ||
+                                     w1->exitCause() == ExitCause::FullListParsingError)) ||
                                    (w2 && w2->exitCode() == ExitCode::BackError &&
-                                    (w2->exitCause() == ExitCause::Http5xx || w2->exitCause() == ExitCause::HttpErr));
+                                    (w2->exitCause() == ExitCause::Http5xx || w2->exitCause() == ExitCause::HttpErr ||
+                                     w2->exitCause() == ExitCause::FullListParsingError));
     const auto syncDirNotAccessible =
             (w1 && w1->exitCode() == ExitCode::SystemError && w1->exitCause() == ExitCause::SyncDirAccessError) ||
             (w2 && w2->exitCode() == ExitCode::SystemError && w2->exitCause() == ExitCause::SyncDirAccessError);


### PR DESCRIPTION
Set a valid `ExitCode` if the data read from the `listing/full` reply is empty.