### PR TITLE
feat: make drive selection window resizable

### DIFF
--- a/src/gui/adddrivewizard.cpp
+++ b/src/gui/adddrivewizard.cpp
@@ -62,8 +62,7 @@ void AddDriveWizard::setButtonIcon(const QColor &value) {
 }
 
 void AddDriveWizard::initUI() {
-    setMinimumSize(windowSize);
-    setMaximumSize(windowSize);
+    setResizable(true);
 
     QVBoxLayout *mainLayout = this->mainLayout();
     mainLayout->setContentsMargins(boxHMargin, boxVTMargin, boxHMargin, boxVBMargin);


### PR DESCRIPTION
In some cases, the button in the drive selection window might  not be clickable. This PR allow to resize this window.

<img width="1194" height="1340" alt="image" src="https://github.com/user-attachments/assets/94bd3e6d-3388-41f6-acc5-e326b75ea0f4" />
