### PR TITLE
Fix mac freeze due to lite sync2

### DIFF
--- a/extensions/MacOSX/kDriveLiteSync/Extension/xpcLiteSyncExtensionProtocol.h
+++ b/extensions/MacOSX/kDriveLiteSync/Extension/xpcLiteSyncExtensionProtocol.h
@@ -26,5 +26,5 @@
 - (void)updateFetchStatus:(NSString *)appId filePath:(NSString *)path fileStatus:(NSString *)status;
 - (void)updateThumbnailFetchStatus:(NSString *)appId filePath:(NSString *)path fileStatus:(NSString *)status;
 - (void)getFetchingAppList:(NSString *)appId callback:(void (^)(NSString *))callback;
-- (void)freeAllStoppedProcesses;
+- (void)freeAllStoppedProcesses:(NSString *)path;
 @end

--- a/extensions/MacOSX/kDriveLiteSync/Extension/xpcLiteSyncExtensionProtocol.h
+++ b/extensions/MacOSX/kDriveLiteSync/Extension/xpcLiteSyncExtensionProtocol.h
@@ -26,5 +26,5 @@
 - (void)updateFetchStatus:(NSString *)appId filePath:(NSString *)path fileStatus:(NSString *)status;
 - (void)updateThumbnailFetchStatus:(NSString *)appId filePath:(NSString *)path fileStatus:(NSString *)status;
 - (void)getFetchingAppList:(NSString *)appId callback:(void (^)(NSString *))callback;
-
+- (void)freeAllStoppedProcesses;
 @end

