### PR TITLE
WinUI 3: Graceful Handling of Server Errors (Step 4 – Sync-Related Requests)

### DIFF
--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/AppNavigationView.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/AppNavigationView.xaml.cs
@@ -24,7 +24,7 @@ namespace Infomaniak.kDrive.CustomControls
             { "HomePage", new List<Type>() {
                 typeof(Pages.HomePage),
                 typeof(Pages.DriveAccessDeniedPage),
-                typeof(Pages.LoggingErrorPage),
+                typeof(Pages.LogginErrorPage),
                 typeof(Pages.NotRenewErrorPage),
                 typeof(Pages.MaintenanceErrorPage),
                 typeof(Pages.AsleepErrorPage)

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/SyncStartPauseButton.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/SyncStartPauseButton.xaml.cs
@@ -85,7 +85,6 @@ public class SyncToButtonEnabledConverter : IValueConverter
         if (value is Sync sync)
         {
             SyncStatus syncStatus = sync.SyncStatus;
-            ;
             return (syncStatus == SyncStatus.Running || syncStatus == SyncStatus.Paused || syncStatus == SyncStatus.Idle || syncStatus == SyncStatus.Stopped || syncStatus == SyncStatus.Error);
         }
         return false;

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/SyncStartPauseButton.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/SyncStartPauseButton.xaml.cs
@@ -29,12 +29,20 @@ public sealed partial class SyncStartPauseButton : UserControl
         if (ViewModel?.SelectedSync is not null && (ViewModel.SelectedSync.SyncStatus == SyncStatus.Running || ViewModel.SelectedSync.SyncStatus == SyncStatus.Idle))
         {
             Logger.Log(Logger.Level.Info, "Pausing sync...");
-            await ViewModel.SelectedSync.Pause();
+            if (!await ViewModel.SelectedSync.Pause())
+            {
+                Logger.Log(Logger.Level.Error, "Failed to pause sync.");
+                Utility.ShowUnexpectedErrorTeachingTip();
+            }
         }
         else if (ViewModel?.SelectedSync is not null)
         {
             Logger.Log(Logger.Level.Info, "Starting sync...");
-            await ViewModel.SelectedSync.Start();
+            if (!await ViewModel.SelectedSync.Start())
+            {
+                Logger.Log(Logger.Level.Error, "Failed to start sync.");
+                Utility.ShowUnexpectedErrorTeachingTip();
+            }
         }
     }
 }
