### PR TITLE
feat: SynchroErrorsInformationBlockView

### DIFF
--- a/src/front/macOS/kDrive/UI/Views/MainWindow/Home/Components/SynchroErrorsInformationBlockView.swift
+++ b/src/front/macOS/kDrive/UI/Views/MainWindow/Home/Components/SynchroErrorsInformationBlockView.swift
@@ -39,15 +39,19 @@ struct SynchroErrorsInformationBlockView: View {
         InformationBlockView(
             title: title,
             subtitle: AttributedString(KDriveLocalizable.informationBlockSynchroErrorSubtitle),
-            button: .init(title: KDriveLocalizable.buttonFixErrors, action: {})
+            button: .init(title: KDriveLocalizable.buttonFixErrors) {
+                // TODO: Connect to MainViewState implementation
+            }
         )
     }
 }
 
 #Preview("One error") {
     SynchroErrorsInformationBlockView(errorCount: 1)
+        .padding(AppPadding.padding32)
 }
 
 #Preview("Multiple errors") {
     SynchroErrorsInformationBlockView(errorCount: 5)
+        .padding(AppPadding.padding32)
 }

--- a/src/front/macOS/kDrive/UI/Views/MainWindow/Home/Components/SynchroErrorsInformationBlockView.swift
+++ b/src/front/macOS/kDrive/UI/Views/MainWindow/Home/Components/SynchroErrorsInformationBlockView.swift
@@ -1,0 +1,53 @@
+/*
+ Infomaniak kDrive - Desktop
+ Copyright (C) 2023-2025 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import kDriveCoreUI
+import kDriveResources
+import SwiftUI
+
+struct SynchroErrorsInformationBlockView: View {
+    let errorCount: Int
+
+    private var title: AttributedString {
+        do {
+            return try AttributedString(markdown: KDriveLocalizable.informationBlockSynchroErrorTitle(errorCount))
+        } catch {
+            #if DEBUG
+            fatalError("Failed decoding AttributedString: \(error)")
+            #else
+            return AttributedString()
+            #endif
+        }
+    }
+
+    var body: some View {
+        InformationBlockView(
+            title: title,
+            subtitle: AttributedString(KDriveLocalizable.informationBlockSynchroErrorSubtitle),
+            button: .init(title: KDriveLocalizable.buttonFixErrors, action: {})
+        )
+    }
+}
+
+#Preview("One error") {
+    SynchroErrorsInformationBlockView(errorCount: 1)
+}
+
+#Preview("Multiple errors") {
+    SynchroErrorsInformationBlockView(errorCount: 5)
+}

--- a/src/front/macOS/kDrive/UI/Views/MainWindow/Home/HomeView.swift
+++ b/src/front/macOS/kDrive/UI/Views/MainWindow/Home/HomeView.swift
@@ -60,6 +60,11 @@ struct HomeView: View {
             GreetingStatusView(name: userName, state: state)
                 .padding(.bottom, AppPadding.padding8)
 
+            if let errorCount = mainViewModel.currentSynchro?.errorCount,
+               errorCount > 0 {
+                SynchroErrorsInformationBlockView(errorCount: errorCount)
+            }
+
             GeometryReader { proxy in
                 HStack(spacing: HomeView.spacing) {
                     SynchroStatusView(state: state, performAction: didTapStateButton)

--- a/src/front/macOS/kDriveCoreUI/Models/UIs/UISynchro+Mappers.swift
+++ b/src/front/macOS/kDriveCoreUI/Models/UIs/UISynchro+Mappers.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import kDriveCore
+import OrderedCollections
 
 public extension UISynchro {
     init(synchro: Synchro) {
@@ -30,7 +31,8 @@ public extension UISynchro {
             dbId: Int(synchro.dbId),
             driveDbId: Int(synchro.driveDbId),
             localPath: URL(fileURLWithPath: synchro.localPath),
-            progressInfo: progressInfo
+            progressInfo: progressInfo,
+            errorCount: synchro.errors.count
         )
     }
 }

--- a/src/front/macOS/kDriveCoreUI/Models/UIs/UISynchro.swift
+++ b/src/front/macOS/kDriveCoreUI/Models/UIs/UISynchro.swift
@@ -29,11 +29,14 @@ public struct UISynchro: Sendable, Equatable, Hashable {
     public let localPath: URL
     public let progressInfo: UISynchroProgressInfo?
 
-    public init(dbId: Int, driveDbId: Int, localPath: URL, progressInfo: UISynchroProgressInfo?) {
+    public let errorCount: Int
+
+    public init(dbId: Int, driveDbId: Int, localPath: URL, progressInfo: UISynchroProgressInfo?, errorCount: Int) {
         self.dbId = dbId
         self.driveDbId = driveDbId
         self.localPath = localPath
         self.progressInfo = progressInfo
+        self.errorCount = errorCount
     }
 }
 

--- a/src/front/macOS/kDriveCoreUI/Tokens/Font+Tokens.swift
+++ b/src/front/macOS/kDriveCoreUI/Tokens/Font+Tokens.swift
@@ -33,7 +33,7 @@ public extension Font {
         public static let title3: Font = .title3
         public static let title3Emphasized: Font = .title3.weight(.emphasized)
 
-        public static let headline: NSFont = .preferredFont(forTextStyle: .headline)
+        public static let headline: Font = .headline
 
         public static let body: Font = .body
         public static let bodyEmphasized: Font = .body.weight(.emphasized)

--- a/src/front/macOS/kDriveResources/Localizable/de.lproj/Localizable.strings
+++ b/src/front/macOS/kDriveResources/Localizable/de.lproj/Localizable.strings
@@ -4,8 +4,11 @@
  * Locale: de, German
  * Tagged: macOS
  * Exported by: Philippe Weidmann
- * Exported at: Fri, 30 Jan 2026 08:14:30 +0100
+ * Exported at: Mon, 02 Feb 2026 14:10:19 +0100
  */
