### PR TITLE
feat(winui-build): Add Bootstrapper & auto version sync

### DIFF
--- a/src/gui4/windows/kDrive client/Bootstrapper/Bootstrapper.csproj
+++ b/src/gui4/windows/kDrive client/Bootstrapper/Bootstrapper.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+	<Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+		<Exec Command="powershell -ExecutionPolicy Bypass -NoProfile -File &quot;$(SolutionDir)fetchVersion.ps1&quot; -CsProjPath &quot;$(SolutionDir)/kDrive client/kDrive client.csproj&quot; -RepositoryRootPath &quot;$(SolutionDir)..\..\..\..\&quot;" />
+	</Target>
+</Project>

--- a/src/gui4/windows/kDrive client/Bootstrapper/Program.cs
+++ b/src/gui4/windows/kDrive client/Bootstrapper/Program.cs
@@ -1,0 +1,2 @@
+﻿// See https://aka.ms/new-console-template for more information
+Console.WriteLine("Hello, World!");

--- a/src/gui4/windows/kDrive client/fetchVersion.ps1
+++ b/src/gui4/windows/kDrive client/fetchVersion.ps1
@@ -1,0 +1,62 @@
+ # Infomaniak kDrive - Desktop
+ # Copyright (C) 2023-2025 Infomaniak Network SA
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$CsProjPath,  # Full path to *.csproj
+
+    [Parameter(Mandatory = $true)]
+    [string]$RepositoryRootPath
+)
+
+$versionString = ""
+$RepositoryRootPath = $RepositoryRootPath.Trim('"')
+. "$RepositoryRootPath\infomaniak-build-tools\version-helpers.ps1"
+$versionString = Get-VersionFromJson -RepositoryRootPath $RepositoryRootPath -IncludeBuildVersion $true
+if($versionString -eq "") {
+    Write-Error "Failed to retrieve version string from JSON"
+    exit 1
+}
+
+if (-Not (Test-Path $CsProjPath)) {
+    Write-Error "*.csproj file not found at path: $CsProjPath"
+    exit 1
+}
+
+[xml]$CsProjXml = Get-Content $CsProjPath
+
+$propertyGroupNode = $CsProjXml.SelectSingleNode(
+    "/Project/PropertyGroup[not(@Condition)]"
+)
+
+if (-not $propertyGroupNode) {
+    Write-Error "No suitable <PropertyGroup> found."
+    exit 1
+}
+
+$assemblyVersionNode = $propertyGroupNode.SelectSingleNode("AssemblyVersion")
+
+if (-not $assemblyVersionNode) {
+    $assemblyVersionNode = $CsProjXml.CreateElement("AssemblyVersion")
+    $propertyGroupNode.AppendChild($assemblyVersionNode) | Out-Null
+}
+
+# SAFE: always XmlElement
+$assemblyVersionNode.InnerText = $versionString
+
+$CsProjXml.Save($CsProjPath)
+
+Write-Output "Updated AssemblyVersion to $versionString in $CsProjPath"
+

--- a/src/gui4/windows/kDrive client/kDrive client.sln
+++ b/src/gui4/windows/kDrive client/kDrive client.sln
@@ -1,9 +1,14 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
-VisualStudioVersion = 18.0.11222.15 d18.0
+VisualStudioVersion = 18.0.11222.15
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "kDrive client", "kDrive client\kDrive client.csproj", "{BB22ACA5-CCBE-4FA0-B379-A79109A198EB}"
+	ProjectSection(ProjectDependencies) = postProject
+		{930B6AD7-77A5-4253-A43E-E10DED8F6D54} = {930B6AD7-77A5-4253-A43E-E10DED8F6D54}
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bootstrapper", "Bootstrapper\Bootstrapper.csproj", "{930B6AD7-77A5-4253-A43E-E10DED8F6D54}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -33,6 +38,18 @@ Global
 		{BB22ACA5-CCBE-4FA0-B379-A79109A198EB}.Release|x86.ActiveCfg = Release|x86
 		{BB22ACA5-CCBE-4FA0-B379-A79109A198EB}.Release|x86.Build.0 = Release|x86
 		{BB22ACA5-CCBE-4FA0-B379-A79109A198EB}.Release|x86.Deploy.0 = Release|x86
