### PR TITLE
fix(progressinfo): make _currentItems thread-safe

### DIFF
--- a/src/libsyncengine/progress/progressinfo.cpp
+++ b/src/libsyncengine/progress/progressinfo.cpp
@@ -31,7 +31,7 @@ ProgressInfo::~ProgressInfo() {
 }
 
 void ProgressInfo::reset() {
-    std::scoped_lock lock(_currentItemsMutex);
+    std::scoped_lock lock(_mutex);
     _currentItems.clear();
     _sizeProgress = Progress();
     _fileProgress = Progress();
@@ -61,20 +61,19 @@ void ProgressInfo::updateEstimates() {
     if (!_update) {
         return;
     }
-
+    std::scoped_lock lock(_mutex);
     _sizeProgress.update();
     _fileProgress.update();
 
     // Update progress of all running items.
-    {
-        std::scoped_lock lock(_currentItemsMutex);
-        for (auto &item: _currentItems) {
-            if (item.second.empty()) {
-                continue;
-            }
-            item.second.front().progress().update();
+
+    for (auto &item: _currentItems) {
+        if (item.second.empty()) {
+            continue;
         }
+        item.second.front().progress().update();
     }
+
     _maxFilesPerSecond = std::max(_fileProgress.progressPerSec(), _maxFilesPerSecond);
     _maxBytesPerSecond = std::max(_sizeProgress.progressPerSec(), _maxBytesPerSecond);
 }
@@ -92,10 +91,10 @@ bool ProgressInfo::initProgress(const SyncFileItem &item) {
         return false;
     }
 
-    {
-        std::scoped_lock lock(_currentItemsMutex);
-        _currentItems[normalizedPath].push(progressItem);
-    }
+
+    std::scoped_lock lock(_mutex);
+    _currentItems[normalizedPath].push(progressItem);
+
     _fileProgress.setTotal(_fileProgress.total() + 1);
     _sizeProgress.setTotal(_sizeProgress.total() + item.size());
     return true;
@@ -108,7 +107,7 @@ bool ProgressInfo::getSyncFileItem(const SyncPath &path, SyncFileItem &item) {
         return false;
     }
 
-    std::scoped_lock lock(_currentItemsMutex);
+    std::scoped_lock lock(_mutex);
     const auto it = _currentItems.find(normalizedPath);
     if (it == _currentItems.end() || it->second.empty()) {
         return false;
@@ -124,7 +123,7 @@ bool ProgressInfo::setProgress(const SyncPath &path, int progress) {
         return false;
     }
 
-    std::scoped_lock lock(_currentItemsMutex);
+    std::scoped_lock lock(_mutex);
     const auto it = _currentItems.find(normalizedPath);
     if (it == _currentItems.end() || it->second.empty()) {
         return true;
@@ -152,7 +151,7 @@ bool ProgressInfo::setProgressComplete(const SyncPath &path, const SyncFileStatu
         return false;
     }
 
-    std::scoped_lock lock(_currentItemsMutex);
+    std::scoped_lock lock(_mutex);
     const auto it = _currentItems.find(normalizedPath);
     if (it == _currentItems.end() || it->second.empty()) {
         LOGW_INFO(Log::instance()->getLogger(),
@@ -192,7 +191,7 @@ bool ProgressInfo::setSyncFileItemRemoteId(const SyncPath &path, const NodeId &r
         LOGW_WARN(Log::instance()->getLogger(), L"Error in Utility::normalizedSyncPath: " << Utility::formatSyncPath(path));
         return false;
     }
-    std::scoped_lock lock(_currentItemsMutex);
+    std::scoped_lock lock(_mutex);
     const auto it = _currentItems.find(normalizedPath);
     if (it == _currentItems.end() || it->second.empty()) {
         LOGW_INFO(Log::instance()->getLogger(),
@@ -212,6 +211,7 @@ bool ProgressInfo::isSizeDependent(const SyncFileItem &item) const {
 }
 
 Estimates ProgressInfo::totalProgress() const {
+    std::scoped_lock lock(_mutex);
     Estimates file = _fileProgress.estimates();
     if (_sizeProgress.total() == 0) {
         return file;
@@ -240,6 +240,7 @@ Estimates ProgressInfo::totalProgress() const {
 }
 
 int64_t ProgressInfo::optimisticEta() const {
+    std::scoped_lock lock(_mutex);
     return static_cast<int64_t>(static_cast<double>(_fileProgress.remaining()) / _maxFilesPerSecond * 1000 +
                                 static_cast<double>(_sizeProgress.remaining()) / _maxBytesPerSecond * 1000);
 }
@@ -249,7 +250,7 @@ bool ProgressInfo::trustEta() const {
 }
 
 void ProgressInfo::recomputeCompletedSize() {
-    std::scoped_lock lock(_currentItemsMutex);
+    std::scoped_lock lock(_mutex);
     int64_t r = _totalSizeOfCompletedJobs;
     for (auto &itemElt: _currentItems) {
         if (isSizeDependent(itemElt.second.front().item())) {

--- a/src/libsyncengine/progress/progressinfo.cpp
+++ b/src/libsyncengine/progress/progressinfo.cpp
@@ -30,6 +30,16 @@ ProgressInfo::~ProgressInfo() {
     LOG_DEBUG(Log::instance()->getLogger(), "~ProgressInfo");
 }
 
+auto ProgressInfo::GetItemIterator(const SyncPath &path) {
+    // The caller must acquire a lock on _mutex before calling this method.
+    SyncPath normalizedPath;
+    if (!Utility::normalizedSyncPath(path, normalizedPath)) {
+        LOGW_WARN(Log::instance()->getLogger(), L"Error in Utility::normalizedSyncPath: " << Utility::formatSyncPath(path));
+        return _currentItems.end();
+    }
+    return _currentItems.find(normalizedPath);
+}
+
 void ProgressInfo::reset() {
     const std::scoped_lock lock(_mutex);
     _currentItems.clear();
@@ -101,14 +111,8 @@ bool ProgressInfo::initProgress(const SyncFileItem &item) {
 }
 
 bool ProgressInfo::getSyncFileItem(const SyncPath &path, SyncFileItem &item) {
-    SyncPath normalizedPath;
-    if (!Utility::normalizedSyncPath(path, normalizedPath)) {
-        LOGW_WARN(Log::instance()->getLogger(), L"Error in Utility::normalizedSyncPath: " << Utility::formatSyncPath(path));
-        return false;
-    }
-
     const std::scoped_lock lock(_mutex);
-    const auto it = _currentItems.find(normalizedPath);
+    const auto it = GetItemIterator(path);
     if (it == _currentItems.end() || it->second.empty()) {
         return false;
     }
@@ -117,14 +121,8 @@ bool ProgressInfo::getSyncFileItem(const SyncPath &path, SyncFileItem &item) {
 }
 
 bool ProgressInfo::setProgress(const SyncPath &path, int progress) {
-    SyncPath normalizedPath;
-    if (!Utility::normalizedSyncPath(path, normalizedPath)) {
-        LOGW_WARN(Log::instance()->getLogger(), L"Error in Utility::normalizedSyncPath: " << Utility::formatSyncPath(path));
-        return false;
-    }
-
     const std::scoped_lock lock(_mutex);
-    const auto it = _currentItems.find(normalizedPath);
+    const auto it = GetItemIterator(path);
     if (it == _currentItems.end() || it->second.empty()) {
         return true;
     }
@@ -145,14 +143,8 @@ bool ProgressInfo::setProgress(const SyncPath &path, int progress) {
 }
 
 bool ProgressInfo::setProgressComplete(const SyncPath &path, const SyncFileStatus status) {
-    SyncPath normalizedPath;
-    if (!Utility::normalizedSyncPath(path, normalizedPath)) {
-        LOGW_WARN(Log::instance()->getLogger(), L"Error in Utility::normalizedSyncPath: " << Utility::formatSyncPath(path));
-        return false;
-    }
-
     const std::scoped_lock lock(_mutex);
-    const auto it = _currentItems.find(normalizedPath);
+    const auto it = GetItemIterator(path);
     if (it == _currentItems.end() || it->second.empty()) {
         LOGW_INFO(Log::instance()->getLogger(),
                   L"Item not found in ProgressInfo list (normal for ommited operation): " << Utility::formatSyncPath(path));
@@ -176,6 +168,7 @@ bool ProgressInfo::setProgressComplete(const SyncPath &path, const SyncFileStatu
 
     it->second.pop();
     if (it->second.empty()) {
+        const auto normalizedPath = it->first;
         _currentItems.erase(normalizedPath);
     }
 
@@ -186,13 +179,8 @@ bool ProgressInfo::setProgressComplete(const SyncPath &path, const SyncFileStatu
 }
 
 bool ProgressInfo::setSyncFileItemRemoteId(const SyncPath &path, const NodeId &remoteId) {
-    SyncPath normalizedPath;
-    if (!Utility::normalizedSyncPath(path, normalizedPath)) {
-        LOGW_WARN(Log::instance()->getLogger(), L"Error in Utility::normalizedSyncPath: " << Utility::formatSyncPath(path));
-        return false;
-    }
     const std::scoped_lock lock(_mutex);
-    const auto it = _currentItems.find(normalizedPath);
+    const auto it = GetItemIterator(path);
     if (it == _currentItems.end() || it->second.empty()) {
         LOGW_INFO(Log::instance()->getLogger(),
                   L"Item not found in ProgressInfo list (normal for omitted operation): " << Utility::formatSyncPath(path));

--- a/src/libsyncengine/progress/progressinfo.cpp
+++ b/src/libsyncengine/progress/progressinfo.cpp
@@ -31,6 +31,7 @@ ProgressInfo::~ProgressInfo() {
 }
 
 void ProgressInfo::reset() {
+    std::scoped_lock lock(_currentItemsMutex);
     _currentItems.clear();
     _sizeProgress = Progress();
     _fileProgress = Progress();
@@ -65,13 +66,15 @@ void ProgressInfo::updateEstimates() {
     _fileProgress.update();
 
     // Update progress of all running items.
-    for (auto &item: _currentItems) {
-        if (item.second.empty()) {
-            continue;
+    {
+        std::scoped_lock lock(_currentItemsMutex);
+        for (auto &item: _currentItems) {
+            if (item.second.empty()) {
+                continue;
+            }
+            item.second.front().progress().update();
         }
-        item.second.front().progress().update();
     }
-
     _maxFilesPerSecond = std::max(_fileProgress.progressPerSec(), _maxFilesPerSecond);
     _maxBytesPerSecond = std::max(_sizeProgress.progressPerSec(), _maxBytesPerSecond);
 }
@@ -89,8 +92,10 @@ bool ProgressInfo::initProgress(const SyncFileItem &item) {
         return false;
     }
 
-    _currentItems[normalizedPath].push(progressItem);
-
+    {
+        std::scoped_lock lock(_currentItemsMutex);
+        _currentItems[normalizedPath].push(progressItem);
+    }
     _fileProgress.setTotal(_fileProgress.total() + 1);
     _sizeProgress.setTotal(_sizeProgress.total() + item.size());
     return true;
@@ -103,6 +108,7 @@ bool ProgressInfo::getSyncFileItem(const SyncPath &path, SyncFileItem &item) {
         return false;
     }
 
+    std::scoped_lock lock(_currentItemsMutex);
     const auto it = _currentItems.find(normalizedPath);
     if (it == _currentItems.end() || it->second.empty()) {
         return false;
@@ -118,6 +124,7 @@ bool ProgressInfo::setProgress(const SyncPath &path, int progress) {
         return false;
     }
 
+    std::scoped_lock lock(_currentItemsMutex);
     const auto it = _currentItems.find(normalizedPath);
     if (it == _currentItems.end() || it->second.empty()) {
         return true;
@@ -145,6 +152,7 @@ bool ProgressInfo::setProgressComplete(const SyncPath &path, const SyncFileStatu
         return false;
     }
 
+    std::scoped_lock lock(_currentItemsMutex);
     const auto it = _currentItems.find(normalizedPath);
     if (it == _currentItems.end() || it->second.empty()) {
         LOGW_INFO(Log::instance()->getLogger(),
@@ -184,6 +192,7 @@ bool ProgressInfo::setSyncFileItemRemoteId(const SyncPath &path, const NodeId &r
         LOGW_WARN(Log::instance()->getLogger(), L"Error in Utility::normalizedSyncPath: " << Utility::formatSyncPath(path));
         return false;
     }
+    std::scoped_lock lock(_currentItemsMutex);
     const auto it = _currentItems.find(normalizedPath);
     if (it == _currentItems.end() || it->second.empty()) {
         LOGW_INFO(Log::instance()->getLogger(),
@@ -240,6 +249,7 @@ bool ProgressInfo::trustEta() const {
 }
 
 void ProgressInfo::recomputeCompletedSize() {
+    std::scoped_lock lock(_currentItemsMutex);
     int64_t r = _totalSizeOfCompletedJobs;
     for (auto &itemElt: _currentItems) {
         if (isSizeDependent(itemElt.second.front().item())) {

--- a/src/libsyncengine/progress/progressinfo.cpp
+++ b/src/libsyncengine/progress/progressinfo.cpp
@@ -31,7 +31,7 @@ ProgressInfo::~ProgressInfo() {
 }
 
 void ProgressInfo::reset() {
-    std::scoped_lock lock(_mutex);
+    const std::scoped_lock lock(_mutex);
     _currentItems.clear();
     _sizeProgress = Progress();
     _fileProgress = Progress();
@@ -61,7 +61,7 @@ void ProgressInfo::updateEstimates() {
     if (!_update) {
         return;
     }
-    std::scoped_lock lock(_mutex);
+    const std::scoped_lock lock(_mutex);
     _sizeProgress.update();
     _fileProgress.update();
 
@@ -92,7 +92,7 @@ bool ProgressInfo::initProgress(const SyncFileItem &item) {
     }
 
 
-    std::scoped_lock lock(_mutex);
+    const std::scoped_lock lock(_mutex);
     _currentItems[normalizedPath].push(progressItem);
 
     _fileProgress.setTotal(_fileProgress.total() + 1);
@@ -107,7 +107,7 @@ bool ProgressInfo::getSyncFileItem(const SyncPath &path, SyncFileItem &item) {
         return false;
     }
 
-    std::scoped_lock lock(_mutex);
+    const std::scoped_lock lock(_mutex);
     const auto it = _currentItems.find(normalizedPath);
     if (it == _currentItems.end() || it->second.empty()) {
         return false;
@@ -123,7 +123,7 @@ bool ProgressInfo::setProgress(const SyncPath &path, int progress) {
         return false;
     }
 
-    std::scoped_lock lock(_mutex);
+    const std::scoped_lock lock(_mutex);
     const auto it = _currentItems.find(normalizedPath);
     if (it == _currentItems.end() || it->second.empty()) {
         return true;
@@ -151,7 +151,7 @@ bool ProgressInfo::setProgressComplete(const SyncPath &path, const SyncFileStatu
         return false;
     }
 
-    std::scoped_lock lock(_mutex);
+    const std::scoped_lock lock(_mutex);
     const auto it = _currentItems.find(normalizedPath);
     if (it == _currentItems.end() || it->second.empty()) {
         LOGW_INFO(Log::instance()->getLogger(),
@@ -191,7 +191,7 @@ bool ProgressInfo::setSyncFileItemRemoteId(const SyncPath &path, const NodeId &r
         LOGW_WARN(Log::instance()->getLogger(), L"Error in Utility::normalizedSyncPath: " << Utility::formatSyncPath(path));
         return false;
     }
-    std::scoped_lock lock(_mutex);
+    const std::scoped_lock lock(_mutex);
     const auto it = _currentItems.find(normalizedPath);
     if (it == _currentItems.end() || it->second.empty()) {
         LOGW_INFO(Log::instance()->getLogger(),
@@ -211,7 +211,7 @@ bool ProgressInfo::isSizeDependent(const SyncFileItem &item) const {
 }
 
 Estimates ProgressInfo::totalProgress() const {
-    std::scoped_lock lock(_mutex);
+    const std::scoped_lock lock(_mutex);
     Estimates file = _fileProgress.estimates();
     if (_sizeProgress.total() == 0) {
         return file;
@@ -240,7 +240,7 @@ Estimates ProgressInfo::totalProgress() const {
 }
 
 int64_t ProgressInfo::optimisticEta() const {
-    std::scoped_lock lock(_mutex);
+    const std::scoped_lock lock(_mutex);
     return static_cast<int64_t>(static_cast<double>(_fileProgress.remaining()) / _maxFilesPerSecond * 1000 +
                                 static_cast<double>(_sizeProgress.remaining()) / _maxBytesPerSecond * 1000);
 }
@@ -250,7 +250,7 @@ bool ProgressInfo::trustEta() const {
 }
 
 void ProgressInfo::recomputeCompletedSize() {
-    std::scoped_lock lock(_mutex);
+    const std::scoped_lock lock(_mutex);
     int64_t r = _totalSizeOfCompletedJobs;
     for (auto &itemElt: _currentItems) {
         if (isSizeDependent(itemElt.second.front().item())) {

--- a/src/libsyncengine/progress/progressinfo.h
+++ b/src/libsyncengine/progress/progressinfo.h
@@ -49,23 +49,23 @@ class ProgressInfo {
         [[nodiscard]] bool getSyncFileItem(const SyncPath &path, SyncFileItem &item);
 
         [[nodiscard]] int64_t totalFiles() const {
-            std::scoped_lock lock(_mutex);
+            const std::scoped_lock lock(_mutex);
             return _fileProgress.total();
         }
         [[nodiscard]] int64_t completedFiles() const {
-            std::scoped_lock lock(_mutex);
+            const std::scoped_lock lock(_mutex);
             return _fileProgress.completed();
         }
         [[nodiscard]] int64_t totalSize() const {
-            std::scoped_lock lock(_mutex);
+            const std::scoped_lock lock(_mutex);
             return _sizeProgress.total();
         }
         [[nodiscard]] int64_t completedSize() const {
-            std::scoped_lock lock(_mutex);
+            const std::scoped_lock lock(_mutex);
             return _sizeProgress.completed();
         }
         [[nodiscard]] int64_t currentFile() const {
-            std::scoped_lock lock(_mutex);
+            const std::scoped_lock lock(_mutex);
             return completedFiles();
         }
         [[nodiscard]] Estimates totalProgress() const;

--- a/src/libsyncengine/progress/progressinfo.h
+++ b/src/libsyncengine/progress/progressinfo.h
@@ -47,7 +47,7 @@ class ProgressInfo {
         [[nodiscard]] bool setProgressComplete(const SyncPath &path, SyncFileStatus status);
         [[nodiscard]] bool setSyncFileItemRemoteId(const SyncPath &path, const NodeId &remoteId);
         [[nodiscard]] bool getSyncFileItem(const SyncPath &path, SyncFileItem &item);
-
+        [[nodiscard]] auto GetItemIterator(const SyncPath &path);
         [[nodiscard]] int64_t totalFiles() const {
             const std::scoped_lock lock(_mutex);
             return _fileProgress.total();

--- a/src/libsyncengine/progress/progressinfo.h
+++ b/src/libsyncengine/progress/progressinfo.h
@@ -72,7 +72,7 @@ class ProgressInfo {
 
     private:
         std::shared_ptr<SyncPal> _syncPal;
-        std::recursive_mutex _mutex;
+        mutable std::recursive_mutex _mutex;
         std::map<SyncPath, std::queue<ProgressItem>>
                 _currentItems; // Use a queue here because in a few cases, we can have several operations on the same path (e.g.:
                                // DELETE a file and CREATE a directory with exact same name)

--- a/src/libsyncengine/progress/progressinfo.h
+++ b/src/libsyncengine/progress/progressinfo.h
@@ -56,6 +56,7 @@ class ProgressInfo {
 
     private:
         std::shared_ptr<SyncPal> _syncPal;
+        std::recursive_mutex _currentItemsMutex;
         std::map<SyncPath, std::queue<ProgressItem>>
                 _currentItems; // Use a queue here because in a few cases, we can have several operations on the same path (e.g.:
                                // DELETE a file and CREATE a directory with exact same name)

--- a/src/libsyncengine/progress/progressinfo.h
+++ b/src/libsyncengine/progress/progressinfo.h
@@ -27,6 +27,7 @@
 #include <map>
 #include <queue>
 #include <list>
+#include <mutex>
 
 namespace KDC {
 
@@ -47,16 +48,31 @@ class ProgressInfo {
         [[nodiscard]] bool setSyncFileItemRemoteId(const SyncPath &path, const NodeId &remoteId);
         [[nodiscard]] bool getSyncFileItem(const SyncPath &path, SyncFileItem &item);
 
-        [[nodiscard]] int64_t totalFiles() const { return _fileProgress.total(); }
-        [[nodiscard]] int64_t completedFiles() const { return _fileProgress.completed(); }
-        [[nodiscard]] int64_t totalSize() const { return _sizeProgress.total(); }
-        [[nodiscard]] int64_t completedSize() const { return _sizeProgress.completed(); }
-        [[nodiscard]] int64_t currentFile() const { return completedFiles(); }
+        [[nodiscard]] int64_t totalFiles() const {
+            std::scoped_lock lock(_mutex);
+            return _fileProgress.total();
+        }
+        [[nodiscard]] int64_t completedFiles() const {
+            std::scoped_lock lock(_mutex);
+            return _fileProgress.completed();
+        }
+        [[nodiscard]] int64_t totalSize() const {
+            std::scoped_lock lock(_mutex);
+            return _sizeProgress.total();
+        }
+        [[nodiscard]] int64_t completedSize() const {
+            std::scoped_lock lock(_mutex);
+            return _sizeProgress.completed();
+        }
+        [[nodiscard]] int64_t currentFile() const {
+            std::scoped_lock lock(_mutex);
+            return completedFiles();
+        }
         [[nodiscard]] Estimates totalProgress() const;
 
     private:
         std::shared_ptr<SyncPal> _syncPal;
-        std::recursive_mutex _currentItemsMutex;
+        std::recursive_mutex _mutex;
         std::map<SyncPath, std::queue<ProgressItem>>
                 _currentItems; // Use a queue here because in a few cases, we can have several operations on the same path (e.g.:
                                // DELETE a file and CREATE a directory with exact same name)


### PR DESCRIPTION
Added a recursive mutex to protect _currentItems access and modifications in ProgressInfo, ensuring thread safety across all relevant methods. This prevents race conditions during concurrent operations.