### PR TITLE
Fix disabled kDrive menu on lite sync

### DIFF
--- a/src/server/comm/extensionjob.cpp
+++ b/src/server/comm/extensionjob.cpp
@@ -435,13 +435,11 @@ void ExtensionJob::commandGetAllMenuItems(const CommString &argument, std::share
         return;
     }
 
-    {
-        CommString msgId = argumentList[0];
-        CommString response(msgId);
-        response.append(responseToFinderArgSeparator);
-        response.append(CommonUtility::str2CommString(Theme::instance()->appName()));
-        channel->sendMessage(response);
-    }
+
+    CommString msgId = argumentList[0];
+    CommString response(msgId);
+    response.append(responseToFinderArgSeparator);
+    response.append(CommonUtility::str2CommString(Theme::instance()->appName()));
 
     // Find the common sync
     std::vector<SyncPath> paths;
@@ -455,7 +453,6 @@ void ExtensionJob::commandGetAllMenuItems(const CommString &argument, std::share
 
         if (syncPalMapIt != AppServer::syncPalMap.end() && syncPalMapIt->second && vfsMapIt != AppServer::vfsMap.end() &&
             vfsMapIt->second) {
-            CommString response;
             response.append(responseToFinderArgSeparator);
             response.append(sync.dbId() ? Vfs::modeToString(vfsMapIt->second->mode()) : Str(""));
 
@@ -467,6 +464,7 @@ void ExtensionJob::commandGetAllMenuItems(const CommString &argument, std::share
                 if (exitCode != ExitCode::Ok) {
                     LOGW_WARN(Log::instance()->getLogger(),
                               L"Error in SyncPal::itemId - " << Utility::formatSyncPath(fileData.relativePath));
+                    channel->sendMessage(response);
                     return;
                 }
                 bool isOnTheServer = !nodeId.empty();
@@ -499,10 +497,9 @@ void ExtensionJob::commandGetAllMenuItems(const CommString &argument, std::share
                 response.append(responseToFinderArgSeparator);
                 response.append(cancelHydrationText());
             }
-
-            channel->sendMessage(response);
         }
     }
+    channel->sendMessage(response);
 }
 
 void ExtensionJob::commandGetThumbnail(const CommString &argument, std::shared_ptr<AbstractCommChannel> channel) {


### PR DESCRIPTION
The GetAllMenuItems function was previously split into two parts, which inadvertently inserted a newline separator mid-command. This caused the file explorer to fail parsing the command. The fix ensures the command is sent as a single, uninterrupted string.