### PR TITLE
fix: do not throw if app fail to load user info

### DIFF
--- a/src/gui/parametersdialog.cpp
+++ b/src/gui/parametersdialog.cpp
@@ -324,6 +324,13 @@ QString ParametersDialog::getAppErrorText(const QString &fctCode, const ExitCode
         case ExitCode::DataError:
         case ExitCode::DbError:
         case ExitCode::BackError:
+            if (exitCause == ExitCause::Http5xx) {
+                return tr(
+                        "A technical error has occurred.<br>"
+                        "Synchronization will resume as soon as possible. Please contact our support team if the error "
+                        "persists.");
+            }
+            [[fallthrough]];
         case ExitCode::FatalError:
             return tr("A technical error has occurred (error %1).<br>"
                       "Please empty the history and if the error persists, contact our support team.")
@@ -470,6 +477,12 @@ QString ParametersDialog::getSyncPalBackErrorText(const QString &err, const Exit
             return tr(
                     "You are not authorised to access this kDrive.<br>"
                     "Synchronization has been paused. Please contact an administrator.");
+        case ExitCause::Http5xx: {
+            return tr(
+                    "A technical error has occurred.<br>"
+                    "Synchronization will resume as soon as possible. Please contact our support team if the error "
+                    "persists.");
+        }
         default:
             return tr("A technical error has occurred (error %1).<br>"
                       "Synchronization will resume as soon as possible. Please contact our support team if the error "

--- a/src/libcommon/utility/cstypes.h
+++ b/src/libcommon/utility/cstypes.h
@@ -135,6 +135,7 @@ enum class ExitCause {
     FileOrDirectoryCorrupted,
     TmpDirAccessError,
     UpdateTreeIntegrityCheckFailed,
+    MissingReplyData,
     EnumEnd
 };
 

--- a/src/libcommon/utility/types.cpp
+++ b/src/libcommon/utility/types.cpp
@@ -226,6 +226,8 @@ std::string toString(const ExitCause e) {
             return "TmpDirAccessError";
         case ExitCause::UpdateTreeIntegrityCheckFailed:
             return "UpdateTreeIntegrityCheckFailed";
+        case ExitCause::MissingReplyData:
+            return "MissingReplyData";
         default:
             return noConversionStr;
     }

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -372,8 +372,7 @@ void AppServer::init() {
     connect(OldCommServer::instance().get(), &OldCommServer::restartClient, this, &AppServer::onRestartClientReceived);
 
     // Update users/accounts/drives info
-    const auto exitInfo = updateAllUsersInfo();
-    if (exitInfo.code() == ExitCode::InvalidToken) {
+    if (const auto exitInfo = updateAllUsersInfo(); exitInfo.code() == ExitCode::InvalidToken) {
         // The user will be asked to enter its credentials later
     } else if (!exitInfo) {
         LOG_WARN(_logger, "Error in updateAllUsersInfo: " << exitInfo);
@@ -2610,11 +2609,8 @@ ExitInfo AppServer::updateUserInfo(User &user) {
     if (user.keychainKey().empty()) {
         return ExitCode::Ok;
     }
-
-    bool found = false;
     bool updated = false;
-    auto exitInfo = ServerRequests::loadUserInfo(user, updated);
-    if (!exitInfo) {
+    if (const auto exitInfo = ServerRequests::loadUserInfo(user, updated); !exitInfo) {
         LOG_WARN(_logger, "Error in Requests::loadUserInfo: " << exitInfo);
         if (exitInfo.code() == ExitCode::InvalidToken) {
             // Notify client app that the user is disconnected
@@ -2627,6 +2623,7 @@ ExitInfo AppServer::updateUserInfo(User &user) {
     }
 
     if (updated) {
+        bool found = false;
         if (!ParmsDb::instance()->updateUser(user, found)) {
             LOG_WARN(_logger, "Error in ParmsDb::updateUser");
             return ExitCode::DbError;
@@ -2657,8 +2654,8 @@ ExitInfo AppServer::updateUserInfo(User &user) {
         for (auto &drive: drives) {
             bool quotaUpdated = false;
             bool accountUpdated = false;
-            exitInfo = ServerRequests::loadDriveInfo(drive, account, updated, quotaUpdated, accountUpdated);
-            if (!exitInfo) {
+            if (const auto exitInfo = ServerRequests::loadDriveInfo(drive, account, updated, quotaUpdated, accountUpdated);
+                !exitInfo) {
                 LOG_WARN(_logger, "Error in Requests::loadDriveInfo: " << exitInfo);
                 return exitInfo;
             }
@@ -2691,6 +2688,7 @@ ExitInfo AppServer::updateUserInfo(User &user) {
             }
 
             if (updated) {
+                bool found = false;
                 if (!ParmsDb::instance()->updateDrive(drive, found)) {
                     LOG_WARN(_logger, "Error in ParmsDb::updateDrive");
                     return ExitCode::DbError;
@@ -2715,6 +2713,7 @@ ExitInfo AppServer::updateUserInfo(User &user) {
 
                 if (accountDbId == 0) {
                     // No existing account with the new accountId, update it
+                    bool found = false;
                     if (!ParmsDb::instance()->updateAccount(account, found)) {
                         LOG_WARN(_logger, "Error in ParmsDb::updateAccount");
                         return ExitCode::DbError;
@@ -2730,6 +2729,7 @@ ExitInfo AppServer::updateUserInfo(User &user) {
                 } else {
                     // An account already exists with the new accountId, link the drive to it
                     drive.setAccountDbId(accountDbId);
+                    bool found = false;
                     if (!ParmsDb::instance()->updateDrive(drive, found)) {
                         LOG_WARN(_logger, "Error in ParmsDb::updateDrive");
                         return ExitCode::DbError;
@@ -2749,7 +2749,7 @@ ExitInfo AppServer::updateUserInfo(User &user) {
                     }
 
                     if (driveList.size() == 0) {
-                        exitInfo = ServerRequests::deleteAccount(account.dbId());
+                        const auto exitInfo = ServerRequests::deleteAccount(account.dbId());
                         if (!exitInfo) {
                             LOG_WARN(_logger, "Error in Requests::deleteAccount: " << exitInfo);
                             return exitInfo;
@@ -3559,8 +3559,7 @@ ExitInfo AppServer::updateAllUsersInfo() {
             continue;
         }
 
-        auto exitInfo = updateUserInfo(user);
-        if (!exitInfo) {
+        if (const auto exitInfo = updateUserInfo(user); !exitInfo) {
             LOG_WARN(_logger, "Error in updateUserInfo: " << exitInfo);
             return exitInfo;
         }

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -372,15 +372,12 @@ void AppServer::init() {
     connect(OldCommServer::instance().get(), &OldCommServer::restartClient, this, &AppServer::onRestartClientReceived);
 
     // Update users/accounts/drives info
-    ExitCode exitCode = updateAllUsersInfo();
-    if (exitCode == ExitCode::InvalidToken) {
+    const auto exitInfo = updateAllUsersInfo();
+    if (exitInfo.code() == ExitCode::InvalidToken) {
         // The user will be asked to enter its credentials later
-    } else if (exitCode != ExitCode::Ok) {
-        LOG_WARN(_logger, "Error in updateAllUsersInfo: code=" << exitCode);
-        addError(Error(ERR_ID, exitCode, ExitCause::Unknown));
-        if (exitCode != ExitCode::NetworkError && exitCode != ExitCode::UpdateRequired) {
-            throw std::runtime_error("Failed to load user data.");
-        }
+    } else if (!exitInfo) {
+        LOG_WARN(_logger, "Error in updateAllUsersInfo: " << exitInfo);
+        addError(Error(ERR_ID, exitInfo.code(), exitInfo.cause()));
     }
 
     // Set sentry user
@@ -2609,24 +2606,24 @@ ExitCode AppServer::migrateConfiguration(bool &proxyNotSupported) {
     return exitCode;
 }
 
-ExitCode AppServer::updateUserInfo(User &user) {
+ExitInfo AppServer::updateUserInfo(User &user) {
     if (user.keychainKey().empty()) {
         return ExitCode::Ok;
     }
 
     bool found = false;
     bool updated = false;
-    ExitCode exitCode = ServerRequests::loadUserInfo(user, updated);
-    if (exitCode != ExitCode::Ok) {
-        LOG_WARN(_logger, "Error in Requests::loadUserInfo: code=" << exitCode);
-        if (exitCode == ExitCode::InvalidToken) {
+    auto exitInfo = ServerRequests::loadUserInfo(user, updated);
+    if (!exitInfo) {
+        LOG_WARN(_logger, "Error in Requests::loadUserInfo: " << exitInfo);
+        if (exitInfo.code() == ExitCode::InvalidToken) {
             // Notify client app that the user is disconnected
             UserInfo userInfo;
             ServerRequests::userToUserInfo(user, userInfo);
             sendUserUpdated(userInfo);
         }
 
-        return exitCode;
+        return exitInfo;
     }
 
     if (updated) {
@@ -2660,10 +2657,10 @@ ExitCode AppServer::updateUserInfo(User &user) {
         for (auto &drive: drives) {
             bool quotaUpdated = false;
             bool accountUpdated = false;
-            exitCode = ServerRequests::loadDriveInfo(drive, account, updated, quotaUpdated, accountUpdated);
-            if (exitCode != ExitCode::Ok) {
-                LOG_WARN(_logger, "Error in Requests::loadDriveInfo: code=" << exitCode);
-                return exitCode;
+            exitInfo = ServerRequests::loadDriveInfo(drive, account, updated, quotaUpdated, accountUpdated);
+            if (!exitInfo) {
+                LOG_WARN(_logger, "Error in Requests::loadDriveInfo: " << exitInfo);
+                return exitInfo;
             }
 
             if (drive.accessDenied() || drive.maintenanceInfo()._maintenance) {
@@ -2752,10 +2749,10 @@ ExitCode AppServer::updateUserInfo(User &user) {
                     }
 
                     if (driveList.size() == 0) {
-                        exitCode = ServerRequests::deleteAccount(account.dbId());
-                        if (exitCode != ExitCode::Ok) {
-                            LOG_WARN(_logger, "Error in Requests::deleteAccount: code=" << exitCode);
-                            return exitCode;
+                        exitInfo = ServerRequests::deleteAccount(account.dbId());
+                        if (!exitInfo) {
+                            LOG_WARN(_logger, "Error in Requests::deleteAccount: " << exitInfo);
+                            return exitInfo;
                         }
                         sendAccountRemoved(account.accountId());
                         accountRemoved = true;
@@ -3537,7 +3534,7 @@ bool AppServer::startClient() {
     return true;
 }
 
-ExitCode AppServer::updateAllUsersInfo() {
+ExitInfo AppServer::updateAllUsersInfo() {
     std::vector<User> users;
     if (!ParmsDb::instance()->selectAllUsers(users)) {
         LOG_WARN(_logger, "Error in ParmsDb::selectAllUsers");
@@ -3562,10 +3559,10 @@ ExitCode AppServer::updateAllUsersInfo() {
             continue;
         }
 
-        ExitCode exitCode = updateUserInfo(user);
-        if (exitCode != ExitCode::Ok) {
-            LOG_WARN(_logger, "Error in updateUserInfo: code=" << exitCode);
-            return exitCode;
+        auto exitInfo = updateUserInfo(user);
+        if (!exitInfo) {
+            LOG_WARN(_logger, "Error in updateUserInfo: " << exitInfo);
+            return exitInfo;
         }
     }
 

--- a/src/server/appserver.h
+++ b/src/server/appserver.h
@@ -211,8 +211,8 @@ class AppServer : public SharedTools::QtSingleApplication {
         void processInterruptedLogsUpload();
 
         ExitCode migrateConfiguration(bool &proxyNotSupported);
-        ExitCode updateUserInfo(User &user);
-        ExitCode updateAllUsersInfo();
+        ExitInfo updateUserInfo(User &user);
+        ExitInfo updateAllUsersInfo();
         [[nodiscard]] ExitInfo initSyncPal(const Sync &sync, const QSet<QString> &blackList, bool start = true,
                                            const std::chrono::seconds &startDelay = std::chrono::seconds(0),
                                            bool resumedByUser = false, bool firstInit = false);

--- a/src/server/requests/serverrequests.cpp
+++ b/src/server/requests/serverrequests.cpp
@@ -125,9 +125,9 @@ ExitCode ServerRequests::deleteUser(int userDbId) {
     return ExitCode::Ok;
 }
 
-ExitCode ServerRequests::deleteAccount(int accountDbId) {
+ExitInfo ServerRequests::deleteAccount(int accountDbId) {
     // Delete account (and linked drives/syncs by cascade)
-    bool found;
+    bool found = false;
     if (!ParmsDb::instance()->deleteAccount(accountDbId, found)) {
         LOG_WARN(Log::instance()->getLogger(), "Error in ParmsDb::deleteAccount");
         return ExitCode::DbError;

--- a/src/server/requests/serverrequests.cpp
+++ b/src/server/requests/serverrequests.cpp
@@ -1172,6 +1172,7 @@ bool ServerRequests::isDisplayableError(const Error &error) {
                 case ExitCause::NotFound:
                 case ExitCause::QuotaExceeded:
                 case ExitCause::FileLocked:
+                case ExitCause::Http5xx:
                     return true;
                 default:
                     return false;
@@ -1765,103 +1766,102 @@ ExitInfo ServerRequests::loadDriveInfo(Drive &drive, Account &account, bool &upd
         return ExitCode::Ok;
     }
     if (httpStatus != Poco::Net::HTTPResponse::HTTPStatus::HTTP_OK) {
-        LOG_WARN(Log::instance()->getLogger(),
-                 "Network error in GetInfoDriveJob::runSynchronously for driveDbId=" << drive.dbId());
-        return ExitCode::NetworkError;
+        LOG_WARN(Log::instance()->getLogger(), "Error in GetInfoDriveJob::runSynchronously for driveDbId=" << drive.dbId());
+        return exitInfo;
     }
 
     Poco::JSON::Object::Ptr dataObj = job->jsonRes()->getObject(dataKey);
-    if (dataObj && dataObj->size() != 0) {
-        std::string name;
-        if (!JsonParserUtility::extractValue(dataObj, nameKey, name)) {
-            return ExitCode::BackError;
-        }
-        if (drive.name() != name) {
-            drive.setName(name);
-            updated = true;
-        }
-
-        int64_t size = 0;
-        if (!JsonParserUtility::extractValue(dataObj, sizeKey, size)) {
-            return ExitCode::BackError;
-        }
-        if (drive.size() != size) {
-            drive.setSize(size);
-            updated = true;
-            quotaUpdated = true;
-        }
-
-        bool admin = false;
-        if (!JsonParserUtility::extractValue(dataObj, accountAdminKey, admin)) {
-            return ExitCode::BackError;
-        }
-        if (drive.admin() != admin) {
-            drive.setAdmin(admin);
-            updated = true;
-        }
-
-        int accountId = 0;
-        if (!JsonParserUtility::extractValue(dataObj, accountIdKey, accountId)) {
-            return ExitCode::BackError;
-        }
-        if (account.accountId() != accountId) {
-            account.setAccountId(accountId);
-            accountUpdated = true;
-        }
-
-        std::string colorHex;
-        if (Poco::JSON::Object::Ptr prefObj = dataObj->getObject(preferencesKey)) {
-            if (!JsonParserUtility::extractValue(prefObj, colorKey, colorHex, false)) {
-                return ExitCode::BackError;
-            }
-            if (drive.color() != colorHex) {
-                drive.setColor(colorHex);
-                updated = true;
-            }
-        }
-
-        // Non DB attributes
-        bool inMaintenance = false;
-        if (!JsonParserUtility::extractValue(dataObj, inMaintenanceKey, inMaintenance)) {
-            return ExitCode::BackError;
-        }
-
-        int64_t maintenanceFrom = 0;
-        if (drive.maintenanceInfo()._maintenance) {
-            if (!JsonParserUtility::extractValue(dataObj, maintenanceAtKey, maintenanceFrom, false)) {
-                return ExitCode::BackError;
-            }
-        }
-
-        bool isLocked = false;
-        if (!JsonParserUtility::extractValue(dataObj, isLockedKey, isLocked)) {
-            return ExitCode::BackError;
-        }
-        drive.setLocked(isLocked);
-        drive.setAccessDenied(false);
-        drive.setMaintenanceInfo({._maintenance = inMaintenance,
-                                  ._notRenew = job->exitInfo().cause() == ExitCause::DriveNotRenew,
-                                  ._asleep = job->exitInfo().cause() == ExitCause::DriveAsleep,
-                                  ._wakingUp = job->exitInfo().cause() == ExitCause::DriveWakingUp,
-                                  ._maintenanceFrom = maintenanceFrom});
-
-        int64_t usedSize = 0;
-        if (!JsonParserUtility::extractValue(dataObj, usedSizeKey, usedSize)) {
-            return ExitCode::BackError;
-        }
-        if (drive.usedSize() != usedSize) {
-            drive.setUsedSize(usedSize);
-            quotaUpdated = true;
-        }
-    } else {
+    if (!dataObj || dataObj->size() == 0) {
         LOG_WARN(Log::instance()->getLogger(), "Unable to read drive info for driveDbId=" << drive.dbId());
         return ExitCode::DataError;
+    }
+
+    std::string name;
+    if (!JsonParserUtility::extractValue(dataObj, nameKey, name)) {
+        return {ExitCode::BackError, ExitCause::MissingReplyData};
+    }
+    if (drive.name() != name) {
+        drive.setName(name);
+        updated = true;
+    }
+
+    int64_t size = 0;
+    if (!JsonParserUtility::extractValue(dataObj, sizeKey, size)) {
+        return {ExitCode::BackError, ExitCause::MissingReplyData};
+    }
+    if (drive.size() != size) {
+        drive.setSize(size);
+        updated = true;
+        quotaUpdated = true;
+    }
+
+    bool admin = false;
+    if (!JsonParserUtility::extractValue(dataObj, accountAdminKey, admin)) {
+        return {ExitCode::BackError, ExitCause::MissingReplyData};
+    }
+    if (drive.admin() != admin) {
+        drive.setAdmin(admin);
+        updated = true;
+    }
+
+    int accountId = 0;
+    if (!JsonParserUtility::extractValue(dataObj, accountIdKey, accountId)) {
+        return {ExitCode::BackError, ExitCause::MissingReplyData};
+    }
+    if (account.accountId() != accountId) {
+        account.setAccountId(accountId);
+        accountUpdated = true;
+    }
+
+    std::string colorHex;
+    if (Poco::JSON::Object::Ptr prefObj = dataObj->getObject(preferencesKey)) {
+        if (!JsonParserUtility::extractValue(prefObj, colorKey, colorHex, false)) {
+            return {ExitCode::BackError, ExitCause::MissingReplyData};
+        }
+        if (drive.color() != colorHex) {
+            drive.setColor(colorHex);
+            updated = true;
+        }
+    }
+
+    // Non DB attributes
+    bool inMaintenance = false;
+    if (!JsonParserUtility::extractValue(dataObj, inMaintenanceKey, inMaintenance)) {
+        return {ExitCode::BackError, ExitCause::MissingReplyData};
+    }
+
+    int64_t maintenanceFrom = 0;
+    if (drive.maintenanceInfo()._maintenance) {
+        if (!JsonParserUtility::extractValue(dataObj, maintenanceAtKey, maintenanceFrom, false)) {
+            return {ExitCode::BackError, ExitCause::MissingReplyData};
+        }
+    }
+
+    bool isLocked = false;
+    if (!JsonParserUtility::extractValue(dataObj, isLockedKey, isLocked)) {
+        return {ExitCode::BackError, ExitCause::MissingReplyData};
+    }
+    drive.setLocked(isLocked);
+    drive.setAccessDenied(false);
+    drive.setMaintenanceInfo({._maintenance = inMaintenance,
+                              ._notRenew = job->exitInfo().cause() == ExitCause::DriveNotRenew,
+                              ._asleep = job->exitInfo().cause() == ExitCause::DriveAsleep,
+                              ._wakingUp = job->exitInfo().cause() == ExitCause::DriveWakingUp,
+                              ._maintenanceFrom = maintenanceFrom});
+
+    int64_t usedSize = 0;
+    if (!JsonParserUtility::extractValue(dataObj, usedSizeKey, usedSize)) {
+        return {ExitCode::BackError, ExitCause::MissingReplyData};
+    }
+    if (drive.usedSize() != usedSize) {
+        drive.setUsedSize(usedSize);
+        quotaUpdated = true;
     }
 
     return ExitCode::Ok;
 }
 
-ExitCode ServerRequests::getThumbnail(int driveDbId, const NodeId &nodeId, int width, std::string &thumbnail) {
+ExitInfo ServerRequests::getThumbnail(int driveDbId, const NodeId &nodeId, int width, std::string &thumbnail) {
     std::shared_ptr<GetThumbnailJob> job = nullptr;
     try {
         job = std::make_shared<GetThumbnailJob>(driveDbId, nodeId, width);
@@ -1871,9 +1871,8 @@ ExitCode ServerRequests::getThumbnail(int driveDbId, const NodeId &nodeId, int w
         return AbstractTokenNetworkJob::exception2ExitCode(e);
     }
 
-    ExitCode exitCode = job->runSynchronously();
-    if (exitCode != ExitCode::Ok) {
-        return exitCode;
+    if (const auto exitInfo = job->runSynchronously(); !exitInfo) {
+        return exitInfo;
     }
 
     Poco::Net::HTTPResponse::HTTPStatus httpStatus = job->getStatusCode();
@@ -1891,7 +1890,7 @@ ExitCode ServerRequests::getThumbnail(int driveDbId, const NodeId &nodeId, int w
     return ExitCode::Ok;
 }
 
-ExitCode ServerRequests::loadUserInfo(User &user, bool &updated) {
+ExitInfo ServerRequests::loadUserInfo(User &user, bool &updated) {
     updated = false;
 
     // Get user data
@@ -1904,12 +1903,12 @@ ExitCode ServerRequests::loadUserInfo(User &user, bool &updated) {
         return AbstractTokenNetworkJob::exception2ExitCode(e);
     }
 
-    ExitCode exitCode = job->runSynchronously();
-    if (exitCode != ExitCode::Ok) {
-        if (exitCode == ExitCode::InvalidToken) {
+    auto exitInfo = job->runSynchronously();
+    if (!exitInfo) {
+        if (exitInfo.code() == ExitCode::InvalidToken) {
             user.setKeychainKey(""); // Invalid keychain key
         }
-        return exitCode;
+        return exitInfo;
     }
 
     if (const Poco::Net::HTTPResponse::HTTPStatus httpStatus = job->getStatusCode();
@@ -1939,7 +1938,7 @@ ExitCode ServerRequests::loadUserInfo(User &user, bool &updated) {
         } else if (user.avatarUrl() != job->avatarUrl()) {
             // get avatarData
             user.setAvatarUrl(job->avatarUrl());
-            exitCode = loadUserAvatar(user);
+            exitInfo = loadUserAvatar(user);
         }
         updated = true;
     }
@@ -1949,15 +1948,15 @@ ExitCode ServerRequests::loadUserInfo(User &user, bool &updated) {
         updated = true;
     }
 
-    return exitCode;
+    return exitInfo;
 }
 
-ExitCode ServerRequests::loadUserAvatar(User &user) {
+ExitInfo ServerRequests::loadUserAvatar(User &user) {
     try {
-        GetAvatarJob getAvatarJob = GetAvatarJob(user.avatarUrl());
-        const ExitCode exitCode = getAvatarJob.runSynchronously();
-        if (exitCode != ExitCode::Ok) {
-            return exitCode;
+        auto getAvatarJob = GetAvatarJob(user.avatarUrl());
+        const auto exitInfo = getAvatarJob.runSynchronously();
+        if (!exitInfo) {
+            return exitInfo;
         }
 
         user.setAvatar(getAvatarJob.avatar());
@@ -1972,7 +1971,7 @@ ExitCode ServerRequests::loadUserAvatar(User &user) {
 ExitCode ServerRequests::processRequestTokenFinished(const Login &login, UserInfo &userInfo, bool &userCreated) {
     // Get user
     User user;
-    bool found;
+    bool found = false;
     if (!ParmsDb::instance()->selectUserByUserId(login.apiToken().userId(), user, found)) {
         LOG_WARN(Log::instance()->getLogger(), "Error in ParmsDb::selectUserByUserId");
         return ExitCode::DbError;

--- a/src/server/requests/serverrequests.h
+++ b/src/server/requests/serverrequests.h
@@ -133,7 +133,7 @@ struct SYNCENGINE_EXPORT ServerRequests {
 
         // C/S requests (others)
         static ExitCode deleteUser(int userDbId); // !!! Use COMM_LONG_TIMEOUT !!!
-        static ExitCode deleteAccount(int accountDbId); // !!! Use COMM_LONG_TIMEOUT !!!
+        static ExitInfo deleteAccount(int accountDbId); // !!! Use COMM_LONG_TIMEOUT !!!
         static ExitCode deleteDrive(int driveDbId); // !!! Use COMM_LONG_TIMEOUT !!!
         static ExitCode deleteSync(int syncDbId); // !!! Use COMM_LONG_TIMEOUT !!!
 

--- a/src/server/requests/serverrequests.h
+++ b/src/server/requests/serverrequests.h
@@ -139,9 +139,9 @@ struct SYNCENGINE_EXPORT ServerRequests {
 
         // Server requests
         static ExitInfo loadDriveInfo(Drive &drive, Account &account, bool &updated, bool &quotaUpdated, bool &accountUpdated);
-        static ExitCode loadUserInfo(User &user, bool &updated);
-        static ExitCode loadUserAvatar(User &user);
-        static ExitCode getThumbnail(int driveDbId, const NodeId &nodeId, int width, std::string &thumbnail);
+        static ExitInfo loadUserInfo(User &user, bool &updated);
+        static ExitInfo loadUserAvatar(User &user);
+        static ExitInfo getThumbnail(int driveDbId, const NodeId &nodeId, int width, std::string &thumbnail);
 
         // Utility
         static void userToUserInfo(const User &user, UserInfo &userInfo);


### PR DESCRIPTION
In the case where the back end is down, returning 503 errors on any request, the app was crashing on startup because of a deliberately uncaught exception. This is not a friendly behavior. The app initialization is now continuing and an error message is displayed.