### PR TITLE
Block app based on version

### DIFF
--- a/src/gui/clientgui.cpp
+++ b/src/gui/clientgui.cpp
@@ -798,6 +798,7 @@ void ClientGui::onShowWindowsUpdateDialog(const VersionInfo &versionInfo) const 
     const std::unique_lock lock(mutex, std::try_to_lock);
     if (!lock.owns_lock()) return;
 #if defined(KD_MACOS)
+    // On macOS we do not show UpdateDialog since it is handled by Sparkle.
     (void) GuiRequests::startInstaller();
 #else
     if (UpdateDialog dialog(versionInfo); dialog.exec() == QDialog::Accepted) {

--- a/src/gui/clientgui.cpp
+++ b/src/gui/clientgui.cpp
@@ -797,11 +797,15 @@ void ClientGui::onShowWindowsUpdateDialog(const VersionInfo &versionInfo) const 
     static std::mutex mutex;
     const std::unique_lock lock(mutex, std::try_to_lock);
     if (!lock.owns_lock()) return;
+#if defined(KD_MACOS)
+    (void) GuiRequests::startInstaller();
+#else
     if (UpdateDialog dialog(versionInfo); dialog.exec() == QDialog::Accepted) {
-        GuiRequests::startInstaller();
+        (void) GuiRequests::startInstaller();
     } else if (dialog.skip()) {
-        GuiRequests::skipUpdate(versionInfo.fullVersion());
+        (void) GuiRequests::skipUpdate(versionInfo.fullVersion());
     }
+#endif
 }
 
 void ClientGui::onDisableNotifications(NotificationsDisabled type, QDateTime value) {

--- a/src/gui/synthesispopover.cpp
+++ b/src/gui/synthesispopover.cpp
@@ -173,9 +173,10 @@ void SynthesisPopover::forceRedraw() {
     });
 #endif
 }
+
 void SynthesisPopover::refreshLockedStatus() {
     auto updateState = UpdateState::Unknown;
-    GuiRequests::updateState(updateState);
+    (void) GuiRequests::updateState(updateState);
     onUpdateAvailabilityChange(updateState);
 }
 
@@ -976,8 +977,7 @@ void SynthesisPopover::onUpdateAvailabilityChange(const UpdateState updateState)
             break;
         default:
             _lockedAppUpdateButton->setText(tr("Unavailable"));
-            sentry::Handler::captureMessage(sentry::Level::Fatal, "AppLocked",
-                                            "HTTP Error426 received but unable to fetch an update");
+            sentry::Handler::captureMessage(sentry::Level::Fatal, "AppLocked", "Update required but unable to fetch an update");
             break;
     }
 }
