### PR TITLE
macOS - Encoding issue with Finder extension commands

### DIFF
--- a/src/server/comm/extensionjob.cpp
+++ b/src/server/comm/extensionjob.cpp
@@ -590,6 +590,7 @@ void ExtensionJob::commandGetThumbnail(const CommString &argument, std::shared_p
     channel->sendMessage(response);
 }
 #endif
+
 #if defined(KD_MACOS)
 void ExtensionJob::commandRetrieveFolderStatus(const CommString &argument, std::shared_ptr<AbstractCommChannel> channel) {
     // This command is the same as RETRIEVE_FILE_STATUS
@@ -753,7 +754,7 @@ void ExtensionJob::manageActionsOnSingleFile(std::shared_ptr<AbstractCommChannel
                                              SyncPalMap::const_iterator syncPalMapIt, VfsMap::const_iterator vfsMapIt,
                                              const Sync &sync) {
     bool exists = false;
-    IoError ioError = IoError::Success;
+    auto ioError = IoError::Success;
     if (!IoHelper::checkIfPathExists(path, exists, ioError) || !exists) {
         return;
     }
@@ -924,6 +925,7 @@ bool ExtensionJob::addDownloadJob(const FileData &fileData, const SyncPath &pare
     return true;
 }
 
+#if defined(KD_MACOS)
 bool ExtensionJob::cancelDownloadJobs(int syncDbId, const std::vector<CommString> &fileList) {
     const std::scoped_lock lock(AppServer::syncPalMapMutex);
 
@@ -942,6 +944,7 @@ bool ExtensionJob::cancelDownloadJobs(int syncDbId, const std::vector<CommString
 
     return true;
 }
+#endif
 
 void ExtensionJob::copyUrlToClipboard(const std::string &link) {
 #if defined(KD_WINDOWS)
@@ -1119,14 +1122,14 @@ void ExtensionJob::buildAndSendMenuItemMessage(std::shared_ptr<AbstractCommChann
     channel->sendMessage(response);
 }
 
+#if defined(KD_MACOS)
 void ExtensionJob::processFileList(const std::vector<CommString> &inFileList, std::vector<SyncPath> &outFileList) {
     // Process all files
     for (const auto &path: inFileList) {
         const FileData fileData = FileData::get(path);
         if (!fileData.isValid()) continue;
 
-#if defined(KD_MACOS)
-        IoError ioError = IoError::Success;
+        auto ioError = IoError::Success;
         IoHelper::DirectoryIterator dirIt;
         bool endOfDir = false;
         DirectoryEntry entry;
@@ -1160,11 +1163,9 @@ void ExtensionJob::processFileList(const std::vector<CommString> &inFileList, st
         } catch (...) {
             LOG_WARN(Log::instance()->getLogger(), "Error caught in ExtensionJob::processFileList");
         }
-#elif defined(KD_WINDOWS)
-        outFileList.push_back(path);
-#endif
     }
 }
+#endif
 
 CommString ExtensionJob::vfsPinActionText() {
     return CommonUtility::qStr2CommString(QObject::tr("Make available locally"));

--- a/src/server/comm/extensionjob.cpp
+++ b/src/server/comm/extensionjob.cpp
@@ -1132,7 +1132,7 @@ void ExtensionJob::processFileList(const std::vector<CommString> &inFileList, st
         DirectoryEntry entry;
 
         try {
-            if (!IoHelper::recursiveDirectoryIterator(path, dirIt)) {
+            if (!IoHelper::getRecursiveDirectoryIterator(path, ioError, dirIt, true)) {
                 LOGW_WARN(_logger, L"Error in IoHelper::recursiveDirectoryIterator");
                 continue;
             }
@@ -1144,7 +1144,7 @@ void ExtensionJob::processFileList(const std::vector<CommString> &inFileList, st
                 auto status = SyncFileStatus::Unknown;
                 if (VfsStatus vfsStatus; !syncFileStatus(tmpFileData, status, vfsStatus)) {
                     LOGW_WARN(Log::instance()->getLogger(),
-                              L"Error in ExtensionJob::syncFileStatus: " << CommonUtility::formatSyncPath(entry.path()));
+                              L"Error in ExtensionJob::syncFileStatus: " << Utility::formatSyncPath(entry.path()));
                     continue;
                 }
 

--- a/src/server/comm/extensionjob.cpp
+++ b/src/server/comm/extensionjob.cpp
@@ -1127,41 +1127,45 @@ void ExtensionJob::processFileList(const std::vector<CommString> &inFileList, st
     // Process all files
     for (const auto &path: inFileList) {
         const FileData fileData = FileData::get(path);
-        if (!fileData.isValid()) continue;
+        if (!fileData.isValid() || fileData.isLink) continue;
 
-        auto ioError = IoError::Success;
-        IoHelper::DirectoryIterator dirIt;
-        bool endOfDir = false;
-        DirectoryEntry entry;
+        if (fileData.isDirectory) {
+            auto ioError = IoError::Success;
+            IoHelper::DirectoryIterator dirIt;
+            bool endOfDir = false;
+            DirectoryEntry entry;
 
-        try {
-            if (!IoHelper::getRecursiveDirectoryIterator(path, ioError, dirIt, true)) {
-                LOGW_WARN(_logger, L"Error in IoHelper::recursiveDirectoryIterator");
-                continue;
-            }
-
-            while (dirIt.next(entry, endOfDir, ioError) && !endOfDir) {
-                FileData tmpFileData = FileData::get(entry.path());
-                if (!tmpFileData.isValid()) continue;
-
-                auto status = SyncFileStatus::Unknown;
-                if (VfsStatus vfsStatus; !syncFileStatus(tmpFileData, status, vfsStatus)) {
-                    LOGW_WARN(Log::instance()->getLogger(),
-                              L"Error in ExtensionJob::syncFileStatus: " << Utility::formatSyncPath(entry.path()));
+            try {
+                if (!IoHelper::getRecursiveDirectoryIterator(path, ioError, dirIt, true)) {
+                    LOGW_WARN(_logger, L"Error in IoHelper::recursiveDirectoryIterator");
                     continue;
                 }
 
-                if (status == SyncFileStatus::Unknown || status == SyncFileStatus::Ignored) {
-                    continue;
-                }
+                while (dirIt.next(entry, endOfDir, ioError) && !endOfDir) {
+                    FileData tmpFileData = FileData::get(entry.path());
+                    if (!tmpFileData.isValid() || tmpFileData.isLink || tmpFileData.isDirectory) continue;
 
-                outFileList.push_back(entry.path());
+                    auto status = SyncFileStatus::Unknown;
+                    if (VfsStatus vfsStatus; !syncFileStatus(tmpFileData, status, vfsStatus)) {
+                        LOGW_WARN(Log::instance()->getLogger(),
+                                  L"Error in ExtensionJob::syncFileStatus: " << Utility::formatSyncPath(entry.path()));
+                        continue;
+                    }
+
+                    if (status == SyncFileStatus::Unknown || status == SyncFileStatus::Ignored) {
+                        continue;
+                    }
+
+                    outFileList.push_back(entry.path());
+                }
+            } catch (std::filesystem::filesystem_error &e) {
+                LOG_WARN(Log::instance()->getLogger(),
+                         "Error caught in ExtensionJob::processFileList: code=" << e.code() << " error=" << e.what());
+            } catch (...) {
+                LOG_WARN(Log::instance()->getLogger(), "Error caught in ExtensionJob::processFileList");
             }
-        } catch (std::filesystem::filesystem_error &e) {
-            LOG_WARN(Log::instance()->getLogger(),
-                     "Error caught in ExtensionJob::processFileList: code=" << e.code() << " error=" << e.what());
-        } catch (...) {
-            LOG_WARN(Log::instance()->getLogger(), "Error caught in ExtensionJob::processFileList");
+        } else {
+            outFileList.push_back(path);
         }
     }
 }

--- a/src/server/comm/extensionjob.cpp
+++ b/src/server/comm/extensionjob.cpp
@@ -1123,40 +1123,46 @@ void ExtensionJob::processFileList(const std::vector<CommString> &inFileList, st
     // Process all files
     for (const auto &path: inFileList) {
         const FileData fileData = FileData::get(path);
-        if (fileData.isValid() && fileData.virtualFileMode == VirtualFileMode::Mac) {
-            const QFileInfo info(CommonUtility::commString2QStr(path));
-            if (info.isDir()) {
-                const QFileInfoList infoList =
-                        QDir(CommonUtility::commString2QStr(path)).entryInfoList(QDir::Dirs | QDir::Files | QDir::NoDotAndDotDot);
-                std::vector<CommString> fileList;
-                for (const auto &tmpInfo: qAsConst(infoList)) {
-                    const SyncPath tmpPath(QStr2Path(tmpInfo.filePath()));
-                    FileData tmpFileData = FileData::get(tmpPath);
-                    if (!tmpFileData.isValid()) continue;
+        if (!fileData.isValid()) continue;
 
-                    auto status = SyncFileStatus::Unknown;
-                    if (VfsStatus vfsStatus; !syncFileStatus(tmpFileData, status, vfsStatus)) {
-                        LOGW_WARN(Log::instance()->getLogger(),
-                                  L"Error in ExtensionJob::syncFileStatus - " << Utility::formatSyncPath(tmpPath));
-                        continue;
-                    }
+#if defined(KD_MACOS)
+        IoError ioError = IoError::Success;
+        IoHelper::DirectoryIterator dirIt;
+        bool endOfDir = false;
+        DirectoryEntry entry;
 
-                    if (status == SyncFileStatus::Unknown || status == SyncFileStatus::Ignored) {
-                        continue;
-                    }
-
-                    fileList.push_back(tmpPath);
-                }
-
-                if (fileList.size() > 0) {
-                    processFileList(fileList, outFileList);
-                }
-            } else {
-                outFileList.push_back(path);
+        try {
+            if (!IoHelper::recursiveDirectoryIterator(path, dirIt)) {
+                LOGW_WARN(_logger, L"Error in IoHelper::recursiveDirectoryIterator");
+                continue;
             }
-        } else {
-            outFileList.push_back(path);
+
+            while (dirIt.next(entry, endOfDir, ioError) && !endOfDir) {
+                FileData tmpFileData = FileData::get(entry.path());
+                if (!tmpFileData.isValid()) continue;
+
+                auto status = SyncFileStatus::Unknown;
+                if (VfsStatus vfsStatus; !syncFileStatus(tmpFileData, status, vfsStatus)) {
+                    LOGW_WARN(Log::instance()->getLogger(),
+                              L"Error in ExtensionJob::syncFileStatus: " << CommonUtility::formatSyncPath(entry.path()));
+                    continue;
+                }
+
+                if (status == SyncFileStatus::Unknown || status == SyncFileStatus::Ignored) {
+                    continue;
+                }
+
+                outFileList.push_back(entry.path());
+            }
+        } catch (std::filesystem::filesystem_error &e) {
+            LOG_WARN(Log::instance()->getLogger(),
+                     "Error caught in ExtensionJob::processFileList: code=" << e.code() << " error=" << e.what());
+        } catch (...) {
+            LOG_WARN(Log::instance()->getLogger(), "Error caught in ExtensionJob::processFileList");
         }
+#elif defined(KD_WINDOWS)
+        outFileList.push_back(path);
+#endif
     }
 }
 

--- a/src/server/comm/extensionjob.h
+++ b/src/server/comm/extensionjob.h
@@ -157,12 +157,15 @@ class ExtensionJob : public AbstractJob {
         void buildAndSendMenuItemMessage(std::shared_ptr<AbstractCommChannel> channel, const CommString &type, bool enabled,
                                          const CommString &text);
 
-        void processFileList(const std::vector<CommString> &inFileList, std::vector<SyncPath> &outFileList);
         bool syncFileStatus(const FileData &fileData, SyncFileStatus &status, VfsStatus &vfsStatus);
         ExitInfo setPinState(const FileData &fileData, PinState pinState);
         ExitInfo dehydratePlaceholder(const FileData &fileData);
         bool addDownloadJob(const FileData &fileData, const SyncPath &parentFolderPath);
+
+#if defined(KD_MACOS)
+        void processFileList(const std::vector<CommString> &inFileList, std::vector<SyncPath> &outFileList);
         bool cancelDownloadJobs(int syncDbId, const std::vector<CommString> &fileList);
+#endif
 
         // Commands texts translated
         CommString vfsPinActionText();


### PR DESCRIPTION
The "Free up local space" and "Make available locally" commands applied to folders do not work for files whose names are encoded in NFC.
The problem stems from the QFileInfoList function (ExtensionJob::processFileList), which returns the contents of a folder with NFC encoding.