### PR TITLE
fix(log): display warning log only of parent item does not have create operation

### DIFF
--- a/src/libsyncengine/reconciliation/conflict_finder/conflictfinderworker.cpp
+++ b/src/libsyncengine/reconciliation/conflict_finder/conflictfinderworker.cpp
@@ -231,8 +231,10 @@ std::optional<Conflict> ConflictFinderWorker::checkCreateCreateConflict(const st
         correspondingParentNode = correspondingNodeInOtherTree(createNode->parentNode());
     }
     if (!correspondingParentNode) {
-        LOGW_SYNCPAL_WARN(_logger,
-                          L"Failed to get corresponding node: " << Utility::formatSyncName(createNode->parentNode()->name()));
+        if (!createNode->parentNode()->hasChangeEvent(OperationType::Create)) {
+            LOGW_SYNCPAL_WARN(_logger,
+                              L"Failed to get corresponding node: " << Utility::formatSyncName(createNode->parentNode()->name()));
+        }
         return std::nullopt;
     }
     std::optional<Conflict> conflict = std::nullopt;


### PR DESCRIPTION
Do not log a warning message about a missing parent corresponding node if the parent node has an associated CREATE operation.