### PR TITLE
fix: reinforce update tree integrity check

### DIFF
--- a/src/libsyncengine/update_detection/update_detector/node.cpp
+++ b/src/libsyncengine/update_detection/update_detector/node.cpp
@@ -265,6 +265,10 @@ bool Node::isParentOf(std::shared_ptr<const Node> potentialChild) const {
     return false;
 }
 
+bool Node::isValid() const {
+    return _id.has_value() && !_id.value().empty() && !_isTmp && !CommonUtility::startsWith(_id.value(), "tmp_");
+}
+
 bool Node::isParentValid(std::shared_ptr<const Node> parentNode) const {
     return !isParentOf(parentNode);
 }

--- a/src/libsyncengine/update_detection/update_detector/node.cpp
+++ b/src/libsyncengine/update_detection/update_detector/node.cpp
@@ -249,6 +249,13 @@ SyncPath Node::getPath() const {
     return path;
 }
 
+bool Node::isTmp() const {
+    assert(_id.has_value());
+    assert((_isTmp && CommonUtility::startsWith(*_id, "tmp_")) ||
+           (!_isTmp && !CommonUtility::startsWith(*_id, "tmp_"))); // Check that the ID is consistent with the "_isTmp" flag
+    return _isTmp;
+}
+
 bool Node::isParentOf(std::shared_ptr<const Node> potentialChild) const {
     if (!potentialChild) return false; // `parentNode` is the root node,
     if (potentialChild->id().has_value() && potentialChild->id() == _id) return false; // potentialChild cannot be its own parent
@@ -266,7 +273,7 @@ bool Node::isParentOf(std::shared_ptr<const Node> potentialChild) const {
 }
 
 bool Node::isValid() const {
-    return _id.has_value() && !_id.value().empty() && !_isTmp && !CommonUtility::startsWith(_id.value(), "tmp_");
+    return _id.has_value() && !_id.value().empty() && !_isTmp;
 }
 
 bool Node::isParentValid(std::shared_ptr<const Node> parentNode) const {

--- a/src/libsyncengine/update_detection/update_detector/node.cpp
+++ b/src/libsyncengine/update_detection/update_detector/node.cpp
@@ -250,9 +250,6 @@ SyncPath Node::getPath() const {
 }
 
 bool Node::isTmp() const {
-    assert(_id.has_value());
-    assert((_isTmp && CommonUtility::startsWith(*_id, "tmp_")) ||
-           (!_isTmp && !CommonUtility::startsWith(*_id, "tmp_"))); // Check that the ID is consistent with the "_isTmp" flag
     return _isTmp;
 }
 

--- a/src/libsyncengine/update_detection/update_detector/node.h
+++ b/src/libsyncengine/update_detection/update_detector/node.h
@@ -160,8 +160,11 @@ class Node {
 
         [[nodiscard]] SyncPath getPath() const;
 
-        [[nodiscard]] inline bool isTmp() const { return _isTmp; }
+        [[nodiscard]] inline bool isTmp() const {
+            return _isTmp || CommonUtility::startsWith(_id.has_value() ? _id.value() : "", "tmp_");
+        }
         inline void setIsTmp(bool newIsTmp) { _isTmp = newIsTmp; }
+        [[nodiscard]] bool isValid() const;
 
     private:
         friend class UpdateTree;

--- a/src/libsyncengine/update_detection/update_detector/node.h
+++ b/src/libsyncengine/update_detection/update_detector/node.h
@@ -160,9 +160,7 @@ class Node {
 
         [[nodiscard]] SyncPath getPath() const;
 
-        [[nodiscard]] inline bool isTmp() const {
-            return _isTmp || CommonUtility::startsWith(_id.has_value() ? _id.value() : "", "tmp_");
-        }
+        [[nodiscard]] bool isTmp() const;
         inline void setIsTmp(bool newIsTmp) { _isTmp = newIsTmp; }
         [[nodiscard]] bool isValid() const;
 

--- a/src/libsyncengine/update_detection/update_detector/updatetree.cpp
+++ b/src/libsyncengine/update_detection/update_detector/updatetree.cpp
@@ -28,7 +28,6 @@
 namespace KDC {
 
 UpdateTree::UpdateTree(ReplicaSide side, const DbNode &dbNode) :
-    _validNodes(std::unordered_map<NodeId, std::shared_ptr<Node>>()),
     _rootNode(std::shared_ptr<Node>(
             new Node(dbNode.nodeId(), side, (side == ReplicaSide::Local ? dbNode.nameLocal() : dbNode.nameRemote()),
                      NodeType::Directory, {}, (side == ReplicaSide::Local ? dbNode.nodeIdLocal() : dbNode.nodeIdRemote()),

--- a/src/libsyncengine/update_detection/update_detector/updatetree.cpp
+++ b/src/libsyncengine/update_detection/update_detector/updatetree.cpp
@@ -28,7 +28,7 @@
 namespace KDC {
 
 UpdateTree::UpdateTree(ReplicaSide side, const DbNode &dbNode) :
-    _nodes(std::unordered_map<NodeId, std::shared_ptr<Node>>()),
+    _validNodes(std::unordered_map<NodeId, std::shared_ptr<Node>>()),
     _rootNode(std::shared_ptr<Node>(
             new Node(dbNode.nodeId(), side, (side == ReplicaSide::Local ? dbNode.nameLocal() : dbNode.nameRemote()),
                      NodeType::Directory, {}, (side == ReplicaSide::Local ? dbNode.nodeIdLocal() : dbNode.nodeIdRemote()),
@@ -45,7 +45,7 @@ void UpdateTree::insertNode(std::shared_ptr<Node> node) {
         return;
     }
 
-    _nodes[*node->id()] = node;
+    _validNodes[*node->id()] = node;
 }
 
 bool UpdateTree::deleteNode(std::shared_ptr<Node> node, bool deleteNodeLater, int depth) {
@@ -72,7 +72,7 @@ bool UpdateTree::deleteNode(std::shared_ptr<Node> node, bool deleteNodeLater, in
     } else {
         // Remove node from tree
         node->parentNode()->deleteChildren(node);
-        _nodes.erase(*node->id());
+        _validNodes.erase(*node->id());
     }
 
     return true;
@@ -143,8 +143,8 @@ std::shared_ptr<Node> UpdateTree::getNodeByPathNormalized(const SyncPath &path) 
 }
 
 std::shared_ptr<Node> UpdateTree::getNodeById(const NodeId &nodeId) {
-    auto it = _nodes.find(nodeId);
-    if (it != _nodes.end()) {
+    auto it = _validNodes.find(nodeId);
+    if (it != _validNodes.end()) {
         return it->second;
     }
     return nullptr;
@@ -155,8 +155,8 @@ bool UpdateTree::exists(const NodeId &id) {
 }
 
 bool UpdateTree::isAncestor(const NodeId &nodeId, const NodeId &ancestorNodeId) const {
-    auto it = _nodes.find(nodeId);
-    if (it == _nodes.end()) {
+    auto it = _validNodes.find(nodeId);
+    if (it == _validNodes.end()) {
         return false;
     }
 
@@ -176,7 +176,7 @@ bool UpdateTree::isAncestor(const NodeId &nodeId, const NodeId &ancestorNodeId) 
 void UpdateTree::markAllNodesUnprocessed() {
     startUpdate();
 
-    for (auto &node: _nodes) {
+    for (auto &node: _validNodes) {
         node.second->setStatus(NodeStatus::Unprocessed);
     }
 }
@@ -210,21 +210,21 @@ bool UpdateTree::updateNodeId(std::shared_ptr<Node> node, const NodeId &newId) {
                                                        << Utility::formatSyncName(node->name()) << L".");
     }
 
-    if (!oldId.empty() && _nodes.contains(oldId)) {
-        auto nodeRef = _nodes.extract(oldId);
+    if (!oldId.empty() && _validNodes.contains(oldId)) {
+        auto nodeRef = _validNodes.extract(oldId);
         nodeRef.key() = newId;
-        _nodes.insert(std::move(nodeRef));
+        _validNodes.insert(std::move(nodeRef));
     }
     return true;
 }
 
 void UpdateTree::clear() {
-    std::unordered_map<NodeId, std::shared_ptr<Node>>::iterator it = _nodes.begin();
-    while (it != _nodes.end()) {
+    std::unordered_map<NodeId, std::shared_ptr<Node>>::iterator it = _validNodes.begin();
+    while (it != _validNodes.end()) {
         it->second->clear();
         it++;
     }
-    _nodes.clear();
+    _validNodes.clear();
     _previousIdSet.clear();
     init();
 }

--- a/src/libsyncengine/update_detection/update_detector/updatetree.h
+++ b/src/libsyncengine/update_detection/update_detector/updatetree.h
@@ -38,7 +38,7 @@ class UpdateTree : public SharedObject {
         [[nodiscard]] bool deleteNode(const NodeId &id, bool deleteNodeLater = false);
         [[nodiscard]] inline const ReplicaSide &side() const { return _side; }
         inline std::shared_ptr<Node> rootNode() { return _rootNode; }
-        inline std::unordered_map<NodeId, std::shared_ptr<Node>> &nodes() { return _nodes; }
+        inline std::unordered_map<NodeId, std::shared_ptr<Node>> &nodes() { return _validNodes; }
         inline std::unordered_map<NodeId, NodeId> &previousIdSet() { return _previousIdSet; }
         std::shared_ptr<Node> getNodeByPath(const SyncPath &path);
         std::shared_ptr<Node> getNodeByPathNormalized(const SyncPath &path);
@@ -66,7 +66,7 @@ class UpdateTree : public SharedObject {
     private:
         void drawUpdateTreeRow(std::shared_ptr<Node> node, SyncName &treeStr, uint64_t depth = 0);
 
-        std::unordered_map<NodeId, std::shared_ptr<Node>> _nodes;
+        std::unordered_map<NodeId, std::shared_ptr<Node>> _validNodes;
         std::shared_ptr<Node> _rootNode;
         ReplicaSide _side;
 

--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
@@ -1193,8 +1193,9 @@ bool UpdateTreeWorker::checkTreeIntegrity() {
 }
 
 bool UpdateTreeWorker::checkNodeIntegrity(const std::shared_ptr<Node> node) {
-    if (!node->isValid()) {
-        if (node->isTmp()) {
+    bool hasTempPrefix = node->id().has_value() && CommonUtility::startsWith(node->id().value(), "tmp_");
+    if (!node->isValid() || hasTempPrefix) {
+        if (node->isTmp() || hasTempPrefix) {
             LOGW_SYNCPAL_WARN(_logger, _side << integrityCheckFailureMsg << L" A temporary node remains in the update tree: "
                                              << logStr(node));
 

--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
@@ -1193,13 +1193,14 @@ bool UpdateTreeWorker::checkTreeIntegrity() {
 }
 
 bool UpdateTreeWorker::checkNodeIntegrity(const std::shared_ptr<Node> node) {
-    if (!node->id().has_value() || node->id() == NodeId{} || node->isTmp() || CommonUtility::startsWith(*node->id(), "tmp_")) {
-        if (!node->id().has_value() || node->id() == NodeId{}) {
-            LOGW_SYNCPAL_WARN(_logger,
-                              _side << integrityCheckFailureMsg << L" Found a non-temporary node without ID: " << logStr(node));
-        } else {
+    if (!node->isValid()) {
+        if (node->isTmp()) {
             LOGW_SYNCPAL_WARN(_logger, _side << integrityCheckFailureMsg << L" A temporary node remains in the update tree: "
                                              << logStr(node));
+
+        } else {
+            LOGW_SYNCPAL_WARN(_logger,
+                              _side << integrityCheckFailureMsg << L" Found a non-temporary node without ID: " << logStr(node));
         }
 
         sentry::Handler::captureMessage(sentry::Level::Warning, "UpdateTreeWorker::integrityCheck",

--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
@@ -1184,6 +1184,8 @@ bool UpdateTreeWorker::checkTreeIntegrity() {
     LOG_SYNCPAL_INFO(_logger, _side << " update tree integrity check started");
     for (const auto &[_, node]: _updateTree->nodes()) {
         if (!checkNodeIntegrity(node)) return false;
+        // In some cases, the pointer to the parent node might not have been updated correctly and still pointing to a temporary
+        // node.
         if (node->parentNode() && !checkNodeIntegrity(node->parentNode())) return false;
         if (!checkOperationTypes(node)) return false;
     }

--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
@@ -97,7 +97,7 @@ void UpdateTreeWorker::execute() {
         }
     }
 
-    if (exitCode == ExitCode::Ok && !integrityCheck()) {
+    if (exitCode == ExitCode::Ok && !checkTreeIntegrity()) {
         exitCode = ExitCode::InvalidOperation;
         setExitCause(ExitCause::UpdateTreeIntegrityCheckFailed);
     }
@@ -1172,34 +1172,40 @@ bool UpdateTreeWorker::mergingTempNodeToRealNode(std::shared_ptr<Node> tmpNode, 
 
 std::wstring logStr(const std::shared_ptr<Node> node) {
     std::wstringstream logStream;
-    logStream << L" (node ID: '" << CommonUtility::s2ws(node->id().value_or("-1")) << L"', DB ID: '" << node->idb().value_or(-1)
-              << L"', " << Utility::formatSyncName(node->name()) << L")";
+    const auto nodeParentId = CommonUtility::s2ws(
+            node->parentNode() && node->parentNode()->id().has_value() ? node->parentNode()->id().value() : "-1");
+    logStream << L" (node ID: '" << CommonUtility::s2ws(node->id().value_or("-1")) << L", node parent ID: " << nodeParentId
+              << L"', DB ID: '" << node->idb().value_or(-1) << L"', " << Utility::formatSyncName(node->name()) << L")";
     return logStream.str();
 }
 static const auto integrityCheckFailureMsg = L" update tree integrity check failed.";
 
-bool UpdateTreeWorker::integrityCheck() {
-    // TODO : check if this does not slow the process too much
-    LOGW_SYNCPAL_INFO(_logger, _side << L" update tree integrity check started");
+bool UpdateTreeWorker::checkTreeIntegrity() {
+    LOG_SYNCPAL_INFO(_logger, _side << " update tree integrity check started");
     for (const auto &[_, node]: _updateTree->nodes()) {
-        if (!node->id().has_value() || node->id() == NodeId{} || node->isTmp() ||
-            CommonUtility::startsWith(*node->id(), "tmp_")) {
-            if (!node->id().has_value() || node->id() == NodeId{}) {
-                LOGW_SYNCPAL_WARN(_logger, _side << integrityCheckFailureMsg << L" Found a non-temporary node without ID: "
-                                                 << logStr(node));
-            } else {
-                LOGW_SYNCPAL_WARN(_logger, _side << integrityCheckFailureMsg << L" A temporary node remains in the update tree: "
-                                                 << logStr(node));
-            }
-
-            sentry::Handler::captureMessage(sentry::Level::Warning, "UpdateTreeWorker::integrityCheck",
-                                            "A node without a valid ID remains in the update tree");
-
-            return false;
-        }
-
+        if (!checkNodeIntegrity(node)) return false;
+        if (node->parentNode() && !checkNodeIntegrity(node->parentNode())) return false;
         if (!checkOperationTypes(node)) return false;
     }
+    return true;
+}
+
+bool UpdateTreeWorker::checkNodeIntegrity(const std::shared_ptr<Node> node) {
+    if (!node->id().has_value() || node->id() == NodeId{} || node->isTmp() || CommonUtility::startsWith(*node->id(), "tmp_")) {
+        if (!node->id().has_value() || node->id() == NodeId{}) {
+            LOGW_SYNCPAL_WARN(_logger,
+                              _side << integrityCheckFailureMsg << L" Found a non-temporary node without ID: " << logStr(node));
+        } else {
+            LOGW_SYNCPAL_WARN(_logger, _side << integrityCheckFailureMsg << L" A temporary node remains in the update tree: "
+                                             << logStr(node));
+        }
+
+        sentry::Handler::captureMessage(sentry::Level::Warning, "UpdateTreeWorker::integrityCheck",
+                                        "A node without a valid ID remains in the update tree");
+
+        return false;
+    }
+
     return true;
 }
 

--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
@@ -1198,7 +1198,7 @@ bool UpdateTreeWorker::checkNodeIntegrity(const std::shared_ptr<Node> node) {
            (!node->isTmp() &&
             !CommonUtility::startsWith(*node->id(), "tmp_"))); // Check that the ID is consistent with the "_isTmp" flag
 
-    bool hasTempPrefix = node->id().has_value() && CommonUtility::startsWith(node->id().value(), "tmp_");
+    const bool hasTempPrefix = node->id().has_value() && CommonUtility::startsWith(node->id().value(), "tmp_");
     if (!node->isValid() || hasTempPrefix) {
         if (node->isTmp() || hasTempPrefix) {
             LOGW_SYNCPAL_WARN(_logger, _side << integrityCheckFailureMsg << L" A temporary node remains in the update tree: "

--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
@@ -1193,6 +1193,11 @@ bool UpdateTreeWorker::checkTreeIntegrity() {
 }
 
 bool UpdateTreeWorker::checkNodeIntegrity(const std::shared_ptr<Node> node) {
+    assert(node->id().has_value());
+    assert((node->isTmp() && CommonUtility::startsWith(*node->id(), "tmp_")) ||
+           (!node->isTmp() &&
+            !CommonUtility::startsWith(*node->id(), "tmp_"))); // Check that the ID is consistent with the "_isTmp" flag
+
     bool hasTempPrefix = node->id().has_value() && CommonUtility::startsWith(node->id().value(), "tmp_");
     if (!node->isValid() || hasTempPrefix) {
         if (node->isTmp() || hasTempPrefix) {

--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.h
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.h
@@ -159,7 +159,8 @@ class UpdateTreeWorker : public ISyncWorker {
          * Check that there is no temporary node remaining in the update tree
          * @return true if no temporary node is found
          */
-        bool integrityCheck();
+        bool checkTreeIntegrity();
+        bool checkNodeIntegrity(const std::shared_ptr<Node> node);
         bool checkOperationTypes(const std::shared_ptr<Node> node);
 
         friend class TestUpdateTreeWorker;

--- a/test/libsyncengine/update_detection/update_detector/testupdatetree.cpp
+++ b/test/libsyncengine/update_detection/update_detector/testupdatetree.cpp
@@ -70,7 +70,7 @@ void TestUpdateTree::testConstructors() {
 }
 
 void TestUpdateTree::testInsertionOfFileNamesWithDifferentEncodings() {
-    CPPUNIT_ASSERT(_myTree->_nodes.empty());
+    CPPUNIT_ASSERT(_myTree->_validNodes.empty());
     auto node1 = std::make_shared<Node>(_myTree->side(), Str("Dir 1"), NodeType::Directory, OperationType::None, "l1", 0, 0,
                                         12345, _myTree->rootNode());
 
@@ -84,7 +84,7 @@ void TestUpdateTree::testInsertionOfFileNamesWithDifferentEncodings() {
 }
 
 void TestUpdateTree::testClear() {
-    CPPUNIT_ASSERT(_myTree->_nodes.empty());
+    CPPUNIT_ASSERT(_myTree->_validNodes.empty());
 
     _myTree->init();
     auto node1 = std::make_shared<Node>(_myTree->side(), Str("Dir 1"), NodeType::Directory, OperationType::None, "l1", 0, 0,
@@ -106,9 +106,9 @@ void TestUpdateTree::testClear() {
     CPPUNIT_ASSERT(node11.use_count() == 4); // Referenced by node11, node1, node111, _myTree->_nodes
     CPPUNIT_ASSERT(node111.use_count() == 3); // Referenced by node111, node11, _myTree->_nodes
 
-    CPPUNIT_ASSERT(_myTree->_nodes.size() == 4); // root, node1, node11, node111
+    CPPUNIT_ASSERT(_myTree->_validNodes.size() == 4); // root, node1, node11, node111
     _myTree->clear();
-    CPPUNIT_ASSERT(_myTree->_nodes.size() == 1); // root
+    CPPUNIT_ASSERT(_myTree->_validNodes.size() == 1); // root
 
     CPPUNIT_ASSERT(node1.use_count() == 1); // Referenced by node1
     CPPUNIT_ASSERT(node11.use_count() == 1); // Referenced by node11
@@ -116,28 +116,28 @@ void TestUpdateTree::testClear() {
 }
 
 void TestUpdateTree::testDelete() {
-    CPPUNIT_ASSERT(_myTree->_nodes.empty());
+    CPPUNIT_ASSERT(_myTree->_validNodes.empty());
     auto node1 = std::make_shared<Node>(_myTree->side(), Str("Dir 1"), NodeType::Directory, OperationType::None, "l1", 0, 0,
                                         12345, _myTree->rootNode());
     _myTree->insertNode(node1);
-    CPPUNIT_ASSERT(_myTree->_nodes.size() == 1);
+    CPPUNIT_ASSERT(_myTree->_validNodes.size() == 1);
 
     // Delete node later
     CPPUNIT_ASSERT(_myTree->deleteNode(*node1->id(), true));
-    CPPUNIT_ASSERT(_myTree->_nodes.size() == 1);
+    CPPUNIT_ASSERT(_myTree->_validNodes.size() == 1);
     CPPUNIT_ASSERT(node1->status() == NodeStatus::ToDelete);
 
     // Delete node now
     CPPUNIT_ASSERT(_myTree->deleteNode(*node1->id()));
-    CPPUNIT_ASSERT(_myTree->_nodes.size() == 0);
+    CPPUNIT_ASSERT(_myTree->_validNodes.size() == 0);
 }
 
 void TestUpdateTree::testAll() {
-    CPPUNIT_ASSERT(_myTree->_nodes.empty());
+    CPPUNIT_ASSERT(_myTree->_validNodes.empty());
     auto node1 = std::make_shared<Node>(_myTree->side(), Str("Dir 1"), NodeType::Directory, OperationType::None, "l1", 0, 0,
                                         12345, _myTree->rootNode());
     _myTree->insertNode(node1);
-    CPPUNIT_ASSERT(_myTree->_nodes.size() == 1);
+    CPPUNIT_ASSERT(_myTree->_validNodes.size() == 1);
 
 
     auto node2 = std::make_shared<Node>(_myTree->side(), Str("Dir 2"), NodeType::Directory, OperationType::None, "l2", 0, 0,

--- a/test/libsyncengine/update_detection/update_detector/testupdatetreeworker.cpp
+++ b/test/libsyncengine/update_detection/update_detector/testupdatetreeworker.cpp
@@ -1168,7 +1168,7 @@ void TestUpdateTreeWorker::testIntegrityCheck() {
     CPPUNIT_ASSERT(newNode->id()->substr(0, 4) == "tmp_");
     CPPUNIT_ASSERT(newNode->isTmp());
 
-    CPPUNIT_ASSERT(_localUpdateTreeWorker->integrityCheck());
+    CPPUNIT_ASSERT(_localUpdateTreeWorker->checkTreeIntegrity()); // OK because update tree is still empty at this point.
 
     const auto createOp = std::make_shared<FSOperation>(OperationType::Create, "id51", NodeType::File, testhelpers::defaultTime,
                                                         testhelpers::defaultTime, testhelpers::defaultFileSize, "Dir 5/File 5.1");
@@ -1176,30 +1176,35 @@ void TestUpdateTreeWorker::testIntegrityCheck() {
             std::make_shared<FSOperation>(OperationType::Delete, "id51bis", NodeType::File, testhelpers::defaultTime,
                                           testhelpers::defaultTime, testhelpers::defaultFileSize, "Dir 5/File 5.1");
     CPPUNIT_ASSERT(_localUpdateTreeWorker->updateTmpFileNode(newNode, createOp, deleteOp, OperationType::Edit));
-    CPPUNIT_ASSERT(_localUpdateTreeWorker->integrityCheck());
+    CPPUNIT_ASSERT(!_localUpdateTreeWorker->checkTreeIntegrity()); // Not OK because "newNode" has been correctly added but its
+                                                                   // parent ("Dir 5") is still a temporary node.
 
-    CPPUNIT_ASSERT(_localUpdateTreeWorker->integrityCheck());
+    CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, _localUpdateTreeWorker->updateTmpNode(newNode->parentNode()));
+    CPPUNIT_ASSERT(_localUpdateTreeWorker->checkTreeIntegrity());
 
     newNode->setId(std::nullopt);
-    CPPUNIT_ASSERT(!_localUpdateTreeWorker->integrityCheck());
+    CPPUNIT_ASSERT(!_localUpdateTreeWorker->checkTreeIntegrity());
 
     newNode->setId(NodeId{});
-    CPPUNIT_ASSERT(!_localUpdateTreeWorker->integrityCheck());
+    CPPUNIT_ASSERT(!_localUpdateTreeWorker->checkTreeIntegrity());
 
     newNode->setId(NodeId{"123"});
-    CPPUNIT_ASSERT(_localUpdateTreeWorker->integrityCheck());
+    CPPUNIT_ASSERT(_localUpdateTreeWorker->checkTreeIntegrity());
 
     newNode->setChangeEvents(OperationType::Create);
-    CPPUNIT_ASSERT(_localUpdateTreeWorker->integrityCheck());
+    CPPUNIT_ASSERT(_localUpdateTreeWorker->checkTreeIntegrity());
     newNode->setChangeEvents(OperationType::Edit);
-    CPPUNIT_ASSERT(_localUpdateTreeWorker->integrityCheck());
+    CPPUNIT_ASSERT(_localUpdateTreeWorker->checkTreeIntegrity());
     newNode->setMoveOriginInfos(Node::MoveOriginInfos("/dummy", "1"));
     newNode->setChangeEvents(OperationType::Move);
-    CPPUNIT_ASSERT(_localUpdateTreeWorker->integrityCheck());
+    CPPUNIT_ASSERT(_localUpdateTreeWorker->checkTreeIntegrity());
     newNode->setChangeEvents(OperationType::Delete);
-    CPPUNIT_ASSERT(_localUpdateTreeWorker->integrityCheck());
+    CPPUNIT_ASSERT(_localUpdateTreeWorker->checkTreeIntegrity());
     newNode->setChangeEvents(OperationType::Edit | OperationType::Move);
-    CPPUNIT_ASSERT(_localUpdateTreeWorker->integrityCheck());
+    CPPUNIT_ASSERT(_localUpdateTreeWorker->checkTreeIntegrity());
+
+    newNode->parentNode()->setId(NodeId{"tmp_123"});
+    CPPUNIT_ASSERT(!_localUpdateTreeWorker->checkTreeIntegrity());
 }
 
 } // namespace KDC


### PR DESCRIPTION
The log from a bug report revealed that, in some cases which are not elucidated yet, the update tree can contain references to temporary nodes:
```
2025-12-27 13:23:26:509 [I] (127564) tmpblacklistmanager.cpp:41 - *2* Item added in error list - node ID='tmp_0AbsDzLMTc' - side='Remote(2)' - path='<item_path>'
2025-12-27 13:23:26:510 [I] (127564) tmpblacklistmanager.cpp:41 - *2* Item added in tmp blacklist - node ID='tmp_0AbsDzLMTc' - side='Remote(2)'
2025-12-27 13:23:26:510 [I] (127564) tmpblacklistmanager.cpp:41 - *2* Item removed from tmp blacklist - node ID='484803' - side='Remote(2)'
2025-12-27 13:23:26:510 [I] (127564) platforminconsistencycheckerworker.cpp:165 - *2* Blacklisting Remote(2) item with path='<item_path>' because Case(1).
2025-12-27 13:23:26:558 [W] (127564) platforminconsistencycheckerworker.cpp:46 - *2* Error in UpdateTree::deleteNode: node id=tmp_0AbsDzLMTc
```

This PR aims at reinforcing the integrity check of the update tree to detect early any issue.