### PR TITLE
WinUI 3: Graceful Handling of Server Errors (Step 1 – User-Related Requests)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,3 +202,4 @@ DerivedData/
 # Misc
 PROXYAI.md
 /src/server/vfs/win/vfs.h
+enc_temp_folder

--- a/src/gui4/windows/kDrive client/kDrive client/App.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/App.xaml.cs
@@ -151,12 +151,6 @@ namespace Infomaniak.kDrive
                 }
             };
 
-
-            // Affiche le spinning wheel
-            CurrentWindow.Content = new CustomControls.SplashScreen();
-
-            TrayIcoManager.Initialize();
-            AppModel appModel = ServiceProvider.GetRequiredService<AppModel>();
             if (!await appModel.InitializeAsync())
             {
                 Logger.Log(Logger.Level.Fatal, "Application failed to initialize, exiting.");

--- a/src/gui4/windows/kDrive client/kDrive client/App.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/App.xaml.cs
@@ -152,7 +152,17 @@ namespace Infomaniak.kDrive
             };
 
 
-            await appModel.InitializeAsync();
+            // Affiche le spinning wheel
+            CurrentWindow.Content = new CustomControls.SplashScreen();
+
+            TrayIcoManager.Initialize();
+            AppModel appModel = ServiceProvider.GetRequiredService<AppModel>();
+            if (!await appModel.InitializeAsync())
+            {
+                Logger.Log(Logger.Level.Fatal, "Application failed to initialize, exiting.");
+                ExitApplication();
+                return;
+            }
             CurrentWindow.Content = currentWindowContent;
             (CurrentWindow as MainWindow)?.AppNavView.Frame.Navigate(typeof(Pages.HomePage));
             StartOnboardingIfNeeded();

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/SyncExclusionPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/SyncExclusionPage.xaml.cs
@@ -118,7 +118,7 @@ namespace Infomaniak.kDrive.Pages.DriveSetupContentDialog
             bool? result = await commServices.IsPathValidForNewSync(folder.Path, CancellationToken.None);
             if (result is null || result == false)
             {
-                Utility.ShowTeachingTip(this.XamlRoot, "CC_DriveSetupContentDialog_SyncSetupPage_TeachingTip_InvalidFolder", control);
+                Utility.ShowTeachingTip("CC_DriveSetupContentDialog_SyncSetupPage_TeachingTip_InvalidFolder", this.XamlRoot, control);
                 Logger.Log(Logger.Level.Warning, $"Selected folder path '{folder.Path}' is not valid for syncing");
                 control.IsEnabled = true;
                 return;

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/SyncExclusionPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/SyncExclusionPage.xaml.cs
@@ -118,7 +118,7 @@ namespace Infomaniak.kDrive.Pages.DriveSetupContentDialog
             bool? result = await commServices.IsPathValidForNewSync(folder.Path, CancellationToken.None);
             if (result is null || result == false)
             {
-                Utility.ShowTeachingTipFromxUid("CC_DriveSetupContentDialog_SyncSetupPage_TeachingTip_InvalidFolder", this.XamlRoot, control);
+                Utility.ShowTeachingTipFromxUid("CC_DriveSetupContentDialog_SyncSetupPage_TeachingTip_InvalidFolder");
                 Logger.Log(Logger.Level.Warning, $"Selected folder path '{folder.Path}' is not valid for syncing");
                 control.IsEnabled = true;
                 return;

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/SyncExclusionPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/SyncExclusionPage.xaml.cs
@@ -118,7 +118,7 @@ namespace Infomaniak.kDrive.Pages.DriveSetupContentDialog
             bool? result = await commServices.IsPathValidForNewSync(folder.Path, CancellationToken.None);
             if (result is null || result == false)
             {
-                Utility.ShowTeachingTip("CC_DriveSetupContentDialog_SyncSetupPage_TeachingTip_InvalidFolder", this.XamlRoot, control);
+                Utility.ShowTeachingTipFromxUid("CC_DriveSetupContentDialog_SyncSetupPage_TeachingTip_InvalidFolder", this.XamlRoot, control);
                 Logger.Log(Logger.Level.Warning, $"Selected folder path '{folder.Path}' is not valid for syncing");
                 control.IsEnabled = true;
                 return;

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/SyncSetupPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/SyncSetupPage.xaml.cs
@@ -132,7 +132,7 @@ namespace Infomaniak.kDrive.Pages.DriveSetupContentDialog
             bool? result = await commServices.IsPathValidForNewSync(folder.Path, CancellationToken.None);
             if (result is null || result == false)
             {
-                Utility.ShowTeachingTip(this.XamlRoot, "CC_DriveSetupContentDialog_SyncSetupPage_TeachingTip_InvalidFolder");
+                Utility.ShowTeachingTip("CC_DriveSetupContentDialog_SyncSetupPage_TeachingTip_InvalidFolder", this.XamlRoot);
                 Logger.Log(Logger.Level.Warning, $"Selected folder path '{folder.Path}' is not valid for syncing");
                 control.IsEnabled = true;
                 return;

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/SyncSetupPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/SyncSetupPage.xaml.cs
@@ -132,7 +132,7 @@ namespace Infomaniak.kDrive.Pages.DriveSetupContentDialog
             bool? result = await commServices.IsPathValidForNewSync(folder.Path, CancellationToken.None);
             if (result is null || result == false)
             {
-                Utility.ShowTeachingTip("CC_DriveSetupContentDialog_SyncSetupPage_TeachingTip_InvalidFolder", this.XamlRoot);
+                Utility.ShowTeachingTipFromxUid("CC_DriveSetupContentDialog_SyncSetupPage_TeachingTip_InvalidFolder", this.XamlRoot);
                 Logger.Log(Logger.Level.Warning, $"Selected folder path '{folder.Path}' is not valid for syncing");
                 control.IsEnabled = true;
                 return;

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/SyncSetupPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/SyncSetupPage.xaml.cs
@@ -132,7 +132,7 @@ namespace Infomaniak.kDrive.Pages.DriveSetupContentDialog
             bool? result = await commServices.IsPathValidForNewSync(folder.Path, CancellationToken.None);
             if (result is null || result == false)
             {
-                Utility.ShowTeachingTipFromxUid("CC_DriveSetupContentDialog_SyncSetupPage_TeachingTip_InvalidFolder", this.XamlRoot);
+                Utility.ShowTeachingTipFromxUid("CC_DriveSetupContentDialog_SyncSetupPage_TeachingTip_InvalidFolder");
                 Logger.Log(Logger.Level.Warning, $"Selected folder path '{folder.Path}' is not valid for syncing");
                 control.IsEnabled = true;
                 return;

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/SyncActivityTable.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/SyncActivityTable.xaml.cs
@@ -208,8 +208,6 @@ namespace Infomaniak.kDrive.CustomControls
             }
 
             // Find parrent button to anchor teaching tip
-
-
             DisplayTeachingTip(Utility.GetLocalizedString(loadingTextXuid), true);
 
 

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/SettingsPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/SettingsPage.xaml.cs
@@ -129,8 +129,6 @@ namespace Infomaniak.kDrive.Pages.Settings
                 return;
             }
             ContentDialog dialog = new ContentDialog();
-
-            // XamlRoot must be set in the case of a ContentDialog running in a Desktop app
             dialog.XamlRoot = this.XamlRoot;
             dialog.Title = Utility.GetLocalizedString("Page_SettingsPage_RemoveAccount_Dialog/Title");
             dialog.PrimaryButtonText = Utility.GetLocalizedString("Page_SettingsPage_RemoveAccount_Dialog/PrimaryButtonText");
@@ -141,20 +139,14 @@ namespace Infomaniak.kDrive.Pages.Settings
             var result = await dialog.ShowAsync();
             if (result == ContentDialogResult.Secondary)
             {
-                if (user is not null)
-                {
-                    var control = sender as Control;
-                    if (control is not null)
-                    {
-                        control.IsEnabled = false;
-                    }
-                    await _viewModel.DisconnectUserAsync(user.DbId);
-                    await Task.Delay(5000);
-                    if (control is not null)
-                    {
-                        control.IsEnabled = true;
-                    }
-                }
+                var control = sender as Control;
+                if (control is not null)
+                    control.IsEnabled = false;
+
+                await _viewModel.DisconnectUserAsync(user.DbId);
+
+                if (control is not null)
+                    control.IsEnabled = true;
             }
         }
 
@@ -384,7 +376,7 @@ namespace Infomaniak.kDrive.Pages.Settings
             }
             if (control is not null)
                 control.IsEnabled = true;
-        }      
+        }
     }
 
     // templateSelector for the drives listview

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/SpecialErrorsPages/LoggingErrorPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/SpecialErrorsPages/LoggingErrorPage.xaml.cs
@@ -64,7 +64,7 @@ namespace Infomaniak.kDrive.Pages
                     }
                     else
                     {
-                        Utility.ShowTeachingTipFromxUid("UnexpectedErrorTeachingTip");
+                        Utility.ShowUnexpectedErrorTeachingTip();
                     }
                 }
                 else
