### PR TITLE
test(network): update expected packInfo name to "pro"

### DIFF
--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -1039,7 +1039,7 @@ void TestNetworkJobs::testGetInfoDrive() {
     CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, exitCode);
 
     CPPUNIT_ASSERT_EQUAL(std::string("kDrive Desktop Team"), job.name());
-    CPPUNIT_ASSERT_EQUAL(std::string("team"), job.packInfo().name);
+    CPPUNIT_ASSERT_EQUAL(std::string("pro"), job.packInfo().name);
     CPPUNIT_ASSERT(!job.packInfo().isFree);
 }
 


### PR DESCRIPTION
Changed the assertion in testGetInfoDrive to expect "pro" instead of "team" for the packInfo().name field. This aligns the test with the updated business logic.