### PR TITLE
ci(kdrive-desktop-ci): add `windows-test` to the runs-on matrix

### DIFF
--- a/.github/workflows/kdrive-desktop-ci.yml
+++ b/.github/workflows/kdrive-desktop-ci.yml
@@ -67,7 +67,7 @@ jobs:
       fail-fast: false
       matrix:
         test_name: ["kDrive_test_common", "kDrive_test_common_server", "kDrive_test_server", "kDrive_test_syncengine", "kDrive_test_parms"]
-    runs-on: [ self-hosted, Windows ]
+    runs-on: [ self-hosted, Windows, windows-test ]
     env:
       KDRIVE_TEST_CI_LOCAL_PATH: "${{ github.workspace }}/test/test_ci"
       KDRIVE_SENTRY_ENVIRONMENT: "windows_ci_runner"


### PR DESCRIPTION
Updated the CI configuration to include `windows-test` in the `runs-on` matrix to improve testing capabilities on Windows environments.

Done in parallel:
- Added the `windows-test` label to every runner and ensured it is applied when creating any `WindowsServer-xxxxxx` runner.