+		{930B6AD7-77A5-4253-A43E-E10DED8F6D54}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{930B6AD7-77A5-4253-A43E-E10DED8F6D54}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{930B6AD7-77A5-4253-A43E-E10DED8F6D54}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{930B6AD7-77A5-4253-A43E-E10DED8F6D54}.Debug|x64.Build.0 = Debug|Any CPU
+		{930B6AD7-77A5-4253-A43E-E10DED8F6D54}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{930B6AD7-77A5-4253-A43E-E10DED8F6D54}.Debug|x86.Build.0 = Debug|Any CPU
+		{930B6AD7-77A5-4253-A43E-E10DED8F6D54}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{930B6AD7-77A5-4253-A43E-E10DED8F6D54}.Release|ARM64.Build.0 = Release|Any CPU
+		{930B6AD7-77A5-4253-A43E-E10DED8F6D54}.Release|x64.ActiveCfg = Release|Any CPU
+		{930B6AD7-77A5-4253-A43E-E10DED8F6D54}.Release|x64.Build.0 = Release|Any CPU
+		{930B6AD7-77A5-4253-A43E-E10DED8F6D54}.Release|x86.ActiveCfg = Release|Any CPU
+		{930B6AD7-77A5-4253-A43E-E10DED8F6D54}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/gui4/windows/kDrive client/kDrive client/kDrive client.csproj
+++ b/src/gui4/windows/kDrive client/kDrive client/kDrive client.csproj
@@ -1,235 +1,230 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup>
-		<OutputType>WinExe</OutputType>
-		<TargetFramework>net9.0-windows10.0.19041</TargetFramework>
-		<TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
-		<RootNamespace>Infomaniak.kDrive</RootNamespace>
-		<SupportedLocales>en-US;fr-FR;de-DE;es-ES;it-IT</SupportedLocales>
-		<ApplicationManifest>app.manifest</ApplicationManifest>
-		<Platforms>x86;x64;ARM64</Platforms>
-		<RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
-		<PublishProfile>win-$(Platform).pubxml</PublishProfile>
-		<UseWinUI>true</UseWinUI>
-		<EnableMsixTooling>false</EnableMsixTooling>
-		<WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
-		<SelfContained>true</SelfContained>
-		<Nullable>enable</Nullable>
-		<EnableTrimAnalyzer>false</EnableTrimAnalyzer>
-		<TrimMode>None</TrimMode>
-		<PublishTrimmed>false</PublishTrimmed>
-	</PropertyGroup>
-	<ItemGroup>
-		<Content Remove="Assets\Custom\Animations\Readme.md" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Content Include="Assets\SplashScreen.scale-200.png" />
-		<Content Include="Assets\Square150x150Logo.scale-200.png" />
-		<Content Include="Assets\Square44x44Logo.scale-200.png" />
-		<Content Include="Assets\Square44x44Logo.targetsize-24_altform-unplated.png" />
-		<Content Include="Assets\Wide310x150Logo.scale-200.png" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Manifest Include="$(ApplicationManifest)" />
-	</ItemGroup>
-
-	<!--
+  <PropertyGroup>
+    <AssemblyVersion>3.8.7.100</AssemblyVersion>
+    <OutputType>WinExe</OutputType>
+    <FileVersion>$(AssemblyVersion)</FileVersion>
+    <Version>$(AssemblyVersion)</Version>
+    <TargetFramework>net9.0-windows10.0.19041</TargetFramework>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <RootNamespace>Infomaniak.kDrive</RootNamespace>
+    <SupportedLocales>en-US;fr-FR;de-DE;es-ES;it-IT</SupportedLocales>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <Platforms>x86;x64;ARM64</Platforms>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <PublishProfile>win-$(Platform).pubxml</PublishProfile>
+    <UseWinUI>true</UseWinUI>
+    <EnableMsixTooling>false</EnableMsixTooling>
+    <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
+    <SelfContained>true</SelfContained>
+    <Nullable>enable</Nullable>
+    <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
+    <TrimMode>None</TrimMode>
+    <PublishTrimmed>false</PublishTrimmed>
+  </PropertyGroup>
+  <ItemGroup>
+    <Content Remove="Assets\Custom\Animations\Readme.md" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Assets\SplashScreen.scale-200.png" />
+    <Content Include="Assets\Square150x150Logo.scale-200.png" />
+    <Content Include="Assets\Square44x44Logo.scale-200.png" />
+    <Content Include="Assets\Square44x44Logo.targetsize-24_altform-unplated.png" />
+    <Content Include="Assets\Wide310x150Logo.scale-200.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <Manifest Include="$(ApplicationManifest)" />
+  </ItemGroup>
+  <!--
     Defining the "Msix" ProjectCapability here allows the Single-project MSIX Packaging
     Tools extension to be activated for this project even if the Windows App SDK Nuget
     package has not yet been restored.
   -->