@@ -79,7 +79,7 @@ namespace Infomaniak.kDrive.Pages
             catch (Exception ex)
             {
                 Logger.Log(Logger.Level.Error, $"Authentication process failed {ex.Message}");
-                Utility.ShowTeachingTipFromxUid("UnexpectedErrorTeachingTip");
+                Utility.ShowUnexpectedErrorTeachingTip();
             }
             finally
             {

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/SpecialErrorsPages/LoggingErrorPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/SpecialErrorsPages/LoggingErrorPage.xaml.cs
@@ -58,9 +58,13 @@ namespace Infomaniak.kDrive.Pages
                     {
                         ViewModel.SelectedSync?.Start();
                     }
-                    else
+                    else if (user is not null)
                     {
                         DisplayUserMismatchContent();
+                    }
+                    else
+                    {
+                        Utility.ShowTeachingTipFromxUid("UnexpectedErrorTeachingTip");
                     }
                 }
                 else
@@ -75,6 +79,7 @@ namespace Infomaniak.kDrive.Pages
             catch (Exception ex)
             {
                 Logger.Log(Logger.Level.Error, $"Authentication process failed {ex.Message}");
+                Utility.ShowTeachingTipFromxUid("UnexpectedErrorTeachingTip");
             }
             finally
             {

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Interfaces/IServerCommProtocol.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Interfaces/IServerCommProtocol.cs
@@ -35,7 +35,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Interfaces
             public ExitCause Cause { get; set; } = ExitCause.Unknown;
 
             // Parameters for requests or data for signals
-            public JsonObject? Params { get; set; }
+            public JsonObject Params { get; set; } = new JsonObject();
         }
 
         public Task<CommData> SendRequestAsync(RequestNum requestNum, JsonObject parameters, CancellationToken cancellationToken = default);

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Interfaces/IServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Interfaces/IServerCommService.cs
@@ -30,7 +30,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Interfaces
          * User are added/removed as necessary to match the server state.
          * Returns a Task that completes when the operation is done.
          */
-        Task RefreshUsers(CancellationToken cancellationToken);
+        Task<bool> RefreshUsers(CancellationToken cancellationToken);
 
         /* Removes the user with the specified DbId from the server and local storage.
          * The view model's Users collection is updated accordingly.

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Interfaces/IServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Interfaces/IServerCommService.cs
@@ -36,7 +36,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Interfaces
          * The view model's Users collection is updated accordingly.
          * Returns true on success, false on failure.
          */
