### PR TITLE
WinUI 3: Graceful Handling of Server Errors (Step 2 – Cache loading)

### DIFF
--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Interfaces/IServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Interfaces/IServerCommService.cs
@@ -53,7 +53,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Interfaces
         Task RefreshUserDrivesAvailable(DbId userDbId, CancellationToken cancellationToken);
 
         // Sync-related requests
-        Task RefreshSyncs(CancellationToken cancellationToken);
+        Task<bool> RefreshSyncs(CancellationToken cancellationToken);
         Task StartSync(DbId syncDbId, CancellationToken cancellationToken);
         Task PauseSync(DbId syncDbId, CancellationToken cancellationToken);
         Task RemoveSync(DbId syncDbId, CancellationToken cancellationToken);

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Interfaces/IServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Interfaces/IServerCommService.cs
@@ -83,7 +83,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Interfaces
         Task<Uri?> GetPublicLink(DbId driveDbId, NodeId nodeId, CancellationToken cancellationToken);
 
         // Setting-related requests
-        Task RefreshSettings(CancellationToken cancellationToken);
+        Task<bool> RefreshSettings(CancellationToken cancellationToken);
 
         // Saves the settings provided in the Settings view model to the server.
         Task SaveSettings(CancellationToken cancellationToken);

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Interfaces/IServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Interfaces/IServerCommService.cs
@@ -44,7 +44,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Interfaces
          * Returns a Task that completes when the operation is done.
          * Note: This does not refresh drives within accounts, only the accounts themselves.
          */
-        Task RefreshAccounts(CancellationToken cancellationToken);
+        Task<bool> RefreshAccounts(CancellationToken cancellationToken);
 
 
         // Drive-related requests

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Interfaces/IServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Interfaces/IServerCommService.cs
@@ -49,7 +49,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Interfaces
 
 
         // Drive-related requests
-        Task RefreshDrives(CancellationToken cancellationToken);
+        Task<bool> RefreshDrives(CancellationToken cancellationToken);
         Task RefreshUserDrivesAvailable(DbId userDbId, CancellationToken cancellationToken);
 
         // Sync-related requests

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Interfaces/IServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Interfaces/IServerCommService.cs
@@ -28,7 +28,8 @@ namespace Infomaniak.kDrive.ServerCommunication.Interfaces
         /* Refreshes the information of all users from the server.
          * This includes their properties (name, email, avatar, etc.), accounts are not refreshed here, call RefreshAccounts for that.
          * User are added/removed as necessary to match the server state.
-         * Returns a Task that completes when the operation is done.
+         * Returns true on success, false on failure.
+         * Note: This does not refresh accounts within users, only the users themselves.
          */
         Task<bool> RefreshUsers(CancellationToken cancellationToken);
 
@@ -41,7 +42,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Interfaces
         // Account-related requests
         /* Refreshes the list of accounts for all users from the server.
          * Accounts are added/removed as necessary to match the server state.
-         * Returns a Task that completes when the operation is done.
+         * Returns true on success, false on failure.
          * Note: This does not refresh drives within accounts, only the accounts themselves.
          */
         Task<bool> RefreshAccounts(CancellationToken cancellationToken);

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Interfaces/IServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Interfaces/IServerCommService.cs
@@ -107,7 +107,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Interfaces
         Task Exit(); // Notify the server that the application is exiting. No cancellation token is required as the app is closing.
 
         // Error-related requests
-        Task RefreshErrors(CancellationToken cancellationToken);
+        Task<bool> RefreshErrors(CancellationToken cancellationToken);
 
         // Event handlers for user-related signals
         Task HandleUserUpdatedOrAddedAsync(object? sender, SignalEventArgs args);

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -40,7 +40,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             return true;
         }
 
