### PR TITLE
fix(io-helper-directory-iterator): Aligns the implementation of `IoHelper::DirectoryIterator::next` with its documentation

### DIFF
--- a/src/libcommon/io/iohelper.cpp
+++ b/src/libcommon/io/iohelper.cpp
@@ -1012,19 +1012,19 @@ IoHelper::DirectoryIterator::DirectoryIterator(const SyncPath &directoryPath, bo
 
 
 bool IoHelper::DirectoryIterator::next(DirectoryEntry &nextEntry, bool &endOfDirectory, IoError &ioError) {
-    std::error_code ec;
     endOfDirectory = false;
     ioError = IoError::Success;
 
     if (_invalid) {
         ioError = IoError::InvalidDirectoryIterator;
-        return true;
+        return false;
     }
 
     if (_directoryPath == "") {
         ioError = IoError::InvalidArgument;
         return false;
     }
+
     const auto dirIteratorEnd = std::filesystem::end(_dirIterator);
     if (_dirIterator == dirIteratorEnd) {
         endOfDirectory = true;
@@ -1036,15 +1036,15 @@ bool IoHelper::DirectoryIterator::next(DirectoryEntry &nextEntry, bool &endOfDir
     }
 
     if (!_firstElement) {
+        std::error_code ec;
         _dirIterator.increment(ec);
         if (ec) {
             ioError = IoHelper::stdError2ioError(ec);
             if (ioError != IoError::Success) {
                 _invalid = true;
-                return true;
+                return false;
             }
         }
-
     } else {
         _firstElement = false;
     }
@@ -1064,11 +1064,11 @@ bool IoHelper::DirectoryIterator::next(DirectoryEntry &nextEntry, bool &endOfDir
 
 #endif
         nextEntry = *_dirIterator;
-        return true;
     } else {
         endOfDirectory = true;
-        return true;
     }
+
+    return true;
 }
 
 void IoHelper::DirectoryIterator::disableRecursionPending() {

--- a/test/libcommon/io/testcheckdirectoryiterator.cpp
+++ b/test/libcommon/io/testcheckdirectoryiterator.cpp
@@ -310,10 +310,10 @@ void TestIo::testCheckDirectoryIteratorUnexpectedDelete() {
 
         (void) IoHelper::deleteItem(path);
 
-        CPPUNIT_ASSERT(it.next(entry, endOfDirectory, ioError));
+        CPPUNIT_ASSERT(!it.next(entry, endOfDirectory, ioError));
         CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
 
-        CPPUNIT_ASSERT(it.next(entry, endOfDirectory, ioError));
+        CPPUNIT_ASSERT(!it.next(entry, endOfDirectory, ioError));
         CPPUNIT_ASSERT_EQUAL(IoError::InvalidDirectoryIterator, ioError);
     }
 }


### PR DESCRIPTION
This revised implementation ensures that `IoHelper::DirectoryIterator::next` is consistent with its docstring, that is, it returns `true` if and only if the returned `ioError` is `IoError::Success`. This should help simplify the use of this method in several `while` loops of our code base.