### PR TITLE
chore(version): bump build number to 3.8.2.2 in version.json

### DIFF
--- a/version.json
+++ b/version.json
@@ -3,7 +3,7 @@
     "major": 3,
     "minor": 8,
     "patch": 2,
-    "build": 1,
+    "build": 2,
     "year": 2026
   }
 }


### PR DESCRIPTION
Incremented the build number from 1 to 2 for version 3.8.2 (2026). No other changes included.