### PR TITLE
fix(git): unignore infomaniak build tools directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,6 +195,7 @@ cmake-build-debug*
 /infomaniak-build-tools/windows/ksigntool/.vs/ksigntool
 **/BundleArtifactss
 /*build*
+!/infomaniak-build-tools/
 
 # Xcode
 DerivedData/


### PR DESCRIPTION
The `infomaniak-build-tools/` directory was being unintentionally ignored by the `/*build*/` rule in `.gitignore`. 

This PR adds a negation rule to explicitly un-ignore it, ensuring the directory is tracked by git as expected.