-        Task RemoveUser(DbId userDbId, CancellationToken cancellationToken);
+        Task<bool> RemoveUser(DbId userDbId, CancellationToken cancellationToken);
 
         // Account-related requests
         /* Refreshes the list of accounts for all users from the server.

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Interfaces/IServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Interfaces/IServerCommService.cs
@@ -1,5 +1,4 @@
-﻿using Infomaniak.kDrive.ServerCommunication.CommStruct;
-using Infomaniak.kDrive.Types;
+﻿using Infomaniak.kDrive.Types;
 using Infomaniak.kDrive.ViewModels;
 using System;
 using System.Collections.Generic;

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -1472,13 +1472,13 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             if (user is not null)
             {
                 Logger.Log(Logger.Level.Extended, $"User with DbId {dbId} already exists in the application, updating...");
-                ConversionHelper.copyToUser(userInfo, user);
+                ConversionHelper.CopyToUser(userInfo, user);
                 Logger.Log(Logger.Level.Info, $"User with DbId {dbId} updated.");
             }
             else
             {
                 User newUser = new User(dbId);
-                ConversionHelper.copyToUser(userInfo, newUser);
+                ConversionHelper.CopyToUser(userInfo, newUser);
                 await Utility.RunOnUIThread(() =>
                 {
                     _viewModel.Users.Add(newUser);

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -117,6 +117,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
         public async Task<bool> RefreshUsers(CancellationToken cancellationToken)
         {
             CommData data = await _commClient.SendRequestAsync(RequestNum.USER_INFOLIST, new JsonObject(), cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
 
             if (!CheckJobResultAndLogIfError(data, new JsonObject()))
                 return false;

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -28,11 +28,38 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             _commClient.SignalReceived += OnSignalReceived;
         }
 
+        // Utility methods
+        private static bool HasRequiredParam(CommData data, string key, [CallerMemberName] string callerName = "")
+        {
+            if (data.Params is null || !data.Params.ContainsKey(key))
+            {
+                Logger.Log(Logger.Level.Error, $"{callerName}: {key} not found in response.");
+                return false;
+            }
+            return true;
+        }
+
+        private static bool CheckJobResultAndLogIfError(CommData data, JsonObject jobInput, [CallerMemberName] string callerName = "")
+        {
+            if (data?.Params is null)
+            {
+                Logger.Log(Logger.Level.Error, $"Job result check failed at {callerName} with input {jobInput}, Params is null.");
+                return false;
+            }
+
+            if (data.Code != ExitCode.Ok)
+            {
+                Logger.Log(Logger.Level.Error, $"Job result check failed at {callerName} with input {jobInput}, exit code: {data.Code}, exit cause: {data.Cause}.");
+                return false;
+            }
+            return true;
+        }
+
         // Requests
         public async Task<List<DbId>?> GetUserDbIds(CancellationToken cancellationToken)
         {
             CommData data = await _commClient.SendRequestAsync(RequestNum.USER_DBIDLIST, new JsonObject(), cancellationToken);
-            if (data.Params == null || !data.Params.ContainsKey(JsonKeys.UserDbIds))
+            if (data.Params is null || !data.Params.ContainsKey(JsonKeys.UserDbIds))
             {
                 Logger.Log(Logger.Level.Error, $"{JsonKeys.UserDbIds} not found in response.");
                 return null;
@@ -42,33 +69,47 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
 
         public async Task<User?> AddOrRelogUser(string oAuthCode, string oAuthCodeVerifier, CancellationToken cancellationToken)
         {
-            CommData data = await _commClient.SendRequestAsync(RequestNum.LOGIN_REQUESTTOKEN, new JsonObject
+            JsonObject parms = new()
             {
                 [JsonKeys.OAuthCode] = Utility.ToBase64String(oAuthCode),
                 [JsonKeys.OAuthCodeVerifier] = Utility.ToBase64String(oAuthCodeVerifier)
-            }, cancellationToken);
+            };
 
-            if (data.Params == null || !data.Params.ContainsKey(JsonKeys.UserDbId) || data.Params[JsonKeys.UserDbId] == null)
+            CommData data = await _commClient.SendRequestAsync(RequestNum.LOGIN_REQUESTTOKEN, parms, cancellationToken);
+
+            if (!CheckJobResultAndLogIfError(data, parms))
+                return null;
+
+            if (!HasRequiredParam(data, JsonKeys.UserDbId))
+                return null;
+
+            DbId userDbId = -1;
+            try
             {
-                Logger.Log(Logger.Level.Error, $"{JsonKeys.UserDbId} not found in response.");
+                userDbId = data.Params[JsonKeys.UserDbId]!.GetValue<DbId>();
+            }
+            catch (Exception ex)
+            {
+                Logger.Log(Logger.Level.Error, $"Failed to parse UserDbId from response: {ex.Message}");
                 return null;
             }
 
-            DbId userDbId = data.Params[JsonKeys.UserDbId]?.GetValue<DbId>() ?? -1;
-
-            await Utility.RunOnUIThread(() =>
+            await Utility.RunOnUIThread(async () =>
             {
-                if (_viewModel.Users.Any(u => u.DbId == userDbId))
+                // The server should send a signal user_added that will add the user to the model, we wait here for max 10s for that to happen
+                int maxRetries = 100;
+                do
                 {
-                    Logger.Log(Logger.Level.Info, $"User with DbId {userDbId} already exists in the application.");
-                }
-                else
-                {
-                    User newUser = new User(userDbId);
-                    _viewModel.Users.Add(newUser);
-                    Logger.Log(Logger.Level.Info, $"AddOrRelogUser: New user added with DbId {userDbId}.");
-                }
-            });
+                    if (_viewModel.Users.Any(u => u.DbId == userDbId))
+                    {
+                        Logger.Log(Logger.Level.Info, $"AddOrRelogUser: User with DbId {userDbId} already exists in the application.");
+                        return;
+                    }
+                    await Task.Delay(100, cancellationToken).ConfigureAwait(false);
+                    --maxRetries;
+                } while (!cancellationToken.IsCancellationRequested && maxRetries > 0);
+                Logger.Log(Logger.Level.Error, $"AddOrRelogUser: Timeout waiting for user with DbId {userDbId} to be added to the application.");
+            }).ConfigureAwait(false);
             return _viewModel.Users.FirstOrDefault(u => u?.DbId == userDbId, null);
         }
 

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -40,9 +40,15 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             return true;
         }
 
-        private static bool CheckJobResultAndLogIfError(CommData data, JsonObject jobInput, [CallerMemberName] string callerName = "")
+        private static bool CheckJobResultAndLogIfError(CommData? data, JsonObject jobInput, [CallerMemberName] string callerName = "")
         {
-            if (data?.Params is null)
+            if (data is null)
+            {
+                Logger.Log(Logger.Level.Error, $"Job result check failed at {callerName} with input {jobInput}, CommData is null.");
+                return false;
+            }
+
+            if (data.Params is null)
             {
                 Logger.Log(Logger.Level.Error, $"Job result check failed at {callerName} with input {jobInput}, Params is null.");
                 return false;
@@ -76,7 +82,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.OAuthCodeVerifier] = Utility.ToBase64String(oAuthCodeVerifier)
             };
 
-            CommData data = await _commClient.SendRequestAsync(RequestNum.LOGIN_REQUESTTOKEN, parms, cancellationToken);
+            CommData data = await _commClient.SendRequestAsync(RequestNum.LOGIN_REQUESTTOKEN, parms, cancellationToken).ConfigureAwait(false);
 
             if (!CheckJobResultAndLogIfError(data, parms))
                 return null;
@@ -116,7 +122,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
 
         public async Task<bool> RefreshUsers(CancellationToken cancellationToken)
         {
-            CommData data = await _commClient.SendRequestAsync(RequestNum.USER_INFOLIST, new JsonObject(), cancellationToken);
+            CommData data = await _commClient.SendRequestAsync(RequestNum.USER_INFOLIST, new JsonObject(), cancellationToken).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
 
             if (!CheckJobResultAndLogIfError(data, new JsonObject()))
@@ -145,7 +151,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                     Logger.Log(Logger.Level.Error, "userInfo.DbId is null.");
                     continue;
                 }
-                await AddOrUpdateUserInModel(userInfo);
+                await AddOrUpdateUserInModel(userInfo).ConfigureAwait(false);
             }
 
             // Remove users that are no longer present
@@ -154,18 +160,34 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             {
                 var usersToRemove = _viewModel.Users.Where(u => !userDbIds.Contains(u.DbId)).ToList();
                 _viewModel.Users.RemoveMany(usersToRemove);
-                Logger.Log(Logger.Level.Info, $"{usersToRemove.Count} users removed from the application.");
-            });
+                Logger.Log(Logger.Level.Info, $"{usersToRemove.Count} users removed.");
+            }).ConfigureAwait(false);
             return true;
         }
 
-        public async Task RemoveUser(DbId userDbId, CancellationToken cancellationToken)
+        public async Task<bool> RemoveUser(DbId userDbId, CancellationToken cancellationToken)
         {
             JsonObject parms = new()
             {
                 [JsonKeys.UserDbId] = userDbId
             };
-            var commData = await _commClient.SendRequestAsync(RequestNum.USER_DELETE, parms, cancellationToken);
+            var commData = await _commClient.SendRequestAsync(RequestNum.USER_DELETE, parms, cancellationToken).ConfigureAwait(false);
+
+            // If the user is not found on the server, we assume it is already deleted and remove it from the model
+            if (commData?.Code == ExitCode.DataError && commData?.Cause == ExitCause.DbEntryNotFound)
+            {
+                Logger.Log(Logger.Level.Warning, $"User with DbId {userDbId} not found on server, assuming already deleted.");
+                await Utility.RunOnUIThread(() =>
+                {
+                    var userToRemove = _viewModel.Users.FirstOrDefault(u => u.DbId == userDbId);
+                    if (userToRemove is not null)
+                        _viewModel.Users.Remove(userToRemove);
+                    Logger.Log(Logger.Level.Info, $"User with DbId {userDbId} removed.");
+                }).ConfigureAwait(false);
+                return true;
+            }
+
+            return CheckJobResultAndLogIfError(commData, parms);
         }
 
         public async Task RefreshAccounts(CancellationToken cancellationToken)

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -1,4 +1,5 @@
-﻿using Infomaniak.kDrive.ServerCommunication.CommStruct;
+﻿using DynamicData;
+using Infomaniak.kDrive.ServerCommunication.CommStruct;
 using Infomaniak.kDrive.ServerCommunication.Interfaces;
 using Infomaniak.kDrive.ServerCommunication.JsonConverters;
 using Infomaniak.kDrive.Types;
@@ -113,20 +114,27 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             return _viewModel.Users.FirstOrDefault(u => u?.DbId == userDbId, null);
         }
 
-        public async Task RefreshUsers(CancellationToken cancellationToken)
+        public async Task<bool> RefreshUsers(CancellationToken cancellationToken)
         {
             CommData data = await _commClient.SendRequestAsync(RequestNum.USER_INFOLIST, new JsonObject(), cancellationToken);
-            if (data.Params == null || !data.Params.ContainsKey(JsonKeys.UserInfoList))
-            {
-                Logger.Log(Logger.Level.Error, $"{JsonKeys.UserInfoList} not found in response.");
-                return;
-            }
+
+            if (!CheckJobResultAndLogIfError(data, new JsonObject()))
+                return false;
+
+            if (!HasRequiredParam(data, JsonKeys.UserInfoList))
+                return false;
+
             var options = new JsonSerializerOptions
             {
                 PropertyNameCaseInsensitive = true
             };
             options.Converters.Add(new Base64StringJsonConverter());
-            List<UserInfo> userInfos = data.Params[JsonKeys.UserInfoList].Deserialize<List<UserInfo>>(options) ?? new List<UserInfo>();
+            List<UserInfo>? userInfos = data.Params[JsonKeys.UserInfoList].Deserialize<List<UserInfo>>(options);
+            if (userInfos is null)
+            {
+                Logger.Log(Logger.Level.Error, "Failed to deserialize UserInfoList.");
+                return false;
+            }
 
             // Add/update users
             foreach (var userInfo in userInfos)
@@ -144,12 +152,10 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             await Utility.RunOnUIThread(() =>
             {
                 var usersToRemove = _viewModel.Users.Where(u => !userDbIds.Contains(u.DbId)).ToList();
-                foreach (var user in usersToRemove)
-                {
-                    _viewModel.Users.Remove(user);
-                    Logger.Log(Logger.Level.Info, $"User with DbId {user.DbId} removed from the application.");
-                }
+                _viewModel.Users.RemoveMany(usersToRemove);
+                Logger.Log(Logger.Level.Info, $"{usersToRemove.Count} users removed from the application.");
             });
+            return true;
         }
 
         public async Task RemoveUser(DbId userDbId, CancellationToken cancellationToken)
@@ -1431,22 +1437,25 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
         // Helpers
         private async Task AddOrUpdateUserInModel(UserInfo userInfo)
         {
-            if (_viewModel.Users.Any(u => u.DbId == userInfo.DbId))
+
+            if (!userInfo.DbId.HasValue)
             {
-                Logger.Log(Logger.Level.Info, $"User with DbId {userInfo.DbId} already exists in the application.");
-                var user = _viewModel.Users.FirstOrDefault(u => u.DbId == userInfo.DbId);
-                if (user == null)
-                {
-                    Logger.Log(Logger.Level.Error, $"Unexpected error, user with DbId {userInfo.DbId} not found after existence check.");
-                    return;
-                }
-                ConversionHelper.CopyToUser(userInfo, user);
-                Logger.Log(Logger.Level.Info, $"User with DbId {userInfo.DbId} updated.");
+                Logger.Log(Logger.Level.Error, "userInfo.DbId is null.");
+                return;
+            }
+            DbId dbId = userInfo.DbId.Value;
+
+            User? user = _viewModel.Users.FirstOrDefault(u => u?.DbId == dbId, null);
+            if (user is not null)
+            {
+                Logger.Log(Logger.Level.Extended, $"User with DbId {dbId} already exists in the application, updating...");
+                ConversionHelper.copyToUser(userInfo, user);
+                Logger.Log(Logger.Level.Info, $"User with DbId {dbId} updated.");
             }
             else
             {
-                User newUser = new User(userInfo.DbId ?? throw new InvalidOperationException("DbId should not be null here."));
-                ConversionHelper.CopyToUser(userInfo, newUser);
+                User newUser = new User(dbId);
+                ConversionHelper.copyToUser(userInfo, newUser);
                 await Utility.RunOnUIThread(() =>
                 {
                     _viewModel.Users.Add(newUser);

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/SocketServerCommProtocol.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/SocketServerCommProtocol.cs
@@ -190,7 +190,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             }
             catch (OperationCanceledException)
             {
-                Logger.Log(Logger.Level.Error, "Request operation was canceled.");
+                Logger.Log(Logger.Level.Info, "Request operation was canceled.");
                 return new CommData();
             }
             catch (Exception ex)

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/SocketServerCommProtocol.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/SocketServerCommProtocol.cs
@@ -291,7 +291,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             options.Converters.Add(new Base64StringJsonConverter());
             Logger.Log(Logger.Level.Debug, $"Deserializing: {jsonString}");
             var messageObj = JsonSerializer.Deserialize<CommData>(jsonString, options);
-            if (messageObj == null)
+            if (messageObj is null)
             {
                 Logger.Log(Logger.Level.Warning, "Invalid message format.");
                 return;

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/fr-FR/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/fr-FR/Resources.resw
@@ -1145,10 +1145,16 @@ Infomaniak</value>
   <data name="CC_DriveSetupContentDialog_SyncSetupPage_TeachingTip_InvalidFolder.Title" xml:space="preserve">
     <value>Ce dossier ne peut pas être sélectionné</value>
   </data>
+  <data name="UnexpectedErrorTeachingTip.Title" xml:space="preserve">
+    <value>Une erreur inattendue est survenue</value>
+  </data>
   <data name="CC_DriveSetupContentDialog_SyncSetupPage_TeachingTip_InvalidFolder.Content" xml:space="preserve">
     <value>Veuillez sélectionner un dossier vide qui ne se trouve pas à la racine d’un lecteur.
 
 Ce dossier ne doit pas être inclus dans un autre dossier de synchronisation et ne doit pas contenir de sous-dossier de synchronisation.</value>
+  </data>
+  <data name="UnexpectedErrorTeachingTip.Content" xml:space="preserve">
+    <value>Veuillez réessayer dans quelques instants. Si le problème persiste, veuillez contacter le support</value>
   </data>
   <data name="CC_DriveSetupContentDialog_SyncExclusionPage_Title.Text" xml:space="preserve">
     <value>Choisissez les dossiers à synchroniser sur cet ordinateur</value>

--- a/src/gui4/windows/kDrive client/kDrive client/Utility/Utility.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Utility/Utility.cs
@@ -316,6 +316,10 @@ namespace Infomaniak.kDrive
                 return new string('*', localPart.Length) + domainPart;
         }
 
+        public static void ShowUnexpectedErrorTeachingTip()
+        {
+            Utility.ShowTeachingTipFromxUid("UnexpectedErrorTeachingTip");
+        }
         public static void ShowTeachingTipFromxUid(string xuid, Control? target = null)
         {
             if (App.Current as App is not App app || app.CurrentWindow is null)

--- a/src/gui4/windows/kDrive client/kDrive client/Utility/Utility.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Utility/Utility.cs
@@ -19,31 +19,64 @@ namespace Infomaniak.kDrive
 {
     public static class Utility
     {
+        public static async Task RunOnUIThread(Func<Task> action)
+        {
+            var dispatcher = AppModel.UIThreadDispatcher;
+
+            if (dispatcher.HasThreadAccess)
+            {
+                await action();
+            }
+            else
+            {
+                TaskCompletionSource tcs = new();
+
+                await dispatcher.EnqueueAsync(async () =>
+                {
+                    try
+                    {
+                        await action();
+                        tcs.SetResult();
+                    }
+                    catch (Exception ex)
+                    {
+                        tcs.SetException(ex);
+                    }
+                });
+
+                await tcs.Task;
+            }
+        }
+
         public static async Task RunOnUIThread(Action action)
         {
             var dispatcher = AppModel.UIThreadDispatcher;
+
             if (dispatcher.HasThreadAccess)
             {
                 action();
             }
             else
             {
-                TaskCompletionSource taskCompletionSource = new TaskCompletionSource();
+                TaskCompletionSource tcs = new();
+
                 await dispatcher.EnqueueAsync(() =>
                 {
                     try
                     {
                         action();
-                        taskCompletionSource.SetResult();
+                        tcs.SetResult();
                     }
                     catch (Exception ex)
                     {
-                        taskCompletionSource.SetException(ex);
+                        tcs.SetException(ex);
                     }
                 });
-                await taskCompletionSource.Task;
+
+                await tcs.Task;
             }
         }
+
         public static async Task OpenFileAsync(string filePath)
         {
             try
@@ -283,17 +316,14 @@ namespace Infomaniak.kDrive
                 return new string('*', localPart.Length) + domainPart;
         }
 
-        public static void ShowTeachingTip(string xuid, XamlRoot? xamlRoot = null, Control? target = null)
+        public static void ShowTeachingTipFromxUid(string xuid, Control? target = null)
         {
-            if (xamlRoot is null)
+            if (App.Current as App is not App app || app.CurrentWindow is null)
             {
-                if (App.Current as App is not App app || app.CurrentWindow is null)
-                {
-                    Logger.Log(Logger.Level.Error, "Cannot show TeachingTip: App.Current or CurrentWindow is null");
-                    return;
-                }
-                xamlRoot = app.CurrentWindow.Content.XamlRoot;
+                Logger.Log(Logger.Level.Error, "Cannot show TeachingTip: App.Current or CurrentWindow is null");
+                return;
             }
+            XamlRoot xamlRoot = app.CurrentWindow.Content.XamlRoot;
 
             var teachingTip = new TeachingTip
             {

--- a/src/gui4/windows/kDrive client/kDrive client/Utility/Utility.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Utility/Utility.cs
@@ -283,8 +283,18 @@ namespace Infomaniak.kDrive
                 return new string('*', localPart.Length) + domainPart;
         }
 
-        public static void ShowTeachingTip(XamlRoot xamlRoot, string xuid, Control? target = null)
+        public static void ShowTeachingTip(string xuid, XamlRoot? xamlRoot = null, Control? target = null)
         {
+            if (xamlRoot is null)
+            {
+                if (App.Current as App is not App app || app.CurrentWindow is null)
+                {
+                    Logger.Log(Logger.Level.Error, "Cannot show TeachingTip: App.Current or CurrentWindow is null");
+                    return;
+                }
+                xamlRoot = app.CurrentWindow.Content.XamlRoot;
+            }
+
             var teachingTip = new TeachingTip
             {
                 XamlRoot = xamlRoot,

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/App.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/App.cs
@@ -108,7 +108,7 @@ namespace Infomaniak.kDrive.ViewModels
                 }
             }
         }
-       
+
         public AppModel()
         {
             // Create a read-only observable collection of active drives across all users
@@ -226,7 +226,7 @@ namespace Infomaniak.kDrive.ViewModels
          *  This method is asynchronous and should be awaited.
          *  It loads the list of users and their properties/drives from the server.
          */
