### PR TITLE
WinUI 3: Graceful Handling of Server Errors (Step 3 – Drive available refresh)

### DIFF
--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Onboarding/DriveSelectionPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Onboarding/DriveSelectionPage.xaml.cs
@@ -34,14 +34,25 @@ namespace Infomaniak.kDrive.Pages.Onboarding
             if (e.Parameter is ViewModels.Onboarding obvm)
             {
                 _onBoardingViewModel = obvm;
-                if (ObViewModel?.SelectedUser is null)
+                if (obvm.SelectedUser is null)
                 {
                     Logger.Log(Logger.Level.Error, "SelectedUser is null in OnBoardingViewModel when navigating to DriveSelectionPage");
-                    Frame.GoBack();
+                    obvm.Reset();
+                    Frame.Navigate(typeof(Onboarding.WelcomePage), obvm);
+                    Utility.ShowUnexpectedErrorTeachingTip();
                     return;
                 }
-                await ObViewModel.SelectedUser.RefreshAvailableDrives();
-                if (!ObViewModel.SelectedUser.AllDrives.Any())
+                if(!await obvm.SelectedUser.RefreshAvailableDrives(CancellationToken.None))
+                {
+                    Logger.Log(Logger.Level.Error, "Failed to refresh available drives for user in DriveSelectionPage");
+                    obvm.Reset();
+                    Frame.Navigate(typeof(Onboarding.WelcomePage), obvm);
+                    Utility.ShowUnexpectedErrorTeachingTip();
+                    return;
+                }
+
+
+                if (!obvm.SelectedUser.AllDrives.Any())
                 {
                     Logger.Log(Logger.Level.Info, "No drives found for user in DriveSelectionPage - Navigating to NoDrivePage");
                     Frame.Navigate(typeof(NoDrivesPage), ObViewModel);

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Onboarding/NoDrivesPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Onboarding/NoDrivesPage.xaml.cs
@@ -88,7 +88,7 @@ namespace Infomaniak.kDrive.Pages.Onboarding
                 return;
             }
 
-            await OnboardingViewModel.SelectedUser.RefreshAvailableDrives(cancellationToken);
+            await OnboardingViewModel.SelectedUser.RefreshAvailableDrives(cancellationToken); // This method is refactored and moved to obvm in an other PR, TODO: handle errors when the PR is merged
             if (!cancellationToken.IsCancellationRequested && OnboardingViewModel.SelectedUser.AllDrives.Any())
             {
                 Logger.Log(Logger.Level.Info, "Drives found for user - Navigating to DriveSelectionPage");

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Onboarding/OAuthLoadingPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Onboarding/OAuthLoadingPage.xaml.cs
@@ -104,12 +104,8 @@ namespace Infomaniak.kDrive.Pages.Onboarding
                     break;
 
                 case OAuth2State.Success:
-                    TitleTextBlock.Text = Utility.GetLocalizedString("Page_Onboarding_OAuthLoadingPage_Success_Title/Text");
-                    SubtitleTextBlock.Text = Utility.GetLocalizedString("Page_Onboarding_OAuthLoadingPage_Success_Subtitle/Text");
-                    RestartOAuthButton.Visibility = Visibility.Collapsed;
-                    if (_onboardingViewModel?.SelectedUser is not null)
+                    if (_onboardingViewModel?.SelectedUser is not null && await _onboardingViewModel.SelectedUser.RefreshAvailableDrives(CancellationToken.None))
                     {
-                        await _onboardingViewModel.SelectedUser.RefreshAvailableDrives();
                         if (_onboardingViewModel.SelectedUser.AllDrives.Any())
                         {
                             Frame.Navigate(typeof(DriveSelectionPage), _onboardingViewModel);
@@ -122,7 +118,7 @@ namespace Infomaniak.kDrive.Pages.Onboarding
                     else
                     {
                         Logger.Log(Logger.Level.Error, "SelectedUser is not set after a successful oAuth");
-                        HandleOAuth2StateChanged(OAuth2State.Error);
+                        _onboardingViewModel!.CurrentOAuth2State = OAuth2State.Error;
                     }
                     break;
 

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/SettingsPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/SettingsPage.xaml.cs
@@ -27,6 +27,7 @@ using Microsoft.UI.Xaml.Navigation;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Infomaniak.kDrive.Pages.Settings
@@ -99,25 +100,28 @@ namespace Infomaniak.kDrive.Pages.Settings
         private async void UserSettingsExpander_Expanded(object sender, EventArgs e)
         {
             User? user = (sender as FrameworkElement)?.DataContext as User;
-            if (user is not null)
+            if (user is null)
             {
-                await user.RefreshAvailableDrives();
+                Logger.Log(Logger.Level.Error, "Unable to find the user from DataContext.");
+                return;
             }
-            else
+
+            if (!await user.RefreshAvailableDrives(CancellationToken.None))
             {
-                Logger.Log(Logger.Level.Warning, "Unable to find the user from DataContext. Refreshing for all users.");
-                await RefreshAvailableDrivesForAllUsers();
+                Logger.Log(Logger.Level.Warning, "Error while refreshing available drives for user.");
+                Utility.ShowUnexpectedErrorTeachingTip(); // Show a generic error message for now, discussion is in progress with UX team to improve this.
             }
         }
 
         private async Task RefreshAvailableDrivesForAllUsers()
         {
-            List<Task> loadAvailableDrivesTasks = new List<Task>();
+            List<Task<bool>> loadAvailableDrivesTasks = new List<Task<bool>>();
             foreach (var user in ViewModel.Users)
             {
-                loadAvailableDrivesTasks.Add(user.RefreshAvailableDrives());
+                loadAvailableDrivesTasks.Add(user.RefreshAvailableDrives(CancellationToken.None));
             }
             await Task.WhenAll(loadAvailableDrivesTasks);
+            // Results are ignored for now; errors are displayed only if the user explicitly expands the user settings.
         }
 
         private async void DisconectUser_Click(object sender, RoutedEventArgs e)

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Interfaces/IServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Interfaces/IServerCommService.cs
@@ -50,7 +50,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Interfaces
 
         // Drive-related requests
         Task<bool> RefreshDrives(CancellationToken cancellationToken);
-        Task RefreshUserDrivesAvailable(DbId userDbId, CancellationToken cancellationToken);
+        Task<bool> RefreshUserDrivesAvailable(DbId userDbId, CancellationToken cancellationToken);
 
         // Sync-related requests
         Task<bool> RefreshSyncs(CancellationToken cancellationToken);

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -306,30 +306,38 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             return true;
         }
 
-        public async Task RefreshUserDrivesAvailable(DbId userDbId, CancellationToken cancellationToken)
+        public async Task<bool> RefreshUserDrivesAvailable(DbId userDbId, CancellationToken cancellationToken)
         {
             JsonObject parms = new()
             {
                 [JsonKeys.UserDbId] = userDbId
             };
-            CommData data = await _commClient.SendRequestAsync(RequestNum.USER_AVAILABLEDRIVES, parms, cancellationToken);
-            if (data.Params == null || !data.Params.ContainsKey(JsonKeys.DriveAvailableInfoList))
-            {
-                Logger.Log(Logger.Level.Error, $"{JsonKeys.DriveAvailableInfoList} not found in response.");
-                return;
-            }
+            CommData data = await _commClient.SendRequestAsync(RequestNum.USER_AVAILABLEDRIVES, parms, cancellationToken).ConfigureAwait(false);
+            if (!CheckJobResultAndLogIfError(data, parms))
+                return false;
+
+            if (!HasRequiredParam(data, JsonKeys.DriveAvailableInfoList))
+                return false;
+
             var options = new JsonSerializerOptions
             {
                 PropertyNameCaseInsensitive = true
             };
             options.Converters.Add(new Base64StringJsonConverter());
             options.Converters.Add(new ColorJsonConverter());
-            List<DriveAvailableInfo> driveAvailableInfoList = data.Params[JsonKeys.DriveAvailableInfoList].Deserialize<List<DriveAvailableInfo>>(options) ?? new List<DriveAvailableInfo>();
+            List<DriveAvailableInfo>? driveAvailableInfoList = data.Params[JsonKeys.DriveAvailableInfoList].Deserialize<List<DriveAvailableInfo>>(options);
+            if (driveAvailableInfoList is null)
+            {
+                Logger.Log(Logger.Level.Error, "Failed to deserialize DriveAvailableInfoList.");
+                return false;
+            }
+
+
             User? user = _viewModel.Users.FirstOrDefault<User>(u => u.DbId == userDbId);
             if (user is null)
             {
-                Logger.Log(Logger.Level.Error, $"User not found for DriveAvailable with dbID {userDbId}.");
-                return;
+                Logger.Log(Logger.Level.Error, $"User not found with dbID {userDbId}.");
+                return false;
             }
 
             // We don't clear and re-add all items to avoid UI flickering
@@ -344,7 +352,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 {
                     var drive = new DriveAvailable();
                     CommStruct.ConversionHelper.CopyToDriveAvailable(info, drive);
-                    await Utility.RunOnUIThread(() => { user.DrivesAvailable.Add(drive); });
+                    await Utility.RunOnUIThread(() => { user.DrivesAvailable.Add(drive); }).ConfigureAwait(false);
                 }
                 else
                 {
@@ -365,7 +373,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                                 {
                                     user.DrivesAvailable.Remove(existingDrive);
                                     user.DrivesAvailable.Add(tempDrive);
-                                });
+                                }).ConfigureAwait(false);
                                 break;
                             }
                         }
