### PR TITLE
feat(settings): disable privacy settings expander

### DIFF
--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/SettingsPage.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/SettingsPage.xaml
@@ -80,7 +80,7 @@
                     <TextBlock x:Uid="Page_SettingsPage_Global"
                                Style="{StaticResource Infomaniak.Style.TextBlock.Subtitle}" />
                     <!-- General - Update -->
-                    <controls:UpdateExpander IsEnabled="False"/>
+                    <controls:UpdateExpander IsEnabled="False" />
 
                     <!-- General - Language -->
                     <toolKit:SettingsCard x:Uid="Page_SettingsPage_Language"
@@ -270,7 +270,8 @@
                     </toolKit:SettingsCard>
 
                     <!-- Advanced - Privacy -->
-                    <toolKit:SettingsExpander x:Uid="Page_SettingsPage_Privacy">
+                    <toolKit:SettingsExpander x:Uid="Page_SettingsPage_Privacy"
+                                              IsEnabled="False">
                         <toolKit:SettingsExpander.HeaderIcon>
                             <controls:SvgIcon UriString="{StaticResource Infomaniak.DS.Icons.Users.user-cog}"
                                               Height="32"


### PR DESCRIPTION
The privacy section in the settings page is now disabled by setting IsEnabled="False" on the corresponding SettingsExpander. This prevents user interaction with the privacy settings for now.