### PR TITLE
[TRELLO-1164] Fixes the Windows MSI package build performed by the CI runner

### DIFF
--- a/.github/actions/build_windows/action.yml
+++ b/.github/actions/build_windows/action.yml
@@ -64,7 +64,7 @@ runs:
           call "C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Auxiliary/Build/vcvars64.bat"
           IF "${{ inputs.release_build }}"=="true" (
             powershell "certutil -scinfo -Silent"
-            powershell "./infomaniak-build-tools/windows/build-drive.ps1" -ci -ext -clean remake -upload -tokenPass ${{ inputs.physical_cert_pass }}
+            powershell "./infomaniak-build-tools/windows/build-drive.ps1" -ci -ext -msi -clean remake -upload -tokenPass ${{ inputs.physical_cert_pass }}
           ) ELSE (
             powershell -File "./infomaniak-build-tools/windows/build-drive.ps1" -ci -unitTests
           )

--- a/.github/workflows/kdrive-desktop-msi-build.yml
+++ b/.github/workflows/kdrive-desktop-msi-build.yml
@@ -1,0 +1,45 @@
+name: Build kDrive-desktop MSI package
+
+on:
+  workflow_dispatch:  
+    inputs:
+      environment:
+        type: environment
+        description: Select the deployment environment
+        default: Internal beta
+
+concurrency:
+  group: kDrive-desktop-release-${{ github.head_ref }}
+  cancel-in-progress: true
+
+env:
+  KDRIVE_TEST_CI_API_TOKEN: ${{ secrets.KDRIVE_TOKEN }}
+  KDRIVE_TEST_CI_ACCOUNT_ID: ${{ vars.KDRIVE_TEST_CI_ACCOUNT_ID }}
+  KDRIVE_TEST_CI_USER_ID: ${{ vars.KDRIVE_TEST_CI_USER_ID }}
+  KDRIVE_TEST_CI_DRIVE_ID: ${{ vars.KDRIVE_TEST_CI_DRIVE_ID }}
+  KDRIVE_TEST_CI_REMOTE_DIR_ID: ${{ vars.KDRIVE_TEST_CI_REMOTE_DIR_ID }}
+  KDRIVE_TEST_CI_LOCAL_PATH: ${{ vars.KDRIVE_TEST_CI_LOCAL_PATH }}
+  KDRIVE_TEST_CI_REMOTE_PATH: ${{ vars.KDRIVE_TEST_CI_REMOTE_PATH }}
+  KDRIVE_TEST_CI_RUNNING_ON_CI: true
+  QT_QPA_PLATFORM: offscreen
+
+jobs:
+# Build apps and MSI
+  build-Windows:
+    runs-on: [ self-hosted, Windows, desktop-kdrive-with-gui ] #with-gui is required for the build_windows action to unlock the release signing certificate
+    outputs:
+      kDrive_version: ${{ steps.build-windows-step.outputs.kDrive_version }}
+    env:
+      KDC_PHYSICAL_AUMID: ${{ secrets.KDC_PHYSICAL_AUMID }}
+    steps:
+      - name: Checkout the PR
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Build Windows
+        id: build-windows-step
+        uses: ./.github/actions/build_windows
+        with:  
+          physical_cert: ${{ secrets.WINDOWS_PHYSICAL_CERT }}
+          physical_cert_pass: ${{ secrets.WINDOWS_PHYSICAL_CERT_PASSWORD }}
+          release_build: true

