### PR TITLE
fix(cmake): correct conditional logic in ECMAddAppIcon.cmake

### DIFF
--- a/cmake/modules/ECMAddAppIcon.cmake
+++ b/cmake/modules/ECMAddAppIcon.cmake
@@ -387,7 +387,7 @@ macro(_ecm_add_app_icon_categorize_icons icons type known_sizes)
 
                     if (offset GREATER -1)
                         list(APPEND ${type}_at_${size}px "${icon_full}")
-                    elseif()
+                    else()
                         message(STATUS "not found ${type}_at_${size}px ${icon_full}")
                     endif()
                 endif()


### PR DESCRIPTION
Fixed invalid CMake syntax where `elseif()` was used without a condition in the `_ecm_add_app_icon_categorize_icons` macro.

Replaced it with `else()` to correctly handle the fallback case when an icon offset isn’t found in the list of known sizes.

<details>
<summary>Causes multiple warnings</summary>

```
CMake Warning (dev) at cmake/modules/ECMAddAppIcon.cmake:390 (elseif):
  ELSEIF called with no arguments, it will be skipped.
Call Stack (most recent call first):
  cmake/modules/ECMAddAppIcon.cmake:142 (_ecm_add_app_icon_categorize_icons)
  src/gui/CMakeLists.txt:195 (ecm_add_app_icon)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at cmake/modules/ECMAddAppIcon.cmake:390 (elseif):
  ELSEIF called with no arguments, it will be skipped.
Call Stack (most recent call first):
  cmake/modules/ECMAddAppIcon.cmake:142 (_ecm_add_app_icon_categorize_icons)
  src/gui/CMakeLists.txt:195 (ecm_add_app_icon)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at cmake/modules/ECMAddAppIcon.cmake:390 (elseif):
  ELSEIF called with no arguments, it will be skipped.
Call Stack (most recent call first):
  cmake/modules/ECMAddAppIcon.cmake:142 (_ecm_add_app_icon_categorize_icons)
  src/gui/CMakeLists.txt:195 (ecm_add_app_icon)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at cmake/modules/ECMAddAppIcon.cmake:390 (elseif):
  ELSEIF called with no arguments, it will be skipped.
Call Stack (most recent call first):
  cmake/modules/ECMAddAppIcon.cmake:142 (_ecm_add_app_icon_categorize_icons)
  src/gui/CMakeLists.txt:195 (ecm_add_app_icon)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at cmake/modules/ECMAddAppIcon.cmake:390 (elseif):
  ELSEIF called with no arguments, it will be skipped.
Call Stack (most recent call first):
  cmake/modules/ECMAddAppIcon.cmake:142 (_ecm_add_app_icon_categorize_icons)
  src/gui/CMakeLists.txt:195 (ecm_add_app_icon)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at cmake/modules/ECMAddAppIcon.cmake:390 (elseif):
  ELSEIF called with no arguments, it will be skipped.
Call Stack (most recent call first):
  cmake/modules/ECMAddAppIcon.cmake:142 (_ecm_add_app_icon_categorize_icons)
  src/gui/CMakeLists.txt:195 (ecm_add_app_icon)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at cmake/modules/ECMAddAppIcon.cmake:390 (elseif):
  ELSEIF called with no arguments, it will be skipped.
Call Stack (most recent call first):
  cmake/modules/ECMAddAppIcon.cmake:142 (_ecm_add_app_icon_categorize_icons)
  src/gui/CMakeLists.txt:195 (ecm_add_app_icon)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at cmake/modules/ECMAddAppIcon.cmake:390 (elseif):
  ELSEIF called with no arguments, it will be skipped.
Call Stack (most recent call first):
  cmake/modules/ECMAddAppIcon.cmake:142 (_ecm_add_app_icon_categorize_icons)
  src/gui/CMakeLists.txt:195 (ecm_add_app_icon)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at cmake/modules/ECMAddAppIcon.cmake:390 (elseif):
  ELSEIF called with no arguments, it will be skipped.
Call Stack (most recent call first):
  cmake/modules/ECMAddAppIcon.cmake:142 (_ecm_add_app_icon_categorize_icons)
  src/gui/CMakeLists.txt:195 (ecm_add_app_icon)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at cmake/modules/ECMAddAppIcon.cmake:390 (elseif):
  ELSEIF called with no arguments, it will be skipped.
Call Stack (most recent call first):
  cmake/modules/ECMAddAppIcon.cmake:142 (_ecm_add_app_icon_categorize_icons)
  src/server/CMakeLists.txt:244 (ecm_add_app_icon)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at cmake/modules/ECMAddAppIcon.cmake:390 (elseif):
  ELSEIF called with no arguments, it will be skipped.
Call Stack (most recent call first):
  cmake/modules/ECMAddAppIcon.cmake:142 (_ecm_add_app_icon_categorize_icons)
  src/server/CMakeLists.txt:244 (ecm_add_app_icon)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at cmake/modules/ECMAddAppIcon.cmake:390 (elseif):
  ELSEIF called with no arguments, it will be skipped.
Call Stack (most recent call first):
  cmake/modules/ECMAddAppIcon.cmake:142 (_ecm_add_app_icon_categorize_icons)
  src/server/CMakeLists.txt:244 (ecm_add_app_icon)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at cmake/modules/ECMAddAppIcon.cmake:390 (elseif):
  ELSEIF called with no arguments, it will be skipped.
Call Stack (most recent call first):
  cmake/modules/ECMAddAppIcon.cmake:142 (_ecm_add_app_icon_categorize_icons)
  src/server/CMakeLists.txt:244 (ecm_add_app_icon)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at cmake/modules/ECMAddAppIcon.cmake:390 (elseif):
  ELSEIF called with no arguments, it will be skipped.
Call Stack (most recent call first):
  cmake/modules/ECMAddAppIcon.cmake:142 (_ecm_add_app_icon_categorize_icons)
  src/server/CMakeLists.txt:244 (ecm_add_app_icon)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at cmake/modules/ECMAddAppIcon.cmake:390 (elseif):
  ELSEIF called with no arguments, it will be skipped.
Call Stack (most recent call first):
  cmake/modules/ECMAddAppIcon.cmake:142 (_ecm_add_app_icon_categorize_icons)
  src/server/CMakeLists.txt:244 (ecm_add_app_icon)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at cmake/modules/ECMAddAppIcon.cmake:390 (elseif):
  ELSEIF called with no arguments, it will be skipped.
Call Stack (most recent call first):
  cmake/modules/ECMAddAppIcon.cmake:142 (_ecm_add_app_icon_categorize_icons)
  src/server/CMakeLists.txt:244 (ecm_add_app_icon)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at cmake/modules/ECMAddAppIcon.cmake:390 (elseif):
  ELSEIF called with no arguments, it will be skipped.
Call Stack (most recent call first):
  cmake/modules/ECMAddAppIcon.cmake:142 (_ecm_add_app_icon_categorize_icons)
  src/server/CMakeLists.txt:244 (ecm_add_app_icon)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at cmake/modules/ECMAddAppIcon.cmake:390 (elseif):
  ELSEIF called with no arguments, it will be skipped.
Call Stack (most recent call first):
  cmake/modules/ECMAddAppIcon.cmake:142 (_ecm_add_app_icon_categorize_icons)
  src/server/CMakeLists.txt:244 (ecm_add_app_icon)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

</details>

File: [`cmake/modules/ECMAddAppIcon.cmake`](https://github.com/Infomaniak/desktop-kDrive/pull/1541/changes)