### PR TITLE
Fix: Settings expander

### DIFF
--- a/src/gui4/windows/kDrive client/kDrive client/App.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/App.xaml.cs
@@ -98,6 +98,7 @@ namespace Infomaniak.kDrive
                 }
                 LegacyCommPort = Int32.Parse(arguments[1]);
             }
+
             // Register oAuth protocol handler
             RegisterOAuthProtocol();
 

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/DriveManagementPage.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/DriveManagementPage.xaml
@@ -73,34 +73,35 @@
 
                         </toolKit:SettingsExpander.HeaderIcon>
                         <toolKit:SettingsExpander.Items>
-                            <!-- Presentation -->
-                            <Grid Padding="{StaticResource SettingsCardPadding}"
-                                  Background="{ThemeResource LayerFillColorDefault}"
-                                  RowSpacing="{StaticResource Infomaniak.Style.Spacing.M}">
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="auto" />
-                                    <RowDefinition Height="*" />
-                                </Grid.RowDefinitions>
-                                <StackPanel Grid.Row="0"
-                                            Spacing="{StaticResource Infomaniak.Style.Spacing.XXS}">
-                                    <TextBlock x:Uid="Page_Settings_DriveManagementPage_FolderSelection_Presentation_Header"
-                                               Style="{StaticResource Infomaniak.Style.TextBlock.Body}"
-                                               TextWrapping="Wrap" />
+                            <toolKit:SettingsCard HorizontalAlignment="Stretch"
+                                                  HorizontalContentAlignment="Stretch"
+                                                  ContentAlignment="Vertical">
+                                <!-- Presentation -->
+                                <Grid RowSpacing="{StaticResource Infomaniak.Style.Spacing.M}">
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="auto" />
+                                        <RowDefinition Height="*" />
+                                    </Grid.RowDefinitions>
+                                    <StackPanel Grid.Row="0"
+                                                Spacing="{StaticResource Infomaniak.Style.Spacing.XXS}">
+                                        <TextBlock x:Uid="Page_Settings_DriveManagementPage_FolderSelection_Presentation_Header"
+                                                   Style="{StaticResource Infomaniak.Style.TextBlock.Body}"
+                                                   TextWrapping="Wrap" />
 
-                                    <TextBlock x:Uid="Page_Settings_DriveManagementPage_FolderSelection_Presentation_Description"
-                                               Style="{StaticResource Infomaniak.Style.TextBlock.Caption}"
-                                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                               TextWrapping="Wrap" />
-                                </StackPanel>
-                                <controls:SyncExclusionSelector x:Name="ExclSelector"
-                                                                Grid.Row="1"
-                                                                DriveId="{x:Bind ManagedDrive.DriveId, Mode=OneWay}"
-                                                                UserDbId="{x:Bind ManagedDrive.Account.User.DbId}"
-                                                                SyncDbId="{x:Bind ManagedDrive.MainSync.DbId, Mode=OneWay}"
-                                                                HorizontalAlignment="Stretch" />
-                            </Grid>
-                            <toolKit:SettingsCard Background="{ThemeResource LayerFillColorDefault}"
-                                                  Visibility="{x:Bind ExclSelector.HasPendingChanges, Mode=OneWay}">
+                                        <TextBlock x:Uid="Page_Settings_DriveManagementPage_FolderSelection_Presentation_Description"
+                                                   Style="{StaticResource Infomaniak.Style.TextBlock.Caption}"
+                                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                   TextWrapping="Wrap" />
+                                    </StackPanel>
+                                    <controls:SyncExclusionSelector x:Name="ExclSelector"
+                                                                    Grid.Row="1"
+                                                                    DriveId="{x:Bind ManagedDrive.DriveId, Mode=OneWay}"
+                                                                    UserDbId="{x:Bind ManagedDrive.Account.User.DbId}"
+                                                                    SyncDbId="{x:Bind ManagedDrive.MainSync.DbId, Mode=OneWay}"
+                                                                    HorizontalAlignment="Stretch" />
+                                </Grid>
+                            </toolKit:SettingsCard>
+                            <toolKit:SettingsCard Visibility="{x:Bind ExclSelector.HasPendingChanges, Mode=OneWay}">
                                 <StackPanel Orientation="Horizontal"
                                             Spacing="{StaticResource Infomaniak.Style.Spacing.S}">
                                     <Button x:Uid="Page_Settings_DriveManagementPage_FolderSelection_CancelButton"

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/SettingsPage.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/SettingsPage.xaml
@@ -270,8 +270,7 @@
                     </toolKit:SettingsCard>
 
                     <!-- Advanced - Privacy -->
