### PR TITLE
feat(searchbox): improve unavailable item indicator UX

### DIFF
--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/SearchBox.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/SearchBox.xaml
@@ -20,17 +20,24 @@
         <!-- File template -->
         <DataTemplate x:Key="FileTemplate"
                       x:DataType="local:ISearchBoxResultItem">
-            <Grid Padding="{StaticResource Infomaniak.Style.Thickness.Sides.Vertical.XS}"
-                  ColumnSpacing="{StaticResource Infomaniak.Style.Spacing.XS}"
-                  RowSpacing="{StaticResource Infomaniak.Style.Spacing.XXS}">
+            <Grid ColumnSpacing="{StaticResource Infomaniak.Style.Spacing.XS}"
+                  RowSpacing="{StaticResource Infomaniak.Style.Spacing.XXS}"
+                  ToolTipService.Placement="Right"
+                  Background="Transparent"
+                  PointerEntered="Template_PointerEntered"
+                  PointerExited="Template_PointerExited"
+                  HorizontalAlignment="Stretch"
+                  VerticalAlignment="Stretch"
+                  Padding="{StaticResource Infomaniak.Style.Thickness.Sides.Vertical.XS}">
+
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" />
-                    <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
 
                 <local:SvgIcon Grid.Column="0"
@@ -42,7 +49,8 @@
                 <TextBlock Grid.Column="1"
                            Grid.Row="0"
                            Text="{x:Bind SearchItem.Name}"
-                           TextTrimming="CharacterEllipsis">
+                           TextTrimming="CharacterEllipsis"
+                           HorizontalAlignment="Left">
                     <ToolTipService.ToolTip>
                         <ToolTip Content="{x:Bind SearchItem.Name}" />
                     </ToolTipService.ToolTip>
@@ -61,34 +69,39 @@
 
                 <local:SvgIcon Grid.Column="2"
                                Grid.Row="0"
-                               Width="16"
+                               Width="10"
                                HorizontalAlignment="Right"
                                UriString="{StaticResource Infomaniak.DS.Icons.Arrows.square-arrow-diagonal-up}"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                               Visibility="{x:Bind SearchItem.IsAvailableLocally, Converter={StaticResource BooleanToVisibilityConverter}, ConverterParameter='Inverted=True', Mode=OneWay}"
-                               ToolTipService.Placement="Right">
-                    <ToolTipService.ToolTip>
-                        <ToolTip Content="{x:Bind kDrive:Localizer.Instance.GetString('itemUnavailableBrowserFallback'), Mode=OneWay}" />
-                    </ToolTipService.ToolTip>
-                </local:SvgIcon>
+                               Visibility="{Binding ShowUnavailableState, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" />
+
             </Grid>
         </DataTemplate>
 
         <!-- Directory template -->
         <DataTemplate x:Key="FolderTemplate"
                       x:DataType="local:ISearchBoxResultItem">
-            <Grid Padding="{StaticResource Infomaniak.Style.Thickness.Sides.Vertical.XS}"
-                  ColumnSpacing="{StaticResource Infomaniak.Style.Spacing.XS}"
-                  RowSpacing="{StaticResource Infomaniak.Style.Spacing.XXS}">
-
+            <Grid ColumnSpacing="{StaticResource Infomaniak.Style.Spacing.XS}"
+                  RowSpacing="{StaticResource Infomaniak.Style.Spacing.XXS}"
+                  Background="Transparent"
+                  HorizontalAlignment="Stretch"
+                  VerticalAlignment="Stretch"
+                  ToolTipService.Placement="Right"
+                  PointerEntered="Template_PointerEntered"
+                  PointerExited="Template_PointerExited"
+                  Padding="{StaticResource Infomaniak.Style.Thickness.Sides.Vertical.XS}">
+                <ToolTipService.ToolTip>
+                    <ToolTip Visibility="{x:Bind SearchItem.IsAvailableLocally, Converter={StaticResource BooleanToVisibilityConverter}, ConverterParameter='Inverted=True', Mode=OneWay}"
+                             Content="{x:Bind kDrive:Localizer.Instance.GetString('itemUnavailableBrowserFallback'), Mode=OneWay}" />
+                </ToolTipService.ToolTip>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" />
-                    <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
 
                 <local:SvgIcon Grid.Column="0"
@@ -115,18 +128,12 @@
                 </TextBlock>
                 <local:SvgIcon Grid.Column="2"
                                Grid.Row="0"
-                               Width="16"
+                               Width="10"
                                HorizontalAlignment="Right"
                                Margin="{StaticResource Infomaniak.Style.Thickness.Left.XS}"
                                UriString="{StaticResource Infomaniak.DS.Icons.Arrows.square-arrow-diagonal-up}"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                               Visibility="{x:Bind SearchItem.IsAvailableLocally, Converter={StaticResource BooleanToVisibilityConverter}, ConverterParameter='Inverted=True', Mode=OneWay}"
