### PR TITLE
doc: remove "Redistributable" part

### DIFF
--- a/infomaniak-build-tools/windows/Readme.md
+++ b/infomaniak-build-tools/windows/Readme.md
@@ -8,7 +8,6 @@
     - [CPPUnit](#cppunit)
     - [Zlib](#zlib)
     - [libzip](#libzip)
-    - [C++ Redistributable](#redistributable)
     - [NSIS](#nsis)
     - [7za](#7za)
     - [Conan](#conan)
@@ -32,11 +31,11 @@
 
 # kDrive files
 
-The folder `F:\Projects` will be used for the installation of sources and dependencies.  
+The folder `F:\Projects` will be used for the installation of sources and dependencies.
 Feel free to use any directory that suits you.
 
 ```powershell
-mkdir F:\Projects 
+mkdir F:\Projects
 cd F:\Projects
 git clone https://github.com/Infomaniak/desktop-kDrive.git
 cd desktop-kDrive && git submodule update --init --recursive
@@ -44,7 +43,7 @@ cd desktop-kDrive && git submodule update --init --recursive
 
 # Installation Requirements
 
-Once `Visual Studio 2019` is installed, **all** commands should to be run using the `x64 Native Tools Command Prompt` with administrator permissions.  
+Once `Visual Studio 2019` is installed, **all** commands should to be run using the `x64 Native Tools Command Prompt` with administrator permissions.
 
 ## Visual Studio 2019/2022/2025
 You must install both `Visual Studio 2019` and either `Visual Studio 2022` or `Visual Studio 2025` to build the project.
@@ -69,8 +68,8 @@ When installing `Visual Studio 2022 or 2025`, select the following components:
 
 ## Qt 6.2.3
 
-From the [Qt Installer](https://www.qt.io/download-qt-installer-oss?hsCtaTracking=99d9dd4f-5681-48d2-b096-470725510d34%7C074ddad0-fdef-4e53-8aa8-5e8a876d6ab4), 
-tick the **Archive** box and then press the `Refresh` button to see earlier `Qt` versions.  
+From the [Qt Installer](https://www.qt.io/download-qt-installer-oss?hsCtaTracking=99d9dd4f-5681-48d2-b096-470725510d34%7C074ddad0-fdef-4e53-8aa8-5e8a876d6ab4),
+tick the **Archive** box and then press the `Refresh` button to see earlier `Qt` versions.
 In `Qt 6.2.3`, select:
 - MSVC 2019 64-bit
 - Sources
@@ -194,11 +193,6 @@ cmake --build . --target install --config Debug
 cmake --build . --target install --config Release
 ```
 
-## Redistributable
-
-Create the `F:\Projects\vcredist` folder and copy-paste the [C++ Redistributable](https://docs.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170) `x64` and `arm64` 
-inside it.
-
 ## NSIS
 
 Download and install [NSIS v3.03](https://sourceforge.net/projects/nsis/files/NSIS%203/3.03/nsis-3.03-setup.exe/download).
@@ -211,20 +205,20 @@ You will need the following `NSIS` plugins:
 
 ## 7za
 
-Download [7za](https://sourceforge.net/projects/sevenzip/files/7-Zip/23.01/7z2301-extra.7z/download) and extract it in `C:\Program Files\7-Zip`. This 
+Download [7za](https://sourceforge.net/projects/sevenzip/files/7-Zip/23.01/7z2301-extra.7z/download) and extract it in `C:\Program Files\7-Zip`. This
 requires the prior installation of `7-Zip`.
 
 ## Icoutils
 
 Download [Icoutils](https://sourceforge.net/projects/unix-utils/files/icoutils/icoutils-0.32.3-x86_64.zip/download) and extract it.
-Add the path to the `Icoutils` folder to your `PATH` environment variable, e.g. `C:\Program Files\icoutils-0.32.3-x86_64\bin`. 
+Add the path to the `Icoutils` folder to your `PATH` environment variable, e.g. `C:\Program Files\icoutils-0.32.3-x86_64\bin`.
 
 # Certificate Configuration
 
 To be able to sign executables, you need to have one of two the Infomaniak certificates installed.
 We use the virtual certificate for `DEBUG` builds and the physical certificate (USB key) for release builds.
- 
-Once the certificates are installed on your machine, open `F:\Projects\desktop-kDrive\extensions\windows\cfapi\kDriveExt.sln` and follow the next steps 
+
+Once the certificates are installed on your machine, open `F:\Projects\desktop-kDrive\extensions\windows\cfapi\kDriveExt.sln` and follow the next steps
 to create an environment variable for each certificate:
 - Select `FileExplorerExtensionPackage\Package.appxmanifest`.
 - Go to the `Packaging` tab.
@@ -282,7 +276,7 @@ Conan version 2.x.x
    This creates `%USERPROFILE%/.conan2/profiles/default`.
 
 2. Open `%USERPROFILE%/.conan2/profiles/default` and customize the settings under the `[settings]` section. For example, to target Windows with C++20 with a debug build type:
-   
+
    ```ini
     [settings]
     arch=x86_64
@@ -374,7 +368,7 @@ If you cannot see it, you need to tick the **Archive** box and filter again.
 
 ### CMake Parameters
 
-Open the file `F:\Projects\desktop-kDrive\CMakeList.txt` in Qt Creator.  
+Open the file `F:\Projects\desktop-kDrive\CMakeList.txt` in Qt Creator.
 Then copy the following list of `CMake` variables in "Initial CMake Parameters" using batch editing:
 
 ```
@@ -413,7 +407,7 @@ Check first your [certificates configuration](# Certificate Configuration) befor
 4. Modify `F:\Projects\` to match your actual path. The last two paths are outputs of the global projects; keep them for later steps.
 5. Save and close the properties window.
 
-Select `Debug x64` and deploy. 
+Select `Debug x64` and deploy.
 
 To build in Release mode, repeat the same steps for `Release x64`.
 
@@ -432,30 +426,30 @@ Open `Visual Studio 2019` and select `Open local folder`. Then choose `F:\Projec
    - Configuration type: Debug
    - Toolset: msvc_x64_x64
    - Build root: The folder set in the post-build events of the `kDriveExt` solution.
-   - CMake command args: 
+   - CMake command args:
     ```
-    -DAPPLICATION_CLIENT_EXECUTABLE=kdrive_client 
-    -DKDRIVE_THEME_DIR=F:/Projects/desktop-kDrive/infomaniak 
-    -DBUILD_UNIT_TESTS:BOOL=ON 
-    -DCMAKE_PREFIX_PATH:STRING=C:/Qt/6.2.3/msvc2019_64 
-    -DZLIB_INCLUDE_DIR:PATH="C:/Program Files (x86)/zlib-1.2.11/include" 
-    -DZLIB_LIBRARY_RELEASE:FILEPATH="C:/Program Files (x86)/zlib-1.2.11/lib/zlib.lib" 
-    -DVFS_STATIC_LIBRARY:FILEPATH=F:/Projects/desktop-kDrive/extensions/windows/cfapi/x64/Debug/Vfs.lib 
-    -DVFS_DIRECTORY:PATH=F:/Projects/desktop-kDrive/extensions/windows/cfapi/x64/Debug 
-    -DPocoCrypto_DIR:PATH="C:/Program Files (x86)/Poco/cmake" 
-    -DPocoFoundation_DIR:PATH="C:/Program Files (x86)/Poco/cmake" 
-    -DPocoJSON_DIR:PATH="C:/Program Files (x86)/Poco/cmake" 
-    -DPocoNetSSL_DIR:PATH="C:/Program Files (x86)/Poco/cmake" 
-    -DPocoNet_DIR:PATH="C:/Program Files (x86)/Poco/cmake" 
-    -DPocoUtil_DIR:PATH="C:/Program Files (x86)/Poco/cmake" 
-    -DPocoXML_DIR:PATH="C:/Program Files (x86)/Poco/cmake" 
+    -DAPPLICATION_CLIENT_EXECUTABLE=kdrive_client
+    -DKDRIVE_THEME_DIR=F:/Projects/desktop-kDrive/infomaniak
+    -DBUILD_UNIT_TESTS:BOOL=ON
+    -DCMAKE_PREFIX_PATH:STRING=C:/Qt/6.2.3/msvc2019_64
+    -DZLIB_INCLUDE_DIR:PATH="C:/Program Files (x86)/zlib-1.2.11/include"
+    -DZLIB_LIBRARY_RELEASE:FILEPATH="C:/Program Files (x86)/zlib-1.2.11/lib/zlib.lib"
+    -DVFS_STATIC_LIBRARY:FILEPATH=F:/Projects/desktop-kDrive/extensions/windows/cfapi/x64/Debug/Vfs.lib
+    -DVFS_DIRECTORY:PATH=F:/Projects/desktop-kDrive/extensions/windows/cfapi/x64/Debug
+    -DPocoCrypto_DIR:PATH="C:/Program Files (x86)/Poco/cmake"
+    -DPocoFoundation_DIR:PATH="C:/Program Files (x86)/Poco/cmake"
+    -DPocoJSON_DIR:PATH="C:/Program Files (x86)/Poco/cmake"
+    -DPocoNetSSL_DIR:PATH="C:/Program Files (x86)/Poco/cmake"
+    -DPocoNet_DIR:PATH="C:/Program Files (x86)/Poco/cmake"
+    -DPocoUtil_DIR:PATH="C:/Program Files (x86)/Poco/cmake"
+    -DPocoXML_DIR:PATH="C:/Program Files (x86)/Poco/cmake"
     -DPoco_DIR:PATH="C:/Program Files (x86)/Poco/cmake"
     ```
    You may need to adjust paths based on your installation.
-   
+
    - Check that `Advanced settings > install path` is the the build root path.
 
-Save (CTRL + S). `CMake` will automatically run in the output window. 
+Save (CTRL + S). `CMake` will automatically run in the output window.
 Make sure no errors occur.
 
 ### Install
@@ -491,7 +485,7 @@ Once `kDrive.exe` is running, right-click on the `kDrive_client` executable: `De
 
 ## Testing the extension
 
-To test the extension in Debug mode, you will first need to install a [release version](https://www.infomaniak.com/en/apps/download-kdrive) of `kDrive`.  
+To test the extension in Debug mode, you will first need to install a [release version](https://www.infomaniak.com/en/apps/download-kdrive) of `kDrive`.
 Once installed and running, stop the `File Explorer` with the command:
 
 ```powershell
@@ -515,7 +509,7 @@ start explorer.exe
 
 ## Build and Packaging
 
-The script `build-drive.ps1` will build, sign, then package the project. You can either start it from the root of the `desktop-kDrive` repository, or provide a path when executing it.    
+The script `build-drive.ps1` will build, sign, then package the project. You can either start it from the root of the `desktop-kDrive` repository, or provide a path when executing it.
 To get more information, call the script with the option `-h` or `-help`
 
 **Note.** For `CMake` to be able to build the project, you need to initialise the environment for `x64` with `vcvarsall.bat`, or `vcvars64.bat` (see the help output of `build-drive.ps1` for details).


### PR DESCRIPTION
We do not need to download the redistributables manually, they are installed by `windeployqt`