@@ -76,7 +84,8 @@ public class SyncToButtonEnabledConverter : IValueConverter
     {
         if (value is Sync sync)
         {
-            SyncStatus syncStatus = sync.SyncStatus; ;
+            SyncStatus syncStatus = sync.SyncStatus;
+            ;
             return (syncStatus == SyncStatus.Running || syncStatus == SyncStatus.Paused || syncStatus == SyncStatus.Idle || syncStatus == SyncStatus.Stopped || syncStatus == SyncStatus.Error);
         }
         return false;

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/HomePage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/HomePage.xaml.cs
@@ -69,7 +69,7 @@ namespace Infomaniak.kDrive.Pages
                     AppModel.UIThreadDispatcher.TryEnqueue(() => Frame.Navigate(typeof(DriveAccessDeniedPage)));
                     break;
                 case SyncErrorStates.LoggingError:
-                    AppModel.UIThreadDispatcher.TryEnqueue(() => Frame.Navigate(typeof(LoggingErrorPage)));
+                    AppModel.UIThreadDispatcher.TryEnqueue(() => Frame.Navigate(typeof(LogginErrorPage)));
                     break;
                 case SyncErrorStates.NotRenew:
                     AppModel.UIThreadDispatcher.TryEnqueue(() => Frame.Navigate(typeof(NotRenewErrorPage)));

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Onboarding/DriveSelectionPage.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Onboarding/DriveSelectionPage.xaml
@@ -149,7 +149,7 @@
                                 <ToolTipService.ToolTip>
                                     <ToolTip x:Uid="Page_Onboarding_DriveSelectionPage_DriveAlreadyConfigured"
                                              VerticalOffset="-80"
-                                             IsEnabled="{x:Bind IsConfigured}" />
+                                             IsEnabled="{x:Bind IsConfigured, Mode=OneWay}" />
                                 </ToolTipService.ToolTip>
                                 <Border Style="{StaticResource Infomaniak.Style.Border.WithContent}"
                                         Background="{ThemeResource LayerFillColorDefaultBrush}"
@@ -159,7 +159,7 @@
                                     <ContentControl Content="{x:Bind}"
                                                     ContentTemplateSelector="{StaticResource DriveTemplateSelector}"
                                                     VerticalContentAlignment="Center"
-                                                    IsEnabled="{x:Bind IsConfigured, Converter={StaticResource BooleanToInvertedBooleanConverter}}" />
+                                                    IsEnabled="{x:Bind IsConfigured, Converter={StaticResource BooleanToInvertedBooleanConverter}, Mode=OneWay}" />
                                 </Border>
 
                             </Grid>

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Onboarding/FinishingPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Onboarding/FinishingPage.xaml.cs
@@ -40,6 +40,8 @@ namespace Infomaniak.kDrive.Pages.Onboarding
                 else
                 {
                     Logger.Log(Logger.Level.Info, "Finishing onboarding failed. Returning to previous page.");
+                    _onBoardingViewModel.NewSyncs.Clear();
+                    Utility.ShowUnexpectedErrorTeachingTip();
                     Frame.GoBack();
                 }
             }

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/DriveAdvancedSyncsPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/DriveAdvancedSyncsPage.xaml.cs
@@ -104,13 +104,14 @@ public sealed partial class DriveAdvancedSyncsPage : Page
 
     private async void RemoveSyncButton_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
     {
-        Control? control = sender as Control;
+        var control = sender as Control;
         if (control is null)
         {
             Logger.Log(Logger.Level.Error, "Remove sync button is null when clicking on remove sync button");
             return;
         }
 
+        control.IsEnabled = false;
         Sync? sync = control.DataContext as Sync;
         if (sync is null)
         {
@@ -119,26 +120,29 @@ public sealed partial class DriveAdvancedSyncsPage : Page
             return;
         }
 
-        if (ManagedDrive is not null)
-        {
-            control.IsEnabled = false;
-            var dialogResult = await Utility.ShowContentDialogAsync(this.XamlRoot, "Page_Settings_DriveManagementPage_SyncDeletion_WarningDialog");
-            if (dialogResult == ContentDialogResult.Primary)
-            {
-                Logger.Log(Logger.Level.Info, "User confirmed advanced sync removal");
-                await sync.Drive.RemoveSync(sync, CancellationToken.None);
-
-            }
-            else
-            {
-                Logger.Log(Logger.Level.Info, "User canceled sync removal");
-            }
-            control.IsEnabled = true;
-        }
-        else
+        if (ManagedDrive is null)
         {
             Logger.Log(Logger.Level.Error, "Cannot remove sync: ManagedDrive or sync is null");
+            control.IsEnabled = true;
+            return;
         }
+
+        var dialogResult = await Utility.ShowContentDialogAsync(this.XamlRoot, "Page_Settings_DriveManagementPage_SyncDeletion_WarningDialog");
+        if (dialogResult != ContentDialogResult.Primary)
+        {
+            Logger.Log(Logger.Level.Info, "User canceled sync removal");
+            control.IsEnabled = true;
+            return;
+        }
+
+        Logger.Log(Logger.Level.Info, "User confirmed advanced sync removal");
+        if (!await sync.Drive.RemoveSync(sync, CancellationToken.None))
+        {
+            Logger.Log(Logger.Level.Error, "Failed to remove sync");
+            Utility.ShowUnexpectedErrorTeachingTip();
+        }
+
+        control.IsEnabled = true;
     }
 
     private async void OnlineRadioButtonChecked(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/DriveManagementPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/DriveManagementPage.xaml.cs
@@ -286,7 +286,14 @@ namespace Infomaniak.kDrive.Pages.Settings
             var commService = App.ServiceProvider.GetRequiredService<IServerCommService>();
 
             Logger.Log(Logger.Level.Debug, $"Setting up new sync: LocalPath={newSync.LocalPath}, RemotePath={newSync.RemotePath}, Drive={newSync.Drive.Name}");
-            await commService.AddSync(newSync, CancellationToken.None);
+            if (!await commService.AddSync(newSync, CancellationToken.None))
+            {
+                Logger.Log(Logger.Level.Error, $"Failed to add new sync for drive '{BaseDrive.Name}'");
+                if (control is not null)
+                    control.IsEnabled = true;
+                Utility.ShowUnexpectedErrorTeachingTip();
+                return;
+            }
 
             if (ManagedDrive is null) // if the drive was not configured before, set it up now
             {

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/DriveManagementPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/DriveManagementPage.xaml.cs
@@ -211,33 +211,45 @@ namespace Infomaniak.kDrive.Pages.Settings
 
         private async void RemoveSyncSettingsCard_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
         {
-            if (ManagedDrive is not null && ManagedDrive.MainSync is not null)
-            {
-                var control = sender as Control;
-                if (control is not null)
-                    control.IsEnabled = false;
-                bool goBackOnceDone = ManagedDrive.Syncs.Count() == 1; // If we are removing the last sync of the drive, go back to settings page once done.
-                var dialogResult = await Utility.ShowContentDialogAsync(this.XamlRoot, "Page_Settings_DriveManagementPage_SyncDeletion_WarningDialog");
-                if (dialogResult == ContentDialogResult.Primary)
-                {
-                    Logger.Log(Logger.Level.Info, "User confirmed sync removal");
-                    await ManagedDrive.RemoveSync(ManagedDrive.MainSync, CancellationToken.None);
-                    if (goBackOnceDone)
-                    {
-                        Frame.Navigate(typeof(SettingsPage));
-                    }
-                }
-                else
-                {
-                    Logger.Log(Logger.Level.Info, "User canceled sync removal");
-                }
-                if (control is not null)
-                    control.IsEnabled = true;
-            }
-            else
+            if (ManagedDrive is null || ManagedDrive.MainSync is null)
             {
                 Logger.Log(Logger.Level.Error, "Cannot remove sync: ManagedDrive or MainSync is null");
+                return;
             }
+
+            var control = sender as Control;
+            if (control is null)
+            {
+                Logger.Log(Logger.Level.Error, "Cannot remove sync: sender is not a Control");
+                return;
+            }
+
+            control.IsEnabled = false;
+            bool goBackOnceDone = ManagedDrive.Syncs.Count() == 1; // If we are removing the last sync of the drive, go back to settings page once done.
+            
+            var dialogResult = await Utility.ShowContentDialogAsync(this.XamlRoot, "Page_Settings_DriveManagementPage_SyncDeletion_WarningDialog");
+            if (dialogResult != ContentDialogResult.Primary)
+            {
+                Logger.Log(Logger.Level.Info, "User canceled sync removal");
+                control.IsEnabled = true;
+                return;
+            }
+
+            Logger.Log(Logger.Level.Info, "User confirmed sync removal");
+            if (!await ManagedDrive.RemoveSync(ManagedDrive.MainSync, CancellationToken.None))
+            {
+                Logger.Log(Logger.Level.Error, "Failed to remove sync");
+                Utility.ShowUnexpectedErrorTeachingTip();
+                control.IsEnabled = true;
+                return;
+            }
+            Logger.Log(Logger.Level.Info, "Sync removed successfully");
+            if (goBackOnceDone)
+            {
+                Frame.Navigate(typeof(SettingsPage));
+            }
+
+            control.IsEnabled = true;
         }
 
         private async void SetupMainSyncButton_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/SpecialErrorsPages/AsleepErrorPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/SpecialErrorsPages/AsleepErrorPage.xaml.cs
@@ -40,7 +40,7 @@ namespace Infomaniak.kDrive.Pages
         private async void SecondaryButton_Click(object sender, RoutedEventArgs e)
         {
             Logger.Log(Logger.Level.Info, "Retry button clicked - Starting sync");
-            ViewModel.SelectedSync?.Start();
+            await RestartSync();
         }
     }
 }

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/SpecialErrorsPages/DriveAccessDeniedPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/SpecialErrorsPages/DriveAccessDeniedPage.xaml.cs
@@ -35,16 +35,9 @@ namespace Infomaniak.kDrive.Pages
 
         private async void RetryButton_Click(object sender, RoutedEventArgs e)
         {
-            if (ViewModel?.SelectedSync is null)
-            {
-                Logger.Log(Logger.Level.Warning, "");
-                DetachHandlers();
-                Frame.Navigate(typeof(HomePage));
-            }
-            else
-            {
-                await ViewModel.SelectedSync.Start();
-            }
+            Logger.Log(Logger.Level.Info, "Retry button clicked - Restarting sync");
+            await RestartSync();
         }
     }
 }