-                    <toolKit:SettingsExpander x:Uid="Page_SettingsPage_Privacy"
-                                              IsEnabled="False">
+                    <toolKit:SettingsExpander x:Uid="Page_SettingsPage_Privacy">
                         <toolKit:SettingsExpander.HeaderIcon>
                             <controls:SvgIcon UriString="{StaticResource Infomaniak.DS.Icons.Users.user-cog}"
                                               Height="32"
@@ -289,21 +288,13 @@
                                                   IsClickEnabled="True"
                                                   Click="MatomoButton_Click"
                                                   IsEnabled="False" />
-                            <controls:ConsentDialog x:Name="MatomoContentDialog"
-                                                    x:Uid="Page_SettingsPage_Privacy_Matomo_ConsentDialog"
-                                                    LogoUriStr="{StaticResource Infomaniak.Custom.Icons.logo-matomo}"
-                                                    CurrentValue="{x:Bind  ViewModel.Settings.MatomoEnabled, Mode=OneWay}" />
-
+                            
                             <!-- Sentry -->
                             <toolKit:SettingsCard x:Uid="Page_SettingsPage_Privacy_Sentry"
                                                   Background="{ThemeResource LayerFillColorDefault}"
                                                   IsClickEnabled="True"
                                                   Click="SentryButton_Click"
                                                   IsEnabled="False" />
-                            <controls:ConsentDialog x:Name="SentryContentDialog"
-                                                    x:Uid="Page_SettingsPage_Privacy_Sentry_ConsentDialog"
-                                                    LogoUriStr="{StaticResource Infomaniak.Custom.Icons.logo-sentry}"
-                                                    CurrentValue="{x:Bind  ViewModel.Settings.SentryEnabled, Mode=OneWay}" />
 
                             <!-- Sources -->
                             <toolKit:SettingsCard x:Uid="Page_SettingsPage_Privacy_Sources"
@@ -316,7 +307,16 @@
                                 </toolKit:SettingsCard.ActionIcon>
                             </toolKit:SettingsCard>
                         </toolKit:SettingsExpander.Items>
+                        
                     </toolKit:SettingsExpander>
+                    <controls:ConsentDialog x:Name="SentryContentDialog"
+                                            x:Uid="Page_SettingsPage_Privacy_Sentry_ConsentDialog"
+                                            LogoUriStr="{StaticResource Infomaniak.Custom.Icons.logo-sentry}"
+                                            CurrentValue="{x:Bind  ViewModel.Settings.SentryEnabled, Mode=OneWay}" />
+                    <controls:ConsentDialog x:Name="MatomoContentDialog"
+                                            x:Uid="Page_SettingsPage_Privacy_Matomo_ConsentDialog"
+                                            LogoUriStr="{StaticResource Infomaniak.Custom.Icons.logo-matomo}"
+                                            CurrentValue="{x:Bind  ViewModel.Settings.MatomoEnabled, Mode=OneWay}" />
 
                     <!-- Advanced - Proxy -->
                     <toolKit:SettingsExpander x:Name="ProxySettingsExpander"


### PR DESCRIPTION
Fix: Settings expander items should only be settings cards, otherwise it may cause a crash in release mode.