### PR TITLE
feat: Build a workaround getxattr

### DIFF
--- a/extensions/MacOSX/kDriveLiteSync/Extension/main.m
+++ b/extensions/MacOSX/kDriveLiteSync/Extension/main.m
@@ -17,14 +17,12 @@
  */
 
 #include "xpcService.h"
-#include "fileAttributes.h"
 
 #import <Foundation/Foundation.h>
 #import <EndpointSecurity/EndpointSecurity.h>
 #import <bsm/libbsm.h>
 
 #include <dispatch/queue.h>
-#include <sys/xattr.h>
 
 es_client_t *g_client = NULL;
 XPCService *g_xpcService = NULL;
@@ -124,24 +122,13 @@ static BOOL processAuthOpen(const es_message_t *msg, BOOL *thumbnail)
               msg->process->signing_id.data);
     }
     
-    // Check file status
-    long bufferLength = getxattr([filePath UTF8String], [EXT_ATTR_STATUS UTF8String], NULL, 0, 0, 0);
-    if (bufferLength >= 0) {
-        char status[bufferLength];
-        if (getxattr([filePath UTF8String], [EXT_ATTR_STATUS UTF8String], status, bufferLength, 0, 0) != bufferLength) {
-            NSLog(@"[KD] ERROR: fgetxattr() failed for file %@: %d", filePath, errno);
-            return FALSE;
-        }
-
-        if (status[0] != EXT_ATTR_STATUS_ONLINE[0]) {
-            // The file is not dehydrated.
-            return FALSE;
-        }
-    }
-    else {
+    // Check file status using cache (workaround for APFS recursive lock bug)
+    // Previously used getxattr() here which caused kernel panic due to recursive APFS locking
+    if (!(g_xpcService && [g_xpcService isFileDehydrated:filePath])) {
+        // The file is not in the dehydrated cache, so it's either not dehydrated or not tracked
         return FALSE;
     }
-    
+
     // Check opening process
     if (msg->process->signing_id.data) {
         NSString *appId = [NSString stringWithUTF8String:msg->process->signing_id.data];
@@ -213,23 +200,13 @@ static BOOL processAuthRename(const es_message_t *msg)
     /*NSLog(@"[KD] Move file %s to destination %s",
           msg->event.rename.source->path.data, msg->event.rename.destination.new_path.dir->path.data);*/
     
-    // Check file status
-    long bufferLength = getxattr([filePath UTF8String], [EXT_ATTR_STATUS UTF8String], NULL, 0, 0, 0);
-    if (bufferLength >= 0) {
-        char status[bufferLength];
-        if (getxattr([filePath UTF8String], [EXT_ATTR_STATUS UTF8String], status, bufferLength, 0, 0) != bufferLength) {
-            NSLog(@"[KD] ERROR: fgetxattr() failed for file %@: %d", filePath, errno);
-            return FALSE;
-        }
-        
-        if (status[0] != EXT_ATTR_STATUS_ONLINE[0]) {
-            return FALSE;
-        }
-    }
-    else {
+    // Check file status using cache (workaround for APFS recursive lock bug)
+    // Previously used getxattr() here which caused kernel panic due to recursive APFS locking
+    if (!(g_xpcService && [g_xpcService isFileDehydrated:filePath])) {
+        // The file is not in the dehydrated cache, so it's either not dehydrated or not tracked
         return FALSE;
     }
-    
+
     NSString *destinationPath = [NSString stringWithUTF8String:msg->event.rename.destination.new_path.dir->path.data];
     
     // Check that the destination is the Trash

--- a/extensions/MacOSX/kDriveLiteSync/Extension/xpcLiteSyncExtensionProtocol.h
+++ b/extensions/MacOSX/kDriveLiteSync/Extension/xpcLiteSyncExtensionProtocol.h
@@ -27,4 +27,9 @@
 - (void)updateThumbnailFetchStatus:(NSString *)appId filePath:(NSString *)path fileStatus:(NSString *)status;
 - (void)getFetchingAppList:(NSString *)appId callback:(void (^)(NSString *))callback;
 
+// Methods to manage dehydrated files cache (workaround for APFS recursive lock bug)
+- (void)addDehydratedFile:(NSString *)appId filePath:(NSString *)path;
+- (void)removeDehydratedFile:(NSString *)appId filePath:(NSString *)path;
+- (void)clearDehydratedFilesCache:(NSString *)appId;
+
 @end

--- a/extensions/MacOSX/kDriveLiteSync/Extension/xpcService.h
+++ b/extensions/MacOSX/kDriveLiteSync/Extension/xpcService.h
@@ -29,6 +29,8 @@
     NSSet<NSString *> *_defaultOpenBlackListSet;
     NSMutableDictionary<NSString *, NSSet<NSString *> *> *_userBlackListMap;
     NSMutableArray<NSString *> *_fetchingAppArray;
+    // Cache of dehydrated (online-only) file paths to avoid getxattr() in ES callback
+    NSMutableSet<NSString *> *_dehydratedFilesCache;
 }
 
 @property(retain) XPCServiceProxy *_Nullable xpcServiceProxy;
@@ -48,5 +50,11 @@
 - (BOOL)fetchFile:(NSString *_Nullable)filePath pid:(pid_t)pid;
 - (BOOL)fetchThumbnail:(NSString *_Nullable)filePath pid:(pid_t)pid;
 - (BOOL)isDirectory:(NSString *_Nullable)path error:(NSError *_Nullable *_Nullable)error;
+
+// Methods for dehydrated files cache (workaround for APFS recursive lock bug)
+- (void)addDehydratedFile:(NSString *_Nullable)filePath;
+- (void)removeDehydratedFile:(NSString *_Nullable)filePath;
+- (void)clearDehydratedFilesCache:(NSString *_Nullable)appId;
+- (BOOL)isFileDehydrated:(NSString *_Nullable)filePath;
 
 @end

--- a/extensions/MacOSX/kDriveLiteSync/Extension/xpcService.m
+++ b/extensions/MacOSX/kDriveLiteSync/Extension/xpcService.m
@@ -30,6 +30,8 @@
     _fetchMap = [[NSMutableDictionary alloc] init];
     _userBlackListMap = [[NSMutableDictionary alloc] init];
     _fetchingAppArray = [[NSMutableArray alloc] init];
+    // Initialize dehydrated files cache (workaround for APFS recursive lock bug)
+    _dehydratedFilesCache = [[NSMutableSet alloc] init];
 
     [self initOpenWhiteListThumbnailSet];
     [self initOpenWhiteListSet];
@@ -325,6 +327,12 @@
         // Remove file path from fetch map
         [_fetchMap removeObjectForKey:filePath];
     }
+
+    // Remove from dehydrated cache - file is now hydrated
+    // Status "F" = Full/Offline, "H" = Hydrating - both mean not dehydrated anymore
+    if (fileStatus && ([fileStatus isEqualToString:@"F"] || [fileStatus isEqualToString:@"H"])) {
+        [self removeDehydratedFile:filePath];
+    }
 }
 
 - (void)updateThumbnailFetchStatus:(NSString *)appId filePath:(NSString *)filePath fileStatus:(NSString *)fileStatus {
@@ -391,6 +399,49 @@
     NSString *fileType = [fileAttribs objectForKey:NSFileType];
 
     return fileType == NSFileTypeDirectory;
+}
+
+// MARK: - Dehydrated Files Cache (workaround for APFS recursive lock bug)
+// These methods avoid calling getxattr() in the Endpoint Security callback,
+// which can cause a recursive lock in APFS and kernel panic.
+
+- (void)addDehydratedFile:(NSString *)filePath {
+    assert(_dehydratedFilesCache);
+
+    if (!filePath) return;
+
+    @synchronized(_dehydratedFilesCache) {
+        [_dehydratedFilesCache addObject:filePath];
+    }
+}
+
+- (void)removeDehydratedFile:(NSString *)filePath {
+    assert(_dehydratedFilesCache);
+
+    if (!filePath) return;
+
+    @synchronized(_dehydratedFilesCache) {
+        [_dehydratedFilesCache removeObject:filePath];
+    }
+}
+
+- (void)clearDehydratedFilesCache:(NSString *)appId {
+    assert(_dehydratedFilesCache);
+
+    NSLog(@"[KD] Clear dehydrated files cache");
+    @synchronized(_dehydratedFilesCache) {
+        [_dehydratedFilesCache removeAllObjects];
+    }
+}
+
+- (BOOL)isFileDehydrated:(NSString *)filePath {
+    assert(_dehydratedFilesCache);
+
+    if (!filePath) return FALSE;
+
+    @synchronized(_dehydratedFilesCache) {
+        return [_dehydratedFilesCache containsObject:filePath];
+    }
 }
 
 @end