+

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/SpecialErrorsPages/LogginErrorPage.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/SpecialErrorsPages/LogginErrorPage.xaml
@@ -17,7 +17,7 @@
  * along with this program.  If not, see<http://www.gnu.org/licenses/> .
  -->
 
-<local:SpecialErroBasePage x:Class="Infomaniak.kDrive.Pages.LoggingErrorPage"
+<local:SpecialErroBasePage x:Class="Infomaniak.kDrive.Pages.LogginErrorPage"
                            xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                            xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                            xmlns:local="using:Infomaniak.kDrive.Pages"

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/SpecialErrorsPages/LogginErrorPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/SpecialErrorsPages/LogginErrorPage.xaml.cs
@@ -28,13 +28,13 @@ using System.Threading;
 
 namespace Infomaniak.kDrive.Pages
 {
-    public sealed partial class LoggingErrorPage : SpecialErroBasePage
+    public sealed partial class LogginErrorPage : SpecialErroBasePage
     {
-        public LoggingErrorPage() : base([SyncErrorStates.LoggingError])
+        public LogginErrorPage() : base([SyncErrorStates.LoggingError])
         {
-            Logger.Log(Logger.Level.Info, "Navigated to LoggingErrorPage - Initializing LoggingErrorPage components");
+            Logger.Log(Logger.Level.Info, "Navigated to LogginErrorPage - Initializing LogginErrorPage components");
             InitializeComponent();
-            Logger.Log(Logger.Level.Debug, "LoggingErrorPage components initialized");
+            Logger.Log(Logger.Level.Debug, "LogginErrorPage components initialized");
         }
 
         private async void ConnectionButton_Click(object sender, RoutedEventArgs e)
@@ -63,25 +63,20 @@ namespace Infomaniak.kDrive.Pages
                 {
                     Logger.Log(Logger.Level.Error, $"Failed to retrieve user information after authentication {user} - {ViewModel.SelectedSync}");
                     Utility.ShowUnexpectedErrorTeachingTip();
+                    return;
                 }
-                else if (user.DbId != ViewModel.SelectedSync.Drive.Account.User.DbId)
+
+                if (user.DbId != ViewModel.SelectedSync.Drive.Account.User.DbId)
                 {
+                    Logger.Log(Logger.Level.Info, "Authenticated user does not match the expected user.");
                     DisplayUserMismatchContent();
-                }
-                else if (user.DbId == ViewModel.SelectedSync.Drive.Account.User.DbId)
-                {
-                    if (!await ViewModel.SelectedSync.Start())
-                    {
-                        Logger.Log(Logger.Level.Error, "Failed to start sync.");
-                        Utility.ShowUnexpectedErrorTeachingTip();
-                    }
-                }
-                else
-                {
-                    Utility.ShowUnexpectedErrorTeachingTip();
+                    return;
                 }
 
+                if (await ViewModel.SelectedSync.Start())
+                    return;
 
+                Logger.Log(Logger.Level.Error, "Failed to start sync.");
             }
             catch (OperationCanceledException)
             {

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/SpecialErrorsPages/LoggingErrorPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/SpecialErrorsPages/LoggingErrorPage.xaml.cs
@@ -50,27 +50,38 @@ namespace Infomaniak.kDrive.Pages
             {
                 using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(120));
                 var OAutCodes = await OAuthHelper.GetCode(cts.Token);
-                if (OAutCodes.Code != "")
+                if (OAutCodes.Code == "")
                 {
-                    Logger.Log(Logger.Level.Debug, "Successfully obtained user code.");
-                    User? user = await App.ServiceProvider.GetRequiredService<IServerCommService>().AddOrRelogUser(OAutCodes.Code, OAutCodes.CodeVerifier, CancellationToken.None);
-                    if (user is not null && user.DbId == ViewModel.SelectedSync?.Drive.Account.User.DbId)
+                    Logger.Log(Logger.Level.Warning, "Failed to obtain user code.");
+                    Utility.ShowUnexpectedErrorTeachingTip();
+                    return;
+                }
+
+                Logger.Log(Logger.Level.Debug, "Successfully obtained user code.");
+                User? user = await App.ServiceProvider.GetRequiredService<IServerCommService>().AddOrRelogUser(OAutCodes.Code, OAutCodes.CodeVerifier, CancellationToken.None);
+                if (user is null || ViewModel.SelectedSync is null)
+                {
+                    Logger.Log(Logger.Level.Error, $"Failed to retrieve user information after authentication {user} - {ViewModel.SelectedSync}");
+                    Utility.ShowUnexpectedErrorTeachingTip();
+                }
+                else if (user.DbId != ViewModel.SelectedSync.Drive.Account.User.DbId)
+                {
+                    DisplayUserMismatchContent();
+                }
+                else if (user.DbId == ViewModel.SelectedSync.Drive.Account.User.DbId)
+                {
+                    if (!await ViewModel.SelectedSync.Start())
                     {
-                        ViewModel.SelectedSync?.Start();
-                    }
-                    else if (user is not null)
-                    {
-                        DisplayUserMismatchContent();
-                    }
-                    else
-                    {
+                        Logger.Log(Logger.Level.Error, "Failed to start sync.");
                         Utility.ShowUnexpectedErrorTeachingTip();
                     }
                 }
                 else
                 {
-                    Logger.Log(Logger.Level.Warning, "Authentication process failed");
+                    Utility.ShowUnexpectedErrorTeachingTip();
                 }
+
+
             }
             catch (OperationCanceledException)
             {

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/SpecialErrorsPages/MaintenanceErrorPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/SpecialErrorsPages/MaintenanceErrorPage.xaml.cs
@@ -33,7 +33,7 @@ namespace Infomaniak.kDrive.Pages
         private async void RetryButton_Click(object sender, RoutedEventArgs e)
         {
             Logger.Log(Logger.Level.Info, "Retry button clicked - Starting sync");
-            ViewModel.SelectedSync?.Start();
+            await RestartSync();
         }
     }
 }

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/SpecialErrorsPages/NotRenewErrorPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/SpecialErrorsPages/NotRenewErrorPage.xaml.cs
@@ -51,10 +51,10 @@ namespace Infomaniak.kDrive.Pages
             }
         }
 