+
+/* loco:698053a65bddc8df790d0212 */
+" informationBlockSynchroErrorSubtitle" = "Einige Dateien konnten nicht synchronisiert werden.";
 
 /* loco:696a483470f3b70399021c12 */
 "buttonAddStorage" = "Speicher hinzufügen";
@@ -14,7 +17,7 @@
 "buttonAdvancedParameters" = "Erweiterte Einstellungen";
 
 /* loco:696a343b72b6dc32e00557a4 */
-"buttonClose" = "Schließen Sie";
+"buttonClose" = "Schliessen Sie";
 
 /* loco:691deb0be15255c13908ba42 */
 "buttonContinue" = "Weiter";
@@ -24,6 +27,9 @@
 
 /* loco:6930506962426d4ff30af473 */
 "buttonFinishInstallation" = "Die Installation beenden";
+
+/* loco:698052d464e4b53cef0e9272 */
+"buttonFixErrors" = "Fehler beheben";
 
 /* loco:69304d546385bb9cfc03e524 */
 "buttonKDriveIsActivated" = "Ich habe kDrive aktiviert";
@@ -101,7 +107,7 @@
 "driveMaintenanceErrorTitle" = "Instandhaltung in Arbeit";
 
 /* loco:6979e3dfba525501090fbfa8 */
-"driveWakingUpErrorDescription" = "Das kDrive wird gerade aufgeweckt... das kann einen Moment dauern.";
+"driveWakingUpErrorDescription" = "Das kDrive wird gerade aufgeweckt… das kann einen Moment dauern.";
 
 /* loco:6979e389195e90fdc909d252 */
 "driveWakingUpErrorTitle" = "Aufwecken des kDrive läuft";
@@ -126,12 +132,6 @@
 
 /* loco:696a47fd5b6db1a9b1063182 */
 "informationBlockKDriveFullTitle" = "Ihr kDrive ist voll";
-
-/* loco:696a4fcf3932da71d1075552 */
-"informationBlockSynchroErrorTitle" = "";
-
-/* loco:696a4fdd3932da71d1075554 */
-"informationBlockSynchroErrorTitle-plural" = "";
 
 /* loco:6930595e7664999c6a08c8a4 */
 "instructionEnableKDrive" = "Aktivieren Sie kDrive.app";
@@ -176,13 +176,13 @@
 "instructionRestartIfNecessary" = "Starten Sie die Anwendung auf Wunsch neu";
 
 /* loco:693050ed6a0836d25507da22 */
-"onboardingAuthorizationExtensionDescription" = "Lassen Sie kDrive in den macOS-Einstellungen zu :";
+"onboardingAuthorizationExtensionDescription" = "Lassen Sie kDrive in den macOS-Einstellungen zu:";
 
 /* loco:6930509e14b396d6fc04b0f2 */
 "onboardingAuthorizationExtensionTitle" = "Aktivieren Sie kDrive auf Ihrem Mac";
 
 /* loco:6930510648920a67910d1094 */
-"onboardingAuthorizationFullDiskDescription" = "Um die Installation abzuschließen, müssen Sie kDrive den Zugriff auf Ihre Ordner erlauben :";
+"onboardingAuthorizationFullDiskDescription" = "Um die Installation abzuschliessen, müssen Sie kDrive den Zugriff auf Ihre Ordner erlauben:";
 
 /* loco:693050bab2a2c1990a0d2f04 */
 "onboardingAuthorizationFullDiskTitle" = "Erlauben Sie den Zugriff auf Ordner";

--- a/src/front/macOS/kDriveResources/Localizable/de.lproj/Localizable.stringsdict
+++ b/src/front/macOS/kDriveResources/Localizable/de.lproj/Localizable.stringsdict
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+ Loco ios export: Xcode Stringsdict (legacy)
+ Project: kDrive Desktop
+ Locale: de, German
+ Tagged: macOS-stringsdict
+ Exported by: Philippe Weidmann
+ Exported at: Mon, 02 Feb 2026 14:09:58 +0100
+-->
+<plist version="1.0">
+  <dict>
+    <key>informationBlockSynchroErrorTitle</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@value@</string>
+      <key>value</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>d</string>
+        <key>one</key>
+        <string>Sie haben **einen Synchronisationsfehler**</string>
+        <key>other</key>
+        <string>Sie haben **%lld Synchronisierungsfehler**</string>
+      </dict>
+    </dict>
+  </dict>
+</plist>

