### PR TITLE
feat(sync): auto-select newly added sync

### DIFF
--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -891,6 +891,9 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 return;
             }
             await AddOrUpdateSyncInModel(syncInfo);
+
+            if (args.SignalNum == SignalNum.SYNC_ADDED)
+                _viewModel.SelectedSync = _viewModel.AllSyncs.FirstOrDefault(s => s?.DbId == syncInfo.DbId, _viewModel.SelectedSync);
         }
 
         public async Task HandleSyncRemovedAsync(object? sender, SignalEventArgs args)


### PR DESCRIPTION
When a new sync is added (SYNC_ADDED signal), the ViewModel now automatically sets SelectedSync to the newly added sync instance. If no matching sync is found, the previous selection is retained. This improves user experience by highlighting the latest added sync.