-        private void SecondaryButton_Click(object sender, RoutedEventArgs e)
+        private async void SecondaryButton_Click(object sender, RoutedEventArgs e)
         {
             Logger.Log(Logger.Level.Info, "Renew drive button clicked - Opening drive renewal page");
-            ViewModel.SelectedSync?.Start();
+            await RestartSync();
         }
 
         private async void MainButton_Click(object sender, RoutedEventArgs e)
@@ -67,7 +67,7 @@ namespace Infomaniak.kDrive.Pages
             else
             {
                 Logger.Log(Logger.Level.Info, "Retry button clicked - Starting sync to retry connection");
-                ViewModel.SelectedSync?.Start();
+                await RestartSync();
             }
         }
     }

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/SpecialErrorsPages/SpecialErroBasePage.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/SpecialErrorsPages/SpecialErroBasePage.cs
@@ -24,6 +24,7 @@ using Microsoft.UI.Xaml.Navigation;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Threading.Tasks;
 
 namespace Infomaniak.kDrive.Pages
 {
@@ -77,6 +78,21 @@ namespace Infomaniak.kDrive.Pages
             {
                 DetachHandlers();
                 AppModel.UIThreadDispatcher.TryEnqueue(() => Frame.Navigate(typeof(HomePage)));
+            }
+        }
+
+        protected async Task RestartSync()
+        {
+            if (ViewModel.SelectedSync is null)
+            {
+                Logger.Log(Logger.Level.Warning, "No selected sync found - Navigating to HomePage");
+                DetachHandlers();
+                Frame.Navigate(typeof(HomePage));
+            }
+            else if (!await ViewModel.SelectedSync.Start())
+            {
+                Logger.Log(Logger.Level.Error, "Failed to start sync.");
+                Utility.ShowUnexpectedErrorTeachingTip();
             }
         }
     }

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/SpecialErrorsPages/SpecialErroBasePage.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/SpecialErrorsPages/SpecialErroBasePage.cs
@@ -88,8 +88,10 @@ namespace Infomaniak.kDrive.Pages
                 Logger.Log(Logger.Level.Warning, "No selected sync found - Navigating to HomePage");
                 DetachHandlers();
                 Frame.Navigate(typeof(HomePage));