--- a/src/front/macOS/kDriveResources/Localizable/en.lproj/Localizable.strings
+++ b/src/front/macOS/kDriveResources/Localizable/en.lproj/Localizable.strings
@@ -4,8 +4,11 @@
  * Locale: en, English
  * Tagged: macOS
  * Exported by: Philippe Weidmann
- * Exported at: Fri, 30 Jan 2026 08:14:30 +0100
+ * Exported at: Mon, 02 Feb 2026 14:10:19 +0100
  */
+
+/* loco:698053a65bddc8df790d0212 */
+" informationBlockSynchroErrorSubtitle" = "Some files could not be synchronized.";
 
 /* loco:696a483470f3b70399021c12 */
 "buttonAddStorage" = "Add Storage";
@@ -25,8 +28,11 @@
 /* loco:6930506962426d4ff30af473 */
 "buttonFinishInstallation" = "Finish installation";
 
+/* loco:698052d464e4b53cef0e9272 */
+"buttonFixErrors" = "Fix errors";
+
 /* loco:69304d546385bb9cfc03e524 */
-"buttonKDriveIsActivated" = "I've activated kDrive";
+"buttonKDriveIsActivated" = "I’ve activated kDrive";
 
 /* loco:695e58701870be5cd709d2a2 */
 "buttonKDriveOnline" = "kDrive Online";
@@ -127,12 +133,6 @@
 /* loco:696a47fd5b6db1a9b1063182 */
 "informationBlockKDriveFullTitle" = "Your kDrive is full";
 
-/* loco:696a4fcf3932da71d1075552 */
-"informationBlockSynchroErrorTitle" = "You have %s synchronization error";
-
-/* loco:696a4fdd3932da71d1075554 */
-"informationBlockSynchroErrorTitle-plural" = "You have %s synchronization errors";
-
 /* loco:6930595e7664999c6a08c8a4 */
 "instructionEnableKDrive" = "Activate kDrive.app";
 
@@ -176,13 +176,13 @@
 "instructionRestartIfNecessary" = "Restart the application if required";
 
 /* loco:693050ed6a0836d25507da22 */
-"onboardingAuthorizationExtensionDescription" = "Authorize kDrive in macOS settings :";
+"onboardingAuthorizationExtensionDescription" = "Authorize kDrive in macOS settings:";
 
 /* loco:6930509e14b396d6fc04b0f2 */
 "onboardingAuthorizationExtensionTitle" = "Activate kDrive on your Mac";
 
 /* loco:6930510648920a67910d1094 */
-"onboardingAuthorizationFullDiskDescription" = "To complete the installation, you must authorize kDrive to access your :";
+"onboardingAuthorizationFullDiskDescription" = "To complete the installation, you must authorize kDrive to access your:";
 
 /* loco:693050bab2a2c1990a0d2f04 */
 "onboardingAuthorizationFullDiskTitle" = "Authorize access to files";
@@ -191,7 +191,7 @@
 "onboardingDriveSelectionNoDriveDescription" = "Get started for free with my kSuite,\nor choose a package tailored to your needs.";
 
 /* loco:692405adc5c224ad2a07ff62 */
-"onboardingDriveSelectionNoDriveTitle" = "You don't have a kDrive yet.";
+"onboardingDriveSelectionNoDriveTitle" = "You don’t have a kDrive yet.";
 
 /* loco:69242dd4299cf487060f2143 */
 "onboardingDriveSelectionSelectTitle" = "Select the kDrive to be synchronized on this computer:";
@@ -212,7 +212,7 @@
 "onboardingLoginErrorTitle" = "Connection error";
 
 /* loco:691deb66e28b84c78e034353 */
-"onboardingLoginHintLoading" = "Just a few more moments, and we'll load your account…";
+"onboardingLoginHintLoading" = "Just a few more moments, and we’ll load your account…";
 
 /* loco:691deb477145f10ab4052cd4 */
 "onboardingLoginHintWebAuth" = "Login from your browser…";

--- a/src/front/macOS/kDriveResources/Localizable/en.lproj/Localizable.stringsdict
+++ b/src/front/macOS/kDriveResources/Localizable/en.lproj/Localizable.stringsdict
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+ Loco ios export: Xcode Stringsdict (legacy)
+ Project: kDrive Desktop
+ Locale: en, English
+ Tagged: macOS-stringsdict
+ Exported by: Philippe Weidmann
+ Exported at: Mon, 02 Feb 2026 14:09:58 +0100
+-->
+<plist version="1.0">
+  <dict>
+    <key>informationBlockSynchroErrorTitle</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@value@</string>
+      <key>value</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>d</string>
+        <key>one</key>
+        <string>You have **one synchronization error**</string>
+        <key>other</key>
+        <string>You have **%lld synchronization errors**</string>
+      </dict>
+    </dict>
+  </dict>
+</plist>

--- a/src/front/macOS/kDriveResources/Localizable/es.lproj/Localizable.strings
+++ b/src/front/macOS/kDriveResources/Localizable/es.lproj/Localizable.strings
@@ -4,8 +4,11 @@
  * Locale: es, Spanish
  * Tagged: macOS
  * Exported by: Philippe Weidmann
- * Exported at: Fri, 30 Jan 2026 08:14:30 +0100
+ * Exported at: Mon, 02 Feb 2026 14:10:19 +0100
  */
