### PR TITLE
App stuck in executor after connexion lost

### DIFF
--- a/src/libsyncengine/jobs/abstractjob.cpp
+++ b/src/libsyncengine/jobs/abstractjob.cpp
@@ -63,17 +63,17 @@ void AbstractJob::abort() {
     if (ParametersCache::isExtendedLogEnabled()) {
         LOG_DEBUG(_logger, "Aborting job " << jobId());
     }
-    _abort = true;
+    _aborted = true;
 }
 
 bool AbstractJob::isAborted() const {
-    return _abort;
+    return _aborted;
 }
 
-void AbstractJob::callback(UniqueId id) {
+void AbstractJob::callback(const UniqueId id) {
     try {
-        std::scoped_lock lock(_additionalCallbackMutex);
-        if (_mainCallback && _additionalCallback) {
+        const std::scoped_lock lock(_additionalCallbackMutex);
+        if (_mainCallback && _additionalCallback && !_aborted) {
             _additionalCallback(id); // Call the "additional" callback first since the main callback might delete the last
                                      // reference on the job
         }
@@ -82,7 +82,7 @@ void AbstractJob::callback(UniqueId id) {
     }
 
     try {
-        if (_mainCallback) {
+        if (_mainCallback && !_aborted) {
             _mainCallback(id);
         }
     } catch (...) {

--- a/src/libsyncengine/jobs/abstractjob.cpp
+++ b/src/libsyncengine/jobs/abstractjob.cpp
@@ -82,7 +82,7 @@ void AbstractJob::callback(const UniqueId id) {
     }
 
     try {
-        if (_mainCallback && !_aborted) {
+        if (_mainCallback) {
             _mainCallback(id);
         }
     } catch (...) {

--- a/src/libsyncengine/jobs/abstractjob.h
+++ b/src/libsyncengine/jobs/abstractjob.h
@@ -78,7 +78,7 @@ class AbstractJob : public Poco::Runnable {
 
         bool _isRunning = false;
         ExitInfo _exitInfo;
-        bool _abort = false;
+        bool _aborted = false;
         bool _isExtendedLog = false;
 };
 

--- a/src/libsyncengine/jobs/network/kDrive_API/upload/upload_session/abstractuploadsession.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/upload/upload_session/abstractuploadsession.cpp
@@ -451,7 +451,6 @@ ExitInfo AbstractUploadSession::cancelSession() {
         for (const auto &[jobId, job]: _ongoingChunkJobs) {
             if (job.get() && job->sessionToken() == _sessionToken) {
                 LOG_INFO(_logger, "Aborting chunk job " << jobId);
-                job->setAdditionalCallback(nullptr);
                 job->abort();
             }
         }

--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -69,114 +69,113 @@ void ExecutorWorker::execute() {
     _opList = _syncPal->_syncOps->opSortedList();
     initProgressManager();
     uint64_t changesCounter = 0;
-    while (!_opList.empty()) { // Same loop twice because we might reschedule the jobs after a pause TODO : refactor double loop
-        // Create all the jobs
-        sentry::pTraces::scoped::JobGeneration perfMonitor(syncDbId());
-        while (!_opList.empty()) {
-            if (const auto exitInfo = deleteFinishedAsyncJobs(); !exitInfo) {
-                executorExitInfo = exitInfo;
-                cancelAllOngoingJobs();
-                break;
-            }
 
-            sendProgress();
-
-            if (stopAsked()) {
-                cancelAllOngoingJobs();
-                break;
-            }
-
-            UniqueId opId = 0;
-            _opListMutex.lock();
-            if (!_opList.empty()) {
-                opId = _opList.front();
-                _opList.pop_front();
-            }
-            _opListMutex.unlock();
-            if (!opId) break;
-
-            SyncOpPtr syncOp = _syncPal->_syncOps->getOp(opId);
-            if (!syncOp) {
-                LOG_SYNCPAL_WARN(_logger, "Operation doesn't exist anymore: id=" << opId);
-                continue;
-            }
-
-            changesCounter++;
-
-            std::shared_ptr<SyncJob> job = nullptr;
-            bool ignored = false;
-            bool bypassProgressComplete = false;
-            bool hydrating = false;
-            switch (syncOp->type()) {
-                case OperationType::Create: {
-                    executorExitInfo = handleCreateOp(syncOp, job, ignored, hydrating);
-                    break;
-                }
-                case OperationType::Edit: {
-                    executorExitInfo = handleEditOp(syncOp, job, ignored);
-                    break;
-                }
-                case OperationType::Move: {
-                    executorExitInfo = handleMoveOp(syncOp, ignored, bypassProgressComplete);
-                    break;
-                }
-                case OperationType::Delete: {
-                    executorExitInfo = handleDeleteOp(syncOp, ignored, bypassProgressComplete);
-                    break;
-                }
-                default: {
-                    LOGW_SYNCPAL_WARN(_logger, L"Unknown operation type: "
-                                                       << syncOp->type() << L" on file "
-                                                       << Utility::formatSyncName(syncOp->affectedNode()->name()));
-                    executorExitInfo = ExitCode::DataError;
-                }
-            }
-
-            // If an operation fails but is correctly handled by handleExecutorError, execution can proceed.
-            if (executorExitInfo.cause() == ExitCause::OperationCanceled) {
-                if (!bypassProgressComplete) setProgressComplete(syncOp, SyncFileStatus::Error);
-                continue;
-            }
-
-            if (!executorExitInfo) {
-                executorExitInfo = handleExecutorError(syncOp, executorExitInfo);
-                if (!executorExitInfo) { // If the error is not handled, stop the execution
-                    increaseErrorCount(syncOp, executorExitInfo);
-                    cancelAllOngoingJobs();
-                    break;
-                }
-
-                // If the error is handled, continue the execution
-                if (!bypassProgressComplete) setProgressComplete(syncOp, SyncFileStatus::Error);
-                continue;
-            }
-
-            if (job) {
-                job->setAdditionalCallback(std::bind_front(&ExecutorWorker::executorCallback, this));
-                SyncJobManagerSingleton::instance()->queueAsyncJob(job, Poco::Thread::PRIO_NORMAL);
-                (void) _ongoingJobs.try_emplace(job->jobId(), job);
-                (void) _jobToSyncOpMap.try_emplace(job->jobId(), syncOp);
-            } else {
-                if (!bypassProgressComplete) {
-                    if (ignored) {
-                        setProgressComplete(syncOp, SyncFileStatus::Ignored);
-                    } else if (syncOp->affectedNode() && syncOp->affectedNode()->inconsistencyType() != InconsistencyType::None) {
-                        setProgressComplete(syncOp, SyncFileStatus::Inconsistency);
-                    } else {
-                        setProgressComplete(syncOp, hydrating ? SyncFileStatus::Syncing : SyncFileStatus::Success);
-                    }
-                }
-            }
-        }
-
-        perfMonitor.stop();
-        sentry::pTraces::scoped::waitForAllJobsToFinish perfMonitorwaitForAllJobsToFinish(syncDbId());
-        if (const auto exitInfo = waitForAllJobsToFinish(); !exitInfo) {
+    // Create all the jobs
+    sentry::pTraces::scoped::JobGeneration perfMonitor(syncDbId());
+    while (!_opList.empty()) {
+        if (const auto exitInfo = deleteFinishedAsyncJobs(); !exitInfo) {
             executorExitInfo = exitInfo;
+            cancelAllOngoingJobs();
             break;
         }
-        perfMonitorwaitForAllJobsToFinish.stop();
+
+        sendProgress();
+
+        if (stopAsked()) {
+            cancelAllOngoingJobs();
+            break;
+        }
+
+        UniqueId opId = 0;
+        _opListMutex.lock();
+        if (!_opList.empty()) {
+            opId = _opList.front();
+            _opList.pop_front();
+        }
+        _opListMutex.unlock();
+        if (!opId) break;
+
+        SyncOpPtr syncOp = _syncPal->_syncOps->getOp(opId);
+        if (!syncOp) {
+            LOG_SYNCPAL_WARN(_logger, "Operation doesn't exist anymore: id=" << opId);
+            continue;
+        }
+
+        changesCounter++;
+
+        std::shared_ptr<SyncJob> job = nullptr;
+        bool ignored = false;
+        bool bypassProgressComplete = false;
+        bool hydrating = false;
+        switch (syncOp->type()) {
+            case OperationType::Create: {
+                executorExitInfo = handleCreateOp(syncOp, job, ignored, hydrating);
+                break;
+            }
+            case OperationType::Edit: {
+                executorExitInfo = handleEditOp(syncOp, job, ignored);
+                break;
+            }
+            case OperationType::Move: {
+                executorExitInfo = handleMoveOp(syncOp, ignored, bypassProgressComplete);
+                break;
+            }
+            case OperationType::Delete: {
+                executorExitInfo = handleDeleteOp(syncOp, ignored, bypassProgressComplete);
+                break;
+            }
+            default: {
+                LOGW_SYNCPAL_WARN(_logger, L"Unknown operation type: "
+                                                   << syncOp->type() << L" on file "
+                                                   << Utility::formatSyncName(syncOp->affectedNode()->name()));
+                executorExitInfo = ExitCode::DataError;
+            }
+        }
+
+        // If an operation fails but is correctly handled by handleExecutorError, execution can proceed.
+        if (executorExitInfo.cause() == ExitCause::OperationCanceled) {
+            if (!bypassProgressComplete) setProgressComplete(syncOp, SyncFileStatus::Error);
+            continue;
+        }
+
+        if (!executorExitInfo) {
+            executorExitInfo = handleExecutorError(syncOp, executorExitInfo);
+            if (!executorExitInfo) { // If the error is not handled, stop the execution
+                increaseErrorCount(syncOp, executorExitInfo);
+                cancelAllOngoingJobs();
+                break;
+            }
+
+            // If the error is handled, continue the execution
+            if (!bypassProgressComplete) setProgressComplete(syncOp, SyncFileStatus::Error);
+            continue;
+        }
+
+        if (job) {
+            job->setAdditionalCallback(std::bind_front(&ExecutorWorker::executorCallback, this));
+            SyncJobManagerSingleton::instance()->queueAsyncJob(job, Poco::Thread::PRIO_NORMAL);
+            (void) _ongoingJobs.try_emplace(job->jobId(), job);
+            (void) _jobToSyncOpMap.try_emplace(job->jobId(), syncOp);
+        } else {
+            if (!bypassProgressComplete) {
+                if (ignored) {
+                    setProgressComplete(syncOp, SyncFileStatus::Ignored);
+                } else if (syncOp->affectedNode() && syncOp->affectedNode()->inconsistencyType() != InconsistencyType::None) {
+                    setProgressComplete(syncOp, SyncFileStatus::Inconsistency);
+                } else {
+                    setProgressComplete(syncOp, hydrating ? SyncFileStatus::Syncing : SyncFileStatus::Success);
+                }
+            }
+        }
     }
+
+    perfMonitor.stop();
+    sentry::pTraces::scoped::waitForAllJobsToFinish perfMonitorwaitForAllJobsToFinish(syncDbId());
+    if (const auto exitInfo = waitForAllJobsToFinish(); !exitInfo) {
+        executorExitInfo = exitInfo;
+    }
+    perfMonitorwaitForAllJobsToFinish.stop();
+
 
     _syncPal->_syncOps->clear();
     _syncPal->_remoteFSObserverWorker->forceUpdate();

--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -53,7 +53,7 @@ namespace KDC {
 ExecutorWorker::ExecutorWorker(std::shared_ptr<SyncPal> syncPal, const std::string &name, const std::string &shortName) :
     OperationProcessor(syncPal, name, shortName, false) {}
 
-void ExecutorWorker::executorCallback(UniqueId jobId) {
+void ExecutorWorker::executorCallback(const UniqueId jobId) {
     _terminatedJobs.push(jobId);
 }
 
@@ -73,7 +73,7 @@ void ExecutorWorker::execute() {
         // Create all the jobs
         sentry::pTraces::scoped::JobGeneration perfMonitor(syncDbId());
         while (!_opList.empty()) {
-            if (ExitInfo exitInfo = deleteFinishedAsyncJobs(); !exitInfo) {
+            if (const auto exitInfo = deleteFinishedAsyncJobs(); !exitInfo) {
                 executorExitInfo = exitInfo;
                 cancelAllOngoingJobs();
                 break;
@@ -93,11 +93,9 @@ void ExecutorWorker::execute() {
                 _opList.pop_front();
             }
             _opListMutex.unlock();
-
             if (!opId) break;
 
             SyncOpPtr syncOp = _syncPal->_syncOps->getOp(opId);
-
             if (!syncOp) {
                 LOG_SYNCPAL_WARN(_logger, "Operation doesn't exist anymore: id=" << opId);
                 continue;
@@ -146,18 +144,18 @@ void ExecutorWorker::execute() {
                     increaseErrorCount(syncOp, executorExitInfo);
                     cancelAllOngoingJobs();
                     break;
-                } else { // If the error is handled, continue the execution
-                    if (!bypassProgressComplete) setProgressComplete(syncOp, SyncFileStatus::Error);
-                    continue;
                 }
+
+                // If the error is handled, continue the execution
                 if (!bypassProgressComplete) setProgressComplete(syncOp, SyncFileStatus::Error);
+                continue;
             }
 
             if (job) {
                 job->setAdditionalCallback(std::bind_front(&ExecutorWorker::executorCallback, this));
                 SyncJobManagerSingleton::instance()->queueAsyncJob(job, Poco::Thread::PRIO_NORMAL);
-                _ongoingJobs.insert({job->jobId(), job});
-                _jobToSyncOpMap.insert({job->jobId(), syncOp});
+                (void) _ongoingJobs.try_emplace(job->jobId(), job);
+                (void) _jobToSyncOpMap.try_emplace(job->jobId(), syncOp);
             } else {
                 if (!bypassProgressComplete) {
                     if (ignored) {
@@ -173,7 +171,7 @@ void ExecutorWorker::execute() {
 
         perfMonitor.stop();
         sentry::pTraces::scoped::waitForAllJobsToFinish perfMonitorwaitForAllJobsToFinish(syncDbId());
-        if (ExitInfo exitInfo = waitForAllJobsToFinish(); !exitInfo) {
+        if (const auto exitInfo = waitForAllJobsToFinish(); !exitInfo) {
             executorExitInfo = exitInfo;
             break;
         }
@@ -190,7 +188,7 @@ void ExecutorWorker::execute() {
         _syncPal->_localFSObserverWorker->invalidateSnapshot();
     }
 
-    _syncPal->vfs()->cleanUpStatuses();
+    (void) _syncPal->vfs()->cleanUpStatuses();
 
     setExitCause(executorExitInfo.cause());
     LOG_SYNCPAL_DEBUG(_logger, "Worker stopped: name=" << name() << " " << executorExitInfo);

--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -2085,7 +2085,6 @@ void ExecutorWorker::cancelAllOngoingJobs() {
     for (const auto &job: _ongoingJobs) {
         if (!job.second->isRunning()) {
             LOG_SYNCPAL_DEBUG(_logger, "Cancelling job: " << job.second->jobId());
-            job.second->setAdditionalCallback(nullptr);
             job.second->abort();
         } else {
             remainingJobs.push_back(job.second);
@@ -2095,7 +2094,6 @@ void ExecutorWorker::cancelAllOngoingJobs() {
     // Then cancel jobs that are currently running
     for (const auto &job: remainingJobs) {
         LOG_SYNCPAL_DEBUG(_logger, "Cancelling job: " << job->jobId());
-        job->setAdditionalCallback(nullptr);
         job->abort();
     }
     _ongoingJobs.clear();

--- a/src/libsyncengine/syncpal/syncpal.cpp
+++ b/src/libsyncengine/syncpal/syncpal.cpp
@@ -765,15 +765,12 @@ ExitCode SyncPal::cancelDlDirectJobs(const std::vector<SyncPath> &fileList) {
     return ExitCode::Ok;
 }
 
-ExitCode SyncPal::cancelAllDlDirectJobs(bool quit) {
+ExitCode SyncPal::cancelAllDlDirectJobs() {
     LOG_SYNCPAL_INFO(_logger, "Cancelling all direct download jobs");
 
     const std::scoped_lock<std::mutex> lock(_directDownloadJobsMapMutex);
     for (auto &directDownloadJobsMapElt: _directDownloadJobsMap) {
         LOG_SYNCPAL_DEBUG(_logger, "Cancelling download job " << directDownloadJobsMapElt.first);
-        if (quit) {
-            directDownloadJobsMapElt.second->setAdditionalCallback(nullptr);
-        }
         directDownloadJobsMapElt.second->abort();
     }
 
@@ -1188,7 +1185,7 @@ std::chrono::time_point<std::chrono::steady_clock> SyncPal::pauseTime() const {
     return std::chrono::steady_clock::now();
 }
 
-void SyncPal::stop(bool pausedByUser, bool quit, bool clear) {
+void SyncPal::stop(bool pausedByUser, bool clear) {
     if (_syncPalWorker) {
         if (_syncPalWorker->isRunning()) {
             // Stop main worker
@@ -1198,7 +1195,7 @@ void SyncPal::stop(bool pausedByUser, bool quit, bool clear) {
     }
 
     // Stop direct download jobs
-    cancelAllDlDirectJobs(quit);
+    cancelAllDlDirectJobs();
 
     if (pausedByUser) {
         // Set paused flag

--- a/src/libsyncengine/syncpal/syncpal.cpp
+++ b/src/libsyncengine/syncpal/syncpal.cpp
@@ -1195,12 +1195,12 @@ void SyncPal::stop(bool pausedByUser, bool clear) {
     }
 
     // Stop direct download jobs
-    cancelAllDlDirectJobs();
+    (void) cancelAllDlDirectJobs();
 
     if (pausedByUser) {
         // Set paused flag
-        ExitCode exitCode = setSyncPaused(true);
-        if (exitCode != ExitCode::Ok) {
+
+        if (const auto exitCode = setSyncPaused(true); exitCode != ExitCode::Ok) {
             LOG_SYNCPAL_DEBUG(_logger, "Error in SyncPal::setSyncPaused");
             addError(Error(syncDbId(), ERR_ID, exitCode, ExitCause::Unknown));
         }

--- a/src/libsyncengine/syncpal/syncpal.h
+++ b/src/libsyncengine/syncpal/syncpal.h
@@ -196,7 +196,7 @@ class SYNCENGINE_EXPORT SyncPal : public std::enable_shared_from_this<SyncPal> {
          \param startDelay represents the time (expressed in seconds) the SyncPalWorker must wait before starting.
          */
         void start(const std::chrono::seconds &startDelay = std::chrono::seconds(0));
-        void stop(bool pausedByUser = false, bool quit = false, bool clear = false);
+        void stop(bool pausedByUser = false, bool clear = false);
 
 
         /* The synchronization will be paused once the ongoing sync reach the Idle state.
@@ -231,7 +231,7 @@ class SYNCENGINE_EXPORT SyncPal : public std::enable_shared_from_this<SyncPal> {
                                 const SyncPath &parentFolderPath);
         void monitorFolderHydration(const SyncPath &absoluteLocalPath);
         ExitCode cancelDlDirectJobs(const std::vector<SyncPath> &fileList);
-        ExitCode cancelAllDlDirectJobs(bool quit);
+        ExitCode cancelAllDlDirectJobs();
         ExitCode cleanOldUploadSessionTokens();
         bool isDownloadOngoing(const SyncPath &localPath);
 

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -586,7 +586,7 @@ void AppServer::reset() {
 // This task can be long and block the GUI
 void AppServer::stopSyncTask(int syncDbId) {
     // Stop sync and remove it from syncPalMap
-    if (const auto exitInfo = stopSyncPal(syncDbId, false, true, true); !exitInfo) {
+    if (const auto exitInfo = stopSyncPal(syncDbId, false, true); !exitInfo) {
         LOG_WARN(_logger, "Error in stopSyncPal for syncDbId=" << syncDbId << " : " << exitInfo);
     }
 
@@ -3689,7 +3689,7 @@ ExitInfo AppServer::initSyncPal(const Sync &sync, const QSet<QString> &blackList
     return ExitCode::Ok;
 }
 
-ExitInfo AppServer::stopSyncPal(int syncDbId, bool pausedByUser, bool quit, bool clear) {
+ExitInfo AppServer::stopSyncPal(int syncDbId, bool pausedByUser, bool clear) {
     LOG_DEBUG(_logger, "Stop SyncPal for syncDbId=" << syncDbId);
 
     // Stop SyncPal
@@ -3706,7 +3706,7 @@ ExitInfo AppServer::stopSyncPal(int syncDbId, bool pausedByUser, bool quit, bool
     }
 
     unregisterSync(syncPalMapIt->second);
-    syncPalMapIt->second->stop(pausedByUser, quit, clear);
+    syncPalMapIt->second->stop(pausedByUser, clear);
 
     LOG_DEBUG(_logger, "Stop SyncPal for syncDbId=" << syncDbId << " done");
 

--- a/src/server/appserver.h
+++ b/src/server/appserver.h
@@ -126,7 +126,7 @@ class AppServer : public SharedTools::QtSingleApplication {
         [[nodiscard]] ExitInfo initSyncPal(const Sync &sync, const NodeSet &blackList = {}, bool start = true,
                                            const std::chrono::seconds &startDelay = std::chrono::seconds(0),
                                            bool resumedByUser = false, bool firstInit = false);
-        [[nodiscard]] ExitInfo stopSyncPal(int syncDbId, bool pausedByUser = false, bool quit = false, bool clear = false);
+        [[nodiscard]] ExitInfo stopSyncPal(int syncDbId, bool pausedByUser = false, bool clear = false);
         void clearSyncCacheMap() { _syncCacheMap.clear(); }
         void loadUsersInfo() { onLoadInfo(); }
 

--- a/test/libsyncengine/integration/testintegration.cpp
+++ b/test/libsyncengine/integration/testintegration.cpp
@@ -134,7 +134,7 @@ void TestIntegration::setUp() {
 }
 
 void TestIntegration::tearDown() {
-    if (_syncPal) _syncPal->stop(false, true, false);
+    if (_syncPal) _syncPal->stop(false, false);
     _remoteSyncDir.deleteDirectory();
 
     ParmsDb::instance()->close();

--- a/test/libsyncengine/syncpal/testoperationprocessor.cpp
+++ b/test/libsyncengine/syncpal/testoperationprocessor.cpp
@@ -86,7 +86,7 @@ void TestOperationProcessor::tearDown() {
     // Stop SyncPal and delete sync DB
     ParmsDb::instance()->close();
     if (_syncPal) {
-        _syncPal->stop(false, true, true);
+        _syncPal->stop(false, true);
     }
     ParmsDb::reset();
     TestBase::stop();

--- a/test/libsyncengine/syncpal/testsyncpal.cpp
+++ b/test/libsyncengine/syncpal/testsyncpal.cpp
@@ -85,7 +85,7 @@ void TestSyncPal::setUp() {
 void TestSyncPal::tearDown() {
     // Stop SyncPal and delete sync DB
     if (_syncPal) {
-        _syncPal->stop(false, true, true);
+        _syncPal->stop(false, true);
     }
     ParmsDb::instance()->close();
     ParmsDb::reset();
@@ -286,7 +286,7 @@ void TestSyncPal::testAll() {
 
 
     // Stop sync
-    _syncPal->stop(false, true, true);
+    _syncPal->stop(false, true);
     CPPUNIT_ASSERT(!_syncPal->isRunning());
 }
 

--- a/test/libsyncengine/syncpal/testsyncpalworker.cpp
+++ b/test/libsyncengine/syncpal/testsyncpalworker.cpp
@@ -83,7 +83,7 @@ void TestSyncPalWorker::tearDown() {
     _testEnded = true;
     // Stop SyncPal and delete sync DB
     if (_syncPal) {
-        _syncPal->stop(false, true, true);
+        _syncPal->stop(false, true);
     }
     ParmsDb::instance()->close();
     ParmsDb::reset();

--- a/test/server/appserver/testappserver.cpp
+++ b/test/server/appserver/testappserver.cpp
@@ -125,7 +125,7 @@ void TestAppServer::testInitAndStopSyncPal() {
     CPPUNIT_ASSERT(syncIsActive(syncDbId));
 
     // Stop SyncPal (cleanup)
-    exitInfo = _appPtr->stopSyncPal(syncDbId, /*pausedByUser*/ false, /*quit*/ true, /*clear*/ true);
+    exitInfo = _appPtr->stopSyncPal(syncDbId, /*pausedByUser*/ false, /*clear*/ true);
     CPPUNIT_ASSERT(exitInfo);
     CPPUNIT_ASSERT(waitForSyncStatus(syncDbId, SyncStatus::Stopped));
 


### PR DESCRIPTION
In case of network loss during the Executor step, the app might get stuck in deadlock while cancelling jobs.