### PR TITLE
test: Observable available drive mechanism

### DIFF
--- a/.github/workflows/macos-redesign.yml
+++ b/.github/workflows/macos-redesign.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           working_directory: src/front/macOS
       - name: SwiftFormat
-        run: swiftformat --lint . --reporter github-actions-log --reporter json
+        run: swiftformat --lint . --reporter github-actions-log
 
   periphery:
     name: Periphery

--- a/.github/workflows/macos-redesign.yml
+++ b/.github/workflows/macos-redesign.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           working_directory: src/front/macOS
       - name: SwiftFormat
-        run: swiftformat --lint . --reporter github-actions-log
+        run: swiftformat --lint . --reporter github-actions-log --reporter json
 
   periphery:
     name: Periphery

--- a/src/front/macOS/kDrive.xcodeproj/project.pbxproj
+++ b/src/front/macOS/kDrive.xcodeproj/project.pbxproj
@@ -121,6 +121,7 @@
 			membershipExceptions = (
 				Cache/CoherentCacheTests/CacheData.swift,
 				Cache/CoherentCacheTests/CoherentCacheAccountTests.swift,
+				Cache/CoherentCacheTests/CoherentCacheAvailableDriveTests.swift,
 				Cache/CoherentCacheTests/CoherentCacheDriveTests.swift,
 				Cache/CoherentCacheTests/CoherentCacheErrorTests.swift,
 				Cache/CoherentCacheTests/CoherentCacheSynchroTests.swift,

--- a/src/front/macOS/kDrive.xcodeproj/project.pbxproj
+++ b/src/front/macOS/kDrive.xcodeproj/project.pbxproj
@@ -130,6 +130,7 @@
 				Cache/Observation/ObservableCoherentCacheTests.swift,
 				Cache/Observation/ObservableData.swift,
 				Cache/Observation/ObservedAccountTests.swift,
+				Cache/Observation/ObservedAvailableDrivesTests.swift,
 				Cache/Observation/ObservedDrivesTests.swift,
 				Cache/Observation/ObservedDriveTests.swift,
 				Cache/Observation/ObservedSynchroNodesTests.swift,

--- a/src/front/macOS/kDrive.xcodeproj/project.pbxproj
+++ b/src/front/macOS/kDrive.xcodeproj/project.pbxproj
@@ -127,6 +127,7 @@
 				Cache/CoherentCacheTests/CoherentCacheSynchroTests.swift,
 				Cache/CoherentCacheTests/CoherentCacheUserTests.swift,
 				Cache/DTOs/SynchroTests.swift,
+				Cache/DTOs/UserUpdateTests.swift,
 				Cache/Observation/ObservableCoherentCacheTests.swift,
 				Cache/Observation/ObservableData.swift,
 				Cache/Observation/ObservedAccountTests.swift,

--- a/src/front/macOS/kDriveCore/Models/DTOs/Drive.swift
+++ b/src/front/macOS/kDriveCore/Models/DTOs/Drive.swift
@@ -59,7 +59,7 @@ public struct Drive: DriveRepresentation {
     }
 }
 