+
+/* loco:698053a65bddc8df790d0212 */
+" informationBlockSynchroErrorSubtitle" = "No se han podido sincronizar algunos archivos.";
 
 /* loco:696a483470f3b70399021c12 */
 "buttonAddStorage" = "Añadir almacenamiento";
@@ -24,6 +27,9 @@
 
 /* loco:6930506962426d4ff30af473 */
 "buttonFinishInstallation" = "Terminar la instalación";
+
+/* loco:698052d464e4b53cef0e9272 */
+"buttonFixErrors" = "Corregir errores";
 
 /* loco:69304d546385bb9cfc03e524 */
 "buttonKDriveIsActivated" = "He activado kDrive";
@@ -101,7 +107,7 @@
 "driveMaintenanceErrorTitle" = "Mantenimiento en curso";
 
 /* loco:6979e3dfba525501090fbfa8 */
-"driveWakingUpErrorDescription" = "El kDrive se está despertando... puede tardar unos momentos.";
+"driveWakingUpErrorDescription" = "El kDrive se está despertando… puede tardar unos momentos.";
 
 /* loco:6979e389195e90fdc909d252 */
 "driveWakingUpErrorTitle" = "Activación de kDrive en curso";
@@ -113,7 +119,7 @@
 "folderShares" = "Comparticiones";
 
 /* loco:695e5889bc7544361b08b834 */
-"folderTrash" = "Basura";
+"folderTrash" = "Papelera";
 
 /* loco:6960b7720cbd5c07340af144 */
 "greetingLabel" = "Hola %s, %s";
@@ -126,12 +132,6 @@
 
 /* loco:696a47fd5b6db1a9b1063182 */
 "informationBlockKDriveFullTitle" = "Tu kDrive está lleno";
-
-/* loco:696a4fcf3932da71d1075552 */
-"informationBlockSynchroErrorTitle" = "";
-
-/* loco:696a4fdd3932da71d1075554 */
-"informationBlockSynchroErrorTitle-plural" = "";
 
 /* loco:6930595e7664999c6a08c8a4 */
 "instructionEnableKDrive" = "Activar kDrive.app";
@@ -176,13 +176,13 @@
 "instructionRestartIfNecessary" = "Reinicie la aplicación si es necesario";
 
 /* loco:693050ed6a0836d25507da22 */
-"onboardingAuthorizationExtensionDescription" = "Autorizar kDrive en los ajustes de macOS :";
+"onboardingAuthorizationExtensionDescription" = "Autorizar kDrive en los ajustes de macOS:";
 
 /* loco:6930509e14b396d6fc04b0f2 */
 "onboardingAuthorizationExtensionTitle" = "Activar kDrive en tu Mac";
 
 /* loco:6930510648920a67910d1094 */
-"onboardingAuthorizationFullDiskDescription" = "Para completar la instalación, debes autorizar a kDrive a acceder a tu :";
+"onboardingAuthorizationFullDiskDescription" = "Para completar la instalación, debes autorizar a kDrive a acceder a tu:";
 
 /* loco:693050bab2a2c1990a0d2f04 */
 "onboardingAuthorizationFullDiskTitle" = "Autorizar el acceso a los expedientes";

--- a/src/front/macOS/kDriveResources/Localizable/es.lproj/Localizable.stringsdict
+++ b/src/front/macOS/kDriveResources/Localizable/es.lproj/Localizable.stringsdict
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+ Loco ios export: Xcode Stringsdict (legacy)
+ Project: kDrive Desktop
+ Locale: es, Spanish
+ Tagged: macOS-stringsdict
+ Exported by: Philippe Weidmann
+ Exported at: Mon, 02 Feb 2026 14:09:58 +0100
+-->
+<plist version="1.0">
+  <dict>
+    <key>informationBlockSynchroErrorTitle</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@value@</string>
+      <key>value</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>d</string>
+        <key>one</key>
+        <string>Tienes **un error** de sincronización</string>
+        <key>other</key>
+        <string>Tiene **%lld errores de sincronización**</string>
+      </dict>
+    </dict>
+  </dict>
+</plist>

--- a/src/front/macOS/kDriveResources/Localizable/fr.lproj/Localizable.strings
+++ b/src/front/macOS/kDriveResources/Localizable/fr.lproj/Localizable.strings
@@ -4,8 +4,11 @@
  * Locale: fr, French
  * Tagged: macOS
  * Exported by: Philippe Weidmann
- * Exported at: Fri, 30 Jan 2026 08:14:30 +0100
+ * Exported at: Mon, 02 Feb 2026 14:10:19 +0100
  */
+
+/* loco:698053a65bddc8df790d0212 */
+" informationBlockSynchroErrorSubtitle" = "Certains fichiers n’ont pas pu être synchronisés.";
 
 /* loco:696a483470f3b70399021c12 */
 "buttonAddStorage" = "Ajouter du stockage";
@@ -24,6 +27,9 @@
 
 /* loco:6930506962426d4ff30af473 */
 "buttonFinishInstallation" = "Terminer l’installation";
+
+/* loco:698052d464e4b53cef0e9272 */
+"buttonFixErrors" = "Corriger les erreurs";
 
 /* loco:69304d546385bb9cfc03e524 */
 "buttonKDriveIsActivated" = "J’ai activé kDrive";