-        public async Task InitializeAsync()
+        public async Task<bool> InitializeAsync()
         {
 
             Logger.Log(Logger.Level.Info, "Initializing AppModel...");
@@ -234,14 +234,21 @@ namespace Infomaniak.kDrive.ViewModels
             SelectedSync = null;
 
             IServerCommService serverCommService = App.ServiceProvider.GetRequiredService<IServerCommService>();
-            await serverCommService.RefreshUsers(new CancellationToken());
-            await serverCommService.RefreshAccounts(new CancellationToken());
-            await serverCommService.RefreshDrives(new CancellationToken());
-            await serverCommService.RefreshSyncs(new CancellationToken());
-            await serverCommService.RefreshSettings(new CancellationToken());
-            await serverCommService.RefreshErrors(new CancellationToken());
+
+            if (!await serverCommService.RefreshUsers(CancellationToken.None))
+            {
+                Logger.Log(Logger.Level.Error, "Failed to refresh users during AppModel initialization.");
+                return false;
+            }
+
+            await serverCommService.RefreshAccounts(CancellationToken.None);
+            await serverCommService.RefreshDrives(CancellationToken.None);
+            await serverCommService.RefreshSyncs(CancellationToken.None);
+            await serverCommService.RefreshSettings(CancellationToken.None);
+            await serverCommService.RefreshErrors(CancellationToken.None);
             Logger.Log(Logger.Level.Info, "All server data loaded successfully.");
             IsInitialized = true;
+            return true;
         }
 
         public async Task DisconnectUserAsync(DbId userDbId)

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/App.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/App.cs
@@ -234,21 +234,37 @@ namespace Infomaniak.kDrive.ViewModels
             SelectedSync = null;
 
             IServerCommService serverCommService = App.ServiceProvider.GetRequiredService<IServerCommService>();
