### PR TITLE
feat(winui activities): Add OperationId for unique activity tracking

### DIFF
--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/CommSharedStructs.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/CommSharedStructs.cs
@@ -108,7 +108,7 @@ namespace Infomaniak.kDrive.ServerCommunication.CommStruct
         {
             CopyProperty(source, target, nameof(source.DbId), nameof(target.DbId));
             CopyProperty(source, target, nameof(source.Id), nameof(target.Id));
-			CopyProperty(source, target, nameof(source.Name), nameof(target.Name));
+            CopyProperty(source, target, nameof(source.Name), nameof(target.Name));
         }
     }
 
@@ -167,7 +167,7 @@ namespace Infomaniak.kDrive.ServerCommunication.CommStruct
             CopyProperty(source, target, nameof(source.DriveId), nameof(target.DriveId));
             CopyProperty(source, target, nameof(source.UserId), nameof(target.UserId));
             CopyProperty(source, target, nameof(source.AccountId), nameof(target.AccountId));
-			CopyProperty(source, target, nameof(source.AccountName), nameof(target.AccountName));
+            CopyProperty(source, target, nameof(source.AccountName), nameof(target.AccountName));
             CopyProperty(source, target, nameof(source.Name), nameof(target.Name));
             CopyProperty(source, target, nameof(source.Color), nameof(target.Color));
             CopyProperty(source, target, nameof(source.UserDbId), nameof(target.UserDbId));
@@ -328,6 +328,7 @@ namespace Infomaniak.kDrive.ServerCommunication.CommStruct
         public string? Error { get; set; }
         public Int64? Size { get; set; }
         public int? Progress { get; set; }
+        public Int64? OperationId { get; set; }
     }
 
     public static partial class ConversionHelper
@@ -348,6 +349,7 @@ namespace Infomaniak.kDrive.ServerCommunication.CommStruct
             CopyProperty(source, target, nameof(source.Error), nameof(target.Error));
             CopyProperty(source, target, nameof(source.Size), nameof(target.Size));
             CopyProperty(source, target, nameof(source.Progress), nameof(target.ProgressPercent));
+            CopyProperty(source, target, nameof(source.OperationId), nameof(target.OperationId));
         }
     }
 

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -1488,6 +1488,10 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 var activities = sync.SyncActivities;
                 var operationId = fileItemInfo.OperationId;
 
+                // Store the position of the last syncing item
+                var lastSyncingItem = activities.LastOrDefault(a => a.Status == SyncFileStatus.Syncing);
+                int destIndex = lastSyncingItem is null ? 0 : activities.IndexOf(lastSyncingItem);
+
                 // Find existing item
                 var existing = activities.FirstOrDefault(a => a.OperationId == operationId);
 
@@ -1499,10 +1503,6 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                         Logger.Log(Logger.Level.Warning, $"Received completion for already finished item. OperationId: {existing.OperationId}, Existing: {existing.Status}, New: {fileItemInfo.Status}");
                         return;
                     }
-
-                    // Store the position of the las syncing item
-                    var lastSyncingItem = activities.LastOrDefault(a => a.Status == SyncFileStatus.Syncing);
-                    int destIndex = lastSyncingItem is null ? 0 : activities.IndexOf(lastSyncingItem);
 
                     // Update state
                     CommStruct.ConversionHelper.CopyToSyncFileItem(fileItemInfo, existing);
@@ -1524,24 +1524,23 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                     return;
                 }
 
+                // Remove any item with the same remote or local node id wich is not syncing or done (ie errored)
+                var toBeRemoved = activities.Where(a => (a.Status != SyncFileStatus.Success && ((!string.IsNullOrEmpty(a.LocalNodeId) && a.LocalNodeId == fileItemInfo.LocalNodeId) || (!string.IsNullOrEmpty(a.RemoteNodeId) && a.RemoteNodeId == fileItemInfo.RemoteNodeId))));
+                activities.RemoveMany(toBeRemoved);
+
                 // Create new item
                 var newItem = new SyncFileItem(sync);
                 CommStruct.ConversionHelper.CopyToSyncFileItem(fileItemInfo, newItem);
 
-                if (newItem.Status != SyncFileStatus.Syncing)
+                if (newItem.Status != SyncFileStatus.Syncing || newItem.Size < 1000)
                 {
                     // Insert item after all syncing items
-                    int destIndex = activities.TakeWhile(a => a.Status == SyncFileStatus.Syncing).Count();
-                    activities.Insert(destIndex, newItem);
+                    activities.Insert(Math.Max(destIndex + 1, activities.Count), newItem);
                 }
                 else
                 {
                     activities.Insert(0, newItem);
                 }
-
-                // Remove any item with the same remote or local node id wich is not syncing or done (ie errored)
-                var toBeRemoved = activities.Where(a => a.Status != SyncFileStatus.Syncing && a.Status != SyncFileStatus.Success);
-                activities.RemoveMany(toBeRemoved);
 
                 // Enforce max size
                 while (activities.Count > MaxActivities)

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -1481,45 +1481,70 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 return;
             }
 