+                return;
             }
-            else if (!await ViewModel.SelectedSync.Start())
+
+            if (!await ViewModel.SelectedSync.Start())
             {
                 Logger.Log(Logger.Level.Error, "Failed to start sync.");
                 Utility.ShowUnexpectedErrorTeachingTip();

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Interfaces/IServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Interfaces/IServerCommService.cs
@@ -56,7 +56,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Interfaces
         Task<bool> RefreshSyncs(CancellationToken cancellationToken);
         Task StartSync(DbId syncDbId, CancellationToken cancellationToken);
         Task PauseSync(DbId syncDbId, CancellationToken cancellationToken);
-        Task RemoveSync(DbId syncDbId, CancellationToken cancellationToken);
+        Task<bool> RemoveSync(DbId syncDbId, CancellationToken cancellationToken);
         Task<bool> AddSync(NewSync newSync, CancellationToken cancellationToken);
         Task<bool> SetSyncType(DbId syncDbId, SyncType type, CancellationToken cancellationToken);
 

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Interfaces/IServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Interfaces/IServerCommService.cs
@@ -58,7 +58,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Interfaces
         Task PauseSync(DbId syncDbId, CancellationToken cancellationToken);
         Task RemoveSync(DbId syncDbId, CancellationToken cancellationToken);
         Task<bool> AddSync(NewSync newSync, CancellationToken cancellationToken);
-        Task<bool> SetSyncType(DbId syncDbId, SyncType mode, CancellationToken cancellationToken);
+        Task<bool> SetSyncType(DbId syncDbId, SyncType type, CancellationToken cancellationToken);
 
         Task<bool?> CanPathSupportLiteSync(string absoluteLocalPath, CancellationToken cancellationToken);
 

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Interfaces/IServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Interfaces/IServerCommService.cs
@@ -54,8 +54,8 @@ namespace Infomaniak.kDrive.ServerCommunication.Interfaces
 
         // Sync-related requests
         Task<bool> RefreshSyncs(CancellationToken cancellationToken);
-        Task StartSync(DbId syncDbId, CancellationToken cancellationToken);
-        Task PauseSync(DbId syncDbId, CancellationToken cancellationToken);
+        Task<bool> StartSync(DbId syncDbId, CancellationToken cancellationToken);
+        Task<bool> PauseSync(DbId syncDbId, CancellationToken cancellationToken);
         Task<bool> RemoveSync(DbId syncDbId, CancellationToken cancellationToken);
         Task<bool> AddSync(NewSync newSync, CancellationToken cancellationToken);
         Task<bool> SetSyncType(DbId syncDbId, SyncType type, CancellationToken cancellationToken);

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -1385,7 +1385,15 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
 
             SyncFileItem syncFileItem = new SyncFileItem(sync);
             CommStruct.ConversionHelper.CopyToSyncFileItem(fileItemInfo, syncFileItem);
-            await Utility.RunOnUIThread(() => { sync.SyncActivities.Insert(0, syncFileItem); });
+            await Utility.RunOnUIThread(() => { 
+                sync.SyncActivities.Insert(0, syncFileItem);
+                // Ensure the list does not exceed 500 items
+                while (sync.SyncActivities.Count > 500)
+                {
+                    sync.SyncActivities.RemoveAt(sync.SyncActivities.Count - 1);
+                }
+
+            });
         }
 
         public async Task HandleUpdaterStateChangedAsync(object? sender, SignalEventArgs args)

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -353,30 +353,29 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                     var drive = new DriveAvailable();
                     CommStruct.ConversionHelper.CopyToDriveAvailable(info, drive);
                     await Utility.RunOnUIThread(() => { user.DrivesAvailable.Add(drive); }).ConfigureAwait(false);
+                    continue;
                 }