@@ -382,11 +390,11 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                     var driveToRemove = user.DrivesAvailable.FirstOrDefault(d => d.DriveId == existingId);
                     if (driveToRemove != null)
                     {
-                        await Utility.RunOnUIThread(() => { user.DrivesAvailable.Remove(driveToRemove); });
+                        await Utility.RunOnUIThread(() => { user.DrivesAvailable.Remove(driveToRemove); }).ConfigureAwait(false);
                     }
                 }
             }
-
+            return true;
         }
 
         public async Task<bool> RefreshSyncs(CancellationToken cancellationToken)
@@ -1029,10 +1037,10 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.Limit] = 1000
             };
             CommData data = await _commClient.SendRequestAsync(RequestNum.ERROR_INFOLIST, parms, cancellationToken).ConfigureAwait(false);
-            if(!CheckJobResultAndLogIfError(data, parms))
+            if (!CheckJobResultAndLogIfError(data, parms))
                 return false;
 
-            if(!HasRequiredParam(data, JsonKeys.ErrorInfoList))
+            if (!HasRequiredParam(data, JsonKeys.ErrorInfoList))
                 return false;
 
             var options = new JsonSerializerOptions

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/User.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/User.cs
@@ -47,6 +47,7 @@ namespace Infomaniak.kDrive.ViewModels
         private readonly ObservableCollection<Account> _accounts = new ObservableCollection<Account>();
         private ObservableCollection<DriveAvailable> _drivesAvailable = new ObservableCollection<DriveAvailable>();
         private bool _driveRefreshInProgress = false;