-
-            if (!await serverCommService.RefreshUsers(CancellationToken.None))
+            try
             {
-                Logger.Log(Logger.Level.Error, "Failed to refresh users during AppModel initialization.");
+                // Allow up to 5 minutes for the initial load as it happen at computer startup wich can be slow
+                using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5)))
+                {
+                    if (!await serverCommService.RefreshUsers(cts.Token))
+                    {
+                        Logger.Log(Logger.Level.Error, "Failed to refresh users during AppModel initialization.");
+                        return false;
+                    }
+
+                    await serverCommService.RefreshAccounts(CancellationToken.None);
+                    await serverCommService.RefreshDrives(CancellationToken.None);
+                    await serverCommService.RefreshSyncs(CancellationToken.None);
+                    await serverCommService.RefreshSettings(CancellationToken.None);
+                    await serverCommService.RefreshErrors(CancellationToken.None);
+                    Logger.Log(Logger.Level.Info, "All server data loaded successfully.");
+                    IsInitialized = true;
+                    return true;
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                Logger.Log(Logger.Level.Error, "Operation canceled during AppModel initialization.");
                 return false;
             }
-
-            await serverCommService.RefreshAccounts(CancellationToken.None);
-            await serverCommService.RefreshDrives(CancellationToken.None);
-            await serverCommService.RefreshSyncs(CancellationToken.None);
-            await serverCommService.RefreshSettings(CancellationToken.None);
-            await serverCommService.RefreshErrors(CancellationToken.None);
-            Logger.Log(Logger.Level.Info, "All server data loaded successfully.");
-            IsInitialized = true;
-            return true;
+            catch (Exception ex)
+            {
+                Logger.Log(Logger.Level.Error, $"Exception during AppModel initialization: {ex}");
+                return false;
+            }
         }
 
         public async Task DisconnectUserAsync(DbId userDbId)

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/App.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/App.cs
@@ -188,7 +188,6 @@ namespace Infomaniak.kDrive.ViewModels
             }
         }
 