--- a/extensions/MacOSX/kDriveLiteSync/Extension/xpcService.h
+++ b/extensions/MacOSX/kDriveLiteSync/Extension/xpcService.h
@@ -22,7 +22,7 @@
 #import "xpcServiceProxy.h"
 
 @interface XPCService : NSObject <XPCServiceProxyDelegate> {
-    NSMutableDictionary<NSString *, NSMutableSet<NSNumber *> *> *_fetchThumbnailMap;
+    NSMutableDictionary<NSString *, NSMutableDictionary *> *_fetchThumbnailMap;
     NSMutableDictionary<NSString *, NSMutableSet<NSNumber *> *> *_fetchMap;
     NSSet<NSString *> *_defaultOpenWhiteListThumbnailSet;
     NSSet<NSString *> *_defaultOpenWhiteListSet;

--- a/extensions/MacOSX/kDriveLiteSync/Extension/xpcService.h
+++ b/extensions/MacOSX/kDriveLiteSync/Extension/xpcService.h
@@ -47,6 +47,7 @@
 - (void)sendMessage:(NSString *_Nullable)filePath query:(NSString *_Nullable)verb oneApp:(BOOL)one;
 - (BOOL)fetchFile:(NSString *_Nullable)filePath pid:(pid_t)pid;
 - (BOOL)fetchThumbnail:(NSString *_Nullable)filePath pid:(pid_t)pid;
+- (void)freeBlockedProcessForThumnail:(NSTimer *)timer;
 - (BOOL)isDirectory:(NSString *_Nullable)path error:(NSError *_Nullable *_Nullable)error;
 
 @end

--- a/extensions/MacOSX/kDriveLiteSync/Extension/xpcService.h
+++ b/extensions/MacOSX/kDriveLiteSync/Extension/xpcService.h
@@ -47,7 +47,6 @@
 - (void)sendMessage:(NSString *_Nullable)filePath query:(NSString *_Nullable)verb oneApp:(BOOL)one;
 - (BOOL)fetchFile:(NSString *_Nullable)filePath pid:(pid_t)pid;
 - (BOOL)fetchThumbnail:(NSString *_Nullable)filePath pid:(pid_t)pid;
-- (void)freeBlockedProcessForThumnail:(NSTimer *)timer;
 - (BOOL)isDirectory:(NSString *_Nullable)path error:(NSError *_Nullable *_Nullable)error;
 
 @end

--- a/extensions/MacOSX/kDriveLiteSync/Extension/xpcService.m
+++ b/extensions/MacOSX/kDriveLiteSync/Extension/xpcService.m
@@ -27,7 +27,6 @@
 
     _registeredFoldersMap = [[NSMutableDictionary alloc] init];
     _fetchThumbnailMap = [[NSMutableDictionary alloc] init];
-    _fetchThumbnailTimerMap = [[NSMutableDictionary alloc] init];
     _fetchMap = [[NSMutableDictionary alloc] init];
     _userBlackListMap = [[NSMutableDictionary alloc] init];
     _fetchingAppArray = [[NSMutableArray alloc] init];
@@ -262,8 +261,8 @@
         kill(pid, SIGSTOP);
         
         // Start cancel timer
-        dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(60.0 * NSEC_PER_SEC));
-        dispatch_after(popTime, dispatch_get_main_queue(), ^{
+        dispatch_time_t time = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(60.0 * NSEC_PER_SEC));
+        dispatch_after(time, dispatch_get_main_queue(), ^{
             if (self->_fetchMap[filePath] != nil) {
                 NSLog(@"[KD] Fetch thumbnail has timed out for path %@, cancelling it.", filePath);
                 [self updateThumbnailFetchStatus:NULL filePath:filePath fileStatus:@"Cancelled"];
@@ -389,6 +388,10 @@
     }
 
     return appList;
+}
+
+- (void)freeAllStoppedProcesses {
+    
 }
 
 - (BOOL)isDirectory:(NSString *)path error:(NSError *_Nullable *)error {

--- a/extensions/MacOSX/kDriveLiteSync/Extension/xpcService.m
+++ b/extensions/MacOSX/kDriveLiteSync/Extension/xpcService.m
@@ -265,11 +265,11 @@ const NSString *timeoutBlockKey = @"timeoutBlock";
                     return;
                 }
                 
-                @synchronized (self->_fetchThumbnailMap) {
-                    NSMutableDictionary *data = self->_fetchThumbnailMap[filePath];
+                @synchronized (strongSelf->_fetchThumbnailMap) {
+                    NSMutableDictionary *data = strongSelf->_fetchThumbnailMap[filePath];
                     if (data != nil) {
                         NSLog(@"[KD] Fetch thumbnail has timed out for path %@, cancelling it.", filePath);
-                        [self updateThumbnailFetchStatus:nil filePath:filePath fileStatus:@"Cancelled"];
+                        [strongSelf updateThumbnailFetchStatus:nil filePath:filePath fileStatus:@"Cancelled"];
                     }
                 }
             });

--- a/extensions/MacOSX/kDriveLiteSync/Extension/xpcService.m
+++ b/extensions/MacOSX/kDriveLiteSync/Extension/xpcService.m
@@ -226,8 +226,6 @@
     @synchronized(_fetchMap) {
         if (_fetchMap[filePath] == nil) {
             [_fetchMap setObject:[[NSMutableSet alloc] init] forKey:filePath];
-            
-            NSLog(@"[KD] TEST_CK: file %@ is in fetch map", filePath);
 
             // Ask to the app to fetch the file
             [self sendMessage:filePath query:@"MAKE_AVAILABLE_LOCALLY_DIRECT" oneApp:TRUE];

--- a/extensions/MacOSX/kDriveLiteSync/Extension/xpcService.m
+++ b/extensions/MacOSX/kDriveLiteSync/Extension/xpcService.m
@@ -391,7 +391,7 @@
 }
 
 - (void)freeAllStoppedProcesses {
-    
+    NSLog(@"[KD] TEST_CK Freeing all stoppend processes!");
 }
 
 - (BOOL)isDirectory:(NSString *)path error:(NSError *_Nullable *)error {

--- a/extensions/MacOSX/kDriveLiteSync/Extension/xpcService.m
+++ b/extensions/MacOSX/kDriveLiteSync/Extension/xpcService.m
@@ -258,7 +258,13 @@ const NSString *timeoutBlockKey = @"timeoutBlock";
             fetchData[pidKey] = [[NSMutableSet alloc] init];
             
             // Create cancelable timeout block
+            __weak typeof(self) weakSelf = self;
             dispatch_block_t timeoutBlock = dispatch_block_create(0, ^{
+                __strong typeof(weakSelf) strongSelf = weakSelf;
+                if (!strongSelf) {
+                    return;
+                }
+                
                 @synchronized (self->_fetchThumbnailMap) {
                     NSMutableDictionary *data = self->_fetchThumbnailMap[filePath];
                     if (data != nil) {

--- a/extensions/MacOSX/kDriveLiteSync/Extension/xpcService.m
+++ b/extensions/MacOSX/kDriveLiteSync/Extension/xpcService.m
@@ -226,6 +226,8 @@
     @synchronized(_fetchMap) {
         if (_fetchMap[filePath] == nil) {
             [_fetchMap setObject:[[NSMutableSet alloc] init] forKey:filePath];
+            
+            NSLog(@"[KD] TEST_CK: file %@ is in fetch map", filePath);
 
             // Ask to the app to fetch the file
             [self sendMessage:filePath query:@"MAKE_AVAILABLE_LOCALLY_DIRECT" oneApp:TRUE];
@@ -390,8 +392,21 @@
     return appList;
 }
 
-- (void)freeAllStoppedProcesses {
-    NSLog(@"[KD] TEST_CK Freeing all stoppend processes!");
+- (void)freeAllStoppedProcesses:(NSString *)path {
+    NSLog(@"[KD] Freeing all stopped processes for path: %@", path);
+    
+    for (NSString *filePath in _fetchThumbnailMap) {
+        if ([filePath hasPrefix:path]) {
+            NSLog(@"[KD] Freeing fetch thumbnail processes for file: %@", path);
+            [self updateThumbnailFetchStatus:NULL filePath:filePath fileStatus:@"Cancelled"];
+        }
+    }
+    for (NSString *filePath in _fetchMap) {
+        if ([filePath hasPrefix:path]) {
+            NSLog(@"[KD] Freeing fetch processes for file: %@", path);
+            [self updateFetchStatus:NULL filePath:filePath fileStatus:@"Cancelled"];
+        }
+    }
 }
 
 - (BOOL)isDirectory:(NSString *)path error:(NSError *_Nullable *)error {

--- a/extensions/MacOSX/kDriveLiteSync/Extension/xpcService.m
+++ b/extensions/MacOSX/kDriveLiteSync/Extension/xpcService.m
@@ -259,7 +259,7 @@
                     NSMutableDictionary *data = self->_fetchThumbnailMap[filePath];
                     if (data != nil) {
                         NSLog(@"[KD] Fetch thumbnail has timed out for path %@, cancelling it.", filePath);
-                        [self updateThumbnailFetchStatus:NULL filePath:filePath fileStatus:@"Cancelled"];
+                        [self updateThumbnailFetchStatus:nil filePath:filePath fileStatus:@"Cancelled"];
                     }
                 }
             });
@@ -417,7 +417,7 @@
         for (NSString *filePath in _fetchThumbnailMap) {
             if ([filePath hasPrefix:path]) {
                 NSLog(@"[KD] Freeing fetch thumbnail processes for file: %@", filePath);
-                [self updateThumbnailFetchStatus:NULL filePath:filePath fileStatus:@"Cancelled"];
+                [self updateThumbnailFetchStatus:nil filePath:filePath fileStatus:@"Cancelled"];
             }
         }
     }
@@ -425,7 +425,7 @@
         for (NSString *filePath in _fetchMap) {
             if ([filePath hasPrefix:path]) {
                 NSLog(@"[KD] Freeing fetch processes for file: %@", filePath);
-                [self updateFetchStatus:NULL filePath:filePath fileStatus:@"Cancelled"];
+                [self updateFetchStatus:nil filePath:filePath fileStatus:@"Cancelled"];
             }
         }
     }

--- a/extensions/MacOSX/kDriveLiteSync/Extension/xpcService.m
+++ b/extensions/MacOSX/kDriveLiteSync/Extension/xpcService.m
@@ -20,6 +20,10 @@
 
 #define CSV_SEPARATOR @";"
 
+const int64_t fetchThumbnailTimeout = 10; // 10 seconds
+const NSString *pidKey = @"pids";
+const NSString *timeoutBlockKey = @"timeoutBlock";
+
 @implementation XPCService
 
 - (instancetype)init {
@@ -251,7 +255,7 @@
         if (fetchData == nil) {
             // Create new entry with pids and timeout block
             fetchData = [NSMutableDictionary dictionary];
-            fetchData[@"pids"] = [[NSMutableSet alloc] init];
+            fetchData[pidKey] = [[NSMutableSet alloc] init];
             
             // Create cancelable timeout block
             dispatch_block_t timeoutBlock = dispatch_block_create(0, ^{
@@ -263,12 +267,12 @@
                     }
                 }
             });
-            fetchData[@"timeoutBlock"] = timeoutBlock;
+            fetchData[timeoutBlockKey] = timeoutBlock;
             
             [_fetchThumbnailMap setObject:fetchData forKey:filePath];
             
             // Schedule the timeout
-            dispatch_time_t time = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(60.0 * NSEC_PER_SEC));
+            dispatch_time_t time = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(fetchThumbnailTimeout * NSEC_PER_SEC));
             dispatch_after(time, dispatch_get_main_queue(), timeoutBlock);
             
             // Ask the app to fetch the thumbnail
@@ -276,7 +280,7 @@
         }
 
         // Store the pid
-        [fetchData[@"pids"] addObject:[NSNumber numberWithInt:pid]];
+        [fetchData[pidKey] addObject:[NSNumber numberWithInt:pid]];
 
         // Stop the process
         NSLog(@"[KD] Stop process %@ opening thumbnail %@", [NSNumber numberWithInt:pid], filePath);
@@ -360,13 +364,13 @@
         }
 
         // Cancel the pending timeout block if it exists
-        dispatch_block_t timeoutBlock = fetchData[@"timeoutBlock"];
+        dispatch_block_t timeoutBlock = fetchData[timeoutBlockKey];
         if (timeoutBlock) {
             dispatch_block_cancel(timeoutBlock);
         }
 
         // Resume the stopped processes
-        for (NSNumber *pidNumber in fetchData[@"pids"]) {
+        for (NSNumber *pidNumber in fetchData[pidKey]) {
             NSLog(@"[KD] Resume process %@ opening thumbnail %@", pidNumber, filePath);
             kill([pidNumber intValue], SIGCONT);
         }

--- a/extensions/MacOSX/kDriveLiteSync/Extension/xpcService.m
+++ b/extensions/MacOSX/kDriveLiteSync/Extension/xpcService.m
@@ -395,13 +395,13 @@
     
     for (NSString *filePath in _fetchThumbnailMap) {
         if ([filePath hasPrefix:path]) {
-            NSLog(@"[KD] Freeing fetch thumbnail processes for file: %@", path);
+            NSLog(@"[KD] Freeing fetch thumbnail processes for file: %@", filePath);
             [self updateThumbnailFetchStatus:NULL filePath:filePath fileStatus:@"Cancelled"];
         }
     }
     for (NSString *filePath in _fetchMap) {
         if ([filePath hasPrefix:path]) {
-            NSLog(@"[KD] Freeing fetch processes for file: %@", path);
+            NSLog(@"[KD] Freeing fetch processes for file: %@", filePath);
             [self updateFetchStatus:NULL filePath:filePath fileStatus:@"Cancelled"];
         }
     }

--- a/extensions/MacOSX/kDriveLiteSync/Extension/xpcService.m
+++ b/extensions/MacOSX/kDriveLiteSync/Extension/xpcService.m
@@ -27,6 +27,7 @@
 
     _registeredFoldersMap = [[NSMutableDictionary alloc] init];
     _fetchThumbnailMap = [[NSMutableDictionary alloc] init];
+    _fetchThumbnailTimerMap = [[NSMutableDictionary alloc] init];
     _fetchMap = [[NSMutableDictionary alloc] init];
     _userBlackListMap = [[NSMutableDictionary alloc] init];
     _fetchingAppArray = [[NSMutableArray alloc] init];
@@ -261,25 +262,16 @@
         kill(pid, SIGSTOP);
         
         // Start cancel timer
-        NSLog(@"TEST_CK stating timer for path : %@", filePath);
-        [NSTimer scheduledTimerWithTimeInterval:60.0
-            target:self
-            selector:@selector(freeBlockedProcessForThumnail:)
-            userInfo: @{@"filePath": filePath}
-            repeats:NO];
-
+        dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(60.0 * NSEC_PER_SEC));
+        dispatch_after(popTime, dispatch_get_main_queue(), ^{
+            if (self->_fetchMap[filePath] != nil) {
+                NSLog(@"[KD] Fetch thumbnail has timed out for path %@, cancelling it.", filePath);
+                [self updateThumbnailFetchStatus:NULL filePath:filePath fileStatus:@"Cancelled"];
+            }
+        });
     }
 
     return TRUE;
