### PR TITLE
Blacklist local edited dehydrated placeholder

### DIFF
--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -2328,8 +2328,8 @@ ExitInfo ExecutorWorker::removeDependentOps(const std::shared_ptr<Node> localNod
 
 ExitInfo ExecutorWorker::excludeFileFromSync(SyncOpPtr syncOp, const SyncPath &absoluteLocalFilepath) {
     // Blacklist placeholder
-    PlatformInconsistencyCheckerUtility::renameLocalFile(absoluteLocalFilepath,
-                                                         PlatformInconsistencyCheckerUtility::SuffixType::Blacklisted);
+    (void) PlatformInconsistencyCheckerUtility::renameLocalFile(absoluteLocalFilepath,
+                                                                PlatformInconsistencyCheckerUtility::SuffixType::Blacklisted);
 
     // Clear update tree
     if (!deleteOpNodes(syncOp)) {

--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -301,6 +301,8 @@ ExitInfo ExecutorWorker::handleCreateOp(SyncOpPtr syncOp, std::shared_ptr<SyncJo
         }
 
         if (isDehydratedPlaceholder) {
+            LOGW_SYNCPAL_WARN(_logger,
+                              L"Do not upload dehydrated placeholder " << Utility::formatSyncPath(absoluteLocalFilePath));
             return excludeFileFromSync(syncOp, absoluteLocalFilePath);
         }
     }
@@ -872,6 +874,7 @@ ExitInfo ExecutorWorker::checkLiteSyncInfoForEdit(SyncOpPtr syncOp, const SyncPa
         case ReplicaSide::Remote:
             if (vfsStatus.isPlaceholder && !vfsStatus.isHydrated) {
                 ignoreItem = true;
+                LOGW_SYNCPAL_WARN(_logger, L"Do not upload dehydrated placeholder " << Utility::formatSyncPath(absolutePath));
                 return excludeFileFromSync(syncOp, absolutePath);
             }
             break;

--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -295,23 +295,13 @@ ExitInfo ExecutorWorker::handleCreateOp(SyncOpPtr syncOp, std::shared_ptr<SyncJo
     SyncPath absoluteLocalFilePath = _syncPal->localPath() / relativeLocalFilePath;
     if (isLiteSyncActivated() && !syncOp->omit()) {
         bool isDehydratedPlaceholder = false;
-        if (ExitInfo exitInfo = checkLiteSyncInfoForCreate(syncOp, absoluteLocalFilePath, isDehydratedPlaceholder); !exitInfo) {
-            LOG_SYNCPAL_WARN(_logger, "Error in checkLiteSyncInfoForCreate" << " " << exitInfo);
+        if (const auto exitInfo = checkLiteSyncInfoForCreate(syncOp, absoluteLocalFilePath, isDehydratedPlaceholder); !exitInfo) {
+            LOG_SYNCPAL_WARN(_logger, "Error in checkLiteSyncInfoForCreate " << exitInfo);
             return exitInfo;
         }
 
         if (isDehydratedPlaceholder) {
-            // Blacklist dehydrated placeholder
-            PlatformInconsistencyCheckerUtility::renameLocalFile(absoluteLocalFilePath,
-                                                                 PlatformInconsistencyCheckerUtility::SuffixType::Blacklisted);
-
-            // Clear update tree
-            if (!deleteOpNodes(syncOp)) {
-                LOG_SYNCPAL_WARN(_logger, "Error in ExecutorWorker::deleteOpNodes");
-                return ExitCode::DataError;
-            }
-
-            return ExitCode::Ok;
+            return excludeFileFromSync(syncOp, absoluteLocalFilePath);
         }
     }
 
@@ -867,38 +857,6 @@ ExitInfo ExecutorWorker::generateEditJob(SyncOpPtr syncOp, std::shared_ptr<SyncJ
     return ExitCode::Ok;
 }
 
-ExitInfo ExecutorWorker::fixModificationDate(SyncOpPtr syncOp, const SyncPath &absolutePath) {
-    const auto id = syncOp->affectedNode()->id().value_or("");
-    LOGW_SYNCPAL_DEBUG(_logger, L"Do not upload dehydrated placeholders: " << Utility::formatSyncPath(absolutePath) << L" ("
-                                                                           << CommonUtility::s2ws(id) << L")");
-
-    // Update last modification date in order to avoid generating more EDIT operations.
-    bool found = false;
-    DbNode dbNode;
-    if (!_syncPal->syncDb()->node(*syncOp->correspondingNode()->idb(), dbNode, found)) {
-        LOG_SYNCPAL_WARN(_logger, "Error in SyncDb::node");
-        return {ExitCode::DbError, ExitCause::DbAccessError};
-    }
-    if (!found) {
-        LOG_SYNCPAL_DEBUG(_logger, "Failed to retrieve node for dbId=" << *syncOp->correspondingNode()->idb());
-        return {ExitCode::DataError, ExitCause::DbEntryNotFound};
-    }
-
-    if (const IoError ioError = IoHelper::setFileDates(absolutePath, dbNode.created().value_or(0),
-                                                       dbNode.lastModifiedRemote().value_or(0), false);
-        ioError == IoError::Success) {
-        LOGW_SYNCPAL_INFO(_logger,
-                          L"Last modification date updated locally to avoid further wrongly generated EDIT operations for file: "
-                                  << Utility::formatSyncPath(absolutePath));
-    } else if (ioError == IoError::NoSuchFileOrDirectory) {
-        // If file does not exist anymore, do nothing special. This is fine, it will not generate EDIT operations anymore.
-    } else {
-        LOGW_SYNCPAL_WARN(_logger, L"Error in IoHelper::setFileDates: " << Utility::formatSyncPath(absolutePath));
-    }
-
-    return ExitCode::Ok;
-}
-
 ExitInfo ExecutorWorker::checkLiteSyncInfoForEdit(SyncOpPtr syncOp, const SyncPath &absolutePath, bool &ignoreItem,
                                                   bool &isSyncing) {
     ignoreItem = false;
@@ -914,7 +872,7 @@ ExitInfo ExecutorWorker::checkLiteSyncInfoForEdit(SyncOpPtr syncOp, const SyncPa
         case ReplicaSide::Remote:
             if (vfsStatus.isPlaceholder && !vfsStatus.isHydrated) {
                 ignoreItem = true;
-                return fixModificationDate(syncOp, absolutePath);
+                return excludeFileFromSync(syncOp, absolutePath);
             }
             break;
         case ReplicaSide::Local:
@@ -2360,6 +2318,20 @@ ExitInfo ExecutorWorker::removeDependentOps(const std::shared_ptr<Node> localNod
     }
     if (!dependentOps.empty()) {
         LOGW_SYNCPAL_DEBUG(_logger, L"Removed " << dependentOps.size() << L" dependent operations.");
+    }
+
+    return ExitCode::Ok;
+}
+
+ExitInfo ExecutorWorker::excludeFileFromSync(SyncOpPtr syncOp, const SyncPath &absoluteLocalFilepath) {
+    // Blacklist placeholder
+    PlatformInconsistencyCheckerUtility::renameLocalFile(absoluteLocalFilepath,
+                                                         PlatformInconsistencyCheckerUtility::SuffixType::Blacklisted);
+
+    // Clear update tree
+    if (!deleteOpNodes(syncOp)) {
+        LOG_SYNCPAL_WARN(_logger, "Error in ExecutorWorker::deleteOpNodes");
+        return ExitCode::DataError;
     }
 
     return ExitCode::Ok;

--- a/src/libsyncengine/propagation/executor/executorworker.h
+++ b/src/libsyncengine/propagation/executor/executorworker.h
@@ -85,15 +85,6 @@ class ExecutorWorker : public OperationProcessor {
         ExitInfo handleEditOp(SyncOpPtr syncOp, std::shared_ptr<SyncJob> &job, bool &ignored);
         ExitInfo generateEditJob(SyncOpPtr syncOp, std::shared_ptr<SyncJob> &job);
 
-        /**
-         * This method aims to fix the last modification date of a local file using the date stored in DB. This allows us to fix
-         * wrong EDIT operations generated on dehydrated placeholders.
-         * @param syncOp : the operation to propagate.
-         * @param absolutePath : absolute local path of the affected file.
-         * @return `true` if the date is modified successfully.
-         * @note _executorExitCode and _executorExitCause must be set when the function returns false
-         */
-        ExitInfo fixModificationDate(SyncOpPtr syncOp, const SyncPath &absolutePath);
         ExitInfo checkLiteSyncInfoForEdit(SyncOpPtr syncOp, const SyncPath &absolutePath, bool &ignoreItem,
                                           bool &isSyncing); // TODO : is called "check..." but perform some actions. Wording not
                                                             // good, function probably does too much
@@ -158,6 +149,8 @@ class ExecutorWorker : public OperationProcessor {
 
         ExitInfo removeDependentOps(SyncOpPtr syncOp);
         ExitInfo removeDependentOps(std::shared_ptr<Node> localNode, std::shared_ptr<Node> remoteNode, OperationType opType);
+
+        ExitInfo excludeFileFromSync(SyncOpPtr syncOp, const SyncPath &absoluteLocalFilepath);
 
         std::unordered_map<UniqueId, std::shared_ptr<SyncJob>> _ongoingJobs;
         TerminatedJobsQueue _terminatedJobs;

--- a/test/libsyncengine/propagation/executor/testexecutorworker.cpp
+++ b/test/libsyncengine/propagation/executor/testexecutorworker.cpp
@@ -618,36 +618,6 @@ void TestExecutorWorker::testCheckAlreadyExcluded() {
     CPPUNIT_ASSERT(exitInfo == ExitInfo(ExitCode::DataError, ExitCause::FileExists));
 }
 
-void TestExecutorWorker::testFixModificationDate() {
-    // Create temp directory
-    const LocalTemporaryDirectory temporaryDirectory;
-    // Create file
-    const SyncName filename = Str("test_file.txt");
-    const SyncPath path = temporaryDirectory.path() / filename;
-    {
-        std::ofstream ofs(path);
-        ofs << "abc";
-        ofs.close();
-    }
-
-    // Update DB
-    DbNode dbNode(0, _syncPal->syncDb()->rootNode().nodeId(), filename, filename, "lid", "rid", testhelpers::defaultTime,
-                  testhelpers::defaultTime, testhelpers::defaultTime, NodeType::File, testhelpers::defaultFileSize, "cs");
-    DbNodeId dbNodeId;
-    bool constraintError = false;
-    _syncPal->syncDb()->insertNode(dbNode, dbNodeId, constraintError);
-
-    SyncOpPtr op = generateSyncOperation(dbNodeId, filename);
-    CPPUNIT_ASSERT(_executorWorker->fixModificationDate(op, path));
-
-    FileStat filestat;
-    IoError ioError = IoError::Unknown;
-    IoHelper::getFileStat(path, &filestat, ioError);
-
-    CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
-    CPPUNIT_ASSERT_EQUAL(testhelpers::defaultTime, filestat.modificationTime);
-}
-
 void TestExecutorWorker::testAffectedUpdateTree() {
     // Normal cases
     auto syncOp = std::make_shared<SyncOperation>();

--- a/test/libsyncengine/propagation/executor/testexecutorworker.h
+++ b/test/libsyncengine/propagation/executor/testexecutorworker.h
@@ -28,7 +28,6 @@ namespace KDC {
 class TestExecutorWorker : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST_SUITE(TestExecutorWorker);
         CPPUNIT_TEST(testCheckLiteSyncInfoForCreate);
-        CPPUNIT_TEST(testFixModificationDate);
         CPPUNIT_TEST(testAffectedUpdateTree);
         CPPUNIT_TEST(testTargetUpdateTree);
         CPPUNIT_TEST(testRemoveDependentOps);
@@ -46,7 +45,6 @@ class TestExecutorWorker : public CppUnit::TestFixture, public TestBase {
 
     private:
         void testCheckLiteSyncInfoForCreate();
-        void testFixModificationDate();
         void testAffectedUpdateTree();
         void testTargetUpdateTree();
         void testRemoveDependentOps();


### PR DESCRIPTION
If the app detect an Edit operation on a dehydrated placeholder, the item should be blacklisted (as is done for create events)