### PR TITLE
fix(build): correct param name and improve error handling

### DIFF
--- a/infomaniak-build-tools/windows/build-drive.ps1
+++ b/infomaniak-build-tools/windows/build-drive.ps1
@@ -530,7 +530,7 @@ function Prepare-Archive {
         # Copy client files
         Write-Host "Copying new client files ($newGuiDir) to the archive ..."
         Remove-Item -Path "$archivePath/client" -Recurse -Force -ErrorAction SilentlyContinue
-        Copy-Item -Path "$newGuiDir/." -Destination "$archivePath/client" -Recurse
+        Copy-Item -Path "$newGuiDir/." -Destination "$archivePath/client" -Recurse -ErrorAction Stop
 
         # Sign all the .exe, .dll and .xbf that have no signature yet
         $filesToSign = Get-ChildItem -Path "$archivePath/client" -Recurse -Include *.exe, *.dll, *.xbf | Where-Object {
@@ -804,7 +804,7 @@ if ($LASTEXITCODE -ne 0) {
 #                                                                                               #
 #################################################################################################
 
-Prepare-Archive -BuildType $buildType -BuildPath $buildPath -VfsDir $vfsDir -ArchivePath $archivePath -Upload $upload -Ci $ci -NewGuitDir $buildpath/bin/client -NewGui $newGui
+Prepare-Archive -BuildType $buildType -BuildPath $buildPath -VfsDir $vfsDir -ArchivePath $archivePath -Upload $upload -Ci $ci -NewGuiDir "$buildpath/bin/client" -NewGui $newGui
 if ($LASTEXITCODE -ne 0)
 {
     Write-Host "Archive preparation failed. Aborting." -f Red

--- a/infomaniak-build-tools/windows/build-drive.ps1
+++ b/infomaniak-build-tools/windows/build-drive.ps1
@@ -804,7 +804,7 @@ if ($LASTEXITCODE -ne 0) {
 #                                                                                               #
 #################################################################################################
 
-Prepare-Archive -BuildType $buildType -BuildPath $buildPath -VfsDir $vfsDir -ArchivePath $archivePath -Upload $upload -Ci $ci -NewGuiDir "$buildpath/bin/client" -NewGui $newGui
+Prepare-Archive -BuildType $buildType -BuildPath $buildPath -VfsDir $vfsDir -ArchivePath $archivePath -Upload $upload -Ci $ci -NewGuiDir "$buildPath/bin/client" -NewGui $newGui
 if ($LASTEXITCODE -ne 0)
 {
     Write-Host "Archive preparation failed. Aborting." -f Red


### PR DESCRIPTION
Replaced incorrect -NewGuitDir param with -NewGuiDir and quoted the path to ensure proper handling. Added -ErrorAction Stop to Copy-Item in Prepare-Archive to halt on copy errors, improving script robustness.