-
         private void EnsureValidSelectedSync()
         {
             // If AllSync is empty, set SelectedSync to null
@@ -196,7 +195,7 @@ namespace Infomaniak.kDrive.ViewModels
             {
                 Logger.Log(Logger.Level.Debug, "There are no syncs available, setting SelectedSync to null.");
                 SelectedSync = null;
-                ((App.Current as App)?.CurrentWindow as MainWindow)?.AppNavView.Frame.Navigate(typeof(SettingsPage));
+                ((App.Current as App)?.CurrentWindow as MainWindow)?.AppNavView?.Frame.Navigate(typeof(SettingsPage));
             }
             else if (_selectedSync == null || (_selectedSync != null && !AllSyncs.Contains(_selectedSync))) // If SelectedSync is null or not in AllSyncs, pick the first one
             {

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/App.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/App.cs
@@ -270,7 +270,11 @@ namespace Infomaniak.kDrive.ViewModels
         public async Task DisconnectUserAsync(DbId userDbId)
         {
             IServerCommService serverCommService = App.ServiceProvider.GetRequiredService<IServerCommService>();
-            await serverCommService.RemoveUser(userDbId, CancellationToken.None);
+            if(!await serverCommService.RemoveUser(userDbId, CancellationToken.None))
+            {
+                Logger.Log(Logger.Level.Error, $"Failed to disconnect user {userDbId}");
+                Utility.ShowUnexpectedErrorTeachingTip();
+            }
         }
 
         public async Task AddErrorAsync(Error error)

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/Onboarding/Onboarding.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/Onboarding/Onboarding.cs
@@ -45,14 +45,17 @@ namespace Infomaniak.kDrive.ViewModels
                     Logger.Log(Logger.Level.Debug, "Successfully obtained user code.");
                     CurrentOAuth2State = OAuth2State.ProcessingResponse;
                     User? user = await _serverCommService.AddOrRelogUser(OAutCodes.Code, OAutCodes.CodeVerifier, cancelationToken);
-                    SelectedUser = user;
-                    CurrentOAuth2State = OAuth2State.Success;
+                    if (user is not null)
+                    {
+                        SelectedUser = user;
+                        CurrentOAuth2State = OAuth2State.Success;
+                        Logger.Log(Logger.Level.Info, $"User {user.Name} successfully connected.");
+                        return;
+                    }
                 }
-                else
-                {
-                    CurrentOAuth2State = OAuth2State.Error;
-                    Logger.Log(Logger.Level.Warning, "Authentication process failed");
-                }
+
+                CurrentOAuth2State = OAuth2State.Error;
+                Logger.Log(Logger.Level.Warning, "Authentication process failed");
             }
             catch (OperationCanceledException)
             {

--- a/src/server/comm/guijobs/userdeletejob.cpp
+++ b/src/server/comm/guijobs/userdeletejob.cpp
@@ -67,7 +67,7 @@ ExitInfo UserDeleteJob::process() {
 
     // Delete user from DB
     const ExitInfo exitInfo = ServerRequests::deleteUser(_userDbId);
-    if (!exitInfo) {
+    if (exitInfo) {
         auto signalUserRemovedJob = std::make_shared<SignalUserRemovedJob>(_userDbId);
         _commManager->sendGuiSignal(signalUserRemovedJob);
     } else {

--- a/src/server/comm/guijobs/userdeletejob.cpp
+++ b/src/server/comm/guijobs/userdeletejob.cpp
@@ -52,6 +52,7 @@ ExitInfo UserDeleteJob::serializeOutputParms() {
 }
 
 ExitInfo UserDeleteJob::process() {
+    return {ExitCode::DataError, ExitCause::DbEntryNotFound};
     // Get syncs do delete
     std::vector<int> syncDbIdList;
     const std::scoped_lock lock(_commManager->appServer().syncPalMapMutex);
@@ -66,14 +67,14 @@ ExitInfo UserDeleteJob::process() {
     _commManager->appServer().stopAllSyncsTask(syncDbIdList);
 
     // Delete user from DB
-    const ExitCode exitCode = ServerRequests::deleteUser(_userDbId);
-    if (exitCode == ExitCode::Ok) {
+    const ExitInfo exitInfo = ServerRequests::deleteUser(_userDbId);
+    if (!exitInfo) {
         auto signalUserRemovedJob = std::make_shared<SignalUserRemovedJob>(_userDbId);
         _commManager->sendGuiSignal(signalUserRemovedJob);
     } else {
-        LOG_WARN(_logger, "Error in ServerRequests::deleteUser: code=" << exitCode);
-        addError(Error(ERR_ID, exitCode, ExitCause::Unknown));
-        return exitCode;
+        LOG_WARN(_logger, "Error in ServerRequests::deleteUser:" << exitInfo);
+        addError(Error(ERR_ID, exitInfo));
+        return exitInfo;
     }
 
     return ExitCode::Ok;

--- a/src/server/comm/guijobs/userdeletejob.cpp
+++ b/src/server/comm/guijobs/userdeletejob.cpp
@@ -52,7 +52,6 @@ ExitInfo UserDeleteJob::serializeOutputParms() {
 }
 
 ExitInfo UserDeleteJob::process() {
-    return {ExitCode::DataError, ExitCause::DbEntryNotFound};
     // Get syncs do delete
     std::vector<int> syncDbIdList;
     const std::scoped_lock lock(_commManager->appServer().syncPalMapMutex);

--- a/src/server/requests/serverrequests.cpp
+++ b/src/server/requests/serverrequests.cpp
@@ -108,7 +108,7 @@ ExitCode ServerRequests::getUserInfoList(std::vector<UserInfo> &list) {
     return ExitCode::Ok;
 }
 
-ExitCode ServerRequests::deleteUser(int userDbId) {
+ExitInfo ServerRequests::deleteUser(int userDbId) {
     // Delete user (and linked accounts/drives/syncs by cascade)
     bool found;
     if (!ParmsDb::instance()->deleteUser(userDbId, found)) {
@@ -117,7 +117,7 @@ ExitCode ServerRequests::deleteUser(int userDbId) {
     }
     if (!found) {
         LOG_WARN(Log::instance()->getLogger(), "User with id=" << userDbId << " not found");
-        return ExitCode::DataError;
+        return {ExitCode::DataError, ExitCause::DbEntryNotFound};
     }
 
     AbstractTokenNetworkJob::clearCacheForUser(userDbId);
@@ -1799,7 +1799,7 @@ ExitCode ServerRequests::deleteLiteSyncErrors() {
 
 ExitInfo ServerRequests::loadDriveInfo(Drive &drive, Account &account, bool &updated, bool &quotaUpdated, bool &accountUpdated) {
     updated = false;
-    accountUpdated = false; 
+    accountUpdated = false;
     quotaUpdated = false; // TODO: variable to be removed once migrated to the new UI
     // Get drive data
     std::shared_ptr<GetInfoDriveJob> job = nullptr;

--- a/src/server/requests/serverrequests.h
+++ b/src/server/requests/serverrequests.h
@@ -134,7 +134,7 @@ struct SYNCENGINE_EXPORT ServerRequests {
         static ExitInfo getPathByNodeId(int userDbId, int driveId, const NodeId &nodeId, CommString &path);
 
         // C/S requests (others)
-        static ExitCode deleteUser(int userDbId); // !!! Use COMM_LONG_TIMEOUT !!!
+        static ExitInfo deleteUser(int userDbId); // !!! Use COMM_LONG_TIMEOUT !!!
         static ExitInfo deleteAccount(int accountDbId); // !!! Use COMM_LONG_TIMEOUT !!!
         static ExitCode deleteDrive(int driveDbId); // !!! Use COMM_LONG_TIMEOUT !!!
         static ExitCode deleteSync(int syncDbId); // !!! Use COMM_LONG_TIMEOUT !!!


### PR DESCRIPTION
### Handled Error Cases

#### ➕ User addition / re-login
- **Related request**: `RequestNum.LOGIN_REQUESTTOKEN`
- **Description**: error occurring during user addition or user re-login  
- **Screenshot / illustration**:  

  https://github.com/user-attachments/assets/f507f36e-b5a2-45fe-941e-9b54f18a3313

#### ➖ User deletion
- **Related request**: `RequestNum.USER_DELETE`
- **Description**: error occurring during user deletion  
- **Screenshot / illustration**:  

  https://github.com/user-attachments/assets/4c46bd96-8802-4686-8522-18c97e36015d

#### ℹ️ User list retrieval
- **Related request**: `RequestNum.USER_INFOLIST`
- **Description**: in case of a server error or a timeout (**5 minutes**), the request currently causes the **application to close**