-}
-
-- (void)freeBlockedProcessForThumnail:(NSTimer *)timer {
-    NSLog(@"TEST_CK timer has timed out");
-    NSDictionary *userInfo = timer.userInfo;
-    NSString *filePath = userInfo[@"filePath"];
-    NSLog(@"TEST_CK filePath: %@", filePath);
-    NSLog(@"[KD] Cancelling fetch thumbnail for path: %@", filePath);
-    [self updateThumbnailFetchStatus:NULL filePath:filePath fileStatus:@"Cancelled"];
 }
 
 // XPCServiceProxyDelegate protocol implementation

--- a/extensions/MacOSX/kDriveLiteSync/Extension/xpcService.m
+++ b/extensions/MacOSX/kDriveLiteSync/Extension/xpcService.m
@@ -263,7 +263,7 @@
         // Start cancel timer
         dispatch_time_t time = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(60.0 * NSEC_PER_SEC));
         dispatch_after(time, dispatch_get_main_queue(), ^{
-            if (self->_fetchMap[filePath] != nil) {
+            if (self->_fetchThumbnailMap[filePath] != nil) {
                 NSLog(@"[KD] Fetch thumbnail has timed out for path %@, cancelling it.", filePath);
                 [self updateThumbnailFetchStatus:NULL filePath:filePath fileStatus:@"Cancelled"];
             }

--- a/extensions/MacOSX/kDriveLiteSync/Extension/xpcService.m
+++ b/extensions/MacOSX/kDriveLiteSync/Extension/xpcService.m
@@ -273,7 +273,7 @@ const NSString *timeoutBlockKey = @"timeoutBlock";
             
             // Schedule the timeout
             dispatch_time_t time = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(fetchThumbnailTimeout * NSEC_PER_SEC));
-            dispatch_after(time, dispatch_get_main_queue(), timeoutBlock);
+            dispatch_after(time, dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), timeoutBlock);
             
             // Ask the app to fetch the thumbnail
             [self sendMessage:filePath query:@"SET_THUMBNAIL" oneApp:TRUE];

--- a/extensions/MacOSX/kDriveLiteSync/Extension/xpcService.m
+++ b/extensions/MacOSX/kDriveLiteSync/Extension/xpcService.m
@@ -259,9 +259,27 @@
         // Stop the process
         NSLog(@"[KD] Stop process %@ opening thumbnail %@", [NSNumber numberWithInt:pid], filePath);
         kill(pid, SIGSTOP);
+        
+        // Start cancel timer
+        NSLog(@"TEST_CK stating timer for path : %@", filePath);
+        [NSTimer scheduledTimerWithTimeInterval:60.0
+            target:self
+            selector:@selector(freeBlockedProcessForThumnail:)
+            userInfo: @{@"filePath": filePath}
+            repeats:NO];
+
     }
 
     return TRUE;