--- a/infomaniak-build-tools/upload-release-to-kDrive.ps1
+++ b/infomaniak-build-tools/upload-release-to-kDrive.ps1
@@ -163,6 +163,7 @@ if ($os -eq "win") {
     Write-Host " - Windows Files - " # Windows
     $win_files = @(
         "$app.exe",
+        "$app.msi",
         "kDrive.pdb",
         "kDrive_client.pdb",
         "kDrive.src.zip",

--- a/infomaniak-build-tools/windows/build-drive.ps1
+++ b/infomaniak-build-tools/windows/build-drive.ps1
@@ -51,7 +51,7 @@ Param(
 
     # include new GUI: Flag to enable or disable the new GUI build. If included, any user in the internal release channel will be able to test it. 
     # The legacy GUI will still be built and installed alongside and can be launched by clicking on kDrive logo on the top left corner of the new GUI.
-    [switch] $newGui,
+    [bool] $newGui,
 
     # Help: Displays the help message and exits
     [switch] $help

--- a/infomaniak-build-tools/windows/build-drive.ps1
+++ b/infomaniak-build-tools/windows/build-drive.ps1
@@ -602,7 +602,7 @@ function Create-MSI-Package {
 
     Write-Host "Creating MSI package ..."
 
-	$appName = Get-Package-Name -msi
+	$appName = Get-Package-Name
     $msiInstallerFolderPath = "$path/installer/windows/kDriveInstaller"
     $msiPackageFolderPath = "$msiInstallerFolderPath/bin/x64/Release/en-US"
 	

--- a/infomaniak-build-tools/windows/build-drive.ps1
+++ b/infomaniak-build-tools/windows/build-drive.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
  Infomaniak kDrive - Desktop App
  Copyright (C) 2023-2025 Infomaniak Network SA
 
@@ -72,9 +72,6 @@ $installPath = "$contentPath/install"
 $extPath = "$path/extensions/windows/cfapi"
 $clientPath = "$path/src/gui4/windows/kDrive client"
 $vfsDir = "$extPath/x64/Release"
-
-$msiInstallerFolderPath = "$path/installer/windows/kDriveInstaller"
-$msiPackageFolderPath = "$msiInstallerFolderPath/bin/x64/Release/en-US"
 
 # Files to be added to the archive and then packaged
 $archivePath = "$installPath/bin"
@@ -388,9 +385,12 @@ function Set-Up-NSIS {
 
     # NSIS needs the path to use backslash
     $iconPath = Get-Icon-Path $buildpath
-    $appName = Get-Package-Name $buildpath -exe
+    $appName = Get-Package-Name -exe
    
-    $installerPath = Get-Installer-Path $buildPath $contentPath
+    $installerPath = Get-Installer-Path -ContentPath $contentPath
+
+    Write-Host "NSIS installer path: '$installerPath'."
+
     Clean $installerPath
 
     $aumid = Get-Aumid $upload
@@ -573,13 +573,13 @@ function Create-Archive {
     & makensis "$buildPath\NSIS.template.nsi"
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-    $appName = Get-Package-Name $buildPath -exe
+    $appName = Get-Package-Name -exe
     Move-Item -Path "$buildPath\$appName" -Destination "$contentPath"
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
     # Sign final installer
     $thumbprint = Get-Thumbprint -Upload $upload -Ci $ci
-    $installerPath = Get-Installer-Path $contentPath
+    $installerPath = Get-Installer-Path -ContentPath $contentPath
 
     if (Test-Path -Path $installerPath) {
         Sign-File -FilePath $installerPath -Upload $upload -Thumbprint $thumbprint -TokenPass $tokenPass -Description $appName
@@ -594,9 +594,17 @@ function Create-Archive {
 }
 
 function Create-MSI-Package {
+    param (
+        [string] $path,
+        [string] $buildPath,
+        [string] $contentPath
+    )
+
     Write-Host "Creating MSI package ..."
 
-	$appName = Get-Package-Name $buildPath
+	$appName = Get-Package-Name -msi
+    $msiInstallerFolderPath = "$path/installer/windows/kDriveInstaller"
+    $msiPackageFolderPath = "$msiInstallerFolderPath/bin/x64/Release/en-US"
 	
 	dotnet build "$msiInstallerFolderPath/kDriveInstaller.sln" /p:Configuration="Release" /p:Platform="x64" /p:OutputName=$appName
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
@@ -609,7 +617,7 @@ function Create-MSI-Package {
 		$thumbprint = Get-Thumbprint $upload
 	}
 
-	$installerPath = Get-Installer-Path $contentPath -msi
+	$installerPath = Get-Installer-Path -ContentPath $contentPath -msi
 
 	if (Test-Path -Path $installerPath) {
 		Sign-File -FilePath $installerPath -Upload $upload -Thumbprint $thumbprint -TokenPass $tokenPass -Description $appName
@@ -817,13 +825,13 @@ if ($LASTEXITCODE -ne 0)
 #                                                                                               #
 #################################################################################################
 
-if (!$ci) {
-    Create-Archive -Path $path -BuildPath $buildPath -ContentPath $contentPath -InstallPath $installPath -Archivename $archiveName -ArchivePath $archivePath -Upload $upload -Ci $ci
-    if ($LASTEXITCODE -ne 0) {
-        Write-Host "Archive creation failed ($LASTEXITCODE) . Aborting." -f Red
-        exit $LASTEXITCODE
-    }
+
+Create-Archive -Path $path -BuildPath $buildPath -ContentPath $contentPath -InstallPath $installPath -Archivename $archiveName -ArchivePath $archivePath -Upload $upload -Ci $ci
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "Archive creation failed ($LASTEXITCODE) . Aborting." -f Red
+    exit $LASTEXITCODE
 }
+
 
 #################################################################################################
 #                                                                                               #
@@ -832,7 +840,7 @@ if (!$ci) {
 #################################################################################################
 
 if ($msi) {
-    Create-MSI-Package
+    Create-MSI-Package -Path $path -buildPath $buildPath -ContentPath $contentPath
     if ($LASTEXITCODE -ne 0) {
         Write-Host "MSI package creation failed ($LASTEXITCODE) . Aborting." -f Red
         exit $LASTEXITCODE

--- a/installer/windows/Bootstraper/fetchVersion.ps1
+++ b/installer/windows/Bootstraper/fetchVersion.ps1
@@ -54,17 +54,19 @@ function Update-Define-Constants {
         # Update existing constant
         $constantIndex = [array]::IndexOf($defineConstants.Value, $existing)
         $defineConstants.Value[$constantIndex] = "$key=$value"
-        Write-Host "Existing $key constant found. Updating to $value."
+        Write-Host "Existing '$key' constant found. Updating to '$value'."
     } else {
         # Add new constant
         $defineConstants.Value += "$key=$value"
-        Write-Host "No existing $key constant found. Adding $key=$value"
+        Write-Host "No existing '$key' constant found. Adding '$key=$value'"
     }
 }
 
 
 $versionString = ""
 $RepositoryRootPath = $RepositoryRootPath.Trim('"')
+$RepositoryRootPath = Resolve-Path $RepositoryRootPath 
+
 . "$RepositoryRootPath\infomaniak-build-tools\version-helpers.ps1"
 $versionString = Get-VersionFromJson -RepositoryRootPath $RepositoryRootPath -IncludeBuildVersion $true
 if($versionString -eq "") {
@@ -80,16 +82,20 @@ if (-Not (Test-Path $WixProjPath)) {
 [xml]$wixProjXml = Get-Content $WixProjPath
 $propertyGroupNode = $wixProjXml.Project.PropertyGroup | Where-Object { $_.DefineConstants } | Select-Object -First 1
 
+$defineConstants = @()
 if (-not $propertyGroupNode) {
-    Write-Error "No <DefineConstants> found in wixproj. Expected exactly one."
-    exit 1
+    Write-Host "No <DefineConstants> found in wixproj. This is consistent with the default template."
+} else {
+    $defineConstants = $propertyGroupNode.DefineConstants -split ';'
 }
-
-$defineConstants = $propertyGroupNode.DefineConstants -split ';'
 
 # Version
 
 Update-Define-Constants -Key "version" -Value $versionString -DefineConstants ([ref]$defineConstants)
+
+# Repository root path
+
+Update-Define-Constants -Key "desktop-kDriveDir" -Value $RepositoryRootPath -DefineConstants ([ref]$defineConstants)
 
 # Overlay GUIDs 
 
@@ -105,8 +111,18 @@ Update-Define-Constants -Key "regKeySyncGUID" -Value $guid -DefineConstants ([re
 $guid = Get-Overlay-Guid -Path $RepositoryRootPath -KeyType "OVERLAY_GUID_WARNING"
 Update-Define-Constants -Key "regKeyWarningGUID" -Value $guid -DefineConstants ([ref]$defineConstants)
 
+# Edit
+
+if (-not $propertyGroupNode) {
+    $defineConstantsNode = $wixProjXml.CreateElement("DefineConstants")
+    $defineConstantsNode.InnerText = ($defineConstants -join ';')
+    $propertyGroupNode = $wixProjXml.Project.PropertyGroup | Select-Object -First 1
+    $propertyGroupNode.AppendChild($defineConstantsNode)
+} else {
+    $propertyGroupNode.DefineConstants = ($defineConstants -join ';')
+}
+
 # Save
 
-$propertyGroupNode.DefineConstants = ($defineConstants -join ';')
 Write-Host "Updated wixproj Version to $versionString"
 $wixProjXml.Save($WixProjPath)

--- a/installer/windows/kDriveInstaller/Package.en-us.wxl
+++ b/installer/windows/kDriveInstaller/Package.en-us.wxl
@@ -1,8 +1,8 @@
 ﻿<!--
 This file contains the declaration of all the localizable strings.
 -->
-<WixLocalization xmlns="http://wixtoolset.org/schemas/v4/wxl" Culture="fr-FR">
+<WixLocalization xmlns="http://wixtoolset.org/schemas/v4/wxl" Culture="en-US">
 
-    <String Id="DowngradeError" Value="Une version plus récente de [ProductName] est déja installée." />
+    <String Id="DowngradeError" Value="A newer version of [ProductName] is already installed." />
 
 </WixLocalization>

--- a/installer/windows/kDriveInstaller/Package.fr-fr.wxl
+++ b/installer/windows/kDriveInstaller/Package.fr-fr.wxl
@@ -1,8 +1,8 @@
 ﻿<!--
 This file contains the declaration of all the localizable strings.
 -->
-<WixLocalization xmlns="http://wixtoolset.org/schemas/v4/wxl" Culture="en-US">
+<WixLocalization xmlns="http://wixtoolset.org/schemas/v4/wxl" Culture="fr-FR">
 
-    <String Id="DowngradeError" Value="A newer version of [ProductName] is already installed." />
+    <String Id="DowngradeError" Value="Une version plus récente de [ProductName] est déja installée." />
 
 </WixLocalization>

--- a/installer/windows/kDriveInstaller/kDriveInstaller.wixproj
+++ b/installer/windows/kDriveInstaller/kDriveInstaller.wixproj
@@ -1,6 +1,5 @@
 <Project Sdk="WixToolset.Sdk/6.0.2">
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <DefineConstants>desktop-kDriveDir=$(SolutionDir)..\..\..</DefineConstants>
     <VerboseOutput>true</VerboseOutput>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <SuppressIces>ICE57;ICE61</SuppressIces>


### PR DESCRIPTION
 This PR shortens the repository root path when defined as a `DefineConstant` in `kDriveInstaller.wixproj`.

It also comprises necessary fixes of the script `build-drive.ps1` as well as a fix for the translations of the error installation message.