### PR TITLE
fix: avoid listing request on simple move operations

### DIFF
--- a/src/libsyncengine/update_detection/file_system_observer/remotefilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/remotefilesystemobserverworker.cpp
@@ -624,9 +624,11 @@ ExitInfo RemoteFileSystemObserverWorker::processAction(ActionInfo &actionInfo, s
         case ActionCode::ActionCodeRestore:
         case ActionCode::ActionCodeCreate:
         case ActionCode::ActionCodeRename: {
-            const bool exploreDir = actionInfo.snapshotItem.type() == NodeType::Directory &&
-                                    actionInfo.actionCode != ActionCode::ActionCodeCreate &&
-                                    !_liveSnapshot.exists(actionInfo.snapshotItem.id());
+            const auto alreadySynced =
+                    _liveSnapshot.exists(actionInfo.snapshotItem.id()) || movedItems.contains(actionInfo.snapshotItem.id());
+            const bool exploreDir = !alreadySynced && actionInfo.snapshotItem.type() == NodeType::Directory &&
+                                    actionInfo.actionCode != ActionCode::ActionCodeCreate;
+
             _liveSnapshot.updateItem(actionInfo.snapshotItem);
             if (exploreDir) {
                 // Retrieve all children
@@ -676,6 +678,7 @@ ExitInfo RemoteFileSystemObserverWorker::processAction(ActionInfo &actionInfo, s
         case ActionCode::ActionCodeMoveOut:
             // Ignore move out action if destination is inside the synced folder.
             if (movedItems.contains(actionInfo.snapshotItem.id())) break;
+            (void) movedItems.insert(actionInfo.snapshotItem.id());
             [[fallthrough]];
         case ActionCode::ActionCodeTrash:
             if (!_liveSnapshot.removeItem(actionInfo.snapshotItem.id())) {


### PR DESCRIPTION
Efficiently handles move operations on already-synchronized directories to prevent redundant API requests.

## Problem
When a move operation occurred on a directory that was already synchronized, the sync engine would still trigger a full listing request (`listing/full` route) to fetch all children. This was redundant since the folder contents were already known and tracked in the snapshot.

## Solution
- Introduced an `alreadySynced` check that considers an item as synced if it either:
  - Exists in the live snapshot, OR
  - Has been moved (tracked in the `movedItems` set)
- Modified the `exploreDir` condition to only request a full listing when the directory is **not** already synced
- Added the item to `movedItems` set during `ActionCodeMoveOut` handling to properly track moved items

## Changes
- `src/libsyncengine/update_detection/file_system_observer/remotefilesystemobserverworker.cpp`
  - Refactored directory exploration logic to check sync status before triggering listing requests
  - Added moved item tracking in move-out action handler

## Impact
Reduces unnecessary API calls to the `listing/full` endpoint, improving sync performance and reducing server load for move operations on existing synchronized folders.