@@ -80,7 +86,7 @@
 "driveAsleepErrorTitle" = "Votre kDrive est en veille";
 
 /* loco:696ddb204d9cd9e240095142 */
-"driveLockedAdminErrorDescription" = "Ce kDrive n’a pas été renouvelé. Vous ne pouvez plus y accéder. \nRenouvelez votre abonnement pour réactiver le service.";
+"driveLockedAdminErrorDescription" = "Ce kDrive n’a pas été renouvelé. Vous ne pouvez plus y accéder.\nRenouvelez votre abonnement pour réactiver le service.";
 
 /* loco:696dda82726515a10a0772c2 */
 "driveLockedErrorDescription" = "Ce kDrive n’a pas été renouvelé. Vous ne pouvez plus y accéder.\nContactez votre administrateur pour réactiver le service.";
@@ -122,16 +128,10 @@
 "helpKDriveName" = "kDrive %s";
 
 /* loco:696a481cf54b5acbc60209c2 */
-"informationBlockKDriveFullSubtitle" = "Libérez de l'espace ou mettez votre forfait à niveau pour continuer à synchroniser vos fichiers.";
+"informationBlockKDriveFullSubtitle" = "Libérez de l’espace ou mettez votre forfait à niveau pour continuer à synchroniser vos fichiers.";
 
 /* loco:696a47fd5b6db1a9b1063182 */
 "informationBlockKDriveFullTitle" = "Votre kDrive est plein";
-
-/* loco:696a4fcf3932da71d1075552 */
-"informationBlockSynchroErrorTitle" = "";
-
-/* loco:696a4fdd3932da71d1075554 */
-"informationBlockSynchroErrorTitle-plural" = "";
 
 /* loco:6930595e7664999c6a08c8a4 */
 "instructionEnableKDrive" = "Activez kDrive.app";
@@ -188,7 +188,7 @@
 "onboardingAuthorizationFullDiskTitle" = "Autorisez l’accès aux dossiers";
 
 /* loco:692406b0258f5599bf01d113 */
-"onboardingDriveSelectionNoDriveDescription" = "Commencez gratuitement avec my kSuite, \nou choisissez une offre adaptée à vos besoins.";
+"onboardingDriveSelectionNoDriveDescription" = "Commencez gratuitement avec my kSuite,\nou choisissez une offre adaptée à vos besoins.";
 
 /* loco:692405adc5c224ad2a07ff62 */
 "onboardingDriveSelectionNoDriveTitle" = "Vous n’avez pas encore de kDrive.";

--- a/src/front/macOS/kDriveResources/Localizable/fr.lproj/Localizable.stringsdict
+++ b/src/front/macOS/kDriveResources/Localizable/fr.lproj/Localizable.stringsdict
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+ Loco ios export: Xcode Stringsdict (legacy)
+ Project: kDrive Desktop
+ Locale: fr, French
+ Tagged: macOS-stringsdict
+ Exported by: Philippe Weidmann
+ Exported at: Mon, 02 Feb 2026 14:09:58 +0100
+-->
+<plist version="1.0">
+  <dict>
+    <key>informationBlockSynchroErrorTitle</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@value@</string>
+      <key>value</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>d</string>
+        <key>one</key>
+        <string>Vous avez **une erreur** de synchronisation</string>
+        <key>other</key>
+        <string>Vous avez **%lld erreurs** de synchronisation</string>
+      </dict>
+    </dict>
+  </dict>
+</plist>

--- a/src/front/macOS/kDriveResources/Localizable/it.lproj/Localizable.strings
+++ b/src/front/macOS/kDriveResources/Localizable/it.lproj/Localizable.strings
@@ -4,11 +4,14 @@
  * Locale: it, Italian
  * Tagged: macOS
  * Exported by: Philippe Weidmann
- * Exported at: Fri, 30 Jan 2026 08:14:30 +0100
+ * Exported at: Mon, 02 Feb 2026 14:10:19 +0100
  */
 
+/* loco:698053a65bddc8df790d0212 */
+" informationBlockSynchroErrorSubtitle" = "Non è stato possibile sincronizzare alcuni file.";
+
 /* loco:696a483470f3b70399021c12 */
-"buttonAddStorage" = "Aggiungere l'archiviazione";
+"buttonAddStorage" = "Aggiungere l’archiviazione";
 
 /* loco:691deb2291b20ac7fd045012 */
 "buttonAdvancedParameters" = "Impostazioni avanzate";
@@ -24,6 +27,9 @@
 
 /* loco:6930506962426d4ff30af473 */
 "buttonFinishInstallation" = "Installazione finale";
+
+/* loco:698052d464e4b53cef0e9272 */
+"buttonFixErrors" = "Correggere gli errori";
 
 /* loco:69304d546385bb9cfc03e524 */
 "buttonKDriveIsActivated" = "Ho attivato kDrive";
@@ -65,13 +71,13 @@
 "buttonStartForFree" = "Iniziare gratuitamente";
 
 /* loco:697b6767849b0ee24c089f46 */
