### PR TITLE
fix(installer): set output path before shortcuts section (3.8.1)

### DIFF
--- a/cmake/modules/NSIS.template.nsi.in
+++ b/cmake/modules/NSIS.template.nsi.in
@@ -503,11 +503,11 @@ SectionEnd
 
 		!insertmacro CheckAndConfirmEndProcesse1 "${EXTENSION_NAME}"
 		${PowerShellExecLog} "Add-AppxPackage -Path '$INSTDIR\shellext\AppX\${VFS_APPX_BUNDLE}' -ForceApplicationShutdown -ForceUpdateFromAnyVersion"
+		SetOutPath "$INSTDIR"
 	${MementoSectionEnd}
 !endif
 
 SectionGroup $SectionGroup_Shortcuts
-
 !ifdef OPTION_SECTION_SC_START_MENU
 	${MementoSection} $OPTION_SECTION_SC_START_MENU_SECTION SEC_START_MENU
 		SectionIn 1 2 3

--- a/src/server/comm/pipecommserver.h
+++ b/src/server/comm/pipecommserver.h
@@ -84,6 +84,7 @@ class PipeCommServer : public AbstractCommServer {
         bool isListening() const { return _isListening; }
         bool isRunning() const { return _isRunning; }
 
+        static SyncPath pipePath();
     protected:
         virtual std::shared_ptr<PipeCommChannel> makeCommChannel() const = 0;
 
@@ -100,7 +101,6 @@ class PipeCommServer : public AbstractCommServer {
         void waitForExit();
 
         static void executeFunc(PipeCommServer *server);
-        static SyncPath pipePath();
 
 #if defined(KD_WINDOWS)
         std::recursive_mutex _channelsMutex;

--- a/test/server/workers/testworkers.cpp
+++ b/test/server/workers/testworkers.cpp
@@ -17,7 +17,6 @@
  */
 
 #include "testworkers.h"
-
 #include "propagation/executor/executorworker.h"
 #include "libcommon/keychainmanager/keychainmanager.h"
 #include "libcommonserver/network/proxy.h"
@@ -28,6 +27,7 @@
 
 #if defined(KD_WINDOWS)
 #include <combaseapi.h>
+#include "comm/pipecommserver.h"
 #endif
 
 namespace KDC {
@@ -135,14 +135,24 @@ void TestWorkers::setUp() {
     std::unordered_map<int, std::shared_ptr<KDC::Vfs>> vfsMap;
     vfsMap[_sync.dbId()] = _vfs;
 
-    // Setup and start CommManager
-    _commManager = std::make_shared<CommManager>(*this);
-    _commManager->start();
-
-
 #if defined(KD_WINDOWS)
     // Initializes the COM library
     CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+
+    // Initialize server pipe for VFS communication (no need to listen, just create the named pipe is enough for the vfs to start)
+    SyncPath pipePath = PipeCommServer::pipePath();
+    CreateNamedPipe(pipePath.native().c_str(), // pipe name
+                    PIPE_ACCESS_DUPLEX | // read/write access
+                            FILE_FLAG_OVERLAPPED, // overlapped mode
+                    PIPE_TYPE_BYTE | // message-type pipe
+                            PIPE_READMODE_BYTE | // message-read mode
+                            PIPE_WAIT, // blocking mode
+                    10, // number of instances
+                    BUFSIZE * sizeof(TCHAR), // output buffer size
+                    BUFSIZE * sizeof(TCHAR), // input buffer size
+                    5000, // client time-out (ms)
+                    nullptr); // default security attributes
+
 #endif
     // Start Vfs
 #if defined(KD_MACOS)
@@ -167,10 +177,6 @@ void TestWorkers::tearDown() {
         // Stop Vfs
         _vfs->stopImpl(true);
         _vfs = nullptr;
-    }
-    if (_commManager) {
-        _commManager->stop();
-        _commManager = nullptr;
     }
     TestBase::stop();
 }

--- a/test/server/workers/testworkers.cpp
+++ b/test/server/workers/testworkers.cpp
@@ -130,11 +130,15 @@ void TestWorkers::setUp() {
     _syncPal->syncDb()->setAutoDelete(true);
     _syncPal->createProgressInfo();
 
-    // Setup and start CommManager
     std::unordered_map<int, std::shared_ptr<KDC::SyncPal>> syncPalMap;
     syncPalMap[_sync.dbId()] = _syncPal;
     std::unordered_map<int, std::shared_ptr<KDC::Vfs>> vfsMap;
     vfsMap[_sync.dbId()] = _vfs;
+
+    // Setup and start CommManager
+    _commManager = std::make_shared<CommManager>(*this);
+    _commManager->start();
+
 
 #if defined(KD_WINDOWS)
     // Initializes the COM library
@@ -163,6 +167,10 @@ void TestWorkers::tearDown() {
         // Stop Vfs
         _vfs->stopImpl(true);
         _vfs = nullptr;
+    }
+    if (_commManager) {
+        _commManager->stop();
+        _commManager = nullptr;
     }
     TestBase::stop();
 }

--- a/test/server/workers/testworkers.h
+++ b/test/server/workers/testworkers.h
@@ -62,7 +62,6 @@ class TestWorkers : public CppUnit::TestFixture, public TestBase {
 #else
         static std::shared_ptr<VfsOff> _vfs;
 #endif
-        std::shared_ptr<CommManager> _commManager;
 
         static bool _vfsInstallationDone;
         static bool _vfsActivationDone;

--- a/test/server/workers/testworkers.h
+++ b/test/server/workers/testworkers.h
@@ -62,6 +62,7 @@ class TestWorkers : public CppUnit::TestFixture, public TestBase {
 #else
         static std::shared_ptr<VfsOff> _vfs;
 #endif
+        std::shared_ptr<CommManager> _commManager;
 
         static bool _vfsInstallationDone;
         static bool _vfsActivationDone;


### PR DESCRIPTION
Added SetOutPath "$INSTDIR" after AppX package install to ensure subsequent files, including shortcuts, are placed in the correct directory during installation. This change improves reliability of file placement in the NSIS installer script.