-            SyncFileItem syncFileItem = new SyncFileItem(sync);
             await Utility.RunOnUIThread(() =>
             {
-                CommStruct.ConversionHelper.CopyToSyncFileItem(fileItemInfo, syncFileItem);
+                const int MaxActivities = 500;
 
-                var existingItems = sync.SyncActivities.Where(item => (item.LocalNodeId == syncFileItem.LocalNodeId && item.LocalNodeId.Length > 0) || (item.RemoteNodeId == syncFileItem.RemoteNodeId && item.RemoteNodeId.Length > 0));
+                var activities = sync.SyncActivities;
+                var operationId = fileItemInfo.OperationId;
 
-                // Remove existing items with same LocalNodeId and RemoteNodeId that are not successful or are still syncing
-                var itemsToRemove = existingItems.Where(item => item.Status != SyncFileStatus.Success && item.Status != SyncFileStatus.Syncing);
-                sync.SyncActivities.RemoveMany(itemsToRemove);
+                // Find existing item
+                var existing = activities.FirstOrDefault(a => a.OperationId == operationId);
 
-                // update existing item if it is syncing
-                var syncingItem = existingItems.FirstOrDefault(item => item.Status == SyncFileStatus.Syncing);
-                if (syncingItem is not null)
+                if (existing != null)
                 {
-                    ConversionHelper.CopyToSyncFileItem(fileItemInfo, syncingItem);
-
-                    // Move the updated item just before the first item that is not 
-                    var firstNonSyncingItem = sync.SyncActivities.FirstOrDefault(item => item.Status != SyncFileStatus.Syncing);
-                    if (firstNonSyncingItem is not null)
+                    // Ignore duplicate completion signals
+                    if (existing.Status != SyncFileStatus.Syncing)
                     {
-                        int index = sync.SyncActivities.IndexOf(firstNonSyncingItem);
-                        if (index < sync.SyncActivities.IndexOf(syncingItem))
-                        {
-                            sync.SyncActivities.Remove(syncingItem);
-                            sync.SyncActivities.Insert(index, syncingItem);
-                        }
+                        Logger.Log(Logger.Level.Warning, $"Received completion for already finished item. OperationId: {existing.OperationId}, Existing: {existing.Status}, New: {fileItemInfo.Status}");
+                        return;
                     }
+
+                    // Store the position of the las syncing item
+                    var lastSyncingItem = activities.LastOrDefault(a => a.Status == SyncFileStatus.Syncing);
+                    int destIndex = lastSyncingItem is null ? 0 : activities.IndexOf(lastSyncingItem);
+
+                    // Update state
+                    CommStruct.ConversionHelper.CopyToSyncFileItem(fileItemInfo, existing);
+                    existing.Timestamp = DateTime.Now;
+
+                    Logger.Log(Logger.Level.Extended, $"Updated item {existing.OperationId} to {existing.Status}");
+
+                    // Still syncing -> nothing more to do
+                    if (existing.Status == SyncFileStatus.Syncing)
+                        return;
+
+                    // Move completed/errored item after syncing group
+                    if (destIndex != activities.IndexOf(existing))
+                    {
+                        activities.Remove(existing);
+                        activities.Insert(Math.Min(destIndex, activities.Count), existing);
+                    }
+
                     return;
                 }
 
-                // Insert the new item at the beginning of the list
-                sync.SyncActivities.Insert(0, syncFileItem);
-                // Ensure the list does not exceed 500 items
-                while (sync.SyncActivities.Count > 500)
-                {
-                    sync.SyncActivities.RemoveAt(sync.SyncActivities.Count - 1);
-                }
+                // Create new item
+                existing = new SyncFileItem(sync);
+                CommStruct.ConversionHelper.CopyToSyncFileItem(fileItemInfo, existing);
 
+                if (existing.Status != SyncFileStatus.Syncing)
+                {
+                    // Insert item after all syncing items
+                    int destIndex = activities.TakeWhile(a => a.Status == SyncFileStatus.Syncing).Count();
+                    activities.Insert(destIndex, existing);
+                }
+                else
+                {
+                    activities.Insert(0, existing);
+                }
+                // Remove any item with the same remote or local node id wich is not syncing or done (ie errored)
+                var toBeRemoved = activities.Where(a => a.Status != SyncFileStatus.Syncing && a.Status != SyncFileStatus.Success);
+                activities.RemoveMany(toBeRemoved);
+
+                // Enforce max size
+                while (activities.Count > MaxActivities)
+                    activities.RemoveAt(activities.Count - 1);
             });
         }
 

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -1525,7 +1525,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 }
 
                 // Remove any item with the same remote or local node id wich is not syncing or done (ie errored)