-"buttonUpdateSubscription" = "Aggiornamento dell'abbonamento";
+"buttonUpdateSubscription" = "Aggiornamento dell’abbonamento";
 
 /* loco:697b65886840f9d35605a132 */
 "buttonWakeUp" = "Risveglio";
 
 /* loco:696a260311ac2de6c6029683 */
-"driveAccessDeniedErrorDescription" = "Non si ha l'autorizzazione ad accedere a questo kDrive.\nControllare le autorizzazioni o contattare l'amministratore.";
+"driveAccessDeniedErrorDescription" = "Non si ha l’autorizzazione ad accedere a questo kDrive.\nControllare le autorizzazioni o contattare l’amministratore.";
 
 /* loco:696a25f0bcde38f2b9018124 */
 "driveAccessDeniedErrorTitle" = "Accesso negato a kDrive";
@@ -80,10 +86,10 @@
 "driveAsleepErrorTitle" = "Il kDrive è in standby";
 
 /* loco:696ddb204d9cd9e240095142 */
-"driveLockedAdminErrorDescription" = "Questo kDrive non è stato rinnovato. Non è più possibile accedervi.\nRinnovare l'abbonamento per riattivare il servizio.";
+"driveLockedAdminErrorDescription" = "Questo kDrive non è stato rinnovato. Non è più possibile accedervi.\nRinnovare l’abbonamento per riattivare il servizio.";
 
 /* loco:696dda82726515a10a0772c2 */
-"driveLockedErrorDescription" = "Questo kDrive non è stato rinnovato. Non è più possibile accedervi.\nContattare l'amministratore per riattivare il servizio.";
+"driveLockedErrorDescription" = "Questo kDrive non è stato rinnovato. Non è più possibile accedervi.\nContattare l’amministratore per riattivare il servizio.";
 
 /* loco:696df7c300e7a6e07201ee53 */
 "driveLockedErrorTitle" = "Il kDrive è scaduto";
@@ -101,7 +107,7 @@
 "driveMaintenanceErrorTitle" = "Manutenzione in corso";
 
 /* loco:6979e3dfba525501090fbfa8 */
-"driveWakingUpErrorDescription" = "Il kDrive si sta svegliando... potrebbe richiedere qualche istante.";
+"driveWakingUpErrorDescription" = "Il kDrive si sta svegliando… potrebbe richiedere qualche istante.";
 
 /* loco:6979e389195e90fdc909d252 */
 "driveWakingUpErrorTitle" = "Risveglio del kDrive in corso";
@@ -127,12 +133,6 @@
 /* loco:696a47fd5b6db1a9b1063182 */
 "informationBlockKDriveFullTitle" = "Il kDrive è pieno";
 
-/* loco:696a4fcf3932da71d1075552 */
-"informationBlockSynchroErrorTitle" = "";
-
-/* loco:696a4fdd3932da71d1075554 */
-"informationBlockSynchroErrorTitle-plural" = "";
-
 /* loco:6930595e7664999c6a08c8a4 */
 "instructionEnableKDrive" = "Attivare kDrive.app";
 
@@ -143,16 +143,16 @@
 "instructionEnableKDriveHint" = "È necessario attivare kDrive.app prima di continuare";
 
 /* loco:69314cfb358e5c25a50b1fb3 */
-"instructionFullDisk" = "Attivare l'estensione kDrive e kDrive LiteSync";
+"instructionFullDisk" = "Attivare l’estensione kDrive e kDrive LiteSync";
 
 /* loco:69314c248389940c6c08d902 */
 "instructionFullDiskHint" = "È necessario attivare le autorizzazioni prima di proseguire";
 
 /* loco:69314c4aba85c2962d068dc2 */
-"instructionOpenPrivacySecurity" = "Andare in Riservatezza e sicurezza > Accesso all'intero disco";
+"instructionOpenPrivacySecurity" = "Andare in Riservatezza e sicurezza > Accesso all’intero disco";
 
 /* loco:69314c54606d30eb26081743 */
-"instructionOpenPrivacySecurityArgument" = "Accesso all'intero disco";
+"instructionOpenPrivacySecurityArgument" = "Accesso all’intero disco";
 
 /* loco:69314c62739c205c410aa082 */
 "instructionOpenPrivacySecurityLink" = "Riservatezza e sicurezza";
@@ -173,19 +173,19 @@
 "instructionOpenSystemSettingsLink" = "Impostazioni di sistema";
 
 /* loco:69314d1a739c205c410aa087 */
-"instructionRestartIfNecessary" = "Riavviare l'applicazione, se necessario";
+"instructionRestartIfNecessary" = "Riavviare l’applicazione, se necessario";
 
 /* loco:693050ed6a0836d25507da22 */
-"onboardingAuthorizationExtensionDescription" = "Autorizzare kDrive nelle impostazioni di macOS :";
+"onboardingAuthorizationExtensionDescription" = "Autorizzare kDrive nelle impostazioni di macOS:";
 
 /* loco:6930509e14b396d6fc04b0f2 */
 "onboardingAuthorizationExtensionTitle" = "Attivare kDrive sul Mac";
 
 /* loco:6930510648920a67910d1094 */