-public typealias IndexedAvailableDrives = [Int32: AvailableDrive]
+public typealias IndexedAvailableDrives = OrderedDictionary<Int32, AvailableDrive>
 
 public struct AvailableDrive: DriveRepresentation {
     public var id: Int32 {

--- a/src/front/macOS/kDriveCore/Models/DTOs/User.swift
+++ b/src/front/macOS/kDriveCore/Models/DTOs/User.swift
@@ -84,21 +84,43 @@ extension User {
 }
 
 public extension User {
-    func updated(with other: User) -> User? {
+    struct UpdateOptions: OptionSet {
+        public let rawValue: Int
+        public init(rawValue: Int) {
+            self.rawValue = rawValue
+        }
+
+        @usableFromInline static let userId = UpdateOptions(rawValue: 1 << 0)
+        @usableFromInline static let name = UpdateOptions(rawValue: 1 << 1)
+        @usableFromInline static let email = UpdateOptions(rawValue: 1 << 2)
+        @usableFromInline static let avatar = UpdateOptions(rawValue: 1 << 3)
+        @usableFromInline static let isConnected = UpdateOptions(rawValue: 1 << 4)
+        @usableFromInline static let isStaff = UpdateOptions(rawValue: 1 << 5)
+        @usableFromInline static let accounts = UpdateOptions(rawValue: 1 << 6)
+        @usableFromInline static let availableDrives = UpdateOptions(rawValue: 1 << 7)
+
+        @usableFromInline
+        static let updateSignal: UpdateOptions = [.userId, .name, .email, .avatar, .isConnected, .isStaff]
+
+        @usableFromInline
+        static let all: UpdateOptions = [.userId, .name, .email, .avatar, .isConnected, .isStaff, .accounts, .availableDrives]
+    }
+
+    func updated(with other: User, updateOptions: UpdateOptions) -> User? {
         guard other.dbId == dbId else {
             return nil
         }
 
         return User(
             dbId: dbId,
-            userId: other.userId,
-            name: other.name.isEmpty ? name : other.name,
-            email: other.email.isEmpty ? email : other.email,
-            accounts: other.accounts.isEmpty ? accounts : other.accounts,
-            availableDrives: other.availableDrives,
-            avatar: other.avatar,
-            isConnected: other.isConnected,
-            isStaff: other.isStaff
+            userId: updateOptions.contains(.userId) ? other.userId : userId,
+            name: updateOptions.contains(.name) ? other.name : name,
+            email: updateOptions.contains(.email) ? other.email : email,
+            accounts: updateOptions.contains(.accounts) ? other.accounts : accounts,
+            availableDrives: updateOptions.contains(.availableDrives) ? other.availableDrives : availableDrives,
+            avatar: updateOptions.contains(.avatar) ? other.avatar : avatar,
+            isConnected: updateOptions.contains(.isConnected) ? other.isConnected : isConnected,
+            isStaff: updateOptions.contains(.isStaff) ? other.isStaff : isStaff
         )
     }
 }

--- a/src/front/macOS/kDriveCore/Models/DTOs/User.swift
+++ b/src/front/macOS/kDriveCore/Models/DTOs/User.swift
@@ -95,7 +95,7 @@ public extension User {
             name: other.name.isEmpty ? name : other.name,
             email: other.email.isEmpty ? email : other.email,
             accounts: other.accounts.isEmpty ? accounts : other.accounts,
-            availableDrives: other.availableDrives.isEmpty ? availableDrives : other.availableDrives,
+            availableDrives: other.availableDrives,
             avatar: other.avatar,
             isConnected: other.isConnected,
             isStaff: other.isStaff

--- a/src/front/macOS/kDriveCore/ServerBridge/Cache/CoherentCache.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Cache/CoherentCache.swift
@@ -27,7 +27,7 @@ public protocol CoherentCache: Sendable {
     func getFirstAvailableUser() async -> User?
     func addUser(_ user: User) async
     func removeUser(dbId: Int32) async
-    func updateUser(_ user: User) async
+    func updateUser(_ user: User, updateOptions: User.UpdateOptions) async
     func updateAvailableDrives(_ drives: [AvailableDrive], forUserDbId accountId: Int32) async throws
 
     // MARK: - Account

--- a/src/front/macOS/kDriveCore/ServerBridge/Cache/ServerCoherentCache.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Cache/ServerCoherentCache.swift
@@ -79,9 +79,9 @@ public actor ServerCoherentCache: CoherentCache, CoherentCacheObservable {
         notifyUpdate()
     }
 
-    public func updateUser(_ user: User) {
+    public func updateUser(_ user: User, updateOptions: User.UpdateOptions) {
         if let existingUser = users[user.dbId],
-           let updatedUser = existingUser.updated(with: user) {
+           let updatedUser = existingUser.updated(with: user, updateOptions: updateOptions) {
             users[user.dbId] = updatedUser
         } else {
             users[user.dbId] = user
@@ -101,7 +101,7 @@ public actor ServerCoherentCache: CoherentCache, CoherentCacheObservable {
 
         user.availableDrives = indexedDrives
 
-        updateUser(user)
+        updateUser(user, updateOptions: .availableDrives)
     }
 
     // MARK: - ACCOUNT

--- a/src/front/macOS/kDriveCore/ServerBridge/Cache/ServerCoherentCache.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Cache/ServerCoherentCache.swift
@@ -95,8 +95,9 @@ public actor ServerCoherentCache: CoherentCache, CoherentCacheObservable {
             throw CacheError.userNotFound(userDbId)
         }
 
-        let indexedDrives: IndexedAvailableDrives = Dictionary(uniqueKeysWithValues:
-            drives.map { drive in (drive.driveId, drive) })
+        let indexedDrives = IndexedAvailableDrives(
+            uniqueKeysWithValues: drives.map { ($0.driveId, $0) }
+        )
 
         user.availableDrives = indexedDrives
 

--- a/src/front/macOS/kDriveCore/ServerBridge/Jobs/UserJobs.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Jobs/UserJobs.swift
@@ -44,7 +44,7 @@ public struct UserJobs: Sendable {
 
         let userList = decodedMessage.body.userInfoList
 
-        await userList.asyncForEach { await coherentCache.updateUser($0.userCache) }
+        await userList.asyncForEach { await coherentCache.updateUser($0.userCache, updateOptions: .all) }
 
         return userList
     }
@@ -54,7 +54,7 @@ public struct UserJobs: Sendable {
         let query = UserQuery(userDbId: dbId)
         let request = await RequestMessage<UserQuery>(num: RequestNum.USER_DELETE, body: query)
 
-        let decodedMessage = try await queryFetcher.query(request, responseType: CallbackMessage<EmptyResponse>.self)
+        _ = try await queryFetcher.query(request, responseType: CallbackMessage<EmptyResponse>.self)
 
         await coherentCache.removeUser(dbId: dbId)
     }

--- a/src/front/macOS/kDriveCore/ServerBridge/Signal/signal handlers/UserSignalHandler.swift
+++ b/src/front/macOS/kDriveCore/ServerBridge/Signal/signal handlers/UserSignalHandler.swift
@@ -29,7 +29,7 @@ struct UserSignalHandler {
         }
 
         let user = User(userInfoMetadata: userInfoSignal.body.userInfo)
-        await coherentCache.updateUser(user)
+        await coherentCache.updateUser(user, updateOptions: .updateSignal)
     }
 
     func handleUserRemoved(_ signal: Data) async throws {

--- a/src/front/macOS/kDriveCoreUI/Models/UIs/Mappers/UISynchroNode+Mappers.swift
+++ b/src/front/macOS/kDriveCoreUI/Models/UIs/Mappers/UISynchroNode+Mappers.swift
@@ -128,7 +128,7 @@ public extension UISynchroNode {
             instruction: UISynchroFileInstruction(syncFileInstruction: synchroNode.instruction),
             size: synchroNode.size,
             progress: synchroNode.progress,
-            synDate: synchroNode.date
+            syncDate: synchroNode.date
         )
     }
 }

--- a/src/front/macOS/kDriveCoreUI/Models/UIs/Synchro/UISynchroNode.swift
+++ b/src/front/macOS/kDriveCoreUI/Models/UIs/Synchro/UISynchroNode.swift
@@ -70,8 +70,7 @@ public struct UISynchroNode: Sendable, Identifiable, Equatable, Hashable {
     }
 
     public var fileType: UTType? {
-        return UTType(
-            filenameExtension: relevantPath.pathExtension)
+        return UTType(filenameExtension: relevantPath.pathExtension)
     }
 
     public var fileTypeRepresentation: FileTypeRepresentation {

--- a/src/front/macOS/kDriveCoreUI/Models/UIs/Synchro/UISynchroNode.swift
+++ b/src/front/macOS/kDriveCoreUI/Models/UIs/Synchro/UISynchroNode.swift
@@ -91,7 +91,7 @@ public struct UISynchroNode: Sendable, Identifiable, Equatable, Hashable {
         instruction: UISynchroFileInstruction?,
         size: Int64,
         progress: Int32,
-        synDate: Date
+        syncDate: Date
     ) {
         self.id = id
         self.remoteID = remoteID
@@ -103,7 +103,7 @@ public struct UISynchroNode: Sendable, Identifiable, Equatable, Hashable {
         self.instruction = instruction
         self.size = size
         self.progress = min(max(progress, 0), 100)
-        self.syncDate = synDate
+        self.syncDate = syncDate
     }
 
     public static func == (lhs: UISynchroNode, rhs: UISynchroNode) -> Bool {

--- a/src/front/macOS/kDriveCoreUI/Utils/Previews/PreviewHelper.swift
+++ b/src/front/macOS/kDriveCoreUI/Utils/Previews/PreviewHelper.swift
@@ -102,7 +102,7 @@ public enum PreviewHelper {
         instruction: .update,
         size: 7_000_000,
         progress: 99,
-        synDate: .now
+        syncDate: .now
     )
     public static let synchroNode2 = UISynchroNode(
         id: "2",
@@ -115,7 +115,7 @@ public enum PreviewHelper {
         instruction: .update,
         size: 12_000_000,
         progress: 1,
-        synDate: .now.addingTimeInterval(-3600)
+        syncDate: .now.addingTimeInterval(-3600)
     )
     public static let synchroNode3 = UISynchroNode(
         id: "3",
@@ -128,7 +128,7 @@ public enum PreviewHelper {
         instruction: .update,
         size: 300_000,
         progress: 10,
-        synDate: .now.addingTimeInterval(-3600)
+        syncDate: .now.addingTimeInterval(-3600)
     )
 
     public static func blockingErrorFor(syncError: SynchroError, isDriveAdmin: Bool) -> UIBlockingError {

--- a/src/front/macOS/kDriveTests/Cache/CoherentCacheTests/CacheData.swift
+++ b/src/front/macOS/kDriveTests/Cache/CoherentCacheTests/CacheData.swift
@@ -231,4 +231,46 @@ enum CacheData {
                                                  inconsistencyType: KDC.InconsistencyType.None,
                                                  destinationPath: "",
                                                  autoResolved: false)
+
+    // MARK: - AvailableDrive
+
+    static let expectedAvailableDriveDbId = Int32.random(in: 0 ... 10000)
+    static let expectedAvailableDriveId = Int32.random(in: 0 ... 10000)
+    static let expectedAvailableDriveName = "My Available Drive"
+    static let expectedAvailableDriveColor: HexColor = .init(hex: "ff5733")!
+    static var expectedAvailableDrive = AvailableDrive(
+        driveId: expectedAvailableDriveId,
+        accountId: expectedAccountId,
+        userDbId: expectedUserDbId,
+        userId: expectedUserAPIId,
+        name: expectedAvailableDriveName,
+        color: expectedAvailableDriveColor
+    )
+
+    static let secondUserDbId = Int32.random(in: 0 ... 10000)
+    static let secondUserAPIId = Int32.random(in: 0 ... 10000)
+    static var secondUser = User(
+        dbId: secondUserDbId,
+        userId: secondUserAPIId,
+        name: "seconduser",
+        email: "second@example.com",
+        accounts: [:],
+        availableDrives: [:],
+        avatar: Data(),
+        isConnected: true,
+        isStaff: false
+    )
+
+    static let secondAvailableDriveDbId = Int32.random(in: 0 ... 10000)
+    static let secondAvailableDriveId = Int32.random(in: 0 ... 10000)
+    static let secondAvailableDriveName = "Second Available Drive"
+    static let secondAvailableDriveColor: HexColor = .init(hex: "33ff57")!
+    static var secondAvailableDrive = AvailableDrive(
+        driveId: secondAvailableDriveId,
+        accountId: expectedAccountId,
+        userDbId: secondUserDbId,
+        userId: secondUserAPIId,
+        name: secondAvailableDriveName,
+        color: secondAvailableDriveColor
+    )
 }

--- a/src/front/macOS/kDriveTests/Cache/CoherentCacheTests/CoherentCacheAvailableDriveTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/CoherentCacheTests/CoherentCacheAvailableDriveTests.swift
@@ -1,0 +1,183 @@
+/*
+ Infomaniak kDrive - Desktop
+ Copyright (C) 2023-2025 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+@testable import kDriveCore
+import OrderedCollections
+import Testing
+
+struct CoherentCacheAvailableDriveTests {
+    @Test(.timeLimit(.minutes(1)))
+    func getAvailableDriveWithUserDbId() async throws {
+        // GIVEN
+        let user = CacheData.expectedUser
+        let cache = ServerCoherentCache()
+        await cache.addUser(user)
+        #expect(await cache.getUser(dbId: CacheData.expectedUserDbId) == user)
+        
+        // Add available drives to the user
+        let availableDrives = [CacheData.expectedAvailableDrive]
+        try await cache.updateAvailableDrives(availableDrives, forUserDbId: CacheData.expectedUserDbId)
+
+        // WHEN
+        let fetchedDrive = await cache.getAvailableDrive(
+            driveDb: CacheData.expectedAvailableDriveId,
+            userDbId: CacheData.expectedUserDbId
+        )
+
+        // THEN
+        #expect(fetchedDrive == CacheData.expectedAvailableDrive)
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func getAvailableDriveWithUserDbIdNotFound() async throws {
+        // GIVEN
+        let user = CacheData.expectedUser
+        let cache = ServerCoherentCache()
+        await cache.addUser(user)
+        #expect(await cache.getUser(dbId: CacheData.expectedUserDbId) == user)
+        
+        // Add available drives to the user
+        let availableDrives = [CacheData.expectedAvailableDrive]
+        try await cache.updateAvailableDrives(availableDrives, forUserDbId: CacheData.expectedUserDbId)
+
+        // WHEN - Try to fetch with wrong driveDbId
+        let fetchedDrive = await cache.getAvailableDrive(
+            driveDb: Int32.random(in: 10001 ... 20000),
+            userDbId: CacheData.expectedUserDbId
+        )
+
+        // THEN
+        #expect(fetchedDrive == nil)
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func getAvailableDriveWithUserDbIdWrongUser() async throws {
+        // GIVEN
+        let user = CacheData.expectedUser
+        let cache = ServerCoherentCache()
+        await cache.addUser(user)
+        #expect(await cache.getUser(dbId: CacheData.expectedUserDbId) == user)
+        
+        // Add available drives to the user
+        let availableDrives = [CacheData.expectedAvailableDrive]
+        try await cache.updateAvailableDrives(availableDrives, forUserDbId: CacheData.expectedUserDbId)
+
+        // WHEN - Try to fetch with wrong userDbId
+        let fetchedDrive = await cache.getAvailableDrive(
+            driveDb: CacheData.expectedAvailableDriveId,
+            userDbId: Int32.random(in: 10001 ... 20000)
+        )
+
+        // THEN
+        #expect(fetchedDrive == nil)
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func getAvailableDriveWithoutUserDbId() async throws {
+        // GIVEN
+        let user = CacheData.expectedUser
+        let cache = ServerCoherentCache()
+        await cache.addUser(user)
+        #expect(await cache.getUser(dbId: CacheData.expectedUserDbId) == user)
+        
+        // Add available drives to the user
+        let availableDrives = [CacheData.expectedAvailableDrive]
+        try await cache.updateAvailableDrives(availableDrives, forUserDbId: CacheData.expectedUserDbId)
+
+        // WHEN - Fetch without specifying userDbId
+        let fetchedDrive = await cache.getAvailableDrive(driveDb: CacheData.expectedAvailableDriveId)
+
+        // THEN
+        #expect(fetchedDrive == CacheData.expectedAvailableDrive)
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func getAvailableDriveWithoutUserDbIdNotFound() async throws {
+        // GIVEN
+        let user = CacheData.expectedUser
+        let cache = ServerCoherentCache()
+        await cache.addUser(user)
+        #expect(await cache.getUser(dbId: CacheData.expectedUserDbId) == user)
+        
+        // Add available drives to the user
+        let availableDrives = [CacheData.expectedAvailableDrive]
+        try await cache.updateAvailableDrives(availableDrives, forUserDbId: CacheData.expectedUserDbId)
+
+        // WHEN - Try to fetch with wrong driveDbId
+        let fetchedDrive = await cache.getAvailableDrive(driveDb: Int32.random(in: 10001 ... 20000))
+
+        // THEN
+        #expect(fetchedDrive == nil)
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func getAvailableDriveWithoutUserDbIdAcrossMultipleUsers() async throws {
+        // GIVEN
+        let cache = ServerCoherentCache()
+        
+        // Add first user with available drive
+        let firstUser = CacheData.expectedUser
+        await cache.addUser(firstUser)
+        let firstAvailableDrives = [CacheData.expectedAvailableDrive]
+        try await cache.updateAvailableDrives(firstAvailableDrives, forUserDbId: CacheData.expectedUserDbId)
+        
+        // Add second user with available drive
+        let secondUser = CacheData.secondUser
+        await cache.addUser(secondUser)
+        let secondAvailableDrives = [CacheData.secondAvailableDrive]
+        try await cache.updateAvailableDrives(secondAvailableDrives, forUserDbId: CacheData.secondUserDbId)
+
+        // WHEN - Fetch first drive without specifying userDbId
+        let fetchedFirstDrive = await cache.getAvailableDrive(driveDb: CacheData.expectedAvailableDriveId)
+        
+        // WHEN - Fetch second drive without specifying userDbId
+        let fetchedSecondDrive = await cache.getAvailableDrive(driveDb: CacheData.secondAvailableDriveId)
+
+        // THEN
+        #expect(fetchedFirstDrive == CacheData.expectedAvailableDrive)
+        #expect(fetchedSecondDrive == CacheData.secondAvailableDrive)
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func getAvailableDriveWithUserDbIdIsolation() async throws {
+        // GIVEN
+        let cache = ServerCoherentCache()
+        
+        // Add first user with available drive
+        let firstUser = CacheData.expectedUser
+        await cache.addUser(firstUser)
+        let firstAvailableDrives = [CacheData.expectedAvailableDrive]
+        try await cache.updateAvailableDrives(firstAvailableDrives, forUserDbId: CacheData.expectedUserDbId)
+        
+        // Add second user with available drive
+        let secondUser = CacheData.secondUser
+        await cache.addUser(secondUser)
+        let secondAvailableDrives = [CacheData.secondAvailableDrive]
+        try await cache.updateAvailableDrives(secondAvailableDrives, forUserDbId: CacheData.secondUserDbId)
+
+        // WHEN - Try to fetch second user's drive using first user's ID
+        let fetchedDrive = await cache.getAvailableDrive(
+            driveDb: CacheData.secondAvailableDriveId,
+            userDbId: CacheData.expectedUserDbId
+        )
+
+        // THEN - Should be nil because the drive doesn't belong to the first user
+        #expect(fetchedDrive == nil)
+    }
+}

--- a/src/front/macOS/kDriveTests/Cache/CoherentCacheTests/CoherentCacheAvailableDriveTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/CoherentCacheTests/CoherentCacheAvailableDriveTests.swift
@@ -29,7 +29,7 @@ struct CoherentCacheAvailableDriveTests {
         let cache = ServerCoherentCache()
         await cache.addUser(user)
         #expect(await cache.getUser(dbId: CacheData.expectedUserDbId) == user)
-        
+
         // Add available drives to the user
         let availableDrives = [CacheData.expectedAvailableDrive]
         try await cache.updateAvailableDrives(availableDrives, forUserDbId: CacheData.expectedUserDbId)
@@ -51,7 +51,7 @@ struct CoherentCacheAvailableDriveTests {
         let cache = ServerCoherentCache()
         await cache.addUser(user)
         #expect(await cache.getUser(dbId: CacheData.expectedUserDbId) == user)
-        
+
         // Add available drives to the user
         let availableDrives = [CacheData.expectedAvailableDrive]
         try await cache.updateAvailableDrives(availableDrives, forUserDbId: CacheData.expectedUserDbId)
@@ -73,7 +73,7 @@ struct CoherentCacheAvailableDriveTests {
         let cache = ServerCoherentCache()
         await cache.addUser(user)
         #expect(await cache.getUser(dbId: CacheData.expectedUserDbId) == user)
-        
+
         // Add available drives to the user
         let availableDrives = [CacheData.expectedAvailableDrive]
         try await cache.updateAvailableDrives(availableDrives, forUserDbId: CacheData.expectedUserDbId)
@@ -95,7 +95,7 @@ struct CoherentCacheAvailableDriveTests {
         let cache = ServerCoherentCache()
         await cache.addUser(user)
         #expect(await cache.getUser(dbId: CacheData.expectedUserDbId) == user)
-        
+
         // Add available drives to the user
         let availableDrives = [CacheData.expectedAvailableDrive]
         try await cache.updateAvailableDrives(availableDrives, forUserDbId: CacheData.expectedUserDbId)
@@ -114,7 +114,7 @@ struct CoherentCacheAvailableDriveTests {
         let cache = ServerCoherentCache()
         await cache.addUser(user)
         #expect(await cache.getUser(dbId: CacheData.expectedUserDbId) == user)
-        
+
         // Add available drives to the user
         let availableDrives = [CacheData.expectedAvailableDrive]
         try await cache.updateAvailableDrives(availableDrives, forUserDbId: CacheData.expectedUserDbId)
@@ -130,13 +130,13 @@ struct CoherentCacheAvailableDriveTests {
     func getAvailableDriveWithoutUserDbIdAcrossMultipleUsers() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
-        
+
         // Add first user with available drive
         let firstUser = CacheData.expectedUser
         await cache.addUser(firstUser)
         let firstAvailableDrives = [CacheData.expectedAvailableDrive]
         try await cache.updateAvailableDrives(firstAvailableDrives, forUserDbId: CacheData.expectedUserDbId)
-        
+
         // Add second user with available drive
         let secondUser = CacheData.secondUser
         await cache.addUser(secondUser)
@@ -145,7 +145,7 @@ struct CoherentCacheAvailableDriveTests {
 
         // WHEN - Fetch first drive without specifying userDbId
         let fetchedFirstDrive = await cache.getAvailableDrive(driveDb: CacheData.expectedAvailableDriveId)
-        
+
         // WHEN - Fetch second drive without specifying userDbId
         let fetchedSecondDrive = await cache.getAvailableDrive(driveDb: CacheData.secondAvailableDriveId)
 
@@ -158,13 +158,13 @@ struct CoherentCacheAvailableDriveTests {
     func getAvailableDriveWithUserDbIdIsolation() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
-        
+
         // Add first user with available drive
         let firstUser = CacheData.expectedUser
         await cache.addUser(firstUser)
         let firstAvailableDrives = [CacheData.expectedAvailableDrive]
         try await cache.updateAvailableDrives(firstAvailableDrives, forUserDbId: CacheData.expectedUserDbId)
-        
+
         // Add second user with available drive
         let secondUser = CacheData.secondUser
         await cache.addUser(secondUser)

--- a/src/front/macOS/kDriveTests/Cache/CoherentCacheTests/CoherentCacheUserTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/CoherentCacheTests/CoherentCacheUserTests.swift
@@ -63,7 +63,7 @@ struct CoherentCacheUserTests {
         #expect(await cache.getUser(dbId: CacheData.expectedUserDbId) == user)
 
         // WHEN
-        await cache.updateUser(CacheData.updatedUser)
+        await cache.updateUser(CacheData.updatedUser, updateOptions: .all)
 
         // THEN
         guard let userByDbId = await cache.getUser(dbId: CacheData.expectedUserDbId) else {

--- a/src/front/macOS/kDriveTests/Cache/CoherentCacheTests/CoherentCacheUserTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/CoherentCacheTests/CoherentCacheUserTests.swift
@@ -23,7 +23,7 @@ import Testing
 
 struct CoherentCacheUserTests {
     @Test(.timeLimit(.minutes(1)))
-    func getUserInCache() async throws {
+    func getUserInCache() async {
         // GIVEN
         let user = CacheData.expectedUser
         let cache = ServerCoherentCache()
@@ -38,7 +38,7 @@ struct CoherentCacheUserTests {
     }
 
     @Test(.timeLimit(.minutes(1)))
-    func removeUserInCacheFromDbId() async throws {
+    func removeUserInCacheFromDbId() async {
         // GIVEN
         let user = CacheData.expectedUser
         let cache = ServerCoherentCache()
@@ -54,7 +54,7 @@ struct CoherentCacheUserTests {
     }
 
     @Test(.timeLimit(.minutes(1)))
-    func updateUserInCache() async throws {
+    func updateUserInCache() async {
         // GIVEN
         let user = CacheData.expectedUser
         let cache = ServerCoherentCache()

--- a/src/front/macOS/kDriveTests/Cache/DTOs/UserUpdateTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/DTOs/UserUpdateTests.swift
@@ -1,0 +1,401 @@
+/*
+ Infomaniak kDrive - Desktop
+ Copyright (C) 2023-2025 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+@testable import kDriveCore
+import OrderedCollections
+import Testing
+
+struct UserUpdateTests {
+    private static let dbId: Int32 = 1
+    private static let userId: Int32 = 100
+    private static let name = "Test User"
+    private static let email = "test@example.com"
+    private static let avatar = Data([0x01, 0x02, 0x03])
+    private static let isConnected = true
+    private static let isStaff = false
+
+    func createUser(
+        dbId: Int32 = dbId,
+        userId: Int32 = userId,
+        name: String = name,
+        email: String = email,
+        accounts: IndexedAccounts = [:],
+        availableDrives: IndexedAvailableDrives = [:],
+        avatar: Data? = avatar,
+        isConnected: Bool = isConnected,
+        isStaff: Bool = isStaff
+    ) -> User {
+        User(
+            dbId: dbId,
+            userId: userId,
+            name: name,
+            email: email,
+            accounts: accounts,
+            availableDrives: availableDrives,
+            avatar: avatar,
+            isConnected: isConnected,
+            isStaff: isStaff
+        )
+    }
+
+    @Test("Update with different dbId returns nil")
+    func updateWithDifferentDbId() {
+        // GIVEN
+        let original = createUser()
+        let other = createUser(dbId: 2, userId: 200, name: "Other User")
+
+        // WHEN
+        let result = original.updated(with: other, updateOptions: .all)
+
+        // THEN
+        #expect(result == nil)
+    }
+
+    @Test("Update userId with .userId option")
+    func updateUserId() {
+        // GIVEN
+        let original = createUser()
+        let other = createUser(userId: 999)
+
+        // WHEN
+        let result = original.updated(with: other, updateOptions: .userId)
+
+        // THEN
+        #expect(result != nil)
+        #expect(result?.userId == 999)
+        // Other fields should be unchanged
+        #expect(result?.name == original.name)
+        #expect(result?.email == original.email)
+        #expect(result?.avatar == original.avatar)
+        #expect(result?.isConnected == original.isConnected)
+        #expect(result?.isStaff == original.isStaff)
+        #expect(result?.accounts == original.accounts)
+        #expect(result?.availableDrives == original.availableDrives)
+    }
+
+    @Test("Update name with .name option")
+    func updateName() {
+        // GIVEN
+        let original = createUser()
+        let other = createUser(name: "Updated Name")
+
+        // WHEN
+        let result = original.updated(with: other, updateOptions: .name)
+
+        // THEN
+        #expect(result != nil)
+        #expect(result?.name == "Updated Name")
+        // Other fields should be unchanged
+        #expect(result?.dbId == original.dbId)
+        #expect(result?.userId == original.userId)
+        #expect(result?.email == original.email)
+        #expect(result?.avatar == original.avatar)
+        #expect(result?.isConnected == original.isConnected)
+        #expect(result?.isStaff == original.isStaff)
+        #expect(result?.accounts == original.accounts)
+        #expect(result?.availableDrives == original.availableDrives)
+    }
+
+    @Test("Update email with .email option")
+    func updateEmail() {
+        // GIVEN
+        let original = createUser()
+        let other = createUser(email: "updated@example.com")
+
+        // WHEN
+        let result = original.updated(with: other, updateOptions: .email)
+
+        // THEN
+        #expect(result != nil)
+        #expect(result?.email == "updated@example.com")
+        // Other fields should be unchanged
+        #expect(result?.dbId == original.dbId)
+        #expect(result?.userId == original.userId)
+        #expect(result?.name == original.name)
+        #expect(result?.avatar == original.avatar)
+        #expect(result?.isConnected == original.isConnected)
+        #expect(result?.isStaff == original.isStaff)
+        #expect(result?.accounts == original.accounts)
+        #expect(result?.availableDrives == original.availableDrives)
+    }
+
+    @Test("Update avatar with .avatar option")
+    func updateAvatar() {
+        // GIVEN
+        let original = createUser()
+        let newAvatar = Data([0xAA, 0xBB, 0xCC])
+        let other = createUser(avatar: newAvatar)
+
+        // WHEN
+        let result = original.updated(with: other, updateOptions: .avatar)
+
+        // THEN
+        #expect(result != nil)
+        #expect(result?.avatar == newAvatar)
+        // Other fields should be unchanged
+        #expect(result?.dbId == original.dbId)
+        #expect(result?.userId == original.userId)
+        #expect(result?.name == original.name)
+        #expect(result?.email == original.email)
+        #expect(result?.isConnected == original.isConnected)
+        #expect(result?.isStaff == original.isStaff)
+        #expect(result?.accounts == original.accounts)
+        #expect(result?.availableDrives == original.availableDrives)
+    }
+
+    @Test("Update isConnected with .isConnected option")
+    func updateIsConnected() {
+        // GIVEN
+        let original = createUser(isConnected: true)
+        let other = createUser(isConnected: false)
+
+        // WHEN
+        let result = original.updated(with: other, updateOptions: .isConnected)
+
+        // THEN
+        #expect(result != nil)
+        #expect(result?.isConnected == false)
+        // Other fields should be unchanged
+        #expect(result?.dbId == original.dbId)
+        #expect(result?.userId == original.userId)
+        #expect(result?.name == original.name)
+        #expect(result?.email == original.email)
+        #expect(result?.avatar == original.avatar)
+        #expect(result?.isStaff == original.isStaff)
+        #expect(result?.accounts == original.accounts)
+        #expect(result?.availableDrives == original.availableDrives)
+    }
+
+    @Test("Update isStaff with .isStaff option")
+    func updateIsStaff() {
+        // GIVEN
+        let original = createUser(isStaff: false)
+        let other = createUser(isStaff: true)
+
+        // WHEN
+        let result = original.updated(with: other, updateOptions: .isStaff)
+
+        // THEN
+        #expect(result != nil)
+        #expect(result?.isStaff == true)
+        // Other fields should be unchanged
+        #expect(result?.dbId == original.dbId)
+        #expect(result?.userId == original.userId)
+        #expect(result?.name == original.name)
+        #expect(result?.email == original.email)
+        #expect(result?.avatar == original.avatar)
+        #expect(result?.isConnected == original.isConnected)
+        #expect(result?.accounts == original.accounts)
+        #expect(result?.availableDrives == original.availableDrives)
+    }
+
+    @Test("Update accounts with .accounts option")
+    func updateAccounts() {
+        // GIVEN
+        let original = createUser()
+        var accounts: IndexedAccounts = [:]
+        accounts[1] = Account(dbId: 1, userDbId: UserUpdateTests.dbId, name: "Test Account", drives: [:])
+        let other = createUser(accounts: accounts)
+
+        // WHEN
+        let result = original.updated(with: other, updateOptions: .accounts)
+
+        // THEN
+        #expect(result != nil)
+        #expect(result?.accounts.count == 1)
+        #expect(result?.accounts[1]?.name == "Test Account")
+        // Other fields should be unchanged
+        #expect(result?.dbId == original.dbId)
+        #expect(result?.userId == original.userId)
+        #expect(result?.name == original.name)
+        #expect(result?.email == original.email)
+        #expect(result?.avatar == original.avatar)
+        #expect(result?.isConnected == original.isConnected)
+        #expect(result?.isStaff == original.isStaff)
+        #expect(result?.availableDrives == original.availableDrives)
+    }
+
+    @Test("Update availableDrives with .availableDrives option")
+    func updateAvailableDrives() {
+        // GIVEN
+        let original = createUser()
+        var drives: IndexedAvailableDrives = [:]
+        drives[1] = AvailableDrive(
+            driveId: 1,
+            accountId: 1,
+            userDbId: UserUpdateTests.dbId,
+            userId: UserUpdateTests.userId,
+            name: "Test Drive",
+            color: HexColor(hex: "FF0000")!
+        )
+        let other = createUser(availableDrives: drives)
+
+        // WHEN
+        let result = original.updated(with: other, updateOptions: .availableDrives)
+
+        // THEN
+        #expect(result != nil)
+        #expect(result?.availableDrives.count == 1)
+        #expect(result?.availableDrives[1]?.name == "Test Drive")
+        // Other fields should be unchanged
+        #expect(result?.dbId == original.dbId)
+        #expect(result?.userId == original.userId)
+        #expect(result?.name == original.name)
+        #expect(result?.email == original.email)
+        #expect(result?.avatar == original.avatar)
+        #expect(result?.isConnected == original.isConnected)
+        #expect(result?.isStaff == original.isStaff)
+        #expect(result?.accounts == original.accounts)
+    }
+
+    @Test("Update all fields with .all option")
+    func updateAllFields() {
+        // GIVEN
+        let original = createUser()
+        let other = createUser(
+            userId: 999,
+            name: "Updated Name",
+            email: "updated@example.com",
+            avatar: Data([0xFF]),
+            isConnected: false,
+            isStaff: true
+        )
+
+        // WHEN
+        let result = original.updated(with: other, updateOptions: .all)
+
+        // THEN
+        #expect(result != nil)
+        #expect(result?.userId == 999)
+        #expect(result?.name == "Updated Name")
+        #expect(result?.email == "updated@example.com")
+        #expect(result?.avatar == Data([0xFF]))
+        #expect(result?.isConnected == false)
+        #expect(result?.isStaff == true)
+    }
+
+    @Test("Update signal fields with .updateSignal option")
+    func updateSignalFields() {
+        // GIVEN
+        let original = createUser()
+        let other = createUser(
+            userId: 999,
+            name: "Updated Name",
+            email: "updated@example.com",
+            avatar: Data([0xFF]),
+            isConnected: false,
+            isStaff: true
+        )
+
+        // WHEN
+        let result = original.updated(with: other, updateOptions: .updateSignal)
+
+        // THEN
+        #expect(result != nil)
+        #expect(result?.userId == 999)
+        #expect(result?.name == "Updated Name")
+        #expect(result?.email == "updated@example.com")
+        #expect(result?.avatar == Data([0xFF]))
+        #expect(result?.isConnected == false)
+        #expect(result?.isStaff == true)
+        // These fields should NOT be updated by .updateSignal
+        #expect(result?.dbId == original.dbId)
+        #expect(result?.accounts == original.accounts)
+        #expect(result?.availableDrives == original.availableDrives)
+    }
+
+    @Test("No update when option not specified")
+    func noUpdateWhenOptionNotSpecified() {
+        // GIVEN
+        let original = createUser(name: "Original", email: "original@example.com")
+        let other = createUser(name: "Updated", email: "updated@example.com")
+
+        // WHEN - Only update name, not email
+        let result = original.updated(with: other, updateOptions: .name)
+
+        // THEN
+        #expect(result != nil)
+        #expect(result?.name == "Updated")
+        // Email should not change
+        #expect(result?.email == "original@example.com")
+        // All other fields should also be unchanged
+        #expect(result?.dbId == original.dbId)
+        #expect(result?.userId == original.userId)
+        #expect(result?.avatar == original.avatar)
+        #expect(result?.isConnected == original.isConnected)
+        #expect(result?.isStaff == original.isStaff)
+        #expect(result?.accounts == original.accounts)
+        #expect(result?.availableDrives == original.availableDrives)
+    }
+
+    @Test("Multiple options combined")
+    func multipleOptionsCombined() {
+        // GIVEN
+        let original = createUser()
+        let other = createUser(name: "Updated", email: "updated@example.com", isConnected: false)
+
+        // WHEN
+        let result = original.updated(with: other, updateOptions: [.name, .email])
+
+        // THEN
+        #expect(result != nil)
+        #expect(result?.name == "Updated")
+        #expect(result?.email == "updated@example.com")
+        // These were not specified and should not change
+        #expect(result?.isConnected == original.isConnected)
+        // All other fields should also be unchanged
+        #expect(result?.dbId == original.dbId)
+        #expect(result?.userId == original.userId)
+        #expect(result?.avatar == original.avatar)
+        #expect(result?.isStaff == original.isStaff)
+        #expect(result?.accounts == original.accounts)
+        #expect(result?.availableDrives == original.availableDrives)
+    }
+
+    @Test("Update preserves dbId")
+    func updatePreservesDbId() {
+        // GIVEN
+        let original = createUser(dbId: 42)
+        let other = createUser(dbId: 42, name: "Updated")
+
+        // WHEN
+        let result = original.updated(with: other, updateOptions: .all)
+
+        // THEN
+        #expect(result != nil)
+        #expect(result?.dbId == 42)
+    }
+
+    @Test("Original user is not mutated")
+    func originalNotMutated() {
+        // GIVEN
+        let original = createUser(name: "Original", email: "original@example.com")
+        let other = createUser(name: "Updated", email: "updated@example.com")
+
+        // WHEN
+        let result = original.updated(with: other, updateOptions: .all)
+
+        // THEN
+        #expect(result != nil)
+        #expect(original.name == "Original")
+        #expect(original.email == "original@example.com")
+        #expect(result?.name == "Updated")
+        #expect(result?.email == "updated@example.com")
+    }
+}

--- a/src/front/macOS/kDriveTests/Cache/DTOs/UserUpdateTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/DTOs/UserUpdateTests.swift
@@ -232,17 +232,17 @@ struct UserUpdateTests {
     }
 
     @Test("Update availableDrives with .availableDrives option")
-    func updateAvailableDrives() {
+    func updateAvailableDrives() throws {
         // GIVEN
         let original = createUser()
         var drives: IndexedAvailableDrives = [:]
-        drives[1] = AvailableDrive(
+        drives[1] = try AvailableDrive(
             driveId: 1,
             accountId: 1,
             userDbId: UserUpdateTests.dbId,
             userId: UserUpdateTests.userId,
             name: "Test Drive",
-            color: HexColor(hex: "FF0000")!
+            color: #require(HexColor(hex: "FF0000"))
         )
         let other = createUser(availableDrives: drives)
 

--- a/src/front/macOS/kDriveTests/Cache/Observation/ObservedAvailableDrivesTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/Observation/ObservedAvailableDrivesTests.swift
@@ -1,0 +1,267 @@
+/*
+ Infomaniak kDrive - Desktop
+ Copyright (C) 2023-2025 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Combine
+import Foundation
+@testable import InfomaniakDI
+@testable import kDriveCore
+import Testing
+
+extension ObservedAvailableDrives {
+    var receivedValues: AsyncStream<[AvailableDriveContext]> {
+        AsyncStream { continuation in
+            let cancellable = $wrappedValue
+                .sink { value in continuation.yield(value) }
+
+            continuation.onTermination = { _ in cancellable.cancel() }
+        }
+    }
+}
+
+@MainActor
+struct ObservedAvailableDrivesTests {
+    @Test(.timeLimit(.minutes(1)))
+    func setObservedAvailableDrives() async throws {
+        // GIVEN
+        let cache = ServerCoherentCache()
+        let initialUser = await cache.getUser(dbId: CacheData.expectedUserDbId)
+        #expect(initialUser == nil, "Cache should initially be empty")
+
+        @ObservedAvailableDrives(cacheObservation: cache) var observedDrives: [AvailableDriveContext]
+        let receivedValues = $observedDrives.receivedValues // Start to save the received values
+
+        #expect(observedDrives == [], "Available drives should initially be empty")
+        await cache.addUser(CacheData.expectedUser)
+
+        // WHEN
+        let expectedDrive = CacheData.expectedAvailableDrive
+        try await cache.updateAvailableDrives([expectedDrive], forUserDbId: CacheData.expectedUserDbId)
+
+        // THEN
+        _ = await receivedValues.first(where: { _ in true })
+
+        let cachedDrive = await cache.getAvailableDrive(
+            driveDb: CacheData.expectedAvailableDriveId,
+            userDbId: CacheData.expectedUserDbId
+        )
+        #expect(cachedDrive == expectedDrive, "The cache should have been updated with an AvailableDrive")
+        #expect(observedDrives.count == 1, "We should have one AvailableDrive in the array")
+
+        guard let firstDrive = observedDrives.first else {
+            Issue.record("Failed to unwrap the first AvailableDrive")
+            return
+        }
+
+        #expect(firstDrive.availableDrive.driveId == expectedDrive.driveId, "The drive should match the one we just added")
+        #expect(firstDrive.user.dbId == CacheData.expectedUserDbId, "The user should match the one we just added")
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func setMultipleObservedAvailableDrives() async throws {
+        // GIVEN
+        let cache = ServerCoherentCache()
+        let initialUser = await cache.getUser(dbId: CacheData.expectedUserDbId)
+        #expect(initialUser == nil, "Cache should initially be empty")
+
+        @ObservedAvailableDrives(cacheObservation: cache) var observedDrives: [AvailableDriveContext]
+        let receivedValues = $observedDrives.receivedValues // Start to save the received values
+
+        #expect(observedDrives == [], "Observed available drives should initially be empty")
+        await cache.addUser(CacheData.expectedUser)
+
+        // WHEN
+        let expectedDrive = CacheData.expectedAvailableDrive
+        try await cache.updateAvailableDrives([expectedDrive], forUserDbId: CacheData.expectedUserDbId)
+
+        let secondaryDrive = CacheData.secondAvailableDrive
+        await cache.addUser(CacheData.secondUser)
+        try await cache.updateAvailableDrives([secondaryDrive], forUserDbId: CacheData.secondUserDbId)
+
+        // THEN
+        _ = await receivedValues.dropFirst().first(where: { _ in true })
+
+        let cachedDrive = await cache.getAvailableDrive(
+            driveDb: CacheData.expectedAvailableDriveId,
+            userDbId: CacheData.expectedUserDbId
+        )
+        #expect(cachedDrive == expectedDrive, "The cache should have been updated with an AvailableDrive")
+        let secondaryCachedDrive = await cache.getAvailableDrive(
+            driveDb: CacheData.secondAvailableDriveId,
+            userDbId: CacheData.secondUserDbId
+        )
+        #expect(secondaryCachedDrive == secondaryDrive, "The cache should have been updated with another AvailableDrive")
+        #expect(observedDrives.count == 2, "We should have two AvailableDrives in the array")
+
+        guard let firstObservedDrive = observedDrives
+            .first(where: { $0.availableDrive.driveId == CacheData.expectedAvailableDriveId }) else {
+            Issue.record("Failed to unwrap the first AvailableDrive")
+            return
+        }
+
+        #expect(firstObservedDrive.availableDrive.driveId == expectedDrive.driveId, "The drive should match")
+        #expect(firstObservedDrive.user.dbId == CacheData.expectedUserDbId, "The user should match")
+
+        guard let secondaryObservedDrive = observedDrives
+            .first(where: { $0.availableDrive.driveId == CacheData.secondAvailableDriveId }) else {
+            Issue.record("Failed to unwrap the secondary AvailableDrive")
+            return
+        }
+
+        #expect(firstObservedDrive.availableDrive != secondaryObservedDrive.availableDrive, "The two drives should not match")
+        #expect(secondaryObservedDrive.availableDrive.driveId == secondaryDrive.driveId, "The drive should match")
+        #expect(secondaryObservedDrive.user.dbId == CacheData.secondUserDbId, "The user should match")
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func updateObservedAvailableDrive() async throws {
+        // GIVEN
+        let cache = ServerCoherentCache()
+        let initialUser = await cache.getUser(dbId: CacheData.expectedUserDbId)
+        #expect(initialUser == nil, "Cache should initially be empty")
+
+        @ObservedAvailableDrives(cacheObservation: cache) var observedDrives: [AvailableDriveContext]
+        let receivedValues = $observedDrives.receivedValues // Start to save the received values
+
+        #expect(observedDrives == [], "Available drives should initially be empty")
+        await cache.addUser(CacheData.expectedUser)
+
+        let expectedDrive = CacheData.expectedAvailableDrive
+        try await cache.updateAvailableDrives([expectedDrive], forUserDbId: CacheData.expectedUserDbId)
+
+        let cachedDrive = await cache.getAvailableDrive(
+            driveDb: CacheData.expectedAvailableDriveId,
+            userDbId: CacheData.expectedUserDbId
+        )
+        #expect(cachedDrive == expectedDrive, "The cache should have been updated with an AvailableDrive")
+
+        // WHEN
+        let updatedDrive = AvailableDrive(
+            driveId: CacheData.expectedAvailableDriveId,
+            accountId: CacheData.expectedAccountId,
+            userDbId: CacheData.expectedUserDbId,
+            userId: CacheData.expectedUserAPIId,
+            name: "Updated Available Drive",
+            color: HexColor(hex: "00ff00")!
+        )
+        try await cache.updateAvailableDrives([updatedDrive], forUserDbId: CacheData.expectedUserDbId)
+
+        // THEN
+        _ = await receivedValues.dropFirst().first(where: { _ in true })
+
+        let latestFetchedDrive = await cache.getAvailableDrive(
+            driveDb: CacheData.expectedAvailableDriveId,
+            userDbId: CacheData.expectedUserDbId
+        )
+        #expect(latestFetchedDrive?.name == "Updated Available Drive", "We should find the object in cache updated")
+        #expect(observedDrives.count == 1, "We should have one object in the array")
+
+        guard let firstDrive = observedDrives.first else {
+            Issue.record("Failed to unwrap the first object")
+            return
+        }
+
+        #expect(firstDrive.availableDrive.name == "Updated Available Drive", "The AvailableDrive in the array should match the updated one")
+        #expect(firstDrive.availableDrive.driveId == expectedDrive.driveId, "The drive should match the one we just added")
+        #expect(firstDrive.user.dbId == CacheData.expectedUserDbId, "The user should match the one we just added")
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func deleteObservedAvailableDrive() async throws {
+        // GIVEN
+        let cache = ServerCoherentCache()
+        let initialUser = await cache.getUser(dbId: CacheData.expectedUserDbId)
+        #expect(initialUser == nil, "Cache should initially be empty")
+
+        @ObservedAvailableDrives(cacheObservation: cache) var observedDrives: [AvailableDriveContext]
+        let receivedValues = $observedDrives.receivedValues // Start to save the received values
+
+        #expect(observedDrives == [], "Available drives should initially be empty")
+        await cache.addUser(CacheData.expectedUser)
+
+        let expectedDrive = CacheData.expectedAvailableDrive
+        try await cache.updateAvailableDrives([expectedDrive], forUserDbId: CacheData.expectedUserDbId)
+
+        let cachedDrive = await cache.getAvailableDrive(
+            driveDb: CacheData.expectedAvailableDriveId,
+            userDbId: CacheData.expectedUserDbId
+        )
+        #expect(cachedDrive == expectedDrive, "The cache should have been updated with an AvailableDrive")
+
+        // WHEN - Update with empty array to remove the drive
+        try await cache.updateAvailableDrives([], forUserDbId: CacheData.expectedUserDbId)
+
+        // THEN
+        _ = await receivedValues.dropFirst().first(where: { $0 == [] })
+
+        let latestFetchedDrive = await cache.getAvailableDrive(
+            driveDb: CacheData.expectedAvailableDriveId,
+            userDbId: CacheData.expectedUserDbId
+        )
+        #expect(latestFetchedDrive == nil, "Object should no longer be available in cache")
+        #expect(observedDrives.isEmpty, "Available drives should be empty once the object is deleted")
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func testRemoveOneAvailableDrive() async throws {
+        // GIVEN
+        let cache = ServerCoherentCache()
+        let initialUser = await cache.getUser(dbId: CacheData.expectedUserDbId)
+        #expect(initialUser == nil, "Cache should initially be empty")
+
+        @ObservedAvailableDrives(cacheObservation: cache) var observedDrives: [AvailableDriveContext]
+        let receivedValues = $observedDrives.receivedValues // Start to save the received values
+
+        #expect(observedDrives == [], "Available drives should initially be empty")
+        await cache.addUser(CacheData.expectedUser)
+
+        let expectedDrive = CacheData.expectedAvailableDrive
+        try await cache.updateAvailableDrives([expectedDrive], forUserDbId: CacheData.expectedUserDbId)
+
+        await cache.addUser(CacheData.secondUser)
+        let secondaryDrive = CacheData.secondAvailableDrive
+        try await cache.updateAvailableDrives([secondaryDrive], forUserDbId: CacheData.secondUserDbId)
+
+        let cachedDrive = await cache.getAvailableDrive(
+            driveDb: CacheData.expectedAvailableDriveId,
+            userDbId: CacheData.expectedUserDbId
+        )
+        #expect(cachedDrive == expectedDrive, "The cache should have been updated with an AvailableDrive")
+        let secondaryCachedDrive = await cache.getAvailableDrive(
+            driveDb: CacheData.secondAvailableDriveId,
+            userDbId: CacheData.secondUserDbId
+        )
+        #expect(secondaryCachedDrive == secondaryDrive, "The cache should have been updated with another AvailableDrive")
+
+        // WHEN - Remove only the secondary drive
+        try await cache.updateAvailableDrives([], forUserDbId: CacheData.secondUserDbId)
+
+        // THEN
+        _ = await receivedValues.dropFirst().dropFirst().first(where: { _ in true })
+
+        #expect(observedDrives.count == 1, "We should have one AvailableDrive after the deletion of a drive")
+
+        guard let firstObservedDrive = observedDrives
+            .first(where: { $0.availableDrive.driveId == CacheData.expectedAvailableDriveId }) else {
+            Issue.record("Failed to unwrap the first AvailableDrive")
+            return
+        }
+
+        #expect(firstObservedDrive.availableDrive.driveId == expectedDrive.driveId, "The drive should match")
+        #expect(firstObservedDrive.user.dbId == CacheData.expectedUserDbId, "The user should match")
+    }
+}

--- a/src/front/macOS/kDriveTests/Cache/Observation/ObservedAvailableDrivesTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/Observation/ObservedAvailableDrivesTests.swift
@@ -150,13 +150,13 @@ struct ObservedAvailableDrivesTests {
         #expect(cachedDrive == expectedDrive, "The cache should have been updated with an AvailableDrive")
 
         // WHEN
-        let updatedDrive = AvailableDrive(
+        let updatedDrive = try AvailableDrive(
             driveId: CacheData.expectedAvailableDriveId,
             accountId: CacheData.expectedAccountId,
             userDbId: CacheData.expectedUserDbId,
             userId: CacheData.expectedUserAPIId,
             name: "Updated Available Drive",
-            color: HexColor(hex: "00ff00")!
+            color: #require(HexColor(hex: "00ff00"))
         )
         try await cache.updateAvailableDrives([updatedDrive], forUserDbId: CacheData.expectedUserDbId)
 
@@ -175,7 +175,10 @@ struct ObservedAvailableDrivesTests {
             return
         }
 
-        #expect(firstDrive.availableDrive.name == "Updated Available Drive", "The AvailableDrive in the array should match the updated one")
+        #expect(
+            firstDrive.availableDrive.name == "Updated Available Drive",
+            "The AvailableDrive in the array should match the updated one"
+        )
         #expect(firstDrive.availableDrive.driveId == expectedDrive.driveId, "The drive should match the one we just added")
         #expect(firstDrive.user.dbId == CacheData.expectedUserDbId, "The user should match the one we just added")
     }
@@ -217,7 +220,7 @@ struct ObservedAvailableDrivesTests {
     }
 
     @Test(.timeLimit(.minutes(1)))
-    func testRemoveOneAvailableDrive() async throws {
+    func removeOneAvailableDrive() async throws {
         // GIVEN
         let cache = ServerCoherentCache()
         let initialUser = await cache.getUser(dbId: CacheData.expectedUserDbId)

--- a/src/front/macOS/kDriveTests/Cache/Observation/ObservedSynchroNodesTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/Observation/ObservedSynchroNodesTests.swift
@@ -191,7 +191,6 @@ struct ObservedSynchroNodesTests {
 
         // THEN
         _ = await receivedValues.dropFirst(2).first(where: { _ in true })
-        _ = await receivedValues.dropFirst().first(where: { _ in true })
 
         #expect(observedNodes.count == 2, "We should still have two nodes")
 

--- a/src/front/macOS/kDriveTests/Cache/Observation/ObservedSynchroNodesTests.swift
+++ b/src/front/macOS/kDriveTests/Cache/Observation/ObservedSynchroNodesTests.swift
@@ -190,7 +190,7 @@ struct ObservedSynchroNodesTests {
         try await cache.updateSynchro(updatedSynchro)
 
         // THEN
-        _ = await receivedValues.dropFirst(2).first(where: { _ in true })
+        _ = await receivedValues.dropFirst().first(where: { _ in true })
 
         #expect(observedNodes.count == 2, "We should still have two nodes")
 

--- a/src/front/macOS/kDriveTests/UI/UISynchroNodeTests.swift
+++ b/src/front/macOS/kDriveTests/UI/UISynchroNodeTests.swift
@@ -33,7 +33,7 @@ struct UISynchroNodeTests {
             instruction: .put,
             size: 1024,
             progress: progress,
-            synDate: Date()
+            syncDate: Date()
         )
     }
 


### PR DESCRIPTION
I also added a fix on the behaviour of updating an `User` within the observable tree.
User update mechanism in well unit tested (300+L)

`IndexedAvailableDrives` was migrated to an ordered dictionary to preserve order of element given by the dedicated Job