-        private static bool CheckJobResultAndLogIfError(CommData? data, JsonObject jobInput, [CallerMemberName] string callerName = "")
+        private static bool CheckJobResultAndLogIfError(CommData? data, JsonObject? jobInput = null, [CallerMemberName] string callerName = "")
         {
             if (data is null)
             {
@@ -189,20 +189,26 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             return CheckJobResultAndLogIfError(commData, parms);
         }
 
-        public async Task RefreshAccounts(CancellationToken cancellationToken)
+        public async Task<bool> RefreshAccounts(CancellationToken cancellationToken)
         {
-            CommData data = await _commClient.SendRequestAsync(RequestNum.ACCOUNT_INFOLIST, new JsonObject(), cancellationToken);
-            if (data.Params == null || !data.Params.ContainsKey(JsonKeys.AccountInfoList))
-            {
-                Logger.Log(Logger.Level.Error, $"{JsonKeys.AccountInfoList} not found in response.");
-                return;
-            }
+            CommData data = await _commClient.SendRequestAsync(RequestNum.ACCOUNT_INFOLIST, new JsonObject(), cancellationToken).ConfigureAwait(false);
+            if (!CheckJobResultAndLogIfError(data))
+                return false;
+
+            if (!HasRequiredParam(data, JsonKeys.AccountInfoList))
+                return false;
+
             var options = new JsonSerializerOptions
             {
                 PropertyNameCaseInsensitive = true
             };
             options.Converters.Add(new Base64StringJsonConverter());
-            List<AccountInfo> accountInfos = data.Params[JsonKeys.AccountInfoList].Deserialize<List<AccountInfo>>(options) ?? new List<AccountInfo>();
+            List<AccountInfo>? accountInfos = data.Params[JsonKeys.AccountInfoList].Deserialize<List<AccountInfo>>(options);
+            if (accountInfos is null)
+            {
+                Logger.Log(Logger.Level.Error, "Failed to deserialize AccountInfoList.");
+                return false;
+            }
 
             // Add/update accounts
             foreach (var accountInfo in accountInfos)
@@ -212,7 +218,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                     Logger.Log(Logger.Level.Error, "accountInfo.DbId is null.");
                     continue;
                 }
-                await AddOrUpdateAccountInModel(accountInfo);
+                await AddOrUpdateAccountInModel(accountInfo).ConfigureAwait(false);
             }
 
             // Remove accounts that are no longer present
@@ -237,7 +243,8 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                         Logger.Log(Logger.Level.Info, $"Account with DbId {account.DbId} removed from user DbId {parentUser.DbId}.");
                     }
                 }
-            });
+            }).ConfigureAwait(false);
+            return true;
         }
 
         public async Task RefreshDrives(CancellationToken cancellationToken)

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -936,7 +936,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 Logger.Log(Logger.Level.Error, $"Failed to deserialize parmsInfo from ${data.Params["parmsInfo"]}.");
                 return false;
             }
-            CommStruct.ConversionHelper.copyToSettings(parametersInfo, _viewModel.Settings);
+            CommStruct.ConversionHelper.CopyToSettings(parametersInfo, _viewModel.Settings);
             return true;
         }
 

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -123,7 +123,6 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
         public async Task<bool> RefreshUsers(CancellationToken cancellationToken)
         {
             CommData data = await _commClient.SendRequestAsync(RequestNum.USER_INFOLIST, new JsonObject(), cancellationToken).ConfigureAwait(false);
-            cancellationToken.ThrowIfCancellationRequested();
 
             if (!CheckJobResultAndLogIfError(data, new JsonObject()))
                 return false;
@@ -160,7 +159,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             {
                 var usersToRemove = _viewModel.Users.Where(u => !userDbIds.Contains(u.DbId)).ToList();
                 _viewModel.Users.RemoveMany(usersToRemove);
-                Logger.Log(Logger.Level.Info, $"{usersToRemove.Count} users removed.");
+                Logger.Log(Logger.Level.Info, $"{usersToRemove.Count} users removed from the application.");
             }).ConfigureAwait(false);
             return true;
         }

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -1022,18 +1022,18 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             }
         }
 
-        public async Task RefreshErrors(CancellationToken cancellationToken)
+        public async Task<bool> RefreshErrors(CancellationToken cancellationToken)
         {
             JsonObject parms = new()
             {
                 [JsonKeys.Limit] = 1000
             };
-            CommData data = await _commClient.SendRequestAsync(RequestNum.ERROR_INFOLIST, parms, cancellationToken);
-            if (data.Params == null || !data.Params.ContainsKey(JsonKeys.ErrorInfoList))
-            {
-                Logger.Log(Logger.Level.Error, $"{JsonKeys.ErrorInfoList} not found in response.");
-                return;
-            }
+            CommData data = await _commClient.SendRequestAsync(RequestNum.ERROR_INFOLIST, parms, cancellationToken).ConfigureAwait(false);
+            if(!CheckJobResultAndLogIfError(data, parms))
+                return false;
+
+            if(!HasRequiredParam(data, JsonKeys.ErrorInfoList))
+                return false;
 
             var options = new JsonSerializerOptions
             {
@@ -1045,17 +1045,18 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             if (errorInfos is null)
             {
                 Logger.Log(Logger.Level.Error, $"Failed to deserialize errorInfoList from ${data.Params[JsonKeys.ErrorInfoList]}.");
-                return;
+                return false;
             }
 
-            await _viewModel.ClearAllErrorsAsync();
+            await _viewModel.ClearAllErrorsAsync().ConfigureAwait(false);
             foreach (var errorInfo in errorInfos)
             {
                 Error error = new();
                 CommStruct.ConversionHelper.CopyToError(errorInfo, error);
                 error.Sync = _viewModel.AllSyncs.FirstOrDefault(s => s.DbId == errorInfo.SyncDbId);
-                await _viewModel.AddErrorAsync(error);
+                await _viewModel.AddErrorAsync(error).ConfigureAwait(false);
             }
+            return true;
         }
 
         // Signals

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -247,21 +247,27 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             return true;
         }
 
