### PR TITLE
feat(server): improve GetNodeInfo error handling

### DIFF
--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/SyncExclusionSelector.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/SyncExclusionSelector.xaml.cs
@@ -376,13 +376,16 @@ namespace Infomaniak.kDrive.CustomControls
             var commService = App.ServiceProvider.GetRequiredService<IServerCommService>();
             async Task<bool> loadPath(NodeId nodeId)
             {
-                var nodeInfo = await commService.GetNodeInfo(UserDbId, DriveId, nodeId, CancellationToken.None);
-                if (nodeId is null || nodeInfo is null || nodeInfo.Path == "")
+                var getNodeInfoResult = await commService.GetNodeInfo(UserDbId, DriveId, nodeId, CancellationToken.None);
+                if (nodeId is null || !getNodeInfoResult.IsSuccess|| getNodeInfoResult.Node is null)
                 {
-                    Logger.Log(Logger.Level.Warning, "Failed to load node info for nodeId: " + nodeId);
+                    if(getNodeInfoResult.Cause == ExitCause.NotFound)
+                        Logger.Log(Logger.Level.Info, $"Excluded node with id {nodeId} not found on server. It might have been deleted since it was blacklisted.");
+                    else
+                        Logger.Log(Logger.Level.Warning, "Failed to load node info for nodeId: " + nodeId);
                     return false;
                 }
-                _excludedNodePathsMap.TryAdd(nodeId, nodeInfo.Path);
+                _excludedNodePathsMap.TryAdd(nodeId, getNodeInfoResult.Node.Path);
                 return true;
             }
             var newExcludedNodePathsMap = _excludedNodePathsMap.Where(pair => _excludedNodeIds.Contains(pair.Key)).ToDictionary(); // Remove all the nodes that are not blacklisted anymore.

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/SyncExclusionSelector.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/SyncExclusionSelector.xaml.cs
@@ -377,16 +377,22 @@ namespace Infomaniak.kDrive.CustomControls
             async Task<bool> loadPath(NodeId nodeId)
             {
                 var getNodeInfoResult = await commService.GetNodeInfo(UserDbId, DriveId, nodeId, CancellationToken.None);
-                if (nodeId is null || !getNodeInfoResult.IsSuccess|| getNodeInfoResult.Node is null)
+                if (nodeId is not null && getNodeInfoResult.IsSuccess && getNodeInfoResult.Node is not null)
                 {
-                    if(getNodeInfoResult.Cause == ExitCause.NotFound)
-                        Logger.Log(Logger.Level.Info, $"Excluded node with id {nodeId} not found on server. It might have been deleted since it was blacklisted.");
-                    else
-                        Logger.Log(Logger.Level.Warning, "Failed to load node info for nodeId: " + nodeId);
+                    _excludedNodePathsMap.TryAdd(nodeId, getNodeInfoResult.Node.Path);
+                    return true;
+                }
+
+                if (getNodeInfoResult.Cause == ExitCause.NotFound)
+                {
+                    Logger.Log(Logger.Level.Info, $"Excluded node with id {nodeId} not found on server. It might have been deleted since it was blacklisted.");
+                    return true;
+                }
+                else
+                {
+                    Logger.Log(Logger.Level.Warning, "Failed to load node info for nodeId: " + nodeId);
                     return false;
                 }
-                _excludedNodePathsMap.TryAdd(nodeId, getNodeInfoResult.Node.Path);
-                return true;
             }
             var newExcludedNodePathsMap = _excludedNodePathsMap.Where(pair => _excludedNodeIds.Contains(pair.Key)).ToDictionary(); // Remove all the nodes that are not blacklisted anymore.
             _excludedNodePathsMap.Clear(); // Cannot just use "=" because of references held by TreeItems.

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Interfaces/IServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Interfaces/IServerCommService.cs
@@ -70,7 +70,20 @@ namespace Infomaniak.kDrive.ServerCommunication.Interfaces
 
         // Node-related requests
         Task<List<Node>?> GetSubFolders(DbId userDbId, DriveId driveId, NodeId parentNodeId /*Leave empty for root node*/, CancellationToken cancellationToken);
-        Task<Node?> GetNodeInfo(DbId userDbId, DriveId driveId, NodeId nodeId, CancellationToken cancellationToken);
+
+        struct GetNodeInfoResult
+        {
+            public ExitCause Cause { get; private set; }
+            public Node? Node { get; private set; }
+            public bool IsSuccess => Node is not null && Cause == ExitCause.Unknown;
+
+            public GetNodeInfoResult(ExitCause cause, Node? node)
+            {
+                Cause = cause;
+                Node = node;
+            }
+        }
+        Task<GetNodeInfoResult> GetNodeInfo(DbId userDbId, DriveId driveId, NodeId nodeId, CancellationToken cancellationToken);
         Task<Int64?> GetFolderSize(DbId userDbId, DriveId driveId, NodeId nodeId, CancellationToken cancellationToken);
         Task<List<NodeId>?> GetBlacklistedNodeIdList(DbId syncDbId, CancellationToken cancellationToken);
         Task<bool> SetBlacklistedNodeIdList(DbId syncDbId, List<NodeId> idList, CancellationToken cancellationToken);

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -13,6 +13,7 @@ using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
 using static Infomaniak.kDrive.ServerCommunication.Interfaces.IServerCommProtocol;
+using static Infomaniak.kDrive.ServerCommunication.Interfaces.IServerCommService;
 
 namespace Infomaniak.kDrive.ServerCommunication.Services
 {
@@ -782,7 +783,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
 
             return nodes;
         }
-        public async Task<Node?> GetNodeInfo(DbId userDbId, DriveId driveId, NodeId nodeId, CancellationToken cancellationToken)
+        public async Task<GetNodeInfoResult> GetNodeInfo(DbId userDbId, DriveId driveId, NodeId nodeId, CancellationToken cancellationToken)
         {
             var parms = new JsonObject
             {
@@ -793,10 +794,10 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             };
             CommData data = await _commClient.SendRequestAsync(RequestNum.NODE_INFO, parms, cancellationToken).ConfigureAwait(false);
             if (!CheckJobResultAndLogIfError(data, parms))
-                return null;
+                return new GetNodeInfoResult(data.Cause, null);
 
             if (!HasRequiredParam(data, JsonKeys.NodeInfo))
-                return null;
+                return new GetNodeInfoResult(data.Cause, null);
 
             var options = new JsonSerializerOptions
             {
@@ -807,9 +808,9 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             if (nodeInfo is null)
             {
                 Logger.Log(Logger.Level.Error, $"Failed to deserialize nodeInfo from ${data.Params[JsonKeys.NodeInfo]}.");
-                return null;
+                return new GetNodeInfoResult(data.Cause, null);
             }
-            return new Node(nodeInfo.NodeId ?? "", nodeInfo.Name ?? "", nodeInfo.Size ?? 0, nodeInfo.ParentNodeId ?? "", nodeInfo.Path ?? "", userDbId, driveId, nodeInfo?.AccessDenied ?? false);
+            return new GetNodeInfoResult(data.Cause, new Node(nodeInfo.NodeId ?? "", nodeInfo.Name ?? "", nodeInfo.Size ?? 0, nodeInfo.ParentNodeId ?? "", nodeInfo.Path ?? "", userDbId, driveId, nodeInfo?.AccessDenied ?? false));
         }
 
         public async Task<Int64?> GetFolderSize(long userDbId, long driveId, string nodeId, CancellationToken cancellationToken)


### PR DESCRIPTION
Refactor GetNodeInfo to return a structured result with error cause and node data. Enhance error logging and handling for missing or deleted nodes.