@@ -1171,7 +1171,6 @@ void SynthesisPopover::retranslateUi() {
     _lockedAppupdateAppLabel->setText(tr("Update kDrive App"));
     _lockedAppLabel->setText(tr(
             "This kDrive app version is not supported anymore. To access the latest features and enhancements, please update."));
-    _lockedAppUpdateButton->setText(tr("Update"));
 #ifdef Q_OS_LINUX
     _lockedAppUpdateManualLabel->setText(tr("Please download the latest version on the website."));
 #endif // Q_OS_LINUX

--- a/src/libcommon/utility/utility.h
+++ b/src/libcommon/utility/utility.h
@@ -139,6 +139,12 @@ struct COMMON_EXPORT CommonUtility {
          */
         static bool isDiskRootFolder(const SyncPath &absolutePath, SyncPath &suggestedPath);
         static const std::string dbVersionNumber(const std::string &dbVersion);
+        /**
+         * @brief Compare versions.
+         * @param currentVersion
+         * @param targetVersion
+         * @return return true if currentVersion < targetVersion.
+         */
         static bool isVersionLower(const std::string &currentVersion, const std::string &targetVersion);
 
 #if defined(KD_MACOS)

--- a/src/libcommonserver/utility/jsonparserutility.h
+++ b/src/libcommonserver/utility/jsonparserutility.h
@@ -37,7 +37,7 @@ struct JsonParserUtility {
             }
 
             if (!obj->has(key)) {
-                LOG_WARN(Log::instance()->getLogger(), "Missing key: " << key);
+                LOG_INFO(Log::instance()->getLogger(), "Missing key: " << key);
                 return mandatory ? false : true;
             }
 

--- a/src/libcommonserver/utility/jsonparserutility.h
+++ b/src/libcommonserver/utility/jsonparserutility.h
@@ -36,7 +36,12 @@ struct JsonParserUtility {
                 return false;
             }
 
-            if (obj->has(key) && obj->isNull(key)) {
+            if (!obj->has(key)) {
+                LOG_WARN(Log::instance()->getLogger(), "Missing key: " << key);
+                return mandatory ? false : true;
+            }
+
+            if (obj->isNull(key)) {
                 // Item exists in JSON but is null, this is ok
                 return true;
             }

--- a/src/libsyncengine/jobs/network/infomaniak_API/getappversionjob.cpp
+++ b/src/libsyncengine/jobs/network/infomaniak_API/getappversionjob.cpp
@@ -39,6 +39,7 @@ static const std::string tagKey = "tag";
 static const std::string buildVersionKey = "build_version";
 static const std::string buildMinOsVersionKey = "build_min_os_version";
 static const std::string downloadUrlKey = "download_link";
+static const std::string minVersionKey = "min_version";
 
 GetAppVersionJob::GetAppVersionJob(const Platform platform, const std::string &appID) :
     GetAppVersionJob(platform, appID, {}) {}
@@ -120,35 +121,44 @@ ExitInfo GetAppVersionJob::handleResponse(std::istream &is) {
     if (const auto exitCode = AbstractNetworkJob::handleJsonResponse(replyBody); !exitCode) return exitCode;
 
     const Poco::JSON::Object::Ptr dataObj = JsonParserUtility::extractJsonObject(jsonRes(), dataKey);
-    if (!dataObj) return {};
+    if (!dataObj) return {ExitCode::BackError, ExitCause::MissingReplyData};
 
     std::string tmpStr;
-    if (!JsonParserUtility::extractValue(dataObj, prodVersionKey, tmpStr)) return {};
+    if (!JsonParserUtility::extractValue(dataObj, prodVersionKey, tmpStr))
+        return {ExitCode::BackError, ExitCause::MissingReplyData};
     _prodVersionChannel = toDistributionChannel(tmpStr);
 
     const Poco::JSON::Object::Ptr applicationObj = JsonParserUtility::extractJsonObject(dataObj, applicationKey);
-    if (!applicationObj) return {};
+    if (!applicationObj) return {ExitCode::BackError, ExitCause::MissingReplyData};
+
+    if (!JsonParserUtility::extractValue(applicationObj, minVersionKey, _minAppVersion))
+        return {ExitCode::BackError, ExitCause::MissingReplyData};
+
 
     const Poco::JSON::Array::Ptr publishedVersions = JsonParserUtility::extractArrayObject(applicationObj, publishedVersionsKey);
-    if (!publishedVersions) return {};
+    if (!publishedVersions) return {ExitCode::BackError, ExitCause::MissingReplyData};
 
     for (const auto &versionInfo: *publishedVersions) {
         const auto &obj = versionInfo.extract<Poco::JSON::Object::Ptr>();
         std::string versionType;
-        if (!JsonParserUtility::extractValue(obj, typeKey, versionType)) return {};
+        if (!JsonParserUtility::extractValue(obj, typeKey, versionType))
+            return {ExitCode::BackError, ExitCause::MissingReplyData};
 
         const VersionChannel channel = toDistributionChannel(versionType);
         _versionsInfo[channel].channel = channel;
 
-        if (!JsonParserUtility::extractValue(obj, tagKey, _versionsInfo[channel].tag)) return {};
-        if (!JsonParserUtility::extractValue(obj, buildVersionKey, _versionsInfo[channel].buildVersion)) return {};
+        if (!JsonParserUtility::extractValue(obj, tagKey, _versionsInfo[channel].tag))
+            return {ExitCode::BackError, ExitCause::MissingReplyData};
+        if (!JsonParserUtility::extractValue(obj, buildVersionKey, _versionsInfo[channel].buildVersion))
+            return {ExitCode::BackError, ExitCause::MissingReplyData};
         if (!JsonParserUtility::extractValue(obj, buildMinOsVersionKey, _versionsInfo[channel].buildMinOsVersion, false))
-            return {};
-        if (!JsonParserUtility::extractValue(obj, downloadUrlKey, _versionsInfo[channel].downloadUrl)) return {};
+            return {ExitCode::BackError, ExitCause::MissingReplyData};
+        if (!JsonParserUtility::extractValue(obj, downloadUrlKey, _versionsInfo[channel].downloadUrl))
+            return {ExitCode::BackError, ExitCause::MissingReplyData};
 
         if (!_versionsInfo[channel].isValid()) {
             LOG_WARN(_logger, "Missing mandatory value.");
-            return {};
+            return {ExitCode::BackError, ExitCause::MissingReplyData};
         }
     }
 

--- a/src/libsyncengine/jobs/network/infomaniak_API/getappversionjob.cpp
+++ b/src/libsyncengine/jobs/network/infomaniak_API/getappversionjob.cpp
@@ -151,7 +151,7 @@ ExitInfo GetAppVersionJob::handleResponse(std::istream &is) {
             return {ExitCode::BackError, ExitCause::MissingReplyData};
         if (!JsonParserUtility::extractValue(obj, buildVersionKey, _versionsInfo[channel].buildVersion))
             return {ExitCode::BackError, ExitCause::MissingReplyData};
-        if (!JsonParserUtility::extractValue(obj, buildMinOsVersionKey, _versionsInfo[channel].buildMinOsVersion, false))
+        if (!JsonParserUtility::extractValue(obj, buildMinOsVersionKey, _versionsInfo[channel].buildMinOsVersion))
             return {ExitCode::BackError, ExitCause::MissingReplyData};
         if (!JsonParserUtility::extractValue(obj, downloadUrlKey, _versionsInfo[channel].downloadUrl))
             return {ExitCode::BackError, ExitCause::MissingReplyData};

--- a/src/libsyncengine/jobs/network/infomaniak_API/getappversionjob.h
+++ b/src/libsyncengine/jobs/network/infomaniak_API/getappversionjob.h
@@ -39,6 +39,8 @@ class GetAppVersionJob : public AbstractNetworkJob {
         [[nodiscard]] const VersionInfo &versionInfo(const VersionChannel channel) { return _versionsInfo[channel]; }
         [[nodiscard]] const AllVersionsInfo &versionsInfo() const { return _versionsInfo; }
 
+        [[nodiscard]] const std::string &minAppVersion() const { return _minAppVersion; }
+
         std::string getUrl() override { return UrlHelper::infomaniakApiUrl(1, true) + getSpecificUrl(); }
 
         static std::string toStr(Platform platform);
@@ -57,8 +59,10 @@ class GetAppVersionJob : public AbstractNetworkJob {
         const Platform _platform{Platform::Unknown};
         const std::string _appId;
         const std::vector<int> _userIdList;
+
         VersionChannel _prodVersionChannel{VersionChannel::Unknown};
         AllVersionsInfo _versionsInfo;
+        std::string _minAppVersion;
 };
 
 } // namespace KDC

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -445,9 +445,10 @@ void AppServer::init() {
         _updateManager.get()->setQuitCallback(quitCallback);
 #endif
 
-        connect(_updateManager.get(), &UpdateManager::updateStateChanged, this, &AppServer::onUpdateStateChanged);
-        connect(_updateManager.get(), &UpdateManager::updateAnnouncement, this, &AppServer::onSendNotifAsked);
-        connect(_updateManager.get(), &UpdateManager::showUpdateDialog, this, &AppServer::onShowWindowsUpdateDialog);
+        (void) connect(_updateManager.get(), &UpdateManager::updateStateChanged, this, &AppServer::onUpdateStateChanged);
+        (void) connect(_updateManager.get(), &UpdateManager::updateAnnouncement, this, &AppServer::onSendNotifAsked);
+        (void) connect(_updateManager.get(), &UpdateManager::showUpdateDialog, this, &AppServer::onShowWindowsUpdateDialog);
+        (void) connect(_updateManager.get(), &UpdateManager::requireUpdate, this, &AppServer::onUpdateRequired);
     }
 
     // Check last crash to avoid crash loop
@@ -531,27 +532,8 @@ void AppServer::cleanup() {
     LOG_DEBUG(_logger, "ExtJobManager stopped");
 #endif
 
-    // Stop SyncPals
-    {
-        const std::scoped_lock lock(syncPalMapMutex);
-        for (const auto &[syncDbId, _]: syncPalMap) {
-            if (const auto exitInfo = stopSyncPal(syncDbId, false, true); !exitInfo) {
-                LOG_WARN(_logger, "Error in stopSyncPal for syncDbId=" << syncDbId << exitInfo);
-            }
-        }
-    }
-    LOG_DEBUG(_logger, "Syncpal(s) stopped");
-
-    // Stop Vfs
-    {
-        const std::scoped_lock lock(vfsMapMutex);
-        for (const auto &[syncDbId, _]: vfsMap) {
-            if (const auto exitInfo = stopVfs(syncDbId, false); !exitInfo) {
-                LOG_WARN(_logger, "Error in stopVfs for syncDbId=" << syncDbId << exitInfo);
-            }
-        }
-    }
-    LOG_DEBUG(_logger, "Vfs(s) stopped");
+    stopAllSyncPals();
+    stopAllVfs();
 
     // Clear CommManager
     if (useCommManager()) {
@@ -628,6 +610,26 @@ ExitInfo AppServer::setSupportsVirtualFilesAsync(int syncDbId, bool value) {
 
 ExitInfo AppServer::setSupportsVirtualFiles(int syncDbId, bool value) {
     return setSupportsVirtualFiles(syncDbId, value, false);
+}
+
+void AppServer::stopAllSyncPals() {
+    const std::scoped_lock lock(syncPalMapMutex);
+    for (const auto &[syncDbId, _]: syncPalMap) {
+        if (const auto exitInfo = stopSyncPal(syncDbId, false, true); !exitInfo) {
+            LOG_WARN(_logger, "Error in stopSyncPal for syncDbId=" << syncDbId << exitInfo);
+        }
+    }
+    LOG_DEBUG(_logger, "Syncpal(s) stopped");
+}
+
+void AppServer::stopAllVfs() {
+    const std::scoped_lock lock(vfsMapMutex);
+    for (const auto &[syncDbId, _]: vfsMap) {
+        if (const auto exitInfo = stopVfs(syncDbId, false); !exitInfo) {
+            LOG_WARN(_logger, "Error in stopVfs for syncDbId=" << syncDbId << exitInfo);
+        }
+    }
+    LOG_DEBUG(_logger, "Vfs(s) stopped");
 }
 
 void AppServer::stopAllSyncsTask(const std::vector<int> &syncDbIdList) {
@@ -2504,6 +2506,11 @@ void AppServer::onShowWindowsUpdateDialog() {
     if (useCommManager()) {
         _commManager->sendGuiSignal(std::make_shared<SignalUpdaterShowDialogJob>(_updateManager->versionInfo()));
     }
+}
+
+void AppServer::onUpdateRequired() {
+    stopAllSyncPals();
+    addError(Error(ERR_ID, ExitCode::UpdateRequired));
 }
 
 void AppServer::onUpdateStateChanged(const UpdateState state) {

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -2509,8 +2509,9 @@ void AppServer::onShowWindowsUpdateDialog() {
 }
 
 void AppServer::onUpdateRequired() {
-    stopAllSyncPals();
     addError(Error(ERR_ID, ExitCode::UpdateRequired));
+    stopAllSyncPals();
+    stopAllVfs();
 }
 
 void AppServer::onUpdateStateChanged(const UpdateState state) {

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -445,10 +445,14 @@ void AppServer::init() {
         _updateManager.get()->setQuitCallback(quitCallback);
 #endif
 
-        (void) connect(_updateManager.get(), &UpdateManager::updateStateChanged, this, &AppServer::onUpdateStateChanged);
-        (void) connect(_updateManager.get(), &UpdateManager::updateAnnouncement, this, &AppServer::onSendNotifAsked);
-        (void) connect(_updateManager.get(), &UpdateManager::showUpdateDialog, this, &AppServer::onShowWindowsUpdateDialog);
-        (void) connect(_updateManager.get(), &UpdateManager::requireUpdate, this, &AppServer::onUpdateRequired);
+        (void) connect(_updateManager.get(), &UpdateManager::updateStateChanged, this, &AppServer::onUpdateStateChanged,
+                       Qt::QueuedConnection);
+        (void) connect(_updateManager.get(), &UpdateManager::updateAnnouncement, this, &AppServer::onSendNotifAsked,
+                       Qt::QueuedConnection);
+        (void) connect(_updateManager.get(), &UpdateManager::showUpdateDialog, this, &AppServer::onShowWindowsUpdateDialog,
+                       Qt::QueuedConnection);
+        (void) connect(_updateManager.get(), &UpdateManager::requireUpdate, this, &AppServer::onUpdateRequired,
+                       Qt::QueuedConnection);
     }
 
     // Check last crash to avoid crash loop

--- a/src/server/appserver.h
+++ b/src/server/appserver.h
@@ -106,6 +106,9 @@ class AppServer : public SharedTools::QtSingleApplication {
 
         void showHint(std::string errorHint);
 
+        void stopAllSyncPals();
+        void stopAllVfs();
+
         void stopAllSyncsTask(const std::vector<int> &syncDbIdList);
 
         void addError(const Error &error) const;
@@ -315,6 +318,7 @@ class AppServer : public SharedTools::QtSingleApplication {
         void onRestartSyncs();
         void onScheduleAppRestart();
         void onShowWindowsUpdateDialog();
+        void onUpdateRequired();
         void onUpdateStateChanged(UpdateState state);
         void onCleanup();
         void onRequestReceived(int id, RequestNum num, const QByteArray &params);

--- a/src/server/updater/abstractupdater.cpp
+++ b/src/server/updater/abstractupdater.cpp
@@ -66,6 +66,8 @@ void AbstractUpdater::onAppVersionReceived() {
         setState(UpdateState::UpToDate);
     }
 
+    _appShouldBeBlocked = _updateChecker->appShouldBeBlocked();
+
     const bool newVersionAvailable = CommonUtility::isVersionLower(CommonUtility::currentVersion(), versionInfo.fullVersion());
     setState(newVersionAvailable ? UpdateState::Available : UpdateState::UpToDate);
     if (newVersionAvailable) {

--- a/src/server/updater/abstractupdater.h
+++ b/src/server/updater/abstractupdater.h
@@ -74,6 +74,8 @@ class AbstractUpdater {
          */
         [[nodiscard]] VersionChannel currentVersionChannel() const;
 
+        [[nodiscard]] bool appShouldBeBlocked() const { return _appShouldBeBlocked; }
+
     protected:
         explicit AbstractUpdater(const std::shared_ptr<UpdateChecker> updateChecker);
         void setState(UpdateState newState);
@@ -87,6 +89,7 @@ class AbstractUpdater {
         std::shared_ptr<UpdateChecker> _updateChecker;
         UpdateState _state{UpdateState::UpToDate}; // Current state of the update process.
         std::function<void(UpdateState)> _stateChangeCallback = nullptr;
+        bool _appShouldBeBlocked{false};
 };
 
 

--- a/src/server/updater/updatechecker.cpp
+++ b/src/server/updater/updatechecker.cpp
@@ -110,6 +110,7 @@ void UpdateChecker::versionInfoReceived(const UniqueId jobId) {
     }
 
     // Check if app should be blocked
+    _appShouldBeBlocked = false;
     if (CommonUtility::isVersionLower(CommonUtility::currentVersion(), getAppVersionJobPtr->minAppVersion())) {
         LOG_WARN(Log::instance()->getLogger(), "The current version needs to be updated. Current version: "
                                                        << CommonUtility::currentVersion()

--- a/src/server/updater/updatechecker.cpp
+++ b/src/server/updater/updatechecker.cpp
@@ -111,7 +111,8 @@ void UpdateChecker::versionInfoReceived(const UniqueId jobId) {
 
     // Check if app should be blocked
     _appShouldBeBlocked = false;
-    if (CommonUtility::isVersionLower(CommonUtility::currentVersion(), getAppVersionJobPtr->minAppVersion())) {
+    if (_isVersionReceived &&
+        CommonUtility::isVersionLower(CommonUtility::currentVersion(), getAppVersionJobPtr->minAppVersion())) {
         LOG_WARN(Log::instance()->getLogger(), "The current version needs to be updated. Current version: "
                                                        << CommonUtility::currentVersion()
                                                        << ", min version: " << getAppVersionJobPtr->minAppVersion());

--- a/src/server/updater/updatechecker.cpp
+++ b/src/server/updater/updatechecker.cpp
@@ -70,9 +70,9 @@ const VersionInfo &UpdateChecker::versionInfo(const VersionChannel chosenChannel
     const VersionInfo &internalVersion =
             _versionsInfo.contains(VersionChannel::Internal) ? _versionsInfo[VersionChannel::Internal] : _defaultVersionInfo;
     std::set<std::reference_wrapper<const VersionInfo>, VersionInfoCmp> sortedVersionList;
-    sortedVersionList.insert(prodVersion);
-    sortedVersionList.insert(betaVersion);
-    sortedVersionList.insert(internalVersion);
+    (void) sortedVersionList.insert(prodVersion);
+    (void) sortedVersionList.insert(betaVersion);
+    (void) sortedVersionList.insert(internalVersion);
     for (const auto &versionInfo: sortedVersionList) {
         if (versionInfo.get().channel <= chosenChannel) return versionInfo;
     }
@@ -80,7 +80,7 @@ const VersionInfo &UpdateChecker::versionInfo(const VersionChannel chosenChannel
     return _defaultVersionInfo;
 }
 
-void UpdateChecker::versionInfoReceived(UniqueId jobId) {
+void UpdateChecker::versionInfoReceived(const UniqueId jobId) {
     // A mutex is needed because this function can be run multiple times simultaneously when the computer wakes from sleep.
     const std::scoped_lock<std::mutex> lock(_mutex);
     _isVersionReceived = false;
@@ -107,6 +107,14 @@ void UpdateChecker::versionInfoReceived(UniqueId jobId) {
         _versionsInfo = getAppVersionJobPtr->versionsInfo();
         _prodVersionChannel = getAppVersionJobPtr->prodVersionChannel();
         _isVersionReceived = true;
+    }
+
+    // Check if app should be blocked
+    if (CommonUtility::isVersionLower(CommonUtility::currentVersion(), getAppVersionJobPtr->minAppVersion())) {
+        LOG_WARN(Log::instance()->getLogger(), "The current version needs to be updated. Current version: "
+                                                       << CommonUtility::currentVersion()
+                                                       << ", min version: " << getAppVersionJobPtr->minAppVersion());
+        _appShouldBeBlocked = true;
     }
 
     _callback();

--- a/src/server/updater/updatechecker.h
+++ b/src/server/updater/updatechecker.h
@@ -53,6 +53,7 @@ class UpdateChecker {
 
         [[nodiscard]] const std::unordered_map<VersionChannel, VersionInfo> &versionsInfo() const { return _versionsInfo; }
         [[nodiscard]] bool isVersionReceived() const { return _isVersionReceived; }
+        [[nodiscard]] bool appShouldBeBlocked() const { return _appShouldBeBlocked; }
 
     private:
         /**
@@ -87,6 +88,7 @@ class UpdateChecker {
         const VersionInfo _defaultVersionInfo;
         AllVersionsInfo _versionsInfo;
         bool _isVersionReceived{false};
+        bool _appShouldBeBlocked{false};
         std::mutex _mutex;
 
         friend class MockUpdateChecker;

--- a/src/server/updater/updatemanager.cpp
+++ b/src/server/updater/updatemanager.cpp
@@ -121,6 +121,7 @@ void UpdateManager::initUpdater() {
 void UpdateManager::onUpdateStateChanged(const UpdateState newState) {
     // Emit signal in order to run `slotUpdateStateChanged` in main thread
     emit updateStateChanged(newState);
+    if (_updater->appShouldBeBlocked()) emit requireUpdate();
 }
 
 } // namespace KDC

--- a/src/server/updater/updatemanager.h
+++ b/src/server/updater/updatemanager.h
@@ -61,6 +61,7 @@ class UpdateManager final : public QObject {
         void requestRestart();
         void updateStateChanged(KDC::UpdateState mewState);
         void showUpdateDialog();
+        void requireUpdate();
 
     private slots:
         void slotTimerFired() const;


### PR DESCRIPTION
If the application's version is lower than a specific value, the app will be blocked and the synchronizations stopped. The user must update to a newer version