### PR TITLE
feat(exclusion): Centralize template normalization server-side

### DIFF
--- a/src/gui/fileexclusiondialog.cpp
+++ b/src/gui/fileexclusiondialog.cpp
@@ -350,77 +350,6 @@ void FileExclusionDialog::onExit() {
     }
 }
 
-namespace {
-
-void logIfTemplateNormalizationFails(const SyncName &template_, bool &normalizationHasFailed) {
-    normalizationHasFailed = false;
-
-    SyncName nfcNormalizedName;
-    const bool nfcSuccess = CommonUtility::normalizedSyncName(template_, nfcNormalizedName, UnicodeNormalization::NFC);
-    if (!nfcSuccess) {
-        qCDebug(lcFileExclusionDialog()) << "Error in CommonUtility::normalizedSyncName. Failed to NFC-normalize the template '"
-                                         << SyncName2QStr(template_) << "'.";
-    }
-
-    SyncName nfdNormalizedName;
-    const bool nfdSuccess = CommonUtility::normalizedSyncName(template_, nfdNormalizedName, UnicodeNormalization::NFD);
-    if (!nfdSuccess) {
-        qCDebug(lcFileExclusionDialog()) << "Error in CommonUtility::normalizedSyncName. Failed to NFD-normalize the template '"
-                                         << SyncName2QStr(template_) << "'.";
-    }
-
-    if (!nfcSuccess || !nfdSuccess) {
-        normalizationHasFailed = true;
-        qCWarning(lcFileExclusionDialog())
-                << "File exclusion based on user templates may fail to exclude file names depending on their normalizations.";
-    }
-}
-
-//
-//! Computes and returns all possible NFC and NFD normalizations of `templateString` segments
-//! interpreted as a file system path.
-/*!
-  \param templateString is the pattern string the normalizations of which are queried.
-  \return a set of QString containing the NFC and NFD normalizations of exclusionTemplate, if those have been successful.
-  The returned set contains additionally the string exclusionTemplate in any case.
-*/
-std::unordered_set<QString> computeNormalizations(const QString &templateString) {
-    bool normalizationHasFailed = false;
-    logIfTemplateNormalizationFails(QStr2SyncName(templateString), normalizationHasFailed);
-
-    if (normalizationHasFailed) return {templateString};
-
-    const auto normalizations = CommonUtility::computePathNormalizations(QStr2SyncName(templateString));
-    std::unordered_set<QString> result;
-
-    for (const SyncName &normalization: normalizations) (void) result.emplace(SyncName2QStr(normalization));
-
-    return result;
-}
-
-
-QList<ExclusionTemplateInfo> computeNormalizations(const QList<ExclusionTemplateInfo> &templateList) {
-    QList<ExclusionTemplateInfo> result;
-
-    for (const auto &templateInfo: templateList) {
-        const auto normalizations = computeNormalizations(templateInfo.templ());
-        for (const auto &normalization: normalizations) result.append(ExclusionTemplateInfo{normalization});
-    }
-
-    return result;
-}
-
-
-bool containsStringPattern(const QList<ExclusionTemplateInfo> &exclusionList, const QString &pattern) {
-    const auto predicate = [&pattern](const ExclusionTemplateInfo &eti) { return eti.templ() == pattern; };
-    const auto &it = std::find_if(exclusionList.cbegin(), exclusionList.cend(), predicate);
-
-    return (it != exclusionList.cend());
-}
-
-} // namespace
-
-
 void FileExclusionDialog::onAddFileButtonTriggered(bool checked) {
     Q_UNUSED(checked)
     MatomoClient::sendEvent("preferencesFileExclusion", MatomoEventAction::Click, "addFileButton");
@@ -430,16 +359,22 @@ void FileExclusionDialog::onAddFileButtonTriggered(bool checked) {
     if (dialog.exec() != QDialog::Accepted) return;
 
     const QString &template_ = dialog.templ();
-    const auto &normalizedTemplates = computeNormalizations(template_);
 
-    const auto predicate = [this](const auto &templateNormalizedString) {
-        return containsStringPattern(_userTemplateList, templateNormalizedString) ||
-               containsStringPattern(_defaultTemplateList, templateNormalizedString);
+    SyncName normalizedTemplate;
+    CommonUtility::normalizedSyncName(QStr2SyncName(template_), normalizedTemplate, UnicodeNormalization::NFC);
+
+    const auto predicate = [&normalizedTemplate](const ExclusionTemplateInfo &templateInfo) {
+        SyncName existingNormalizedTemplate;
+        CommonUtility::normalizedSyncName(QStr2SyncName(templateInfo.templ()), existingNormalizedTemplate,
+                                         UnicodeNormalization::NFC);
+        return existingNormalizedTemplate == normalizedTemplate;
     };
+   
 
-    // Insert `template_` only if none of its normalizations can be found in the default and user lists.
-    if (const auto it = std::find_if(normalizedTemplates.cbegin(), normalizedTemplates.cend(), predicate);
-        it != normalizedTemplates.cend()) {
+    // Insert `template_` only if it cannot be found in the default and user lists.
+    const auto userTemplateListIt = std::find_if(_userTemplateList.cbegin(), _userTemplateList.cend(), predicate);
+    const auto defaultTemplateListIt = std::find_if(_defaultTemplateList.cbegin(), _defaultTemplateList.cend(), predicate);
+    if (userTemplateListIt != _userTemplateList.cend() || defaultTemplateListIt != _defaultTemplateList.cend()) {
         CustomMessageBox msgBox(QMessageBox::Information, tr("Exclusion template already exists!"), QMessageBox::Ok, this);
         msgBox.exec();
         return;
@@ -526,8 +461,7 @@ void FileExclusionDialog::onSaveButtonTriggered(bool checked) {
         return;
     }
 
-    const auto expandedUserTemplateList = computeNormalizations(_userTemplateList);
-    if (const auto exitCode = GuiRequests::setExclusionTemplateList(false, expandedUserTemplateList); exitCode != ExitCode::Ok) {
+    if (const auto exitCode = GuiRequests::setExclusionTemplateList(false, _userTemplateList); exitCode != ExitCode::Ok) {
         qCWarning(lcFileExclusionDialog()) << "Error in Requests::setExclusionTemplateList: code=" << exitCode;
         CustomMessageBox msgBox(QMessageBox::Warning, tr("Cannot save changes!"), QMessageBox::Ok, this);
         msgBox.exec();

--- a/src/gui/fileexclusiondialog.cpp
+++ b/src/gui/fileexclusiondialog.cpp
@@ -361,15 +361,21 @@ void FileExclusionDialog::onAddFileButtonTriggered(bool checked) {
     const QString &template_ = dialog.templ();
 
     SyncName normalizedTemplate;
-    CommonUtility::normalizedSyncName(QStr2SyncName(template_), normalizedTemplate, UnicodeNormalization::NFC);
+    if (!CommonUtility::normalizedSyncName(QStr2SyncName(template_), normalizedTemplate, UnicodeNormalization::NFC)) {
+        qCWarning(lcFileExclusionDialog()) << "Failed to NFC-normalize the template, might cause duplicates: " << template_;
+        normalizedTemplate = QStr2SyncName(template_);
+    }
 
     const auto predicate = [&normalizedTemplate](const ExclusionTemplateInfo &templateInfo) {
         SyncName existingNormalizedTemplate;
-        CommonUtility::normalizedSyncName(QStr2SyncName(templateInfo.templ()), existingNormalizedTemplate,
-                                         UnicodeNormalization::NFC);
+        if (!CommonUtility::normalizedSyncName(QStr2SyncName(templateInfo.templ()), existingNormalizedTemplate,
+                                               UnicodeNormalization::NFC)) {
+            qCWarning(lcFileExclusionDialog())
+                    << "Failed to NFC-normalize the template, might cause duplicates: " << templateInfo.templ();
+            existingNormalizedTemplate = QStr2SyncName(templateInfo.templ());
+        }
         return existingNormalizedTemplate == normalizedTemplate;
     };
-   
 
     // Insert `template_` only if it cannot be found in the default and user lists.
     const auto userTemplateListIt = std::find_if(_userTemplateList.cbegin(), _userTemplateList.cend(), predicate);

--- a/src/libsyncengine/requests/exclusiontemplatecache.cpp
+++ b/src/libsyncengine/requests/exclusiontemplatecache.cpp
@@ -204,7 +204,7 @@ bool ExclusionTemplateCache::isExcluded(const SyncPath &relativePath) noexcept {
     return isExcluded(relativePath, dummy);
 }
 
-bool ExclusionTemplateCache::isExcluded(const SyncPath & , bool &isWarning) noexcept {
+bool ExclusionTemplateCache::isExcluded(const SyncPath &relativePath, bool &isWarning) noexcept {
     const std::scoped_lock lock(_mutex);
     const std::string fileName = SyncName2Str(relativePath.filename().native());
     for (const auto &[regex, exclusionTemplate]: _regexPatterns) {

--- a/src/libsyncengine/requests/exclusiontemplatecache.cpp
+++ b/src/libsyncengine/requests/exclusiontemplatecache.cpp
@@ -204,7 +204,7 @@ bool ExclusionTemplateCache::isExcluded(const SyncPath &relativePath) noexcept {
     return isExcluded(relativePath, dummy);
 }
 
-bool ExclusionTemplateCache::isExcluded(const SyncPath &relativePath, bool &isWarning) noexcept {
+bool ExclusionTemplateCache::isExcluded(const SyncPath & , bool &isWarning) noexcept {
     const std::scoped_lock lock(_mutex);
     const std::string fileName = SyncName2Str(relativePath.filename().native());
     for (const auto &[regex, exclusionTemplate]: _regexPatterns) {

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -1810,11 +1810,11 @@ void AppServer::onRequestReceived(int id, RequestNum num, const QByteArray &para
             paramsStream >> def;
             paramsStream >> list;
             ExclTemplSetListJob exclTemplSetListJob(_commManager, -1, Poco::DynamicStruct(), nullptr);
-            std::vector<ExclusionTemplateInfo> _exclTemplList;
+            std::vector<ExclusionTemplateInfo> exclTemplList;
             for (auto &info: list) {
-                _exclTemplList.push_back(info);
+                exclTemplList.push_back(info);
             }
-            exclTemplSetListJob.setInParms(def, _exclTemplList);
+            exclTemplSetListJob.setInParms(def, exclTemplList);
             ExitInfo exitInfo = exclTemplSetListJob.process();
             resultStream << toInt(exitInfo.code());
             break;

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -85,6 +85,8 @@
 #include <QStandardPaths>
 #include <QTimer>
 #include <QUuid>
+#include <comm/guijobs/excltemplsetlistjob.h>
+#include <comm/guijobs/excltemplgetlistjob.h>
 
 #define QUIT_DELAY 1000 // ms
 #define LOAD_PROGRESS_INTERVAL 1000 // ms
@@ -1790,14 +1792,14 @@ void AppServer::onRequestReceived(int id, RequestNum num, const QByteArray &para
             QDataStream paramsStream(params);
             paramsStream >> def;
 
+            ExclTemplGetListJob exclTemplGetListJob(_commManager, -1, Poco::DynamicStruct(), nullptr);
+            exclTemplGetListJob.setInParms(def);
+            ExitInfo exitInfo = exclTemplGetListJob.process();
             QList<ExclusionTemplateInfo> list;
-            ExitCode exitCode = ServerRequests::getExclusionTemplateList(def, list);
-            if (exitCode != ExitCode::Ok) {
-                LOG_WARN(_logger, "Error in Requests::getExclusionTemplateList: code=" << exitCode);
-                addError(Error(ERR_ID, exitCode, ExitCause::Unknown));
+            for (auto &exclTemp: exclTemplGetListJob.getOutParmsExclusionTemplateList()) {
+                list.push_back(exclTemp);
             }
-
-            resultStream << toInt(exitCode);
+            resultStream << toInt(exitInfo.code());
             resultStream << list;
             break;
         }
@@ -1807,16 +1809,14 @@ void AppServer::onRequestReceived(int id, RequestNum num, const QByteArray &para
             QDataStream paramsStream(params);
             paramsStream >> def;
             paramsStream >> list;
-
-            ExitCode exitCode = ServerRequests::setExclusionTemplateList(def, list);
-            if (exitCode != ExitCode::Ok) {
-                LOG_WARN(_logger, "Error in Requests::setExclusionTemplateList: code=" << exitCode);
-                addError(Error(ERR_ID, exitCode, ExitCause::Unknown));
-                resultStream << toInt(exitCode);
-                break;
+            ExclTemplSetListJob exclTemplSetListJob(_commManager, -1, Poco::DynamicStruct(), nullptr);
+            std::vector<ExclusionTemplateInfo> _exclTemplList;
+            for (auto &info: list) {
+                _exclTemplList.push_back(info);
             }
-
-            resultStream << toInt(exitCode);
+            exclTemplSetListJob.setInParms(def, _exclTemplList);
+            ExitInfo exitInfo = exclTemplSetListJob.process();
+            resultStream << toInt(exitInfo.code());
             break;
         }
         case RequestNum::EXCLTEMPL_PROPAGATE_CHANGE: {
@@ -2586,11 +2586,11 @@ ExitCode AppServer::migrateConfiguration(bool &proxyNotSupported) {
 
     MigrationParams mp = MigrationParams();
     std::vector<std::pair<migrateptr, std::string>> migrateArr = {
-        {&MigrationParams::migrateGeneralParams, "migrateGeneralParams"},
-        {&MigrationParams::migrateAccountsParams, "migrateAccountsParams"},
-        {&MigrationParams::migrateTemplateExclusion, "migrateFileExclusion"},
+            {&MigrationParams::migrateGeneralParams, "migrateGeneralParams"},
+            {&MigrationParams::migrateAccountsParams, "migrateAccountsParams"},
+            {&MigrationParams::migrateTemplateExclusion, "migrateFileExclusion"},
 #if defined(KD_MACOS)
-        {&MigrationParams::migrateAppExclusion, "migrateAppExclusion"},
+            {&MigrationParams::migrateAppExclusion, "migrateAppExclusion"},
 #endif
     };
 

--- a/src/server/comm/guijobs/excltemplgetlistjob.cpp
+++ b/src/server/comm/guijobs/excltemplgetlistjob.cpp
@@ -51,8 +51,35 @@ ExitInfo ExclTemplGetListJob::process() {
 
         return exitCode;
     }
+    _exclusionTemplateList = filterOutTemplatesWrtNfcNormalization(_exclusionTemplateList);
 
     return ExitCode::Ok;
+}
+
+std::vector<ExclusionTemplateInfo> ExclTemplGetListJob::filterOutTemplatesWrtNfcNormalization(
+        const std::vector<ExclusionTemplateInfo> &templateList) {
+    std::vector<ExclusionTemplateInfo> result;
+
+    SyncNameSet uniqueTemplateNames; // Unique template names up to NFC-encoding.
+    for (const auto &templateInfo: templateList) {
+        SyncName normalizedName;
+        SyncName insertedName = QStr2SyncName(templateInfo.templ());
+        std::string insertedString;
+
+        if (const bool nfcSuccess = CommonUtility::normalizedSyncName(insertedName, normalizedName, UnicodeNormalization::NFC);
+            !nfcSuccess) {
+            LOG_WARN(_logger, "Failed to NFC-normalize the template " << templateInfo.templ().toStdString());
+            insertedString = templateInfo.templ().toStdString();
+        } else {
+            insertedName = normalizedName;
+            insertedString = SyncName2Str(normalizedName);
+        }
+
+        const bool isNew = uniqueTemplateNames.emplace(insertedName).second;
+        if (isNew) result.push_back(ExclusionTemplateInfo{QString::fromStdString(insertedString)});
+    }
+
+    return result;
 }
 
 } // namespace KDC

--- a/src/server/comm/guijobs/excltemplgetlistjob.h
+++ b/src/server/comm/guijobs/excltemplgetlistjob.h
@@ -28,13 +28,10 @@ class ExclTemplGetListJob : public AbstractGuiJob {
     public:
         ExclTemplGetListJob(std::shared_ptr<CommManager> commManager, int requestId, const Poco::DynamicStruct &inParams,
                             std::shared_ptr<AbstractCommChannel> channel);
-        
+
         // Setters for compatibility with legacy comm layer
-        void setInParms(bool def) {
-            _default = def;
-        }
-        std::vector<ExclusionTemplateInfo> getOutParmsExclusionTemplateList() const {
-            return _exclusionTemplateList; }
+        void setInParms(bool def) { _default = def; }
+        std::vector<ExclusionTemplateInfo> getOutParmsExclusionTemplateList() const { return _exclusionTemplateList; }
         ExitInfo process() override;
 
     private:

--- a/src/server/comm/guijobs/excltemplgetlistjob.h
+++ b/src/server/comm/guijobs/excltemplgetlistjob.h
@@ -28,6 +28,14 @@ class ExclTemplGetListJob : public AbstractGuiJob {
     public:
         ExclTemplGetListJob(std::shared_ptr<CommManager> commManager, int requestId, const Poco::DynamicStruct &inParams,
                             std::shared_ptr<AbstractCommChannel> channel);
+        
+        // Setters for compatibility with legacy comm layer
+        void setInParms(bool def) {
+            _default = def;
+        }
+        std::vector<ExclusionTemplateInfo> getOutParmsExclusionTemplateList() const {
+            return _exclusionTemplateList; }
+        ExitInfo process() override;
 
     private:
         // Input parameters
@@ -38,8 +46,8 @@ class ExclTemplGetListJob : public AbstractGuiJob {
 
         ExitInfo deserializeInputParms() override;
         ExitInfo serializeOutputParms() override;
-        ExitInfo process() override;
-
+        std::vector<ExclusionTemplateInfo> filterOutTemplatesWrtNfcNormalization(
+                const std::vector<ExclusionTemplateInfo> &templateList);
         friend class TestGuiCommChannel;
 };
 

--- a/src/server/comm/guijobs/excltemplsetlistjob.cpp
+++ b/src/server/comm/guijobs/excltemplsetlistjob.cpp
@@ -62,7 +62,7 @@ std::vector<ExclusionTemplateInfo> ExclTemplSetListJob::computeNormalizations(
     std::vector<ExclusionTemplateInfo> result;
 
     for (const auto &templateInfo: templateList) {
-        const auto normalizations = computeNormalizations(Str2SyncName(templateInfo.templ().toStdString()));
+        const auto normalizations = computeNormalizations(QStr2SyncName(templateInfo.templ()));
         for (const auto &normalization: normalizations)
             result.push_back(ExclusionTemplateInfo{QString::fromStdString(SyncName2Str(normalization))});
     }

--- a/src/server/comm/guijobs/excltemplsetlistjob.cpp
+++ b/src/server/comm/guijobs/excltemplsetlistjob.cpp
@@ -38,7 +38,15 @@ ExitInfo ExclTemplSetListJob::deserializeInputParms() {
 
 
 ExitInfo ExclTemplSetListJob::process() {
-    if (const auto exitCode = ServerRequests::setExclusionTemplateList(_default, _exclusionTemplateList);
+    std::vector<ExclusionTemplateInfo> expandedUserTemplateList;
+
+    if (!_default) {
+        expandedUserTemplateList = computeNormalizations(_exclusionTemplateList);
+    } else {
+        expandedUserTemplateList = _exclusionTemplateList;
+    }
+
+    if (const auto exitCode = ServerRequests::setExclusionTemplateList(_default, expandedUserTemplateList);
         exitCode != ExitCode::Ok) {
         LOG_WARN(_logger, "Error in Requests::setExclusionTemplateList: code=" << exitCode);
         AppServer::addError(Error(ERR_ID, exitCode));
@@ -47,6 +55,62 @@ ExitInfo ExclTemplSetListJob::process() {
     }
 
     return ExitCode::Ok;
+}
+
+std::vector<ExclusionTemplateInfo> ExclTemplSetListJob::computeNormalizations(
+        const std::vector<ExclusionTemplateInfo> &templateList) {
+    std::vector<ExclusionTemplateInfo> result;
+
+    for (const auto &templateInfo: templateList) {
+        const auto normalizations = computeNormalizations(Str2SyncName(templateInfo.templ().toStdString()));
+        for (const auto &normalization: normalizations)
+            result.push_back(ExclusionTemplateInfo{QString::fromStdString(SyncName2Str(normalization))});
+    }
+
+    return result;
+}
+
+//
+//! Computes and returns all possible NFC and NFD normalizations of `templateString` segments
+//! interpreted as a file system path.
+/*!
+  \param templateString is the pattern string the normalizations of which are queried.
+  \return a set of std::string containing the NFC and NFD normalizations of exclusionTemplate, if those have been successful.
+  The returned set contains additionally the string exclusionTemplate in any case.
+*/
+std::unordered_set<SyncName> ExclTemplSetListJob::computeNormalizations(const SyncName &templateString) {
+    if (!canNormalize(templateString)) return {templateString};
+
+    const auto normalizations = CommonUtility::computePathNormalizations(templateString);
+    std::unordered_set<SyncName> result;
+    for (const SyncName &normalization: normalizations) (void) result.emplace(normalization);
+    return result;
+}
+
+
+bool ExclTemplSetListJob::canNormalize(const SyncName &template_) {
+    SyncName nfcNormalizedName;
+    const bool nfcSuccess = CommonUtility::normalizedSyncName(template_, nfcNormalizedName, UnicodeNormalization::NFC);
+    if (!nfcSuccess) {
+        LOG_WARN(Log::instance()->getLogger(),
+                 "Error in CommonUtility::normalizedSyncName. Failed to NFC-normalize the template '" << SyncName2Str(template_)
+                                                                                                      << "'.");
+    }
+
+    SyncName nfdNormalizedName;
+    const bool nfdSuccess = CommonUtility::normalizedSyncName(template_, nfdNormalizedName, UnicodeNormalization::NFD);
+    if (!nfdSuccess) {
+        LOG_WARN(Log::instance()->getLogger(),
+                 "Error in CommonUtility::normalizedSyncName. Failed to NFD-normalize the template '" << SyncName2Str(template_)
+                                                                                                      << "'.");
+    }
+
+    if (!nfcSuccess || !nfdSuccess) {
+        LOG_WARN(Log::instance()->getLogger(),
+                 "File exclusion based on user templates may fail to exclude file names depending on their normalizations.");
+        return false;
+    }
+    return true;
 }
 
 } // namespace KDC

--- a/src/server/comm/guijobs/excltemplsetlistjob.h
+++ b/src/server/comm/guijobs/excltemplsetlistjob.h
@@ -29,6 +29,13 @@ class ExclTemplSetListJob : public AbstractGuiJob {
         ExclTemplSetListJob(std::shared_ptr<CommManager> commManager, int requestId, const Poco::DynamicStruct &inParams,
                             std::shared_ptr<AbstractCommChannel> channel);
 
+        // Setters for compatibility with legacy comm layer
+        void setInParms(bool def, const std::vector<ExclusionTemplateInfo> &exclusionTemplateList) {
+            _default = def;
+            _exclusionTemplateList = exclusionTemplateList;
+        }
+        ExitInfo process() override;
+
     private:
         // Input parameters
         bool _default = false;
@@ -39,8 +46,10 @@ class ExclTemplSetListJob : public AbstractGuiJob {
 
         ExitInfo deserializeInputParms() override;
         ExitInfo serializeOutputParms() override { return ExitCode::Ok; };
-        ExitInfo process() override;
 
+        std::vector<ExclusionTemplateInfo> computeNormalizations(const std::vector<ExclusionTemplateInfo> &templateList);
+        static std::unordered_set<SyncName> computeNormalizations(const SyncName &templateString);
+        static bool canNormalize(const SyncName &template_);
         friend class TestGuiCommChannel;
 };
 


### PR DESCRIPTION
Move Unicode normalization logic for exclusion templates from client to server.
- Remove client-side normalization and duplicate checks.
- Add normalization and deduplication in ExclTemplSetListJob/ExclTemplGetListJob.
- Update dialog logic to check existence using NFC only.
- Refactor server requests to use new job classes.
- Simplify and adapt interfaces for new workflow.

This ensures consistent handling of Unicode variants and reduces client complexity.