### PR TITLE
feat(ui): add update badge to settings nav item

### DIFF
--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/AppNavigationView.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/AppNavigationView.xaml
@@ -16,8 +16,7 @@
                 OpenPaneLength="280"
                 CompactPaneLength="52"
                 Loaded="AppNavigationView_Loaded"
-                Unloaded="AppNavigationView_Unloaded"
-                >
+                Unloaded="AppNavigationView_Unloaded">
     <!--
     CompactPaneLength must be overridden (default is 48px) due to the following issue:
     https://github.com/microsoft/microsoft-ui-xaml/issues/10415

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/AppNavigationView.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/AppNavigationView.xaml.cs
@@ -3,6 +3,7 @@ using Infomaniak.kDrive.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Data;
 using Microsoft.UI.Xaml.Input;
 using System;
 using System.Collections.Generic;
@@ -42,6 +43,33 @@ namespace Infomaniak.kDrive.CustomControls
         private void AppNavigationView_Loaded(object sender, RoutedEventArgs e)
         {
             Frame.Navigated += Frame_Navigated;
+
+            // Add an infobadge to SettingsItem
+            var infoBadge = new InfoBadge()
+            {
+                HorizontalAlignment = HorizontalAlignment.Right,
+                VerticalAlignment = VerticalAlignment.Center,
+            };
+
+            // Bind the visibility of the infobadge to the HasAvailableUpdates property of the ViewModel
+            infoBadge.SetBinding(InfoBadge.VisibilityProperty, new Binding()
+            {
+                Source = ViewModel.Settings.UpdateManager,
+                Path = new PropertyPath(nameof(ViewModel.Settings.UpdateManager.AvailableUpdate)),
+                Converter = new Converters.IsNullToBoolOrVisibilityConverter(),
+                ConverterParameter = "Inverted=True",
+                Mode = BindingMode.OneWay
+            });
+
+            NavigationViewItem? settingItem = SettingsItem as NavigationViewItem;
+            if (settingItem is null)
+            {
+                Logger.Log(Logger.Level.Error, "SettingsItem is not a NavigationViewItem. Cannot add InfoBadge.");
+                return;
+            }
+
+            settingItem.InfoBadge = infoBadge;
+
         }
         private void AppNavigationView_Unloaded(object sender, RoutedEventArgs e)
         {


### PR DESCRIPTION
An InfoBadge is now shown on the Settings navigation item when an update is available, using a binding to the UpdateManager. Also includes minor XAML formatting adjustment.



https://github.com/user-attachments/assets/478b4a37-1e81-4983-b2b5-71dd9e90891a