+}
+
+- (void)freeBlockedProcessForThumnail:(NSTimer *)timer {
+    NSLog(@"TEST_CK timer has timed out");
+    NSDictionary *userInfo = timer.userInfo;
+    NSString *filePath = userInfo[@"filePath"];
+    NSLog(@"TEST_CK filePath: %@", filePath);
+    NSLog(@"[KD] Cancelling fetch thumbnail for path: %@", filePath);
+    [self updateThumbnailFetchStatus:NULL filePath:filePath fileStatus:@"Cancelled"];
 }
 
 // XPCServiceProxyDelegate protocol implementation

--- a/extensions/MacOSX/kDriveLiteSync/Extension/xpcService.m
+++ b/extensions/MacOSX/kDriveLiteSync/Extension/xpcService.m
@@ -393,16 +393,20 @@
 - (void)freeAllStoppedProcesses:(NSString *)path {
     NSLog(@"[KD] Freeing all stopped processes for path: %@", path);
     
-    for (NSString *filePath in _fetchThumbnailMap) {
-        if ([filePath hasPrefix:path]) {
-            NSLog(@"[KD] Freeing fetch thumbnail processes for file: %@", filePath);
-            [self updateThumbnailFetchStatus:NULL filePath:filePath fileStatus:@"Cancelled"];
+    @synchronized (_fetchThumbnailMap) {
+        for (NSString *filePath in _fetchThumbnailMap) {
+            if ([filePath hasPrefix:path]) {
+                NSLog(@"[KD] Freeing fetch thumbnail processes for file: %@", filePath);
+                [self updateThumbnailFetchStatus:NULL filePath:filePath fileStatus:@"Cancelled"];
+            }
         }
     }
-    for (NSString *filePath in _fetchMap) {
-        if ([filePath hasPrefix:path]) {
-            NSLog(@"[KD] Freeing fetch processes for file: %@", filePath);
-            [self updateFetchStatus:NULL filePath:filePath fileStatus:@"Cancelled"];
+    @synchronized (_fetchThumbnailMap) {
+        for (NSString *filePath in _fetchMap) {
+            if ([filePath hasPrefix:path]) {
+                NSLog(@"[KD] Freeing fetch processes for file: %@", filePath);
+                [self updateFetchStatus:NULL filePath:filePath fileStatus:@"Cancelled"];
+            }
         }
     }
 }

--- a/extensions/MacOSX/kDriveLiteSync/Extension/xpcService.m
+++ b/extensions/MacOSX/kDriveLiteSync/Extension/xpcService.m
@@ -246,30 +246,41 @@
     assert(_fetchThumbnailMap);
 
     @synchronized(_fetchThumbnailMap) {
-        if (_fetchThumbnailMap[filePath] == nil) {
-            [_fetchThumbnailMap setObject:[[NSMutableSet alloc] init] forKey:filePath];
-
-            // Ask to the app to fetch the thumbnail
+        NSMutableDictionary *fetchData = _fetchThumbnailMap[filePath];
+        
+        if (fetchData == nil) {
+            // Create new entry with pids and timeout block
+            fetchData = [NSMutableDictionary dictionary];
+            fetchData[@"pids"] = [[NSMutableSet alloc] init];
+            
+            // Create cancelable timeout block
+            dispatch_block_t timeoutBlock = dispatch_block_create(0, ^{
+                @synchronized (self->_fetchThumbnailMap) {
+                    NSMutableDictionary *data = self->_fetchThumbnailMap[filePath];
+                    if (data != nil) {
+                        NSLog(@"[KD] Fetch thumbnail has timed out for path %@, cancelling it.", filePath);
+                        [self updateThumbnailFetchStatus:NULL filePath:filePath fileStatus:@"Cancelled"];
+                    }
+                }
+            });
+            fetchData[@"timeoutBlock"] = timeoutBlock;
+            
+            [_fetchThumbnailMap setObject:fetchData forKey:filePath];
+            
+            // Schedule the timeout
+            dispatch_time_t time = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(60.0 * NSEC_PER_SEC));
+            dispatch_after(time, dispatch_get_main_queue(), timeoutBlock);
+            
+            // Ask the app to fetch the thumbnail
             [self sendMessage:filePath query:@"SET_THUMBNAIL" oneApp:TRUE];
         }
 
         // Store the pid
-        [[_fetchThumbnailMap objectForKey:filePath] addObject:[NSNumber numberWithInt:pid]];
+        [fetchData[@"pids"] addObject:[NSNumber numberWithInt:pid]];
 
         // Stop the process
         NSLog(@"[KD] Stop process %@ opening thumbnail %@", [NSNumber numberWithInt:pid], filePath);
         kill(pid, SIGSTOP);
-        
-        // Start cancel timer
-        dispatch_time_t time = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(60.0 * NSEC_PER_SEC));
-        dispatch_after(time, dispatch_get_main_queue(), ^{
-            @synchronized (self->_fetchThumbnailMap) {
-                if (self->_fetchThumbnailMap[filePath] != nil) {
-                    NSLog(@"[KD] Fetch thumbnail has timed out for path %@, cancelling it.", filePath);
-                    [self updateThumbnailFetchStatus:NULL filePath:filePath fileStatus:@"Cancelled"];
-                }
-            }
-        });
     }
 
     return TRUE;
@@ -342,13 +353,20 @@
 
     NSLog(@"[KD] updateThumbnailFetchStatus %@ %@", filePath, fileStatus);
     @synchronized(_fetchThumbnailMap) {
-        if (_fetchThumbnailMap[filePath] == nil) {
+        NSMutableDictionary *fetchData = _fetchThumbnailMap[filePath];
+        if (fetchData == nil) {
             NSLog(@"[KD] Warning: File not registered %@", filePath);
             return;
         }
 
+        // Cancel the pending timeout block if it exists
+        dispatch_block_t timeoutBlock = fetchData[@"timeoutBlock"];
+        if (timeoutBlock) {
+            dispatch_block_cancel(timeoutBlock);
+        }
+
         // Resume the stopped processes
-        for (NSNumber *pidNumber in _fetchThumbnailMap[filePath]) {
+        for (NSNumber *pidNumber in fetchData[@"pids"]) {
             NSLog(@"[KD] Resume process %@ opening thumbnail %@", pidNumber, filePath);
             kill([pidNumber intValue], SIGCONT);
         }
@@ -403,7 +421,7 @@
             }
         }
     }
-    @synchronized (_fetchThumbnailMap) {
+    @synchronized (_fetchMap) {
         for (NSString *filePath in _fetchMap) {
             if ([filePath hasPrefix:path]) {
                 NSLog(@"[KD] Freeing fetch processes for file: %@", filePath);

--- a/extensions/MacOSX/kDriveLiteSync/Extension/xpcService.m
+++ b/extensions/MacOSX/kDriveLiteSync/Extension/xpcService.m
@@ -263,9 +263,11 @@
         // Start cancel timer
         dispatch_time_t time = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(60.0 * NSEC_PER_SEC));
         dispatch_after(time, dispatch_get_main_queue(), ^{
-            if (self->_fetchThumbnailMap[filePath] != nil) {
-                NSLog(@"[KD] Fetch thumbnail has timed out for path %@, cancelling it.", filePath);
-                [self updateThumbnailFetchStatus:NULL filePath:filePath fileStatus:@"Cancelled"];
+            @synchronized (self->_fetchThumbnailMap) {
+                if (self->_fetchThumbnailMap[filePath] != nil) {
+                    NSLog(@"[KD] Fetch thumbnail has timed out for path %@, cancelling it.", filePath);
+                    [self updateThumbnailFetchStatus:NULL filePath:filePath fileStatus:@"Cancelled"];
+                }
             }
         });
     }

--- a/extensions/MacOSX/kDriveLiteSync/Extension/xpcServiceProxy.h
+++ b/extensions/MacOSX/kDriveLiteSync/Extension/xpcServiceProxy.h
@@ -28,7 +28,7 @@
 - (void)updateThumbnailFetchStatus:(NSString *)appId filePath:(NSString *)filePath fileStatus:(NSString *)fileStatus;
 - (void)connectionEnded:(NSString *)appId;
 - (NSMutableString *)getFetchingAppList;
-- (void)freeAllStoppedProcesses;
+- (void)freeAllStoppedProcesses:(NSString *)path;
 @end
 
 @interface XPCServiceProxy : NSObject <XPCLiteSyncExtensionProtocol, NSXPCListenerDelegate>

--- a/extensions/MacOSX/kDriveLiteSync/Extension/xpcServiceProxy.h
+++ b/extensions/MacOSX/kDriveLiteSync/Extension/xpcServiceProxy.h
@@ -28,7 +28,7 @@
 - (void)updateThumbnailFetchStatus:(NSString *)appId filePath:(NSString *)filePath fileStatus:(NSString *)fileStatus;
 - (void)connectionEnded:(NSString *)appId;
 - (NSMutableString *)getFetchingAppList;
-- (void)freeAllStoppedProcesses;
+- (void)freeAllStoppedProcesses;
 @end
 
 @interface XPCServiceProxy : NSObject <XPCLiteSyncExtensionProtocol, NSXPCListenerDelegate>

--- a/extensions/MacOSX/kDriveLiteSync/Extension/xpcServiceProxy.h
+++ b/extensions/MacOSX/kDriveLiteSync/Extension/xpcServiceProxy.h
@@ -28,6 +28,7 @@
 - (void)updateThumbnailFetchStatus:(NSString *)appId filePath:(NSString *)filePath fileStatus:(NSString *)fileStatus;
 - (void)connectionEnded:(NSString *)appId;
 - (NSMutableString *)getFetchingAppList;
+- (void)freeAllStoppedProcesses;
 @end
 
 @interface XPCServiceProxy : NSObject <XPCLiteSyncExtensionProtocol, NSXPCListenerDelegate>

--- a/extensions/MacOSX/kDriveLiteSync/Extension/xpcServiceProxy.m
+++ b/extensions/MacOSX/kDriveLiteSync/Extension/xpcServiceProxy.m
@@ -151,5 +151,11 @@
     callback([_delegate getFetchingAppList]);
 }
 
+- (void)freeAllStoppedProcesses
+{
+    NSLog(@"[KD] freeAllStoppedProcesses called");
+    [_delegate freeAllStoppedProcesses];
+}
+
 @end
 

--- a/extensions/MacOSX/kDriveLiteSync/Extension/xpcServiceProxy.m
+++ b/extensions/MacOSX/kDriveLiteSync/Extension/xpcServiceProxy.m
@@ -151,10 +151,10 @@
     callback([_delegate getFetchingAppList]);
 }
 
-- (void)freeAllStoppedProcesses
+- (void)freeAllStoppedProcesses:(NSString *)path
 {
     NSLog(@"[KD] freeAllStoppedProcesses called");
-    [_delegate freeAllStoppedProcesses];
+    [_delegate freeAllStoppedProcesses:path];
 }
 
 @end

--- a/extensions/windows/cfapi/Vfs/dllmain.cpp
+++ b/extensions/windows/cfapi/Vfs/dllmain.cpp
@@ -98,21 +98,19 @@ DLL_EXP int __cdecl vfsStart(const wchar_t *driveId, const wchar_t *userId, cons
     return S_OK;
 }
 
-DLL_EXP int __cdecl vfsStop(const wchar_t *driveId, const wchar_t *folderId, bool unregister) {
+DLL_EXP int __cdecl vfsStop(const wchar_t *driveId, const wchar_t *folderId) {
     TRACE_DEBUG(L"Stop VFS");
 
     int ret = S_OK;
 
     CloudProvider *cloudProvider = s_cloudProviders[PROVIDERID(driveId, folderId)];
     if (cloudProvider) {
-        if (unregister) {
-            TRACE_DEBUG(L"Stop cloud provider");
-            if (!cloudProvider->stop()) {
-                TRACE_ERROR(L"Stop failed!");
-                ret = E_ABORT;
-            }
-            TRACE_DEBUG(L"Stop cloud provider done");
+        TRACE_DEBUG(L"Stop cloud provider");
+        if (!cloudProvider->stop()) {
+            TRACE_ERROR(L"Stop failed!");
+            ret = E_ABORT;
         }
+        TRACE_DEBUG(L"Stop cloud provider done");
 
         delete cloudProvider;
         s_cloudProviders.erase(PROVIDERID(driveId, folderId));

--- a/extensions/windows/cfapi/Vfs/vfs.h
+++ b/extensions/windows/cfapi/Vfs/vfs.h
@@ -43,7 +43,7 @@ DLL_EXP int __cdecl vfsInit(TraceCbk debugCallback, const wchar_t *appName, DWOR
 DLL_EXP int __cdecl vfsStart(const wchar_t *driveId, const wchar_t *userId, const wchar_t *folderId, const wchar_t *folderName,
                              const wchar_t *folderPath, wchar_t *namespaceCLSID, DWORD *namespaceCLSIDSize);
 
-DLL_EXP int __cdecl vfsStop(const wchar_t *driveId, const wchar_t *folderId, bool unregister);
+DLL_EXP int __cdecl vfsStop(const wchar_t *driveId, const wchar_t *folderId);
 
 DLL_EXP int __cdecl vfsGetPlaceHolderStatus(const wchar_t *filePath, bool *isPlaceholder, bool *isDehydrated, bool *isSynced);
 

--- a/src/libcommonserver/vfs/vfs.cpp
+++ b/src/libcommonserver/vfs/vfs.cpp
@@ -34,9 +34,7 @@ using namespace KDC;
 
 Vfs::Vfs(const VfsSetupParams &vfsSetupParams, QObject *parent) :
     QObject(parent),
-    _vfsSetupParams(vfsSetupParams),
-    _extendedLog(false),
-    _started(false) {}
+    _vfsSetupParams(vfsSetupParams) {}
 
 void Vfs::starVfsWorkers() {
     // Start hydration/dehydration workers
@@ -111,9 +109,9 @@ ExitInfo Vfs::start(bool &installationDone, bool &activationDone, bool &connecti
     return ExitCode::Ok;
 }
 
-void Vfs::stop(bool unregister) {
+void Vfs::stop() {
     if (_started) {
-        stopImpl(unregister);
+        stopImpl();
         _started = false;
     }
 }

--- a/src/libcommonserver/vfs/vfs.h
+++ b/src/libcommonserver/vfs/vfs.h
@@ -122,7 +122,7 @@ class Vfs : public QObject {
 
         /// Stop interaction with VFS provider. Like when the client application quits.
         /// Also deregister the folder with the sync provider, like when a folder is removed.
-        void stop(bool unregister);
+        void stop();
 
         /** Whether the socket api should show pin state options
          *
@@ -349,7 +349,7 @@ class Vfs : public QObject {
          */
         virtual ExitInfo startImpl(bool &installationDone, bool &activationDone, bool &connectionDone) = 0;
 
-        virtual void stopImpl(bool unregister) = 0;
+        virtual void stopImpl() = 0;
 
         log4cplus::Logger logger() const { return _vfsSetupParams.logger; }
 
@@ -386,8 +386,8 @@ class Vfs : public QObject {
         }
 
     private:
-        bool _extendedLog;
-        bool _started;
+        bool _extendedLog{false};
+        bool _started{false};
 };
 } // namespace KDC
 
@@ -437,24 +437,18 @@ class VfsOff : public Vfs {
         ExitInfo setAppExcludeList() override { return ExitCode::Ok; }
         ExitInfo getFetchingAppList(AppTable &) override { return ExitCode::Ok; }
         ExitInfo getFetchingAppList(QHash<QString, QString> &) override { return ExitCode::Ok; }
-        void exclude(const SyncPath &) override { /*VfsOff*/
-        }
+        void exclude(const SyncPath &) override { /*VfsOff*/ }
         bool isExcluded(const SyncPath &) override { return false; }
         bool fileStatusChanged(const SyncPath &, const SyncFileStatus) override { return true; }
 
-        void clearFileAttributes(const SyncPath &) override { /*VfsOff*/
-        }
-        void dehydrate(const SyncPath &) override { /*VfsOff*/
-        }
-        void hydrate(const SyncPath &) override { /*VfsOff*/
-        }
-        void cancelHydrate(const SyncPath &) override { /*VfsOff*/
-        }
+        void clearFileAttributes(const SyncPath &) override { /*VfsOff*/ }
+        void dehydrate(const SyncPath &) override { /*VfsOff*/ }
+        void hydrate(const SyncPath &) override { /*VfsOff*/ }
+        void cancelHydrate(const SyncPath &) override { /*VfsOff*/ }
 
     protected:
         ExitInfo startImpl(bool &installationDone, bool &activationDone, bool &connectionDone) override;
-        void stopImpl(bool /*unregister*/) override { /*VfsOff*/
-        }
+        void stopImpl() override { /*VfsOff*/ }
 
         friend class TestWorkers;
 };

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -535,7 +535,7 @@ void AppServer::cleanup() {
     {
         const std::scoped_lock lock(vfsMapMutex);
         for (const auto &[syncDbId, _]: vfsMap) {
-            if (const auto exitInfo = stopVfs(syncDbId, false); !exitInfo) {
+            if (const auto exitInfo = stopVfs(syncDbId); !exitInfo) {
                 LOG_WARN(_logger, "Error in stopVfs for syncDbId=" << syncDbId << exitInfo);
             }
         }
@@ -591,7 +591,7 @@ void AppServer::stopSyncTask(int syncDbId) {
     }
 
     // Stop Vfs
-    if (const auto exitInfo = stopVfs(syncDbId, true); !exitInfo) {
+    if (const auto exitInfo = stopVfs(syncDbId); !exitInfo) {
         LOG_WARN(_logger, "Error in stopVfs for syncDbId=" << syncDbId << " : " << exitInfo);
     }
 
@@ -3855,7 +3855,7 @@ ExitInfo AppServer::createAndStartVfs(const Sync &sync) noexcept {
     return ExitCode::Ok;
 }
 
-ExitInfo AppServer::stopVfs(int syncDbId, bool unregister) {
+ExitInfo AppServer::stopVfs(int syncDbId) {
     LOG_DEBUG(_logger, "Stop VFS for syncDbId=" << syncDbId);
 
     // Stop Vfs
@@ -3871,7 +3871,7 @@ ExitInfo AppServer::stopVfs(int syncDbId, bool unregister) {
         return {ExitCode::DataError, ExitCause::Unknown};
     }
 
-    vfsMapIt->second->stop(unregister);
+    vfsMapIt->second->stop();
 
     LOG_DEBUG(_logger, "Stop VFS for syncDbId=" << syncDbId << " done");
 
@@ -3919,7 +3919,7 @@ ExitInfo AppServer::setSupportsVirtualFiles(int syncDbId, bool value) {
         syncPalMapIt->second->stop();
 
         // Stop Vfs
-        if (const auto exitInfo = stopVfs(syncDbId, true); !exitInfo) {
+        if (const auto exitInfo = stopVfs(syncDbId); !exitInfo) {
             LOG_WARN(_logger, "Error in stopVfs for syncDbId=" << sync.dbId() << " : " << exitInfo);
             return exitInfo;
         }

--- a/src/server/appserver.h
+++ b/src/server/appserver.h
@@ -130,7 +130,7 @@ class AppServer : public SharedTools::QtSingleApplication {
         void clearSyncCacheMap() { _syncCacheMap.clear(); }
         void loadUsersInfo() { onLoadInfo(); }
 
-        [[nodiscard]] ExitInfo stopVfs(int syncDbId, bool unregister);
+        [[nodiscard]] ExitInfo stopVfs(int syncDbId);
         [[nodiscard]] ExitInfo startSyncs(User &user);
         void stopSyncTask(int syncDbId);
         [[nodiscard]] ExitInfo setSupportsVirtualFiles(int syncDbId, bool value);

--- a/src/server/comm/litesynccommclient_mac.mm
+++ b/src/server/comm/litesynccommclient_mac.mm
@@ -111,6 +111,8 @@ class LiteSyncCommClientPrivate {
         log4cplus::Logger _logger;
         Connector *_connector = nullptr;
         ExecuteCommand _executeCommand = nullptr;
+
+        void freeAllStoppedProcesses();
 };
 
 } // namespace KDC
@@ -560,6 +562,8 @@ bool LiteSyncCommClientPrivate::vfsStart(const SyncPath &folderPath) {
         return false;
     }
 
+    freeAllStoppedProcesses();
+
     NSString *nsPath = [NSString stringWithCString:folderPath.c_str() encoding:NSUTF8StringEncoding];
     if (![_connector registerFolder:nsPath]) {
         LOG_ERROR(_logger, "Cannot register folder!");
@@ -609,6 +613,8 @@ bool LiteSyncCommClientPrivate::vfsStop(const SyncPath &folderPath) {
         LOG_ERROR(_logger, "Connector not initialized!");
         return false;
     }
+
+    freeAllStoppedProcesses();
 
     NSString *nsPath = [NSString stringWithCString:folderPath.c_str() encoding:NSUTF8StringEncoding];
     if (![_connector unregisterFolder:nsPath]) {
@@ -730,6 +736,10 @@ bool LiteSyncCommClientPrivate::getFetchingAppList(AppTable &appTable) {
     }
 
     return true;
+}
+
+void LiteSyncCommClientPrivate::freeAllStoppedProcesses() {
+
 }
 
 // LiteSyncCommClient implementation
@@ -1593,6 +1603,10 @@ void LiteSyncCommClient::resetConnector(log4cplus::Logger logger, ExecuteCommand
             throw std::runtime_error("Error in LiteSyncCommClientPrivate constructor!");
         }
     }
+}
+
+void LiteSyncCommClient::freeAllStoppedProcesses() {
+
 }
 
 } // namespace KDC

--- a/src/server/comm/litesynccommclient_mac.mm
+++ b/src/server/comm/litesynccommclient_mac.mm
@@ -84,7 +84,7 @@
 - (BOOL)updateThumbnailFetchStatus:(NSString *_Nonnull)path fileStatus:(NSString *_Nonnull)status;
 - (BOOL)getFetchingAppList:(NSMutableDictionary<NSString *, NSString *> *_Nonnull *_Nonnull)appMap;
 - (BOOL)setThumbnail:(NSString *_Nonnull)path image:(NSImage *_Nonnull)image;
-- (void)freeAllStoppedProcesses;
+- (void)freeAllStoppedProcesses:(NSString *_Nonnull)path;
 @end
 
 namespace KDC {
@@ -462,9 +462,9 @@ class LiteSyncCommClientPrivate {
     return true;
 }
 
-- (void)freeAllStoppedProcesses {
+- (void)freeAllStoppedProcesses:(NSString *_Nonnull)path {
     if (_connection) {
-        [[_connection remoteObjectProxy] freeAllStoppedProcesses];
+        [[_connection remoteObjectProxy] freeAllStoppedProcesses:path];
     }
 }
 
@@ -566,9 +566,9 @@ bool LiteSyncCommClientPrivate::vfsStart(const SyncPath &folderPath) {
         return false;
     }
 
-    [_connector freeAllStoppedProcesses];
-
     NSString *nsPath = [NSString stringWithCString:folderPath.c_str() encoding:NSUTF8StringEncoding];
+    [_connector freeAllStoppedProcesses:nsPath];
+
     if (![_connector registerFolder:nsPath]) {
         LOG_ERROR(_logger, "Cannot register folder!");
         return false;
@@ -618,9 +618,9 @@ bool LiteSyncCommClientPrivate::vfsStop(const SyncPath &folderPath) {
         return false;
     }
 
-    [_connector freeAllStoppedProcesses];
-
     NSString *nsPath = [NSString stringWithCString:folderPath.c_str() encoding:NSUTF8StringEncoding];
+    [_connector freeAllStoppedProcesses:nsPath];
+
     if (![_connector unregisterFolder:nsPath]) {
         LOG_ERROR(_logger, "Cannot unregister folder!");
         return false;

--- a/src/server/comm/litesynccommclient_mac.mm
+++ b/src/server/comm/litesynccommclient_mac.mm
@@ -84,7 +84,7 @@
 - (BOOL)updateThumbnailFetchStatus:(NSString *_Nonnull)path fileStatus:(NSString *_Nonnull)status;
 - (BOOL)getFetchingAppList:(NSMutableDictionary<NSString *, NSString *> *_Nonnull *_Nonnull)appMap;
 - (BOOL)setThumbnail:(NSString *_Nonnull)path image:(NSImage *_Nonnull)image;
-
+- (void)freeAllStoppedProcesses;
 @end
 
 namespace KDC {
@@ -111,8 +111,6 @@ class LiteSyncCommClientPrivate {
         log4cplus::Logger _logger;
         Connector *_connector = nullptr;
         ExecuteCommand _executeCommand = nullptr;
-
-        void freeAllStoppedProcesses();
 };
 
 } // namespace KDC
@@ -464,6 +462,12 @@ class LiteSyncCommClientPrivate {
     return true;
 }
 
+- (void)freeAllStoppedProcesses {
+    if (_connection) {
+        [[_connection remoteObjectProxy] freeAllStoppedProcesses];
+    }
+}
+
 // xpcLiteSyncExtensionRemoteProtocol protocol implementation
 - (void)getAppId:(void (^)(NSString *))callback {
     NSLog(@"[KD] getAppId called");
@@ -562,7 +566,7 @@ bool LiteSyncCommClientPrivate::vfsStart(const SyncPath &folderPath) {
         return false;
     }
 
-    freeAllStoppedProcesses();
+    [_connector freeAllStoppedProcesses];
 
     NSString *nsPath = [NSString stringWithCString:folderPath.c_str() encoding:NSUTF8StringEncoding];
     if (![_connector registerFolder:nsPath]) {
@@ -614,7 +618,7 @@ bool LiteSyncCommClientPrivate::vfsStop(const SyncPath &folderPath) {
         return false;
     }
 
-    freeAllStoppedProcesses();
+    [_connector freeAllStoppedProcesses];
 
     NSString *nsPath = [NSString stringWithCString:folderPath.c_str() encoding:NSUTF8StringEncoding];
     if (![_connector unregisterFolder:nsPath]) {
@@ -736,10 +740,6 @@ bool LiteSyncCommClientPrivate::getFetchingAppList(AppTable &appTable) {
     }
 
     return true;
-}
-
-void LiteSyncCommClientPrivate::freeAllStoppedProcesses() {
-
 }
 
 // LiteSyncCommClient implementation
@@ -1603,10 +1603,6 @@ void LiteSyncCommClient::resetConnector(log4cplus::Logger logger, ExecuteCommand
             throw std::runtime_error("Error in LiteSyncCommClientPrivate constructor!");
         }
     }
-}
-
-void LiteSyncCommClient::freeAllStoppedProcesses() {
-
 }
 
 } // namespace KDC

--- a/src/server/vfs/mac/vfs_mac.cpp
+++ b/src/server/vfs/mac/vfs_mac.cpp
@@ -134,19 +134,17 @@ ExitInfo VfsMac::startImpl(bool &installationDone, bool &activationDone, bool &c
     return ExitCode::Ok;
 }
 
-void VfsMac::stopImpl(bool unregister) {
+void VfsMac::stopImpl() {
     LOG_DEBUG(logger(), "stop - syncDbId = " << _vfsSetupParams.syncDbId);
 
-    if (unregister) {
-        if (!_connector) {
-            LOG_WARN(logger(), "LiteSyncExtConnector not initialized!");
-            return;
-        }
+    if (!_connector) {
+        LOG_WARN(logger(), "LiteSyncExtConnector not initialized!");
+        return;
+    }
 
-        if (!_connector->vfsStop(_vfsSetupParams.syncDbId)) {
-            LOG_WARN(logger(), "Error in vfsStop!");
-            return;
-        }
+    if (!_connector->vfsStop(_vfsSetupParams.syncDbId)) {
+        LOG_WARN(logger(), "Error in vfsStop!");
+        return;
     }
 }
 

--- a/src/server/vfs/mac/vfs_mac.h
+++ b/src/server/vfs/mac/vfs_mac.h
@@ -74,7 +74,7 @@ class VfsMac : public Vfs {
 
     protected:
         ExitInfo startImpl(bool &installationDone, bool &activationDone, bool &connectionDone) override;
-        void stopImpl(bool unregister) override;
+        void stopImpl() override;
 
         friend class TestWorkers;
 

--- a/src/server/vfs/win/vfs_win.cpp
+++ b/src/server/vfs/win/vfs_win.cpp
@@ -93,11 +93,10 @@ ExitInfo VfsWin::startImpl(bool &, bool &, bool &) {
     return ExitCode::Ok;
 }
 
-void VfsWin::stopImpl(bool unregister) {
+void VfsWin::stopImpl() {
     LOG_DEBUG(logger(), "stop: syncDbId=" << _vfsSetupParams.syncDbId);
 
-    if (vfsStop(std::to_wstring(_vfsSetupParams.driveId).c_str(), std::to_wstring(_vfsSetupParams.syncDbId).c_str(),
-                unregister) != S_OK) {
+    if (vfsStop(std::to_wstring(_vfsSetupParams.driveId).c_str(), std::to_wstring(_vfsSetupParams.syncDbId).c_str()) != S_OK) {
         LOG_WARN(logger(), "Error in vfsStop: syncDbId=" << _vfsSetupParams.syncDbId);
     }
 

--- a/src/server/vfs/win/vfs_win.h
+++ b/src/server/vfs/win/vfs_win.h
@@ -80,7 +80,7 @@ class VFS_EXPORT VfsWin : public Vfs {
 
     protected:
         ExitInfo startImpl(bool &installationDone, bool &activationDone, bool &connectionDone) override;
-        void stopImpl(bool unregister) override;
+        void stopImpl() override;
 
         friend class TestWorkers;
 

--- a/test/server/appserver/testappserver.cpp
+++ b/test/server/appserver/testappserver.cpp
@@ -130,7 +130,7 @@ void TestAppServer::testInitAndStopSyncPal() {
     CPPUNIT_ASSERT(waitForSyncStatus(syncDbId, SyncStatus::Stopped));
 
     // Stop Vfs
-    exitInfo = _appPtr->stopVfs(syncDbId, /*unregister*/ false);
+    exitInfo = _appPtr->stopVfs(syncDbId);
     CPPUNIT_ASSERT(exitInfo);
 }
 

--- a/test/server/workers/testworkers.cpp
+++ b/test/server/workers/testworkers.cpp
@@ -171,7 +171,7 @@ void TestWorkers::tearDown() {
     }
     if (_vfs) {
         // Stop Vfs
-        _vfs->stopImpl(true);
+        _vfs->stopImpl();
         _vfs = nullptr;
     }
     TestBase::stop();

--- a/version.json
+++ b/version.json
@@ -3,7 +3,7 @@
     "major": 3,
     "minor": 8,
     "patch": 2,
-    "build": 3,
+    "build": 200,
     "year": 2026
   }
 }


### PR DESCRIPTION
This PR implements 2 features:
- Free the fetch thumbnail processes after 60 seconds if they are not finished yet.
- Free all processes stopped by the LiteSync on sync start and stop.

Also, the parameter `unregister` has been removed from the method `AppServer::stopVfs` meaning that the LiteSync will stop watching a folder whose associated synchronization has been stopped.