### PR TITLE
feat(sync): clear sync cache on start and stop jobs

### DIFF
--- a/src/server/comm/guijobs/syncstartjob.cpp
+++ b/src/server/comm/guijobs/syncstartjob.cpp
@@ -92,6 +92,7 @@ ExitInfo SyncStartJob::process() {
 #if defined(KD_MACOS)
     Utility::restartFinderExtension();
 #endif
+    (void) _commManager->appServer().clearSyncCacheMap();
 
     return mainExitInfo;
 }

--- a/src/server/comm/guijobs/syncstartjob.cpp
+++ b/src/server/comm/guijobs/syncstartjob.cpp
@@ -51,6 +51,9 @@ ExitInfo SyncStartJob::serializeOutputParms() {
 }
 
 ExitInfo SyncStartJob::process() {
+    _commManager->appServer().clearSyncCacheMap();
+
+
     Sync sync;
     bool found = false;
     if (!ParmsDb::instance()->selectSync(_syncDbId, sync, found)) {
@@ -92,7 +95,6 @@ ExitInfo SyncStartJob::process() {
 #if defined(KD_MACOS)
     Utility::restartFinderExtension();
 #endif
-    (void) _commManager->appServer().clearSyncCacheMap();
 
     return mainExitInfo;
 }

--- a/src/server/comm/guijobs/syncstopjob.cpp
+++ b/src/server/comm/guijobs/syncstopjob.cpp
@@ -56,6 +56,7 @@ ExitInfo SyncStopJob::process() {
         LOG_WARN(_logger, "Error in stopSyncPal for syncDbId=" << _syncDbId << " : " << exitInfo);
         return exitInfo;
     }
+    (void) _commManager->appServer().clearSyncCacheMap();
 
     // Note: we do not Stop Vfs in case of a pause
 

--- a/src/server/comm/guijobs/syncstopjob.cpp
+++ b/src/server/comm/guijobs/syncstopjob.cpp
@@ -51,12 +51,13 @@ ExitInfo SyncStopJob::serializeOutputParms() {
 }
 
 ExitInfo SyncStopJob::process() {
+    _commManager->appServer().clearSyncCacheMap();
+
     // Stop SyncPal
     if (const auto exitInfo = _commManager->appServer().stopSyncPal(_syncDbId, true); !exitInfo) {
         LOG_WARN(_logger, "Error in stopSyncPal for syncDbId=" << _syncDbId << " : " << exitInfo);
         return exitInfo;
     }
-    (void) _commManager->appServer().clearSyncCacheMap();
 
     // Note: we do not Stop Vfs in case of a pause
 


### PR DESCRIPTION
Added calls to clearSyncCacheMap() in SyncStartJob and SyncStopJob process() methods to ensure the sync state is sent at least once to the gui even if the sync could not start.