### PR TITLE
feat: Syncfileiteminfo now include size

### DIFF
--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/SyncActivityTable.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/SyncActivityTable.xaml
@@ -112,7 +112,7 @@
                             <DataTemplate x:Key="FileSizeTemplate"
                                           x:DataType="viewmodels:SyncFileItem">
                                 <TextBlock VerticalAlignment="Center"
-                                           Text="{x:Bind FileSize, Converter={StaticResource BytesToHumanReadableStringConverter}}" />
+                                           Text="{x:Bind Size, Converter={StaticResource BytesToHumanReadableStringConverter}}" />
                             </DataTemplate>
                             <DataTemplate x:Key="DirectorySizeTemplate"
                                           x:DataType="viewmodels:SyncFileItem">

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/CommSharedStructs.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/CommSharedStructs.cs
@@ -307,6 +307,7 @@ namespace Infomaniak.kDrive.ServerCommunication.CommStruct
         public InconsistencyType? Inconsistency { get; set; }
         public CancelType? CancelType { get; set; }
         public string? Error { get; set; }
+        public Int64? Size { get; set; }
     }
 
     public static partial class ConversionHelper
@@ -325,6 +326,7 @@ namespace Infomaniak.kDrive.ServerCommunication.CommStruct
             copyProperty(source, target, nameof(source.Inconsistency), nameof(target.Inconsistency));
             copyProperty(source, target, nameof(source.CancelType), nameof(target.CancelType));
             copyProperty(source, target, nameof(source.Error), nameof(target.Error));
+            copyProperty(source, target, nameof(source.Size), nameof(target.Size));
         }
     }
 

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/SyncFileItem.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/SyncFileItem.cs
@@ -17,7 +17,7 @@ namespace Infomaniak.kDrive.ViewModels
         private ConflictType _conflict;
         private InconsistencyType _inconsistency;
         private CancelType _cancelType;
-        private UInt64 _fileSize = 0;
+        private Int64 _size = 0;
         private string _error = "";
         private DateTime _timestamp = DateTime.Now;
         private string _localPath = "";
@@ -103,10 +103,10 @@ namespace Infomaniak.kDrive.ViewModels
             set => SetPropertyInUIThread(ref _error, value);
         }
 
-        public UInt64 FileSize
+        public Int64 Size
         {
-            get => _fileSize;
-            set => SetPropertyInUIThread(ref _fileSize, value);
+            get => _size;
+            set => SetPropertyInUIThread(ref _size, value);
         }
 
         public DateTime Timestamp

--- a/src/libcommon/info/syncfileiteminfo.cpp
+++ b/src/libcommon/info/syncfileiteminfo.cpp
@@ -31,6 +31,7 @@ static const auto outParamsConflict = "conflict";
 static const auto outParamsInconsistency = "inconsistency";
 static const auto outParamsCancelType = "cancelType";
 static const auto outParamsError = "error";
+static const auto outParamsSize = "size";
 
 
 namespace KDC {
@@ -66,6 +67,7 @@ void SyncFileItemInfo::toDynamicStruct(Poco::DynamicStruct &dstruct) const {
     CommonUtility::writeValueToStruct(dstruct, outParamsInconsistency, _inconsistency);
     CommonUtility::writeValueToStruct(dstruct, outParamsCancelType, _cancelType);
     CommonUtility::writeValueToStruct(dstruct, outParamsError, _error.toStdString());
+    CommonUtility::writeValueToStruct(dstruct, outParamsSize, _size);
 }
 
 QDataStream &operator>>(QDataStream &in, SyncFileItemInfo &info) {

--- a/src/libcommon/info/syncfileiteminfo.h
+++ b/src/libcommon/info/syncfileiteminfo.h
@@ -58,6 +58,8 @@ class SyncFileItemInfo {
         inline void setCancelType(CancelType newCancelType) { _cancelType = newCancelType; }
         inline const QString &error() const { return _error; }
         inline void setError(const QString &newError) { _error = newError; }
+        inline int64_t size() const { return _size; }
+        inline void setSize(int64_t newSize) { _size = newSize; }
 
         friend QDataStream &operator>>(QDataStream &in, SyncFileItemInfo &info);
         friend QDataStream &operator<<(QDataStream &out, const SyncFileItemInfo &info);
@@ -79,6 +81,7 @@ class SyncFileItemInfo {
         InconsistencyType _inconsistency;
         CancelType _cancelType;
         QString _error;
+        int64_t _size{0};
 };
 
 } // namespace KDC

--- a/src/libcommon/info/syncfileiteminfo.h
+++ b/src/libcommon/info/syncfileiteminfo.h
@@ -59,7 +59,7 @@ class SyncFileItemInfo {
         inline const QString &error() const { return _error; }
         inline void setError(const QString &newError) { _error = newError; }
         inline int64_t size() const { return _size; }
-        inline void setSize(int64_t newSize) { _size = newSize; }
+        inline void setSize(const int64_t newSize) { _size = newSize; }
 
         friend QDataStream &operator>>(QDataStream &in, SyncFileItemInfo &info);
         friend QDataStream &operator<<(QDataStream &out, const SyncFileItemInfo &info);

--- a/src/server/requests/serverrequests.cpp
+++ b/src/server/requests/serverrequests.cpp
@@ -2279,6 +2279,7 @@ void ServerRequests::syncFileItemToSyncFileItemInfo(const SyncFileItem &item, Sy
     itemInfo.setInconsistency(item.inconsistency());
     itemInfo.setCancelType(item.cancelType());
     itemInfo.setError(QString::fromStdString(item.error()));
+    itemInfo.setSize(item.size());
 }
 
 void ServerRequests::parametersToParametersInfo(const Parameters &parameters, ParametersInfo &parametersInfo) {


### PR DESCRIPTION
This pull request introduces support for tracking and displaying the size of sync file items throughout the application. The changes add a new `Size` property to the relevant data structures, ensure it is copied and serialized correctly, and update the UI (WinUI) to use this new property instead of the old `FileSize` property.

**Backend and Data Model Updates:**

* Added a `size` field (`int64_t _size`) to the `SyncFileItemInfo` class in C++ and provided getter/setter methods, as well as serialization support in `toDynamicStruct`. 
* Updated the server request logic to set the new `size` field when converting from a `SyncFileItem` to a `SyncFileItemInfo`.

**C# ViewModel and Data Transfer:**

* Replaced the `FileSize` property with a new `Size` property (`Int64`) in the `SyncFileItem` class, updating both the field and property names.

**UI Update:**

* Updated the `SyncActivityTable.xaml` data template to bind the file size display to the new `Size` property instead of the old `FileSize` property.

<img width="1529" height="787" alt="image" src="https://github.com/user-attachments/assets/1910ec8c-d994-44ec-a68f-a5f553e38feb" />
