### PR TITLE
feat: generalize the job priority system

### DIFF
--- a/src/libsyncengine/jobs/abstractjob.h
+++ b/src/libsyncengine/jobs/abstractjob.h
@@ -21,6 +21,7 @@
 #include "utility/types.h"
 
 #include <Poco/Runnable.h>
+#include <Poco/Thread.h>
 
 #include <log4cplus/logger.h>
 
@@ -57,9 +58,13 @@ class AbstractJob : public Poco::Runnable {
         virtual void abort();
         bool isAborted() const;
 
+        [[nodiscard]] Poco::Thread::Priority jobPriority() const { return _jobPriority; }
+
     protected:
         void run() override;
         virtual ExitInfo canRun() { return ExitCode::Ok; }
+
+        void setJobPriority(Poco::Thread::Priority jobPriority) { _jobPriority = jobPriority; }
 
         log4cplus::Logger _logger;
 
@@ -80,6 +85,8 @@ class AbstractJob : public Poco::Runnable {
         ExitInfo _exitInfo;
         bool _abort = false;
         bool _isExtendedLog = false;
+
+        Poco::Thread::Priority _jobPriority = Poco::Thread::PRIO_NORMAL;
 };
 
 } // namespace KDC

--- a/src/libsyncengine/jobs/jobmanager.cpp
+++ b/src/libsyncengine/jobs/jobmanager.cpp
@@ -57,8 +57,7 @@ void JobManager::clear() {
     _stop = false;
 }
 