-                else
+
+                // Check if any of the properties have changed, if yes remove and re-add to trigger UI update
+                var existingDrive = user.DrivesAvailable.FirstOrDefault(d => d.DriveId == info.DriveId);
+                if (existingDrive is null)
+                    continue;
+
+                var tempDrive = new DriveAvailable();
+                CommStruct.ConversionHelper.CopyToDriveAvailable(info, tempDrive);
+                // compare properties individually
+                foreach (var prop in typeof(DriveAvailable).GetProperties())
                 {
-                    // Check if any of the properties have changed, if yes remove and re-add to trigger UI update
-                    var existingDrive = user.DrivesAvailable.FirstOrDefault(d => d.DriveId == info.DriveId);
-                    if (existingDrive != null)
+                    var existingValue = prop.GetValue(existingDrive);
+                    var newValue = prop.GetValue(tempDrive);
+                    if (!Equals(existingValue, newValue))
                     {
-                        var tempDrive = new DriveAvailable();
-                        CommStruct.ConversionHelper.CopyToDriveAvailable(info, tempDrive);
-                        // compare properties individually
-                        foreach (var prop in typeof(DriveAvailable).GetProperties())
+                        await Utility.RunOnUIThread(() =>
                         {
-                            var existingValue = prop.GetValue(existingDrive);
-                            var newValue = prop.GetValue(tempDrive);
-                            if (!Equals(existingValue, newValue))
-                            {
-                                await Utility.RunOnUIThread(() =>
-                                {
-                                    user.DrivesAvailable.Remove(existingDrive);
-                                    user.DrivesAvailable.Add(tempDrive);
-                                }).ConfigureAwait(false);
-                                break;
-                            }
-                        }
+                            user.DrivesAvailable.Remove(existingDrive);
+                            user.DrivesAvailable.Add(tempDrive);
+                        }).ConfigureAwait(false);
+                        break;
                     }
                 }
             }
@@ -525,6 +524,21 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.SyncDbId] = syncDbId
             };
             var commData = await _commClient.SendRequestAsync(RequestNum.SYNC_DELETE, parms, cancellationToken).ConfigureAwait(false);
+
+            // If the sync is not found on the server, we assume it is already deleted and remove it from the model
+            if (commData?.Code == ExitCode.DataError && commData?.Cause == ExitCause.DbEntryNotFound)
+            {
+                Logger.Log(Logger.Level.Info, $"Sync with DbId {syncDbId} not found on server, assuming already deleted.");
+                await Utility.RunOnUIThread(() =>
+                {
+                    var syncToRemove = _viewModel.AllSyncs.FirstOrDefault(s => s.DbId == syncDbId);
+                    if (syncToRemove is not null)
+                        syncToRemove.Drive.Syncs.Remove(syncToRemove);
+                    Logger.Log(Logger.Level.Info, $"Sync with DbId {syncDbId} removed.");
+                }).ConfigureAwait(false);
+                return true;
+            }
+
             if (!CheckJobResultAndLogIfError(commData, parms))
                 return false;
 
@@ -1385,7 +1399,8 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
 
             SyncFileItem syncFileItem = new SyncFileItem(sync);
             CommStruct.ConversionHelper.CopyToSyncFileItem(fileItemInfo, syncFileItem);
-            await Utility.RunOnUIThread(() => { 
+            await Utility.RunOnUIThread(() =>
+            {
                 sync.SyncActivities.Insert(0, syncFileItem);
                 // Ensure the list does not exceed 500 items
                 while (sync.SyncActivities.Count > 500)

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -546,37 +546,40 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             return true;
         }
 
-        public async Task StartSync(DbId syncDbId, CancellationToken cancellationToken)
+        public async Task<bool> StartSync(DbId syncDbId, CancellationToken cancellationToken)
         {
             Sync? sync = _viewModel.AllSyncs.FirstOrDefault(s => s.DbId == syncDbId);
             if (sync is null)
             {
                 Logger.Log(Logger.Level.Error, $"Sync with DbId {syncDbId} not found in model.");
-                return;
+                return false;
             }
+            var previousStatus = sync.SyncStatus;
             sync.SyncStatus = SyncStatus.Starting;
 
             var parms = new JsonObject
             {
                 [JsonKeys.SyncDbId] = syncDbId
             };
-
             CommData data = await _commClient.SendRequestAsync(RequestNum.SYNC_START, parms, cancellationToken);
-            if (data.Params?.ContainsKey(JsonKeys.ExitCode) ?? false && data.Params?[JsonKeys.ExitCode]?.GetValue<int>() != 0)
+            if (!CheckJobResultAndLogIfError(data, parms))
             {
-                Logger.Log(Logger.Level.Error, $"Failed to start sync with DbId {syncDbId}, exit code: {data.Params[JsonKeys.ExitCode]?.GetValue<int>()}");
-                return;
+                sync.SyncStatus = previousStatus;
+                return false;
             }
+
+            return true;
         }
 
-        public async Task PauseSync(DbId syncDbId, CancellationToken cancellationToken)
+        public async Task<bool> PauseSync(DbId syncDbId, CancellationToken cancellationToken)
         {
             Sync? sync = _viewModel.AllSyncs.FirstOrDefault(s => s.DbId == syncDbId);
             if (sync is null)
             {
                 Logger.Log(Logger.Level.Error, $"Sync with DbId {syncDbId} not found in model.");
-                return;
+                return false;
             }
+            var previousStatus = sync.SyncStatus;
             sync.SyncStatus = SyncStatus.StopAsked;
 
             var parms = new JsonObject
@@ -584,11 +587,12 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.SyncDbId] = syncDbId
             };
             CommData data = await _commClient.SendRequestAsync(RequestNum.SYNC_STOP, parms, cancellationToken);
-            if (data.Params?.ContainsKey(JsonKeys.ExitCode) ?? false && data.Params?[JsonKeys.ExitCode]?.GetValue<int>() != 0)
+            if(!CheckJobResultAndLogIfError(data, parms))
             {
-                Logger.Log(Logger.Level.Error, $"Failed to pause sync with DbId {syncDbId}, exit code: {data.Params[JsonKeys.ExitCode]?.GetValue<int>()}");
-                return;
+                sync.SyncStatus = previousStatus;
+                return false;
             }
+            return true;
         }
 
         public async Task<bool?> CanPathSupportLiteSync(string absoluteLocalPath, CancellationToken cancellationToken)

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -494,17 +494,11 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 return false;
             }
 