-	<ItemGroup Condition="'$(DisableMsixProjectCapabilityAddedByProject)'!='true' and '$(EnableMsixTooling)'=='true'">
-		<ProjectCapability Include="Msix" />
-	</ItemGroup>
-	<ItemGroup>
-		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-		<PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.2.250402" />
-		<PackageReference Include="CommunityToolkit.WinUI.Lottie" Version="8.2.250604" />
-		<PackageReference Include="DynamicData" Version="9.4.1" />
-		<PackageReference Include="H.NotifyIcon.WinUI" Version="2.3.1" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.9" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.9" />
-		<PackageReference Include="Microsoft.Graphics.Win2D" Version="1.3.2" />
-		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.6584" />
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.250916003" />
-		<PackageReference Include="Sentry" Version="6.0.0" />
-		<PackageReference Include="Svg" Version="3.4.7" />
-	</ItemGroup>
-
-	<!--
+  <ItemGroup Condition="'$(DisableMsixProjectCapabilityAddedByProject)'!='true' and '$(EnableMsixTooling)'=='true'">
+    <ProjectCapability Include="Msix" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+    <PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.2.250402" />
+    <PackageReference Include="CommunityToolkit.WinUI.Lottie" Version="8.2.250604" />
+    <PackageReference Include="DynamicData" Version="9.4.1" />
+    <PackageReference Include="H.NotifyIcon.WinUI" Version="2.3.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.9" />
+    <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.3.2" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.6584" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.250916003" />
+    <PackageReference Include="Sentry" Version="6.0.0" />
+    <PackageReference Include="Svg" Version="3.4.7" />
+  </ItemGroup>
+  <!--
     Defining the "HasPackageAndPublishMenuAddedByProject" property here allows the Solution
     Explorer "Package and Publish" context menu entry to be enabled for this project even if
     the Windows App SDK Nuget package has not yet been restored.
   -->
