### PR TITLE
refactor: Mac GUI ordered cache

### DIFF
--- a/src/front/macOS/kDriveCore/Models/DTOs/Account.swift
+++ b/src/front/macOS/kDriveCore/Models/DTOs/Account.swift
@@ -32,7 +32,7 @@ public struct Account: Identifiable, Hashable, Sendable {
         dbId
     }
 
-    public init(dbId: Int32, userDbId: Int32, name: String, drives: [Int32: Drive]) {
+    public init(dbId: Int32, userDbId: Int32, name: String, drives: IndexedDrives) {
         self.dbId = dbId
         self.userDbId = userDbId
         self.name = name

--- a/src/front/macOS/kDriveCore/Models/DTOs/Account.swift
+++ b/src/front/macOS/kDriveCore/Models/DTOs/Account.swift
@@ -17,9 +17,9 @@
  */
 
 import Foundation
+import OrderedCollections
 
-public typealias IndexedAccounts = [Int32: Account]
-public typealias UserAccounts = (userDbId: Int32, indexedAccounts: [Int32: Account])
+public typealias IndexedAccounts = OrderedDictionary<Int32, Account>
 
 // TODO: Update to track userDbId in Account to match server type
 public struct Account: Identifiable, Hashable, Sendable {

--- a/src/front/macOS/kDriveCore/Models/DTOs/Drive.swift
+++ b/src/front/macOS/kDriveCore/Models/DTOs/Drive.swift
@@ -17,8 +17,9 @@
  */
 
 import Foundation
+import OrderedCollections
 
-public typealias IndexedDrives = [Int32: Drive]
+public typealias IndexedDrives = OrderedDictionary<Int32, Drive>
 
 public enum DriveType: Equatable, Hashable, Sendable {
     case available(userId: Int32)

--- a/src/front/macOS/kDriveCore/Models/DTOs/Synchro.swift
+++ b/src/front/macOS/kDriveCore/Models/DTOs/Synchro.swift
@@ -18,8 +18,9 @@
 
 import Collections
 import Foundation
+import OrderedCollections
 
-public typealias IndexedSynchros = [Int32: Synchro]
+public typealias IndexedSynchros = OrderedDictionary<Int32, Synchro>
 
 public struct Synchro: Identifiable, Hashable, Sendable {
     public var id: Int32 {

--- a/src/front/macOS/kDriveCore/Models/DTOs/User.swift
+++ b/src/front/macOS/kDriveCore/Models/DTOs/User.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 
-public typealias IndexedUsers = [Int32: User]
+public typealias IndexedUsers = OrderedDictionary<Int32, User>
 
 public struct User: Identifiable, Hashable, Sendable {
     public var id: Int32 {

--- a/src/front/macOS/kDriveCore/Models/DTOs/User.swift
+++ b/src/front/macOS/kDriveCore/Models/DTOs/User.swift
@@ -17,6 +17,7 @@
  */
 
 import Foundation
+import OrderedCollections
 
 public typealias IndexedUsers = OrderedDictionary<Int32, User>
 

--- a/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedAccount.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedAccount.swift
@@ -19,6 +19,7 @@
 import Combine
 import Foundation
 import InfomaniakDI
+import OrderedCollections
 
 @MainActor
 @propertyWrapper

--- a/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedDrive.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedDrive.swift
@@ -19,6 +19,7 @@
 import Combine
 import Foundation
 import InfomaniakDI
+import OrderedCollections
 
 @MainActor
 @propertyWrapper

--- a/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedDrives.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedDrives.swift
@@ -19,6 +19,7 @@
 import Combine
 import Foundation
 import InfomaniakDI
+import OrderedCollections
 
 public struct DriveContext: Sendable, Equatable {
     public let drive: Drive

--- a/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedSynchro.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedSynchro.swift
@@ -19,6 +19,7 @@
 import Combine
 import Foundation
 import InfomaniakDI
+import OrderedCollections
 
 @MainActor
 @propertyWrapper

--- a/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedSynchro.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedSynchro.swift
@@ -64,7 +64,7 @@ public final class ObservedSynchro: ObservableObject {
     public var projectedValue: ObservedSynchro { self }
 }
 
-public extension AnyPublisher where Output == [Int32: User], Failure == Never {
+public extension AnyPublisher where Output == IndexedUsers, Failure == Never {
     func synchroEventPublisher(
         userDbId: Int32,
         accountDbId: Int32,
@@ -118,7 +118,7 @@ public extension AnyPublisher where Output == [Int32: User], Failure == Never {
         )
         .map { event -> Synchro? in
             switch event {
-            case .update(let synchro): return synchro
+            case let .update(synchro): return synchro
             case .removed: return nil
             }
         }
@@ -130,7 +130,7 @@ public extension AnyPublisher where Output == [Int32: User], Failure == Never {
         synchroEventPublisher(synchroDbId: synchroDbId)
             .map { event -> Synchro? in
                 switch event {
-                case .update(let synchro): return synchro
+                case let .update(synchro): return synchro
                 case .removed: return nil
                 }
             }

--- a/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedSynchro.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedSynchro.swift
@@ -119,7 +119,7 @@ public extension AnyPublisher where Output == IndexedUsers, Failure == Never {
         )
         .map { event -> Synchro? in
             switch event {
-            case let .update(synchro): return synchro
+            case .update(let synchro): return synchro
             case .removed: return nil
             }
         }
@@ -131,7 +131,7 @@ public extension AnyPublisher where Output == IndexedUsers, Failure == Never {
         synchroEventPublisher(synchroDbId: synchroDbId)
             .map { event -> Synchro? in
                 switch event {
-                case let .update(synchro): return synchro
+                case .update(let synchro): return synchro
                 case .removed: return nil
                 }
             }

--- a/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedSynchros.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedSynchros.swift
@@ -19,6 +19,7 @@
 import Combine
 import Foundation
 import InfomaniakDI
+import OrderedCollections
 
 @MainActor
 @propertyWrapper

--- a/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedUser.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedUser.swift
@@ -19,6 +19,7 @@
 import Combine
 import Foundation
 import InfomaniakDI
+import OrderedCollections
 
 public enum ObservationEvent<Some: Equatable>: Equatable {
     case update(Some)

--- a/src/front/macOS/kDriveCore/ServerBridge/Cache/ServerCoherentCache.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Cache/ServerCoherentCache.swift
@@ -55,7 +55,7 @@ public actor ServerCoherentCache: CoherentCache, CoherentCacheObservable {
     }
 
     public func getFirstAvailableUser() -> User? {
-        users.first?.value
+        users.values.first
     }
 
     public func addUser(_ user: User) {

--- a/src/front/macOS/kDriveCore/ServerBridge/Cache/ServerCoherentCache.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Cache/ServerCoherentCache.swift
@@ -18,6 +18,7 @@
 
 import Combine
 import Foundation
+import OrderedCollections
 
 public protocol CoherentCacheObservable: Sendable {
     var usersPublisher: AnyPublisher<IndexedUsers, Never> { get }

--- a/src/front/macOS/kDriveCore/ServerBridge/Jobs/DTOs/AccountResponse.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Jobs/DTOs/AccountResponse.swift
@@ -29,6 +29,6 @@ public struct AccountInfoResponse: Codable, Sendable {
 
 extension AccountInfoResponse {
     var asAccount: Account {
-        Account(dbId: dbId, userDbId: userDbId, name: "", drives: IndexedDrives())
+        Account(dbId: dbId, userDbId: userDbId, name: "", drives: [:])
     }
 }

--- a/src/front/macOS/kDriveCore/ServerBridge/Jobs/DTOs/AccountResponse.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Jobs/DTOs/AccountResponse.swift
@@ -17,6 +17,7 @@
  */
 
 import OrderedCollections
+
 struct AccountListResponse: Codable, Sendable {
     let accountInfoList: [AccountInfoResponse]
 }

--- a/src/front/macOS/kDriveCore/ServerBridge/Jobs/DTOs/AccountResponse.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Jobs/DTOs/AccountResponse.swift
@@ -16,6 +16,7 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import OrderedCollections
 struct AccountListResponse: Codable, Sendable {
     let accountInfoList: [AccountInfoResponse]
 }
@@ -28,6 +29,6 @@ public struct AccountInfoResponse: Codable, Sendable {
 
 extension AccountInfoResponse {
     var asAccount: Account {
-        Account(dbId: dbId, userDbId: userDbId, name: "", drives: [:])
+        Account(dbId: dbId, userDbId: userDbId, name: "", drives: IndexedDrives())
     }
 }

--- a/src/front/macOS/kDriveCore/ServerBridge/Jobs/DTOs/DriveResponse.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Jobs/DTOs/DriveResponse.swift
@@ -67,7 +67,7 @@ public struct DriveResponse: Codable, Sendable {
 }
 
 extension DriveResponse {
-    func asDrive(accountId: Int32, userDbId: Int32, synchros: IndexedSynchros = IndexedSynchros()) -> Drive {
+    func asDrive(accountId: Int32, userDbId: Int32, synchros: IndexedSynchros = [:]) -> Drive {
         Drive(driveDbId: driveDbId,
               driveId: driveId,
               accountDbId: accountDbId,

--- a/src/front/macOS/kDriveCore/ServerBridge/Jobs/DTOs/DriveResponse.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Jobs/DTOs/DriveResponse.swift
@@ -17,6 +17,7 @@
  */
 
 import Foundation
+import OrderedCollections
 
 struct DriveListQuery: Codable, Sendable {
     let userDbId: Int32
@@ -66,7 +67,7 @@ public struct DriveResponse: Codable, Sendable {
 }
 
 extension DriveResponse {
-    func asDrive(accountId: Int32, userDbId: Int32, synchros: IndexedSynchros = [:]) -> Drive {
+    func asDrive(accountId: Int32, userDbId: Int32, synchros: IndexedSynchros = IndexedSynchros()) -> Drive {
         Drive(driveDbId: driveDbId,
               driveId: driveId,
               accountDbId: accountDbId,

--- a/src/front/macOS/kDriveCore/ServerBridge/Jobs/DTOs/UserResponse.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Jobs/DTOs/UserResponse.swift
@@ -17,6 +17,7 @@
  */
 
 import Foundation
+import OrderedCollections
 
 struct UserQuery: Codable, Sendable {
     let userDbId: Int32

--- a/src/front/macOS/kDriveCore/ServerBridge/Jobs/DriveJobs.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Jobs/DriveJobs.swift
@@ -19,6 +19,7 @@
 import Foundation
 import InfomaniakConcurrency
 import InfomaniakDI
+import OrderedCollections
 
 public extension CoherentCache {
     func addDriveResponse(_ driveResponse: DriveResponse) async throws {

--- a/src/front/macOS/kDriveCore/ServerBridge/Signal/DTOs/AccountInfoSignal.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Signal/DTOs/AccountInfoSignal.swift
@@ -31,7 +31,7 @@ struct AccountInfoSignalMetadata: Codable, Sendable {
 
 extension AccountInfoSignalMetadata {
     var asAccount: Account {
-        Account(dbId: dbId, userDbId: userDbId, name: "", drives: IndexedDrives())
+        Account(dbId: dbId, userDbId: userDbId, name: "", drives: [:])
     }
 }
 

--- a/src/front/macOS/kDriveCore/ServerBridge/Signal/DTOs/AccountInfoSignal.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Signal/DTOs/AccountInfoSignal.swift
@@ -17,6 +17,7 @@
  */
 
 import Foundation
+import OrderedCollections
 
 struct AccountInfoSignal: Codable, Sendable {
     let accountInfo: AccountInfoSignalMetadata
@@ -30,7 +31,7 @@ struct AccountInfoSignalMetadata: Codable, Sendable {
 
 extension AccountInfoSignalMetadata {
     var asAccount: Account {
-        Account(dbId: dbId, userDbId: userDbId, name: "", drives: [:])
+        Account(dbId: dbId, userDbId: userDbId, name: "", drives: IndexedDrives())
     }
 }
 

--- a/src/front/macOS/kDriveCore/ServerBridge/Signal/DTOs/DriveInfoSignal.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Signal/DTOs/DriveInfoSignal.swift
@@ -17,6 +17,7 @@
  */
 
 import Foundation
+import OrderedCollections
 
 struct DriveInfoSignal: Codable, Sendable {
     let driveInfo: DriveInfoSignalMetadata
@@ -36,7 +37,7 @@ struct DriveInfoSignalMetadata: Codable, Sendable {
 }
 
 extension DriveInfoSignalMetadata {
-    func asDrive(accountId: Int32, userDbId: Int32, synchros: IndexedSynchros = [:]) -> Drive {
+    func asDrive(accountId: Int32, userDbId: Int32, synchros: IndexedSynchros = IndexedSynchros()) -> Drive {
         Drive(driveDbId: dbId,
               driveId: id,
               accountDbId: accountDbId,
@@ -49,7 +50,7 @@ extension DriveInfoSignalMetadata {
               locked: locked,
               maintenance: maintenance,
               notifications: notifications,
-              synchros: [:])
+              synchros: synchros)
     }
 }
 

--- a/src/front/macOS/kDriveCore/ServerBridge/Signal/DTOs/DriveInfoSignal.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Signal/DTOs/DriveInfoSignal.swift
@@ -37,7 +37,7 @@ struct DriveInfoSignalMetadata: Codable, Sendable {
 }
 
 extension DriveInfoSignalMetadata {
-    func asDrive(accountId: Int32, userDbId: Int32, synchros: IndexedSynchros = IndexedSynchros()) -> Drive {
+    func asDrive(accountId: Int32, userDbId: Int32, synchros: IndexedSynchros = [:]) -> Drive {
         Drive(driveDbId: dbId,
               driveId: id,
               accountDbId: accountDbId,

--- a/src/front/macOS/kDriveCore/ServerBridge/Signal/DTOs/UserInfoSignal.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Signal/DTOs/UserInfoSignal.swift
@@ -17,6 +17,7 @@
  */
 
 import Foundation
+import OrderedCollections
 
 struct UserRemoveSignal: Codable, Sendable {
     let userDbId: Int32

--- a/src/front/macOS/kDriveCore/ServerBridge/Signal/signal handlers/DriveSignalHandler.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Signal/signal handlers/DriveSignalHandler.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import InfomaniakDI
+import OrderedCollections
 
 struct DriveSignalHandler {
     private let decoder = JSONDecoder()
@@ -52,7 +53,7 @@ extension CoherentCache {
         let existingDrive = account.drives[driveSignal.dbId]
         let updatedDrive = driveSignal.asDrive(accountId: account.id,
                                                userDbId: account.userDbId,
-                                               synchros: existingDrive?.synchros ?? [:])
+                                               synchros: existingDrive?.synchros ?? IndexedSynchros())
         account.drives[driveSignal.dbId] = updatedDrive
 
         try await updateAccount(account)

--- a/src/front/macOS/kDriveCore/ServerBridge/Signal/signal handlers/DriveSignalHandler.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Signal/signal handlers/DriveSignalHandler.swift
@@ -53,7 +53,7 @@ extension CoherentCache {
         let existingDrive = account.drives[driveSignal.dbId]
         let updatedDrive = driveSignal.asDrive(accountId: account.id,
                                                userDbId: account.userDbId,
-                                               synchros: existingDrive?.synchros ?? IndexedSynchros())
+                                               synchros: existingDrive?.synchros ?? [:])
         account.drives[driveSignal.dbId] = updatedDrive
 
         try await updateAccount(account)

--- a/src/front/macOS/kDriveCore/ServerBridge/XPC/MockServer/XPCServerMock.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/XPC/MockServer/XPCServerMock.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import InfomaniakDI
+import OrderedCollections
 
 public struct RequestMock: Codable, Sendable {
     public let id: Int32

--- a/src/front/macOS/kDriveTests/Cache/CoherentCacheTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/CoherentCacheTests.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 @testable import kDriveCore
+import OrderedCollections
 import Testing
 
 enum CacheData {

--- a/src/front/macOS/kDriveTests/Cache/Observation/ObservableCoherentCacheTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/Observation/ObservableCoherentCacheTests.swift
@@ -71,9 +71,9 @@ final class ObservableCoherentCacheTests: XCTestCase {
 
         XCTAssertEqual(receivedUsers!.count, 1, "Should have received one user update")
 
-        if let receivedUser = receivedUsers?.first {
-            XCTAssertEqual(receivedUser.value.dbId, Self.expectedUserDbId, "Received user ID should match expected")
-            XCTAssertEqual(receivedUser.value.name, "appleseed", "Received user name should match expected")
+        if let receivedUser = receivedUsers?.values.first {
+            XCTAssertEqual(receivedUser.dbId, Self.expectedUserDbId, "Received user ID should match expected")
+            XCTAssertEqual(receivedUser.name, "appleseed", "Received user name should match expected")
         } else {
             XCTFail("Expected to find a user in the combine event")
         }

--- a/src/front/macOS/kDriveTests/Cache/Observation/ObservableCoherentCacheTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/Observation/ObservableCoherentCacheTests.swift
@@ -19,6 +19,7 @@
 import Combine
 import Foundation
 import kDriveCore
+import OrderedCollections
 import XCTest
 
 final class ObservableCoherentCacheTests: XCTestCase {

--- a/src/front/macOS/kDriveTests/Cache/Observation/ObservableData.swift
+++ b/src/front/macOS/kDriveTests/Cache/Observation/ObservableData.swift
@@ -17,6 +17,7 @@
  */
 
 @testable import kDriveCore
+import OrderedCollections
 
 extension Drive {
     static func some(driveDbId: Int32,


### PR DESCRIPTION
This refactors also aims at tracking the order of objects in cache. This is mostly a drop in data structure replacement.
New mac GUI Tests are passing fine.