-"onboardingAuthorizationFullDiskDescription" = "Per completare l'installazione, è necessario autorizzare kDrive ad accedere al proprio computer :";
+"onboardingAuthorizationFullDiskDescription" = "Per completare l’installazione, è necessario autorizzare kDrive ad accedere al proprio computer:";
 
 /* loco:693050bab2a2c1990a0d2f04 */
-"onboardingAuthorizationFullDiskTitle" = "Autorizzare l'accesso ai file";
+"onboardingAuthorizationFullDiskTitle" = "Autorizzare l’accesso ai file";
 
 /* loco:692406b0258f5599bf01d113 */
 "onboardingDriveSelectionNoDriveDescription" = "Iniziate gratuitamente con my kSuite,\noppure scegliete un pacchetto su misura per le vostre esigenze.";
@@ -224,7 +224,7 @@
 "onboardingSynchronizationAppReadyDescription" = "I file sono pronti per essere sincronizzati in modo sicuro sul vostro computer.";
 
 /* loco:6931a16c3498d5205b0380d3 */
-"onboardingSynchronizationAppReadyTitle" = "Tutto è pronto per l'uso!";
+"onboardingSynchronizationAppReadyTitle" = "Tutto è pronto per l’uso!";
 
 /* loco:6931a1582ee1a869eb0303f4 */
 "onboardingSynchronizationInProgressDescription" = "I file di kDrive sono in fase di sincronizzazione.\nAttendere qualche istante.";

--- a/src/front/macOS/kDriveResources/Localizable/it.lproj/Localizable.stringsdict
+++ b/src/front/macOS/kDriveResources/Localizable/it.lproj/Localizable.stringsdict
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+ Loco ios export: Xcode Stringsdict (legacy)
+ Project: kDrive Desktop
+ Locale: it, Italian
+ Tagged: macOS-stringsdict
+ Exported by: Philippe Weidmann
+ Exported at: Mon, 02 Feb 2026 14:09:58 +0100
+-->
+<plist version="1.0">
+  <dict>
+    <key>informationBlockSynchroErrorTitle</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@value@</string>
+      <key>value</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>d</string>
+        <key>one</key>
+        <string>Si è verificato **un errore** di sincronizzazione</string>
+        <key>other</key>
+        <string>Si sono verificati **%lld errori di sincronizzazione**</string>
+      </dict>
+    </dict>
+  </dict>
+</plist>