-                var toBeRemoved = activities.Where(a => (a.Status != SyncFileStatus.Success && ((!string.IsNullOrEmpty(a.LocalNodeId) && a.LocalNodeId == fileItemInfo.LocalNodeId) || (!string.IsNullOrEmpty(a.RemoteNodeId) && a.RemoteNodeId == fileItemInfo.RemoteNodeId))));
+                var toBeRemoved = activities.Where(a => (a.Status == fileItemInfo.Status || a.Status != SyncFileStatus.Success && ((!string.IsNullOrEmpty(a.LocalNodeId) && a.LocalNodeId == fileItemInfo.LocalNodeId) || (!string.IsNullOrEmpty(a.RemoteNodeId) && a.RemoteNodeId == fileItemInfo.RemoteNodeId))));
                 activities.RemoveMany(toBeRemoved);
 
                 // Create new item

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -1532,7 +1532,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 var newItem = new SyncFileItem(sync);
                 CommStruct.ConversionHelper.CopyToSyncFileItem(fileItemInfo, newItem);
 
-                const int MinFileSizeForTopSticking = 1024; // Only stick items bigger than 1KB to the top as they are likely to complete very fast, otherwise we might end up with flickering in the UI with items jumping from the top to the middle of the list when they are completed.
+                const int MinFileSizeForTopSticking = 1024; // Don't stick items smaller than 1KB to the top as they are likely to complete very fast, otherwise we might end up with flickering in the UI with items jumping from the top to the middle of the list when they are completed.
                 if (newItem.Status != SyncFileStatus.Syncing || newItem.Size < MinFileSizeForTopSticking)
                 {
                     // Insert item after all syncing items

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -1532,7 +1532,8 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 var newItem = new SyncFileItem(sync);
                 CommStruct.ConversionHelper.CopyToSyncFileItem(fileItemInfo, newItem);
 
-                if (newItem.Status != SyncFileStatus.Syncing || newItem.Size < 1000)
+                const int MinFileSizeForTopSticking = 1024; // Only stick items bigger than 1KB to the top as they are likely to complete very fast, otherwise we might end up with flickering in the UI with items jumping from the top to the middle of the list when they are completed.
+                if (newItem.Status != SyncFileStatus.Syncing || newItem.Size < MinFileSizeForTopSticking)
                 {
                     // Insert item after all syncing items
                     activities.Insert(Math.Max(destIndex + 1, activities.Count), newItem);

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -1491,7 +1491,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 // Find existing item
                 var existing = activities.FirstOrDefault(a => a.OperationId == operationId);
 
-                if (existing != null)
+                if (existing is not null)
                 {
                     // Ignore duplicate completion signals
                     if (existing.Status != SyncFileStatus.Syncing)
@@ -1525,19 +1525,20 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 }
 
                 // Create new item
-                existing = new SyncFileItem(sync);
-                CommStruct.ConversionHelper.CopyToSyncFileItem(fileItemInfo, existing);
+                var newItem = new SyncFileItem(sync);
+                CommStruct.ConversionHelper.CopyToSyncFileItem(fileItemInfo, newItem);
 
-                if (existing.Status != SyncFileStatus.Syncing)
+                if (newItem.Status != SyncFileStatus.Syncing)
                 {
                     // Insert item after all syncing items
                     int destIndex = activities.TakeWhile(a => a.Status == SyncFileStatus.Syncing).Count();
-                    activities.Insert(destIndex, existing);
+                    activities.Insert(destIndex, newItem);
                 }
                 else
                 {
-                    activities.Insert(0, existing);
+                    activities.Insert(0, newItem);
                 }
+
                 // Remove any item with the same remote or local node id wich is not syncing or done (ie errored)
                 var toBeRemoved = activities.Where(a => a.Status != SyncFileStatus.Syncing && a.Status != SyncFileStatus.Success);
                 activities.RemoveMany(toBeRemoved);

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/SyncFileItem.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/SyncFileItem.cs
@@ -24,6 +24,7 @@ namespace Infomaniak.kDrive.ViewModels
         private string _localPath = "";
         private string _parentFolderPath = "";
         private int _progressPercent = 0;
+        public Int64 _perationId = 0;
 
         public Sync Sync { get; }
 
@@ -127,7 +128,15 @@ namespace Infomaniak.kDrive.ViewModels
         public DateTime Timestamp
         {
             get => _timestamp;
+            set => SetPropertyInUIThread(ref _timestamp, value);
         }
+
+        public Int64 OperationId
+        {
+            get => _perationId;
+            set => SetPropertyInUIThread(ref _perationId, value);
+        }
+
         // Calculated properties
         public string ParentFolderPath
         {


### PR DESCRIPTION
Introduces OperationId to SyncFileItem and SyncFileItemInfo for unique identification of sync operations. Refactors activity management logic to use OperationId, improving deduplication, ordering, and UI updates. Limits activity list to 500 items.

https://github.com/user-attachments/assets/894b54c8-d969-4183-95ef-58dc264690ed