--- a/extensions/MacOSX/kDriveLiteSync/Extension/xpcServiceProxy.h
+++ b/extensions/MacOSX/kDriveLiteSync/Extension/xpcServiceProxy.h
@@ -28,6 +28,11 @@
 - (void)updateThumbnailFetchStatus:(NSString *)appId filePath:(NSString *)filePath fileStatus:(NSString *)fileStatus;
 - (void)connectionEnded:(NSString *)appId;
 - (NSMutableString *)getFetchingAppList;
+
+// Delegate methods for dehydrated files cache (workaround for APFS recursive lock bug)
+- (void)addDehydratedFile:(NSString *)filePath;
+- (void)removeDehydratedFile:(NSString *)filePath;
+- (void)clearDehydratedFilesCache:(NSString *)appId;
 @end
 
 @interface XPCServiceProxy : NSObject <XPCLiteSyncExtensionProtocol, NSXPCListenerDelegate>

--- a/extensions/MacOSX/kDriveLiteSync/Extension/xpcServiceProxy.m
+++ b/extensions/MacOSX/kDriveLiteSync/Extension/xpcServiceProxy.m
@@ -151,5 +151,25 @@
     callback([_delegate getFetchingAppList]);
 }
 
+// MARK: - Dehydrated Files Cache (workaround for APFS recursive lock bug)
+
+- (void)addDehydratedFile:(NSString *)appId filePath:(NSString *)path
+{
+    NSLog(@"[KD] addDehydratedFile called: %@", path);
+    [_delegate addDehydratedFile:path];
+}
+
+- (void)removeDehydratedFile:(NSString *)appId filePath:(NSString *)path
+{
+    NSLog(@"[KD] removeDehydratedFile called: %@", path);
+    [_delegate removeDehydratedFile:path];
+}
+
+- (void)clearDehydratedFilesCache:(NSString *)appId
+{
+    NSLog(@"[KD] clearDehydratedFilesCache called");
+    [_delegate clearDehydratedFilesCache:appId];
+}
+
 @end
 

