### PR TITLE
feat(ObservedDrives): New way to observe all drives as a collection

### DIFF
--- a/src/front/macOS/kDrive.xcodeproj/project.pbxproj
+++ b/src/front/macOS/kDrive.xcodeproj/project.pbxproj
@@ -121,6 +121,7 @@
 				Cache/Observation/ObservableCoherentCacheTests.swift,
 				Cache/Observation/ObservableData.swift,
 				Cache/Observation/ObservedAccountTests.swift,
+				Cache/Observation/ObservedDrivesTests.swift,
 				Cache/Observation/ObservedDriveTests.swift,
 				Cache/Observation/ObservedSynchrosTests.swift,
 				Cache/Observation/ObservedSynchroTests.swift,

--- a/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedDrives.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedDrives.swift
@@ -1,0 +1,68 @@
+/*
+ Infomaniak kDrive - Desktop
+ Copyright (C) 2023-2025 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Combine
+import Foundation
+import InfomaniakDI
+
+public struct DriveContext: Sendable, Equatable {
+    public let drive: Drive
+    public let account: Account
+    public let user: User
+}
+
+@MainActor
+@propertyWrapper
+public final class ObservedDrives: ObservableObject {
+    @Published public private(set) var wrappedValue: [DriveContext] = []
+    private var cancellable: AnyCancellable?
+
+    public init(
+        cacheObservation: CoherentCacheObservable? = nil
+    ) {
+        let cacheObservation =
+            cacheObservation ?? InjectService<CoherentCacheObservable>().wrappedValue
+
+        cancellable = cacheObservation.usersPublisher
+            .allDrivesPublisher()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] drives in
+                self?.wrappedValue = drives
+            }
+    }
+
+    deinit { cancellable?.cancel() }
+
+    public var projectedValue: ObservedDrives { self }
+}
+
+public extension AnyPublisher where Output == IndexedUsers, Failure == Never {
+    func allDrivesPublisher() -> AnyPublisher<[DriveContext], Never> {
+        map { usersDict in
+            usersDict.values.flatMap { user in
+                user.accounts.values.flatMap { account in
+                    account.drives.values.map { drive in
+                        DriveContext(drive: drive, account: account, user: user)
+                    }
+                }
+            }
+        }
+        .removeDuplicates()
+        .eraseToAnyPublisher()
+    }
+}

--- a/src/front/macOS/kDriveTests/Cache/Observation/ObservedDrivesTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/Observation/ObservedDrivesTests.swift
@@ -191,14 +191,45 @@ struct ObservedDrivesTests {
         #expect(observedDrives.isEmpty, "Drives should be empty once the object is deleted")
     }
 
-         // WHEN
-         try await cache.removeDrive(driveDbId: ObservableData.expectedDriveDbId)
+    @Test(.timeLimit(.minutes(1)))
+    func testRemoveDrive() async throws {
+        // GIVEN
+        let cache = ServerCoherentCache()
+        let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        #expect(initialUser == nil, "Cache should initially be empty")
 
-         // THEN
-         _ = await receivedValues.dropFirst().first(where: { $0 == [] })
+        @ObservedDrives(cacheObservation: cache) var observedDrives: [DriveContext]
+        let receivedValues = $observedDrives.receivedValues // Start to save the received values
 
-         let latestFetchedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
-         #expect(latestFetchedDrive == nil, "Object should no longer be available in cache")
-         #expect(observedDrives.isEmpty, "Drives should be empty once the object is deleted")
-     }
+        #expect(observedDrives == [], "Drives should initially be empty")
+        await cache.addUser(ObservableData.expectedUserWithAccounts)
+
+        let expectedDrive = ObservableData.expectedDrive
+        try await cache.addDrive(expectedDrive, accountDbId: ObservableData.expectedAccountDbId)
+
+        let secondaryDrive = ObservableData.secondaryDrive
+        try await cache.addDrive(secondaryDrive, accountDbId: ObservableData.expectedAccountDbId)
+
+        let cachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
+        #expect(cachedDrive == expectedDrive, "The cache should have been updated with a Drive")
+        let secondaryCachedDrive = await cache.getDrive(driveDbId: ObservableData.secondaryDriveDbId)
+        #expect(secondaryCachedDrive == secondaryDrive, "The cache should have been updated with another Drive")
+
+        // WHEN
+        try await cache.removeDrive(driveDbId: ObservableData.secondaryDriveDbId)
+
+        // THEN
+        _ = await receivedValues.dropFirst().dropFirst().first(where: { _ in true })
+
+        #expect(observedDrives.count == 1, "We should have one Drive after the deletion of a drive")
+
+        guard let firstObservedDrive = observedDrives.first(where: { $0.drive.driveDbId == ObservableData.expectedDriveDbId }) else {
+            Issue.record("Failed to unwrap the first Drive")
+            return
+        }
+
+        #expect(firstObservedDrive.drive.driveDbId == expectedDrive.driveDbId, "The drive should match")
+        #expect(firstObservedDrive.account.dbId == ObservableData.expectedAccount.dbId, "The account should match")
+        #expect(firstObservedDrive.user.dbId == ObservableData.expectedUser.dbId, "The user should match")
+    }
 }

--- a/src/front/macOS/kDriveTests/Cache/Observation/ObservedDrivesTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/Observation/ObservedDrivesTests.swift
@@ -117,4 +117,47 @@ struct ObservedDrivesTests {
         #expect(secondaryObservedDrive.account.dbId == ObservableData.expectedAccount.dbId, "The account should match")
         #expect(secondaryObservedDrive.user.dbId == ObservableData.expectedUser.dbId, "The user should match")
     }
+
+    @Test(.timeLimit(.minutes(1)))
+    func updateObservedDrive() async throws {
+        // GIVEN
+        let cache = ServerCoherentCache()
+        let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        #expect(initialUser == nil, "Cache should initially be empty")
+
+        @ObservedDrives(cacheObservation: cache) var observedDrives: [DriveContext]
+        let receivedValues = $observedDrives.receivedValues // Start to save the received values
+
+        #expect(observedDrives == [], "Drives should initially be empty")
+        await cache.addUser(ObservableData.expectedUserWithAccounts)
+
+        let expectedDrive = ObservableData.expectedDrive
+        try await cache.addDrive(expectedDrive, accountDbId: ObservableData.expectedAccountDbId)
+
+        let cachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
+        #expect(cachedDrive == expectedDrive, "The cache should have been updated with a Drive")
+
+        // WHEN
+        let updatedDrive = ObservableData.updatedDrive
+        try await cache.updateDrive(drive: updatedDrive)
+
+        // THEN
+        _ = await receivedValues.dropFirst().first(where: { _ in true })
+
+        let latestFetchedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
+        #expect(latestFetchedDrive == ObservableData.updatedDrive, "We should find the object in cache updated")
+        #expect(observedDrives.count == 1, "We should have one object in the array")
+
+        guard let firstDrive = observedDrives.first else {
+            Issue.record("Failed to unwrap the first object")
+            return
+        }
+
+        #expect(firstDrive.drive != expectedDrive, "The Drive in the array should not match the old one")
+        #expect(firstDrive.drive == updatedDrive, "The Drive in the array should match the updated one")
+
+        #expect(firstDrive.drive.driveDbId == expectedDrive.driveDbId, "The drive should match the one we just added")
+        #expect(firstDrive.account.dbId == ObservableData.expectedAccount.dbId, "The account should match the one we just added")
+        #expect(firstDrive.user.dbId == ObservableData.expectedUser.dbId, "The user should match the one we just added")
+    }
 }

--- a/src/front/macOS/kDriveTests/Cache/Observation/ObservedDrivesTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/Observation/ObservedDrivesTests.swift
@@ -160,4 +160,45 @@ struct ObservedDrivesTests {
         #expect(firstDrive.account.dbId == ObservableData.expectedAccount.dbId, "The account should match the one we just added")
         #expect(firstDrive.user.dbId == ObservableData.expectedUser.dbId, "The user should match the one we just added")
     }
+
+    @Test(.timeLimit(.minutes(1)))
+    func deleteObservedDrive() async throws {
+        // GIVEN
+        let cache = ServerCoherentCache()
+        let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        #expect(initialUser == nil, "Cache should initially be empty")
+
+        @ObservedDrives(cacheObservation: cache) var observedDrives: [DriveContext]
+        let receivedValues = $observedDrives.receivedValues // Start to save the received values
+
+        #expect(observedDrives == [], "Drives should initially be empty")
+        await cache.addUser(ObservableData.expectedUserWithAccounts)
+
+        let expectedDrive = ObservableData.expectedDrive
+        try await cache.addDrive(expectedDrive, accountDbId: ObservableData.expectedAccountDbId)
+
+        let cachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
+        #expect(cachedDrive == expectedDrive, "The cache should have been updated with a Drive")
+
+        // WHEN
+        try await cache.removeDrive(driveDbId: ObservableData.expectedDriveDbId)
+
+        // THEN
+        _ = await receivedValues.dropFirst().first(where: { $0 == [] })
+
+        let latestFetchedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
+        #expect(latestFetchedDrive == nil, "Object should no longer be available in cache")
+        #expect(observedDrives.isEmpty, "Drives should be empty once the object is deleted")
+    }
+
+         // WHEN
+         try await cache.removeDrive(driveDbId: ObservableData.expectedDriveDbId)
+
+         // THEN
+         _ = await receivedValues.dropFirst().first(where: { $0 == [] })
+
+         let latestFetchedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
+         #expect(latestFetchedDrive == nil, "Object should no longer be available in cache")
+         #expect(observedDrives.isEmpty, "Drives should be empty once the object is deleted")
+     }
 }

--- a/src/front/macOS/kDriveTests/Cache/Observation/ObservedDrivesTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/Observation/ObservedDrivesTests.swift
@@ -1,0 +1,71 @@
+/*
+ Infomaniak kDrive - Desktop
+ Copyright (C) 2023-2025 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Combine
+import Foundation
+@testable import InfomaniakDI
+@testable import kDriveCore
+import Testing
+
+extension ObservedDrives {
+    var receivedValues: AsyncStream<[DriveContext]> {
+        AsyncStream { continuation in
+            let cancellable = $wrappedValue
+                .sink { value in continuation.yield(value) }
+
+            continuation.onTermination = { _ in cancellable.cancel() }
+        }
+    }
+}
+
+@MainActor
+struct ObservedDrivesTests {
+    @Test(.timeLimit(.minutes(1)))
+    func setObservedDrives() async throws {
+        // GIVEN
+        let cache = ServerCoherentCache()
+        let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        #expect(initialUser == nil, "Cache should initially be empty")
+
+        @ObservedDrives(cacheObservation: cache) var observedDrives: [DriveContext]
+        let receivedValues = $observedDrives.receivedValues // Start to save the received values
+
+        #expect(observedDrives == [], "Drives should initially be empty")
+        await cache.addUser(ObservableData.expectedUserWithAccounts)
+
+        // WHEN
+        let expectedDrive = ObservableData.expectedDrive
+        try await cache.addDrive(expectedDrive, accountDbId: ObservableData.expectedAccountDbId)
+
+        // THEN
+        _ = await receivedValues.first(where: { _ in true })
+
+        let cachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
+        #expect(cachedDrive == expectedDrive, "The cache should have been updated with a Drive")
+        #expect(observedDrives.count == 1, "We should have one Drive in the array")
+
+        guard let firstDrive = observedDrives.first else {
+            Issue.record("Failed to unwrap the first Drive")
+            return
+        }
+
+        #expect(firstDrive.drive.driveDbId == expectedDrive.driveDbId, "The drive should match the one we just added")
+        #expect(firstDrive.account.dbId == ObservableData.expectedAccount.dbId, "The account should match the one we just added")
+        #expect(firstDrive.user.dbId == ObservableData.expectedUser.dbId, "The user should match the one we just added")
+    }
+}

--- a/src/front/macOS/kDriveTests/Cache/Observation/ObservedDrivesTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/Observation/ObservedDrivesTests.swift
@@ -68,4 +68,53 @@ struct ObservedDrivesTests {
         #expect(firstDrive.account.dbId == ObservableData.expectedAccount.dbId, "The account should match the one we just added")
         #expect(firstDrive.user.dbId == ObservableData.expectedUser.dbId, "The user should match the one we just added")
     }
+
+    @Test(.timeLimit(.minutes(1)))
+    func setMultipleObservedDrives() async throws {
+        // GIVEN
+        let cache = ServerCoherentCache()
+        let initialUser = await cache.getUser(dbId: ObservableData.expectedUserDbId)
+        #expect(initialUser == nil, "Cache should initially be empty")
+
+        @ObservedDrives(cacheObservation: cache) var observedDrives: [DriveContext]
+        let receivedValues = $observedDrives.receivedValues // Start to save the received values
+
+        #expect(observedDrives == [], "Observed Drives should initially be empty")
+        await cache.addUser(ObservableData.expectedUserWithAccounts)
+
+        // WHEN
+        let expectedDrive = ObservableData.expectedDrive
+        try await cache.addDrive(expectedDrive, accountDbId: ObservableData.expectedAccountDbId)
+
+        let secondaryDrive = ObservableData.secondaryDrive
+        try await cache.addDrive(secondaryDrive, accountDbId: ObservableData.expectedAccountDbId)
+
+        // THEN
+        _ = await receivedValues.dropFirst().first(where: { _ in true })
+
+        let cachedDrive = await cache.getDrive(driveDbId: ObservableData.expectedDriveDbId)
+        #expect(cachedDrive == expectedDrive, "The cache should have been updated with a Drive")
+        let secondaryCachedDrive = await cache.getDrive(driveDbId: ObservableData.secondaryDriveDbId)
+        #expect(secondaryCachedDrive == secondaryDrive, "The cache should have been updated with another Drive")
+        #expect(observedDrives.count == 2, "We should have two Drives in the array")
+
+        guard let firstObservedDrive = observedDrives.first(where: { $0.drive.driveDbId == ObservableData.expectedDriveDbId }) else {
+            Issue.record("Failed to unwrap the first Drive")
+            return
+        }
+
+        #expect(firstObservedDrive.drive.driveDbId == expectedDrive.driveDbId, "The drive should match")
+        #expect(firstObservedDrive.account.dbId == ObservableData.expectedAccount.dbId, "The account should match")
+        #expect(firstObservedDrive.user.dbId == ObservableData.expectedUser.dbId, "The user should match")
+
+        guard let secondaryObservedDrive = observedDrives.first(where: { $0.drive.driveDbId == ObservableData.secondaryDriveDbId }) else {
+            Issue.record("Failed to unwrap the secondary Drive")
+            return
+        }
+
+        #expect(firstObservedDrive.drive != secondaryObservedDrive.drive, "The two drives should not match")
+        #expect(secondaryObservedDrive.drive.driveDbId == secondaryDrive.driveDbId, "The drive should match")
+        #expect(secondaryObservedDrive.account.dbId == ObservableData.expectedAccount.dbId, "The account should match")
+        #expect(secondaryObservedDrive.user.dbId == ObservableData.expectedUser.dbId, "The user should match")
+    }
 }


### PR DESCRIPTION
#### Abstract

New way to observe all drives as a collection with all linked data, akin to what was done recently with `Synchros`