-                               ToolTipService.Placement="Right">
-                    <ToolTipService.ToolTip>
-                        <ToolTip Content="{x:Bind kDrive:Localizer.Instance.GetString('itemUnavailableBrowserFallback'), Mode=OneWay}" />
-                    </ToolTipService.ToolTip>
-                </local:SvgIcon>
-
+                               Visibility="{Binding ShowUnavailableState, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" />
             </Grid>
         </DataTemplate>
 
@@ -216,7 +223,5 @@
                     UpdateTextOnSelect="False"
                     SuggestionChosen="TitleBarSearchBox_SuggestionChosen"
                     QuerySubmitted="TitleBarSearchBox_QuerySubmitted"
-                    Visibility="{x:Bind ViewModel.SelectedSync, Converter={StaticResource IsNullToBoolOrVisibilityConverter}, ConverterParameter='Inverted=True', Mode=OneWay}">
-    </AutoSuggestBox>
-
+                    Visibility="{x:Bind ViewModel.SelectedSync, Converter={StaticResource IsNullToBoolOrVisibilityConverter}, ConverterParameter='Inverted=True', Mode=OneWay}" />
 </UserControl>

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/SearchBox.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/SearchBox.xaml.cs
@@ -7,6 +7,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using System;
 using System.Collections.Generic;
+using System.Drawing.Printing;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -21,20 +22,39 @@ namespace Infomaniak.kDrive.CustomControls
     {
         SearchItem? SearchItem { get; }
         bool IsSelectable { get; }
+        bool ShowUnavailableState { get; }
     }
 
-    public sealed record SearchBoxResultItem(SearchItem? SearchItem, bool IsSelectable = true) : ISearchBoxResultItem;
+    public sealed class SearchBoxResultItem : UISafeObservableObject, ISearchBoxResultItem
+    {
+        private bool _showUnavailableState = false;
+        public SearchBoxResultItem(SearchItem? SearchItem, bool IsSelectable = true)
+        {
+            this.SearchItem = SearchItem;
+            this.IsSelectable = IsSelectable;
+        }
+
+        public SearchItem? SearchItem { get; }
+        public bool IsSelectable { get; }
+        public bool ShowUnavailableState
+        {
+            get => _showUnavailableState;
+            set => SetPropertyInUIThread(ref _showUnavailableState, value);
+        }
+    }
 
     public sealed record SearchBoxLoaderItem() : ISearchBoxResultItem
     {
         public SearchItem? SearchItem => null;
         public bool IsSelectable => false;
+        public bool ShowUnavailableState => false;
     };
 
     public sealed record SearchBoxNotFoundItem() : ISearchBoxResultItem
     {
         public SearchItem? SearchItem => null;
         public bool IsSelectable => false;
+        public bool ShowUnavailableState => false;
     };
 
     public sealed partial class SearchBox : UserControl
@@ -43,6 +63,7 @@ namespace Infomaniak.kDrive.CustomControls
         private AppModel ViewModel => App.ServiceProvider.GetRequiredService<AppModel>();
         private const string _privateFolderName = "Private/";
         private const string _sharedFolderName = "Shared/";
+        private ISearchBoxResultItem? _lastItemOver;
         public SearchBox()
         {
             InitializeComponent();
@@ -255,6 +276,35 @@ namespace Infomaniak.kDrive.CustomControls
                 string path = System.IO.Path.Combine(ViewModel.SelectedSync.LocalPath, itemRelativePath);
                 await Utility.OpenFolderSecurely(path);
             }
+        }
+
+        private void Template_PointerEntered(object sender, Microsoft.UI.Xaml.Input.PointerRoutedEventArgs e)
+        {
+            FrameworkElement? frameworkElement = sender as FrameworkElement;
+            if (frameworkElement is null)
+            {
+                Logger.Log(Logger.Level.Warning, "sender is expected to be a FrameworkElement.");
+                return;
+            }
+
+            SearchBoxResultItem? searchResultItem = frameworkElement.DataContext as SearchBoxResultItem;
+            if (searchResultItem is null)
+                return;
+
+            if (_lastItemOver is SearchBoxResultItem lastItemOver && lastItemOver != searchResultItem)
+                lastItemOver.ShowUnavailableState = false;
+
+            if (!searchResultItem.SearchItem?.IsAvailableLocally ?? false)
+            {
+                searchResultItem.ShowUnavailableState = true;
+                _lastItemOver = searchResultItem;
+            }
+        }
+
+        private void Template_PointerExited(object sender, Microsoft.UI.Xaml.Input.PointerRoutedEventArgs e)
+        {
+            if (_lastItemOver is SearchBoxResultItem lastItemOver)
+                lastItemOver.ShowUnavailableState = false;
         }
     }
 


### PR DESCRIPTION
Refactor item templates to show unavailable state indicator and tooltip only on pointer hover. Introduces ShowUnavailableState property and updates SearchBoxResultItem for dynamic UI updates. Icon size reduced for better clarity.