-            if (type == sync.SyncType)
-            {
-                Logger.Log(Logger.Level.Debug, $"Sync with DbId {syncDbId} is already of type {type}, no change needed.");
-                return true;
-            }
-
             if (type == SyncType.Online)
             {
                 // Ensure the path supports online mode
                 bool? canSupportOnlineMode = await CanPathSupportLiteSync(sync.LocalPath, CancellationToken.None);
-                if (!canSupportOnlineMode.HasValue || canSupportOnlineMode.Value == false)
+                if (!canSupportOnlineMode.HasValue || !canSupportOnlineMode.Value)
                 {
                     Logger.Log(Logger.Level.Warning, $"Local path {sync.LocalPath} does not support online sync mode, unable to change sync type for sync with DbId {syncDbId}.");
                     return false;
@@ -518,11 +512,8 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             };
 
             CommData data = await _commClient.SendRequestAsync(RequestNum.SYNC_SETSUPPORTSVIRTUALFILES, parms, cancellationToken);
-            if (data?.Code != ExitCode.Ok)
-            {
-                Logger.Log(Logger.Level.Error, $"Failed to set sync type for sync with DbId {syncDbId}, exit code: {(ExitCode?)data?.Params?[JsonKeys.ExitCode]?.GetValue<int>()}");
+            if(!CheckJobResultAndLogIfError(data, parms))
                 return false;
-            }
 
             return true;
         }

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -475,10 +475,10 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.BlackList] = JsonSerializer.SerializeToNode(newSync.ExcludedNodeIds, new JsonSerializerOptions { Converters = { new Base64StringJsonConverter() } })
             };
             CommData data = await _commClient.SendRequestAsync(RequestNum.SYNC_ADD, parms, cancellationToken).ConfigureAwait(false);
-            if(!CheckJobResultAndLogIfError(data, parms))
+            if (!CheckJobResultAndLogIfError(data, parms))
                 return false;
 
-            if(!HasRequiredParam(data, JsonKeys.SyncInfo))
+            if (!HasRequiredParam(data, JsonKeys.SyncInfo))
                 return false;
 
             // Rely on signal to add the sync to the model
@@ -511,20 +511,25 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.Value] = type == SyncType.Online
             };
 
-            CommData data = await _commClient.SendRequestAsync(RequestNum.SYNC_SETSUPPORTSVIRTUALFILES, parms, cancellationToken);
-            if(!CheckJobResultAndLogIfError(data, parms))
+            CommData data = await _commClient.SendRequestAsync(RequestNum.SYNC_SETSUPPORTSVIRTUALFILES, parms, cancellationToken).ConfigureAwait(false);
+            if (!CheckJobResultAndLogIfError(data, parms))
                 return false;
 
             return true;
         }
 
-        public async Task RemoveSync(DbId syncDbId, CancellationToken cancellationToken)
+        public async Task<bool> RemoveSync(DbId syncDbId, CancellationToken cancellationToken)
         {
             JsonObject parms = new()
             {
                 [JsonKeys.SyncDbId] = syncDbId
             };
-            var commData = await _commClient.SendRequestAsync(RequestNum.SYNC_DELETE, parms, cancellationToken);
+            var commData = await _commClient.SendRequestAsync(RequestNum.SYNC_DELETE, parms, cancellationToken).ConfigureAwait(false);
+            if (!CheckJobResultAndLogIfError(commData, parms))
+                return false;
+
+            // Rely on signal to remove the sync from the model
+            return true;
         }
 
         public async Task StartSync(DbId syncDbId, CancellationToken cancellationToken)

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -474,12 +474,12 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 [JsonKeys.LiteSync] = newSync.SyncType == SyncType.Online,
                 [JsonKeys.BlackList] = JsonSerializer.SerializeToNode(newSync.ExcludedNodeIds, new JsonSerializerOptions { Converters = { new Base64StringJsonConverter() } })
             };
-            CommData data = await _commClient.SendRequestAsync(RequestNum.SYNC_ADD, parms, cancellationToken);
-            if (data.Params == null || !data.Params.ContainsKey(JsonKeys.SyncInfo))
-            {
-                Logger.Log(Logger.Level.Error, $"{JsonKeys.SyncInfo} not found in response.");
+            CommData data = await _commClient.SendRequestAsync(RequestNum.SYNC_ADD, parms, cancellationToken).ConfigureAwait(false);
+            if(!CheckJobResultAndLogIfError(data, parms))
                 return false;
-            }
+
+            if(!HasRequiredParam(data, JsonKeys.SyncInfo))
+                return false;
 
             // Rely on signal to add the sync to the model
             return true;

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/App.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/App.cs
@@ -236,7 +236,7 @@ namespace Infomaniak.kDrive.ViewModels
             IServerCommService serverCommService = App.ServiceProvider.GetRequiredService<IServerCommService>();
             try
             {
-                // Allow up to 5 minutes for the initial load as it happen at computer startup wich can be slow
+                // Allow up to 5 minutes for the initial load as it happen at computer startup which can be slow
                 using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5)))
                 {
                     if (!await serverCommService.RefreshUsers(cts.Token))

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/Drive.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/Drive.cs
@@ -192,10 +192,10 @@ namespace Infomaniak.kDrive.ViewModels
             set => SetPropertyInUIThread(ref _account, value);
         }
 