-        public async Task RefreshDrives(CancellationToken cancellationToken)
+        public async Task<bool> RefreshDrives(CancellationToken cancellationToken)
         {
-            CommData data = await _commClient.SendRequestAsync(RequestNum.DRIVE_INFOLIST, new JsonObject(), cancellationToken);
-            if (data.Params == null || !data.Params.ContainsKey(JsonKeys.DriveInfoList))
-            {
-                Logger.Log(Logger.Level.Error, $"{JsonKeys.DriveInfoList} not found in response.");
-                return;
-            }
+            CommData data = await _commClient.SendRequestAsync(RequestNum.DRIVE_INFOLIST, new JsonObject(), cancellationToken).ConfigureAwait(false);
+            if (!CheckJobResultAndLogIfError(data))
+                return false;
+
+            if (!HasRequiredParam(data, JsonKeys.DriveInfoList))
+                return false;
+
             var options = new JsonSerializerOptions
             {
                 PropertyNameCaseInsensitive = true
             };
             options.Converters.Add(new Base64StringJsonConverter());
             options.Converters.Add(new ColorJsonConverter());
-            List<DriveInfo> driveInfos = data.Params[JsonKeys.DriveInfoList].Deserialize<List<DriveInfo>>(options) ?? new List<DriveInfo>();
+            List<DriveInfo>? driveInfos = data.Params[JsonKeys.DriveInfoList].Deserialize<List<DriveInfo>>(options);
+            if (driveInfos is null)
+            {
+                Logger.Log(Logger.Level.Error, "Failed to deserialize DriveInfoList.");
+                return false;
+            }
 
             // Add/update drives
             foreach (var driveInfo in driveInfos)
@@ -271,7 +277,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                     Logger.Log(Logger.Level.Error, "driveInfo.DbId is null.");
                     continue;
                 }
-                await AddOrUpdateDriveInModel(driveInfo);
+                await AddOrUpdateDriveInModel(driveInfo).ConfigureAwait(false);
             }
 
             // Remove drives that are no longer present
@@ -296,7 +302,8 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                         Logger.Log(Logger.Level.Info, $"Drive with DbId {drive.DbId} removed from account DbId {parentAccount.DbId}.");
                     }
                 }
-            });
+            }).ConfigureAwait(false);
+            return true;
         }
 
         public async Task RefreshUserDrivesAvailable(DbId userDbId, CancellationToken cancellationToken)

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -389,20 +389,26 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
 
         }
 
-        public async Task RefreshSyncs(CancellationToken cancellationToken)
+        public async Task<bool> RefreshSyncs(CancellationToken cancellationToken)
         {
-            CommData data = await _commClient.SendRequestAsync(RequestNum.SYNC_INFOLIST, new JsonObject(), cancellationToken);
-            if (data.Params == null || !data.Params.ContainsKey(JsonKeys.SyncInfoList))
-            {
-                Logger.Log(Logger.Level.Error, $"{JsonKeys.DriveInfoList} not found in response.");
-                return;
-            }
+            CommData data = await _commClient.SendRequestAsync(RequestNum.SYNC_INFOLIST, new JsonObject(), cancellationToken).ConfigureAwait(false);
+            if (!CheckJobResultAndLogIfError(data))
+                return false;
+
+            if (!HasRequiredParam(data, JsonKeys.SyncInfoList))
+                return false;
+
             var options = new JsonSerializerOptions
             {
                 PropertyNameCaseInsensitive = true
             };
             options.Converters.Add(new Base64StringJsonConverter());
-            List<SyncInfo> syncInfos = data.Params[JsonKeys.SyncInfoList].Deserialize<List<SyncInfo>>(options) ?? new List<SyncInfo>();
+            List<SyncInfo>? syncInfos = data.Params[JsonKeys.SyncInfoList].Deserialize<List<SyncInfo>>(options);
+            if (syncInfos is null)
+            {
+                Logger.Log(Logger.Level.Error, "Failed to deserialize SyncInfoList.");
+                return false;
+            }
 
             // Add/update drives
             foreach (var syncInfo in syncInfos)
@@ -412,7 +418,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                     Logger.Log(Logger.Level.Error, "syncInfo.DbId is null.");
                     continue;
                 }