--- a/src/server/comm/litesynccommclient_mac.mm
+++ b/src/server/comm/litesynccommclient_mac.mm
@@ -85,6 +85,11 @@
 - (BOOL)getFetchingAppList:(NSMutableDictionary<NSString *, NSString *> *_Nonnull *_Nonnull)appMap;
 - (BOOL)setThumbnail:(NSString *_Nonnull)path image:(NSImage *_Nonnull)image;
 
+// Methods to manage dehydrated files cache (workaround for APFS recursive lock bug)
+- (BOOL)addDehydratedFile:(NSString *_Nonnull)path;
+- (BOOL)removeDehydratedFile:(NSString *_Nonnull)path;
+- (BOOL)clearDehydratedFilesCache;
+
 @end
 
 namespace KDC {
@@ -106,6 +111,11 @@ class LiteSyncCommClientPrivate {
         bool setThumbnail(const SyncPath &filePath, const QPixmap &pixmap);
         bool setAppExcludeList(const std::string &appList);
         bool getFetchingAppList(AppTable &appTable);
+
+        // Methods to manage dehydrated files cache (workaround for APFS recursive lock bug)
+        bool addDehydratedFile(const SyncPath &filePath);
+        bool removeDehydratedFile(const SyncPath &filePath);
+        bool clearDehydratedFilesCache();
 
     private:
         log4cplus::Logger _logger;
@@ -462,6 +472,35 @@ class LiteSyncCommClientPrivate {
     return true;
 }
 
+// MARK: - Dehydrated Files Cache (workaround for APFS recursive lock bug)
+
+- (BOOL)addDehydratedFile:(NSString *)path {
+    if (_connection) {
+        [[_connection remoteObjectProxy] addDehydratedFile:_pId filePath:path];
+        return TRUE;
+    }
+
+    return FALSE;
+}
+
+- (BOOL)removeDehydratedFile:(NSString *)path {
+    if (_connection) {
+        [[_connection remoteObjectProxy] removeDehydratedFile:_pId filePath:path];
+        return TRUE;
+    }
+
+    return FALSE;
+}
+
+- (BOOL)clearDehydratedFilesCache {
+    if (_connection) {
+        [[_connection remoteObjectProxy] clearDehydratedFilesCache:_pId];
+        return TRUE;
+    }
+
+    return FALSE;
+}
+
 // xpcLiteSyncExtensionRemoteProtocol protocol implementation
 - (void)getAppId:(void (^)(NSString *))callback {
     NSLog(@ "[KD] getAppId called");
@@ -732,6 +771,52 @@ bool LiteSyncCommClientPrivate::getFetchingAppList(AppTable &appTable) {
     return true;
 }
 
+// MARK: - Dehydrated Files Cache (workaround for APFS recursive lock bug)
+
+bool LiteSyncCommClientPrivate::addDehydratedFile(const SyncPath &filePath) {
+    if (!_connector) {
+        LOG_WARN(_logger, "Connector not initialized!");
+        return false;
+    }
+
+    NSString *nsPath = [NSString stringWithUTF8String:filePath.c_str()];
+    if (![_connector addDehydratedFile:nsPath]) {
+        LOGW_WARN(_logger, L"Call to addDehydratedFile failed: " << Utility::formatSyncPath(filePath));
+        return false;
+    }
+
+    return true;
+}
+
+bool LiteSyncCommClientPrivate::removeDehydratedFile(const SyncPath &filePath) {
+    if (!_connector) {
+        LOG_WARN(_logger, "Connector not initialized!");
+        return false;
+    }
+
+    NSString *nsPath = [NSString stringWithUTF8String:filePath.c_str()];
+    if (![_connector removeDehydratedFile:nsPath]) {
+        LOGW_WARN(_logger, L"Call to removeDehydratedFile failed: " << Utility::formatSyncPath(filePath));
+        return false;
+    }
+
+    return true;
+}
+
+bool LiteSyncCommClientPrivate::clearDehydratedFilesCache() {
+    if (!_connector) {
+        LOG_WARN(_logger, "Connector not initialized!");
+        return false;
+    }
+
+    if (![_connector clearDehydratedFilesCache]) {
+        LOG_WARN(_logger, "Call to clearDehydratedFilesCache failed!");
+        return false;
+    }
+
+    return true;
+}
+
 // LiteSyncCommClient implementation
 LiteSyncCommClient::LiteSyncCommClient(log4cplus::Logger logger, ExecuteCommand executeCommand) :
     _logger(logger) {
@@ -925,6 +1010,13 @@ bool LiteSyncCommClient::vfsDehydratePlaceHolder(const SyncPath &absoluteFilepat
         return false;
     }
 
+    // Add to dehydrated files cache (workaround for APFS recursive lock bug)
+    // This avoids calling getxattr() in the Endpoint Security callback
+    if (!_private->addDehydratedFile(absoluteFilepath)) {
+        LOGW_WARN(_logger, L"Call to addDehydratedFile failed: " << Utility::formatSyncPath(absoluteFilepath));
+        // Don't fail - cache miss is not critical
+    }
+
     return true;
 }
 
@@ -1077,6 +1169,13 @@ bool LiteSyncCommClient::vfsCreatePlaceHolder(const SyncPath &relativePath, cons
 
     if (checkIoErrorAndLogIfNeeded(ioError, "Item", absolutePath, _logger)) {
         return false;
+    }
+
+    // Add to dehydrated files cache (workaround for APFS recursive lock bug)
+    // This avoids calling getxattr() in the Endpoint Security callback
+    if (!_private->addDehydratedFile(absolutePath)) {
+        LOGW_WARN(_logger, L"Call to addDehydratedFile failed: " << Utility::formatSyncPath(absolutePath));
+        // Don't fail - cache miss is not critical
     }
 
     // Set pin state


### PR DESCRIPTION
## Summary of the Fix

I've implemented a **dehydrated files cache** to avoid the `getxattr()` calls in the Endpoint Security callback, which was causing the APFS recursive lock kernel panic.

### Key Changes:

**Extension side (`extensions/MacOSX/kDriveLiteSync/Extension/`):**
1. **`xpcService.h/m`** - Added `_dehydratedFilesCache` NSMutableSet with thread-safe methods
2. **`main.m`** - Replaced `getxattr()` calls with cache lookups using `isFileDehydrated:`
3. **Protocol files** - Added XPC methods for app-to-extension cache management

**Client side (`src/server/comm/litesynccommclient_mac.mm`):**
4. Added `addDehydratedFile:`, `removeDehydratedFile:`, `clearDehydratedFilesCache:` methods
5. Cache is populated when files are created as placeholders or dehydrated in `vfsCreatePlaceHolder()` and `vfsDehydratePlaceHolder()`

### How it works:
- When a file becomes dehydrated (status "O"), the main app notifies the extension via XPC to add it to the cache
- The ES callback checks this cache instead of calling `getxattr()` 
- When a file is hydrated, the extension automatically removes it from cache in `updateFetchStatus:`

This avoids the recursive APFS locking that was causing your kernel panics.