### PR TITLE
Sync loop after a character case modification

### DIFF
--- a/src/libcommon/utility/utility_base.h
+++ b/src/libcommon/utility/utility_base.h
@@ -55,9 +55,10 @@ inline std::wstring getErrorMessage(DWORD errorMessageID) {
 inline std::wstring getLastErrorMessage() {
     return getErrorMessage(GetLastError());
 }
+
 inline bool isLikeFileNotFoundError(const DWORD dwError) noexcept {
     return (dwError == ERROR_FILE_NOT_FOUND) || (dwError == ERROR_PATH_NOT_FOUND) || (dwError == ERROR_INVALID_DRIVE) ||
-           (dwError == ERROR_BAD_NETPATH);
+           (dwError == ERROR_BAD_NETPATH) || (dwError == ERROR_INVALID_NAME) || (dwError == ERROR_DIRECTORY);
 }
 
 inline bool isLikeFileNotFoundError(const std::error_code &ec) noexcept {

--- a/src/libcommonserver/db/db.cpp
+++ b/src/libcommonserver/db/db.cpp
@@ -145,7 +145,7 @@ std::filesystem::path Db::makeDbName(int userId, int accountId, int driveId, int
     bool exists = false;
     IoError ioError = IoError::Success;
 
-    if (!IoHelper::checkIfPathExists(dbPath, exists, ioError)) {
+    if (!IoHelper::checkIfPathExists(dbPath, exists, ioError, IoHelper::PathCheckOption::Insensitive)) {
         LOGW_WARN(Log::instance()->getLogger(),
                   L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(dbPath, ioError));
         return {};
@@ -166,7 +166,7 @@ std::filesystem::path Db::makeDbName(int userId, int accountId, int driveId, int
     (void) dbPath.append(fileName);
 
     // If it exists already, the path is clearly usable
-    if (!IoHelper::checkIfPathExists(dbPath, exists, ioError)) {
+    if (!IoHelper::checkIfPathExists(dbPath, exists, ioError, IoHelper::PathCheckOption::Insensitive)) {
         LOGW_WARN(Log::instance()->getLogger(),
                   L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(dbPath, ioError));
         return {};
@@ -199,7 +199,7 @@ bool Db::exists() {
     } else {
         bool exists = false;
         IoError ioError = IoError::Success;
-        if (!IoHelper::checkIfPathExists(_dbPath, exists, ioError)) {
+        if (!IoHelper::checkIfPathExists(_dbPath, exists, ioError, IoHelper::PathCheckOption::Insensitive)) {
             LOGW_WARN(_logger, L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(_dbPath, ioError));
             return false;
         }
@@ -454,7 +454,7 @@ bool Db::checkConnect(const std::string &version) {
         // has become unavailable - and then some operations may cause crashes.
         bool exists = false;
         IoError ioError = IoError::Success;
-        if (!IoHelper::checkIfPathExists(_dbPath, exists, ioError)) {
+        if (!IoHelper::checkIfPathExists(_dbPath, exists, ioError, IoHelper::PathCheckOption::Insensitive)) {
             LOGW_WARN(_logger, L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(_dbPath, ioError));
             close();
             return false;
@@ -483,7 +483,7 @@ bool Db::checkConnect(const std::string &version) {
 
     bool exists = false;
     IoError ioError = IoError::Success;
-    if (!IoHelper::checkIfPathExists(_dbPath, exists, ioError)) {
+    if (!IoHelper::checkIfPathExists(_dbPath, exists, ioError, IoHelper::PathCheckOption::Insensitive)) {
         LOGW_WARN(_logger, L"Error in IoHelper::checkIfPathExists for path=" << Utility::formatIoError(_dbPath, ioError));
         return false;
     }

--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -799,15 +799,17 @@ bool IoHelper::checkIfPathExists(const SyncPath &path, bool &exists, IoError &io
 
     exists = (ioError != IoError::NoSuchFileOrDirectory) && (ioError != IoError::FileNameTooLong);
 
+#if defined(KD_MACOS) || defined(KD_WINDOWS)
     if (exists && option == PathCheckOption::Sensitive) {
         // Case & encoding check
         // NB:
         // - On Windows, the standard check is encoding insensitive
         // - On macOS, the standard check is case & encoding insensitive
         return _checkIfPathExistsSensitive(path, status, exists, ioError);
-    } else {
-        return ioError == IoError::Success || (ioError == IoError::FileNameTooLong) || isExpectedError(ioError);
     }
+#endif
+
+    return ioError == IoError::Success || (ioError == IoError::FileNameTooLong) || isExpectedError(ioError);
 }
 
 bool IoHelper::checkIfPathExistsWithSameNodeId(const SyncPath &path, const NodeId &nodeId, bool &existsWithSameId,

--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -48,9 +48,14 @@ std::function<SyncPath(std::error_code &ec)> IoHelper::_tempDirectoryPath =
         static_cast<SyncPath (*)(std::error_code &ec)>(&std::filesystem::temp_directory_path);
 
 std::function<bool(const SyncPath &path, FileStat *filestat, IoError &ioError)> IoHelper::_getFileStat = IoHelper::_getFileStatFn;
+
+#if defined(KD_MACOS) || defined(KD_WINDOWS)
 std::function<bool(const SyncPath &path, const std::filesystem::file_status &status, bool &exists, IoError &ioError)>
         IoHelper::_checkIfPathExistsSensitive = IoHelper::_checkIfPathExistsSensitiveFn;
+#endif
+
 bool IoHelper::_unsuportedFSLogged = false;
+
 #if defined(KD_MACOS)
 std::function<bool(const SyncPath &path, SyncPath &targetPath, IoError &ioError)> IoHelper::_readAlias =
         [](const SyncPath &path, SyncPath &targetPath, IoError &ioError) -> bool {

--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -48,8 +48,8 @@ std::function<SyncPath(std::error_code &ec)> IoHelper::_tempDirectoryPath =
         static_cast<SyncPath (*)(std::error_code &ec)>(&std::filesystem::temp_directory_path);
 
 std::function<bool(const SyncPath &path, FileStat *filestat, IoError &ioError)> IoHelper::_getFileStat = IoHelper::_getFileStatFn;
-std::function<bool(const SyncPath &path, bool &exists, IoError &ioError)> IoHelper::_checkIfPathExistsSensitive =
-        IoHelper::_checkIfPathExistsSensitiveFn;
+std::function<bool(const SyncPath &path, const std::filesystem::file_status &status, bool &exists, IoError &ioError)>
+        IoHelper::_checkIfPathExistsSensitive = IoHelper::_checkIfPathExistsSensitiveFn;
 bool IoHelper::_unsuportedFSLogged = false;
 #if defined(KD_MACOS)
 std::function<bool(const SyncPath &path, SyncPath &targetPath, IoError &ioError)> IoHelper::_readAlias =
@@ -774,7 +774,7 @@ bool IoHelper::checkIfPathExists(const SyncPath &path, bool &exists, IoError &io
     exists = false;
     ioError = IoError::Success;
     std::error_code ec;
-    (void) std::filesystem::symlink_status(path, ec); // symlink_status does not follow symlinks.
+    auto status = std::filesystem::symlink_status(path, ec); // symlink_status does not follow symlinks.
     ioError = stdError2ioError(ec);
     if (ioError == IoError::NoSuchFileOrDirectory) {
         ioError = IoError::Success;
@@ -804,7 +804,7 @@ bool IoHelper::checkIfPathExists(const SyncPath &path, bool &exists, IoError &io
         // NB:
         // - On Windows, the standard check is encoding insensitive
         // - On macOS, the standard check is case & encoding insensitive
-        return _checkIfPathExistsSensitive(path, exists, ioError);
+        return _checkIfPathExistsSensitive(path, status, exists, ioError);
     } else {
         return ioError == IoError::Success || (ioError == IoError::FileNameTooLong) || isExpectedError(ioError);
     }

--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -167,7 +167,7 @@ bool IoHelper::openFile(const SyncPath &path, std::ifstream &file, IoError &ioEr
         file.open(path.native(), std::ifstream::binary);
         if (!file.is_open()) {
             bool exists = false;
-            if (!IoHelper::checkIfPathExists(path, exists, ioError)) {
+            if (!IoHelper::checkIfPathExists(path, exists, ioError, IoHelper::PathCheckOption::Insensitive)) {
                 LOGW_WARN(logger(), L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(path, ioError));
                 return isExpectedError(ioError);
             }
@@ -282,7 +282,7 @@ bool IoHelper::_checkIfIsHiddenFile(const SyncPath &path, bool &isHidden, IoErro
     }
 
     FileStat filestat;
-    if (!getFileStat(path, &filestat, ioError)) {
+    if (!getFileStat(path, &filestat, ioError, IoHelper::PathCheckOption::Insensitive)) {
         LOGW_WARN(logger(), L"Error in IoHelper::getFileStat: " << Utility::formatIoError(path, ioError));
         return false;
     }
@@ -384,7 +384,7 @@ bool IoHelper::getItemType(const SyncPath &path, ItemType &itemType) noexcept {
 
         // Get target type
         FileStat filestat;
-        if (!getFileStat(path, &filestat, itemType.ioError)) {
+        if (!getFileStat(path, &filestat, itemType.ioError, IoHelper::PathCheckOption::Insensitive)) {
             LOGW_WARN(logger(), L"Error in IoHelper::getFileStat: " << Utility::formatIoError(path, itemType.ioError));
             return false;
         }
@@ -770,7 +770,7 @@ bool IoHelper::logArchiverDirectoryPath(SyncPath &directoryPath, IoError &ioErro
 }
 
 
-bool IoHelper::checkIfPathExists(const SyncPath &path, bool &exists, IoError &ioError, bool sensitive) noexcept {
+bool IoHelper::checkIfPathExists(const SyncPath &path, bool &exists, IoError &ioError, PathCheckOption option) noexcept {
     exists = false;
     ioError = IoError::Success;
     std::error_code ec;
@@ -799,7 +799,7 @@ bool IoHelper::checkIfPathExists(const SyncPath &path, bool &exists, IoError &io
 
     exists = (ioError != IoError::NoSuchFileOrDirectory) && (ioError != IoError::FileNameTooLong);
 
-    if (exists && sensitive) {
+    if (exists && option == PathCheckOption::Sensitive) {
         // Case & encoding check
         // NB:
         // - On Windows, the standard check is encoding insensitive
@@ -811,13 +811,13 @@ bool IoHelper::checkIfPathExists(const SyncPath &path, bool &exists, IoError &io
 }
 
 bool IoHelper::checkIfPathExistsWithSameNodeId(const SyncPath &path, const NodeId &nodeId, bool &existsWithSameId,
-                                               NodeId &otherNodeId, IoError &ioError, bool sensitive) noexcept {
+                                               NodeId &otherNodeId, IoError &ioError, PathCheckOption option) noexcept {
     existsWithSameId = false;
     otherNodeId.clear();
     ioError = IoError::Success;
 
     bool exists = false;
-    if (!checkIfPathExists(path, exists, ioError, sensitive)) {
+    if (!checkIfPathExists(path, exists, ioError, option)) {
         return false;
     }
 
@@ -833,11 +833,11 @@ bool IoHelper::checkIfPathExistsWithSameNodeId(const SyncPath &path, const NodeI
     return true;
 }
 
-bool IoHelper::getFileStat(const SyncPath &path, FileStat *filestat, IoError &ioError, bool sensitive) noexcept {
+bool IoHelper::getFileStat(const SyncPath &path, FileStat *filestat, IoError &ioError, PathCheckOption option) noexcept {
     ioError = IoError::Success;
 
     bool exists = false;
-    if (!checkIfPathExists(path, exists, ioError, sensitive)) {
+    if (!checkIfPathExists(path, exists, ioError, option)) {
         return false;
     }
     if (!exists) {
@@ -848,10 +848,10 @@ bool IoHelper::getFileStat(const SyncPath &path, FileStat *filestat, IoError &io
     return _getFileStat(path, filestat, ioError);
 }
 
-void IoHelper::getFileStat(const SyncPath &path, FileStat *buf, bool &exists, bool sensitive) {
+void IoHelper::getFileStat(const SyncPath &path, FileStat *buf, bool &exists, PathCheckOption option) {
     exists = true;
     IoError ioError = IoError::Success;
-    if (!getFileStat(path, buf, ioError, sensitive)) {
+    if (!getFileStat(path, buf, ioError, option)) {
         exists = (ioError != IoError::NoSuchFileOrDirectory);
         std::string message = ioError2StdString(ioError);
         throw std::runtime_error("IoHelper::getFileStat error: " + message);
@@ -863,7 +863,7 @@ bool IoHelper::checkIfFileChanged(const SyncPath &path, int64_t previousSize, Sy
     changed = false;
 
     FileStat fileStat;
-    if (!getFileStat(path, &fileStat, ioError)) {
+    if (!getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive)) {
         LOGW_WARN(logger(), L"Error in IoHelper::getFileStat: " << Utility::formatIoError(path, ioError));
         return false;
     }

--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -48,8 +48,8 @@ std::function<SyncPath(std::error_code &ec)> IoHelper::_tempDirectoryPath =
         static_cast<SyncPath (*)(std::error_code &ec)>(&std::filesystem::temp_directory_path);
 
 std::function<bool(const SyncPath &path, FileStat *filestat, IoError &ioError)> IoHelper::_getFileStat = IoHelper::_getFileStatFn;
-std::function<bool(const SyncPath &path, bool &exists, IoError &ioError)> IoHelper::_checkIfPathExists =
-        IoHelper::_checkIfPathExistsFn;
+std::function<bool(const SyncPath &path, bool &exists, IoError &ioError)> IoHelper::_checkIfPathExistsSensitive =
+        IoHelper::_checkIfPathExistsSensitiveFn;
 bool IoHelper::_unsuportedFSLogged = false;
 #if defined(KD_MACOS)
 std::function<bool(const SyncPath &path, SyncPath &targetPath, IoError &ioError)> IoHelper::_readAlias =
@@ -385,7 +385,7 @@ bool IoHelper::getItemType(const SyncPath &path, ItemType &itemType) noexcept {
         // Get target type
         FileStat filestat;
         if (!getFileStat(path, &filestat, itemType.ioError)) {
-            LOGW_WARN(logger(), L"Error in getFileStat: " << Utility::formatStdError(path, ec));
+            LOGW_WARN(logger(), L"Error in IoHelper::getFileStat: " << Utility::formatIoError(path, itemType.ioError));
             return false;
         }
 
@@ -770,18 +770,54 @@ bool IoHelper::logArchiverDirectoryPath(SyncPath &directoryPath, IoError &ioErro
 }
 
 
-bool IoHelper::checkIfPathExists(const SyncPath &path, bool &exists, IoError &ioError) noexcept {
-    return _checkIfPathExists(path, exists, ioError);
+bool IoHelper::checkIfPathExists(const SyncPath &path, bool &exists, IoError &ioError, bool sensitive) noexcept {
+    exists = false;
+    ioError = IoError::Success;
+    std::error_code ec;
+    (void) std::filesystem::symlink_status(path, ec); // symlink_status does not follow symlinks.
+    ioError = stdError2ioError(ec);
+    if (ioError == IoError::NoSuchFileOrDirectory) {
+        ioError = IoError::Success;
+        return true;
+    }
+
+#if defined(KD_WINDOWS) // TODO: Remove this block when migrating the release process to Visual Studio 2022.
+    // Prior to Visual Studio 2022, std::filesystem::symlink_status would return a misleading InvalidArgument if the path is
+    // found but located on a FAT32 disk. If the file is not found, it works as expected. This behavior is fixed when
+    // compiling with VS2022, see
+    // https://developercommunity.visualstudio.com/t/std::filesystem::is_symlink-is-broken-on/1638272
+    if (ioError == IoError::InvalidArgument && !CommonUtility::isNTFS(path)) {
+        (void) std::filesystem::status(
+                path, ec); // Symlink are only supported on NTFS on Windows, there is no risk to follow a symlink.
+        ioError = stdError2ioError(ec);
+        if (ioError == IoError::NoSuchFileOrDirectory) {
+            ioError = IoError::Success;
+            return true;
+        }
+    }
+#endif
+
+    exists = (ioError != IoError::NoSuchFileOrDirectory) && (ioError != IoError::FileNameTooLong);
+
+    if (exists && sensitive) {
+        // Case & encoding check
+        // NB:
+        // - On Windows, the standard check is encoding insensitive
+        // - On macOS, the standard check is case & encoding insensitive
+        return _checkIfPathExistsSensitive(path, exists, ioError);
+    } else {
+        return ioError == IoError::Success || (ioError == IoError::FileNameTooLong) || isExpectedError(ioError);
+    }
 }
 
 bool IoHelper::checkIfPathExistsWithSameNodeId(const SyncPath &path, const NodeId &nodeId, bool &existsWithSameId,
-                                               NodeId &otherNodeId, IoError &ioError) noexcept {
+                                               NodeId &otherNodeId, IoError &ioError, bool sensitive) noexcept {
     existsWithSameId = false;
     otherNodeId.clear();
     ioError = IoError::Success;
 
     bool exists = false;
-    if (!checkIfPathExists(path, exists, ioError)) {
+    if (!checkIfPathExists(path, exists, ioError, sensitive)) {
         return false;
     }
 
@@ -797,14 +833,25 @@ bool IoHelper::checkIfPathExistsWithSameNodeId(const SyncPath &path, const NodeI
     return true;
 }
 
-bool IoHelper::getFileStat(const SyncPath &path, FileStat *filestat, IoError &ioError) noexcept {
+bool IoHelper::getFileStat(const SyncPath &path, FileStat *filestat, IoError &ioError, bool sensitive) noexcept {
+    ioError = IoError::Success;
+
+    bool exists = false;
+    if (!checkIfPathExists(path, exists, ioError, sensitive)) {
+        return false;
+    }
+    if (!exists) {
+        if (ioError == IoError::Success) ioError = IoError::NoSuchFileOrDirectory;
+        return true;
+    }
+
     return _getFileStat(path, filestat, ioError);
 }
 
-void IoHelper::getFileStat(const SyncPath &path, FileStat *buf, bool &exists) {
+void IoHelper::getFileStat(const SyncPath &path, FileStat *buf, bool &exists, bool sensitive) {
     exists = true;
     IoError ioError = IoError::Success;
-    if (!getFileStat(path, buf, ioError)) {
+    if (!getFileStat(path, buf, ioError, sensitive)) {
         exists = (ioError != IoError::NoSuchFileOrDirectory);
         std::string message = ioError2StdString(ioError);
         throw std::runtime_error("IoHelper::getFileStat error: " + message);
@@ -817,8 +864,7 @@ bool IoHelper::checkIfFileChanged(const SyncPath &path, int64_t previousSize, Sy
 
     FileStat fileStat;
     if (!getFileStat(path, &fileStat, ioError)) {
-        LOGW_WARN(logger(), L"Failed to get file status: " << Utility::formatIoError(path, ioError));
-
+        LOGW_WARN(logger(), L"Error in IoHelper::getFileStat: " << Utility::formatIoError(path, ioError));
         return false;
     }
 

--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -48,6 +48,8 @@ std::function<SyncPath(std::error_code &ec)> IoHelper::_tempDirectoryPath =
         static_cast<SyncPath (*)(std::error_code &ec)>(&std::filesystem::temp_directory_path);
 
 std::function<bool(const SyncPath &path, FileStat *filestat, IoError &ioError)> IoHelper::_getFileStat = IoHelper::_getFileStatFn;
+std::function<bool(const SyncPath &path, bool &exists, IoError &ioError)> IoHelper::_checkIfPathExists =
+        IoHelper::_checkIfPathExistsFn;
 bool IoHelper::_unsuportedFSLogged = false;
 #if defined(KD_MACOS)
 std::function<bool(const SyncPath &path, SyncPath &targetPath, IoError &ioError)> IoHelper::_readAlias =
@@ -769,33 +771,7 @@ bool IoHelper::logArchiverDirectoryPath(SyncPath &directoryPath, IoError &ioErro
 
 
 bool IoHelper::checkIfPathExists(const SyncPath &path, bool &exists, IoError &ioError) noexcept {
-    exists = false;
-    ioError = IoError::Success;
-    std::error_code ec;
-    (void) std::filesystem::symlink_status(path, ec); // symlink_status does not follow symlinks.
-    ioError = stdError2ioError(ec);
-    if (ioError == IoError::NoSuchFileOrDirectory) {
-        ioError = IoError::Success;
-        return true;
-    }
-#if defined(KD_WINDOWS) // TODO: Remove this block when migrating the release process to Visual Studio 2022.
-    // Prior to Visual Studio 2022, std::filesystem::symlink_status would return a misleading InvalidArgument if the path is
-    // found but located on a FAT32 disk. If the file is not found, it works as expected. This behavior is fixed when
-    // compiling with VS2022, see
-    // https://developercommunity.visualstudio.com/t/std::filesystem::is_symlink-is-broken-on/1638272
-    if (ioError == IoError::InvalidArgument && !CommonUtility::isNTFS(path)) {
-        (void) std::filesystem::status(
-                path, ec); // Symlink are only supported on NTFS on Windows, there is no risk to follow a symlink.
-        ioError = stdError2ioError(ec);
-        if (ioError == IoError::NoSuchFileOrDirectory) {
-            ioError = IoError::Success;
-            return true;
-        }
-    }
-#endif
-
-    exists = (ioError != IoError::NoSuchFileOrDirectory) && (ioError != IoError::FileNameTooLong);
-    return ioError == IoError::Success || (ioError == IoError::FileNameTooLong) || isExpectedError(ioError);
+    return _checkIfPathExists(path, exists, ioError);
 }
 
 bool IoHelper::checkIfPathExistsWithSameNodeId(const SyncPath &path, const NodeId &nodeId, bool &existsWithSameId,

--- a/src/libcommonserver/io/iohelper.h
+++ b/src/libcommonserver/io/iohelper.h
@@ -568,9 +568,12 @@ struct IoHelper {
         // Can be modified in tests.
         static std::function<bool(const SyncPath &path, SyncPath &targetPath, IoError &ioError)> _readAlias;
 #endif
-        static std::function<bool(const SyncPath &path, bool &exists, IoError &ioError)> _checkIfPathExistsSensitive;
+        static std::function<bool(const SyncPath &path, const std::filesystem::file_status &status, bool &exists,
+                                  IoError &ioError)>
+                _checkIfPathExistsSensitive;
         static std::function<bool(const SyncPath &path, FileStat *filestat, IoError &ioError)> _getFileStat;
-        static bool _checkIfPathExistsSensitiveFn(const SyncPath &path, bool &exists, IoError &ioError) noexcept;
+        static bool _checkIfPathExistsSensitiveFn(const SyncPath &path, const std::filesystem::file_status &status, bool &exists,
+                                                  IoError &ioError) noexcept;
         static bool _getFileStatFn(const SyncPath &path, FileStat *filestat, IoError &ioError) noexcept;
         static bool _unsuportedFSLogged;
         static void setCacheDirectoryPath(const SyncPath &newPath);

--- a/src/libcommonserver/io/iohelper.h
+++ b/src/libcommonserver/io/iohelper.h
@@ -79,6 +79,13 @@ struct IoHelper {
                 SyncPath _directoryPath;
                 std::filesystem::recursive_directory_iterator _dirIterator;
         };
+
+        enum class PathCheckOption {
+            Sensitive = 0,
+            Insensitive,
+            EnumEnd
+        };
+
         IoHelper() = default;
 
         inline static void setLogger(const log4cplus::Logger &logger) { _logger = logger; }
@@ -156,11 +163,11 @@ struct IoHelper {
          \param sensitive is a boolean set with true for a case & encoding sensitive check.
          \return true if no unexpected error occurred, false otherwise.
          */
-        static bool getFileStat(const SyncPath &path, FileStat *filestat, IoError &ioError, bool sensitive = false) noexcept;
+        static bool getFileStat(const SyncPath &path, FileStat *filestat, IoError &ioError, PathCheckOption option) noexcept;
 
         // The following prototype throws a std::runtime_error if some unexpected error is encountered when trying to retrieve the
         // file status. This is a convenience function to be used in tests only.
-        static void getFileStat(const SyncPath &path, FileStat *filestat, bool &exists, bool sensitive = false);
+        static void getFileStat(const SyncPath &path, FileStat *filestat, bool &exists, PathCheckOption option);
 
         //! Check if the item indicated by path has a size or a modification date different from the specified ones.
         /*!
@@ -205,7 +212,7 @@ struct IoHelper {
          \param sensitive is a boolean set with true for a case & encoding sensitive check.
          \return true if no unexpected error occurred, false otherwise.
          */
-        static bool checkIfPathExists(const SyncPath &path, bool &exists, IoError &ioError, bool sensitive = false) noexcept;
+        static bool checkIfPathExists(const SyncPath &path, bool &exists, IoError &ioError, PathCheckOption option) noexcept;
 
         //! Checks if the item indicated by the specified path exists and has the specified node identifier.
         /*!
@@ -218,7 +225,7 @@ struct IoHelper {
          \return true if no unexpected error occurred, false otherwise.
          */
         static bool checkIfPathExistsWithSameNodeId(const SyncPath &path, const NodeId &nodeId, bool &existsWithSameId,
-                                                    NodeId &otherNodeId, IoError &ioError, bool sensitive = false) noexcept;
+                                                    NodeId &otherNodeId, IoError &ioError, PathCheckOption option) noexcept;
 
         //! Get the size of the file indicated by `path`, in bytes.
         /*!

--- a/src/libcommonserver/io/iohelper.h
+++ b/src/libcommonserver/io/iohelper.h
@@ -565,7 +565,9 @@ struct IoHelper {
         // Can be modified in tests.
         static std::function<bool(const SyncPath &path, SyncPath &targetPath, IoError &ioError)> _readAlias;
 #endif
+        static std::function<bool(const SyncPath &path, bool &exists, IoError &ioError)> _checkIfPathExists;
         static std::function<bool(const SyncPath &path, FileStat *filestat, IoError &ioError)> _getFileStat;
+        static bool _checkIfPathExistsFn(const SyncPath &path, bool &exists, IoError &ioError) noexcept;
         static bool _getFileStatFn(const SyncPath &path, FileStat *filestat, IoError &ioError) noexcept;
         static bool _unsuportedFSLogged;
         static void setCacheDirectoryPath(const SyncPath &newPath);

--- a/src/libcommonserver/io/iohelper.h
+++ b/src/libcommonserver/io/iohelper.h
@@ -153,13 +153,14 @@ struct IoHelper {
          successfully retrieved, nullptr otherwise.
          !!! For a symlink, filestat.nodeType is set with the type of the target !!!
          \param ioError holds the error returned when an underlying OS API call fails.
+         \param sensitive is a boolean set with true for a case & encoding sensitive check.
          \return true if no unexpected error occurred, false otherwise.
          */
-        static bool getFileStat(const SyncPath &path, FileStat *filestat, IoError &ioError) noexcept;
+        static bool getFileStat(const SyncPath &path, FileStat *filestat, IoError &ioError, bool sensitive = false) noexcept;
 
         // The following prototype throws a std::runtime_error if some unexpected error is encountered when trying to retrieve the
         // file status. This is a convenience function to be used in tests only.
-        static void getFileStat(const SyncPath &path, FileStat *filestat, bool &exists);
+        static void getFileStat(const SyncPath &path, FileStat *filestat, bool &exists, bool sensitive = false);
 
         //! Check if the item indicated by path has a size or a modification date different from the specified ones.
         /*!
@@ -201,9 +202,10 @@ struct IoHelper {
          \param path is the file system path indicating the item to check.
          \param exists is a boolean set with true if an item indicated by the path exists, false otherwise.
          \param ioError holds the error returned when an underlying OS API call fails.
+         \param sensitive is a boolean set with true for a case & encoding sensitive check.
          \return true if no unexpected error occurred, false otherwise.
          */
-        static bool checkIfPathExists(const SyncPath &path, bool &exists, IoError &ioError) noexcept;
+        static bool checkIfPathExists(const SyncPath &path, bool &exists, IoError &ioError, bool sensitive = false) noexcept;
 
         //! Checks if the item indicated by the specified path exists and has the specified node identifier.
         /*!
@@ -212,10 +214,11 @@ struct IoHelper {
          \param exists is a boolean set with true if an item indicated by the path exists with the specified node identifier,
          false otherwise.
          \param ioError holds the error returned when an underlying OS API call fails.
+         \param sensitive is a boolean set with true for a case & encoding sensitive check.
          \return true if no unexpected error occurred, false otherwise.
          */
         static bool checkIfPathExistsWithSameNodeId(const SyncPath &path, const NodeId &nodeId, bool &existsWithSameId,
-                                                    NodeId &otherNodeId, IoError &ioError) noexcept;
+                                                    NodeId &otherNodeId, IoError &ioError, bool sensitive = false) noexcept;
 
         //! Get the size of the file indicated by `path`, in bytes.
         /*!
@@ -565,9 +568,9 @@ struct IoHelper {
         // Can be modified in tests.
         static std::function<bool(const SyncPath &path, SyncPath &targetPath, IoError &ioError)> _readAlias;
 #endif
-        static std::function<bool(const SyncPath &path, bool &exists, IoError &ioError)> _checkIfPathExists;
+        static std::function<bool(const SyncPath &path, bool &exists, IoError &ioError)> _checkIfPathExistsSensitive;
         static std::function<bool(const SyncPath &path, FileStat *filestat, IoError &ioError)> _getFileStat;
-        static bool _checkIfPathExistsFn(const SyncPath &path, bool &exists, IoError &ioError) noexcept;
+        static bool _checkIfPathExistsSensitiveFn(const SyncPath &path, bool &exists, IoError &ioError) noexcept;
         static bool _getFileStatFn(const SyncPath &path, FileStat *filestat, IoError &ioError) noexcept;
         static bool _unsuportedFSLogged;
         static void setCacheDirectoryPath(const SyncPath &newPath);

--- a/src/libcommonserver/io/iohelper_linux.cpp
+++ b/src/libcommonserver/io/iohelper_linux.cpp
@@ -45,17 +45,6 @@ bool IoHelper::checkIfFileIsDehydrated(const SyncPath &itemPath, bool &isDehydra
     return true;
 }
 
-bool IoHelper::_checkIfPathExistsSensitiveFn(const SyncPath &path, const std::filesystem::file_status &status, bool &exists,
-                                             IoError &ioError) noexcept {
-    (void) path;
-    (void) status;
-    (void) exists;
-    (void) ioError;
-
-    // NB: The check done by the caller is already case & encoding sensitive
-    return true;
-}
-
 bool IoHelper::_getFileStatFn(const SyncPath &path, FileStat *buf, IoError &ioError) noexcept {
     ioError = IoError::Success;
 

--- a/src/libcommonserver/io/iohelper_linux.cpp
+++ b/src/libcommonserver/io/iohelper_linux.cpp
@@ -51,13 +51,15 @@ bool IoHelper::_checkIfPathExistsFn(const SyncPath &path, bool &exists, IoError 
 
     std::error_code ec;
     (void) std::filesystem::symlink_status(path, ec); // symlink_status does not follow symlinks.
-    ioError = stdError2ioError(ec);
-    if (ioError == IoError::NoSuchFileOrDirectory) {
-        ioError = IoError::Success;
-        return true;
+    if (ec) {
+        ioError = stdError2ioError(ec);
+        if (ioError == IoError::NoSuchFileOrDirectory) {
+            ioError = IoError::Success;
+        }
+    } else {
+        exists = true;
     }
 
-    exists = (ioError != IoError::FileNameTooLong);
     return ioError == IoError::Success || ioError == IoError::FileNameTooLong || isExpectedError(ioError);
 }
 

--- a/src/libcommonserver/io/iohelper_linux.cpp
+++ b/src/libcommonserver/io/iohelper_linux.cpp
@@ -45,8 +45,10 @@ bool IoHelper::checkIfFileIsDehydrated(const SyncPath &itemPath, bool &isDehydra
     return true;
 }
 
-bool IoHelper::_checkIfPathExistsSensitiveFn(const SyncPath &path, bool &exists, IoError &ioError) noexcept {
+bool IoHelper::_checkIfPathExistsSensitiveFn(const SyncPath &path, const std::filesystem::file_status &status, bool &exists,
+                                             IoError &ioError) noexcept {
     (void) path;
+    (void) status;
     (void) exists;
     (void) ioError;
 

--- a/src/libcommonserver/io/iohelper_linux.cpp
+++ b/src/libcommonserver/io/iohelper_linux.cpp
@@ -57,6 +57,8 @@ bool IoHelper::_checkIfPathExistsSensitiveFn(const SyncPath &path, const std::fi
 }
 
 bool IoHelper::_getFileStatFn(const SyncPath &path, FileStat *buf, IoError &ioError) noexcept {
+    ioError = IoError::Success;
+
     struct statx sb;
     if (statx(AT_FDCWD, path.string().c_str(), AT_SYMLINK_NOFOLLOW, STATX_BASIC_STATS | STATX_BTIME, &sb) < 0) {
         ioError = posixError2ioError(errno);

--- a/src/libcommonserver/io/iohelper_linux.cpp
+++ b/src/libcommonserver/io/iohelper_linux.cpp
@@ -48,6 +48,7 @@ bool IoHelper::checkIfFileIsDehydrated(const SyncPath &itemPath, bool &isDehydra
 bool IoHelper::_checkIfPathExistsFn(const SyncPath &path, bool &exists, IoError &ioError) noexcept {
     exists = false;
     ioError = IoError::Success;
+
     std::error_code ec;
     (void) std::filesystem::symlink_status(path, ec); // symlink_status does not follow symlinks.
     ioError = stdError2ioError(ec);

--- a/src/libcommonserver/io/iohelper_linux.cpp
+++ b/src/libcommonserver/io/iohelper_linux.cpp
@@ -45,6 +45,21 @@ bool IoHelper::checkIfFileIsDehydrated(const SyncPath &itemPath, bool &isDehydra
     return true;
 }
 
+bool IoHelper::_checkIfPathExistsFn(const SyncPath &path, bool &exists, IoError &ioError) noexcept {
+    exists = false;
+    ioError = IoError::Success;
+    std::error_code ec;
+    (void) std::filesystem::symlink_status(path, ec); // symlink_status does not follow symlinks.
+    ioError = stdError2ioError(ec);
+    if (ioError == IoError::NoSuchFileOrDirectory) {
+        ioError = IoError::Success;
+        return true;
+    }
+
+    exists = (ioError != IoError::FileNameTooLong);
+    return ioError == IoError::Success || ioError == IoError::FileNameTooLong || isExpectedError(ioError);
+}
+
 bool IoHelper::_getFileStatFn(const SyncPath &path, FileStat *buf, IoError &ioError) noexcept {
     ioError = IoError::Success;
 

--- a/src/libcommonserver/io/iohelper_linux.cpp
+++ b/src/libcommonserver/io/iohelper_linux.cpp
@@ -45,37 +45,16 @@ bool IoHelper::checkIfFileIsDehydrated(const SyncPath &itemPath, bool &isDehydra
     return true;
 }
 
-bool IoHelper::_checkIfPathExistsFn(const SyncPath &path, bool &exists, IoError &ioError) noexcept {
-    exists = false;
-    ioError = IoError::Success;
+bool IoHelper::_checkIfPathExistsSensitiveFn(const SyncPath &path, bool &exists, IoError &ioError) noexcept {
+    (void) path;
+    (void) exists;
+    (void) ioError;
 
-    std::error_code ec;
-    (void) std::filesystem::symlink_status(path, ec); // symlink_status does not follow symlinks.
-    if (ec) {
-        ioError = stdError2ioError(ec);
-        if (ioError == IoError::NoSuchFileOrDirectory) {
-            ioError = IoError::Success;
-        }
-    } else {
-        exists = true;
-    }
-
-    return ioError == IoError::Success || ioError == IoError::FileNameTooLong || isExpectedError(ioError);
+    // NB: The check done by the caller is already case & encoding sensitive
+    return true;
 }
 
 bool IoHelper::_getFileStatFn(const SyncPath &path, FileStat *buf, IoError &ioError) noexcept {
-    ioError = IoError::Success;
-
-    // Case-sensitive and encoding-accurate existence checking
-    bool exists = false;
-    if (!_checkIfPathExistsFn(path, exists, ioError)) {
-        return false;
-    }
-    if (!exists) {
-        if (ioError == IoError::Success) ioError = IoError::NoSuchFileOrDirectory;
-        return true;
-    }
-
     struct statx sb;
     if (statx(AT_FDCWD, path.string().c_str(), AT_SYMLINK_NOFOLLOW, STATX_BASIC_STATS | STATX_BTIME, &sb) < 0) {
         ioError = posixError2ioError(errno);

--- a/src/libcommonserver/io/iohelper_linux.cpp
+++ b/src/libcommonserver/io/iohelper_linux.cpp
@@ -66,8 +66,17 @@ bool IoHelper::_checkIfPathExistsFn(const SyncPath &path, bool &exists, IoError 
 bool IoHelper::_getFileStatFn(const SyncPath &path, FileStat *buf, IoError &ioError) noexcept {
     ioError = IoError::Success;
 
-    struct statx sb;
+    // Case-sensitive and encoding-accurate existence checking
+    bool exists = false;
+    if (!_checkIfPathExistsFn(path, exists, ioError)) {
+        return false;
+    }
+    if (!exists) {
+        if (ioError == IoError::Success) ioError = IoError::NoSuchFileOrDirectory;
+        return true;
+    }
 
+    struct statx sb;
     if (statx(AT_FDCWD, path.string().c_str(), AT_SYMLINK_NOFOLLOW, STATX_BASIC_STATS | STATX_BTIME, &sb) < 0) {
         ioError = posixError2ioError(errno);
         return isExpectedError(ioError);

--- a/src/libcommonserver/io/iohelper_mac.cpp
+++ b/src/libcommonserver/io/iohelper_mac.cpp
@@ -181,7 +181,7 @@ IoError IoHelper::lock(const SyncPath &path) noexcept {
 IoError IoHelper::unlock(const SyncPath &path) noexcept {
     FileStat filestat;
     bool found = false;
-    IoHelper::getFileStat(path, &filestat, found);
+    IoHelper::getFileStat(path, &filestat, found, IoHelper::PathCheckOption::Insensitive);
     if (!found) {
         LOGW_DEBUG(Log::instance()->getLogger(), L"Not found: " << Utility::formatSyncPath(path));
         return IoError::NoSuchFileOrDirectory;
@@ -200,7 +200,7 @@ IoError IoHelper::unlock(const SyncPath &path) noexcept {
 IoError IoHelper::isLocked(const SyncPath &path, bool &locked) noexcept {
     FileStat filestat;
     bool found = false;
-    IoHelper::getFileStat(path, &filestat, found);
+    IoHelper::getFileStat(path, &filestat, found, IoHelper::PathCheckOption::Insensitive);
     if (!found) {
         LOGW_DEBUG(Log::instance()->getLogger(), L"Not found: " << Utility::formatSyncPath(path));
         return IoError::NoSuchFileOrDirectory;

--- a/src/libcommonserver/io/iohelper_mac.cpp
+++ b/src/libcommonserver/io/iohelper_mac.cpp
@@ -146,10 +146,19 @@ bool IoHelper::_getFileStatFn(const SyncPath &path, FileStat *buf, IoError &ioEr
     ioError = IoError::Success;
 
     struct stat sb;
-
     if (lstat(path.string().c_str(), &sb) < 0) {
         ioError = posixError2ioError(errno);
         return isExpectedError(ioError);
+    }
+
+    // Case sensitive check
+    bool exists = false;
+    if (!_checkIfPathExistsFn(path, exists, ioError)) {
+        return false;
+    }
+    if (!exists) {
+        ioError = IoError::NoSuchFileOrDirectory;
+        return true;
     }
 
     buf->isHidden = false;

--- a/src/libcommonserver/io/iohelper_mac.cpp
+++ b/src/libcommonserver/io/iohelper_mac.cpp
@@ -145,13 +145,7 @@ bool IoHelper::checkIfFileIsDehydrated(const SyncPath &itemPath, bool &isDehydra
 bool IoHelper::_getFileStatFn(const SyncPath &path, FileStat *buf, IoError &ioError) noexcept {
     ioError = IoError::Success;
 
-    struct stat sb;
-    if (lstat(path.string().c_str(), &sb) < 0) {
-        ioError = posixError2ioError(errno);
-        return isExpectedError(ioError);
-    }
-
-    // Case sensitive check
+    // Case sensitive existence check
     bool exists = false;
     if (!_checkIfPathExistsFn(path, exists, ioError)) {
         return false;
@@ -159,6 +153,12 @@ bool IoHelper::_getFileStatFn(const SyncPath &path, FileStat *buf, IoError &ioEr
     if (!exists) {
         ioError = IoError::NoSuchFileOrDirectory;
         return true;
+    }
+
+    struct stat sb;
+    if (lstat(path.string().c_str(), &sb) < 0) {
+        ioError = posixError2ioError(errno);
+        return isExpectedError(ioError);
     }
 
     buf->isHidden = false;

--- a/src/libcommonserver/io/iohelper_mac.cpp
+++ b/src/libcommonserver/io/iohelper_mac.cpp
@@ -143,18 +143,6 @@ bool IoHelper::checkIfFileIsDehydrated(const SyncPath &itemPath, bool &isDehydra
 }
 
 bool IoHelper::_getFileStatFn(const SyncPath &path, FileStat *buf, IoError &ioError) noexcept {
-    ioError = IoError::Success;
-
-    // Case-sensitive and encoding-accurate existence checking
-    bool exists = false;
-    if (!_checkIfPathExistsFn(path, exists, ioError)) {
-        return false;
-    }
-    if (!exists) {
-        if (ioError == IoError::Success) ioError = IoError::NoSuchFileOrDirectory;
-        return true;
-    }
-
     struct stat sb;
     if (lstat(path.string().c_str(), &sb) < 0) {
         ioError = posixError2ioError(errno);

--- a/src/libcommonserver/io/iohelper_mac.cpp
+++ b/src/libcommonserver/io/iohelper_mac.cpp
@@ -143,6 +143,8 @@ bool IoHelper::checkIfFileIsDehydrated(const SyncPath &itemPath, bool &isDehydra
 }
 
 bool IoHelper::_getFileStatFn(const SyncPath &path, FileStat *buf, IoError &ioError) noexcept {
+    ioError = IoError::Success;
+
     struct stat sb;
     if (lstat(path.string().c_str(), &sb) < 0) {
         ioError = posixError2ioError(errno);

--- a/src/libcommonserver/io/iohelper_mac.cpp
+++ b/src/libcommonserver/io/iohelper_mac.cpp
@@ -145,13 +145,13 @@ bool IoHelper::checkIfFileIsDehydrated(const SyncPath &itemPath, bool &isDehydra
 bool IoHelper::_getFileStatFn(const SyncPath &path, FileStat *buf, IoError &ioError) noexcept {
     ioError = IoError::Success;
 
-    // Case sensitive existence check
+    // Case-sensitive and encoding-accurate existence checking
     bool exists = false;
     if (!_checkIfPathExistsFn(path, exists, ioError)) {
         return false;
     }
     if (!exists) {
-        ioError = IoError::NoSuchFileOrDirectory;
+        if (ioError == IoError::Success) ioError = IoError::NoSuchFileOrDirectory;
         return true;
     }
 

--- a/src/libcommonserver/io/iohelper_mac.mm
+++ b/src/libcommonserver/io/iohelper_mac.mm
@@ -312,46 +312,36 @@ bool IoHelper::_checkIfPathExistsFn(const SyncPath &path, bool &exists, IoError 
     exists = false;
     ioError = IoError::Success;
 
-    std::error_code ec;
-    (void) std::filesystem::symlink_status(path, ec); // symlink_status does not follow symlinks.
-    ioError = stdError2ioError(ec);
-    if (ioError == IoError::NoSuchFileOrDirectory) {
-        ioError = IoError::Success;
-        return true;
-    }
-
-    exists = (ioError != IoError::FileNameTooLong);
-
-    if (ioError == IoError::Success && exists) {
-        // Case sensitive check
-        assert(!path.empty());
-        auto *_Nonnull parentPathStr = (NSString *_Nonnull) [NSString stringWithCString:path.parent_path().c_str()
-                                                                               encoding:NSUTF8StringEncoding];
-        auto *_Nonnull parentPathURL = [NSURL fileURLWithPath:parentPathStr];
-        NSError *err = nil;
-        auto *parentFileWrapper = [[NSFileWrapper alloc] initWithURL:parentPathURL
-                                                             options:NSFileWrapperReadingWithoutMapping
-                                                               error:&err];
-        if (parentFileWrapper) {
-            NSDictionary<NSString *, NSFileWrapper *> *fileWrappers = nil;
-            @try {
-                fileWrappers = [parentFileWrapper fileWrappers];
-            } @catch (NSException *e) {
-                ioError = IoError::Unknown;
-                return false;
-            }
-
-            if (fileWrappers) {
-                auto *_Nonnull fileNameStr = (NSString *_Nonnull) [NSString stringWithCString:path.filename().c_str()
-                                                                                     encoding:NSUTF8StringEncoding];
-                if (![fileWrappers objectForKey:fileNameStr]) {
-                    exists = false;
-                }
-            }
+    // Case-sensitive and encoding-accurate checking
+    assert(!path.empty());
+    auto *_Nonnull parentPathStr = (NSString *_Nonnull) [NSString stringWithCString:path.parent_path().c_str()
+                                                                           encoding:NSUTF8StringEncoding];
+    auto *_Nonnull parentPathURL = [NSURL fileURLWithPath:parentPathStr];
+    NSError *error = nil;
+    auto *parentFileWrapper = [[NSFileWrapper alloc] initWithURL:parentPathURL
+                                                         options:NSFileWrapperReadingWithoutMapping
+                                                           error:&error];
+    if (parentFileWrapper) {
+        NSDictionary<NSString *, NSFileWrapper *> *fileWrappers = nil;
+        @try {
+            fileWrappers = [parentFileWrapper fileWrappers];
+        } @catch (NSException *e) {
+            // The file wrapper object is not a directory file wrapper (=> exists == false)
+            return true;
         }
+
+        if (fileWrappers) {
+            auto *_Nonnull fileNameStr = (NSString *_Nonnull) [NSString stringWithCString:path.filename().c_str()
+                                                                                 encoding:NSUTF8StringEncoding];
+            exists = [fileWrappers objectForKey:fileNameStr] != nil;
+        } else {
+            ioError = IoError::AccessDenied;
+        }
+    } else {
+        exists = (error.code == NSFileReadNoPermissionError) || (error.code == NSFileReadTooLargeError);
     }
 
-    return ioError == IoError::Success || ioError == IoError::FileNameTooLong || isExpectedError(ioError);
+    return true;
 }
 
 } // namespace KDC

--- a/src/libcommonserver/io/iohelper_mac.mm
+++ b/src/libcommonserver/io/iohelper_mac.mm
@@ -312,33 +312,19 @@ bool IoHelper::_checkIfPathExistsFn(const SyncPath &path, bool &exists, IoError 
     exists = false;
     ioError = IoError::Success;
 
-    // Case-sensitive and encoding-accurate checking
-    assert(!path.empty());
-    auto *_Nonnull parentPathStr = (NSString *_Nonnull) [NSString stringWithCString:path.parent_path().c_str()
-                                                                           encoding:NSUTF8StringEncoding];
-    auto *_Nonnull parentPathURL = [NSURL fileURLWithPath:parentPathStr];
-    NSError *error = nil;
-    auto *parentFileWrapper = [[NSFileWrapper alloc] initWithURL:parentPathURL
-                                                         options:NSFileWrapperReadingWithoutMapping
-                                                           error:&error];
-    if (parentFileWrapper) {
-        NSDictionary<NSString *, NSFileWrapper *> *fileWrappers = nil;
-        @try {
-            fileWrappers = [parentFileWrapper fileWrappers];
-        } @catch (NSException *e) {
-            // The file wrapper object is not a directory file wrapper (=> exists == false)
-            return true;
+    auto filename = path.filename();
+    std::error_code ec;
+    for (auto const &dir_entry: std::filesystem::directory_iterator{path.parent_path(), ec}) {
+        if (dir_entry.path().filename() == filename) {
+            exists = true;
+            break;
         }
-
-        if (fileWrappers) {
-            auto *_Nonnull fileNameStr = (NSString *_Nonnull) [NSString stringWithCString:path.filename().c_str()
-                                                                                 encoding:NSUTF8StringEncoding];
-            exists = [fileWrappers objectForKey:fileNameStr] != nil;
-        } else {
-            ioError = IoError::AccessDenied;
+    }
+    if (ec) {
+        ioError = stdError2ioError(ec);
+        if (ioError == IoError::NoSuchFileOrDirectory || ioError == IoError::FileNameTooLong) {
+            ioError = IoError::Success;
         }
-    } else {
-        exists = (error.code == NSFileReadNoPermissionError) || (error.code == NSFileReadTooLargeError);
     }
 
     return true;

--- a/src/libcommonserver/io/iohelper_mac.mm
+++ b/src/libcommonserver/io/iohelper_mac.mm
@@ -308,26 +308,20 @@ bool IoHelper::moveItemToTrash(const SyncPath &itemPath) {
     return success;
 }
 
-bool IoHelper::_checkIfPathExistsFn(const SyncPath &path, bool &exists, IoError &ioError) noexcept {
+bool IoHelper::_checkIfPathExistsSensitiveFn(const SyncPath &path, bool &exists, IoError &ioError) noexcept {
     exists = false;
     ioError = IoError::Success;
 
-    auto filename = path.filename();
     std::error_code ec;
-    for (auto const &dir_entry: std::filesystem::directory_iterator{path.parent_path(), ec}) {
-        if (dir_entry.path().filename() == filename) {
-            exists = true;
-            break;
-        }
-    }
+    auto p = std::filesystem::canonical(path, ec);
     if (ec) {
         ioError = stdError2ioError(ec);
-        if (ioError == IoError::NoSuchFileOrDirectory || ioError == IoError::FileNameTooLong) {
-            ioError = IoError::Success;
-        }
+        exists = (ioError != IoError::NoSuchFileOrDirectory) && (ioError != IoError::FileNameTooLong);
+    } else {
+        exists = p.filename() == path.filename();
     }
 
-    return true;
+    return ioError == IoError::Success || (ioError == IoError::FileNameTooLong) || isExpectedError(ioError);
 }
 
 } // namespace KDC

--- a/src/libcommonserver/io/iohelper_mac.mm
+++ b/src/libcommonserver/io/iohelper_mac.mm
@@ -311,8 +311,9 @@ bool IoHelper::moveItemToTrash(const SyncPath &itemPath) {
 bool IoHelper::_checkIfPathExistsFn(const SyncPath &path, bool &exists, IoError &ioError) noexcept {
     exists = false;
     ioError = IoError::Success;
+
     std::error_code ec;
-    auto status = std::filesystem::symlink_status(path, ec); // symlink_status does not follow symlinks.
+    (void) std::filesystem::symlink_status(path, ec); // symlink_status does not follow symlinks.
     ioError = stdError2ioError(ec);
     if (ioError == IoError::NoSuchFileOrDirectory) {
         ioError = IoError::Success;
@@ -323,45 +324,29 @@ bool IoHelper::_checkIfPathExistsFn(const SyncPath &path, bool &exists, IoError 
 
     if (ioError == IoError::Success && exists) {
         // Case sensitive check
-        /*int flags = O_RDONLY;
-        if (status.type() == std::filesystem::file_type::symlink) {
-            // Don't follow symlinks
-            flags |= O_SYMLINK;
-        }
-        if (int fd = open(path.native().c_str(), flags); fd < 0) {
-            ioError = posixError2ioError(errno);
-        } else {
-            char pathBuf[MAXPATHLEN];
-            if (fcntl(fd, F_GETPATH, pathBuf) < 0) {
-                ioError = posixError2ioError(errno);
-            } else {
-                const SyncPath realPath{pathBuf};
-                exists = realPath.filename() == path.filename();
-            }
-            close(fd);
-        }*/
-
-        NSString *nstr = [NSString stringWithCString:path.filename().c_str() encoding:NSUTF8StringEncoding];
-        NSString *ppstr = [NSString stringWithCString:path.parent_path().c_str() encoding:NSUTF8StringEncoding];
-        NSURL *purl = [NSURL fileURLWithPath:ppstr];
+        assert(!path.empty());
+        auto *_Nonnull parentPathStr = (NSString *_Nonnull) [NSString stringWithCString:path.parent_path().c_str()
+                                                                               encoding:NSUTF8StringEncoding];
+        auto *_Nonnull parentPathURL = [NSURL fileURLWithPath:parentPathStr];
         NSError *err = nil;
-        NSFileWrapper *pfw = [[NSFileWrapper alloc] initWithURL:purl options:NSFileWrapperReadingImmediate error:&err];
-        if (!err) {
-            auto wrappers = [pfw fileWrappers];
-            NSString *n = @"picture-1.jpg";
-            auto fw2 = [wrappers objectForKey:n];
-            if (fw2) {
-                NSString *n2 = [fw2 filename];
-                NSString *np2 = [fw2 preferredFilename];
-                auto e = [n isEqualToString:n2];
+        auto *parentFileWrapper = [[NSFileWrapper alloc] initWithURL:parentPathURL
+                                                             options:NSFileWrapperReadingWithoutMapping
+                                                               error:&err];
+        if (parentFileWrapper) {
+            NSDictionary<NSString *, NSFileWrapper *> *fileWrappers = nil;
+            @try {
+                fileWrappers = [parentFileWrapper fileWrappers];
+            } @catch (NSException *e) {
+                ioError = IoError::Unknown;
+                return false;
             }
-            auto fw = [wrappers objectForKey:nstr];
-            if (fw) {
-                NSString *nstr2 = [fw filename];
-                NSString *npstr = [fw preferredFilename];
-                exists = [nstr isEqualToString:nstr2];
-            } else {
-                exists = false;
+
+            if (fileWrappers) {
+                auto *_Nonnull fileNameStr = (NSString *_Nonnull) [NSString stringWithCString:path.filename().c_str()
+                                                                                     encoding:NSUTF8StringEncoding];
+                if (![fileWrappers objectForKey:fileNameStr]) {
+                    exists = false;
+                }
             }
         }
     }

--- a/src/libcommonserver/io/iohelper_mac.mm
+++ b/src/libcommonserver/io/iohelper_mac.mm
@@ -314,7 +314,7 @@ bool IoHelper::_checkIfPathExistsSensitiveFn(const SyncPath &path, const std::fi
     ioError = IoError::Success;
 
     std::error_code ec;
-    auto filename = path.filename();
+    const auto filename = path.filename();
     if (status.type() == std::filesystem::file_type::symlink) {
         // Used only for symlinks because it can be long
         for (auto const &dir_entry: std::filesystem::directory_iterator{path.parent_path(), ec}) {
@@ -324,9 +324,9 @@ bool IoHelper::_checkIfPathExistsSensitiveFn(const SyncPath &path, const std::fi
             }
         }
     } else {
-        auto p = std::filesystem::canonical(path, ec); // canonical does follow symlinks.
+        const auto canonicalPath = std::filesystem::canonical(path, ec); // canonical does follow symlinks.
         if (!ec) {
-            exists = p.filename() == filename;
+            exists = canonicalPath.filename() == filename;
         }
     }
 

--- a/src/libcommonserver/io/iohelper_mac.mm
+++ b/src/libcommonserver/io/iohelper_mac.mm
@@ -18,6 +18,7 @@
 
 #import "libcommon/utility/types.h"
 #import "libcommonserver/io/iohelper.h"
+#import "libcommonserver/io/filestat.h"
 #import "libcommonserver/utility/utility.h"
 
 #import "config.h"
@@ -233,9 +234,9 @@ void IoHelper::setFileHidden(const SyncPath &path, bool hidden) noexcept {
 
 IoError IoHelper::setFileDates(const SyncPath &filePath, SyncTime creationDate, SyncTime modificationDate,
                                bool symlink) noexcept {
-    NSDate *cDate = [[NSDate alloc] initWithTimeIntervalSince1970:creationDate];
-    NSDate *mDate = [[NSDate alloc] initWithTimeIntervalSince1970:modificationDate];
-    NSString *filePathStr = [NSString stringWithUTF8String:filePath.native().c_str()];
+    NSDate *_Nonnull cDate = [[NSDate alloc] initWithTimeIntervalSince1970:creationDate];
+    NSDate *_Nonnull mDate = [[NSDate alloc] initWithTimeIntervalSince1970:modificationDate];
+    NSString *_Nonnull filePathStr = (NSString *_Nonnull) [NSString stringWithUTF8String:filePath.native().c_str()];
     NSError *error = nil;
     bool ret = false;
     if (symlink) {
@@ -305,6 +306,67 @@ bool IoHelper::moveItemToTrash(const SyncPath &itemPath) {
     }
 
     return success;
+}
+
+bool IoHelper::_checkIfPathExistsFn(const SyncPath &path, bool &exists, IoError &ioError) noexcept {
+    exists = false;
+    ioError = IoError::Success;
+    std::error_code ec;
+    auto status = std::filesystem::symlink_status(path, ec); // symlink_status does not follow symlinks.
+    ioError = stdError2ioError(ec);
+    if (ioError == IoError::NoSuchFileOrDirectory) {
+        ioError = IoError::Success;
+        return true;
+    }
+
+    exists = (ioError != IoError::FileNameTooLong);
+
+    if (ioError == IoError::Success && exists) {
+        // Case sensitive check
+        /*int flags = O_RDONLY;
+        if (status.type() == std::filesystem::file_type::symlink) {
+            // Don't follow symlinks
+            flags |= O_SYMLINK;
+        }
+        if (int fd = open(path.native().c_str(), flags); fd < 0) {
+            ioError = posixError2ioError(errno);
+        } else {
+            char pathBuf[MAXPATHLEN];
+            if (fcntl(fd, F_GETPATH, pathBuf) < 0) {
+                ioError = posixError2ioError(errno);
+            } else {
+                const SyncPath realPath{pathBuf};
+                exists = realPath.filename() == path.filename();
+            }
+            close(fd);
+        }*/
+
+        NSString *nstr = [NSString stringWithCString:path.filename().c_str() encoding:NSUTF8StringEncoding];
+        NSString *ppstr = [NSString stringWithCString:path.parent_path().c_str() encoding:NSUTF8StringEncoding];
+        NSURL *purl = [NSURL fileURLWithPath:ppstr];
+        NSError *err = nil;
+        NSFileWrapper *pfw = [[NSFileWrapper alloc] initWithURL:purl options:NSFileWrapperReadingImmediate error:&err];
+        if (!err) {
+            auto wrappers = [pfw fileWrappers];
+            NSString *n = @"picture-1.jpg";
+            auto fw2 = [wrappers objectForKey:n];
+            if (fw2) {
+                NSString *n2 = [fw2 filename];
+                NSString *np2 = [fw2 preferredFilename];
+                auto e = [n isEqualToString:n2];
+            }
+            auto fw = [wrappers objectForKey:nstr];
+            if (fw) {
+                NSString *nstr2 = [fw filename];
+                NSString *npstr = [fw preferredFilename];
+                exists = [nstr isEqualToString:nstr2];
+            } else {
+                exists = false;
+            }
+        }
+    }
+
+    return ioError == IoError::Success || ioError == IoError::FileNameTooLong || isExpectedError(ioError);
 }
 
 } // namespace KDC

--- a/src/libcommonserver/io/iohelper_mac.mm
+++ b/src/libcommonserver/io/iohelper_mac.mm
@@ -315,18 +315,18 @@ bool IoHelper::_checkIfPathExistsSensitiveFn(const SyncPath &path, const std::fi
 
     std::error_code ec;
     const auto filename = path.filename();
-    if (status.type() == std::filesystem::file_type::symlink) {
-        // Used only for symlinks because it can be long
+    if (status.type() != std::filesystem::file_type::symlink) {
+        const auto canonicalPath = std::filesystem::canonical(path, ec); // canonical does follow symlinks.
+        if (!ec) {
+            exists = canonicalPath.filename() == filename;
+        }
+    } else {
+        // Inefficient method used only for symlinks
         for (auto const &dir_entry: std::filesystem::directory_iterator{path.parent_path(), ec}) {
             if (dir_entry.path().filename() == filename) {
                 exists = true;
                 break;
             }
-        }
-    } else {
-        const auto canonicalPath = std::filesystem::canonical(path, ec); // canonical does follow symlinks.
-        if (!ec) {
-            exists = canonicalPath.filename() == filename;
         }
     }
 

--- a/src/libcommonserver/io/iohelper_mac.mm
+++ b/src/libcommonserver/io/iohelper_mac.mm
@@ -308,17 +308,31 @@ bool IoHelper::moveItemToTrash(const SyncPath &itemPath) {
     return success;
 }
 
-bool IoHelper::_checkIfPathExistsSensitiveFn(const SyncPath &path, bool &exists, IoError &ioError) noexcept {
+bool IoHelper::_checkIfPathExistsSensitiveFn(const SyncPath &path, const std::filesystem::file_status &status, bool &exists,
+                                             IoError &ioError) noexcept {
     exists = false;
     ioError = IoError::Success;
 
     std::error_code ec;
-    auto p = std::filesystem::canonical(path, ec);
+    auto filename = path.filename();
+    if (status.type() == std::filesystem::file_type::symlink) {
+        // Used only for symlinks because it can be long
+        for (auto const &dir_entry: std::filesystem::directory_iterator{path.parent_path(), ec}) {
+            if (dir_entry.path().filename() == filename) {
+                exists = true;
+                break;
+            }
+        }
+    } else {
+        auto p = std::filesystem::canonical(path, ec); // canonical does follow symlinks.
+        if (!ec) {
+            exists = p.filename() == filename;
+        }
+    }
+
     if (ec) {
         ioError = stdError2ioError(ec);
         exists = (ioError != IoError::NoSuchFileOrDirectory) && (ioError != IoError::FileNameTooLong);
-    } else {
-        exists = p.filename() == path.filename();
     }
 
     return ioError == IoError::Success || (ioError == IoError::FileNameTooLong) || isExpectedError(ioError);

--- a/src/libcommonserver/io/iohelper_win.cpp
+++ b/src/libcommonserver/io/iohelper_win.cpp
@@ -206,8 +206,8 @@ bool IoHelper::_checkIfPathExistsFn(const SyncPath &path, bool &exists, IoError 
     } else {
         DWORD dwError = GetLastError();
         ioError = dWordError2ioError(dwError, logger());
-        if (ioError != IoError::NoSuchFileOrDirectory) {
-            return false;
+        if (ioError == IoError::NoSuchFileOrDirectory) {
+            ioError = IoError::Success;
         }
     }
 
@@ -223,7 +223,7 @@ bool IoHelper::_getFileStatFn(const SyncPath &path, FileStat *filestat, IoError 
         return false;
     }
     if (!exists) {
-        ioError = IoError::NoSuchFileOrDirectory;
+        if (ioError == IoError::Success) ioError = IoError::NoSuchFileOrDirectory;
         return true;
     }
 

--- a/src/libcommonserver/io/iohelper_win.cpp
+++ b/src/libcommonserver/io/iohelper_win.cpp
@@ -196,6 +196,7 @@ bool IoHelper::getNodeId(const SyncPath &path, NodeId &nodeId) noexcept {
 bool IoHelper::_checkIfPathExistsFn(const SyncPath &path, bool &exists, IoError &ioError) noexcept {
     exists = false;
     ioError = IoError::Success;
+
     std::error_code ec;
     (void) std::filesystem::symlink_status(path, ec); // symlink_status does not follow symlinks.
     ioError = stdError2ioError(ec);

--- a/src/libcommonserver/io/iohelper_win.cpp
+++ b/src/libcommonserver/io/iohelper_win.cpp
@@ -193,6 +193,36 @@ bool IoHelper::getNodeId(const SyncPath &path, NodeId &nodeId) noexcept {
     return true;
 }
 
+bool IoHelper::_checkIfPathExistsFn(const SyncPath &path, bool &exists, IoError &ioError) noexcept {
+    exists = false;
+    ioError = IoError::Success;
+    std::error_code ec;
+    (void) std::filesystem::symlink_status(path, ec); // symlink_status does not follow symlinks.
+    ioError = stdError2ioError(ec);
+    if (ioError == IoError::NoSuchFileOrDirectory) {
+        ioError = IoError::Success;
+        return true;
+    }
+
+    // TODO: Remove this block when migrating the release process to Visual Studio 2022.
+    // Prior to Visual Studio 2022, std::filesystem::symlink_status would return a misleading InvalidArgument if the path is
+    // found but located on a FAT32 disk. If the file is not found, it works as expected. This behavior is fixed when
+    // compiling with VS2022, see
+    // https://developercommunity.visualstudio.com/t/std::filesystem::is_symlink-is-broken-on/1638272
+    if (ioError == IoError::InvalidArgument && !CommonUtility::isNTFS(path)) {
+        (void) std::filesystem::status(
+                path, ec); // Symlink are only supported on NTFS on Windows, there is no risk to follow a symlink.
+        ioError = stdError2ioError(ec);
+        if (ioError == IoError::NoSuchFileOrDirectory) {
+            ioError = IoError::Success;
+            return true;
+        }
+    }
+
+    exists = (ioError != IoError::FileNameTooLong);
+    return ioError == IoError::Success || ioError == IoError::FileNameTooLong || isExpectedError(ioError);
+}
+
 bool IoHelper::_getFileStatFn(const SyncPath &path, FileStat *filestat, IoError &ioError) noexcept {
     ioError = IoError::Success;
 

--- a/src/libcommonserver/io/iohelper_win.cpp
+++ b/src/libcommonserver/io/iohelper_win.cpp
@@ -222,6 +222,8 @@ bool IoHelper::_checkIfPathExistsSensitiveFn(const SyncPath &path, const std::fi
 }
 
 bool IoHelper::_getFileStatFn(const SyncPath &path, FileStat *filestat, IoError &ioError) noexcept {
+    ioError = IoError::Success;
+
     // Get parent folder handle
     HANDLE hParent;
     bool retry = true;

--- a/src/libcommonserver/io/iohelper_win.cpp
+++ b/src/libcommonserver/io/iohelper_win.cpp
@@ -193,40 +193,32 @@ bool IoHelper::getNodeId(const SyncPath &path, NodeId &nodeId) noexcept {
     return true;
 }
 
-bool IoHelper::_checkIfPathExistsFn(const SyncPath &path, bool &exists, IoError &ioError) noexcept {
+bool IoHelper::_checkIfPathExistsSensitiveFn(const SyncPath &path, bool &exists, IoError &ioError) noexcept {
     exists = false;
     ioError = IoError::Success;
 
-    // Case-sensitive and encoding-accurate checking
+    // NB: The check done by the caller is already case sensitive
     WIN32_FIND_DATAW findFileData;
     if (HANDLE h = FindFirstFile(path.c_str(), &findFileData); h != INVALID_HANDLE_VALUE) {
-        SyncName fileName{findFileData.cFileName};
+        do {
+            // Loop through the variants up to the encoding
+            SyncName fileName{findFileData.cFileName};
+            if (fileName == path.filename()) {
+                exists = true;
+                break;
+            }
+        } while (FindNextFileA(h, &findFileData));
         FindClose(h);
-        exists = (fileName == path.filename());
     } else {
         DWORD dwError = GetLastError();
         ioError = dWordError2ioError(dwError, logger());
-        if (ioError == IoError::NoSuchFileOrDirectory) {
-            ioError = IoError::Success;
-        }
+        exists = (ioError != IoError::NoSuchFileOrDirectory) && (ioError != IoError::FileNameTooLong);
     }
 
-    return ioError == IoError::Success || ioError == IoError::FileNameTooLong || isExpectedError(ioError);
+    return ioError == IoError::Success || (ioError == IoError::FileNameTooLong) || isExpectedError(ioError);
 }
 
 bool IoHelper::_getFileStatFn(const SyncPath &path, FileStat *filestat, IoError &ioError) noexcept {
-    ioError = IoError::Success;
-
-    // Case-sensitive and encoding-accurate existence checking
-    bool exists = false;
-    if (!_checkIfPathExistsFn(path, exists, ioError)) {
-        return false;
-    }
-    if (!exists) {
-        if (ioError == IoError::Success) ioError = IoError::NoSuchFileOrDirectory;
-        return true;
-    }
-
     // Get parent folder handle
     HANDLE hParent;
     bool retry = true;

--- a/src/libcommonserver/io/iohelper_win.cpp
+++ b/src/libcommonserver/io/iohelper_win.cpp
@@ -66,11 +66,12 @@ IoError dWordError2ioError(DWORD error, log4cplus::Logger logger) noexcept {
             return IoError::InvalidArgument;
         case ERROR_FILENAME_EXCED_RANGE:
             return IoError::FileNameTooLong;
-        case ERROR_BAD_NETPATH:
         case ERROR_FILE_NOT_FOUND:
-        case ERROR_INVALID_DRIVE:
-        case ERROR_INVALID_NAME:
         case ERROR_PATH_NOT_FOUND:
+        case ERROR_INVALID_DRIVE:
+        case ERROR_BAD_NETPATH:
+        case ERROR_INVALID_NAME:
+        case ERROR_DIRECTORY:
             return IoError::NoSuchFileOrDirectory;
         case ERROR_NOT_SAME_DEVICE:
             return IoError::CrossDeviceLink;
@@ -197,35 +198,37 @@ bool IoHelper::_checkIfPathExistsFn(const SyncPath &path, bool &exists, IoError 
     exists = false;
     ioError = IoError::Success;
 
-    std::error_code ec;
-    (void) std::filesystem::symlink_status(path, ec); // symlink_status does not follow symlinks.
-    ioError = stdError2ioError(ec);
-    if (ioError == IoError::NoSuchFileOrDirectory) {
-        ioError = IoError::Success;
-        return true;
-    }
-
-    // TODO: Remove this block when migrating the release process to Visual Studio 2022.
-    // Prior to Visual Studio 2022, std::filesystem::symlink_status would return a misleading InvalidArgument if the path is
-    // found but located on a FAT32 disk. If the file is not found, it works as expected. This behavior is fixed when
-    // compiling with VS2022, see
-    // https://developercommunity.visualstudio.com/t/std::filesystem::is_symlink-is-broken-on/1638272
-    if (ioError == IoError::InvalidArgument && !CommonUtility::isNTFS(path)) {
-        (void) std::filesystem::status(
-                path, ec); // Symlink are only supported on NTFS on Windows, there is no risk to follow a symlink.
-        ioError = stdError2ioError(ec);
-        if (ioError == IoError::NoSuchFileOrDirectory) {
-            ioError = IoError::Success;
-            return true;
+    // Case sensitive check
+    WIN32_FIND_DATAW findFileData;
+    if (HANDLE h = FindFirstFile(path.c_str(), &findFileData); h != INVALID_HANDLE_VALUE) {
+        SyncName fileName{findFileData.cFileName};
+        FindClose(h);
+        exists = (fileName == path.filename());
+    } else {
+        DWORD dwError = GetLastError();
+        if (utility_base::isLikeFileNotFoundError(dwError)) {
+            exists = false;
+        } else {
+            ioError = dWordError2ioError(dwError, logger());
+            return false;
         }
     }
 
-    exists = (ioError != IoError::FileNameTooLong);
     return ioError == IoError::Success || ioError == IoError::FileNameTooLong || isExpectedError(ioError);
 }
 
 bool IoHelper::_getFileStatFn(const SyncPath &path, FileStat *filestat, IoError &ioError) noexcept {
     ioError = IoError::Success;
+
+    // Case sensitive existence check
+    bool exists = false;
+    if (!_checkIfPathExistsFn(path, exists, ioError)) {
+        return false;
+    }
+    if (!exists) {
+        ioError = IoError::NoSuchFileOrDirectory;
+        return true;
+    }
 
     // Get parent folder handle
     HANDLE hParent;

--- a/src/libcommonserver/io/iohelper_win.cpp
+++ b/src/libcommonserver/io/iohelper_win.cpp
@@ -15,12 +15,11 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+#include "libcommon/utility/utility.h"
 #include "libcommonserver/io/filestat.h"
 #include "libcommonserver/io/iohelper.h"
 #include "libcommonserver/io/iohelper_win.h"
-
 #include "libcommonserver/utility/utility.h"
-#include "libcommon/utility/utility.h"
 
 #include "log/log.h"
 
@@ -198,7 +197,7 @@ bool IoHelper::_checkIfPathExistsFn(const SyncPath &path, bool &exists, IoError 
     exists = false;
     ioError = IoError::Success;
 
-    // Case sensitive check
+    // Case-sensitive and encoding-accurate checking
     WIN32_FIND_DATAW findFileData;
     if (HANDLE h = FindFirstFile(path.c_str(), &findFileData); h != INVALID_HANDLE_VALUE) {
         SyncName fileName{findFileData.cFileName};
@@ -206,10 +205,8 @@ bool IoHelper::_checkIfPathExistsFn(const SyncPath &path, bool &exists, IoError 
         exists = (fileName == path.filename());
     } else {
         DWORD dwError = GetLastError();
-        if (utility_base::isLikeFileNotFoundError(dwError)) {
-            exists = false;
-        } else {
-            ioError = dWordError2ioError(dwError, logger());
+        ioError = dWordError2ioError(dwError, logger());
+        if (ioError != IoError::NoSuchFileOrDirectory) {
             return false;
         }
     }
@@ -220,7 +217,7 @@ bool IoHelper::_checkIfPathExistsFn(const SyncPath &path, bool &exists, IoError 
 bool IoHelper::_getFileStatFn(const SyncPath &path, FileStat *filestat, IoError &ioError) noexcept {
     ioError = IoError::Success;
 
-    // Case sensitive existence check
+    // Case-sensitive and encoding-accurate existence checking
     bool exists = false;
     if (!_checkIfPathExistsFn(path, exists, ioError)) {
         return false;

--- a/src/libcommonserver/io/iohelper_win.cpp
+++ b/src/libcommonserver/io/iohelper_win.cpp
@@ -193,7 +193,10 @@ bool IoHelper::getNodeId(const SyncPath &path, NodeId &nodeId) noexcept {
     return true;
 }
 
-bool IoHelper::_checkIfPathExistsSensitiveFn(const SyncPath &path, bool &exists, IoError &ioError) noexcept {
+bool IoHelper::_checkIfPathExistsSensitiveFn(const SyncPath &path, const std::filesystem::file_status &status, bool &exists,
+                                             IoError &ioError) noexcept {
+    (void) status;
+
     exists = false;
     ioError = IoError::Success;
 
@@ -207,7 +210,7 @@ bool IoHelper::_checkIfPathExistsSensitiveFn(const SyncPath &path, bool &exists,
                 exists = true;
                 break;
             }
-        } while (FindNextFileA(h, &findFileData));
+        } while (FindNextFile(h, &findFileData));
         FindClose(h);
     } else {
         DWORD dwError = GetLastError();

--- a/src/libcommonserver/log/customrollingfileappender.cpp
+++ b/src/libcommonserver/log/customrollingfileappender.cpp
@@ -255,7 +255,7 @@ void CustomRollingFileAppender::customRollover(bool alreadyLocked) {
 
         bool exists;
         IoError ioError = IoError::Success;
-        const bool success = IoHelper::checkIfPathExists(ztarget, exists, ioError);
+        const bool success = IoHelper::checkIfPathExists(ztarget, exists, ioError, IoHelper::PathCheckOption::Insensitive);
         if (!success) {
             loglog.debug(filename + LOG4CPLUS_TEXT(" failed to check if path exists"));
         }
@@ -291,7 +291,7 @@ void CustomRollingFileAppender::checkForExpiredFiles() {
     DirectoryEntry entry;
     while (dirIt.next(entry, endOfDir, ioError) && !endOfDir && ioError == IoError::Success) {
         FileStat fileStat;
-        IoHelper::getFileStat(entry.path(), &fileStat, ioError);
+        IoHelper::getFileStat(entry.path(), &fileStat, ioError, IoHelper::PathCheckOption::Insensitive);
         if (ioError != IoError::Success || fileStat.nodeType != NodeType::File) {
             continue;
         }

--- a/src/libcommonserver/utility/utility.cpp
+++ b/src/libcommonserver/utility/utility.cpp
@@ -730,7 +730,7 @@ IoError Utility::tryCreateTmpFile(const SyncName &name /*= Str("testFile")*/) {
         bool exists = false;
         auto ioError = IoError::Unknown;
         // Check if item already exist (it should not exist at this point)
-        if (!IoHelper::checkIfPathExists(tmpPath, exists, ioError)) {
+        if (!IoHelper::checkIfPathExists(tmpPath, exists, ioError, IoHelper::PathCheckOption::Insensitive)) {
             LOGW_WARN(_logger, L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(tmpPath, ioError));
             return ioError;
         }
@@ -761,7 +761,7 @@ IoError Utility::tryCreateTmpFile(const SyncName &name /*= Str("testFile")*/) {
         output.close();
 
         // Check again if item already exist (it should exist at this point)
-        if (!IoHelper::checkIfPathExists(tmpPath, exists, ioError)) {
+        if (!IoHelper::checkIfPathExists(tmpPath, exists, ioError, IoHelper::PathCheckOption::Insensitive)) {
             LOGW_WARN(_logger, L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(tmpPath, ioError));
             return ioError;
         }

--- a/src/libcommonserver/vfs/vfs.cpp
+++ b/src/libcommonserver/vfs/vfs.cpp
@@ -132,7 +132,7 @@ ExitInfo Vfs::checkIfPathIsValid(const SyncPath &itemPath, bool shouldExist, con
 
     bool exists = false;
     IoError ioError = IoError::Unknown;
-    if (!IoHelper::checkIfPathExists(itemPath, exists, ioError)) {
+    if (!IoHelper::checkIfPathExists(itemPath, exists, ioError, IoHelper::PathCheckOption::Insensitive)) {
         LOGW_WARN(logger(), L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(itemPath, ioError));
         return {ExitCode::SystemError};
     }

--- a/src/libparms/db/parmsdb.cpp
+++ b/src/libparms/db/parmsdb.cpp
@@ -3216,7 +3216,7 @@ bool ParmsDb::replaceShortDbPathsWithLongPaths() {
             continue;
         }
         bool exists = false;
-        if (!IoHelper::checkIfPathExists(longPathName, exists, ioError)) {
+        if (!IoHelper::checkIfPathExists(longPathName, exists, ioError, IoHelper::PathCheckOption::Insensitive)) {
             LOGW_WARN(_logger, L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(sync.dbPath(), ioError));
             continue;
         } else if (!exists) {

--- a/src/libsyncengine/db/syncdb.cpp
+++ b/src/libsyncengine/db/syncdb.cpp
@@ -2563,7 +2563,7 @@ bool SyncDb::reinstateEncodingOfLocalNames(const std::string &dbFromVersionNumbe
 
     bool exists = false;
     IoError existenceCheckError = IoError::Success;
-    if (!IoHelper::checkIfPathExists(localDrivePath, exists, existenceCheckError)) {
+    if (!IoHelper::checkIfPathExists(localDrivePath, exists, existenceCheckError, IoHelper::PathCheckOption::Insensitive)) {
         LOGW_WARN(_logger,
                   L"Error in IoHelper::checkIfPathExists" << Utility::formatIoError(localDrivePath, existenceCheckError));
         return false;

--- a/src/libsyncengine/jobs/local/localcopyjob.cpp
+++ b/src/libsyncengine/jobs/local/localcopyjob.cpp
@@ -38,7 +38,7 @@ ExitInfo LocalCopyJob::canRun() {
     // Check that we can copy the file in destination
     bool exists = false;
     IoError ioError = IoError::Success;
-    if (!IoHelper::checkIfPathExists(_dest, exists, ioError)) {
+    if (!IoHelper::checkIfPathExists(_dest, exists, ioError, IoHelper::PathCheckOption::Insensitive)) {
         LOGW_WARN(_logger, L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(_dest, ioError));
         return ExitCode::SystemError;
     }
@@ -53,7 +53,7 @@ ExitInfo LocalCopyJob::canRun() {
     }
 
     // Check that source file still exists
-    if (!IoHelper::checkIfPathExists(_source, exists, ioError)) {
+    if (!IoHelper::checkIfPathExists(_source, exists, ioError, IoHelper::PathCheckOption::Insensitive)) {
         LOGW_WARN(_logger, L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(_source, ioError));
         return ExitCode::SystemError;
     }

--- a/src/libsyncengine/jobs/local/localcreatedirjob.cpp
+++ b/src/libsyncengine/jobs/local/localcreatedirjob.cpp
@@ -39,7 +39,7 @@ ExitInfo LocalCreateDirJob::canRun() {
     // Check that we can create the directory here
     bool exists = false;
     IoError ioError = IoError::Success;
-    if (!IoHelper::checkIfPathExists(_destFilePath, exists, ioError)) {
+    if (!IoHelper::checkIfPathExists(_destFilePath, exists, ioError, IoHelper::PathCheckOption::Insensitive)) {
         LOGW_WARN(_logger, L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(_destFilePath, ioError));
         return ExitCode::SystemError;
     }
@@ -80,7 +80,7 @@ ExitInfo LocalCreateDirJob::runJob() {
     }
 
     FileStat filestat;
-    if (!IoHelper::getFileStat(_destFilePath, &filestat, ioError)) {
+    if (!IoHelper::getFileStat(_destFilePath, &filestat, ioError, IoHelper::PathCheckOption::Insensitive)) {
         LOGW_WARN(_logger, L"Error in IoHelper::getFileStat: " << Utility::formatIoError(_destFilePath, ioError));
         return ExitCode::SystemError;
     }

--- a/src/libsyncengine/jobs/local/localmovejob.cpp
+++ b/src/libsyncengine/jobs/local/localmovejob.cpp
@@ -48,7 +48,7 @@ ExitInfo LocalMoveJob::canRun() {
     if (!isEqual) {
         // Check that we can move the file in destination
         bool exists = false;
-        if (!IoHelper::checkIfPathExists(_dest, exists, ioError)) {
+        if (!IoHelper::checkIfPathExists(_dest, exists, ioError, IoHelper::PathCheckOption::Insensitive)) {
             LOGW_WARN(_logger, L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(_dest, ioError));
             return ExitCode::SystemError;
         }
@@ -65,7 +65,7 @@ ExitInfo LocalMoveJob::canRun() {
 
     // Check that the source file still exists.
     bool exists = false;
-    if (!IoHelper::checkIfPathExists(_source, exists, ioError)) {
+    if (!IoHelper::checkIfPathExists(_source, exists, ioError, IoHelper::PathCheckOption::Insensitive)) {
         LOGW_WARN(_logger, L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(_source, ioError));
         return {ExitCode::SystemError, ExitCause::FileAccessError};
     }

--- a/src/libsyncengine/jobs/local/synclocaldeletejob.cpp
+++ b/src/libsyncengine/jobs/local/synclocaldeletejob.cpp
@@ -103,7 +103,7 @@ ExitInfo SyncLocalDeleteJob::canRun() {
     // The item must exist locally for the job to run
     bool exists = false;
     IoError ioError = IoError::Success;
-    if (!IoHelper::checkIfPathExists(absolutePath(), exists, ioError)) {
+    if (!IoHelper::checkIfPathExists(absolutePath(), exists, ioError, IoHelper::PathCheckOption::Insensitive)) {
         LOGW_WARN(_logger, L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(absolutePath(), ioError));
         return ExitCode::SystemError;
     }

--- a/src/libsyncengine/jobs/network/kDrive_API/deletejob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/deletejob.cpp
@@ -56,8 +56,8 @@ ExitInfo DeleteJob::canRun() {
     bool existsWithSameId = false;
     NodeId otherNodeId;
     IoError ioError = IoError::Success;
-    if (!IoHelper::checkIfPathExistsWithSameNodeId(_absoluteLocalFilepath, _localItemId, existsWithSameId, otherNodeId,
-                                                   ioError)) {
+    if (!IoHelper::checkIfPathExistsWithSameNodeId(_absoluteLocalFilepath, _localItemId, existsWithSameId, otherNodeId, ioError,
+                                                   IoHelper::PathCheckOption::Insensitive)) {
         LOGW_WARN(_logger, L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(_absoluteLocalFilepath, ioError));
         return ExitCode::SystemError;
     }
@@ -68,7 +68,7 @@ ExitInfo DeleteJob::canRun() {
     if (existsWithSameId) {
         FileStat filestat;
         ioError = IoError::Success;
-        if (!IoHelper::getFileStat(_absoluteLocalFilepath, &filestat, ioError)) {
+        if (!IoHelper::getFileStat(_absoluteLocalFilepath, &filestat, ioError, IoHelper::PathCheckOption::Insensitive)) {
             LOGW_WARN(_logger, L"Error in IoHelper::getFileStat: " << Utility::formatIoError(_absoluteLocalFilepath, ioError));
             return ExitCode::SystemError;
         }

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
@@ -128,7 +128,7 @@ ExitInfo DownloadJob::canRun() {
     // Check that we can create the item here
     bool exists = false;
     IoError ioError = IoError::Success;
-    if (!IoHelper::checkIfPathExists(_localpath, exists, ioError)) {
+    if (!IoHelper::checkIfPathExists(_localpath, exists, ioError, IoHelper::PathCheckOption::Insensitive)) {
         LOGW_WARN(_logger, L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(_localpath, ioError));
         return {ExitCode::SystemError, ExitCause::FileAccessError};
     }
@@ -152,7 +152,7 @@ ExitInfo DownloadJob::runJob() noexcept {
         // Update size on file system
         FileStat filestat;
         IoError ioError = IoError::Success;
-        if (!IoHelper::getFileStat(_localpath, &filestat, ioError)) {
+        if (!IoHelper::getFileStat(_localpath, &filestat, ioError, IoHelper::PathCheckOption::Insensitive)) {
             LOGW_WARN(_logger, L"Error in IoHelper::getFileStat: " << Utility::formatIoError(_localpath, ioError));
             return ExitCode::SystemError;
         }
@@ -284,7 +284,7 @@ ExitInfo DownloadJob::handleResponse(std::istream &is) {
     // Retrieve inode
     FileStat filestat;
     IoError ioError = IoError::Success;
-    if (!IoHelper::getFileStat(_localpath, &filestat, ioError)) {
+    if (!IoHelper::getFileStat(_localpath, &filestat, ioError, IoHelper::PathCheckOption::Insensitive)) {
         LOGW_WARN(_logger, L"Error in IoHelper::getFileStat: " << Utility::formatIoError(_localpath, ioError));
         return ExitCode::SystemError;
     }
@@ -515,7 +515,8 @@ ExitInfo DownloadJob::moveTmpFile() {
             } else {
                 bool exists = false;
                 IoError ioError = IoError::Success;
-                if (!IoHelper::checkIfPathExists(_localpath.parent_path(), exists, ioError)) {
+                if (!IoHelper::checkIfPathExists(_localpath.parent_path(), exists, ioError,
+                                                 IoHelper::PathCheckOption::Insensitive)) {
                     LOGW_WARN(_logger, L"Error in IoHelper::checkIfPathExists: "
                                                << Utility::formatIoError(_localpath.parent_path(), ioError));
                     return ExitCode::SystemError;

--- a/src/libsyncengine/jobs/network/kDrive_API/movejob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/movejob.cpp
@@ -60,7 +60,7 @@ ExitInfo MoveJob::canRun() {
     // Check that we still have to move the folder
     bool exists = false;
     IoError ioError = IoError::Success;
-    if (!IoHelper::checkIfPathExists(_destFilepath, exists, ioError)) {
+    if (!IoHelper::checkIfPathExists(_destFilepath, exists, ioError, IoHelper::PathCheckOption::Insensitive)) {
         LOGW_WARN(_logger, L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(_destFilepath, ioError));
         return ExitCode::SystemError;
     }

--- a/src/libsyncengine/jobs/network/kDrive_API/upload/upload_session/abstractuploadsession.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/upload/upload_session/abstractuploadsession.cpp
@@ -162,7 +162,7 @@ ExitInfo AbstractUploadSession::canRun() {
     // Check that the item still exist
     bool exists = false;
     auto ioError = IoError::Success;
-    if (!IoHelper::checkIfPathExists(_filePath, exists, ioError)) {
+    if (!IoHelper::checkIfPathExists(_filePath, exists, ioError, IoHelper::PathCheckOption::Insensitive)) {
         LOGW_WARN(_logger, L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(_filePath, ioError));
         return ExitCode::SystemError;
     }

--- a/src/libsyncengine/jobs/network/kDrive_API/upload/upload_session/driveuploadsession.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/upload/upload_session/driveuploadsession.cpp
@@ -48,7 +48,8 @@ DriveUploadSession::DriveUploadSession(const std::shared_ptr<Vfs> &vfs, const in
     // Retrieve creation date from the local file
     FileStat fileStat;
     auto ioError = IoError::Unknown;
-    if (!IoHelper::getFileStat(filepath, &fileStat, ioError) || ioError != IoError::Success) {
+    if (!IoHelper::getFileStat(filepath, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive) ||
+        ioError != IoError::Success) {
         LOGW_WARN(getLogger(), L"Failed to get FileStat for " << Utility::formatSyncPath(filepath) << L": " << ioError);
     }
     _creationTimeIn = fileStat.creationTime;

--- a/src/libsyncengine/jobs/network/kDrive_API/upload/uploadjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/upload/uploadjob.cpp
@@ -53,7 +53,8 @@ UploadJob::UploadJob(const std::shared_ptr<Vfs> &vfs, const int driveDbId, const
     // Retrieve creation date from the local file
     FileStat fileStat;
     auto ioError = IoError::Unknown;
-    if (!IoHelper::getFileStat(_absoluteFilePath, &fileStat, ioError) || ioError != IoError::Success) {
+    if (!IoHelper::getFileStat(_absoluteFilePath, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive) ||
+        ioError != IoError::Success) {
         LOGW_WARN(_logger, L"Failed to get FileStat for " << Utility::formatSyncPath(_absoluteFilePath) << L": " << ioError);
     }
     _creationTimeIn = fileStat.creationTime;
@@ -79,7 +80,7 @@ ExitInfo UploadJob::canRun() {
     // Check that the item still exist
     bool exists = false;
     IoError ioError = IoError::Success;
-    if (!IoHelper::checkIfPathExists(_absoluteFilePath, exists, ioError)) {
+    if (!IoHelper::checkIfPathExists(_absoluteFilePath, exists, ioError, IoHelper::PathCheckOption::Insensitive)) {
         LOGW_WARN(_logger, L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(_absoluteFilePath, ioError));
         return ExitCode::SystemError;
     }

--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -322,7 +322,8 @@ ExitInfo ExecutorWorker::handleCreateOp(SyncOpPtr syncOp, std::shared_ptr<SyncJo
         if (!isValidDestination(syncOp)) {
             if (syncOp->targetSide() == ReplicaSide::Remote) {
                 bool exists = false;
-                if (auto ioError = IoError::Success; !IoHelper::checkIfPathExists(absoluteLocalFilePath, exists, ioError)) {
+                if (auto ioError = IoError::Success; !IoHelper::checkIfPathExists(absoluteLocalFilePath, exists, ioError,
+                                                                                  IoHelper::PathCheckOption::Insensitive)) {
                     LOGW_WARN(_logger,
                               L"Error in Utility::checkIfPathExists: " << Utility::formatSyncPath(absoluteLocalFilePath));
                     return ExitCode::SystemError;
@@ -492,7 +493,7 @@ ExitInfo ExecutorWorker::generateCreateJob(SyncOpPtr syncOp, std::shared_ptr<Syn
 
             FileStat fileStat;
             IoError ioError = IoError::Success;
-            if (!IoHelper::getFileStat(absoluteLocalFilePath, &fileStat, ioError)) {
+            if (!IoHelper::getFileStat(absoluteLocalFilePath, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive)) {
                 LOGW_SYNCPAL_WARN(_logger,
                                   L"Error in IoHelper::getFileStat: " << Utility::formatIoError(absoluteLocalFilePath, ioError));
                 return ExitCode::SystemError;
@@ -526,7 +527,8 @@ ExitInfo ExecutorWorker::generateCreateJob(SyncOpPtr syncOp, std::shared_ptr<Syn
             } else {
                 bool exists = false;
                 IoError ioError = IoError::Success;
-                if (!IoHelper::checkIfPathExists(absoluteLocalFilePath, exists, ioError)) {
+                if (!IoHelper::checkIfPathExists(absoluteLocalFilePath, exists, ioError,
+                                                 IoHelper::PathCheckOption::Insensitive)) {
                     LOGW_WARN(_logger, L"Error in IoHelper::checkIfPathExists: "
                                                << Utility::formatIoError(absoluteLocalFilePath, ioError));
                     return ExitCode::SystemError;
@@ -2172,7 +2174,8 @@ ExitInfo ExecutorWorker::handleExecutorError(SyncOpPtr syncOp, const ExitInfo &o
     if (opsExitInfo.cause() == ExitCause::NotFound || opsExitInfo.cause() == ExitCause::FileAccessError) {
         // Check that the root of the sync folder is still accessible
         bool exists = false;
-        if (IoError ioError = IoError::Success; !IoHelper::checkIfPathExists(_syncPal->localPath(), exists, ioError)) {
+        if (IoError ioError = IoError::Success;
+            !IoHelper::checkIfPathExists(_syncPal->localPath(), exists, ioError, IoHelper::PathCheckOption::Insensitive)) {
             LOGW_WARN(_logger,
                       L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(_syncPal->localPath(), ioError));
             return {ExitCode::SystemError, ExitCause::FileAccessError};

--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -701,7 +701,7 @@ ExitInfo ExecutorWorker::convertToPlaceholder(const SyncPath &relativeLocalPath,
     // VfsWin::convertToPlaceholder needs only SyncFileItem::_localNodeId
     FileStat fileStat;
     IoError ioError = IoError::Success;
-    if (!IoHelper::getFileStat(absoluteLocalFilePath, &fileStat, ioError)) {
+    if (!IoHelper::getFileStat(absoluteLocalFilePath, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive)) {
         LOGW_SYNCPAL_WARN(_logger, L"Error in IoHelper::getFileStat: " << Utility::formatIoError(absoluteLocalFilePath, ioError));
         return ExitCode::SystemError;
     }

--- a/src/libsyncengine/propagation/executor/filerescuer.cpp
+++ b/src/libsyncengine/propagation/executor/filerescuer.cpp
@@ -52,7 +52,7 @@ ExitInfo FileRescuer::createRescueFolderIfNeeded() const {
 
     bool exists = false;
     auto ioError = IoError::Unknown;
-    (void) IoHelper::checkIfPathExists(rescueFolderPath, exists, ioError);
+    (void) IoHelper::checkIfPathExists(rescueFolderPath, exists, ioError, IoHelper::PathCheckOption::Insensitive);
     if (ioError != IoError::Success) {
         // Failed to check directory existence
         LOGW_WARN(KDC::Log::instance()->getLogger(),

--- a/src/libsyncengine/syncpal/conflictingfilescorrector.cpp
+++ b/src/libsyncengine/syncpal/conflictingfilescorrector.cpp
@@ -41,7 +41,8 @@ ExitInfo ConflictingFilesCorrector::runJob() {
     for (auto &error: _errors) {
         bool exists = false;
         IoError ioError = IoError::Success;
-        if (!IoHelper::checkIfPathExists(_syncPal->localPath() / error.destinationPath(), exists, ioError)) {
+        if (!IoHelper::checkIfPathExists(_syncPal->localPath() / error.destinationPath(), exists, ioError,
+                                         IoHelper::PathCheckOption::Insensitive)) {
             LOGW_WARN(Log::instance()->getLogger(),
                       L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(error.destinationPath(), ioError));
             _nbErrors++;

--- a/src/libsyncengine/syncpal/syncpal.cpp
+++ b/src/libsyncengine/syncpal/syncpal.cpp
@@ -1390,7 +1390,7 @@ ExitInfo SyncPal::handleAccessDeniedItem(const SyncPath &relativeLocalPath, bool
         if (!IoHelper::getNodeId(absolutePath, localNodeId)) {
             bool exists = false;
             IoError ioError = IoError::Success;
-            if (!IoHelper::checkIfPathExists(absolutePath, exists, ioError)) {
+            if (!IoHelper::checkIfPathExists(absolutePath, exists, ioError, IoHelper::PathCheckOption::Insensitive)) {
                 LOGW_WARN(_logger, L"IoHelper::checkIfPathExists failed with: " << Utility::formatIoError(absolutePath, ioError));
                 return ExitCode::SystemError;
             }

--- a/src/libsyncengine/update_detection/blacklist_changes_propagator/blacklistpropagator.cpp
+++ b/src/libsyncengine/update_detection/blacklist_changes_propagator/blacklistpropagator.cpp
@@ -217,7 +217,7 @@ ExitCode BlacklistPropagator::removeItem(const NodeId &localNodeId, const NodeId
     // Remove item from filesystem
     bool exists = false;
     IoError ioError = IoError::Success;
-    if (!IoHelper::checkIfPathExists(absoluteLocalPath, exists, ioError)) {
+    if (!IoHelper::checkIfPathExists(absoluteLocalPath, exists, ioError, IoHelper::PathCheckOption::Insensitive)) {
         LOGW_WARN(Log::instance()->getLogger(),
                   L"Error in IoHelper::checkIfPathExists for " << Utility::formatIoError(absoluteLocalPath, ioError));
         return ExitCode::SystemError;

--- a/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
@@ -234,7 +234,8 @@ ExitCode ComputeFSOperationWorker::inferChangeFromDbNode(const ReplicaSide side,
             if (!nodeExistsInSnapshot) {
                 bool exists = false;
                 IoError ioError = IoError::Success;
-                if (!IoHelper::checkIfPathExists(localPath, exists, ioError) || ioError == IoError::AccessDenied) {
+                if (!IoHelper::checkIfPathExists(localPath, exists, ioError, IoHelper::PathCheckOption::Insensitive) ||
+                    ioError == IoError::AccessDenied) {
                     LOGW_SYNCPAL_WARN(_logger,
                                       L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(localPath, ioError));
                     return ExitCode::SystemError;
@@ -783,7 +784,8 @@ ExitInfo ComputeFSOperationWorker::checkIfOkToDelete(const ReplicaSide side, con
     bool existsWithSameId = false;
     NodeId otherNodeId;
     IoError ioError = IoError::Success;
-    if (!IoHelper::checkIfPathExistsWithSameNodeId(absolutePath, nodeId, existsWithSameId, otherNodeId, ioError)) {
+    if (!IoHelper::checkIfPathExistsWithSameNodeId(absolutePath, nodeId, existsWithSameId, otherNodeId, ioError,
+                                                   IoHelper::PathCheckOption::Insensitive)) {
         LOGW_SYNCPAL_WARN(_logger, L"Error in IoHelper::checkIfPathExistsWithSameNodeId: "
                                            << Utility::formatIoError(absolutePath, ioError));
 

--- a/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
@@ -112,7 +112,8 @@ ExitInfo LocalFileSystemObserverWorker::changesDetected(
 
         FileStat fileStat;
         auto ioError = IoError::Success;
-        if (!IoHelper::getFileStat(absolutePath, &fileStat, ioError)) {
+        if (!IoHelper::getFileStat(absolutePath, &fileStat, ioError,
+                                   true)) { // Sensitive existence check is needed for MOVE operation
             LOGW_SYNCPAL_WARN(_logger, L"Error in IoHelper::getFileStat: " << Utility::formatIoError(absolutePath, ioError));
             tryToInvalidateSnapshot();
             return ExitCode::SystemError;

--- a/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
@@ -97,8 +97,8 @@ ExitInfo LocalFileSystemObserverWorker::changesDetected(
                 bool existsWithSameId = false;
                 NodeId otherNodeId;
                 if (auto checkError = IoError::Success;
-                    IoHelper::checkIfPathExistsWithSameNodeId(absolutePath, prevNodeId, existsWithSameId, otherNodeId,
-                                                              checkError) &&
+                    IoHelper::checkIfPathExistsWithSameNodeId(absolutePath, prevNodeId, existsWithSameId, otherNodeId, checkError,
+                                                              IoHelper::PathCheckOption::Insensitive) &&
                     !existsWithSameId) {
                     if (_liveSnapshot.removeItem(prevNodeId)) {
                         LOGW_SYNCPAL_DEBUG(_logger, L"Item removed from local snapshot: "
@@ -112,8 +112,9 @@ ExitInfo LocalFileSystemObserverWorker::changesDetected(
 
         FileStat fileStat;
         auto ioError = IoError::Success;
-        if (!IoHelper::getFileStat(absolutePath, &fileStat, ioError,
-                                   true)) { // Sensitive existence check is needed for MOVE operation
+        if (!IoHelper::getFileStat(
+                    absolutePath, &fileStat, ioError,
+                    IoHelper::PathCheckOption::Sensitive)) { // Sensitive existence check is needed for MOVE operation
             LOGW_SYNCPAL_WARN(_logger, L"Error in IoHelper::getFileStat: " << Utility::formatIoError(absolutePath, ioError));
             tryToInvalidateSnapshot();
             return ExitCode::SystemError;
@@ -677,7 +678,7 @@ ExitInfo LocalFileSystemObserverWorker::exploreDir(const SyncPath &absoluteParen
             FileStat fileStat;
             NodeId nodeId;
             if (!toExclude) {
-                if (!IoHelper::getFileStat(absolutePath, &fileStat, entryIoError)) {
+                if (!IoHelper::getFileStat(absolutePath, &fileStat, entryIoError, IoHelper::PathCheckOption::Insensitive)) {
                     LOGW_SYNCPAL_DEBUG(_logger,
                                        L"Error in IoHelper::getFileStat: " << Utility::formatIoError(absolutePath, entryIoError));
                     dirIt.disableRecursionPending();
@@ -711,7 +712,8 @@ ExitInfo LocalFileSystemObserverWorker::exploreDir(const SyncPath &absoluteParen
                 parentNodeId = _liveSnapshot.itemId(relativePath.parent_path());
                 if (parentNodeId.empty()) {
                     FileStat parentFileStat;
-                    if (!IoHelper::getFileStat(absolutePath.parent_path(), &parentFileStat, entryIoError)) {
+                    if (!IoHelper::getFileStat(absolutePath.parent_path(), &parentFileStat, entryIoError,
+                                               IoHelper::PathCheckOption::Insensitive)) {
                         LOGW_WARN(_logger, L"Error in IoHelper::getFileStat: "
                                                    << Utility::formatIoError(absolutePath.parent_path(), entryIoError));
                         return {ExitCode::SystemError, ExitCause::FileAccessError};

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -3553,8 +3553,9 @@ bool AppServer::startClient() {
 
             IoError ioError = IoError::Success;
             bool exists = false;
-            if (!IoHelper::checkIfPathExists(pathToExecutable.toStdString(), exists, ioError) || !exists ||
-                ioError != IoError::Success) {
+            if (!IoHelper::checkIfPathExists(pathToExecutable.toStdString(), exists, ioError,
+                                             IoHelper::PathCheckOption::Insensitive) ||
+                !exists || ioError != IoError::Success) {
                 pathToExecutable.clear();
             }
         }

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -209,7 +209,8 @@ void AppServer::init() {
 
     bool newDbExists = false;
     IoError ioError = IoError::Success;
-    if (!IoHelper::checkIfPathExists(parmsDbPath, newDbExists, ioError) || ioError != IoError::Success) {
+    if (!IoHelper::checkIfPathExists(parmsDbPath, newDbExists, ioError, IoHelper::PathCheckOption::Insensitive) ||
+        ioError != IoError::Success) {
         LOGW_WARN(_logger, L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(parmsDbPath, ioError));
         throw std::runtime_error("Unable to check if ParmsDb exists.");
     }
@@ -217,7 +218,8 @@ void AppServer::init() {
     std::filesystem::path pre334ConfigFilePath =
             std::filesystem::path(QStr2SyncName(MigrationParams::configDir().filePath(MigrationParams::configFileName())));
     bool oldConfigExists;
-    if (!IoHelper::checkIfPathExists(pre334ConfigFilePath, oldConfigExists, ioError) || ioError != IoError::Success) {
+    if (!IoHelper::checkIfPathExists(pre334ConfigFilePath, oldConfigExists, ioError, IoHelper::PathCheckOption::Insensitive) ||
+        ioError != IoError::Success) {
         LOGW_WARN(_logger, L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(pre334ConfigFilePath, ioError));
         throw std::runtime_error("Unable to check if a pre 3.3.4 config exists.");
     }
@@ -402,7 +404,9 @@ void AppServer::init() {
             const auto noUpdateFilePath = CommonUtility::applicationFilePath().parent_path() / SyncPath("no_update");
             bool noUpdateFlagFileExists = false;
             ioError = IoError::Success;
-            if (!IoHelper::checkIfPathExists(noUpdateFilePath, noUpdateFlagFileExists, ioError) || ioError != IoError::Success) {
+            if (!IoHelper::checkIfPathExists(noUpdateFilePath, noUpdateFlagFileExists, ioError,
+                                             IoHelper::PathCheckOption::Insensitive) ||
+                ioError != IoError::Success) {
                 std::string errorMsg = "Error in checkIfPathExists(noUpdateFilePath, ...): ioError=" + toString(ioError);
                 LOG_ERROR(_logger, errorMsg);
                 KDC::sentry::Handler::captureMessage(KDC::sentry::Level::Error, "noUpdateFilePath lookup error", errorMsg);
@@ -3717,7 +3721,7 @@ ExitInfo AppServer::createAndStartVfs(const Sync &sync) noexcept {
     // Check that the sync folder exists.
     bool exists = false;
     IoError ioError = IoError::Success;
-    if (!IoHelper::checkIfPathExists(sync.localPath(), exists, ioError)) {
+    if (!IoHelper::checkIfPathExists(sync.localPath(), exists, ioError, IoHelper::PathCheckOption::Insensitive)) {
         LOGW_WARN(_logger, L"Error in IoHelper::checkIfPathExists " << Utility::formatIoError(sync.localPath(), ioError));
         return ExitCode::SystemError;
     }

--- a/src/server/comm/extensionjob.cpp
+++ b/src/server/comm/extensionjob.cpp
@@ -755,7 +755,7 @@ void ExtensionJob::manageActionsOnSingleFile(std::shared_ptr<AbstractCommChannel
                                              const Sync &sync) {
     bool exists = false;
     auto ioError = IoError::Success;
-    if (!IoHelper::checkIfPathExists(path, exists, ioError) || !exists) {
+    if (!IoHelper::checkIfPathExists(path, exists, ioError, IoHelper::PathCheckOption::Insensitive) || !exists) {
         return;
     }
 

--- a/src/server/comm/guijobs/guijobfactory.cpp
+++ b/src/server/comm/guijobs/guijobfactory.cpp
@@ -103,7 +103,6 @@ GuiJobFactory::GuiJobFactory() {
                 {RequestNum::BLACKLISTED_NODE_SETLIST, makeShared<BlacklistedNodeSetListJob>},
                 {RequestNum::NODE_PATH, makeShared<NodePathJob>},
                 {RequestNum::NODE_INFO, makeShared<NodeInfoJob>},
-                {RequestNum::SYNC_GETPRIVATELINKURL, makeShared<SyncGetPrivateLinkUrlJob>},
                 {RequestNum::NODE_SUBFOLDERS, makeShared<NodeSubFoldersJob>},
                 {RequestNum::NODE_SUBFOLDERS2, makeShared<NodeSubFolders2Job>},
                 {RequestNum::NODE_FOLDER_SIZE, makeShared<NodeFolderSizeJob>},

--- a/src/server/comm/guijobs/utilityfindgoodpathfornewsyncjob.cpp
+++ b/src/server/comm/guijobs/utilityfindgoodpathfornewsyncjob.cpp
@@ -22,7 +22,6 @@
 #include "requests/serverrequests.h"
 
 // Input parameters keys
-static const auto inParamsDriveDbId = "driveDbId";
 static const auto inParamsBasePath = "basePath";
 
 // Output parameters keys

--- a/src/server/comm/litesynccommclient_mac.mm
+++ b/src/server/comm/litesynccommclient_mac.mm
@@ -272,7 +272,7 @@ class LiteSyncCommClientPrivate {
         liteSyncExtMachName = [NSString stringWithUTF8String:KDC::CommonUtility::liteSyncExtBundleId().c_str()];
     }
 
-    _connection = [[NSXPCConnection alloc] initWithMachServiceName:liteSyncExtMachName options:0];
+    _connection = [[NSXPCConnection alloc] initWithMachServiceName:(NSString *_Nonnull) liteSyncExtMachName options:0];
     if (_connection == nil) {
         NSLog(@"[KD] Failed to connect to LiteSync extension");
         return FALSE;
@@ -560,7 +560,9 @@ bool LiteSyncCommClientPrivate::vfsStart(const SyncPath &folderPath) {
         return false;
     }
 
-    NSString *nsPath = [NSString stringWithCString:folderPath.c_str() encoding:NSUTF8StringEncoding];
+    assert(!folderPath.empty());
+    NSString *_Nonnull nsPath = (NSString *_Nonnull) [NSString stringWithCString:folderPath.c_str()
+                                                                        encoding:NSUTF8StringEncoding];
     if (![_connector registerFolder:nsPath]) {
         LOG_ERROR(_logger, "Cannot register folder!");
         return false;
@@ -610,7 +612,9 @@ bool LiteSyncCommClientPrivate::vfsStop(const SyncPath &folderPath) {
         return false;
     }
 
-    NSString *nsPath = [NSString stringWithCString:folderPath.c_str() encoding:NSUTF8StringEncoding];
+    assert(!folderPath.empty());
+    NSString *_Nonnull nsPath = (NSString *_Nonnull) [NSString stringWithCString:folderPath.c_str()
+                                                                        encoding:NSUTF8StringEncoding];
     if (![_connector unregisterFolder:nsPath]) {
         LOG_ERROR(_logger, "Cannot unregister folder!");
         return false;
@@ -642,8 +646,10 @@ bool LiteSyncCommClientPrivate::updateFetchStatus(const SyncPath &filePath, cons
         return false;
     }
 
-    NSString *nsPath = [NSString stringWithUTF8String:filePath.c_str()];
-    NSString *nsStatus = [NSString stringWithUTF8String:status.c_str()];
+    assert(!filePath.empty());
+    NSString *_Nonnull nsPath = (NSString *_Nonnull) [NSString stringWithUTF8String:filePath.c_str()];
+    assert(!status.empty());
+    NSString *_Nonnull nsStatus = (NSString *_Nonnull) [NSString stringWithUTF8String:status.c_str()];
     if (![_connector updateFetchStatus:nsPath fileStatus:nsStatus]) {
         LOGW_ERROR(_logger, L"Call to updateFetchStatus failed: " << Utility::formatSyncPath(filePath));
         return false;
@@ -670,11 +676,12 @@ bool LiteSyncCommClientPrivate::setThumbnail(const SyncPath &filePath, const QPi
         error = true;
     }
 
-    NSString *nsPath = [NSString stringWithUTF8String:filePath.c_str()];
+    assert(!filePath.empty());
+    NSString *_Nonnull nsPath = (NSString *_Nonnull) [NSString stringWithUTF8String:filePath.c_str()];
     if (!error) {
         // Destination image
         int size = static_cast<int>(qMax(srcImage.size.width, srcImage.size.height));
-        NSImage *dstImage = [[NSImage alloc] initWithSize:CGSizeMake(size, size)];
+        NSImage *_Nonnull dstImage = [[NSImage alloc] initWithSize:CGSizeMake(size, size)];
 
         // Copy source image into destination image
         NSRect dstRect = NSMakeRect(size == srcImage.size.width ? 0 : (size - srcImage.size.width) / 2,
@@ -704,7 +711,8 @@ bool LiteSyncCommClientPrivate::setAppExcludeList(const std::string &appList) {
         return false;
     }
 
-    NSString *nsAppList = [NSString stringWithUTF8String:appList.c_str()];
+    assert(!appList.empty());
+    NSString *_Nonnull nsAppList = (NSString *_Nonnull) [NSString stringWithUTF8String:appList.c_str()];
     if (![_connector setAppExcludeList:nsAppList]) {
         LOG_ERROR(_logger, "Error in setAppExcludeList!");
         return false;
@@ -1119,12 +1127,15 @@ bool LiteSyncCommClient::vfsCreatePlaceHolder(const SyncPath &relativePath, cons
 bool LiteSyncCommClient::vfsUpdateFetchStatus(const SyncPath &tmpFilePath, const SyncPath &filePath,
                                               const SyncPath &localSyncPath, unsigned long long completed, bool &canceled,
                                               bool &finished) {
+    (void) tmpFilePath;
     canceled = false;
 
     @autoreleasepool {
         // Get file attributes
+        assert(!filePath.empty());
+        NSString *_Nonnull nsPath = (NSString *_Nonnull) [NSString stringWithUTF8String:filePath.c_str()];
+
         NSError *error = nil;
-        NSString *nsPath = [NSString stringWithUTF8String:filePath.c_str()];
         NSDictionary<NSFileAttributeKey, id> *attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:nsPath
                                                                                                             error:&error];
         NSInteger errorCode = error ? error.code : 0;
@@ -1161,7 +1172,8 @@ bool LiteSyncCommClient::vfsUpdateFetchStatus(const SyncPath &tmpFilePath, const
                 LOGW_INFO(_logger, L"Copying temp file from " << Utility::formatSyncPath(tmpFilePath) << L" to "
                                                               << Utility::formatSyncPath(filePath));
 
-                NSString *nsTmpPath = [NSString stringWithUTF8String:tmpFilePath.c_str()];
+                assert(!tmpFilePath.empty());
+                NSString *_Nonnull nsTmpPath = (NSString *_Nonnull) [NSString stringWithUTF8String:tmpFilePath.c_str()];
                 NSFileHandle *tmpFileHandle = [NSFileHandle fileHandleForReadingAtPath:nsTmpPath];
                 NSFileHandle *fileHandle = [NSFileHandle fileHandleForWritingAtPath:nsPath];
                 NSData *buffer = nil;
@@ -1174,7 +1186,6 @@ bool LiteSyncCommClient::vfsUpdateFetchStatus(const SyncPath &tmpFilePath, const
                                        L"Error while reading tmp file: " << Utility::formatErrno(tmpFilePath, errorCode));
                             break;
                         }
-                        errorCode = error ? error.code : 0;
                         if (buffer.length == 0) {
                             // Nothing else to read
                             break;

--- a/src/server/comm/litesynccommclient_mac.mm
+++ b/src/server/comm/litesynccommclient_mac.mm
@@ -1158,7 +1158,7 @@ bool LiteSyncCommClient::vfsUpdateFetchStatus(const SyncPath &tmpFilePath, const
             // Get file dates
             IoError ioError = IoError::Success;
             FileStat filestat;
-            if (!IoHelper::getFileStat(filePath, &filestat, ioError)) {
+            if (!IoHelper::getFileStat(filePath, &filestat, ioError, IoHelper::PathCheckOption::Insensitive)) {
                 LOGW_WARN(_logger, L"Error in IoHelper::getFileStat: " << Utility::formatIoError(filePath, ioError));
                 return false;
             }

--- a/src/server/requests/serverrequests.cpp
+++ b/src/server/requests/serverrequests.cpp
@@ -1730,7 +1730,8 @@ bool keepError(const int syncDbId, const Error &error, ExitInfo &exitInfo) {
 
         auto ioError = IoError::Success;
         const SyncPath dest = sync.localPath() / error.destinationPath();
-        if (const bool success = IoHelper::checkIfPathExists(dest, found, ioError); !success) {
+        if (const bool success = IoHelper::checkIfPathExists(dest, found, ioError, IoHelper::PathCheckOption::Insensitive);
+            !success) {
             LOGW_WARN(Log::instance()->getLogger(),
                       L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(dest, ioError));
             exitInfo = ExitCode::SystemError;
@@ -2141,7 +2142,7 @@ ExitInfo ServerRequests::checkPathValidityForNewFolder(const std::vector<Sync> &
     // Check if the local directory already exists
     IoError ioError = IoError::Success;
     bool found = false;
-    const bool success = IoHelper::checkIfPathExists(QStr2Path(userDir), found, ioError);
+    const bool success = IoHelper::checkIfPathExists(QStr2Path(userDir), found, ioError, IoHelper::PathCheckOption::Insensitive);
     if (!success) {
         LOGW_WARN(Log::instance()->getLogger(), L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(ioError));
         error = QObject::tr("An error occurred while checking the local folder. Please try again.");

--- a/src/server/vfs/win/vfs_win.cpp
+++ b/src/server/vfs/win/vfs_win.cpp
@@ -351,7 +351,7 @@ void VfsWin::convertDirContentToPlaceholder(const QString &filePath, bool isHydr
         if (!isPlaceholder) {
             FileStat fileStat;
             IoError ioError = IoError::Success;
-            if (!IoHelper::getFileStat(fullPath, &fileStat, ioError)) {
+            if (!IoHelper::getFileStat(fullPath, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive)) {
                 LOGW_WARN(logger(), L"Error in IoHelper::getFileStat: " << Utility::formatIoError(fullPath, ioError));
                 break;
             }
@@ -457,7 +457,7 @@ ExitInfo VfsWin::forceStatus(const SyncPath &absolutePathStd, const VfsStatus &v
     if (!isPlaceholder) {
         FileStat filestat;
         auto ioError = IoError::Success;
-        if (!IoHelper::getFileStat(absolutePathStd, &filestat, ioError)) {
+        if (!IoHelper::getFileStat(absolutePathStd, &filestat, ioError, IoHelper::PathCheckOption::Insensitive)) {
             LOGW_WARN(logger(), L"Error in IoHelper::getFileStat: " << Utility::formatIoError(absolutePathStd, ioError));
             return ExitCode::SystemError;
         }

--- a/test/libcommon/utility/testutility.cpp
+++ b/test/libcommon/utility/testutility.cpp
@@ -315,7 +315,8 @@ void TestUtility::testCompressFile() {
 
     bool exists = false;
     IoError ioError = IoError::Unknown;
-    CPPUNIT_ASSERT_MESSAGE(toString(ioError), IoHelper::checkIfPathExists(outPath, exists, ioError));
+    CPPUNIT_ASSERT_MESSAGE(toString(ioError),
+                           IoHelper::checkIfPathExists(outPath, exists, ioError, IoHelper::PathCheckOption::Insensitive));
     CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
     CPPUNIT_ASSERT(exists);
 
@@ -333,7 +334,8 @@ void TestUtility::testCompressFile() {
     outPath = tmpDir.path() / "resFile.zip";
     (void) CommonUtility::compressFile(filePath.string(), outPath.string());
 
-    CPPUNIT_ASSERT_MESSAGE(toString(ioError), IoHelper::checkIfPathExists(outPath, exists, ioError));
+    CPPUNIT_ASSERT_MESSAGE(toString(ioError),
+                           IoHelper::checkIfPathExists(outPath, exists, ioError, IoHelper::PathCheckOption::Insensitive));
     CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
     CPPUNIT_ASSERT(exists);
 
@@ -345,21 +347,24 @@ void TestUtility::testCompressFile() {
     // Test with a non-existing file
     outPath = tmpDir.path() / "resNonExistingFile.zip";
     CPPUNIT_ASSERT(!CommonUtility::compressFile("nonExistingFile.txt", outPath.string()));
-    CPPUNIT_ASSERT_MESSAGE(toString(ioError), IoHelper::checkIfPathExists(outPath, exists, ioError));
+    CPPUNIT_ASSERT_MESSAGE(toString(ioError),
+                           IoHelper::checkIfPathExists(outPath, exists, ioError, IoHelper::PathCheckOption::Insensitive));
     CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
     CPPUNIT_ASSERT(!exists);
 
     // Test with a non-existing output dir
     outPath = tmpDir.path() / "nonExistingDir" / "resNonExistingDir.zip";
     CPPUNIT_ASSERT(!CommonUtility::compressFile(filePath.string(), outPath.string()));
-    CPPUNIT_ASSERT_MESSAGE(toString(ioError), IoHelper::checkIfPathExists(outPath, exists, ioError));
+    CPPUNIT_ASSERT_MESSAGE(toString(ioError),
+                           IoHelper::checkIfPathExists(outPath, exists, ioError, IoHelper::PathCheckOption::Insensitive));
     CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
     CPPUNIT_ASSERT(!exists);
 
     // Test with wstring path
     outPath = tmpDir.path() / "resWstring.zip";
     (void) CommonUtility::compressFile(filePath.wstring(), outPath.wstring());
-    CPPUNIT_ASSERT_MESSAGE(toString(ioError), IoHelper::checkIfPathExists(outPath, exists, ioError));
+    CPPUNIT_ASSERT_MESSAGE(toString(ioError),
+                           IoHelper::checkIfPathExists(outPath, exists, ioError, IoHelper::PathCheckOption::Insensitive));
     CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
     CPPUNIT_ASSERT(exists);
 }

--- a/test/libcommonserver/io/testcheckifpathexists.cpp
+++ b/test/libcommonserver/io/testcheckifpathexists.cpp
@@ -105,8 +105,9 @@ void TestIo::testCheckIfPathExistsSimpleCases() {
 #if defined(KD_MACOS) || defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
 #else
-        CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::FileNameTooLong), IoError::FileNameTooLong, ioError);
-#end        
+        CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::FileNameTooLong), IoError::FileNameTooLong,
+                                     ioError);
+#endif
     }
     // A dangling symbolic link
     {

--- a/test/libcommonserver/io/testcheckifpathexists.cpp
+++ b/test/libcommonserver/io/testcheckifpathexists.cpp
@@ -513,7 +513,12 @@ void TestIo::testCheckIfPathExistWithDistinctEncodings() {
         IoError ioError = IoError::Unknown;
 
         CPPUNIT_ASSERT(IoHelper::checkIfPathExists(nfcPath, exists, ioError) && exists);
+
+#if defined(KD_MACOS)
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(nfdPath, exists, ioError) && !exists);
+#else
         CPPUNIT_ASSERT(IoHelper::checkIfPathExists(nfdPath, exists, ioError) && exists);
+#endif
 
         NodeId nfcNodeId, nfdNodeId;
         IoHelper::getNodeId(nfcPath, nfcNodeId);
@@ -544,7 +549,12 @@ void TestIo::testCheckIfPathExistWithDistinctEncodings() {
         bool exists = false;
         IoError ioError = IoError::Unknown;
 
+#if defined(KD_MACOS)
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(nfcPath, exists, ioError) && !exists);
+#else
         CPPUNIT_ASSERT(IoHelper::checkIfPathExists(nfcPath, exists, ioError) && exists);
+#endif
+
         CPPUNIT_ASSERT(IoHelper::checkIfPathExists(nfdPath, exists, ioError) && exists);
 
         NodeId nfcNodeId, nfdNodeId;

--- a/test/libcommonserver/io/testcheckifpathexists.cpp
+++ b/test/libcommonserver/io/testcheckifpathexists.cpp
@@ -43,6 +43,10 @@ void TestIo::testCheckIfPathExistsSimpleCases() {
         bool exists = false;
         IoError ioError = IoError::Unknown;
         CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError));
+        CPPUNIT_ASSERT(exists);
+        CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
+
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError, true));
         CPPUNIT_ASSERT(!exists);
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
     }
@@ -102,7 +106,7 @@ void TestIo::testCheckIfPathExistsSimpleCases() {
         IoError ioError = IoError::Unknown;
         CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError));
         CPPUNIT_ASSERT(!exists);
-#if defined(KD_MACOS) || defined(KD_WINDOWS)
+#if defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
 #else
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::FileNameTooLong), IoError::FileNameTooLong,
@@ -513,11 +517,13 @@ void TestIo::testCheckIfPathExistWithDistinctEncodings() {
         IoError ioError = IoError::Unknown;
 
         CPPUNIT_ASSERT(IoHelper::checkIfPathExists(nfcPath, exists, ioError) && exists);
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(nfcPath, exists, ioError, true) && exists);
 
-#if defined(KD_MACOS)
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(nfdPath, exists, ioError) && !exists);
-#else
         CPPUNIT_ASSERT(IoHelper::checkIfPathExists(nfdPath, exists, ioError) && exists);
+#if defined(KD_MACOS)
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(nfdPath, exists, ioError, true) && !exists);
+#else
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(nfdPath, exists, ioError, true) && exists);
 #endif
 
         NodeId nfcNodeId, nfdNodeId;
@@ -549,10 +555,11 @@ void TestIo::testCheckIfPathExistWithDistinctEncodings() {
         bool exists = false;
         IoError ioError = IoError::Unknown;
 
-#if defined(KD_MACOS)
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(nfcPath, exists, ioError) && !exists);
-#else
         CPPUNIT_ASSERT(IoHelper::checkIfPathExists(nfcPath, exists, ioError) && exists);
+#if defined(KD_MACOS)
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(nfcPath, exists, ioError, true) && !exists);
+#else
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(nfcPath, exists, ioError, true) && exists);
 #endif
 
         CPPUNIT_ASSERT(IoHelper::checkIfPathExists(nfdPath, exists, ioError) && exists);

--- a/test/libcommonserver/io/testcheckifpathexists.cpp
+++ b/test/libcommonserver/io/testcheckifpathexists.cpp
@@ -37,6 +37,16 @@ void TestIo::testCheckIfPathExistsSimpleCases() {
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
     }
 
+    // A regular file whose name exists with a different capitalization
+    {
+        const SyncPath path = _localTestDirPath / "test_pictures/Picture-1.jpg";
+        bool exists = false;
+        IoError ioError = IoError::Unknown;
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError));
+        CPPUNIT_ASSERT(!exists);
+        CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
+    }
+
     // A regular directory
     {
         const SyncPath path = _localTestDirPath / "test_pictures";

--- a/test/libcommonserver/io/testcheckifpathexists.cpp
+++ b/test/libcommonserver/io/testcheckifpathexists.cpp
@@ -102,7 +102,11 @@ void TestIo::testCheckIfPathExistsSimpleCases() {
         IoError ioError = IoError::Unknown;
         CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError));
         CPPUNIT_ASSERT(!exists);
+#if defined(KD_MACOS) || defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
+#else
+        CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::FileNameTooLong), IoError::FileNameTooLong, ioError);
+#end        
     }
     // A dangling symbolic link
     {

--- a/test/libcommonserver/io/testcheckifpathexists.cpp
+++ b/test/libcommonserver/io/testcheckifpathexists.cpp
@@ -45,7 +45,11 @@ void TestIo::testCheckIfPathExistsSimpleCases() {
         path = _localTestDirPath / "test_pictures/Picture-1.jpg";
 
         CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError));
+#if defined(KD_MACOS) || defined(KD_WINDOWS)
         CPPUNIT_ASSERT(exists);
+#else
+        CPPUNIT_ASSERT(!exists);
+#endif
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
 
         CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError, true));
@@ -71,7 +75,11 @@ void TestIo::testCheckIfPathExistsSimpleCases() {
         path = _localTestDirPath / "test_Pictures";
 
         CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError));
+#if defined(KD_MACOS) || defined(KD_WINDOWS)
         CPPUNIT_ASSERT(exists);
+#else
+        CPPUNIT_ASSERT(!exists);
+#endif
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
 
         CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError, true));
@@ -101,7 +109,11 @@ void TestIo::testCheckIfPathExistsSimpleCases() {
         path = temporaryDirectory.path() / "Regular_file_symbolic_link";
 
         CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError));
+#if defined(KD_MACOS) || defined(KD_WINDOWS)
         CPPUNIT_ASSERT(exists);
+#else
+        CPPUNIT_ASSERT(!exists);
+#endif
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
 
         CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError, true));
@@ -131,7 +143,11 @@ void TestIo::testCheckIfPathExistsSimpleCases() {
         path = temporaryDirectory.path() / "Regular_dir_symbolic_link";
 
         CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError));
+#if defined(KD_MACOS) || defined(KD_WINDOWS)
         CPPUNIT_ASSERT(exists);
+#else
+        CPPUNIT_ASSERT(!exists);
+#endif
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
 
         CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError, true));

--- a/test/libcommonserver/io/testcheckifpathexists.cpp
+++ b/test/libcommonserver/io/testcheckifpathexists.cpp
@@ -33,18 +33,18 @@ void TestIo::testCheckIfPathExistsSimpleCases() {
         SyncPath path = _localTestDirPath / "test_pictures/picture-1.jpg";
         bool exists = false;
         IoError ioError = IoError::Unknown;
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError));
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError, IoHelper::PathCheckOption::Insensitive));
         CPPUNIT_ASSERT(exists);
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
 
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError, true));
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError, IoHelper::PathCheckOption::Sensitive));
         CPPUNIT_ASSERT(exists);
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
 
         // The file exists with a different capitalization
         path = _localTestDirPath / "test_pictures/Picture-1.jpg";
 
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError));
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError, IoHelper::PathCheckOption::Insensitive));
 #if defined(KD_MACOS) || defined(KD_WINDOWS)
         CPPUNIT_ASSERT(exists);
 #else
@@ -52,7 +52,7 @@ void TestIo::testCheckIfPathExistsSimpleCases() {
 #endif
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
 
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError, true));
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError, IoHelper::PathCheckOption::Sensitive));
         CPPUNIT_ASSERT(!exists);
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
     }
@@ -63,18 +63,18 @@ void TestIo::testCheckIfPathExistsSimpleCases() {
         SyncPath path = _localTestDirPath / "test_pictures";
         bool exists = false;
         IoError ioError = IoError::Unknown;
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError));
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError, IoHelper::PathCheckOption::Insensitive));
         CPPUNIT_ASSERT(exists);
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
 
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError, true));
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError, IoHelper::PathCheckOption::Sensitive));
         CPPUNIT_ASSERT(exists);
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
 
         // The directory exists with a different capitalization
         path = _localTestDirPath / "test_Pictures";
 
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError));
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError, IoHelper::PathCheckOption::Insensitive));
 #if defined(KD_MACOS) || defined(KD_WINDOWS)
         CPPUNIT_ASSERT(exists);
 #else
@@ -82,7 +82,7 @@ void TestIo::testCheckIfPathExistsSimpleCases() {
 #endif
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
 
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError, true));
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError, IoHelper::PathCheckOption::Sensitive));
         CPPUNIT_ASSERT(!exists);
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
     }
@@ -97,18 +97,18 @@ void TestIo::testCheckIfPathExistsSimpleCases() {
 
         bool exists = false;
         IoError ioError = IoError::Unknown;
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError));
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError, IoHelper::PathCheckOption::Insensitive));
         CPPUNIT_ASSERT(exists);
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
 
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError, true));
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError, IoHelper::PathCheckOption::Sensitive));
         CPPUNIT_ASSERT(exists);
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
 
         // The symbolic link exists with a different capitalization
         path = temporaryDirectory.path() / "Regular_file_symbolic_link";
 
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError));
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError, IoHelper::PathCheckOption::Insensitive));
 #if defined(KD_MACOS) || defined(KD_WINDOWS)
         CPPUNIT_ASSERT(exists);
 #else
@@ -116,7 +116,7 @@ void TestIo::testCheckIfPathExistsSimpleCases() {
 #endif
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
 
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError, true));
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError, IoHelper::PathCheckOption::Sensitive));
         CPPUNIT_ASSERT(!exists);
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
     }
@@ -131,18 +131,18 @@ void TestIo::testCheckIfPathExistsSimpleCases() {
 
         bool exists = false;
         IoError ioError = IoError::Unknown;
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError));
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError, IoHelper::PathCheckOption::Insensitive));
         CPPUNIT_ASSERT(exists);
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
 
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError, true));
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError, IoHelper::PathCheckOption::Sensitive));
         CPPUNIT_ASSERT(exists);
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
 
         // The symbolic link exists with a different capitalization
         path = temporaryDirectory.path() / "Regular_dir_symbolic_link";
 
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError));
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError, IoHelper::PathCheckOption::Insensitive));
 #if defined(KD_MACOS) || defined(KD_WINDOWS)
         CPPUNIT_ASSERT(exists);
 #else
@@ -150,7 +150,7 @@ void TestIo::testCheckIfPathExistsSimpleCases() {
 #endif
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
 
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError, true));
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError, IoHelper::PathCheckOption::Sensitive));
         CPPUNIT_ASSERT(!exists);
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
     }
@@ -160,7 +160,7 @@ void TestIo::testCheckIfPathExistsSimpleCases() {
         const SyncPath path = _localTestDirPath / "non_existing.jpg";
         bool exists = false;
         IoError ioError = IoError::Unknown;
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError));
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError, IoHelper::PathCheckOption::Insensitive));
         CPPUNIT_ASSERT(!exists);
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
     }
@@ -170,7 +170,7 @@ void TestIo::testCheckIfPathExistsSimpleCases() {
         const SyncPath path = std::string(1000, 'a');
         bool exists = false;
         IoError ioError = IoError::Unknown;
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError));
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError, IoHelper::PathCheckOption::Insensitive));
         CPPUNIT_ASSERT(!exists);
 #if defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
@@ -188,7 +188,7 @@ void TestIo::testCheckIfPathExistsSimpleCases() {
 
         bool exists = false;
         IoError ioError = IoError::Unknown;
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError));
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError, IoHelper::PathCheckOption::Insensitive));
         CPPUNIT_ASSERT(exists);
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
     }
@@ -205,7 +205,8 @@ void TestIo::testCheckIfPathExistsSimpleCases() {
             CPPUNIT_FAIL("Failed to set rights on the file");
         }
         bool exists = false;
-        const bool checkIfPathExistsResult = IoHelper::checkIfPathExists(path, exists, ioError);
+        const bool checkIfPathExistsResult =
+                IoHelper::checkIfPathExists(path, exists, ioError, IoHelper::PathCheckOption::Insensitive);
         IoHelper::setRights(path, true, true, true, ioError);
 
         CPPUNIT_ASSERT(checkIfPathExistsResult);
@@ -219,7 +220,7 @@ void TestIo::testCheckIfPathExistsSimpleCases() {
         const SyncPath path = _localTestDirPath / "test_pictures" / "picture-1.jpg" / "A";
         bool exists = false;
         IoError ioError = IoError::Unknown;
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError));
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError, IoHelper::PathCheckOption::Insensitive));
         CPPUNIT_ASSERT(!exists);
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
     }
@@ -236,7 +237,7 @@ void TestIo::testCheckIfPathExistsSimpleCases() {
 
         bool exists = false;
         IoError ioError = IoError::Unknown;
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError));
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError, IoHelper::PathCheckOption::Insensitive));
         CPPUNIT_ASSERT(exists);
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
     }
@@ -259,7 +260,7 @@ void TestIo::testCheckIfPathExistsSimpleCases() {
 
         bool exists = false;
         IoError ioError = IoError::Unknown;
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError));
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError, IoHelper::PathCheckOption::Insensitive));
         CPPUNIT_ASSERT(exists);
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
     }
@@ -277,7 +278,7 @@ void TestIo::testCheckIfPathExistsSimpleCases() {
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
 
         bool exists = false;
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError));
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError, IoHelper::PathCheckOption::Insensitive));
         CPPUNIT_ASSERT(exists);
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
     }
@@ -293,7 +294,7 @@ void TestIo::testCheckIfPathExistsSimpleCases() {
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
 
         bool exists = false;
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError));
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError, IoHelper::PathCheckOption::Insensitive));
         CPPUNIT_ASSERT(exists);
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
     }
@@ -309,7 +310,7 @@ void TestIo::testCheckIfPathExistsSimpleCases() {
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
         bool exists = false;
 
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError));
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError, IoHelper::PathCheckOption::Insensitive));
         CPPUNIT_ASSERT(exists);
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
     }
@@ -326,7 +327,8 @@ void TestIo::testCheckIfPathExistsWithSameNodeIdSimpleCases() {
         NodeId nodeId;
 
         CPPUNIT_ASSERT(_testObj->getNodeId(path, nodeId));
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExistsWithSameNodeId(path, nodeId, existsWithSameId, otherNodeId, ioError));
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExistsWithSameNodeId(path, nodeId, existsWithSameId, otherNodeId, ioError,
+                                                                 IoHelper::PathCheckOption::Insensitive));
         CPPUNIT_ASSERT(existsWithSameId);
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
     }
@@ -340,7 +342,8 @@ void TestIo::testCheckIfPathExistsWithSameNodeIdSimpleCases() {
         NodeId nodeId;
 
         CPPUNIT_ASSERT(_testObj->getNodeId(path, nodeId));
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExistsWithSameNodeId(path, nodeId, existsWithSameId, otherNodeId, ioError));
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExistsWithSameNodeId(path, nodeId, existsWithSameId, otherNodeId, ioError,
+                                                                 IoHelper::PathCheckOption::Insensitive));
         CPPUNIT_ASSERT(existsWithSameId);
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
     }
@@ -358,7 +361,8 @@ void TestIo::testCheckIfPathExistsWithSameNodeIdSimpleCases() {
         NodeId nodeId;
 
         CPPUNIT_ASSERT(_testObj->getNodeId(path, nodeId));
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExistsWithSameNodeId(path, nodeId, existsWithSameId, otherNodeId, ioError));
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExistsWithSameNodeId(path, nodeId, existsWithSameId, otherNodeId, ioError,
+                                                                 IoHelper::PathCheckOption::Insensitive));
         CPPUNIT_ASSERT(existsWithSameId);
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
     }
@@ -376,7 +380,8 @@ void TestIo::testCheckIfPathExistsWithSameNodeIdSimpleCases() {
         NodeId nodeId;
 
         CPPUNIT_ASSERT(_testObj->getNodeId(path, nodeId));
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExistsWithSameNodeId(path, nodeId, existsWithSameId, otherNodeId, ioError));
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExistsWithSameNodeId(path, nodeId, existsWithSameId, otherNodeId, ioError,
+                                                                 IoHelper::PathCheckOption::Insensitive));
         CPPUNIT_ASSERT(existsWithSameId);
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
     }
@@ -390,7 +395,8 @@ void TestIo::testCheckIfPathExistsWithSameNodeIdSimpleCases() {
         NodeId nodeId;
 
         CPPUNIT_ASSERT(!_testObj->getNodeId(path, nodeId));
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExistsWithSameNodeId(path, nodeId, existsWithSameId, otherNodeId, ioError));
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExistsWithSameNodeId(path, nodeId, existsWithSameId, otherNodeId, ioError,
+                                                                 IoHelper::PathCheckOption::Insensitive));
         CPPUNIT_ASSERT(!existsWithSameId);
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
     }
@@ -408,7 +414,8 @@ void TestIo::testCheckIfPathExistsWithSameNodeIdSimpleCases() {
         NodeId nodeId;
 
         CPPUNIT_ASSERT(_testObj->getNodeId(path, nodeId));
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExistsWithSameNodeId(path, nodeId, existsWithSameId, otherNodeId, ioError));
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExistsWithSameNodeId(path, nodeId, existsWithSameId, otherNodeId, ioError,
+                                                                 IoHelper::PathCheckOption::Insensitive));
         CPPUNIT_ASSERT(existsWithSameId);
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
     }
@@ -421,7 +428,8 @@ void TestIo::testCheckIfPathExistsWithSameNodeIdSimpleCases() {
         IoError ioError = IoError::Unknown;
         NodeId nodeId = "wrong_node_id";
 
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExistsWithSameNodeId(path, nodeId, existsWithSameId, otherNodeId, ioError));
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExistsWithSameNodeId(path, nodeId, existsWithSameId, otherNodeId, ioError,
+                                                                 IoHelper::PathCheckOption::Insensitive));
         CPPUNIT_ASSERT(!existsWithSameId);
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
     }
@@ -444,8 +452,8 @@ void TestIo::testCheckIfPathExistsWithSameNodeIdSimpleCases() {
             IoHelper::setRights(path, true, true, true, ioError);
             CPPUNIT_FAIL("Failed to set rights on the file");
         }
-        bool checkIfPathExistsResult =
-                IoHelper::checkIfPathExistsWithSameNodeId(path, nodeId, existsWithSameId, otherNodeId, ioError);
+        bool checkIfPathExistsResult = IoHelper::checkIfPathExistsWithSameNodeId(path, nodeId, existsWithSameId, otherNodeId,
+                                                                                 ioError, IoHelper::PathCheckOption::Insensitive);
         IoHelper::setRights(path, true, true, true, ioError);
         CPPUNIT_ASSERT(checkIfPathExistsResult);
         CPPUNIT_ASSERT(existsWithSameId);
@@ -468,7 +476,8 @@ void TestIo::testCheckIfPathExistsWithSameNodeIdSimpleCases() {
         IoError ioError = IoError::Unknown;
 
         CPPUNIT_ASSERT(_testObj->getNodeId(path, nodeId));
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExistsWithSameNodeId(path, nodeId, existsWithSameId, otherNodeId, ioError));
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExistsWithSameNodeId(path, nodeId, existsWithSameId, otherNodeId, ioError,
+                                                                 IoHelper::PathCheckOption::Insensitive));
         CPPUNIT_ASSERT(existsWithSameId);
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
     }
@@ -492,7 +501,8 @@ void TestIo::testCheckIfPathExistsWithSameNodeIdSimpleCases() {
         IoError ioError = IoError::Unknown;
 
         CPPUNIT_ASSERT(_testObj->getNodeId(path, nodeId));
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExistsWithSameNodeId(path, nodeId, existsWithSameId, otherNodeId, ioError));
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExistsWithSameNodeId(path, nodeId, existsWithSameId, otherNodeId, ioError,
+                                                                 IoHelper::PathCheckOption::Insensitive));
         CPPUNIT_ASSERT(existsWithSameId);
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
     }
@@ -514,7 +524,8 @@ void TestIo::testCheckIfPathExistsWithSameNodeIdSimpleCases() {
         NodeId nodeId;
 
         CPPUNIT_ASSERT(_testObj->getNodeId(path, nodeId));
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExistsWithSameNodeId(path, nodeId, existsWithSameId, otherNodeId, ioError));
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExistsWithSameNodeId(path, nodeId, existsWithSameId, otherNodeId, ioError,
+                                                                 IoHelper::PathCheckOption::Insensitive));
         CPPUNIT_ASSERT(existsWithSameId);
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
     }
@@ -534,7 +545,8 @@ void TestIo::testCheckIfPathExistsWithSameNodeIdSimpleCases() {
         NodeId nodeId;
 
         CPPUNIT_ASSERT(_testObj->getNodeId(path, nodeId));
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExistsWithSameNodeId(path, nodeId, existsWithSameId, otherNodeId, ioError));
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExistsWithSameNodeId(path, nodeId, existsWithSameId, otherNodeId, ioError,
+                                                                 IoHelper::PathCheckOption::Insensitive));
         CPPUNIT_ASSERT(existsWithSameId);
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
     }
@@ -554,7 +566,8 @@ void TestIo::testCheckIfPathExistsWithSameNodeIdSimpleCases() {
         NodeId nodeId;
 
         CPPUNIT_ASSERT(_testObj->getNodeId(path, nodeId));
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExistsWithSameNodeId(path, nodeId, existsWithSameId, otherNodeId, ioError));
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExistsWithSameNodeId(path, nodeId, existsWithSameId, otherNodeId, ioError,
+                                                                 IoHelper::PathCheckOption::Insensitive));
         CPPUNIT_ASSERT(existsWithSameId);
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
     }
@@ -582,14 +595,14 @@ void TestIo::testCheckIfPathExistWithDistinctEncodings() {
         bool exists = false;
         IoError ioError = IoError::Unknown;
 
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(nfcPath, exists, ioError) && exists);
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(nfcPath, exists, ioError, true) && exists);
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(nfcPath, exists, ioError, IoHelper::PathCheckOption::Insensitive) && exists);
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(nfcPath, exists, ioError, IoHelper::PathCheckOption::Sensitive) && exists);
 
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(nfdPath, exists, ioError) && exists);
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(nfdPath, exists, ioError, IoHelper::PathCheckOption::Insensitive) && exists);
 #if defined(KD_MACOS)
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(nfdPath, exists, ioError, true) && !exists);
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(nfdPath, exists, ioError, IoHelper::PathCheckOption::Sensitive) && !exists);
 #else
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(nfdPath, exists, ioError, true) && exists);
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(nfdPath, exists, ioError, IoHelper::PathCheckOption::Sensitive) && exists);
 #endif
 
         NodeId nfcNodeId, nfdNodeId;
@@ -621,14 +634,14 @@ void TestIo::testCheckIfPathExistWithDistinctEncodings() {
         bool exists = false;
         IoError ioError = IoError::Unknown;
 
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(nfcPath, exists, ioError) && exists);
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(nfcPath, exists, ioError, IoHelper::PathCheckOption::Insensitive) && exists);
 #if defined(KD_MACOS)
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(nfcPath, exists, ioError, true) && !exists);
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(nfcPath, exists, ioError, IoHelper::PathCheckOption::Sensitive) && !exists);
 #else
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(nfcPath, exists, ioError, true) && exists);
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(nfcPath, exists, ioError, IoHelper::PathCheckOption::Sensitive) && exists);
 #endif
 
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(nfdPath, exists, ioError) && exists);
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(nfdPath, exists, ioError, IoHelper::PathCheckOption::Insensitive) && exists);
 
         NodeId nfcNodeId, nfdNodeId;
         IoHelper::getNodeId(nfcPath, nfcNodeId);
@@ -667,19 +680,19 @@ void TestIo::testCheckIfPathExistsMixedSeparators(void) {
 
     // Checked that CheckIfPathExist can handle all the directory separators
     bool exist = false;
-    CPPUNIT_ASSERT(IoHelper::checkIfPathExists(subDirForward, exist, ioError));
+    CPPUNIT_ASSERT(IoHelper::checkIfPathExists(subDirForward, exist, ioError, IoHelper::PathCheckOption::Insensitive));
     CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
     CPPUNIT_ASSERT(exist);
 
-    CPPUNIT_ASSERT(IoHelper::checkIfPathExists(subFileForward, exist, ioError));
+    CPPUNIT_ASSERT(IoHelper::checkIfPathExists(subFileForward, exist, ioError, IoHelper::PathCheckOption::Insensitive));
     CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
     CPPUNIT_ASSERT(exist);
 
-    CPPUNIT_ASSERT(IoHelper::checkIfPathExists(subDirBackward, exist, ioError));
+    CPPUNIT_ASSERT(IoHelper::checkIfPathExists(subDirBackward, exist, ioError, IoHelper::PathCheckOption::Insensitive));
     CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
     CPPUNIT_ASSERT(exist);
 
-    CPPUNIT_ASSERT(IoHelper::checkIfPathExists(subFileBackward, exist, ioError));
+    CPPUNIT_ASSERT(IoHelper::checkIfPathExists(subFileBackward, exist, ioError, IoHelper::PathCheckOption::Insensitive));
     CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
     CPPUNIT_ASSERT(exist);
 }

--- a/test/libcommonserver/io/testcheckifpathexists.cpp
+++ b/test/libcommonserver/io/testcheckifpathexists.cpp
@@ -102,12 +102,7 @@ void TestIo::testCheckIfPathExistsSimpleCases() {
         IoError ioError = IoError::Unknown;
         CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError));
         CPPUNIT_ASSERT(!exists);
-#if defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
-#else
-        CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::FileNameTooLong), IoError::FileNameTooLong,
-                                     ioError);
-#endif
     }
     // A dangling symbolic link
     {

--- a/test/libcommonserver/io/testcheckifpathexists.cpp
+++ b/test/libcommonserver/io/testcheckifpathexists.cpp
@@ -29,19 +29,21 @@ namespace KDC {
 void TestIo::testCheckIfPathExistsSimpleCases() {
     // A regular file
     {
-        const SyncPath path = _localTestDirPath / "test_pictures/picture-1.jpg";
+        // The file exists
+        SyncPath path = _localTestDirPath / "test_pictures/picture-1.jpg";
         bool exists = false;
         IoError ioError = IoError::Unknown;
         CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError));
         CPPUNIT_ASSERT(exists);
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
-    }
 
-    // A regular file whose name exists with a different capitalization
-    {
-        const SyncPath path = _localTestDirPath / "test_pictures/Picture-1.jpg";
-        bool exists = false;
-        IoError ioError = IoError::Unknown;
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError, true));
+        CPPUNIT_ASSERT(exists);
+        CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
+
+        // The file exists with a different capitalization
+        path = _localTestDirPath / "test_pictures/Picture-1.jpg";
+
         CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError));
         CPPUNIT_ASSERT(exists);
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
@@ -53,19 +55,36 @@ void TestIo::testCheckIfPathExistsSimpleCases() {
 
     // A regular directory
     {
-        const SyncPath path = _localTestDirPath / "test_pictures";
+        // The directory exists
+        SyncPath path = _localTestDirPath / "test_pictures";
         bool exists = false;
         IoError ioError = IoError::Unknown;
         CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError));
         CPPUNIT_ASSERT(exists);
+        CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
+
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError, true));
+        CPPUNIT_ASSERT(exists);
+        CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
+
+        // The directory exists with a different capitalization
+        path = _localTestDirPath / "test_Pictures";
+
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError));
+        CPPUNIT_ASSERT(exists);
+        CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
+
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError, true));
+        CPPUNIT_ASSERT(!exists);
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
     }
 
     // A regular symbolic link on a file
     {
+        // The symbolic link exists
         const SyncPath targetPath = _localTestDirPath / "test_pictures/picture-1.jpg";
         const LocalTemporaryDirectory temporaryDirectory("TestIo");
-        const SyncPath path = temporaryDirectory.path() / "regular_file_symbolic_link";
+        SyncPath path = temporaryDirectory.path() / "regular_file_symbolic_link";
         std::filesystem::create_symlink(targetPath, path);
 
         bool exists = false;
@@ -73,19 +92,50 @@ void TestIo::testCheckIfPathExistsSimpleCases() {
         CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError));
         CPPUNIT_ASSERT(exists);
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
+
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError, true));
+        CPPUNIT_ASSERT(exists);
+        CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
+
+        // The symbolic link exists with a different capitalization
+        path = temporaryDirectory.path() / "Regular_file_symbolic_link";
+
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError));
+        CPPUNIT_ASSERT(exists);
+        CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
+
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError, true));
+        CPPUNIT_ASSERT(!exists);
+        CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
     }
 
     // A regular symbolic link on a folder
     {
+        // The symbolic link exists
         const SyncPath targetPath = _localTestDirPath / "test_pictures";
         const LocalTemporaryDirectory temporaryDirectory("TestIo");
-        const SyncPath path = temporaryDirectory.path() / "regular_dir_symbolic_link";
+        SyncPath path = temporaryDirectory.path() / "regular_dir_symbolic_link";
         std::filesystem::create_symlink(targetPath, path);
 
         bool exists = false;
         IoError ioError = IoError::Unknown;
         CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError));
         CPPUNIT_ASSERT(exists);
+        CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
+
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError, true));
+        CPPUNIT_ASSERT(exists);
+        CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
+
+        // The symbolic link exists with a different capitalization
+        path = temporaryDirectory.path() / "Regular_dir_symbolic_link";
+
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError));
+        CPPUNIT_ASSERT(exists);
+        CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
+
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(path, exists, ioError, true));
+        CPPUNIT_ASSERT(!exists);
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
     }
 

--- a/test/libcommonserver/io/testfilechanged.cpp
+++ b/test/libcommonserver/io/testfilechanged.cpp
@@ -32,7 +32,7 @@ void TestIo::testFileChanged() {
         const SyncPath path = _localTestDirPath / "test_pictures/picture-1.jpg";
         FileStat fileStat;
         IoError ioError = IoError::Success;
-        IoHelper::getFileStat(path, &fileStat, ioError);
+        IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive);
 
         bool changed = true;
         CPPUNIT_ASSERT(IoHelper::checkIfFileChanged(path, fileStat.size, fileStat.modificationTime, fileStat.creationTime,
@@ -47,7 +47,7 @@ void TestIo::testFileChanged() {
         FileStat fileStat;
         IoError ioError = IoError::Success;
 
-        IoHelper::getFileStat(path, &fileStat, ioError);
+        IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive);
 
         bool changed = true;
         CPPUNIT_ASSERT(IoHelper::checkIfFileChanged(path, fileStat.size, fileStat.modificationTime, fileStat.creationTime,
@@ -65,7 +65,7 @@ void TestIo::testFileChanged() {
 
         FileStat fileStat;
         IoError ioError = IoError::Success;
-        IoHelper::getFileStat(path, &fileStat, ioError);
+        IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive);
 
         bool changed = true;
         CPPUNIT_ASSERT(IoHelper::checkIfFileChanged(path, fileStat.size, fileStat.modificationTime, fileStat.creationTime,
@@ -96,7 +96,7 @@ void TestIo::testFileChanged() {
 
         FileStat fileStat;
         IoError ioError = IoError::Success;
-        IoHelper::getFileStat(path, &fileStat, ioError);
+        IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive);
 
         // Editing
         {
@@ -123,7 +123,7 @@ void TestIo::testFileChanged() {
         FileStat fileStat;
         IoError ioError = IoError::Success;
 
-        IoHelper::getFileStat(path, &fileStat, ioError);
+        IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive);
 
         std::filesystem::permissions(path, std::filesystem::perms::all, std::filesystem::perm_options::remove);
 
@@ -147,7 +147,7 @@ void TestIo::testFileChanged() {
         FileStat fileStat;
         IoError ioError = IoError::Success;
 
-        IoHelper::getFileStat(path, &fileStat, ioError);
+        IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive);
 
         IoHelper::setFileHidden(path, true);
         bool changed = true;

--- a/test/libcommonserver/io/testfilechanged.cpp
+++ b/test/libcommonserver/io/testfilechanged.cpp
@@ -343,7 +343,7 @@ void TestIo::testCheckIfIsHiddenFile() {
     }
 #endif
 
-    // A with a very long path
+    // A non-existing file with a very long path causes an error.
     {
         const std::string pathSegment(50, 'a');
         SyncPath path = _localTestDirPath;
@@ -353,10 +353,14 @@ void TestIo::testCheckIfIsHiddenFile() {
 
         bool isHidden = true;
         IoError ioError = IoError::Success;
+#if defined(KD_WINDOWS)
         CPPUNIT_ASSERT(IoHelper::checkIfIsHiddenFile(path, false, isHidden, ioError));
-#if defined(KD_WINDOWS) || defined(KD_MACOS)
         CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
+#elif defined(KD_MACOS)
+        CPPUNIT_ASSERT(!IoHelper::checkIfIsHiddenFile(path, false, isHidden, ioError));
+        CPPUNIT_ASSERT_EQUAL(IoError::FileNameTooLong, ioError);
 #elif defined(KD_LINUX)
+        CPPUNIT_ASSERT(IoHelper::checkIfIsHiddenFile(path, false, isHidden, ioError));
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
 #endif
         CPPUNIT_ASSERT(!isHidden);

--- a/test/libcommonserver/io/testfilechanged.cpp
+++ b/test/libcommonserver/io/testfilechanged.cpp
@@ -343,7 +343,7 @@ void TestIo::testCheckIfIsHiddenFile() {
     }
 #endif
 
-    // A non-existing file with a very long path causes an error.
+    // A with a very long path
     {
         const std::string pathSegment(50, 'a');
         SyncPath path = _localTestDirPath;
@@ -353,14 +353,10 @@ void TestIo::testCheckIfIsHiddenFile() {
 
         bool isHidden = true;
         IoError ioError = IoError::Success;
-#if defined(KD_WINDOWS)
         CPPUNIT_ASSERT(IoHelper::checkIfIsHiddenFile(path, false, isHidden, ioError));
+#if defined(KD_WINDOWS) || defined(KD_MACOS)
         CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
-#elif defined(KD_MACOS)
-        CPPUNIT_ASSERT(!IoHelper::checkIfIsHiddenFile(path, false, isHidden, ioError));
-        CPPUNIT_ASSERT_EQUAL(IoError::FileNameTooLong, ioError);
 #elif defined(KD_LINUX)
-        CPPUNIT_ASSERT(IoHelper::checkIfIsHiddenFile(path, false, isHidden, ioError));
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
 #endif
         CPPUNIT_ASSERT(!isHidden);

--- a/test/libcommonserver/io/testgetfilestat.cpp
+++ b/test/libcommonserver/io/testgetfilestat.cpp
@@ -233,7 +233,7 @@ void TestIo::testGetFileStat() {
         CPPUNIT_ASSERT_EQUAL(NodeType::Directory, fileStat.nodeType);
     }
 
-    // An existing file with dots and colons in its name
+    // A file with dots and colons in its name
     {
         const LocalTemporaryDirectory temporaryDirectory;
         const SyncPath path = temporaryDirectory.path() / ":.file.::.name.:";
@@ -245,13 +245,23 @@ void TestIo::testGetFileStat() {
         FileStat fileStat;
         IoError ioError = IoError::Unknown;
         CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError));
+
+#if defined(KD_WINDOWS)
+        CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
         CPPUNIT_ASSERT(!fileStat.isHidden);
         CPPUNIT_ASSERT_EQUAL(int64_t{0}, fileStat.size);
         CPPUNIT_ASSERT_EQUAL(uint64_t{0}, fileStat.inode);
         CPPUNIT_ASSERT_EQUAL(SyncTime{0}, fileStat.modificationTime);
         CPPUNIT_ASSERT_EQUAL(SyncTime{0}, fileStat.creationTime);
         CPPUNIT_ASSERT_EQUAL(NodeType::Unknown, fileStat.nodeType);
-        CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
+#else
+        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+        CPPUNIT_ASSERT(!fileStat.isHidden);
+        CPPUNIT_ASSERT_GREATER(int64_t{0}, fileStat.size);
+        CPPUNIT_ASSERT_GREATER(SyncTime{0}, fileStat.creationTime);
+        CPPUNIT_ASSERT_EQUAL(fileStat.modificationTime, fileStat.creationTime);
+        CPPUNIT_ASSERT_EQUAL(NodeType::File, fileStat.nodeType);
+#endif
     }
 
     // An existing file with emojis in its name
@@ -513,11 +523,8 @@ void TestIo::testGetFileStat() {
 
         FileStat fileStat;
         IoError ioError = IoError::Unknown;
-#if defined(KD_WINDOWS)
         CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError));
-#else
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError));
-#endif
+
         // Restore permission to allow subdir removal
         std::filesystem::permissions(subdir, std::filesystem::perms::owner_read, std::filesystem::perm_options::add);
 
@@ -556,6 +563,7 @@ void TestIo::testGetFileStat() {
         CPPUNIT_ASSERT_GREATER(SyncTime{0}, fileStat.modificationTime);
         CPPUNIT_ASSERT_GREATEREQUAL(fileStat.creationTime, fileStat.modificationTime);
         CPPUNIT_ASSERT_EQUAL(NodeType::File, fileStat.nodeType);
+        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
 #else
         CPPUNIT_ASSERT_EQUAL(int64_t{0}, fileStat.size);
         CPPUNIT_ASSERT_EQUAL(SyncTime{0}, fileStat.modificationTime);

--- a/test/libcommonserver/io/testgetfilestat.cpp
+++ b/test/libcommonserver/io/testgetfilestat.cpp
@@ -53,7 +53,11 @@ void TestIo::testGetFileStat() {
         IoError ioError = IoError::Unknown;
 
         CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError));
+#if defined(KD_MACOS) || defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+#else
+        CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
+#endif
 
         CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, true));
         CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);

--- a/test/libcommonserver/io/testgetfilestat.cpp
+++ b/test/libcommonserver/io/testgetfilestat.cpp
@@ -156,7 +156,11 @@ void TestIo::testGetFileStat() {
         CPPUNIT_ASSERT_EQUAL(SyncTime{0}, fileStat.modificationTime);
         CPPUNIT_ASSERT_EQUAL(SyncTime{0}, fileStat.creationTime);
         CPPUNIT_ASSERT_EQUAL(NodeType::Unknown, fileStat.nodeType);
+#if defined(KD_MACOS) || defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
+#else
+        CPPUNIT_ASSERT_EQUAL(IoError::FileNameTooLong, ioError);
+#end
     }
 
     // A non-existing file with a very long path

--- a/test/libcommonserver/io/testgetfilestat.cpp
+++ b/test/libcommonserver/io/testgetfilestat.cpp
@@ -53,6 +53,9 @@ void TestIo::testGetFileStat() {
         IoError ioError = IoError::Unknown;
 
         CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError));
+        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, true));
         CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
     }
 
@@ -156,7 +159,7 @@ void TestIo::testGetFileStat() {
         CPPUNIT_ASSERT_EQUAL(SyncTime{0}, fileStat.modificationTime);
         CPPUNIT_ASSERT_EQUAL(SyncTime{0}, fileStat.creationTime);
         CPPUNIT_ASSERT_EQUAL(NodeType::Unknown, fileStat.nodeType);
-#if defined(KD_MACOS) || defined(KD_WINDOWS)
+#if defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
 #else
         CPPUNIT_ASSERT_EQUAL(IoError::FileNameTooLong, ioError);
@@ -180,7 +183,11 @@ void TestIo::testGetFileStat() {
         CPPUNIT_ASSERT_EQUAL(SyncTime{0}, fileStat.modificationTime);
         CPPUNIT_ASSERT_EQUAL(SyncTime{0}, fileStat.creationTime);
         CPPUNIT_ASSERT_EQUAL(NodeType::Unknown, fileStat.nodeType);
+#if defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
+#else
+        CPPUNIT_ASSERT_EQUAL(IoError::FileNameTooLong, ioError);
+#endif
     }
 
     // A hidden file
@@ -533,19 +540,11 @@ void TestIo::testGetFileStat() {
         std::filesystem::permissions(subdir, std::filesystem::perms::owner_read, std::filesystem::perm_options::add);
 
         CPPUNIT_ASSERT(!fileStat.isHidden);
-#if defined(KD_WINDOWS)
         CPPUNIT_ASSERT_GREATER(int64_t{0}, fileStat.size);
         CPPUNIT_ASSERT_GREATER(SyncTime{0}, fileStat.creationTime);
         CPPUNIT_ASSERT_GREATEREQUAL(fileStat.creationTime, fileStat.modificationTime);
         CPPUNIT_ASSERT_EQUAL(NodeType::File, fileStat.nodeType);
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
-#else
-        CPPUNIT_ASSERT_EQUAL(int64_t{0}, fileStat.size);
-        CPPUNIT_ASSERT_EQUAL(SyncTime{0}, fileStat.modificationTime);
-        CPPUNIT_ASSERT_EQUAL(SyncTime{0}, fileStat.creationTime);
-        CPPUNIT_ASSERT_EQUAL(NodeType::Unknown, fileStat.nodeType);
-        CPPUNIT_ASSERT_EQUAL(IoError::AccessDenied, ioError);
-#endif
     }
 
     // A regular file within a subdirectory that misses owner search/exec permission:

--- a/test/libcommonserver/io/testgetfilestat.cpp
+++ b/test/libcommonserver/io/testgetfilestat.cpp
@@ -126,6 +126,7 @@ void TestIo::testGetFileStat() {
         CPPUNIT_ASSERT_EQUAL(NodeType::Directory, fileStat.nodeType);
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
     }
+
     // A non-existing file
     {
         const SyncPath path = _localTestDirPath / "non-existing.jpg"; // This file does not exist.
@@ -148,19 +149,16 @@ void TestIo::testGetFileStat() {
         const SyncPath path = _localTestDirPath / veryLongfileName; // This file doesn't exist.
         FileStat fileStat;
         IoError ioError = IoError::Success;
-        CPPUNIT_ASSERT(!IoHelper::getFileStat(path, &fileStat, ioError));
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError));
         CPPUNIT_ASSERT(!fileStat.isHidden);
         CPPUNIT_ASSERT_EQUAL(int64_t{0}, fileStat.size);
         CPPUNIT_ASSERT_EQUAL(uint64_t{0}, fileStat.inode);
         CPPUNIT_ASSERT_EQUAL(SyncTime{0}, fileStat.modificationTime);
         CPPUNIT_ASSERT_EQUAL(SyncTime{0}, fileStat.creationTime);
         CPPUNIT_ASSERT_EQUAL(NodeType::Unknown, fileStat.nodeType);
-#if defined(KD_WINDOWS)
-        CPPUNIT_ASSERT_EQUAL(IoError::InvalidArgument, ioError);
-#else
-        CPPUNIT_ASSERT_EQUAL(IoError::FileNameTooLong, ioError);
-#endif
+        CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
     }
+
     // A non-existing file with a very long path
     {
         const std::string pathSegment(50, 'a');
@@ -171,15 +169,16 @@ void TestIo::testGetFileStat() {
         FileStat fileStat;
         IoError ioError = IoError::Success;
 
-        CPPUNIT_ASSERT(!IoHelper::getFileStat(path, &fileStat, ioError));
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError));
         CPPUNIT_ASSERT(!fileStat.isHidden);
         CPPUNIT_ASSERT_EQUAL(int64_t{0}, fileStat.size);
         CPPUNIT_ASSERT_EQUAL(uint64_t{0}, fileStat.inode);
         CPPUNIT_ASSERT_EQUAL(SyncTime{0}, fileStat.modificationTime);
         CPPUNIT_ASSERT_EQUAL(SyncTime{0}, fileStat.creationTime);
         CPPUNIT_ASSERT_EQUAL(NodeType::Unknown, fileStat.nodeType);
-        CPPUNIT_ASSERT_EQUAL(IoError::FileNameTooLong, ioError);
+        CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
     }
+
     // A hidden file
     {
         const LocalTemporaryDirectory temporaryDirectory;
@@ -233,6 +232,7 @@ void TestIo::testGetFileStat() {
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
         CPPUNIT_ASSERT_EQUAL(NodeType::Directory, fileStat.nodeType);
     }
+
     // An existing file with dots and colons in its name
     {
         const LocalTemporaryDirectory temporaryDirectory;
@@ -244,23 +244,14 @@ void TestIo::testGetFileStat() {
 
         FileStat fileStat;
         IoError ioError = IoError::Unknown;
-#if defined(KD_WINDOWS)
-        CPPUNIT_ASSERT(!IoHelper::getFileStat(path, &fileStat, ioError));
-        CPPUNIT_ASSERT(!fileStat.isHidden);
-        CPPUNIT_ASSERT_EQUAL(SyncTime(0u), fileStat.size);
-        CPPUNIT_ASSERT_EQUAL(SyncTime(0u), fileStat.modificationTime);
-        CPPUNIT_ASSERT_EQUAL(fileStat.creationTime, fileStat.modificationTime);
-        CPPUNIT_ASSERT_EQUAL(NodeType::Unknown, fileStat.nodeType);
-        CPPUNIT_ASSERT_EQUAL(IoError::Unknown, ioError);
-#else
         CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError));
         CPPUNIT_ASSERT(!fileStat.isHidden);
-        CPPUNIT_ASSERT_GREATER(int64_t{0}, fileStat.size);
-        CPPUNIT_ASSERT_GREATER(SyncTime{0}, fileStat.creationTime);
-        CPPUNIT_ASSERT_EQUAL(fileStat.modificationTime, fileStat.creationTime);
-        CPPUNIT_ASSERT_EQUAL(NodeType::File, fileStat.nodeType);
-        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
-#endif
+        CPPUNIT_ASSERT_EQUAL(int64_t{0}, fileStat.size);
+        CPPUNIT_ASSERT_EQUAL(uint64_t{0}, fileStat.inode);
+        CPPUNIT_ASSERT_EQUAL(SyncTime{0}, fileStat.modificationTime);
+        CPPUNIT_ASSERT_EQUAL(SyncTime{0}, fileStat.creationTime);
+        CPPUNIT_ASSERT_EQUAL(NodeType::Unknown, fileStat.nodeType);
+        CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
     }
 
     // An existing file with emojis in its name
@@ -300,7 +291,6 @@ void TestIo::testGetFileStat() {
         CPPUNIT_ASSERT(!fileStat.isHidden);
 #if defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL(int64_t{0}, fileStat.size);
-
 #else
         CPPUNIT_ASSERT_EQUAL(static_cast<int64_t>(targetPath.native().length()), fileStat.size);
 #endif
@@ -455,6 +445,7 @@ void TestIo::testGetFileStat() {
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
     }
 #endif
+
     // A regular file missing all permissions (no error expected)
     {
         const LocalTemporaryDirectory temporaryDirectory;

--- a/test/libcommonserver/io/testgetfilestat.cpp
+++ b/test/libcommonserver/io/testgetfilestat.cpp
@@ -33,7 +33,7 @@ void TestIo::testGetFileStat() {
         FileStat fileStat;
         IoError ioError = IoError::Unknown;
 
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError));
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
         CPPUNIT_ASSERT(!fileStat.isHidden);
         CPPUNIT_ASSERT_EQUAL(int64_t(408278u), fileStat.size);
         CPPUNIT_ASSERT_GREATER(SyncTime{0}, fileStat.creationTime);
@@ -52,14 +52,14 @@ void TestIo::testGetFileStat() {
         FileStat fileStat;
         IoError ioError = IoError::Unknown;
 
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError));
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
 #if defined(KD_MACOS) || defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
 #else
         CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
 #endif
 
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, true));
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Sensitive));
         CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
     }
 
@@ -69,7 +69,7 @@ void TestIo::testGetFileStat() {
         FileStat fileStat;
         IoError ioError = IoError::Unknown;
 
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError));
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
         CPPUNIT_ASSERT(!fileStat.isHidden);
 #if defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL(int64_t{0}, fileStat.size);
@@ -97,7 +97,7 @@ void TestIo::testGetFileStat() {
         FileStat fileStat;
         IoError ioError = IoError::Unknown;
 
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError));
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
         CPPUNIT_ASSERT(!fileStat.isHidden);
 #if defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL(int64_t{0}, fileStat.size);
@@ -123,7 +123,7 @@ void TestIo::testGetFileStat() {
         FileStat fileStat;
         IoError ioError = IoError::Unknown;
 
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError));
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
         CPPUNIT_ASSERT(!fileStat.isHidden);
 #if defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL(int64_t{0}, fileStat.size);
@@ -140,7 +140,7 @@ void TestIo::testGetFileStat() {
         FileStat fileStat;
         IoError ioError = IoError::Success;
 
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError));
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
         CPPUNIT_ASSERT(!fileStat.isHidden);
         CPPUNIT_ASSERT_EQUAL(int64_t{0}, fileStat.size);
         CPPUNIT_ASSERT_EQUAL(SyncTime{0}, fileStat.modificationTime);
@@ -156,7 +156,7 @@ void TestIo::testGetFileStat() {
         const SyncPath path = _localTestDirPath / veryLongfileName; // This file doesn't exist.
         FileStat fileStat;
         IoError ioError = IoError::Success;
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError));
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
         CPPUNIT_ASSERT(!fileStat.isHidden);
         CPPUNIT_ASSERT_EQUAL(int64_t{0}, fileStat.size);
         CPPUNIT_ASSERT_EQUAL(uint64_t{0}, fileStat.inode);
@@ -180,7 +180,7 @@ void TestIo::testGetFileStat() {
         FileStat fileStat;
         IoError ioError = IoError::Success;
 
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError));
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
         CPPUNIT_ASSERT(!fileStat.isHidden);
         CPPUNIT_ASSERT_EQUAL(int64_t{0}, fileStat.size);
         CPPUNIT_ASSERT_EQUAL(uint64_t{0}, fileStat.inode);
@@ -214,7 +214,7 @@ void TestIo::testGetFileStat() {
         FileStat fileStat;
         IoError ioError = IoError::Unknown;
 
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError));
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
 
         CPPUNIT_ASSERT(fileStat.isHidden);
         CPPUNIT_ASSERT_GREATER(int64_t{0}, fileStat.size);
@@ -240,7 +240,7 @@ void TestIo::testGetFileStat() {
         FileStat fileStat;
         IoError ioError = IoError::Unknown;
 
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError));
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
         CPPUNIT_ASSERT(fileStat.isHidden);
         CPPUNIT_ASSERT_GREATER(SyncTime{0}, fileStat.creationTime);
         CPPUNIT_ASSERT_GREATEREQUAL(fileStat.creationTime, fileStat.modificationTime);
@@ -259,7 +259,7 @@ void TestIo::testGetFileStat() {
 
         FileStat fileStat;
         IoError ioError = IoError::Unknown;
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError));
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
 
 #if defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
@@ -292,7 +292,7 @@ void TestIo::testGetFileStat() {
         FileStat fileStat;
         IoError ioError = IoError::Unknown;
 
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError));
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
         CPPUNIT_ASSERT(!fileStat.isHidden);
         CPPUNIT_ASSERT_GREATER(int64_t{0}, fileStat.size);
         CPPUNIT_ASSERT_GREATER(SyncTime{0}, fileStat.creationTime);
@@ -311,7 +311,7 @@ void TestIo::testGetFileStat() {
         FileStat fileStat;
         IoError ioError = IoError::Unknown;
 
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError));
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
         CPPUNIT_ASSERT_GREATER(SyncTime{0}, fileStat.creationTime);
         CPPUNIT_ASSERT(!fileStat.isHidden);
 #if defined(KD_WINDOWS)
@@ -341,7 +341,7 @@ void TestIo::testGetFileStat() {
         FileStat fileStat;
         IoError ioError = IoError::Unknown;
 
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError));
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
         CPPUNIT_ASSERT(!fileStat.isHidden);
         CPPUNIT_ASSERT_GREATER(int64_t{0},
                                fileStat.size); // `fileStat.size` is greater than `static_cast<int64_t>(path.native().length())`
@@ -364,7 +364,7 @@ void TestIo::testGetFileStat() {
         FileStat fileStat;
         IoError ioError = IoError::Unknown;
 
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError));
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
         CPPUNIT_ASSERT(!fileStat.isHidden);
         CPPUNIT_ASSERT_GREATER(int64_t{0}, fileStat.size);
         CPPUNIT_ASSERT_GREATER(SyncTime{0}, fileStat.creationTime);
@@ -390,7 +390,7 @@ void TestIo::testGetFileStat() {
         FileStat fileStat;
         IoError ioError = IoError::Unknown;
 
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError));
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
         CPPUNIT_ASSERT(!fileStat.isHidden);
         CPPUNIT_ASSERT_GREATER(int64_t{0},
                                fileStat.size); // `fileStat.size` is greater than `static_cast<int64_t>(path.native().length())`
@@ -414,7 +414,7 @@ void TestIo::testGetFileStat() {
         FileStat fileStat;
         IoError ioError = IoError::Unknown;
 
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError));
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
         CPPUNIT_ASSERT(!fileStat.isHidden);
         CPPUNIT_ASSERT_GREATER(int64_t{0},
                                fileStat.size); // `fileStat.size` is greater than `static_cast<int64_t>(path.native().length())`
@@ -439,7 +439,7 @@ void TestIo::testGetFileStat() {
         FileStat fileStat;
         IoError ioError = IoError::Unknown;
 
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError));
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
         CPPUNIT_ASSERT(!fileStat.isHidden);
         CPPUNIT_ASSERT_EQUAL(int64_t{0},
                              fileStat.size); // `fileStat.size` is 0 for a junction`
@@ -461,7 +461,7 @@ void TestIo::testGetFileStat() {
         FileStat fileStat;
         IoError ioError = IoError::Unknown;
 
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError));
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
         CPPUNIT_ASSERT(!fileStat.isHidden);
         CPPUNIT_ASSERT_EQUAL(int64_t{0},
                              fileStat.size); // `fileStat.size` is 0 for a junction`
@@ -485,7 +485,7 @@ void TestIo::testGetFileStat() {
         FileStat fileStat;
         IoError ioError = IoError::Unknown;
 
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError));
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
 
         std::filesystem::permissions(path, std::filesystem::perms::all, std::filesystem::perm_options::add);
 
@@ -508,7 +508,7 @@ void TestIo::testGetFileStat() {
         FileStat fileStat;
         IoError ioError = IoError::Unknown;
 
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError));
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
 
         std::filesystem::permissions(path, std::filesystem::perms::all, std::filesystem::perm_options::add);
 
@@ -538,7 +538,7 @@ void TestIo::testGetFileStat() {
 
         FileStat fileStat;
         IoError ioError = IoError::Unknown;
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError));
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
 
         // Restore permission to allow subdir removal
         std::filesystem::permissions(subdir, std::filesystem::perms::owner_read, std::filesystem::perm_options::add);
@@ -567,7 +567,7 @@ void TestIo::testGetFileStat() {
 
         FileStat fileStat;
         IoError ioError = IoError::Unknown;
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError));
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
 
         // Restore permission to allow subdir removal
         std::filesystem::permissions(subdir, std::filesystem::perms::owner_exec, std::filesystem::perm_options::add);

--- a/test/libcommonserver/io/testgetfilestat.cpp
+++ b/test/libcommonserver/io/testgetfilestat.cpp
@@ -46,6 +46,16 @@ void TestIo::testGetFileStat() {
         CPPUNIT_ASSERT_EQUAL(nodeId, std::to_string(fileStat.inode));
     }
 
+    // A regular file whose name exists with a different capitalization
+    {
+        const SyncPath path = _localTestDirPath / "test_pictures/Picture-1.jpg";
+        FileStat fileStat;
+        IoError ioError = IoError::Unknown;
+
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError));
+        CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
+    }
+
     // A regular directory
     {
         const SyncPath path = _localTestDirPath / "test_pictures";

--- a/test/libcommonserver/io/testgetfilestat.cpp
+++ b/test/libcommonserver/io/testgetfilestat.cpp
@@ -160,7 +160,7 @@ void TestIo::testGetFileStat() {
         CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
 #else
         CPPUNIT_ASSERT_EQUAL(IoError::FileNameTooLong, ioError);
-#end
+#endif
     }
 
     // A non-existing file with a very long path

--- a/test/libcommonserver/io/testgetfilestat.cpp
+++ b/test/libcommonserver/io/testgetfilestat.cpp
@@ -533,11 +533,19 @@ void TestIo::testGetFileStat() {
         std::filesystem::permissions(subdir, std::filesystem::perms::owner_read, std::filesystem::perm_options::add);
 
         CPPUNIT_ASSERT(!fileStat.isHidden);
+#if defined(KD_WINDOWS)
         CPPUNIT_ASSERT_GREATER(int64_t{0}, fileStat.size);
         CPPUNIT_ASSERT_GREATER(SyncTime{0}, fileStat.creationTime);
         CPPUNIT_ASSERT_GREATEREQUAL(fileStat.creationTime, fileStat.modificationTime);
         CPPUNIT_ASSERT_EQUAL(NodeType::File, fileStat.nodeType);
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+#else
+        CPPUNIT_ASSERT_EQUAL(int64_t{0}, fileStat.size);
+        CPPUNIT_ASSERT_EQUAL(SyncTime{0}, fileStat.modificationTime);
+        CPPUNIT_ASSERT_EQUAL(SyncTime{0}, fileStat.creationTime);
+        CPPUNIT_ASSERT_EQUAL(NodeType::Unknown, fileStat.nodeType);
+        CPPUNIT_ASSERT_EQUAL(IoError::AccessDenied, ioError);
+#endif
     }
 
     // A regular file within a subdirectory that misses owner search/exec permission:

--- a/test/libcommonserver/io/testio.cpp
+++ b/test/libcommonserver/io/testio.cpp
@@ -179,7 +179,7 @@ void TestIo::testSetFileDates() {
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
 
         FileStat filestat;
-        (void) IoHelper::getFileStat(filepath, &filestat, ioError);
+        (void) IoHelper::getFileStat(filepath, &filestat, ioError, IoHelper::PathCheckOption::Insensitive);
 #if defined(KD_MACOS) || defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL(timestamp, filestat.creationTime);
 #endif
@@ -192,7 +192,7 @@ void TestIo::testSetFileDates() {
         ioError = IoHelper::setFileDates(folderPath, timestamp, timestamp + 10, false);
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
 
-        (void) IoHelper::getFileStat(folderPath, &filestat, ioError);
+        (void) IoHelper::getFileStat(folderPath, &filestat, ioError, IoHelper::PathCheckOption::Insensitive);
 #if defined(KD_MACOS) || defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL(timestamp, filestat.creationTime);
 #endif
@@ -214,7 +214,7 @@ void TestIo::testSetFileDates() {
         ioError = IoHelper::setFileDates(filepath, timestamp, timestamp + 10, false);
         CPPUNIT_ASSERT_EQUAL(IoError::AccessDenied, ioError);
 
-        (void) IoHelper::getFileStat(filepath, &filestat, ioError);
+        (void) IoHelper::getFileStat(filepath, &filestat, ioError, IoHelper::PathCheckOption::Insensitive);
 #if defined(KD_MACOS) || defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL(timestamp, filestat.creationTime);
 #endif
@@ -229,12 +229,12 @@ void TestIo::testSetFileDates() {
         ioError = IoHelper::setFileDates(linkPath, linkTimestamp, linkTimestamp + 10, true);
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
 
-        (void) IoHelper::getFileStat(linkPath, &filestat, ioError);
+        (void) IoHelper::getFileStat(linkPath, &filestat, ioError, IoHelper::PathCheckOption::Insensitive);
 #if defined(KD_MACOS) || defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL(linkTimestamp, filestat.creationTime);
 #endif
         CPPUNIT_ASSERT_EQUAL(linkTimestamp + 10, filestat.modificationTime);
-        (void) IoHelper::getFileStat(filepath, &filestat, ioError);
+        (void) IoHelper::getFileStat(filepath, &filestat, ioError, IoHelper::PathCheckOption::Insensitive);
 #if defined(KD_MACOS) || defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL(timestamp, filestat.creationTime);
 #endif
@@ -246,12 +246,12 @@ void TestIo::testSetFileDates() {
         ioError = IoHelper::setFileDates(linkPath, linkTimestamp, linkTimestamp + 10, true);
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
 
-        (void) IoHelper::getFileStat(linkPath, &filestat, ioError);
+        (void) IoHelper::getFileStat(linkPath, &filestat, ioError, IoHelper::PathCheckOption::Insensitive);
 #if defined(KD_MACOS) || defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL(linkTimestamp, filestat.creationTime);
 #endif
         CPPUNIT_ASSERT_EQUAL(linkTimestamp + 10, filestat.modificationTime);
-        (void) IoHelper::getFileStat(folderPath, &filestat, ioError);
+        (void) IoHelper::getFileStat(folderPath, &filestat, ioError, IoHelper::PathCheckOption::Insensitive);
 #if defined(KD_MACOS) || defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL(timestamp, filestat.creationTime);
 #endif
@@ -266,10 +266,10 @@ void TestIo::testSetFileDates() {
         ioError = IoHelper::setFileDates(linkPath, linkTimestamp, linkTimestamp + 10, true);
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
 
-        (void) IoHelper::getFileStat(linkPath, &filestat, ioError);
+        (void) IoHelper::getFileStat(linkPath, &filestat, ioError, IoHelper::PathCheckOption::Insensitive);
         CPPUNIT_ASSERT_EQUAL(linkTimestamp, filestat.creationTime);
         CPPUNIT_ASSERT_EQUAL(linkTimestamp + 10, filestat.modificationTime);
-        (void) IoHelper::getFileStat(filepath, &filestat, ioError);
+        (void) IoHelper::getFileStat(filepath, &filestat, ioError, IoHelper::PathCheckOption::Insensitive);
         CPPUNIT_ASSERT_EQUAL(timestamp, filestat.creationTime);
         CPPUNIT_ASSERT_EQUAL(timestamp + 10, filestat.modificationTime);
 
@@ -281,10 +281,10 @@ void TestIo::testSetFileDates() {
         ioError = IoHelper::setFileDates(linkPath, linkTimestamp, linkTimestamp + 10, true);
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
 
-        (void) IoHelper::getFileStat(linkPath, &filestat, ioError);
+        (void) IoHelper::getFileStat(linkPath, &filestat, ioError, IoHelper::PathCheckOption::Insensitive);
         CPPUNIT_ASSERT_EQUAL(linkTimestamp, filestat.creationTime);
         CPPUNIT_ASSERT_EQUAL(linkTimestamp + 10, filestat.modificationTime);
-        (void) IoHelper::getFileStat(filepath, &filestat, ioError);
+        (void) IoHelper::getFileStat(filepath, &filestat, ioError, IoHelper::PathCheckOption::Insensitive);
         CPPUNIT_ASSERT_EQUAL(timestamp, filestat.creationTime);
         CPPUNIT_ASSERT_EQUAL(timestamp + 10, filestat.modificationTime);
 #endif
@@ -298,10 +298,10 @@ void TestIo::testSetFileDates() {
         ioError = IoHelper::setFileDates(linkPath, linkTimestamp, linkTimestamp + 10, true);
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
 
-        (void) IoHelper::getFileStat(linkPath, &filestat, ioError);
+        (void) IoHelper::getFileStat(linkPath, &filestat, ioError, IoHelper::PathCheckOption::Insensitive);
         CPPUNIT_ASSERT_EQUAL(linkTimestamp, filestat.creationTime);
         CPPUNIT_ASSERT_EQUAL(linkTimestamp + 10, filestat.modificationTime);
-        (void) IoHelper::getFileStat(filepath, &filestat, ioError);
+        (void) IoHelper::getFileStat(filepath, &filestat, ioError, IoHelper::PathCheckOption::Insensitive);
         CPPUNIT_ASSERT_EQUAL(timestamp, filestat.creationTime);
         CPPUNIT_ASSERT_EQUAL(timestamp + 10, filestat.modificationTime);
 
@@ -313,10 +313,10 @@ void TestIo::testSetFileDates() {
         ioError = IoHelper::setFileDates(linkPath, linkTimestamp, linkTimestamp + 10, true);
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
 
-        (void) IoHelper::getFileStat(linkPath, &filestat, ioError);
+        (void) IoHelper::getFileStat(linkPath, &filestat, ioError, IoHelper::PathCheckOption::Insensitive);
         CPPUNIT_ASSERT_EQUAL(linkTimestamp, filestat.creationTime);
         CPPUNIT_ASSERT_EQUAL(linkTimestamp + 10, filestat.modificationTime);
-        (void) IoHelper::getFileStat(filepath, &filestat, ioError);
+        (void) IoHelper::getFileStat(filepath, &filestat, ioError, IoHelper::PathCheckOption::Insensitive);
         CPPUNIT_ASSERT_EQUAL(timestamp, filestat.creationTime);
         CPPUNIT_ASSERT_EQUAL(timestamp + 10, filestat.modificationTime);
 #endif
@@ -328,7 +328,7 @@ void TestIo::testSetFileDates() {
         ioError = IoHelper::setFileDates(filepath, timestamp + 10, timestamp, false);
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
 
-        (void) IoHelper::getFileStat(filepath, &filestat, ioError);
+        (void) IoHelper::getFileStat(filepath, &filestat, ioError, IoHelper::PathCheckOption::Insensitive);
 #if defined(KD_MACOS)
         // Creation date is set to modification date
         CPPUNIT_ASSERT_EQUAL(timestamp, filestat.creationTime);
@@ -344,7 +344,7 @@ void TestIo::testSetFileDates() {
         ioError = IoHelper::setFileDates(filepath, 0, timestamp, false);
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
 
-        (void) IoHelper::getFileStat(filepath, &filestat, ioError);
+        (void) IoHelper::getFileStat(filepath, &filestat, ioError, IoHelper::PathCheckOption::Insensitive);
 #if defined(KD_MACOS) || defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL(SyncTime{0}, filestat.creationTime);
 #endif
@@ -357,7 +357,7 @@ void TestIo::testSetFileDates() {
         ioError = IoHelper::setFileDates(filepath, timestamp, 0, false);
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
 
-        (void) IoHelper::getFileStat(filepath, &filestat, ioError);
+        (void) IoHelper::getFileStat(filepath, &filestat, ioError, IoHelper::PathCheckOption::Insensitive);
 #if defined(KD_MACOS)
         // Creation date is set to modification date = 0
         CPPUNIT_ASSERT(filestat.creationTime == 0);

--- a/test/libsyncengine/integration/testintegration.cpp
+++ b/test/libsyncengine/integration/testintegration.cpp
@@ -113,7 +113,7 @@ void TestIntegration::setUp() {
 
     FileStat fileStat;
     IoError ioError = IoError::Unknown;
-    (void) IoHelper::getFileStat(_localSyncDir.path(), &fileStat, ioError);
+    (void) IoHelper::getFileStat(_localSyncDir.path(), &fileStat, ioError, IoHelper::PathCheckOption::Insensitive);
 
     // This is an advanced sync. Define remote target path and remote target node ID.
     const Sync sync(1, drive.dbId(), _localSyncDir.path(), std::to_string(fileStat.inode),
@@ -215,7 +215,7 @@ void TestIntegration::inconsistencyTests() {
     testhelpers::generateOrEditTestFile(nameClashLocalPath);
     FileStat filestat;
     IoError ioError = IoError::Unknown;
-    (void) IoHelper::getFileStat(nameClashLocalPath, &filestat, ioError);
+    (void) IoHelper::getFileStat(nameClashLocalPath, &filestat, ioError, IoHelper::PathCheckOption::Insensitive);
     waitForSyncToBeIdle(SourceLocation::currentLoc());
 
     auto remoteFileInfo = getRemoteFileInfoByName(_driveDbId, _remoteSyncDir.id(), Str("testnameclash"));
@@ -231,7 +231,8 @@ void TestIntegration::inconsistencyTests() {
     // and a new edit operation, with the new path, is generated.
     waitForSyncToBeIdle(SourceLocation::currentLoc());
 
-    (void) IoHelper::getFileStat(_syncPal->localPath() / "testnameclash2", &filestat, ioError);
+    (void) IoHelper::getFileStat(_syncPal->localPath() / "testnameclash2", &filestat, ioError,
+                                 IoHelper::PathCheckOption::Insensitive);
     remoteFileInfo = getRemoteFileInfoByName(_driveDbId, _remoteSyncDir.id(), Str("testnameclash2"));
 
     CPPUNIT_ASSERT(remoteFileInfo.isValid());
@@ -382,7 +383,8 @@ void TestIntegration::testExclusionTemplates() {
     const RemoteTemporaryDirectory exclusionTemplatesTestDir(_driveDbId, tmpRemoteDir.id(), "testDir");
     FileStat filestat;
     bool found = false;
-    IoHelper::getFileStat(_syncPal->localPath() / tmpRemoteDir.name() / exclusionTemplatesTestDir.name(), &filestat, found);
+    IoHelper::getFileStat(_syncPal->localPath() / tmpRemoteDir.name() / exclusionTemplatesTestDir.name(), &filestat, found,
+                          IoHelper::PathCheckOption::Insensitive);
     const auto dirLocalId = std::to_string(filestat.inode);
 
     const auto filename = "testExclusionTemplates";
@@ -392,7 +394,7 @@ void TestIntegration::testExclusionTemplates() {
     waitForSyncToBeIdle(SourceLocation::currentLoc());
 
     const auto excludedFilePath = _syncPal->localPath() / tmpRemoteDir.name() / testName;
-    IoHelper::getFileStat(excludedFilePath, &filestat, found);
+    IoHelper::getFileStat(excludedFilePath, &filestat, found, IoHelper::PathCheckOption::Insensitive);
     auto fileLocalId = std::to_string(filestat.inode);
     CPPUNIT_ASSERT(std::filesystem::exists(excludedFilePath));
 
@@ -417,7 +419,8 @@ void TestIntegration::testExclusionTemplates() {
     CPPUNIT_ASSERT(_syncPal->liveSnapshot(ReplicaSide::Remote).exists(fileRemoteId));
     // ... but the local file is still excluded. A new file is therefore downloaded.
     CPPUNIT_ASSERT(!_syncPal->liveSnapshot(ReplicaSide::Local).exists(fileLocalId));
-    IoHelper::getFileStat(_syncPal->localPath() / tmpRemoteDir.name() / filename, &filestat, found);
+    IoHelper::getFileStat(_syncPal->localPath() / tmpRemoteDir.name() / filename, &filestat, found,
+                          IoHelper::PathCheckOption::Insensitive);
     fileLocalId = std::to_string(filestat.inode);
     CPPUNIT_ASSERT(_syncPal->liveSnapshot(ReplicaSide::Local).exists(fileLocalId));
 
@@ -445,7 +448,8 @@ void TestIntegration::testExclusionTemplates() {
     CPPUNIT_ASSERT(std::filesystem::exists(_syncPal->localPath() / tmpRemoteDir.name() / filename));
     // Local file ID has changed again.
     CPPUNIT_ASSERT(!_syncPal->liveSnapshot(ReplicaSide::Local).exists(fileLocalId));
-    IoHelper::getFileStat(_syncPal->localPath() / tmpRemoteDir.name() / filename, &filestat, found);
+    IoHelper::getFileStat(_syncPal->localPath() / tmpRemoteDir.name() / filename, &filestat, found,
+                          IoHelper::PathCheckOption::Insensitive);
     fileLocalId = std::to_string(filestat.inode);
     CPPUNIT_ASSERT(_syncPal->liveSnapshot(ReplicaSide::Local).exists(fileLocalId));
 
@@ -482,7 +486,8 @@ void TestIntegration::testExclusionTemplates() {
     CPPUNIT_ASSERT(_syncPal->liveSnapshot(ReplicaSide::Remote).exists(fileRemoteId));
     // Local file ID has changed again.
     CPPUNIT_ASSERT(!_syncPal->liveSnapshot(ReplicaSide::Local).exists(fileLocalId));
-    IoHelper::getFileStat(_syncPal->localPath() / tmpRemoteDir.name() / testName, &filestat, found);
+    IoHelper::getFileStat(_syncPal->localPath() / tmpRemoteDir.name() / testName, &filestat, found,
+                          IoHelper::PathCheckOption::Insensitive);
     fileLocalId = std::to_string(filestat.inode);
     CPPUNIT_ASSERT(_syncPal->liveSnapshot(ReplicaSide::Local).exists(fileLocalId));
 
@@ -560,7 +565,7 @@ void TestIntegration::testNegativeModificationTime() {
         testhelpers::generateOrEditTestFile(filepath);
         FileStat fileStat;
         bool found = false;
-        IoHelper::getFileStat(filepath, &fileStat, found);
+        IoHelper::getFileStat(filepath, &fileStat, found, IoHelper::PathCheckOption::Insensitive);
         (void) IoHelper::setFileDates(filepath, fileStat.creationTime, timeInput, false);
         waitForSyncToBeIdle(SourceLocation::currentLoc());
 
@@ -579,7 +584,7 @@ void TestIntegration::testNegativeModificationTime() {
         testhelpers::generateOrEditTestFile(filepath);
         FileStat fileStat;
         bool found = false;
-        IoHelper::getFileStat(filepath, &fileStat, found);
+        IoHelper::getFileStat(filepath, &fileStat, found, IoHelper::PathCheckOption::Insensitive);
         (void) IoHelper::setFileDates(filepath, timeInput, fileStat.modificationTime, false);
         waitForSyncToBeIdle(SourceLocation::currentLoc());
 
@@ -605,7 +610,7 @@ void TestIntegration::testNegativeModificationTime() {
         testhelpers::generateOrEditTestFile(filepath);
         FileStat fileStat;
         bool found = false;
-        IoHelper::getFileStat(filepath, &fileStat, found);
+        IoHelper::getFileStat(filepath, &fileStat, found, IoHelper::PathCheckOption::Insensitive);
         (void) IoHelper::setFileDates(filepath, timeInput, timeInput, false);
         waitForSyncToBeIdle(SourceLocation::currentLoc());
 

--- a/test/libsyncengine/integration/testintegration_basics.cpp
+++ b/test/libsyncengine/integration/testintegration_basics.cpp
@@ -48,7 +48,7 @@ void TestIntegration::testLocalChanges() {
 
     FileStat fileStat;
     bool exists = false;
-    IoHelper::getFileStat(filePath, &fileStat, exists);
+    IoHelper::getFileStat(filePath, &fileStat, exists, IoHelper::PathCheckOption::Insensitive);
     waitForSyncToBeIdle(SourceLocation::currentLoc());
 
     auto remoteTestFileInfo = getRemoteFileInfoByName(_driveDbId, _remoteSyncDir.id(), filePath.filename());
@@ -62,7 +62,7 @@ void TestIntegration::testLocalChanges() {
 
     // Generate an edit operation.
     testhelpers::generateOrEditTestFile(filePath);
-    IoHelper::getFileStat(filePath, &fileStat, exists);
+    IoHelper::getFileStat(filePath, &fileStat, exists, IoHelper::PathCheckOption::Insensitive);
     waitForSyncToBeIdle(SourceLocation::currentLoc());
 
     const auto prevRemoteTestFileInfo = remoteTestFileInfo;
@@ -132,7 +132,7 @@ void TestIntegration::testRemoteChanges() {
 
     FileStat fileStat;
     bool exists = false;
-    IoHelper::getFileStat(filePath, &fileStat, exists);
+    IoHelper::getFileStat(filePath, &fileStat, exists, IoHelper::PathCheckOption::Insensitive);
     CPPUNIT_ASSERT_EQUAL(fileInfoJob.size(), fileStat.size);
     CPPUNIT_ASSERT_EQUAL(fileInfoJob.modificationTime(), fileStat.modificationTime);
 
@@ -147,7 +147,7 @@ void TestIntegration::testRemoteChanges() {
 
     FileStat filestat;
     IoError ioError = IoError::Unknown;
-    (void) IoHelper::getFileStat(filePath, &filestat, ioError);
+    (void) IoHelper::getFileStat(filePath, &filestat, ioError, IoHelper::PathCheckOption::Insensitive);
     CPPUNIT_ASSERT_EQUAL(modificationTime, filestat.modificationTime);
     CPPUNIT_ASSERT_EQUAL(size, filestat.size);
     logStep("test edit remote file");
@@ -209,7 +209,7 @@ void TestIntegration::testUploadBigFile() {
 
     bool found = false;
     FileStat fileStat;
-    IoHelper::getFileStat(localFilePath, &fileStat, found);
+    IoHelper::getFileStat(localFilePath, &fileStat, found, IoHelper::PathCheckOption::Insensitive);
 
     waitForSyncToBeIdle(SourceLocation::currentLoc());
 

--- a/test/libsyncengine/integration/testintegration_conflicts.cpp
+++ b/test/libsyncengine/integration/testintegration_conflicts.cpp
@@ -105,7 +105,8 @@ void TestIntegration::testEditEditPseudoConflict() {
     // Check that the modification time has been updated in DB.
     FileStat fileStat;
     bool exists = false;
-    IoHelper::getFileStat(_syncPal->localPath() / dbNode.name(ReplicaSide::Local), &fileStat, exists);
+    IoHelper::getFileStat(_syncPal->localPath() / dbNode.name(ReplicaSide::Local), &fileStat, exists,
+                          IoHelper::PathCheckOption::Insensitive);
     std::optional<SyncTime> lastModified = std::nullopt;
     CPPUNIT_ASSERT_EQUAL(true,
                          _syncPal->syncDb()->lastModified(ReplicaSide::Remote, _testFileRemoteId, lastModified, found) && found);
@@ -216,7 +217,7 @@ void TestIntegration::testEditDeleteConflict() {
         // Edit operation has won.
         CPPUNIT_ASSERT(std::filesystem::exists(filepath));
         FileStat fileStat;
-        (void) IoHelper::getFileStat(filepath, &fileStat, ioError);
+        (void) IoHelper::getFileStat(filepath, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive);
         CPPUNIT_ASSERT_EQUAL(modificationTime, fileStat.modificationTime);
         CPPUNIT_ASSERT_EQUAL(size, fileStat.size);
         logStep("testEditDeleteConflict1");

--- a/test/libsyncengine/integration/testintegration_nodeid_reuse.cpp
+++ b/test/libsyncengine/integration/testintegration_nodeid_reuse.cpp
@@ -216,7 +216,7 @@ void TestIntegration::testNodeIdReuseFalsePositive() {
         IoError ioError = IoError::Unknown;
         FileStat filestatA;
         const SyncPath absoluteLocalPathA = localTmpDir.path() / "A";
-        (void) IoHelper::getFileStat(absoluteLocalPathA, &filestatA, ioError);
+        (void) IoHelper::getFileStat(absoluteLocalPathA, &filestatA, ioError, IoHelper::PathCheckOption::Insensitive);
         DbNode dbNode;
         bool found = false;
         CPPUNIT_ASSERT(_syncPal->syncDb()->node(ReplicaSide::Local, std::to_string(filestatA.inode), dbNode, found) && found);
@@ -247,7 +247,7 @@ void TestIntegration::testNodeIdReuseFalsePositive() {
         IoError ioError = IoError::Unknown;
         FileStat filestatA;
         const SyncPath absoluteLocalPathA = localTmpDir.path() / "A";
-        (void) IoHelper::getFileStat(absoluteLocalPathA, &filestatA, ioError);
+        (void) IoHelper::getFileStat(absoluteLocalPathA, &filestatA, ioError, IoHelper::PathCheckOption::Insensitive);
         DbNode dbNode;
         bool found = false;
         CPPUNIT_ASSERT(_syncPal->syncDb()->node(ReplicaSide::Local, std::to_string(filestatA.inode), dbNode, found) && found);
@@ -278,7 +278,7 @@ void TestIntegration::testNodeIdReuseFalsePositive() {
         IoError ioError = IoError::Unknown;
         FileStat filestatA;
         const SyncPath absoluteLocalPathA = localTmpDir.path() / "A";
-        (void) IoHelper::getFileStat(absoluteLocalPathA, &filestatA, ioError);
+        (void) IoHelper::getFileStat(absoluteLocalPathA, &filestatA, ioError, IoHelper::PathCheckOption::Insensitive);
         DbNode dbNode;
         bool found = false;
         CPPUNIT_ASSERT(_syncPal->syncDb()->node(ReplicaSide::Local, std::to_string(filestatA.inode), dbNode, found) && found);

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -309,7 +309,7 @@ void TestNetworkJobs::testDownload() {
         {
             FileStat fileStat;
             IoError ioError = IoError::Success;
-            IoHelper::getFileStat(localDestFilePath, &fileStat, ioError);
+            IoHelper::getFileStat(localDestFilePath, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive);
             CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
 #if defined(KD_MACOS) or defined(KD_WINDOWS)
             CPPUNIT_ASSERT_EQUAL(fileStat.creationTime, creationTimeIn.count());
@@ -343,7 +343,7 @@ void TestNetworkJobs::testDownload() {
         {
             FileStat fileStat;
             IoError ioError = IoError::Success;
-            IoHelper::getFileStat(localDestFilePath, &fileStat, ioError);
+            IoHelper::getFileStat(localDestFilePath, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive);
             CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
 #if defined(KD_MACOS) or defined(KD_WINDOWS)
             CPPUNIT_ASSERT_EQUAL(fileStat.creationTime, creationTimeIn.count());
@@ -392,7 +392,7 @@ void TestNetworkJobs::testDownload() {
         {
             FileStat fileStat;
             IoError ioError = IoError::Success;
-            IoHelper::getFileStat(localDestFilePath, &fileStat, ioError);
+            IoHelper::getFileStat(localDestFilePath, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive);
             CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
 #if defined(KD_MACOS) or defined(KD_WINDOWS)
             CPPUNIT_ASSERT_EQUAL(fileStat.creationTime, creationTimeIn.count());
@@ -501,7 +501,8 @@ void TestNetworkJobs::testDownload() {
         CPPUNIT_ASSERT(!smallPartitionPath.empty());
         IoError ioError = IoError::Unknown;
         bool exist = false;
-        CPPUNIT_ASSERT_MESSAGE(toString(ioError), IoHelper::checkIfPathExists(smallPartitionPath, exist, ioError));
+        CPPUNIT_ASSERT_MESSAGE(toString(ioError), IoHelper::checkIfPathExists(smallPartitionPath, exist, ioError,
+                                                                              IoHelper::PathCheckOption::Insensitive));
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
         CPPUNIT_ASSERT_MESSAGE("Small partition not found", exist);
 
@@ -584,7 +585,8 @@ void TestNetworkJobs::testDownload() {
         // Check that the file has been copied
         bool exists = false;
         IoError error = IoError::Success;
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(localDestFilePath, exists, error) && exists);
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(localDestFilePath, exists, error, IoHelper::PathCheckOption::Insensitive) &&
+                       exists);
 
         // Check that the tmp file has been deleted
         CPPUNIT_ASSERT(std::filesystem::is_empty(temporaryDirectory.path()));
@@ -593,7 +595,7 @@ void TestNetworkJobs::testDownload() {
         {
             FileStat fileStat;
             IoError ioError = IoError::Success;
-            IoHelper::getFileStat(localDestFilePath, &fileStat, ioError);
+            IoHelper::getFileStat(localDestFilePath, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive);
             CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
 #if defined(KD_MACOS) or defined(KD_WINDOWS)
             CPPUNIT_ASSERT_EQUAL(fileStat.creationTime, creationTimeIn.count());
@@ -624,7 +626,8 @@ void TestNetworkJobs::testDownload() {
         // Check that the file has been copied
         bool exists = false;
         IoError error = IoError::Success;
-        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(localDestFilePath, exists, error) && exists);
+        CPPUNIT_ASSERT(IoHelper::checkIfPathExists(localDestFilePath, exists, error, IoHelper::PathCheckOption::Insensitive) &&
+                       exists);
 
         // Check that the tmp file has been deleted
         CPPUNIT_ASSERT(std::filesystem::is_empty(temporaryDirectory.path()));
@@ -633,7 +636,7 @@ void TestNetworkJobs::testDownload() {
         {
             FileStat fileStat;
             IoError ioError = IoError::Success;
-            IoHelper::getFileStat(localDestFilePath, &fileStat, ioError);
+            IoHelper::getFileStat(localDestFilePath, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive);
             CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
 #if defined(KD_MACOS) or defined(KD_WINDOWS)
             CPPUNIT_ASSERT_EQUAL(fileStat.creationTime, creationTimeIn.count());
@@ -671,7 +674,7 @@ void TestNetworkJobs::testDownload() {
         {
             FileStat fileStat;
             IoError ioError = IoError::Success;
-            IoHelper::getFileStat(localDestFilePath, &fileStat, ioError);
+            IoHelper::getFileStat(localDestFilePath, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive);
             CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
             CPPUNIT_ASSERT_EQUAL(fileStat.creationTime, creationTimeIn.count());
             CPPUNIT_ASSERT_EQUAL(fileStat.modificationTime, modificationTimeIn.count());
@@ -1120,7 +1123,7 @@ void TestNetworkJobs::testUpload(const SyncTime creationTimeIn, const SyncTime m
 
     bool exist = false;
     FileStat fileStat;
-    IoHelper::getFileStat(localFilePath, &fileStat, exist);
+    IoHelper::getFileStat(localFilePath, &fileStat, exist, IoHelper::PathCheckOption::Insensitive);
 
     const RemoteTemporaryDirectory remoteTmpDir(_driveDbId, _remoteDirId, "testUpload");
     UploadJob job(nullptr, _driveDbId, localFilePath, localFilePath.filename().native(), remoteTmpDir.id(), creationTimeIn,
@@ -1268,7 +1271,7 @@ void TestNetworkJobs::testDriveUploadSessionSynchronous() {
     const SyncPath localFilePath = testhelpers::generateBigFile(localTmpDir.path(), 97);
     bool exist = false;
     FileStat fileStat;
-    IoHelper::getFileStat(localFilePath, &fileStat, exist);
+    IoHelper::getFileStat(localFilePath, &fileStat, exist, IoHelper::PathCheckOption::Insensitive);
 
     DriveUploadSession driveUploadSessionJobCreate(nullptr, _driveDbId, nullptr, localFilePath, localFilePath.filename().native(),
                                                    remoteTmpDir.id(), fileStat.creationTime, fileStat.modificationTime, false, 1);
@@ -1283,7 +1286,7 @@ void TestNetworkJobs::testDriveUploadSessionSynchronous() {
     LOGW_DEBUG(Log::instance()->getLogger(), L"$$$$$ testDriveUploadSessionSynchronous Edit");
 
     testhelpers::generateOrEditTestFile(localFilePath);
-    IoHelper::getFileStat(localFilePath, &fileStat, exist);
+    IoHelper::getFileStat(localFilePath, &fileStat, exist, IoHelper::PathCheckOption::Insensitive);
 
     DriveUploadSession driveUploadSessionJobEdit(nullptr, _driveDbId, nullptr, localFilePath,
                                                  driveUploadSessionJobCreate.nodeId(), fileStat.modificationTime, false, 1);
@@ -1317,7 +1320,7 @@ void TestNetworkJobs::testDriveUploadSessionAsynchronous() {
 
     bool exist = false;
     FileStat fileStat;
-    IoHelper::getFileStat(localFilePath, &fileStat, exist);
+    IoHelper::getFileStat(localFilePath, &fileStat, exist, IoHelper::PathCheckOption::Insensitive);
 
     DriveUploadSession driveUploadSessionJobEdit(nullptr, _driveDbId, nullptr, localFilePath,
                                                  driveUploadSessionJobCreate.nodeId(), testhelpers::defaultTime + 1, false, 3);
@@ -1528,7 +1531,7 @@ bool TestNetworkJobs::createTestFiles() {
     // Extract local file ID
     FileStat fileStat;
     IoError ioError = IoError::Success;
-    IoHelper::getFileStat(_dummyLocalFilePath, &fileStat, ioError);
+    IoHelper::getFileStat(_dummyLocalFilePath, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive);
     CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
     _dummyLocalFileId = std::to_string(fileStat.inode);
 

--- a/test/libsyncengine/propagation/executor/testexecutorworker.cpp
+++ b/test/libsyncengine/propagation/executor/testexecutorworker.cpp
@@ -642,7 +642,7 @@ void TestExecutorWorker::testFixModificationDate() {
 
     FileStat filestat;
     IoError ioError = IoError::Unknown;
-    IoHelper::getFileStat(path, &filestat, ioError);
+    IoHelper::getFileStat(path, &filestat, ioError, IoHelper::PathCheckOption::Insensitive);
 
     CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
     CPPUNIT_ASSERT_EQUAL(testhelpers::defaultTime, filestat.modificationTime);

--- a/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.cpp
+++ b/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.cpp
@@ -64,7 +64,7 @@ void TestLocalFileSystemObserverWorker::setUp() {
         testhelpers::generateOrEditTestFile(filepath);
         FileStat fileStat;
         bool exists = false;
-        IoHelper::getFileStat(filepath, &fileStat, exists);
+        IoHelper::getFileStat(filepath, &fileStat, exists, IoHelper::PathCheckOption::Insensitive);
         _testFiles.emplace_back(std::to_string(fileStat.inode), filepath);
     }
 
@@ -181,7 +181,7 @@ void TestLocalFileSystemObserverWorker::testLFSOWithFiles() {
 
         FileStat fileStat;
         bool exists = false;
-        IoHelper::getFileStat(testAbsolutePath, &fileStat, exists);
+        IoHelper::getFileStat(testAbsolutePath, &fileStat, exists, IoHelper::PathCheckOption::Insensitive);
         itemId = std::to_string(fileStat.inode);
         _syncPal->copySnapshots();
         CPPUNIT_ASSERT(_syncPal->liveSnapshot(ReplicaSide::Local).exists(itemId));
@@ -281,7 +281,7 @@ void TestLocalFileSystemObserverWorker::testLFSOWithDuplicateFileNames() {
     FileStat fileStat;
     bool exists = false;
 
-    IoHelper::getFileStat(_rootFolderPath / makeNfcSyncName(), &fileStat, exists);
+    IoHelper::getFileStat(_rootFolderPath / makeNfcSyncName(), &fileStat, exists, IoHelper::PathCheckOption::Insensitive);
     const NodeId nfcNamedItemId = std::to_string(fileStat.inode);
     CPPUNIT_ASSERT(_syncPal->liveSnapshot(ReplicaSide::Local).exists(nfcNamedItemId));
 
@@ -290,7 +290,7 @@ void TestLocalFileSystemObserverWorker::testLFSOWithDuplicateFileNames() {
     generateOrEditTestFile(_rootFolderPath / makeNfdSyncName()); // Should replace the NFC item in the snapshot.
     slowObserver->waitForUpdate(previousRevision);
 
-    IoHelper::getFileStat(_rootFolderPath / makeNfdSyncName(), &fileStat, exists);
+    IoHelper::getFileStat(_rootFolderPath / makeNfdSyncName(), &fileStat, exists, IoHelper::PathCheckOption::Insensitive);
     const NodeId nfdNamedItemId = std::to_string(fileStat.inode);
 
     // Check that only the last modified item is in the snapshot.
@@ -318,7 +318,7 @@ void TestLocalFileSystemObserverWorker::testLFSOWithDirs() {
 
         FileStat fileStat;
         bool exists = false;
-        IoHelper::getFileStat(testAbsolutePath, &fileStat, exists);
+        IoHelper::getFileStat(testAbsolutePath, &fileStat, exists, IoHelper::PathCheckOption::Insensitive);
         itemId = std::to_string(fileStat.inode);
         CPPUNIT_ASSERT(_syncPal->liveSnapshot(ReplicaSide::Local).exists(itemId));
         SyncPath path;
@@ -374,12 +374,12 @@ void TestLocalFileSystemObserverWorker::testLFSOWithDirs() {
 
         FileStat fileStat;
         bool exists = false;
-        IoHelper::getFileStat(destinationPath, &fileStat, exists);
+        IoHelper::getFileStat(destinationPath, &fileStat, exists, IoHelper::PathCheckOption::Insensitive);
         itemId = std::to_string(fileStat.inode);
         CPPUNIT_ASSERT(_syncPal->liveSnapshot(ReplicaSide::Local).exists(itemId));
 
         testAbsolutePath = destinationPath / Str("test0.txt");
-        IoHelper::getFileStat(testAbsolutePath, &fileStat, exists);
+        IoHelper::getFileStat(testAbsolutePath, &fileStat, exists, IoHelper::PathCheckOption::Insensitive);
         itemId = std::to_string(fileStat.inode);
         CPPUNIT_ASSERT(_syncPal->liveSnapshot(ReplicaSide::Local).exists(itemId));
     }
@@ -409,14 +409,14 @@ void TestLocalFileSystemObserverWorker::testLFSOWithSpecialCases1() {
     //// delete
     FileStat fileStat;
     bool exists = false;
-    IoHelper::getFileStat(sourcePath, &fileStat, exists);
+    IoHelper::getFileStat(sourcePath, &fileStat, exists, IoHelper::PathCheckOption::Insensitive);
     NodeId initItemId = std::to_string(fileStat.inode);
 
     auto ioError = IoError::Unknown;
     IoHelper::deleteItem(sourcePath, ioError);
     //// create
     KDC::testhelpers::generateOrEditTestFile(sourcePath);
-    IoHelper::getFileStat(sourcePath, &fileStat, exists);
+    IoHelper::getFileStat(sourcePath, &fileStat, exists, IoHelper::PathCheckOption::Insensitive);
     NodeId newItemId = std::to_string(fileStat.inode);
     //// edit
     KDC::testhelpers::generateOrEditTestFile(sourcePath);
@@ -440,14 +440,14 @@ void TestLocalFileSystemObserverWorker::testLFSOWithSpecialCases2() {
     //// move
     FileStat fileStat;
     bool exists = false;
-    IoHelper::getFileStat(sourcePath, &fileStat, exists);
+    IoHelper::getFileStat(sourcePath, &fileStat, exists, IoHelper::PathCheckOption::Insensitive);
     NodeId initItemId = std::to_string(fileStat.inode);
 
     auto ioError = IoError::Unknown;
     IoHelper::moveItem(sourcePath, destinationPath, ioError);
     //// create
     KDC::testhelpers::generateOrEditTestFile(sourcePath);
-    IoHelper::getFileStat(sourcePath, &fileStat, exists);
+    IoHelper::getFileStat(sourcePath, &fileStat, exists, IoHelper::PathCheckOption::Insensitive);
     NodeId newItemId = std::to_string(fileStat.inode);
     //// edit
     KDC::testhelpers::generateOrEditTestFile(sourcePath);
@@ -504,7 +504,8 @@ void TestLocalFileSystemObserverWorker::testLFSOFastMoveDeleteMove() { // MS Off
     slowObserver->waitForUpdate(previousRevision);
 
     FileStat fileStat;
-    CPPUNIT_ASSERT_MESSAGE(toString(ioError), IoHelper::getFileStat(_testFiles[0].second, &fileStat, ioError));
+    CPPUNIT_ASSERT_MESSAGE(toString(ioError), IoHelper::getFileStat(_testFiles[0].second, &fileStat, ioError,
+                                                                    IoHelper::PathCheckOption::Insensitive));
     CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
 
     CPPUNIT_ASSERT(!_syncPal->liveSnapshot(ReplicaSide::Local).exists(_testFiles[0].first));
@@ -544,7 +545,7 @@ void TestLocalFileSystemObserverWorker::testLFSOFastMoveDeleteMoveWithEncodingCh
 
     SnapshotRevision previousRevision = _syncPal->liveSnapshot(ReplicaSide::Local).revision();
     generateOrEditTestFile(nfcFilePath);
-    IoHelper::getFileStat(nfcFilePath, &fileStat, exists);
+    IoHelper::getFileStat(nfcFilePath, &fileStat, exists, IoHelper::PathCheckOption::Insensitive);
     NodeId nfcFileId = std::to_string(fileStat.inode);
 
     // Prepare the path of the NFD encoded file.
@@ -572,7 +573,8 @@ void TestLocalFileSystemObserverWorker::testLFSOFastMoveDeleteMoveWithEncodingCh
 
     slowObserver->waitForUpdate(previousRevision);
 
-    CPPUNIT_ASSERT_MESSAGE(toString(ioError), IoHelper::getFileStat(nfdFilePath, &fileStat, ioError));
+    CPPUNIT_ASSERT_MESSAGE(toString(ioError),
+                           IoHelper::getFileStat(nfdFilePath, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
     CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
     NodeId nfdFileId = std::to_string(fileStat.inode);
 

--- a/test/test_utility/localtemporarydirectory.cpp
+++ b/test/test_utility/localtemporarydirectory.cpp
@@ -46,7 +46,7 @@ LocalTemporaryDirectory::LocalTemporaryDirectory(const std::string &testType, co
     _path = std::filesystem::canonical(_path); // Follows symlinks to work around the symlink /var -> private/var on MacOSX.
     FileStat fileStat;
     IoError ioError = IoError::Success;
-    IoHelper::getFileStat(_path, &fileStat, ioError);
+    IoHelper::getFileStat(_path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive);
     _id = std::to_string(fileStat.inode);
 }
 


### PR DESCRIPTION
Issue on macOS with IoHelper::getFileStatus non case/encoding sensitive in LocalFileSystemObserverWorker::changesDetected.