-	<PropertyGroup Condition="'$(DisableHasPackageAndPublishMenuAddedByProject)'!='true' and '$(EnableMsixTooling)'=='true'">
-		<HasPackageAndPublishMenu>true</HasPackageAndPublishMenu>
-	</PropertyGroup>
-
-	<!-- Publish Properties -->
-	<PropertyGroup>
-		<PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-		<PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
-		<PublishTrimmed Condition="'$(Configuration)' == 'Debug'">False</PublishTrimmed>
-		<DefaultLanguage>en-US</DefaultLanguage>
-		<PackageCertificateThumbprint>B1D273E77CAF9DBDA865896F3C51A3EB31C6C5AD</PackageCertificateThumbprint>
-		<AppxPackageSigningEnabled>True</AppxPackageSigningEnabled>
-		<GenerateAppInstallerFile>False</GenerateAppInstallerFile>
-		<AppxPackageSigningTimestampDigestAlgorithm>SHA256</AppxPackageSigningTimestampDigestAlgorithm>
-		<AppxAutoIncrementPackageRevision>False</AppxAutoIncrementPackageRevision>
-		<GenerateTestArtifacts>True</GenerateTestArtifacts>
-		<AppxBundle>Never</AppxBundle>
-		<HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
-		<StartupObject>Infomaniak.kDrive.Program</StartupObject>
-		<AssemblyName>kDrive</AssemblyName>
-		<ApplicationIcon>Assets\kdrive.ico</ApplicationIcon>
-		<NuGetAuditMode>direct</NuGetAuditMode>
-		<SignAssembly>False</SignAssembly>
-		<DelaySign>False</DelaySign>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">
-	  <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-	  <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
-	  <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'">
-	  <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-	  <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
-	  <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
-	</PropertyGroup>
-	<ItemGroup>
-		<Page Update="CustomControls\DynamicTextBlock.xaml">
-			<SubType>Designer</SubType>
-		</Page>
-		<Page Update="CustomControls\Errors\ErrorPresenter.xaml">
-		  <SubType>Designer</SubType>
-		</Page>
-		<Page Update="CustomControls\Errors\DefaultError.xaml">
-		  <SubType>Designer</SubType>
-		</Page>
-		<Page Update="CustomControls\Errors\ErrorBar.xaml">
-		  <SubType>Designer</SubType>
-		</Page>
-		<Page Update="CustomControls\Errors\Templates\Node\LocalAccessError.xaml">
-		  <SubType>Designer</SubType>
-		</Page>
-		<Page Update="CustomControls\Errors\Templates\Node\ForbiddenCharError.xaml">
-		  <SubType>Designer</SubType>
-		</Page>
-		<Page Update="CustomControls\SplashScreen.xaml">
-		  <SubType>Designer</SubType>
-		</Page>
-		<Page Update="CustomControls\SyncExclusionSelector.xaml">
-			<SubType>Designer</SubType>
-		</Page>
-		<Page Update="CustomControls\LottiePlayer.xaml">
-			<SubType>Designer</SubType>
-		</Page>
-		<Page Update="CustomControls\MultiValueProgressBar.xaml">
-			<SubType>Designer</SubType>
-		</Page>
-		<Page Update="CustomControls\QuickAccess.xaml">
-			<SubType>Designer</SubType>
-		</Page>
-		<Page Update="HomePage.xaml">
-			<Generator>MSBuild:Compile</Generator>
-		</Page>
-		<Page Update="Pages\ActivityPage - Copy.xaml">
-			<SubType>Designer</SubType>
-		</Page>
-		<Page Update="Pages\ErrorPage.xaml">
-			<SubType>Designer</SubType>
-		</Page>
-		<Page Update="Pages\Onboarding\FinishingPage.xaml">
-			<SubType>Designer</SubType>
-		</Page>
-		<Page Update="Pages\Settings\DriveManagementPage.xaml">
-			<SubType>Designer</SubType>
-		</Page>
-		<Page Update="Styles\Custom\InfomaniakStylesDark.xaml">
-			<SubType>Designer</SubType>
-		</Page>
-		<Page Update="Styles\Custom\InfomaniakStylesStatic.xaml">
-			<SubType>Designer</SubType>
-		</Page>
-		<Page Update="Styles\Custom\InfomaniakStylesLight.xaml">
-			<SubType>Designer</SubType>
-		</Page>
-		<Page Update="Styles\DS\InfomaniakStylesDark.xaml">
-			<SubType>Designer</SubType>
-		</Page>
-		<Page Update="Styles\DS\InfomaniakStylesLight.xaml">
-			<SubType>Designer</SubType>
-		</Page>
-		<Page Update="Styles\DS\InfomaniakStylesStatic.xaml">
-			<SubType>Designer</SubType>
-		</Page>
-	</ItemGroup>
-	<ItemGroup>
-		<PRIResource Update="Strings\fr-FR\Resources.resw">
-			<Generator></Generator>
-		</PRIResource>
-	</ItemGroup>
-	<ItemGroup>
-		<Folder Include="AnimatedElements\" />
-		<Folder Include="Assets\DS\Icons\Communication\" />
-		<Folder Include="CustomControls\Errors\Templates\Server\" />
-		<Folder Include="CustomControls\Errors\Templates\SyncPal\" />
-	</ItemGroup>
-	<ItemGroup>
-		<None Update="Pages\Onboarding\NoDrivesPage.xaml">
-			<Generator>MSBuild:Compile</Generator>
-		</None>
-	</ItemGroup>
-	<ItemGroup>
-		<Page Update="CustomControls\AppTitleBarLogo.xaml">
-			<Generator>MSBuild:Compile</Generator>
-		</Page>
-	</ItemGroup>
-	<ItemGroup>
-		<Page Update="CustomControls\SyncActivityTable.xaml">
-			<Generator>MSBuild:Compile</Generator>
-		</Page>
-	</ItemGroup>
-	<ItemGroup>
-		<Page Update="Pages\KSuiteUpgradeBar.xaml">
-			<Generator>MSBuild:Compile</Generator>
-		</Page>
-	</ItemGroup>
-	<ItemGroup>
-		<Page Update="CustomControls\SyncStartPauseButton.xaml">
-			<Generator>MSBuild:Compile</Generator>
-		</Page>
-	</ItemGroup>
-	<ItemGroup>
-		<Content Include="Server\**\*.*">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-			<PackageCopyToOutput>true</PackageCopyToOutput>
-		</Content>
-	</ItemGroup>
-	<Target Name="PreBuild" BeforeTargets="PreBuildEvent">
-		<Exec Command="powershell -ExecutionPolicy Bypass -NoProfile -File &quot;$(ProjectDir)Assets\Custom\Animations\lottieConverter.ps1&quot; -Directory &quot;$(ProjectDir)Assets\Custom\Animations&quot;" />
-	</Target>
-	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
-		<!-- Rename the generated .pri file to Resources.pri | This is a bug in the generations of unpackaged winui apps -->
-		<Exec Command="powershell -ExecutionPolicy Bypass -NoProfile -Command &quot;$src = '$(OutDir)$(AssemblyName).pri'; $dst = '$(OutDir)Resources.pri'; if (Test-Path $dst) { Remove-Item $dst -Force }; Rename-Item -Path $src -NewName 'Resources.pri';&quot;" />
-
-
-		<ItemGroup>
-			<!-- Keep only fr-FR, en-US, es-ES, it-IT, de-DE -->
-			<RemovingFiles Include="$(OutDir)*\*.mui" Exclude="&#xD;&#xA;            $(OutDir)fr-FR\*.mui;&#xD;&#xA;            $(OutDir)en-US\*.mui;&#xD;&#xA;            $(OutDir)es-ES\*.mui;&#xD;&#xA;            $(OutDir)it-IT\*.mui;&#xD;&#xA;            $(OutDir)de-DE\*.mui" />
-
-			<RemovingFolders Include="@(RemovingFiles->'%(RootDir)%(Directory)')" />
-		</ItemGroup>
-
-		<RemoveDir Directories="@(RemovingFolders)" />
-	</Target>
+  <PropertyGroup Condition="'$(DisableHasPackageAndPublishMenuAddedByProject)'!='true' and '$(EnableMsixTooling)'=='true'">
+    <HasPackageAndPublishMenu>true</HasPackageAndPublishMenu>
+  </PropertyGroup>
+  <!-- Publish Properties -->
+  <PropertyGroup>
+    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    <PublishTrimmed Condition="'$(Configuration)' == 'Debug'">False</PublishTrimmed>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <PackageCertificateThumbprint>B1D273E77CAF9DBDA865896F3C51A3EB31C6C5AD</PackageCertificateThumbprint>
+    <AppxPackageSigningEnabled>True</AppxPackageSigningEnabled>
+    <GenerateAppInstallerFile>False</GenerateAppInstallerFile>
+    <AppxPackageSigningTimestampDigestAlgorithm>SHA256</AppxPackageSigningTimestampDigestAlgorithm>
+    <AppxAutoIncrementPackageRevision>False</AppxAutoIncrementPackageRevision>
+    <GenerateTestArtifacts>True</GenerateTestArtifacts>
+    <AppxBundle>Never</AppxBundle>
+    <HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
+    <StartupObject>Infomaniak.kDrive.Program</StartupObject>
+    <AssemblyName>kDrive</AssemblyName>
+    <ApplicationIcon>Assets\kdrive.ico</ApplicationIcon>
+    <NuGetAuditMode>direct</NuGetAuditMode>
+    <SignAssembly>False</SignAssembly>
+    <DelaySign>False</DelaySign>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">
+    <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'">
+    <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
+  </PropertyGroup>
+  <ItemGroup>
+    <Page Update="CustomControls\DynamicTextBlock.xaml">
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Update="CustomControls\Errors\ErrorPresenter.xaml">
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Update="CustomControls\Errors\DefaultError.xaml">
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Update="CustomControls\Errors\ErrorBar.xaml">
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Update="CustomControls\Errors\Templates\Node\LocalAccessError.xaml">
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Update="CustomControls\Errors\Templates\Node\ForbiddenCharError.xaml">
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Update="CustomControls\SplashScreen.xaml">
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Update="CustomControls\SyncExclusionSelector.xaml">
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Update="CustomControls\LottiePlayer.xaml">
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Update="CustomControls\MultiValueProgressBar.xaml">
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Update="CustomControls\QuickAccess.xaml">
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Update="HomePage.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Update="Pages\ActivityPage - Copy.xaml">
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Update="Pages\ErrorPage.xaml">
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Update="Pages\Onboarding\FinishingPage.xaml">
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Update="Pages\Settings\DriveManagementPage.xaml">
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Update="Styles\Custom\InfomaniakStylesDark.xaml">
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Update="Styles\Custom\InfomaniakStylesStatic.xaml">
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Update="Styles\Custom\InfomaniakStylesLight.xaml">
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Update="Styles\DS\InfomaniakStylesDark.xaml">
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Update="Styles\DS\InfomaniakStylesLight.xaml">
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Update="Styles\DS\InfomaniakStylesStatic.xaml">
+      <SubType>Designer</SubType>
+    </Page>
+  </ItemGroup>
+  <ItemGroup>
+    <PRIResource Update="Strings\fr-FR\Resources.resw">
+      <Generator>
+      </Generator>
+    </PRIResource>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="AnimatedElements\" />
+    <Folder Include="Assets\DS\Icons\Communication\" />
+    <Folder Include="CustomControls\Errors\Templates\Server\" />
+    <Folder Include="CustomControls\Errors\Templates\SyncPal\" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="Pages\Onboarding\NoDrivesPage.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Page Update="CustomControls\AppTitleBarLogo.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+  </ItemGroup>
+  <ItemGroup>
+    <Page Update="CustomControls\SyncActivityTable.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+  </ItemGroup>
+  <ItemGroup>
+    <Page Update="Pages\KSuiteUpgradeBar.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+  </ItemGroup>
+  <ItemGroup>
+    <Page Update="CustomControls\SyncStartPauseButton.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Server\**\*.*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <PackageCopyToOutput>true</PackageCopyToOutput>
+    </Content>
+  </ItemGroup>
+  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+    <Exec Command="powershell -ExecutionPolicy Bypass -NoProfile -File &quot;$(ProjectDir)Assets\Custom\Animations\lottieConverter.ps1&quot; -Directory &quot;$(ProjectDir)Assets\Custom\Animations&quot;" />
+  </Target>
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <!-- Rename the generated .pri file to Resources.pri | This is a bug in the generations of unpackaged winui apps -->
+    <Exec Command="powershell -ExecutionPolicy Bypass -NoProfile -Command &quot;$src = '$(OutDir)$(AssemblyName).pri'; $dst = '$(OutDir)Resources.pri'; if (Test-Path $dst) { Remove-Item $dst -Force }; Rename-Item -Path $src -NewName 'Resources.pri';&quot;" />
+    <ItemGroup>
+      <!-- Keep only fr-FR, en-US, es-ES, it-IT, de-DE -->
+      <RemovingFiles Include="$(OutDir)*\*.mui" Exclude="&#xD;&#xA;            $(OutDir)fr-FR\*.mui;&#xD;&#xA;            $(OutDir)en-US\*.mui;&#xD;&#xA;            $(OutDir)es-ES\*.mui;&#xD;&#xA;            $(OutDir)it-IT\*.mui;&#xD;&#xA;            $(OutDir)de-DE\*.mui" />
+      <RemovingFolders Include="@(RemovingFiles-&gt;'%(RootDir)%(Directory)')" />
+    </ItemGroup>
+    <RemoveDir Directories="@(RemovingFolders)" />
+  </Target>
 </Project>


### PR DESCRIPTION
Introduce Bootstrapper project and automate versioning

- Add new Bootstrapper project targeting .NET 10.0 with a minimal Program.cs
- Add fetchVersion.ps1 script to extract version from JSON and update kDrive client.csproj before build
- Update solution file to include Bootstrapper and its build configs
- Refactor kDrive client.csproj for clarity and to support automated AssemblyVersion updates
- Enable centralized and automated version management for CI/CD workflows