--- a/src/front/macOS/kDriveResources/Symbols/Strings+Symbols.swift
+++ b/src/front/macOS/kDriveResources/Symbols/Strings+Symbols.swift
@@ -10,6 +10,8 @@ import Foundation
 // swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:disable nesting type_body_length type_name vertical_whitespace_opening_braces
 public enum KDriveLocalizable {
+  /// loco:698053a65bddc8df790d0212
+  public static let informationBlockSynchroErrorSubtitle = KDriveLocalizable.tr("Localizable", " informationBlockSynchroErrorSubtitle", fallback: "Some files could not be synchronized.")
   /// loco:696a483470f3b70399021c12
   public static let buttonAddStorage = KDriveLocalizable.tr("Localizable", "buttonAddStorage", fallback: "Add Storage")
   /// loco:691deb2291b20ac7fd045012
@@ -22,8 +24,10 @@ public enum KDriveLocalizable {
   public static let buttonCreateAccount = KDriveLocalizable.tr("Localizable", "buttonCreateAccount", fallback: "Create an account")
   /// loco:6930506962426d4ff30af473
   public static let buttonFinishInstallation = KDriveLocalizable.tr("Localizable", "buttonFinishInstallation", fallback: "Finish installation")
+  /// loco:698052d464e4b53cef0e9272
+  public static let buttonFixErrors = KDriveLocalizable.tr("Localizable", "buttonFixErrors", fallback: "Fix errors")
   /// loco:69304d546385bb9cfc03e524
-  public static let buttonKDriveIsActivated = KDriveLocalizable.tr("Localizable", "buttonKDriveIsActivated", fallback: "I've activated kDrive")
+  public static let buttonKDriveIsActivated = KDriveLocalizable.tr("Localizable", "buttonKDriveIsActivated", fallback: "I’ve activated kDrive")
   /// loco:695e58701870be5cd709d2a2
   public static let buttonKDriveOnline = KDriveLocalizable.tr("Localizable", "buttonKDriveOnline", fallback: "kDrive Online")
   /// loco:68e673b2042a15d8470f9452
@@ -94,13 +98,9 @@ public enum KDriveLocalizable {
   public static let informationBlockKDriveFullSubtitle = KDriveLocalizable.tr("Localizable", "informationBlockKDriveFullSubtitle", fallback: "Free up space or upgrade your plan to continue syncing your files.")
   /// loco:696a47fd5b6db1a9b1063182
   public static let informationBlockKDriveFullTitle = KDriveLocalizable.tr("Localizable", "informationBlockKDriveFullTitle", fallback: "Your kDrive is full")
-  /// loco:696a4fcf3932da71d1075552
-  public static func informationBlockSynchroErrorTitle(_ p1: UnsafePointer<CChar>) -> String {
-    return KDriveLocalizable.tr("Localizable", "informationBlockSynchroErrorTitle", p1, fallback: "You have %s synchronization error")
-  }
-  /// loco:696a4fdd3932da71d1075554
-  public static func informationBlockSynchroErrorTitlePlural(_ p1: UnsafePointer<CChar>) -> String {
-    return KDriveLocalizable.tr("Localizable", "informationBlockSynchroErrorTitle-plural", p1, fallback: "You have %s synchronization errors")
+  /// Plural format key: "%#@value@"
+  public static func informationBlockSynchroErrorTitle(_ p1: Int) -> String {
+    return KDriveLocalizable.tr("Localizable", "informationBlockSynchroErrorTitle", p1, fallback: "Plural format key: \"%#@value@\"")
   }
   /// loco:6930595e7664999c6a08c8a4
   public static let instructionEnableKDrive = KDriveLocalizable.tr("Localizable", "instructionEnableKDrive", fallback: "Activate kDrive.app")
@@ -131,17 +131,17 @@ public enum KDriveLocalizable {
   /// loco:69314d1a739c205c410aa087
   public static let instructionRestartIfNecessary = KDriveLocalizable.tr("Localizable", "instructionRestartIfNecessary", fallback: "Restart the application if required")
   /// loco:693050ed6a0836d25507da22
-  public static let onboardingAuthorizationExtensionDescription = KDriveLocalizable.tr("Localizable", "onboardingAuthorizationExtensionDescription", fallback: "Authorize kDrive in macOS settings :")
+  public static let onboardingAuthorizationExtensionDescription = KDriveLocalizable.tr("Localizable", "onboardingAuthorizationExtensionDescription", fallback: "Authorize kDrive in macOS settings:")
   /// loco:6930509e14b396d6fc04b0f2
   public static let onboardingAuthorizationExtensionTitle = KDriveLocalizable.tr("Localizable", "onboardingAuthorizationExtensionTitle", fallback: "Activate kDrive on your Mac")
   /// loco:6930510648920a67910d1094
-  public static let onboardingAuthorizationFullDiskDescription = KDriveLocalizable.tr("Localizable", "onboardingAuthorizationFullDiskDescription", fallback: "To complete the installation, you must authorize kDrive to access your :")
+  public static let onboardingAuthorizationFullDiskDescription = KDriveLocalizable.tr("Localizable", "onboardingAuthorizationFullDiskDescription", fallback: "To complete the installation, you must authorize kDrive to access your:")
   /// loco:693050bab2a2c1990a0d2f04
   public static let onboardingAuthorizationFullDiskTitle = KDriveLocalizable.tr("Localizable", "onboardingAuthorizationFullDiskTitle", fallback: "Authorize access to files")
   /// loco:692406b0258f5599bf01d113
   public static let onboardingDriveSelectionNoDriveDescription = KDriveLocalizable.tr("Localizable", "onboardingDriveSelectionNoDriveDescription", fallback: "Get started for free with my kSuite,\nor choose a package tailored to your needs.")
   /// loco:692405adc5c224ad2a07ff62
-  public static let onboardingDriveSelectionNoDriveTitle = KDriveLocalizable.tr("Localizable", "onboardingDriveSelectionNoDriveTitle", fallback: "You don't have a kDrive yet.")
+  public static let onboardingDriveSelectionNoDriveTitle = KDriveLocalizable.tr("Localizable", "onboardingDriveSelectionNoDriveTitle", fallback: "You don’t have a kDrive yet.")
   /// loco:69242dd4299cf487060f2143
   public static let onboardingDriveSelectionSelectTitle = KDriveLocalizable.tr("Localizable", "onboardingDriveSelectionSelectTitle", fallback: "Select the kDrive to be synchronized on this computer:")
   /// loco:69271e987f61390c0e053442
@@ -155,7 +155,7 @@ public enum KDriveLocalizable {
   /// loco:68e8fa06c1b003290f0ccf42
   public static let onboardingLoginErrorTitle = KDriveLocalizable.tr("Localizable", "onboardingLoginErrorTitle", fallback: "Connection error")
   /// loco:691deb66e28b84c78e034353
-  public static let onboardingLoginHintLoading = KDriveLocalizable.tr("Localizable", "onboardingLoginHintLoading", fallback: "Just a few more moments, and we'll load your account…")
+  public static let onboardingLoginHintLoading = KDriveLocalizable.tr("Localizable", "onboardingLoginHintLoading", fallback: "Just a few more moments, and we’ll load your account…")
   /// loco:691deb477145f10ab4052cd4
   public static let onboardingLoginHintWebAuth = KDriveLocalizable.tr("Localizable", "onboardingLoginHintWebAuth", fallback: "Login from your browser…")
   /// loco:68e673754d80559c460bdf02


### PR DESCRIPTION
Information block for sync errors.

There is no singular version for subtitle / button. Do we want one ?

<img width="1200" height="324" alt="One error" src="https://github.com/user-attachments/assets/e6667fd6-3b38-4917-9698-c45ae3295f72" />
<img width="1200" height="324" alt="Multiple errors" src="https://github.com/user-attachments/assets/0e6533e8-4d1b-4d46-9da7-c304b052b1bd" />
<img width="2512" height="1622" alt="CleanShot 2026-02-02 at 16 01 29@2x" src="https://github.com/user-attachments/assets/d51cf4da-742d-4e42-b55f-15d0399bbbbc" />