-                await AddOrUpdateSyncInModel(syncInfo);
+                await AddOrUpdateSyncInModel(syncInfo).ConfigureAwait(false);
             }
 
             // Remove syncs that are no longer present
@@ -438,7 +444,8 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                         Logger.Log(Logger.Level.Info, $"Sync with DbId {sync.DbId} removed from drive DbId {parentDrive.DbId}.");
                     }
                 }
-            });
+            }).ConfigureAwait(false);
+            return true;
         }
         public async Task<bool> AddSync(NewSync newSync, CancellationToken cancellationToken)
         {

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -916,26 +916,28 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             await _commClient.SendRequestAsync(RequestNum.UTILITY_CANCEL_LOG_TO_SUPPORT, new JsonObject { }, cancellationToken);
         }
 
-        public async Task RefreshSettings(CancellationToken cancellationToken)
+        public async Task<bool> RefreshSettings(CancellationToken cancellationToken)
         {
             CommData data = await _commClient.SendRequestAsync(RequestNum.PARAMETERS_INFO, new JsonObject(), cancellationToken);
-            if (data.Params == null || !data.Params.ContainsKey(JsonKeys.ParmsInfo))
-            {
-                Logger.Log(Logger.Level.Error, $"{JsonKeys.ParmsInfo} not found in response.");
-                return;
-            }
+            if (!CheckJobResultAndLogIfError(data))
+                return false;
+
+            if (!HasRequiredParam(data, JsonKeys.ParmsInfo))
+                return false;
+
             var options = new JsonSerializerOptions
             {
                 PropertyNameCaseInsensitive = true
             };
             options.Converters.Add(new Base64StringJsonConverter());
             ParmsInfo? parametersInfo = data.Params[JsonKeys.ParmsInfo].Deserialize<ParmsInfo>(options);
-            if (parametersInfo == null)
+            if (parametersInfo is null)
             {
                 Logger.Log(Logger.Level.Error, $"Failed to deserialize parmsInfo from ${data.Params["parmsInfo"]}.");
-                return;
+                return false;
             }
-            CommStruct.ConversionHelper.CopyToSettings(parametersInfo, _viewModel.Settings);
+            CommStruct.ConversionHelper.copyToSettings(parametersInfo, _viewModel.Settings);
+            return true;
         }
 
         public async Task ActivateLoadInfo(CancellationToken cancellationToken)

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/App.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/App.cs
@@ -262,7 +262,12 @@ namespace Infomaniak.kDrive.ViewModels
                         Logger.Log(Logger.Level.Error, "Failed to refresh syncs during AppModel initialization.");
                         return false;
                     }
-                    await serverCommService.RefreshSettings(CancellationToken.None);
+
+                    if (!await serverCommService.RefreshSettings(cts.Token))
+                    {
+                        Logger.Log(Logger.Level.Error, "Failed to refresh settings during AppModel initialization.");
+                        return false;
+                    }
                     await serverCommService.RefreshErrors(CancellationToken.None);
                     Logger.Log(Logger.Level.Info, "All server data loaded successfully.");
                     IsInitialized = true;

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/App.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/App.cs
@@ -268,7 +268,13 @@ namespace Infomaniak.kDrive.ViewModels
                         Logger.Log(Logger.Level.Error, "Failed to refresh settings during AppModel initialization.");
                         return false;
                     }
-                    await serverCommService.RefreshErrors(CancellationToken.None);
+
+                    if (!await serverCommService.RefreshErrors(cts.Token))
+                    {
+                        Logger.Log(Logger.Level.Error, "Failed to refresh errors during AppModel initialization.");
+                        return false;
+                    }
+
                     Logger.Log(Logger.Level.Info, "All server data loaded successfully.");
                     IsInitialized = true;
                     return true;
