### PR TITLE
chore: add more info in log about blacklisted items

### DIFF
--- a/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerutility.cpp
+++ b/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerutility.cpp
@@ -95,9 +95,9 @@ ExitInfo PlatformInconsistencyCheckerUtility::renameLocalFile(const SyncPath &ab
     return moveJob.exitInfo();
 }
 
-bool PlatformInconsistencyCheckerUtility::nameHasForbiddenChars(const SyncPath &name) {
+bool PlatformInconsistencyCheckerUtility::nameHasForbiddenChars(const SyncName &name) {
     for (auto c: forbiddenFilenameChars) {
-        if (name.native().find(c) != std::string::npos) {
+        if (name.find(c) != std::string::npos) {
             LOGW_INFO(Log::instance()->getLogger(),
                       L"Name '" << SyncName2WStr(name) << L"' contains forbidden character: '" << std::wstring(1, c) << L"'");
             return true;
@@ -106,10 +106,11 @@ bool PlatformInconsistencyCheckerUtility::nameHasForbiddenChars(const SyncPath &
 
 #if defined(KD_WINDOWS)
     // Check for forbidden ascii codes
-    for (const SyncChar c: name.native()) {
-        int asciiCode(c);
+    for (const SyncChar c: name) {
+        const int64_t asciiCode(c);
         if (asciiCode <= 31) {
-            if (forbiddenChar) *forbiddenChar = c;
+            LOGW_INFO(Log::instance()->getLogger(),
+                      L"Name '" << SyncName2WStr(name) << L"' contains forbidden character: '" << std::wstring(1, c) << L"'");
             return true;
         }
     }

--- a/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerutility.cpp
+++ b/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerutility.cpp
@@ -95,10 +95,11 @@ ExitInfo PlatformInconsistencyCheckerUtility::renameLocalFile(const SyncPath &ab
     return moveJob.exitInfo();
 }
 
-bool PlatformInconsistencyCheckerUtility::nameHasForbiddenChars(const SyncPath &name, SyncChar *forbiddenChar /*= nullptr*/) {
+bool PlatformInconsistencyCheckerUtility::nameHasForbiddenChars(const SyncPath &name) {
     for (auto c: forbiddenFilenameChars) {
         if (name.native().find(c) != std::string::npos) {
-            if (forbiddenChar) *forbiddenChar = c;
+            LOGW_INFO(Log::instance()->getLogger(),
+                      L"Name '" << SyncName2WStr(name) << L"' contains forbidden character: '" << std::wstring(1, c) << L"'");
             return true;
         }
     }
@@ -159,22 +160,27 @@ bool PlatformInconsistencyCheckerUtility::checkReservedNames(const SyncName &nam
     }
 
     if (name == Str("..") || name == Str(".")) {
+        LOGW_INFO(Log::instance()->getLogger(), L"Items named '.' or '..' are forbidden on the filesystem");
         return true;
     }
 
 #if defined(KD_WINDOWS)
     // Can't have only dots
     if (std::ranges::count(name, '.') == name.size()) {
+        LOGW_INFO(Log::instance()->getLogger(), L"Names containing only dots are forbidden on the filesystem");
         return true;
     }
 
     // Can't finish with a '.'
     if (name[name.size() - 1] == '.') {
+        LOGW_INFO(Log::instance()->getLogger(),
+                  L"Names ending with a dot are forbidden on the filesystem: " << Utility::formatSyncName(name));
         return true;
     }
 
     for (const auto &reserved: reservedWinNames) {
         if (CommonUtility::startsWithInsensitive(name, Str2SyncName(reserved)) && name.size() == reserved.size()) {
+            LOGW_INFO(Log::instance()->getLogger(), L"Name '" << Str2SyncName(reserved) << L"' is reserved on the filesystem");
             return true;
         }
     }

--- a/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerutility.cpp
+++ b/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerutility.cpp
@@ -95,9 +95,10 @@ ExitInfo PlatformInconsistencyCheckerUtility::renameLocalFile(const SyncPath &ab
     return moveJob.exitInfo();
 }
 
-bool PlatformInconsistencyCheckerUtility::nameHasForbiddenChars(const SyncPath &name) {
+bool PlatformInconsistencyCheckerUtility::nameHasForbiddenChars(const SyncPath &name, wchar_t *forbiddenChar /*= nullptr*/) {
     for (auto c: forbiddenFilenameChars) {
         if (name.native().find(c) != std::string::npos) {
+            if (forbiddenChar) *forbiddenChar = c;
             return true;
         }
     }
@@ -107,6 +108,7 @@ bool PlatformInconsistencyCheckerUtility::nameHasForbiddenChars(const SyncPath &
     for (wchar_t c: name.native()) {
         int asciiCode(c);
         if (asciiCode <= 31) {
+            if (forbiddenChar) *forbiddenChar = c;
             return true;
         }
     }

--- a/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerutility.cpp
+++ b/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerutility.cpp
@@ -95,7 +95,7 @@ ExitInfo PlatformInconsistencyCheckerUtility::renameLocalFile(const SyncPath &ab
     return moveJob.exitInfo();
 }
 
-bool PlatformInconsistencyCheckerUtility::nameHasForbiddenChars(const SyncPath &name, wchar_t *forbiddenChar /*= nullptr*/) {
+bool PlatformInconsistencyCheckerUtility::nameHasForbiddenChars(const SyncPath &name, SyncChar *forbiddenChar /*= nullptr*/) {
     for (auto c: forbiddenFilenameChars) {
         if (name.native().find(c) != std::string::npos) {
             if (forbiddenChar) *forbiddenChar = c;
@@ -105,7 +105,7 @@ bool PlatformInconsistencyCheckerUtility::nameHasForbiddenChars(const SyncPath &
 
 #if defined(KD_WINDOWS)
     // Check for forbidden ascii codes
-    for (wchar_t c: name.native()) {
+    for (const SyncChar c: name.native()) {
         int asciiCode(c);
         if (asciiCode <= 31) {
             if (forbiddenChar) *forbiddenChar = c;

--- a/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerutility.h
+++ b/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerutility.h
@@ -38,7 +38,7 @@ class PlatformInconsistencyCheckerUtility {
 
         bool isNameTooLong(const SyncName &name) const;
         bool isPathTooLong(size_t pathSize);
-        bool nameHasForbiddenChars(const SyncPath &name, wchar_t *forbiddenChar = nullptr);
+        bool nameHasForbiddenChars(const SyncPath &name, SyncChar *forbiddenChar = nullptr);
         static bool isNameOnlySpaces(const SyncName &name);
         static bool nameEndWithForbiddenSpace(const SyncName &name);
 

--- a/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerutility.h
+++ b/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerutility.h
@@ -38,7 +38,7 @@ class PlatformInconsistencyCheckerUtility {
 
         bool isNameTooLong(const SyncName &name) const;
         bool isPathTooLong(size_t pathSize);
-        bool nameHasForbiddenChars(const SyncPath &name);
+        bool nameHasForbiddenChars(const SyncName &name);
         static bool isNameOnlySpaces(const SyncName &name);
         static bool nameEndWithForbiddenSpace(const SyncName &name);
 

--- a/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerutility.h
+++ b/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerutility.h
@@ -38,7 +38,7 @@ class PlatformInconsistencyCheckerUtility {
 
         bool isNameTooLong(const SyncName &name) const;
         bool isPathTooLong(size_t pathSize);
-        bool nameHasForbiddenChars(const SyncPath &name);
+        bool nameHasForbiddenChars(const SyncPath &name, wchar_t *forbiddenChar = nullptr);
         static bool isNameOnlySpaces(const SyncName &name);
         static bool nameEndWithForbiddenSpace(const SyncName &name);
 

--- a/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerutility.h
+++ b/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerutility.h
@@ -38,7 +38,7 @@ class PlatformInconsistencyCheckerUtility {
 
         bool isNameTooLong(const SyncName &name) const;
         bool isPathTooLong(size_t pathSize);
-        bool nameHasForbiddenChars(const SyncPath &name, SyncChar *forbiddenChar = nullptr);
+        bool nameHasForbiddenChars(const SyncPath &name);
         static bool isNameOnlySpaces(const SyncName &name);
         static bool nameEndWithForbiddenSpace(const SyncName &name);
 

--- a/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerworker.cpp
+++ b/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerworker.cpp
@@ -174,7 +174,12 @@ void PlatformInconsistencyCheckerWorker::blacklistNode(const std::shared_ptr<Nod
 
 bool PlatformInconsistencyCheckerWorker::checkPathAndName(std::shared_ptr<Node> remoteNode) {
     const SyncPath relativePath = remoteNode->getPath();
-    if (PlatformInconsistencyCheckerUtility::instance()->nameHasForbiddenChars(remoteNode->name())) {
+    wchar_t forbiddenChar;
+    if (PlatformInconsistencyCheckerUtility::instance()->nameHasForbiddenChars(remoteNode->name(), &forbiddenChar)) {
+        std::wstring msg = L"Name '" + SyncName2WStr(remoteNode->name()) + L"' contains forbidden character: '";
+        msg.push_back(forbiddenChar);
+        msg.push_back('\'');
+        LOGW_INFO(_logger, msg);
         blacklistNode(remoteNode, InconsistencyType::ForbiddenChar);
         return false;
     }
@@ -183,8 +188,13 @@ bool PlatformInconsistencyCheckerWorker::checkPathAndName(std::shared_ptr<Node> 
         blacklistNode(remoteNode, InconsistencyType::ForbiddenCharEndWithSpace);
         return false;
     }
-
     if (PlatformInconsistencyCheckerUtility::instance()->checkReservedNames(remoteNode->name())) {
+#if defined(KD_WINDOWS)
+        if (CommonUtility::endsWith(remoteNode->name(), ".")) {
+            LOGW_INFO(_logger, L"Names ending with a dot are forbidden on your filesystem: "
+                                       << Utility::formatSyncName(remoteNode->name()));
+        }
+#endif
         blacklistNode(remoteNode, InconsistencyType::ReservedName);
         return false;
     }

--- a/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerworker.cpp
+++ b/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerworker.cpp
@@ -176,10 +176,8 @@ bool PlatformInconsistencyCheckerWorker::checkPathAndName(std::shared_ptr<Node> 
     const SyncPath relativePath = remoteNode->getPath();
     SyncChar forbiddenChar;
     if (PlatformInconsistencyCheckerUtility::instance()->nameHasForbiddenChars(remoteNode->name(), &forbiddenChar)) {
-        std::wstring msg = L"Name '" + SyncName2WStr(remoteNode->name()) + L"' contains forbidden character: '";
-        msg.push_back(forbiddenChar);
-        msg.push_back('\'');
-        LOGW_INFO(_logger, msg);
+        LOGW_INFO(_logger, L"Name '" << SyncName2WStr(remoteNode->name()) << L"' contains forbidden character: '"
+                                     << std::wstring(1, forbiddenChar) << L"\'");
         blacklistNode(remoteNode, InconsistencyType::ForbiddenChar);
         return false;
     }

--- a/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerworker.cpp
+++ b/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerworker.cpp
@@ -174,10 +174,7 @@ void PlatformInconsistencyCheckerWorker::blacklistNode(const std::shared_ptr<Nod
 
 bool PlatformInconsistencyCheckerWorker::checkPathAndName(std::shared_ptr<Node> remoteNode) {
     const SyncPath relativePath = remoteNode->getPath();
-    SyncChar forbiddenChar;
-    if (PlatformInconsistencyCheckerUtility::instance()->nameHasForbiddenChars(remoteNode->name(), &forbiddenChar)) {
-        LOGW_INFO(_logger, L"Name '" << SyncName2WStr(remoteNode->name()) << L"' contains forbidden character: '"
-                                     << std::wstring(1, forbiddenChar) << L"\'");
+    if (PlatformInconsistencyCheckerUtility::instance()->nameHasForbiddenChars(remoteNode->name())) {
         blacklistNode(remoteNode, InconsistencyType::ForbiddenChar);
         return false;
     }
@@ -187,12 +184,6 @@ bool PlatformInconsistencyCheckerWorker::checkPathAndName(std::shared_ptr<Node> 
         return false;
     }
     if (PlatformInconsistencyCheckerUtility::instance()->checkReservedNames(remoteNode->name())) {
-#if defined(KD_WINDOWS)
-        if (CommonUtility::endsWith(remoteNode->name(), Str("."))) {
-            LOGW_INFO(_logger, L"Names ending with a dot are forbidden on the filesystem: "
-                                       << Utility::formatSyncName(remoteNode->name()));
-        }
-#endif
         blacklistNode(remoteNode, InconsistencyType::ReservedName);
         return false;
     }

--- a/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerworker.cpp
+++ b/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerworker.cpp
@@ -174,7 +174,7 @@ void PlatformInconsistencyCheckerWorker::blacklistNode(const std::shared_ptr<Nod
 
 bool PlatformInconsistencyCheckerWorker::checkPathAndName(std::shared_ptr<Node> remoteNode) {
     const SyncPath relativePath = remoteNode->getPath();
-    wchar_t forbiddenChar;
+    SyncChar forbiddenChar;
     if (PlatformInconsistencyCheckerUtility::instance()->nameHasForbiddenChars(remoteNode->name(), &forbiddenChar)) {
         std::wstring msg = L"Name '" + SyncName2WStr(remoteNode->name()) + L"' contains forbidden character: '";
         msg.push_back(forbiddenChar);

--- a/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerworker.cpp
+++ b/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerworker.cpp
@@ -190,8 +190,8 @@ bool PlatformInconsistencyCheckerWorker::checkPathAndName(std::shared_ptr<Node> 
     }
     if (PlatformInconsistencyCheckerUtility::instance()->checkReservedNames(remoteNode->name())) {
 #if defined(KD_WINDOWS)
-        if (CommonUtility::endsWith(remoteNode->name(), ".")) {
-            LOGW_INFO(_logger, L"Names ending with a dot are forbidden on your filesystem: "
+        if (CommonUtility::endsWith(remoteNode->name(), Str("."))) {
+            LOGW_INFO(_logger, L"Names ending with a dot are forbidden on the filesystem: "
                                        << Utility::formatSyncName(remoteNode->name()));
         }
 #endif


### PR DESCRIPTION
Add more logs when blacklisting an item because of unsupported characters or reserved names.