-        public async Task RemoveSync(Sync sync, CancellationToken cancellationToken)
+        public async Task<bool> RemoveSync(Sync sync, CancellationToken cancellationToken)
         {
             var commService = App.ServiceProvider.GetRequiredService<IServerCommService>();
-            await commService.RemoveSync(sync.DbId, cancellationToken);
+            return await commService.RemoveSync(sync.DbId, cancellationToken);
         }
 
     }

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/Sync.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/Sync.cs
@@ -186,16 +186,16 @@ namespace Infomaniak.kDrive.ViewModels
             set => SetPropertyInUIThread(ref _showIncomingActivity, value);
         }
 
-        public async Task Start()
+        public async Task<bool> Start()
         {
             var commService = App.ServiceProvider.GetRequiredService<IServerCommService>();
-            await commService.StartSync(DbId, CancellationToken.None);
+            return await commService.StartSync(DbId, CancellationToken.None);
         }
 
-        public async Task Pause()
+        public async Task<bool> Pause()
         {
             var commService = App.ServiceProvider.GetRequiredService<IServerCommService>();
-            await commService.PauseSync(DbId, CancellationToken.None);
+            return await commService.PauseSync(DbId, CancellationToken.None);
         }
 
         public async Task<bool> ChangeSyncType(SyncType newType)

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/Onboarding/Onboarding.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/Onboarding/Onboarding.cs
@@ -83,15 +83,23 @@ namespace Infomaniak.kDrive.ViewModels
             }
 
             Logger.Log(Logger.Level.Info, $"Finishing onboarding for user {SelectedUser.Name} with {NewSyncs.Count} new syncs.");
-            var commService = _serverCommService;
+            int successCount = 0;
             foreach (NewSync sync in NewSyncs)
             {
-                Logger.Log(Logger.Level.Debug, $"Setting up new sync: LocalPath={sync.LocalPath}, RemotePath={sync.RemotePath}, Drive={sync?.Drive?.Name ?? "unknown"}");
-                await _serverCommService.AddSync(sync!, CancellationToken.None);
-            }
+                Logger.Log(Logger.Level.Debug, $"Setting up new sync: LocalPath={sync.LocalPath}, RemotePath={sync.RemotePath}, Drive={sync.Drive?.Name ?? "unknown"}");
+                bool result = await _serverCommService.AddSync(sync, CancellationToken.None);
+                if (!result)
+                {
+                    Logger.Log(Logger.Level.Warning, $"Failed to set up sync: LocalPath={sync.LocalPath}, RemotePath={sync.RemotePath}");
+                }
+                else
+                {
 
-            Logger.Log(Logger.Level.Info, $"Onboarding finished for user {SelectedUser.Name}.");
-            return true;
+                }
+                successCount += result ? 1 : 0;
+            }
+            Logger.Log(Logger.Level.Info, $"Onboarding sync setup completed: {successCount}/{NewSyncs.Count} syncs successfully set up.");
+            return successCount == NewSyncs.Count;
         }
 
         public void Reset()

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/Onboarding/Onboarding.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/Onboarding/Onboarding.cs
@@ -89,13 +89,8 @@ namespace Infomaniak.kDrive.ViewModels
                 Logger.Log(Logger.Level.Debug, $"Setting up new sync: LocalPath={sync.LocalPath}, RemotePath={sync.RemotePath}, Drive={sync.Drive?.Name ?? "unknown"}");
                 bool result = await _serverCommService.AddSync(sync, CancellationToken.None);
                 if (!result)
-                {
                     Logger.Log(Logger.Level.Warning, $"Failed to set up sync: LocalPath={sync.LocalPath}, RemotePath={sync.RemotePath}");
-                }
-                else
-                {
 
-                }
                 successCount += result ? 1 : 0;
             }
             Logger.Log(Logger.Level.Info, $"Onboarding sync setup completed: {successCount}/{NewSyncs.Count} syncs successfully set up.");


### PR DESCRIPTION
depends on #1463 

### Handled Error Cases

#### 🔄 Sync lifecycle operations
Server errors are now handled gracefully for the following sync-related requests, preventing unexpected crashes or inconsistent states:

- `RequestNum.SYNC_START`
- `RequestNum.SYNC_PAUSE`

https://github.com/user-attachments/assets/98f98729-eedb-4484-8560-d5cfc5df3aa4

- `RequestNum.SYNC_ADD`
- `RequestNum.SYNC_DELETE`

https://github.com/user-attachments/assets/77134830-a83e-480e-becd-1f3c61f6b687

- `RequestNum.SYNC_SETSUPPORTSVIRTUALFILES`

https://github.com/user-attachments/assets/97c2b676-5a77-4a78-b92d-6a9e8f6b40ad