-void JobManager::queueAsyncJob(const std::shared_ptr<AbstractJob> job,
-                               const Poco::Thread::Priority priority /*= Poco::Thread::PRIO_NORMAL*/) noexcept {
+void JobManager::queueAsyncJob(const std::shared_ptr<AbstractJob> job, const Poco::Thread::Priority priority) noexcept {
     startMainThreadIfNeeded();
     const std::function<void(const UniqueId)> callback = std::bind_front(&JobManager::eraseJob, this);
     job->setMainCallback(callback);

--- a/src/libsyncengine/jobs/jobmanager.cpp
+++ b/src/libsyncengine/jobs/jobmanager.cpp
@@ -64,7 +64,7 @@ void JobManager::queueAsyncJob(const std::shared_ptr<AbstractJob> job, const Poc
     _data.queue(job, priority);
 }
 
-void JobManager::queueAsyncJob(std::shared_ptr<AbstractJob> job) noexcept {
+void JobManager::queueAsyncJob(const std::shared_ptr<AbstractJob> job) noexcept {
     queueAsyncJob(job, job->jobPriority());
 }
 
@@ -135,7 +135,7 @@ void JobManager::run() noexcept {
     }
 }
 
-void JobManager::startJob(std::shared_ptr<AbstractJob> job, Poco::Thread::Priority priority) {
+void JobManager::startJob(const std::shared_ptr<AbstractJob> job, const Poco::Thread::Priority priority) {
     try {
         if (job->isAborted()) {
             LOG_DEBUG(Log::instance()->getLogger(), "Job " << job->jobId() << " has been canceled");
@@ -169,7 +169,7 @@ void JobManager::addToPendingJobs(const std::shared_ptr<AbstractJob> job, const 
 
 int JobManager::availableThreadsInPool() const {
     try {
-        return static_cast<int>(_threadPool.available());
+        return _threadPool.available();
     } catch (Poco::Exception &) {
         return 0;
     }

--- a/src/libsyncengine/jobs/jobmanager.cpp
+++ b/src/libsyncengine/jobs/jobmanager.cpp
@@ -65,6 +65,10 @@ void JobManager::queueAsyncJob(const std::shared_ptr<AbstractJob> job,
     _data.queue(job, priority);
 }
 
+void JobManager::queueAsyncJob(std::shared_ptr<AbstractJob> job) noexcept {
+    queueAsyncJob(job, job->jobPriority());
+}
+
 bool JobManager::isJobFinished(const UniqueId jobId) const {
     return !_data.isManaged(jobId);
 }

--- a/src/libsyncengine/jobs/jobmanager.h
+++ b/src/libsyncengine/jobs/jobmanager.h
@@ -43,13 +43,16 @@ class JobManager {
         void clear();
 
         /**
-         * @brief Queue a job to be executed as soon as a thread is available in the default thread pool.
+         * @brief Queue a job to be executed as soon as a thread is available in the thread pool.
          * @param job The job to be run asynchronously.
-         * @param priority Job's priority level.
-         * @param externalCallback Callback to be run once the job is done.
+         * @param priority Job's priority level. Bypass the internal job's priority.
          */
-        void queueAsyncJob(std::shared_ptr<AbstractJob> job,
-                           Poco::Thread::Priority priority = Poco::Thread::PRIO_NORMAL) noexcept;
+        void queueAsyncJob(std::shared_ptr<AbstractJob> job, Poco::Thread::Priority priority) noexcept;
+        /**
+         * Queue a job to be executed as soon as a thread is available in the thread pool. The job's internal priority is used.
+         * @param job The job to be run asynchronously.
+         */
+        void queueAsyncJob(std::shared_ptr<AbstractJob> job) noexcept;
 
         bool isJobFinished(const UniqueId jobId) const;
         std::shared_ptr<AbstractJob> getJob(const UniqueId jobId) const;

--- a/src/libsyncengine/jobs/jobmanagerdata.h
+++ b/src/libsyncengine/jobs/jobmanagerdata.h
@@ -138,5 +138,6 @@ class JobManagerData {
         mutable std::mutex _mutex;
 
         friend class TestSyncJobManagerSingleton;
+        friend class TestGuiJobPriority;
 };
 } // namespace KDC

--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -155,7 +155,7 @@ void ExecutorWorker::execute() {
 
             if (job) {
                 job->setAdditionalCallback(std::bind_front(&ExecutorWorker::executorCallback, this));
-                SyncJobManagerSingleton::instance()->queueAsyncJob(job, Poco::Thread::PRIO_NORMAL);
+                SyncJobManagerSingleton::instance()->queueAsyncJob(job);
                 _ongoingJobs.insert({job->jobId(), job});
                 _jobToSyncOpMap.insert({job->jobId(), syncOp});
             } else {

--- a/src/server/comm/commmanager.cpp
+++ b/src/server/comm/commmanager.cpp
@@ -275,7 +275,7 @@ void CommManager::executeGuiQuery(const CommString &commandLineStr, std::shared_
     }
 
     // Add job to JobManager pool
-    GuiJobManagerSingleton::instance()->queueAsyncJob(job, Poco::Thread::PRIO_NORMAL);
+    GuiJobManagerSingleton::instance()->queueAsyncJob(job);
 }
 
 void CommManager::sendGuiSignal(std::shared_ptr<AbstractGuiJob> signal) {
@@ -290,7 +290,7 @@ void CommManager::sendGuiSignal(std::shared_ptr<AbstractGuiJob> signal) {
     signal->setChannels(_guiCommServer->connections());
 
     // Add job to JobManager pool
-    GuiJobManagerSingleton::instance()->queueAsyncJob(signal, Poco::Thread::PRIO_NORMAL);
+    GuiJobManagerSingleton::instance()->queueAsyncJob(signal);
 }
 
 void CommManager::onNewGuiConnection() {

--- a/src/server/comm/guijobs/nodefoldersizejob.cpp
+++ b/src/server/comm/guijobs/nodefoldersizejob.cpp
@@ -38,6 +38,7 @@ NodeFolderSizeJob::NodeFolderSizeJob(std::shared_ptr<CommManager> commManager, i
                                      std::shared_ptr<AbstractCommChannel> channel) :
     AbstractGuiJob(commManager, requestId, inParams, channel) {
     _requestNum = RequestNum::NODE_FOLDER_SIZE;
+    setJobPriority(Poco::Thread::PRIO_LOW);
 }
 
 ExitInfo NodeFolderSizeJob::deserializeInputParms() {

--- a/src/server/comm/guijobs/nodefoldersizejob.h
+++ b/src/server/comm/guijobs/nodefoldersizejob.h
@@ -18,8 +18,9 @@
 
 #pragma once
 
-#include "server/comm/guijobs/abstractguijob.h"
+#include "comm/guijobs/abstractguijob.h"
 #include "libcommon/info/nodeinfo.h"
+
 namespace KDC {
 
 class NodeFolderSizeJob : public AbstractGuiJob {

--- a/test/server/CMakeLists.txt
+++ b/test/server/CMakeLists.txt
@@ -203,6 +203,7 @@ set(testserver_SRCS
     comm/guicommchannel/testsignaljobs.cpp
 
     comm/guijobs/testabstractguijob.h comm/guijobs/testabstractguijob.cpp
+    comm/testguijobpriority.h comm/testguijobpriority.cpp
 )
 
 if(APPLE)

--- a/test/server/comm/guicommchannel/testgenericjob.cpp
+++ b/test/server/comm/guicommchannel/testgenericjob.cpp
@@ -17,7 +17,7 @@
  */
 
 #include "testguicommchannel.h"
-#include "../../../../src/libcommon/log/log.h"
+#include "libcommon/log/log.h"
 
 namespace KDC {
 

--- a/test/server/comm/guicommchannel/testguicommchannel.cpp
+++ b/test/server/comm/guicommchannel/testguicommchannel.cpp
@@ -30,7 +30,7 @@
 #include "comm/guijobs/driveupdatejob.h"
 
 #include "libcommon/comm.h"
-#include "../../../../src/libcommon/log/log.h"
+#include "libcommon/log/log.h"
 
 #include "mocks/libcommonserver/db/mockdb.h"
 #include "test_utility/testhelpers.h"
@@ -43,7 +43,7 @@ using namespace testcommhelpers;
 
 uint64_t GuiCommChannelTest::readData(CommChar *data, uint64_t maxlen) {
     std::scoped_lock lock(_bufferMutex);
-    uint64_t toRead = (std::min)(maxlen, static_cast<uint64_t>(_buffer.size()));
+    uint64_t toRead = (std::min) (maxlen, static_cast<uint64_t>(_buffer.size()));
     if (toRead > 0) {
         std::memcpy(data, _buffer.data(), toRead * sizeof(CommChar));
         _buffer.erase(0, toRead);

--- a/test/server/comm/testguijobpriority.cpp
+++ b/test/server/comm/testguijobpriority.cpp
@@ -33,9 +33,9 @@ void TestGuiJobPriority::setUp() {
 
     // Create parmsDb
     bool alreadyExists = false;
-    std::filesystem::path parmsDbPath = MockDb::makeDbName(alreadyExists);
+    const std::filesystem::path parmsDbPath = MockDb::makeDbName(alreadyExists);
     (void) IoHelper::deleteItem(parmsDbPath);
-    ParmsDb::instance(parmsDbPath, KDRIVE_VERSION_STRING, true, true);
+    (void) ParmsDb::instance(parmsDbPath, KDRIVE_VERSION_STRING, true, true);
 }
 
 void TestGuiJobPriority::tearDown() {
@@ -45,15 +45,14 @@ void TestGuiJobPriority::tearDown() {
 void TestGuiJobPriority::testPriority() {
     GuiJobFactory guiJobFactory;
     JobManagerData jobManagerData;
-    auto testChannel = std::make_shared<GuiCommChannel>(Poco::Net::StreamSocket());
     for (auto i = 0; i < 10; i++) {
-        auto job = guiJobFactory.make(RequestNum::NODE_FOLDER_SIZE, nullptr, i, {}, testChannel);
+        const auto job = guiJobFactory.make(RequestNum::NODE_FOLDER_SIZE, nullptr, i, {}, nullptr);
         jobManagerData.queue(job, job->jobPriority());
     }
-    auto setBlacklistJob = guiJobFactory.make(RequestNum::BLACKLISTED_NODE_SETLIST, nullptr, 10, {}, testChannel);
+    const auto setBlacklistJob = guiJobFactory.make(RequestNum::BLACKLISTED_NODE_SETLIST, nullptr, 10, {}, nullptr);
     jobManagerData.queue(setBlacklistJob, setBlacklistJob->jobPriority());
 
-    auto topJob = jobManagerData._queuedJobs.top().first;
+    const auto topJob = jobManagerData._queuedJobs.top().first;
     CPPUNIT_ASSERT_EQUAL(setBlacklistJob->jobId(), topJob->jobId());
 }
 } // namespace KDC

--- a/test/server/comm/testguijobpriority.cpp
+++ b/test/server/comm/testguijobpriority.cpp
@@ -1,0 +1,59 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "testguijobpriority.h"
+
+#include "comm/guijobmanager.h"
+#include "comm/guijobs/blacklistednodesetlistjob.h"
+#include "comm/guijobs/nodefoldersizejob.h"
+#include "io/iohelper.h"
+#include "mocks/libcommonserver/db/mockdb.h"
+
+#include <version.h>
+
+namespace KDC {
+
+void TestGuiJobPriority::setUp() {
+    TestBase::start();
+
+    // Create parmsDb
+    bool alreadyExists = false;
+    std::filesystem::path parmsDbPath = MockDb::makeDbName(alreadyExists);
+    (void) IoHelper::deleteItem(parmsDbPath);
+    ParmsDb::instance(parmsDbPath, KDRIVE_VERSION_STRING, true, true);
+}
+
+void TestGuiJobPriority::tearDown() {
+    TestBase::stop();
+}
+
+void TestGuiJobPriority::testPriority() {
+    GuiJobFactory guiJobFactory;
+    JobManagerData jobManagerData;
+    auto testChannel = std::make_shared<GuiCommChannel>(Poco::Net::StreamSocket());
+    for (auto i = 0; i < 10; i++) {
+        auto job = guiJobFactory.make(RequestNum::NODE_FOLDER_SIZE, nullptr, i, {}, testChannel);
+        jobManagerData.queue(job, job->jobPriority());
+    }
+    auto setBlacklistJob = guiJobFactory.make(RequestNum::BLACKLISTED_NODE_SETLIST, nullptr, 10, {}, testChannel);
+    jobManagerData.queue(setBlacklistJob, setBlacklistJob->jobPriority());
+
+    auto topJob = jobManagerData._queuedJobs.top().first;
+    CPPUNIT_ASSERT_EQUAL(setBlacklistJob->jobId(), topJob->jobId());
+}
+} // namespace KDC

--- a/test/server/comm/testguijobpriority.h
+++ b/test/server/comm/testguijobpriority.h
@@ -1,0 +1,38 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "testincludes.h"
+#include "server/comm/guicommserver.h"
+#include "server/comm/guijobs/guijobfactory.h"
+
+#include <log4cplus/logger.h>
+
+namespace KDC {
+
+class TestGuiJobPriority : public CppUnit::TestFixture, public TestBase {
+        CPPUNIT_TEST_SUITE(TestGuiJobPriority);
+        CPPUNIT_TEST(testPriority);
+        CPPUNIT_TEST_SUITE_END();
+
+    public:
+        void setUp() final;
+        void tearDown() final;
+ void testPriority();
+};
+
+} // namespace KDC

--- a/test/server/test.cpp
+++ b/test/server/test.cpp
@@ -36,6 +36,7 @@
 #include "comm/testpipecomm.h"
 #endif
 #include "comm/guijobs/testabstractguijob.h"
+#include "comm/testguijobpriority.h"
 
 namespace KDC {
 
@@ -57,6 +58,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION(TestPipeComm);
 #endif
 CPPUNIT_TEST_SUITE_REGISTRATION(TestGuiCommChannel);
 CPPUNIT_TEST_SUITE_REGISTRATION(TestAbstractGuiJob);
+CPPUNIT_TEST_SUITE_REGISTRATION(TestGuiJobPriority);
 
 } // namespace KDC
 


### PR DESCRIPTION
This PR generalizes a priority system for jobs in the sync engine.
## Changes
### Core Functionality
- Added `_jobPriority` attribute to `AbstractJob` (default: `PRIO_NORMAL`)
- Added getter (`jobPriority()`) and setter (`setJobPriority()`) methods
- Added overloaded `queueAsyncJob(job)` method that uses job's internal priority
### Updated Job Classes
- `NodeFolderSizeJob` now uses `PRIO_LOW` priority
### Updated Call Sites
- `ExecutorWorker::execute()`: Uses `queueAsyncJob(job)` without explicit priority
- `CommManager::executeGuiQuery()`: Uses `queueAsyncJob(job)` without explicit priority  
- `CommManager::sendGuiSignal()`: Uses `queueAsyncJob(job)` without explicit priority
### Tests
- Added `TestGuiJobPriority` to validate priority queue behavior
- Verifies that higher priority jobs are queued before lower priority jobs
### Minor Fixes
- Fixed include paths in `nodefoldersizejob.h` and test files
- Fixed formatting in `testguicommchannel.cpp`