@@ -317,7 +323,7 @@ namespace Infomaniak.kDrive.ViewModels
         {
             Logger.Log(Logger.Level.Info, $"AppModel: Removing error - {errorDbId}");
             var appError = AppErrors.FirstOrDefault(e => e.DbId == errorDbId);
-            if (appError != null)
+            if (appError is not null)
             {
                 await Utility.RunOnUIThread(void () => AppErrors.Remove(appError));
                 return;

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/App.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/App.cs
@@ -256,7 +256,12 @@ namespace Infomaniak.kDrive.ViewModels
                         Logger.Log(Logger.Level.Error, "Failed to refresh drives during AppModel initialization.");
                         return false;
                     }
-                    await serverCommService.RefreshSyncs(CancellationToken.None);
+
+                    if (!await serverCommService.RefreshSyncs(cts.Token))
+                    {
+                        Logger.Log(Logger.Level.Error, "Failed to refresh syncs during AppModel initialization.");
+                        return false;
+                    }
                     await serverCommService.RefreshSettings(CancellationToken.None);
                     await serverCommService.RefreshErrors(CancellationToken.None);
                     Logger.Log(Logger.Level.Info, "All server data loaded successfully.");

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/App.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/App.cs
@@ -245,7 +245,11 @@ namespace Infomaniak.kDrive.ViewModels
                         return false;
                     }
 
-                    await serverCommService.RefreshAccounts(CancellationToken.None);
+                    if (!await serverCommService.RefreshAccounts(cts.Token))
+                    {
+                        Logger.Log(Logger.Level.Error, "Failed to refresh accounts during AppModel initialization.");
+                        return false;
+                    }
                     await serverCommService.RefreshDrives(CancellationToken.None);
                     await serverCommService.RefreshSyncs(CancellationToken.None);
                     await serverCommService.RefreshSettings(CancellationToken.None);
@@ -270,7 +274,7 @@ namespace Infomaniak.kDrive.ViewModels
         public async Task DisconnectUserAsync(DbId userDbId)
         {
             IServerCommService serverCommService = App.ServiceProvider.GetRequiredService<IServerCommService>();
-            if(!await serverCommService.RemoveUser(userDbId, CancellationToken.None))
+            if (!await serverCommService.RemoveUser(userDbId, CancellationToken.None))
             {
                 Logger.Log(Logger.Level.Error, $"Failed to disconnect user {userDbId}");
                 Utility.ShowUnexpectedErrorTeachingTip();

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/App.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/App.cs
@@ -250,7 +250,12 @@ namespace Infomaniak.kDrive.ViewModels
                         Logger.Log(Logger.Level.Error, "Failed to refresh accounts during AppModel initialization.");
                         return false;
                     }
-                    await serverCommService.RefreshDrives(CancellationToken.None);
+
+                    if (!await serverCommService.RefreshDrives(cts.Token))
+                    {
+                        Logger.Log(Logger.Level.Error, "Failed to refresh drives during AppModel initialization.");
+                        return false;
+                    }
                     await serverCommService.RefreshSyncs(CancellationToken.None);
                     await serverCommService.RefreshSettings(CancellationToken.None);
                     await serverCommService.RefreshErrors(CancellationToken.None);

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/Settings/Settings.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/Settings/Settings.cs
@@ -133,10 +133,5 @@ namespace Infomaniak.kDrive.ViewModels
             PurgeOldLogs = enabled;
             await App.ServiceProvider.GetRequiredService<IServerCommService>().SaveSettings(CancellationToken.None);
         }
-
-        public async Task Refresh()
-        {
-            await App.ServiceProvider.GetRequiredService<IServerCommService>().RefreshSettings(CancellationToken.None);
-        }
     }
 }


### PR DESCRIPTION
depends on #1461 

### Handled Error Cases

#### ℹ️ Account list retrieval
- **Related request**: `RequestNum.ACCOUNT_INFOLIST`
- **Description**: in case of a server error or a timeout (**5 minutes**), the request currently causes the **application to close**

#### ℹ️ Drive list retrieval
- **Related request**: `RequestNum.DRIVE_INFOLIST`
- **Description**: in case of a server error or a timeout (**5 minutes**), the request currently causes the **application to close**

#### ℹ️ Sync list retrieval
- **Related request**: `RequestNum.SYNC_INFOLIST`
- **Description**: in case of a server error or a timeout (**5 minutes**), the request currently causes the **application to close**

#### ℹ️ Settings retrieval
- **Related request**: `RequestNum.PARAMETERS_INFO`
- **Description**: in case of a server error or a timeout (**5 minutes**), the request currently causes the **application to close**

#### ℹ️ Errors list retrieval
- **Related request**: `RequestNum.ERROR_INFOLIST`
- **Description**: in case of a server error or a timeout (**5 minutes**), the request currently causes the **application to close**