+        private Task<bool>? _refreshAvailableDrivesTask;
         private readonly IDisposable _allDriveSubscribtion;
         public User(DbId dbId)
         {
@@ -135,6 +136,7 @@ namespace Infomaniak.kDrive.ViewModels
         public bool DriveRefreshInProgress
         {
             get => _driveRefreshInProgress;
+            private set => SetPropertyInUIThread(ref _driveRefreshInProgress, value);
         }
 
         public ReadOnlyObservableCollection<Drive> Drives
@@ -159,17 +161,30 @@ namespace Infomaniak.kDrive.ViewModels
             return bitmap;
         }
 
-        public async Task RefreshAvailableDrives(CancellationToken cancellationToken = default)
+        public async Task<bool> RefreshAvailableDrives(CancellationToken cancellationToken)
         {
-            if (DriveRefreshInProgress)
+            if (_refreshAvailableDrivesTask is not null && !_refreshAvailableDrivesTask.IsCompleted)
             {
-                Logger.Log(Logger.Level.Info, $"Drive refresh already in progress for user {Name} ({DbId}), skipping.");
-                return;
+                Logger.Log(Logger.Level.Info, $"Drive refresh already in progress for user {Name} ({DbId}), awaiting existing task.");
+                return await _refreshAvailableDrivesTask;
             }
-            SetPropertyInUIThread(ref _driveRefreshInProgress, true, nameof(DriveRefreshInProgress));
-            await App.ServiceProvider.GetRequiredService<IServerCommService>().RefreshUserDrivesAvailable(this.DbId, cancellationToken);
+
+            _refreshAvailableDrivesTask = RefreshAvailableDrivesInternal(cancellationToken);
+            return await _refreshAvailableDrivesTask;
+        }
+
+        private async Task<bool> RefreshAvailableDrivesInternal(CancellationToken cancellationToken)
+        {
+            DriveRefreshInProgress = true;
+            bool result = await App.ServiceProvider.GetRequiredService<IServerCommService>().RefreshUserDrivesAvailable(this.DbId, cancellationToken);
+            if (!result)
+            {
+                Logger.Log(Logger.Level.Warning, $"Failed to refresh available drives for user {Name} ({DbId}), clearing available drives.");
+                DrivesAvailable.Clear();
+            }
             MergeDrives();
-            SetPropertyInUIThread(ref _driveRefreshInProgress, false, nameof(DriveRefreshInProgress));
+            DriveRefreshInProgress = false;
+            return result;
         }
 
         /* Merges the Drives and DrivesAvailable collections into the AllDrives collection,

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/Onboarding/Onboarding.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/Onboarding/Onboarding.cs
@@ -93,5 +93,12 @@ namespace Infomaniak.kDrive.ViewModels
             Logger.Log(Logger.Level.Info, $"Onboarding finished for user {SelectedUser.Name}.");
             return true;
         }
+
+        public void Reset()
+        {
+            SelectedUser = null;
+            NewSyncs.Clear();
+            CurrentOAuth2State = OAuth2State.None;
+        }
     }
 }


### PR DESCRIPTION
depends on #1462 

### Handled Error Cases

#### ➕ User drive available list refresh
- **Related request**: `RequestNum.USER_AVAILABLEDRIVES`
- **Description**: error occurring when fetching the available drive list for a user
- **Screenshot / illustration**:  


https://github.com/user-attachments/assets/72723565-4c0f-4e5c-a74a-88cbd37bd796

A discussion is ongoing with the UX team to improve the error display when the user is not connected or when the network is unavailable on the settings page.