### PR TITLE
refactor(core): modernize collections and code style

### DIFF
--- a/src/gui4/windows/kDrive client/kDrive client/Converters/BooleanToIntegerConverter.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Converters/BooleanToIntegerConverter.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.UI.Xaml.Data;
+﻿using Microsoft.UI.Xaml.Data;
+using System;
 
 namespace Infomaniak.kDrive.Converters
 {

--- a/src/gui4/windows/kDrive client/kDrive client/Converters/BooleanToInvertedBooleanConverter.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Converters/BooleanToInvertedBooleanConverter.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.UI.Xaml.Data;
+﻿using Microsoft.UI.Xaml.Data;
+using System;
 
 namespace Infomaniak.kDrive.Converters
 {

--- a/src/gui4/windows/kDrive client/kDrive client/Converters/ColorToBrushConverter.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Converters/ColorToBrushConverter.cs
@@ -10,7 +10,7 @@ namespace Infomaniak.kDrive.Converters
         public object Convert(object value, Type targetType, object parameter, string language)
         {
             if (value is Color color)
-            {   
+            {
                 return new SolidColorBrush(Microsoft.UI.ColorHelper.FromArgb(color.A, color.R, color.G, color.B));
             }
             Logger.Log(Logger.Level.Fatal, "ColorToBrushConverter: value is not a Windows.UI.Color.");

--- a/src/gui4/windows/kDrive client/kDrive client/Converters/DateToStringConverter.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Converters/DateToStringConverter.cs
@@ -1,11 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using Microsoft.UI.Xaml.Data;
+using System;
 using System.Globalization;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.UI.Xaml.Data;
-using Infomaniak.kDrive.ViewModels;
 
 namespace Infomaniak.kDrive.Converters
 {

--- a/src/gui4/windows/kDrive client/kDrive client/Converters/IntegerToBooleanConverter.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Converters/IntegerToBooleanConverter.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.UI.Xaml.Data;
+﻿using Microsoft.UI.Xaml.Data;
+using System;
 
 namespace Infomaniak.kDrive.Converters
 {

--- a/src/gui4/windows/kDrive client/kDrive client/Converters/IsGreaterConverter.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Converters/IsGreaterConverter.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.UI.Xaml.Data;
+﻿using Microsoft.UI.Xaml.Data;
+using System;
 
 namespace Infomaniak.kDrive.Converters
 {

--- a/src/gui4/windows/kDrive client/kDrive client/Converters/IsNullToBoolOrVisibilityConverter.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Converters/IsNullToBoolOrVisibilityConverter.cs
@@ -1,11 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.UI.Xaml.Data;
-using Infomaniak.kDrive.ViewModels;
+﻿using Microsoft.UI.Xaml.Data;
+using System;
 
 namespace Infomaniak.kDrive.Converters
 {

--- a/src/gui4/windows/kDrive client/kDrive client/Converters/ListEmptyToInvertedBooleanConverter.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Converters/ListEmptyToInvertedBooleanConverter.cs
@@ -1,17 +1,13 @@
-﻿using System;
+﻿using Microsoft.UI.Xaml.Data;
+using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Data;
 
 namespace Infomaniak.kDrive.Converters
 {
     public class ListEmptyToInvertedBooleanConverter : IValueConverter
     {
-       public object Convert(object value, Type targetType, object parameter, string language)
+        public object Convert(object value, Type targetType, object parameter, string language)
         {
             if (value is IEnumerable<object> list)
             {
@@ -21,7 +17,7 @@ namespace Infomaniak.kDrive.Converters
             throw new ArgumentException("Invalid value type", nameof(value));
         }
 
-       public object ConvertBack(object value, Type targetType, object parameter, string language)
+        public object ConvertBack(object value, Type targetType, object parameter, string language)
         {
             Logger.Log(Logger.Level.Fatal, "ListEmptyToInvertedBooleanConverter: ConvertBack is not supported.");
             throw new NotSupportedException("ConvertBack is not supported.");

--- a/src/gui4/windows/kDrive client/kDrive client/Converters/ListEmptyToInvertedVisibilityConverter.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Converters/ListEmptyToInvertedVisibilityConverter.cs
@@ -1,17 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.UI.Xaml;
+﻿using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Data;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Infomaniak.kDrive.Converters
 {
     public class ListEmptyToInvertedVisibilityConverter : IValueConverter
     {
-       public object Convert(object value, Type targetType, object parameter, string language)
+        public object Convert(object value, Type targetType, object parameter, string language)
         {
             if (value is IEnumerable<object> list)
             {
@@ -21,7 +18,7 @@ namespace Infomaniak.kDrive.Converters
             throw new ArgumentException("Invalid value type", nameof(value));
         }
 
-       public object ConvertBack(object value, Type targetType, object parameter, string language)
+        public object ConvertBack(object value, Type targetType, object parameter, string language)
         {
             Logger.Log(Logger.Level.Fatal, "ListEmptyToInvertedVisibilityConverter: ConvertBack is not supported.");
             throw new NotSupportedException("ConvertBack is not supported.");

--- a/src/gui4/windows/kDrive client/kDrive client/Converters/ListEmptyToVisibilityConverter.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Converters/ListEmptyToVisibilityConverter.cs
@@ -1,17 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.UI.Xaml;
+﻿using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Data;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Infomaniak.kDrive.Converters
 {
     public class ListEmptyToVisibilityConverter : IValueConverter
     {
-       public object Convert(object value, Type targetType, object parameter, string language)
+        public object Convert(object value, Type targetType, object parameter, string language)
         {
             if (value is IEnumerable<object> list)
             {
@@ -21,7 +18,7 @@ namespace Infomaniak.kDrive.Converters
             throw new ArgumentException("Invalid value type", nameof(value));
         }
 
-       public object ConvertBack(object value, Type targetType, object parameter, string language)
+        public object ConvertBack(object value, Type targetType, object parameter, string language)
         {
             Logger.Log(Logger.Level.Fatal, "ListEmptyToVisibilityConverter: ConvertBack is not supported.");
             throw new NotSupportedException("ConvertBack is not supported.");

--- a/src/gui4/windows/kDrive client/kDrive client/Converters/ParamaterParser.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Converters/ParamaterParser.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Infomaniak.kDrive.Converters
 {

--- a/src/gui4/windows/kDrive client/kDrive client/Converters/SyncDirectionToIconUriConverter.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Converters/SyncDirectionToIconUriConverter.cs
@@ -1,7 +1,7 @@
 ﻿using Infomaniak.kDrive.Types;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Data;
 using System;
-using Microsoft.UI.Xaml;
 
 namespace Infomaniak.kDrive.Converters
 {

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/AppNavigationView.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/AppNavigationView.xaml.cs
@@ -9,9 +9,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
-
 namespace Infomaniak.kDrive.CustomControls
 {
     public sealed partial class AppNavigationView : NavigationView
@@ -20,7 +17,7 @@ namespace Infomaniak.kDrive.CustomControls
            App.ServiceProvider.GetRequiredService<AppModel>();
 
         public Frame Frame { get { return ContentFrame; } }
-        private Dictionary<string, List<Type>> _navigationItemToPage = new Dictionary<string, List<Type>>()
+        private readonly Dictionary<string, List<Type>> _navigationItemToPage = new Dictionary<string, List<Type>>()
         {
             { "HomePage", new List<Type>() {
                 typeof(Pages.HomePage),

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/AppTitleBarLogo.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/AppTitleBarLogo.xaml.cs
@@ -3,9 +3,6 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using System;
 
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
-
 namespace Infomaniak.kDrive.CustomControls
 {
     public sealed partial class AppTitleBarLogo : UserControl

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/ConsentContentDialog.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/ConsentContentDialog.xaml.cs
@@ -18,7 +18,6 @@
 
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using System;
 using System.Threading.Tasks;
 
 namespace Infomaniak.kDrive.CustomControls

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/ConsentContentDialog.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/ConsentContentDialog.xaml.cs
@@ -18,6 +18,7 @@
 
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using System;
 using System.Threading.Tasks;
 
 namespace Infomaniak.kDrive.CustomControls

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/ContentLoader.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/ContentLoader.xaml.cs
@@ -1,9 +1,6 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
-
 namespace Infomaniak.kDrive.CustomControls
 {
     public sealed partial class ContentLoader : UserControl
@@ -20,7 +17,7 @@ namespace Infomaniak.kDrive.CustomControls
         }
         public object LoaderContent
         {
-            get { return (object)GetValue(LoaderContentProperty); }
+            get { return GetValue(LoaderContentProperty); }
             set { SetValue(LoaderContentProperty, value); }
         }
         public double LoaderMinHeight

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/DriveSelectionPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/DriveSelectionPage.xaml.cs
@@ -64,7 +64,7 @@ namespace Infomaniak.kDrive.Pages.DriveSetupContentDialog
 
         private void DriveSetupContentDialogVM_CurrentStepCancelled(object? sender, EventArgs e)
         {
-            (DriveSetupContentDialogVM?.RevertAllChanges());
+            DriveSetupContentDialogVM?.RevertAllChanges();
             DriveSetupContentDialogVM?.FinishSetup(CustomControls.DriveSetupContentDialog.DriveSetupResult.Cancelled);
         }
 

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/DriveSelectionPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/DriveSelectionPage.xaml.cs
@@ -11,7 +11,7 @@ namespace Infomaniak.kDrive.Pages.DriveSetupContentDialog
 {
     public sealed partial class DriveSelectionPage : Page
     {
-        private AppModel _viewModel = App.ServiceProvider.GetRequiredService<AppModel>();
+        private readonly AppModel _viewModel = App.ServiceProvider.GetRequiredService<AppModel>();
         public AppModel ViewModel { get { return _viewModel; } }
 
         private DriveSetupContentDialogVM? DriveSetupContentDialogVM { get; set; }
@@ -64,7 +64,7 @@ namespace Infomaniak.kDrive.Pages.DriveSetupContentDialog
 
         private void DriveSetupContentDialogVM_CurrentStepCancelled(object? sender, EventArgs e)
         {
-            DriveSetupContentDialogVM?.RevertAllChanges();
+            (DriveSetupContentDialogVM?.RevertAllChanges());
             DriveSetupContentDialogVM?.FinishSetup(CustomControls.DriveSetupContentDialog.DriveSetupResult.Cancelled);
         }
 

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/SyncExclusionPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/SyncExclusionPage.xaml.cs
@@ -5,16 +5,16 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
-using Windows.Storage.Pickers;
 using System;
-using System.Threading;
 using System.Linq;
+using System.Threading;
+using Windows.Storage.Pickers;
 
 namespace Infomaniak.kDrive.Pages.DriveSetupContentDialog
 {
     public sealed partial class SyncExclusionPage : Page
     {
-        private AppModel _viewModel = App.ServiceProvider.GetRequiredService<AppModel>();
+        private readonly AppModel _viewModel = App.ServiceProvider.GetRequiredService<AppModel>();
         public AppModel ViewModel { get { return _viewModel; } }
 
         private DriveSetupContentDialogVM? DriveSetupContentDialogVM { get; set; }

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/SyncSetupPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/SyncSetupPage.xaml.cs
@@ -5,16 +5,16 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
-using Windows.Storage.Pickers;
 using System;
-using System.Threading;
 using System.Linq;
+using System.Threading;
+using Windows.Storage.Pickers;
 
 namespace Infomaniak.kDrive.Pages.DriveSetupContentDialog
 {
     public sealed partial class SyncSetupPage : Page
     {
-        private AppModel _viewModel = App.ServiceProvider.GetRequiredService<AppModel>();
+        private readonly AppModel _viewModel = App.ServiceProvider.GetRequiredService<AppModel>();
         public AppModel ViewModel { get { return _viewModel; } }
 
         private DriveSetupContentDialogVM? DriveSetupContentDialogVM { get; set; }

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DriveSetupContentDialog.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DriveSetupContentDialog.cs
@@ -14,7 +14,7 @@ namespace Infomaniak.kDrive.CustomControls
             Cancelled
         }
 
-        private DriveSetupContentDialogVM _driveSetupContentDialogVM;
+        private readonly DriveSetupContentDialogVM _driveSetupContentDialogVM;
         public DriveSetupResult Result { get; private set; }
 
         public DriveSetupContentDialog(XamlRoot xamlRoot, IList<NewSync> newSyncs)

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DriveSetupContentDialogVM.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DriveSetupContentDialogVM.cs
@@ -1,13 +1,8 @@
 using DynamicData;
-using Infomaniak.kDrive.ServerCommunication.Interfaces;
-using Infomaniak.kDrive.Types;
 using Infomaniak.kDrive.ViewModels;
-using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using static Infomaniak.kDrive.CustomControls.DriveSetupContentDialog;
 
@@ -15,9 +10,9 @@ namespace Infomaniak.kDrive.CustomControls
 {
     public partial class DriveSetupContentDialogVM : UISafeObservableObject
     {
-        private IList<NewSync> _initialState;
+        private readonly IList<NewSync> _initialState;
 
-        private IList<NewSync> _newSyncs;
+        private readonly IList<NewSync> _newSyncs;
         public IList<NewSync> NewSyncs
         {
             get => _newSyncs;
@@ -41,7 +36,7 @@ namespace Infomaniak.kDrive.CustomControls
 
         public DriveSetupContentDialogVM(IList<NewSync> newSyncs)
         {
-            _initialState = new List<NewSync>(newSyncs.Select(ns => new NewSync(ns)));
+            _initialState = [.. newSyncs.Select(ns => new NewSync(ns))];
             _newSyncs = newSyncs;
         }
 

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/DefaultError.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/DefaultError.xaml.cs
@@ -52,7 +52,7 @@ namespace Infomaniak.kDrive.CustomControls.Errors
                 AddIfNotEmpty("Cancel Type:", Error.CancelType);
                 AddIfNotEmpty("Auto-resolved:", Error.AutoResolved);
 
-                DetailsTextBlock.Text = lines.Count > 0 
+                DetailsTextBlock.Text = lines.Count > 0
                     ? string.Join(Environment.NewLine, lines)
                     : "No additional error details available.";
             }
@@ -67,7 +67,11 @@ namespace Infomaniak.kDrive.CustomControls.Errors
             Control? control = sender as Control;
             if (control is not null)
                 control.IsEnabled = false;
-            await Windows.System.Launcher.LaunchUriAsync(App.Constants.Drive.HelpDeskUri);
+            if(!await Windows.System.Launcher.LaunchUriAsync(App.Constants.Drive.HelpDeskUri))
+            {
+                Logger.Log(Logger.Level.Error, "Failed to launch HelpDesk URI.");
+                Utility.ShowUnexpectedErrorTeachingTip();
+            }
             await Task.Delay(1000);
             if (control is not null)
                 control.IsEnabled = true;

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Dialogs/LocalAccessErrorDialog.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Dialogs/LocalAccessErrorDialog.xaml.cs
@@ -1,7 +1,5 @@
 using Infomaniak.kDrive.ViewModels;
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Windows.ApplicationModel.DataTransfer;
 
 namespace Infomaniak.kDrive.CustomControls.Errors;
 

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Dialogs/SystemErrorSyncDirAccessErrorDialog.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Dialogs/SystemErrorSyncDirAccessErrorDialog.xaml.cs
@@ -1,14 +1,8 @@
 using DynamicData;
-using Infomaniak.kDrive.ServerCommunication.Interfaces;
 using Infomaniak.kDrive.ViewModels;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Documents;
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Threading;
 
 namespace Infomaniak.kDrive.CustomControls.Errors;
 
@@ -38,8 +32,10 @@ public partial class SystemErrorSyncDirAccessErrorDialog : Page
         AccessRightsModifiedTextBlock.Inlines.Add(new Run { Text = parts[0] });
 
         // Add hyperlink
-        var hyperlink = new Hyperlink();
-        hyperlink.UnderlineStyle = UnderlineStyle.None;
+        var hyperlink = new Hyperlink
+        {
+            UnderlineStyle = UnderlineStyle.None
+        };
         hyperlink.Inlines.Add(new Run { Text = faqText });
         hyperlink.Click += FaqHyperlink_Click;
         AccessRightsModifiedTextBlock.Inlines.Add(hyperlink);
@@ -59,8 +55,10 @@ public partial class SystemErrorSyncDirAccessErrorDialog : Page
         FolderDeletedTextBlock.Inlines.Add(new Run { Text = parts[0] });
 
         // Add hyperlink
-        var hyperlink2 = new Hyperlink();
-        hyperlink2.UnderlineStyle = UnderlineStyle.None;
+        var hyperlink2 = new Hyperlink
+        {
+            UnderlineStyle = UnderlineStyle.None
+        };
         hyperlink2.Inlines.Add(new Run { Text = newSyncText });
         hyperlink2.Click += RecreateSync_Click;
         FolderDeletedTextBlock.Inlines.Add(hyperlink2);

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Dialogs/SystemErrorSyncDirChangedErrorDialog.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Dialogs/SystemErrorSyncDirChangedErrorDialog.xaml.cs
@@ -1,14 +1,5 @@
-using DynamicData;
-using Infomaniak.kDrive.ServerCommunication.Interfaces;
 using Infomaniak.kDrive.ViewModels;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
-using Microsoft.UI.Xaml.Documents;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Threading;
 
 namespace Infomaniak.kDrive.CustomControls.Errors;
 

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Dialogs/SystemErrorSyncDirDiskMissingErrorDialog.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Dialogs/SystemErrorSyncDirDiskMissingErrorDialog.xaml.cs
@@ -1,14 +1,5 @@
-using DynamicData;
-using Infomaniak.kDrive.ServerCommunication.Interfaces;
 using Infomaniak.kDrive.ViewModels;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
-using Microsoft.UI.Xaml.Documents;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Threading;
 
 namespace Infomaniak.kDrive.CustomControls.Errors;
 

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/ErrorBar.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/ErrorBar.xaml.cs
@@ -3,11 +3,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using System;
-using System.Collections.Specialized;
-using System.ComponentModel;
-
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
 
 namespace Infomaniak.kDrive.CustomControls.Errors
 {

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/ErrorCard.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/ErrorCard.xaml.cs
@@ -3,9 +3,6 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using System.Linq;
 
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
-
 namespace Infomaniak.kDrive.CustomControls.Errors
 {
     public partial class ErrorCard : UserControl

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/ErrorFactory.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/ErrorFactory.cs
@@ -1,11 +1,9 @@
 ﻿using Infomaniak.kDrive.CustomControls.Errors.Templates;
-using Infomaniak.kDrive.Types;
 using Infomaniak.kDrive.ViewModels;
 using Microsoft.UI.Xaml.Controls;
 using System;
 using System.Linq;
 using System.Reflection;
-using WinRT;
 
 namespace Infomaniak.kDrive.CustomControls.Errors
 {
@@ -17,7 +15,7 @@ namespace Infomaniak.kDrive.CustomControls.Errors
         public static UserControl CreateErrorControl(Error error)
         {
             var matchType = GetBestControlType(error);
-            if(matchType is null)
+            if (matchType is null)
             {
                 Logger.Log(Logger.Level.Warning, $"No matching control type found for error: {error}. Returning default error control.");
                 return new DefaultError(error);

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/ErrorList.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/ErrorList.xaml.cs
@@ -3,9 +3,6 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using System.Collections.Generic;
 
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
-
 namespace Infomaniak.kDrive.CustomControls.Errors
 {
     public partial class ErrorList : UserControl

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/ErrorPresenter.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/ErrorPresenter.xaml.cs
@@ -2,9 +2,6 @@ using Infomaniak.kDrive.ViewModels;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
-
 namespace Infomaniak.kDrive.CustomControls.Errors
 {
     public sealed partial class ErrorPresenter : UserControl

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/RemoteDiskFullBar.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/RemoteDiskFullBar.xaml.cs
@@ -5,9 +5,6 @@ using Microsoft.UI.Xaml.Controls;
 using System;
 using Windows.System;
 
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
-
 namespace Infomaniak.kDrive.CustomControls.Errors
 {
     public partial class RemoteDiskFullBar : UserControl

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/ErrorMetadataAttribute.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/ErrorMetadataAttribute.cs
@@ -1,6 +1,5 @@
 ﻿using Infomaniak.kDrive.Types;
 using System;
-using System.Collections.Generic;
 
 namespace Infomaniak.kDrive.CustomControls.Errors.Templates
 {

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/CreateCancelError.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/CreateCancelError.xaml.cs
@@ -1,12 +1,6 @@
 using Infomaniak.kDrive.Types;
 using Infomaniak.kDrive.ViewModels;
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using System;
-using System.Collections.Generic;
-
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
 
 namespace Infomaniak.kDrive.CustomControls.Errors.Templates.Node
 {

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/DeleteCancelError.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/DeleteCancelError.xaml.cs
@@ -1,12 +1,6 @@
 using Infomaniak.kDrive.Types;
 using Infomaniak.kDrive.ViewModels;
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using System;
-using System.Collections.Generic;
-
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
 
 namespace Infomaniak.kDrive.CustomControls.Errors.Templates.Node
 {

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/EditCancelError.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/EditCancelError.xaml.cs
@@ -2,9 +2,6 @@ using Infomaniak.kDrive.Types;
 using Infomaniak.kDrive.ViewModels;
 using Microsoft.UI.Xaml.Controls;
 
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
-
 namespace Infomaniak.kDrive.CustomControls.Errors.Templates.Node
 {
     [ErrorMetadata(

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/ExcludedByTemplateError.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/ExcludedByTemplateError.xaml.cs
@@ -2,11 +2,6 @@ using Infomaniak.kDrive.Types;
 using Infomaniak.kDrive.ViewModels;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using System;
-using System.Collections.Generic;
-
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
 
 namespace Infomaniak.kDrive.CustomControls.Errors.Templates.Node
 {
@@ -27,7 +22,7 @@ namespace Infomaniak.kDrive.CustomControls.Errors.Templates.Node
         private void ErrorCard_ActionClick(object sender, RoutedEventArgs e)
         {
             var frame = ((App.Current as App)?.CurrentWindow as MainWindow).AppNavView.Frame;
-            if(frame is null)
+            if (frame is null)
             {
                 Logger.Log(Logger.Level.Warning, "Unable to fetch main frame");
                 Utility.ShowUnexpectedErrorTeachingTip();

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/FileLockedError.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/FileLockedError.xaml.cs
@@ -1,12 +1,6 @@
 using Infomaniak.kDrive.Types;
 using Infomaniak.kDrive.ViewModels;
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using System;
-using System.Collections.Generic;
-
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
 
 namespace Infomaniak.kDrive.CustomControls.Errors.Templates.Node
 {

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/FileRescuedError.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/FileRescuedError.xaml.cs
@@ -1,12 +1,6 @@
 using Infomaniak.kDrive.Types;
 using Infomaniak.kDrive.ViewModels;
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using System;
-using System.Collections.Generic;
-
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
 
 namespace Infomaniak.kDrive.CustomControls.Errors.Templates.Node
 {

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/FileTooBigError.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/FileTooBigError.xaml.cs
@@ -1,12 +1,6 @@
 using Infomaniak.kDrive.Types;
 using Infomaniak.kDrive.ViewModels;
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using System;
-using System.Collections.Generic;
-
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
 
 namespace Infomaniak.kDrive.CustomControls.Errors.Templates.Node
 {

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/ForbiddenCharEndWithSpaceError.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/ForbiddenCharEndWithSpaceError.xaml.cs
@@ -1,12 +1,6 @@
 using Infomaniak.kDrive.Types;
 using Infomaniak.kDrive.ViewModels;
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using System;
-using System.Collections.Generic;
-
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
 
 namespace Infomaniak.kDrive.CustomControls.Errors.Templates.Node
 {

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/ForbiddenCharError.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/ForbiddenCharError.xaml.cs
@@ -1,12 +1,6 @@
 using Infomaniak.kDrive.Types;
 using Infomaniak.kDrive.ViewModels;
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using System;
-using System.Collections.Generic;
-
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
 
 namespace Infomaniak.kDrive.CustomControls.Errors.Templates.Node
 {

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/ForbiddenCharOnlySpacesError.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/ForbiddenCharOnlySpacesError.xaml.cs
@@ -1,12 +1,6 @@
 using Infomaniak.kDrive.Types;
 using Infomaniak.kDrive.ViewModels;
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using System;
-using System.Collections.Generic;
-
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
 
 namespace Infomaniak.kDrive.CustomControls.Errors.Templates.Node
 {

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/HardlinkError.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/HardlinkError.xaml.cs
@@ -1,12 +1,6 @@
 using Infomaniak.kDrive.Types;
 using Infomaniak.kDrive.ViewModels;
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using System;
-using System.Collections.Generic;
-
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
 
 namespace Infomaniak.kDrive.CustomControls.Errors.Templates.Node
 {

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/HttpErrForbiddenError.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/HttpErrForbiddenError.xaml.cs
@@ -2,9 +2,6 @@ using Infomaniak.kDrive.Types;
 using Infomaniak.kDrive.ViewModels;
 using Microsoft.UI.Xaml.Controls;
 
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
-
 namespace Infomaniak.kDrive.CustomControls.Errors.Templates.Node
 {
     [ErrorMetadata(

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/LocalAccessError.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/LocalAccessError.xaml.cs
@@ -3,12 +3,7 @@ using Infomaniak.kDrive.ViewModels;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
-
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
 
 namespace Infomaniak.kDrive.CustomControls.Errors.Templates.Node
 {
@@ -23,7 +18,7 @@ namespace Infomaniak.kDrive.CustomControls.Errors.Templates.Node
     )]
     public sealed partial class LocalAccessError : UserControl
     {
-        private Error _error;
+        private readonly Error _error;
         public LocalAccessError(Error error)
         {
             this.InitializeComponent();

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/MoveCancelError.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/MoveCancelError.xaml.cs
@@ -1,12 +1,6 @@
 using Infomaniak.kDrive.Types;
 using Infomaniak.kDrive.ViewModels;
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using System;
-using System.Collections.Generic;
-
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
 
 namespace Infomaniak.kDrive.CustomControls.Errors.Templates.Node
 {

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/NameLengthError.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/NameLengthError.xaml.cs
@@ -1,12 +1,6 @@
 using Infomaniak.kDrive.Types;
 using Infomaniak.kDrive.ViewModels;
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using System;
-using System.Collections.Generic;
-
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
 
 namespace Infomaniak.kDrive.CustomControls.Errors.Templates.Node
 {

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/NotEnoughDiskSpaceError.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/NotEnoughDiskSpaceError.xaml.cs
@@ -3,10 +3,6 @@ using Infomaniak.kDrive.ViewModels;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using System;
-using System.Collections.Generic;
-
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
 
 namespace Infomaniak.kDrive.CustomControls.Errors.Templates.Node
 {
@@ -31,7 +27,7 @@ namespace Infomaniak.kDrive.CustomControls.Errors.Templates.Node
             if (!result)
             {
                 Logger.Log(Logger.Level.Warning, "Failed to launch settings for NotEnoughDiskSpaceError");
-                Utility.ShowUnexpectedErrorTeachingTip(); 
+                Utility.ShowUnexpectedErrorTeachingTip();
             }
         }
     }

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/NotYetSupportedCharError.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/NotYetSupportedCharError.xaml.cs
@@ -1,12 +1,6 @@
 using Infomaniak.kDrive.Types;
 using Infomaniak.kDrive.ViewModels;
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using System;
-using System.Collections.Generic;
-
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
 
 namespace Infomaniak.kDrive.CustomControls.Errors.Templates.Node
 {

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/PathLengthError.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/PathLengthError.xaml.cs
@@ -1,12 +1,6 @@
 using Infomaniak.kDrive.Types;
 using Infomaniak.kDrive.ViewModels;
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using System;
-using System.Collections.Generic;
-
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
 
 namespace Infomaniak.kDrive.CustomControls.Errors.Templates.Node
 {

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/QuotaExceededError.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/QuotaExceededError.xaml.cs
@@ -1,12 +1,6 @@
 using Infomaniak.kDrive.Types;
 using Infomaniak.kDrive.ViewModels;
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using System;
-using System.Collections.Generic;
-
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
 
 namespace Infomaniak.kDrive.CustomControls.Errors.Templates.Node
 {

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/ReservedNameError.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/ReservedNameError.xaml.cs
@@ -1,12 +1,6 @@
 using Infomaniak.kDrive.Types;
 using Infomaniak.kDrive.ViewModels;
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using System;
-using System.Collections.Generic;
-
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
 
 namespace Infomaniak.kDrive.CustomControls.Errors.Templates.Node
 {

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/TmpBlacklistedError.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/TmpBlacklistedError.xaml.cs
@@ -1,12 +1,6 @@
 using Infomaniak.kDrive.Types;
 using Infomaniak.kDrive.ViewModels;
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using System;
-using System.Collections.Generic;
-
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
 
 namespace Infomaniak.kDrive.CustomControls.Errors.Templates.Node
 {

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/SyncPal/BackErrorDriveMaintenance.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/SyncPal/BackErrorDriveMaintenance.xaml.cs
@@ -1,7 +1,6 @@
 using Infomaniak.kDrive.Types;
 using Infomaniak.kDrive.ViewModels;
 using Microsoft.UI.Xaml.Controls;
-using System;
 
 namespace Infomaniak.kDrive.CustomControls.Errors.Templates.SyncPal
 {

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/SyncPal/DataErrorSyncDirChanged.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/SyncPal/DataErrorSyncDirChanged.xaml.cs
@@ -2,7 +2,6 @@ using Infomaniak.kDrive.Types;
 using Infomaniak.kDrive.ViewModels;
 using Microsoft.UI.Xaml.Controls;
 using System;
-using System.IO;
 
 namespace Infomaniak.kDrive.CustomControls.Errors.Templates.SyncPal
 {
@@ -38,13 +37,13 @@ namespace Infomaniak.kDrive.CustomControls.Errors.Templates.SyncPal
                 DefaultButton = ContentDialogButton.Primary,
                 SecondaryButtonText = Localizer.Instance.GetString("buttonClose"),
                 PrimaryButtonText = Localizer.Instance.GetString("buttonCreateNewSync"),
+                Content = new SystemErrorSyncDirChangedErrorDialog(Error) { XamlRoot = xamlRoot }
             };
-            dialog.Content = new SystemErrorSyncDirChangedErrorDialog(Error) { XamlRoot = xamlRoot };
 
             if (await dialog.ShowAsync() == ContentDialogResult.Primary)
             {
                 var frame = ((App.Current as App)?.CurrentWindow as MainWindow)?.AppNavView.Frame;
-                if(frame is null)
+                if (frame is null)
                 {
                     Logger.Log(Logger.Level.Error, "Failed to navigate to the sync setup page after a sync directory change error because the main frame could not be found.");
                     return;

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/SyncPal/SystemErrorSyncDirAccessError.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/SyncPal/SystemErrorSyncDirAccessError.xaml.cs
@@ -38,8 +38,8 @@ namespace Infomaniak.kDrive.CustomControls.Errors.Templates.SyncPal
                 DefaultButton = ContentDialogButton.Primary,
                 SecondaryButtonText = Localizer.Instance.GetString("buttonClose"),
                 PrimaryButtonText = Localizer.Instance.GetString("buttonOpenParentFolder"),
+                Content = new SystemErrorSyncDirAccessErrorDialog(Error) { XamlRoot = xamlRoot }
             };
-            dialog.Content = new SystemErrorSyncDirAccessErrorDialog(Error) { XamlRoot = xamlRoot };
 
             if (await dialog.ShowAsync() == ContentDialogResult.Primary)
             {

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/SyncPal/SystemErrorSyncDirDiskMissing.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/SyncPal/SystemErrorSyncDirDiskMissing.xaml.cs
@@ -38,8 +38,8 @@ namespace Infomaniak.kDrive.CustomControls.Errors.Templates.SyncPal
                 DefaultButton = ContentDialogButton.Primary,
                 SecondaryButtonText = Localizer.Instance.GetString("buttonClose"),
                 PrimaryButtonText = Localizer.Instance.GetString("buttonRestartSync"),
+                Content = new SystemErrorSyncDirDiskMissingErrorDialog(Error) { XamlRoot = xamlRoot }
             };
-            dialog.Content = new SystemErrorSyncDirDiskMissingErrorDialog(Error) { XamlRoot = xamlRoot };
 
             if (await dialog.ShowAsync() == ContentDialogResult.Primary)
             {

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/SyncPal/SystemErrorUnableToStartVfs.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/SyncPal/SystemErrorUnableToStartVfs.xaml.cs
@@ -41,7 +41,7 @@ namespace Infomaniak.kDrive.CustomControls.Errors.Templates.SyncPal
                 return;
             }
             var destPage = Error.Sync.IsAdvanced ? typeof(Pages.Settings.DriveAdvancedSyncsPage) : typeof(Pages.Settings.DriveManagementPage);
-            frame?.Navigate(destPage, Error.Sync.Drive);
+            (frame?.Navigate(destPage, Error.Sync.Drive));
 
             if (control is not null)
                 control.IsEnabled = true;

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/SyncPal/SystemErrorUnableToStartVfs.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/SyncPal/SystemErrorUnableToStartVfs.xaml.cs
@@ -41,7 +41,7 @@ namespace Infomaniak.kDrive.CustomControls.Errors.Templates.SyncPal
                 return;
             }
             var destPage = Error.Sync.IsAdvanced ? typeof(Pages.Settings.DriveAdvancedSyncsPage) : typeof(Pages.Settings.DriveManagementPage);
-            (frame?.Navigate(destPage, Error.Sync.Drive));
+            frame?.Navigate(destPage, Error.Sync.Drive);
 
             if (control is not null)
                 control.IsEnabled = true;

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/ItemNamePresenter.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/ItemNamePresenter.xaml.cs
@@ -17,7 +17,7 @@ namespace Infomaniak.kDrive.CustomControls
         public string ItemPath
         {
             get => (string)GetValue(ItemPathProperty);
-            set => SetValue(ItemPathProperty,value);
+            set => SetValue(ItemPathProperty, value);
         }
 
         public NodeType? NodeType

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/ItemPathPresenter.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/ItemPathPresenter.xaml.cs
@@ -86,8 +86,10 @@ namespace Infomaniak.kDrive.CustomControls
             if (string.IsNullOrWhiteSpace(ToolTipPath))
                 return;
 
-            DataPackage dataPackage = new();
-            dataPackage.RequestedOperation = DataPackageOperation.Copy;
+            DataPackage dataPackage = new()
+            {
+                RequestedOperation = DataPackageOperation.Copy
+            };
             dataPackage.SetText(ToolTipPath);
             Clipboard.SetContent(dataPackage);
 

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/KSuiteUpgradeBar.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/KSuiteUpgradeBar.xaml.cs
@@ -1,8 +1,5 @@
 using Microsoft.UI.Xaml.Controls;
 
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
-
 namespace Infomaniak.kDrive.CustomControls
 {
     public sealed partial class KSuiteUpgradeBar : UserControl

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/LogUploadSettingsCard.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/LogUploadSettingsCard.xaml.cs
@@ -24,12 +24,14 @@ namespace Infomaniak.kDrive.CustomControls
 
         private async void SendLogsButton_Click(object sender, RoutedEventArgs e)
         {
-            ContentDialog dialog = new ContentDialog();
-            dialog.XamlRoot = XamlRoot;
-            dialog.Title = Localizer.Instance.GetString("logUploadPopupTitle");
-            dialog.DefaultButton = ContentDialogButton.Primary;
-            dialog.PrimaryButtonText = Localizer.Instance.GetString("buttonSend");
-            dialog.SecondaryButtonText = Localizer.Instance.GetString("buttonCancel");
+            ContentDialog dialog = new ContentDialog
+            {
+                XamlRoot = XamlRoot,
+                Title = Localizer.Instance.GetString("logUploadPopupTitle"),
+                DefaultButton = ContentDialogButton.Primary,
+                PrimaryButtonText = Localizer.Instance.GetString("buttonSend"),
+                SecondaryButtonText = Localizer.Instance.GetString("buttonCancel")
+            };
             var popupPage = new Pages.Popup.LogUploadPopup();
             dialog.Content = popupPage;
 

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/LottiePlayer.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/LottiePlayer.xaml.cs
@@ -48,7 +48,7 @@ namespace Infomaniak.kDrive.CustomControls
             if (d is LottiePlayer lottiePlayer && e.NewValue is Uri)
             {
                 // Fire-and-forget the async method
-                _ = lottiePlayer.UpdateLottieAsync();
+                lottiePlayer.UpdateLottieAsync();
             }
         }
 

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/MultiValueProgressBar.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/MultiValueProgressBar.xaml.cs
@@ -2,9 +2,6 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
-
 namespace Infomaniak.kDrive.CustomControls
 {
     public sealed partial class MultiValueProgressBar : UserControl

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/QuickAccess.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/QuickAccess.xaml.cs
@@ -4,14 +4,11 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using System;
 
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
-
 namespace Infomaniak.kDrive.CustomControls
 {
     public sealed partial class QuickAccess : UserControl
     {
-        private AppModel _viewModel = App.ServiceProvider.GetRequiredService<AppModel>();
+        private readonly AppModel _viewModel = App.ServiceProvider.GetRequiredService<AppModel>();
         public AppModel ViewModel => _viewModel;
 
         public QuickAccess()

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/SearchBox.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/SearchBox.xaml.cs
@@ -7,14 +7,10 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using System;
 using System.Collections.Generic;
-using System.Drawing.Printing;
 using System.IO;
 using System.Linq;
 using System.Threading;
 using Windows.System;
-
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
 
 namespace Infomaniak.kDrive.CustomControls
 {
@@ -121,7 +117,7 @@ namespace Infomaniak.kDrive.CustomControls
                     return;
                 }
 
-                List<ISearchBoxResultItem> items = new();
+                List<ISearchBoxResultItem> items = [];
 
                 if (result.Count == 0)
                 {

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/SvgIcon.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/SvgIcon.cs
@@ -59,7 +59,6 @@ namespace Infomaniak.kDrive.CustomControls
 
         private static void OnUriChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            var type = d.GetType();
             if (d is SvgIcon icon && icon._isLoaded)
                 icon.ScheduleRefresh();
         }
@@ -102,7 +101,7 @@ namespace Infomaniak.kDrive.CustomControls
             var token = _refreshCts.Token;
 
             // Enqueue on UI dispatcher
-            _ = DispatcherQueue.TryEnqueue(async () =>
+            DispatcherQueue.TryEnqueue(async () =>
             {
                 try
                 {
@@ -209,8 +208,10 @@ namespace Infomaniak.kDrive.CustomControls
             if (double.IsNaN(ratio) || double.IsInfinity(ratio))
                 ratio = 1.0F;
 
-            double targetWidth = 0;
-            double targetHeight = 0;
+
+            double targetWidth;
+
+            double targetHeight;
             if (double.IsNaN(Width) && double.IsNaN(Height))
             {
                 targetHeight = svgDoc.Height.Value;

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/SyncActivityTable.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/SyncActivityTable.xaml.cs
@@ -6,7 +6,6 @@ using Infomaniak.kDrive.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Media;
 using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
@@ -15,9 +14,6 @@ using System.Reactive.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Windows.ApplicationModel.DataTransfer;
-
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
 
 namespace Infomaniak.kDrive.CustomControls
 {
@@ -221,8 +217,10 @@ namespace Infomaniak.kDrive.CustomControls
             Uri? publicLink = await commService.GetPublicLink(activity.Sync.Drive.DbId, activity.RemoteNodeId, CancellationToken.None);
             if (publicLink is not null)
             {
-                DataPackage dataPackage = new();
-                dataPackage.RequestedOperation = DataPackageOperation.Copy;
+                DataPackage dataPackage = new()
+                {
+                    RequestedOperation = DataPackageOperation.Copy
+                };
                 dataPackage.SetText(publicLink.ToString());
                 Clipboard.SetContent(dataPackage);
                 DisplayTeachingTip(Localizer.Instance.GetString("linkCopiedToClipboardTitle"), false);
@@ -262,7 +260,7 @@ namespace Infomaniak.kDrive.CustomControls
         {
             NotificationTeachingTip.IsOpen = false;
         }
-        
+
         public static string GetSyncDirectionToolTip(SyncDirection direction)
         {
             return direction switch

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/SyncExclusionSelector.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/SyncExclusionSelector.xaml.cs
@@ -222,7 +222,7 @@ namespace Infomaniak.kDrive.CustomControls
         // Compute the list of node IDs that are currently excluded (unchecked) in the UI tree
         public List<NodeId> GetExcludedNodeIds()
         {
-            List<NodeId> excluded = new List<NodeId>();
+            List<NodeId> excluded = [];
             foreach (var item in _rootLevelItems)
             {
                 excluded.AddRange(GetExcludedDescendantNodeIds(item));
@@ -324,7 +324,7 @@ namespace Infomaniak.kDrive.CustomControls
             await RootTreeItem.LoadImmediateChildrenAsync();
 
             _rootLevelItems.AddRange(RootTreeItem.Children);
-            List<Task> tasks = new();
+            List<Task> tasks = [];
             foreach (var item in _rootLevelItems)
             {
                 tasks.Add(item.LoadImmediateChildrenAsync());
@@ -408,7 +408,7 @@ namespace Infomaniak.kDrive.CustomControls
         #region TreeView events
         private async void TreeView_Expanding(TreeView sender, TreeViewExpandingEventArgs args)
         {
-            List<Task> tasks = new();
+            List<Task> tasks = [];
             if (args.Item is TreeItem item)
             {
                 foreach (var child in item.Children)
@@ -579,7 +579,7 @@ namespace Infomaniak.kDrive.CustomControls
         private bool _childrenLoaded = false;
         private bool? _isSelected = true; // true=include, false=exclude, null=partial
         private readonly Dictionary<NodeId, string> _excludedNodes;
-        private readonly CompositeDisposable _disposables = new CompositeDisposable();
+        private readonly CompositeDisposable _disposables = [];
         private bool _disposed = false;
         #endregion
 
@@ -606,7 +606,7 @@ namespace Infomaniak.kDrive.CustomControls
             }
         }
 
-        public ObservableCollection<TreeItem> Children { get; } = new ObservableCollection<TreeItem>();
+        public ObservableCollection<TreeItem> Children { get; } = [];
         public TreeItem? ParentItem { get; }
         #endregion
 

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/SyncSelector.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/SyncSelector.xaml.cs
@@ -1,4 +1,3 @@
-using Infomaniak.kDrive.Types;
 using Infomaniak.kDrive.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml;
@@ -6,7 +5,7 @@ using Microsoft.UI.Xaml.Controls;
 
 namespace Infomaniak.kDrive.CustomControls
 {
- 
+
     public sealed partial class SyncSelector : UserControl
     {
         public AppModel ViewModel { get; } =
@@ -29,7 +28,7 @@ namespace Infomaniak.kDrive.CustomControls
                 return null;
             if (item is Sync sync)
             {
-                if(sync.Drive.MainSync == sync)
+                if (sync.Drive.MainSync == sync)
                 {
                     return MainSyncTemplate;
                 }

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/SyncStartPauseButton.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/SyncStartPauseButton.xaml.cs
@@ -6,14 +6,11 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Data;
 using System;
 
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
-
 namespace Infomaniak.kDrive.CustomControls;
 
 public sealed partial class SyncStartPauseButton : UserControl
 {
-    private AppModel _viewModel = App.ServiceProvider.GetRequiredService<AppModel>();
+    private readonly AppModel _viewModel = App.ServiceProvider.GetRequiredService<AppModel>();
     public AppModel ViewModel
     {
         get { return _viewModel; }
@@ -85,7 +82,7 @@ public class SyncToButtonEnabledConverter : IValueConverter
         if (value is Sync sync)
         {
             SyncStatus syncStatus = sync.SyncStatus;
-            return (syncStatus == SyncStatus.Running || syncStatus == SyncStatus.Paused || syncStatus == SyncStatus.Idle || syncStatus == SyncStatus.Stopped || syncStatus == SyncStatus.Error);
+            return syncStatus == SyncStatus.Running || syncStatus == SyncStatus.Paused || syncStatus == SyncStatus.Idle || syncStatus == SyncStatus.Stopped || syncStatus == SyncStatus.Error;
         }
         return false;
     }

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/UpdateExpander.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/UpdateExpander.xaml.cs
@@ -11,7 +11,7 @@ namespace Infomaniak.kDrive.CustomControls
 {
     public sealed partial class UpdateExpander : SettingsExpander
     {
-        private AppModel _viewModel = App.ServiceProvider.GetRequiredService<AppModel>();
+        private readonly AppModel _viewModel = App.ServiceProvider.GetRequiredService<AppModel>();
         public AppModel ViewModel => _viewModel;
 
         public UpdateExpander()

--- a/src/gui4/windows/kDrive client/kDrive client/Localizer/Localizer.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Localizer/Localizer.cs
@@ -9,7 +9,7 @@ namespace Infomaniak.kDrive
     internal class Localizer : UISafeObservableObject
     {
         public static Localizer Instance { get; } = new Localizer();
-        private static ResourceContext context = ResourceContext.GetForViewIndependentUse();
+        private static readonly ResourceContext context = ResourceContext.GetForViewIndependentUse();
 
         public void SetLanguage(Types.Language language)
         {

--- a/src/gui4/windows/kDrive client/kDrive client/Logger/Logger.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Logger/Logger.cs
@@ -140,7 +140,7 @@ namespace Infomaniak.kDrive
             }
         }
 
-        static private IDisposable? _sentryHandler;
+        private static IDisposable? _sentryHandler;
         public static void StartSentry([CallerMemberName] string memberName = "?")
         {
             if (_sentryHandler is not null)

--- a/src/gui4/windows/kDrive client/kDrive client/MainWindow.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/MainWindow.xaml.cs
@@ -20,9 +20,6 @@ using Infomaniak.kDrive.CustomControls;
 using Infomaniak.kDrive.ViewModels;
 using Microsoft.UI.Xaml;
 
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
-
 namespace Infomaniak.kDrive
 {
     public sealed partial class MainWindow : Window

--- a/src/gui4/windows/kDrive client/kDrive client/OnBoardingWindow.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/OnBoardingWindow.xaml.cs
@@ -20,18 +20,13 @@ using Infomaniak.kDrive.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml;
 using System;
-using System.Linq;
-using System.Reactive.Linq;
-
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
 
 namespace Infomaniak.kDrive.OnBoarding
 {
     public sealed partial class OnBoardingWindow : Window
     {
         private readonly AppModel _viewModel = App.ServiceProvider.GetRequiredService<AppModel>();
-        private ViewModels.Onboarding _onBoardingViewModel = new(App.ServiceProvider.GetRequiredService<ServerCommunication.Interfaces.IServerCommService>());
+        private readonly ViewModels.Onboarding _onBoardingViewModel = new(App.ServiceProvider.GetRequiredService<ServerCommunication.Interfaces.IServerCommService>());
         private string _lottieRessourceKey = "Infomaniak.Custom.Animations.loader-stroke";
         public AppModel ViewModel { get { return _viewModel; } }
         public OnBoardingWindow()

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/ActivityPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/ActivityPage.xaml.cs
@@ -12,7 +12,7 @@ namespace Infomaniak.kDrive.Pages
 {
     public sealed partial class ActivityPage : Page
     {
-        private AppModel _viewModel = App.ServiceProvider.GetRequiredService<AppModel>();
+        private readonly AppModel _viewModel = App.ServiceProvider.GetRequiredService<AppModel>();
         public AppModel ViewModel { get { return _viewModel; } }
         public ActivityPage()
         {

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Errors/ErrorPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Errors/ErrorPage.xaml.cs
@@ -1,4 +1,3 @@
-using Infomaniak.kDrive.CustomControls;
 using Infomaniak.kDrive.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml.Controls;
@@ -10,7 +9,7 @@ namespace Infomaniak.kDrive.Pages.Errors
 {
     public sealed partial class ErrorPage : Page
     {
-        private AppModel _viewModel = App.ServiceProvider.GetRequiredService<AppModel>();
+        private readonly AppModel _viewModel = App.ServiceProvider.GetRequiredService<AppModel>();
         public AppModel ViewModel { get { return _viewModel; } }
         private ErrorPageVM? _errorPageVM;
         public ErrorPage()

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Errors/ErrorPageVM.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Errors/ErrorPageVM.cs
@@ -1,6 +1,5 @@
 ﻿using DynamicData;
 using DynamicData.Binding;
-using ExCSS;
 using Infomaniak.kDrive.CustomControls.Errors;
 using Infomaniak.kDrive.Types;
 using Infomaniak.kDrive.ViewModels;
@@ -13,7 +12,7 @@ namespace Infomaniak.kDrive.Pages.Errors
     partial class ErrorPageVM : UISafeObservableObject, IDisposable
     {
         private Sync _syncVM;
-        private readonly List<IDisposable?> _errorsSubscription = new();
+        private readonly List<IDisposable?> _errorsSubscription = [];
 
         public Sync SyncVM
         {
@@ -49,9 +48,9 @@ namespace Infomaniak.kDrive.Pages.Errors
 
             if (Sync is null)
             {
-                FileErrors = new ReadOnlyObservableCollection<Error>(new ObservableCollection<Error>());
-                SyncDirErrors = new ReadOnlyObservableCollection<Error>(new ObservableCollection<Error>());
-                OtherErrors = new ReadOnlyObservableCollection<Error>(new ObservableCollection<Error>());
+                FileErrors = new ReadOnlyObservableCollection<Error>([]);
+                SyncDirErrors = new ReadOnlyObservableCollection<Error>([]);
+                OtherErrors = new ReadOnlyObservableCollection<Error>([]);
                 return;
             }
 
@@ -94,15 +93,16 @@ namespace Infomaniak.kDrive.Pages.Errors
         private static bool IsInSyncDirErrorList(Error error)
         {
             // List of Types of errors to be included in the SyncDirErrors list:
-            List<Type> syncDirErrorTypes = new List<Type>
-            {
+            List<Type> syncDirErrorTypes =
+            [
                 typeof(CustomControls.Errors.Templates.SyncPal.SystemErrorSyncDirAccessError),
                 typeof(CustomControls.Errors.Templates.SyncPal.SystemErrorSyncDirDiskMissing),
                 typeof(CustomControls.Errors.Templates.SyncPal.DataErrorSyncDirChanged)
-            };
+            ];
 
             Type? errorType = ErrorFactory.GetBestControlType(error);
-            if(errorType is null) {
+            if (errorType is null)
+            {
                 return false;
             }
             return syncDirErrorTypes.Contains(errorType);

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/HomePage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/HomePage.xaml.cs
@@ -30,7 +30,7 @@ namespace Infomaniak.kDrive.Pages
 {
     public sealed partial class HomePage : Page
     {
-        private AppModel _viewModel = App.ServiceProvider.GetRequiredService<AppModel>();
+        private readonly AppModel _viewModel = App.ServiceProvider.GetRequiredService<AppModel>();
         public AppModel ViewModel => _viewModel;
         public HomePage()
         {

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Onboarding/DriveSelectionPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Onboarding/DriveSelectionPage.xaml.cs
@@ -11,7 +11,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace Infomaniak.kDrive.Pages.Onboarding
 {
@@ -42,7 +41,7 @@ namespace Infomaniak.kDrive.Pages.Onboarding
                     Utility.ShowUnexpectedErrorTeachingTip();
                     return;
                 }
-                if(!await obvm.SelectedUser.RefreshAvailableDrives(CancellationToken.None))
+                if (!await obvm.SelectedUser.RefreshAvailableDrives(CancellationToken.None))
                 {
                     Logger.Log(Logger.Level.Error, "Failed to refresh available drives for user in DriveSelectionPage");
                     obvm.Reset();

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Onboarding/FinishPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Onboarding/FinishPage.xaml.cs
@@ -10,7 +10,7 @@ namespace Infomaniak.kDrive.Pages.Onboarding
 {
     public sealed partial class FinishPage : Page
     {
-        private AppModel _viewModel = App.ServiceProvider.GetRequiredService<AppModel>();
+        private readonly AppModel _viewModel = App.ServiceProvider.GetRequiredService<AppModel>();
         public AppModel ViewModel { get { return _viewModel; } }
         public FinishPage()
         {

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Onboarding/FinishingPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Onboarding/FinishingPage.xaml.cs
@@ -9,7 +9,7 @@ namespace Infomaniak.kDrive.Pages.Onboarding
 {
     public sealed partial class FinishingPage : Page
     {
-        private AppModel _viewModel = App.ServiceProvider.GetRequiredService<AppModel>();
+        private readonly AppModel _viewModel = App.ServiceProvider.GetRequiredService<AppModel>();
         private ViewModels.Onboarding? _onBoardingViewModel;
         public AppModel ViewModel { get { return _viewModel; } }
 
@@ -20,7 +20,7 @@ namespace Infomaniak.kDrive.Pages.Onboarding
             Logger.Log(Logger.Level.Debug, "FinishingPage components initialized");
         }
 
-        protected async override void OnNavigatedTo(NavigationEventArgs e)
+        protected override async void OnNavigatedTo(NavigationEventArgs e)
         {
             if (e.Parameter is ViewModels.Onboarding obvm)
             {

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Onboarding/NoDrivesPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Onboarding/NoDrivesPage.xaml.cs
@@ -6,7 +6,6 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
 using System;
-using System.Threading.Tasks;
 
 namespace Infomaniak.kDrive.Pages.Onboarding
 {

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Onboarding/OAuthLoadingPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Onboarding/OAuthLoadingPage.xaml.cs
@@ -1,24 +1,22 @@
 using Infomaniak.kDrive.OnBoarding;
-using Infomaniak.kDrive.ViewModels;
 using Infomaniak.kDrive.Types;
-using Microsoft.UI;
+using Infomaniak.kDrive.ViewModels;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Navigation;
 using System;
 using System.ComponentModel;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Linq;
-using Microsoft.Extensions.DependencyInjection;
 
 
 namespace Infomaniak.kDrive.Pages.Onboarding
 {
     public sealed partial class OAuthLoadingPage : Page
     {
-        private static TimeSpan _oauthTimeOut = TimeSpan.FromMinutes(5);
+        private static readonly TimeSpan _oauthTimeOut = TimeSpan.FromMinutes(5);
         private readonly AppModel _viewModel = App.ServiceProvider.GetRequiredService<AppModel>();
         private ViewModels.Onboarding? _onboardingViewModel;
 

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Onboarding/WelcomePage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Onboarding/WelcomePage.xaml.cs
@@ -11,7 +11,7 @@ namespace Infomaniak.kDrive.Pages.Onboarding
 {
     public sealed partial class WelcomePage : Page
     {
-        private AppModel _viewModel = App.ServiceProvider.GetRequiredService<AppModel>();
+        private readonly AppModel _viewModel = App.ServiceProvider.GetRequiredService<AppModel>();
         private ViewModels.Onboarding? _onBoardingViewModel;
         public AppModel ViewModel { get { return _viewModel; } }
         public WelcomePage()

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Popup/LogUploadPopup.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Popup/LogUploadPopup.xaml.cs
@@ -7,7 +7,7 @@ namespace Infomaniak.kDrive.Pages.Popup
 {
     public sealed partial class LogUploadPopup : Page
     {
-        private AppModel _viewModel = App.ServiceProvider.GetRequiredService<AppModel>();
+        private readonly AppModel _viewModel = App.ServiceProvider.GetRequiredService<AppModel>();
         public AppModel ViewModel { get { return _viewModel; } }
         public CheckBox LastSessionCheckBox => CheckBox;
         public LogUploadPopup()

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/DriveAdvancedSyncsPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/DriveAdvancedSyncsPage.xaml.cs
@@ -7,16 +7,12 @@ using Microsoft.UI.Xaml.Navigation;
 using System;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
-
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
 
 namespace Infomaniak.kDrive.Pages.Settings;
 
 public sealed partial class DriveAdvancedSyncsPage : Page
 {
-    private AppModel _viewModel = App.ServiceProvider.GetRequiredService<AppModel>();
+    private readonly AppModel _viewModel = App.ServiceProvider.GetRequiredService<AppModel>();
     private IDrive? _baseDrive;
     private Drive? ManagedDrive { get; set; }
 
@@ -50,7 +46,7 @@ public sealed partial class DriveAdvancedSyncsPage : Page
 
             ManagedDrive = drive;
         }
-        else if (_viewModel.AllDrives.FirstOrDefault(d => (d.DriveId == _baseDrive.DriveId && d.AccountId == _baseDrive.AccountId && d.UserDbId == _baseDrive.UserDbId), null) is not null)
+        else if (_viewModel.AllDrives.FirstOrDefault(d => d.DriveId == _baseDrive.DriveId && d.AccountId == _baseDrive.AccountId && d.UserDbId == _baseDrive.UserDbId, null) is not null)
         {
             // Can happen if a user uses the back button after setting up a new drive.
             Logger.Log(Logger.Level.Info, "The Available drive have an equivalent configured drive that should be used");

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/DriveManagementPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/DriveManagementPage.xaml.cs
@@ -17,7 +17,7 @@ namespace Infomaniak.kDrive.Pages.Settings
 
     public sealed partial class DriveManagementPage : Page
     {
-        private AppModel _viewModel = App.ServiceProvider.GetRequiredService<AppModel>();
+        private readonly AppModel _viewModel = App.ServiceProvider.GetRequiredService<AppModel>();
         public AppModel ViewModel { get { return _viewModel; } }
         public Drive? ManagedDrive { get; set; }
         public IDrive? BaseDrive { get; set; }
@@ -53,7 +53,7 @@ namespace Infomaniak.kDrive.Pages.Settings
 
                 ManagedDrive = drive;
             }
-            else if (ViewModel.AllDrives.FirstOrDefault(d => (d.DriveId == BaseDrive.DriveId && d.AccountId == BaseDrive.AccountId && d.UserDbId == BaseDrive.UserDbId), null) is not null)
+            else if (ViewModel.AllDrives.FirstOrDefault(d => d.DriveId == BaseDrive.DriveId && d.AccountId == BaseDrive.AccountId && d.UserDbId == BaseDrive.UserDbId, null) is not null)
             {
                 // Can happen if a user uses the back button after setting up a new drive.
                 Logger.Log(Logger.Level.Info, "The Available drive have an equivalent configured drive that should be used");
@@ -219,7 +219,7 @@ namespace Infomaniak.kDrive.Pages.Settings
 
             NewSync newSync = new() { Drive = BaseDrive, DefaultPath = result, LocalPath = result };
             await newSync.SelectBestVfsMode();
-            List<NewSync> newSyncs = new() { newSync };
+            List<NewSync> newSyncs = [newSync];
 
             CustomControls.DriveSetupContentDialog dialog = new(this.XamlRoot, newSyncs);
             await dialog.ShowAsync();

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/SettingsPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/SettingsPage.xaml.cs
@@ -33,7 +33,7 @@ namespace Infomaniak.kDrive.Pages.Settings
 {
     public sealed partial class SettingsPage : Page
     {
-        private AppModel _viewModel = App.ServiceProvider.GetRequiredService<AppModel>();
+        private readonly AppModel _viewModel = App.ServiceProvider.GetRequiredService<AppModel>();
         public AppModel ViewModel => _viewModel;
 
         public SettingsPage()
@@ -141,7 +141,7 @@ namespace Infomaniak.kDrive.Pages.Settings
 
         private async Task RefreshAvailableDrivesForAllUsers()
         {
-            List<Task<bool>> loadAvailableDrivesTasks = new List<Task<bool>>();
+            List<Task<bool>> loadAvailableDrivesTasks = [];
             foreach (var user in ViewModel.Users)
             {
                 loadAvailableDrivesTasks.Add(user.RefreshAvailableDrives(CancellationToken.None));
@@ -162,13 +162,15 @@ namespace Infomaniak.kDrive.Pages.Settings
             if (control is not null)
                 control.IsEnabled = false;
 
-            ContentDialog dialog = new ContentDialog();
-            dialog.XamlRoot = this.XamlRoot;
-            dialog.Title = Localizer.Instance.GetString("dialogRemoveAccountTitle");
-            dialog.PrimaryButtonText = Localizer.Instance.GetString("dialogRemoveAccountPrimaryButton");
-            dialog.SecondaryButtonText = Localizer.Instance.GetString("dialogRemoveAccountSecondaryButton");
-            dialog.DefaultButton = ContentDialogButton.Primary;
-            dialog.Content = Localizer.Instance.GetString("dialogRemoveAccountContent", user.Name);
+            ContentDialog dialog = new ContentDialog
+            {
+                XamlRoot = this.XamlRoot,
+                Title = Localizer.Instance.GetString("dialogRemoveAccountTitle"),
+                PrimaryButtonText = Localizer.Instance.GetString("dialogRemoveAccountPrimaryButton"),
+                SecondaryButtonText = Localizer.Instance.GetString("dialogRemoveAccountSecondaryButton"),
+                DefaultButton = ContentDialogButton.Primary,
+                Content = Localizer.Instance.GetString("dialogRemoveAccountContent", user.Name)
+            };
 
             var result = await dialog.ShowAsync();
             if (result == ContentDialogResult.Secondary)
@@ -384,7 +386,7 @@ namespace Infomaniak.kDrive.Pages.Settings
                 LogSettingsExpander.IsEnabled = false;
                 toggleSwitch.IsEnabled = false;
 
-                if (ViewModel.Settings.LogLevel == Logger.Level.Extended && toggleSwitch.IsOn || ViewModel.Settings.LogLevel != Logger.Level.Extended && !toggleSwitch.IsOn)
+                if ((ViewModel.Settings.LogLevel == Logger.Level.Extended && toggleSwitch.IsOn) || (ViewModel.Settings.LogLevel != Logger.Level.Extended && !toggleSwitch.IsOn))
                 {
                     toggleSwitch.IsEnabled = true;
                     LogSettingsExpander.IsEnabled = true;
@@ -483,7 +485,7 @@ namespace Infomaniak.kDrive.Pages.Settings
             Logger.Log(Logger.Level.Info, $"Language changed to {selectedLanguage}");
             control.IsEnabled = true;
         }
-        
+
         private async void HelpDeskButton_Click(object sender, RoutedEventArgs e)
         {
             Control? control = sender as Control;

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/TemplateExclusionPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/TemplateExclusionPage.xaml.cs
@@ -10,7 +10,7 @@ namespace Infomaniak.kDrive.Pages.Settings
 {
     public sealed partial class TemplateExclusionPage : Page
     {
-        private AppModel _viewModel = App.ServiceProvider.GetRequiredService<AppModel>();
+        private readonly AppModel _viewModel = App.ServiceProvider.GetRequiredService<AppModel>();
         public AppModel ViewModel { get => _viewModel; }
         private ExclusionTemplateListModel? _templateListModel;
         public Drive? ManagedDrive { get; set; }
@@ -177,7 +177,7 @@ namespace Infomaniak.kDrive.Pages.Settings
             }
 
             exclusionTemplate.Warning = toggleSwitch.IsOn;
-            _ = _templateListModel.SaveUserTemplates();
+            _templateListModel.SaveUserTemplates();
         }
     }
 }

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/SpecialErrorsPages/DriveAccessDeniedPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/SpecialErrorsPages/DriveAccessDeniedPage.xaml.cs
@@ -18,9 +18,6 @@
 
 using Infomaniak.kDrive.Types;
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
-using System;
-using System.ComponentModel;
 
 namespace Infomaniak.kDrive.Pages
 {

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/SpecialErrorsPages/LogginErrorPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/SpecialErrorsPages/LogginErrorPage.xaml.cs
@@ -21,9 +21,7 @@ using Infomaniak.kDrive.Types;
 using Infomaniak.kDrive.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
 using System;
-using System.Text.RegularExpressions;
 using System.Threading;
 
 namespace Infomaniak.kDrive.Pages
@@ -39,8 +37,6 @@ namespace Infomaniak.kDrive.Pages
 
         private async void ConnectionButton_Click(object sender, RoutedEventArgs e)
         {
-            Control? control = sender as Control;
-
             try
             {
                 using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(120));

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/SpecialErrorsPages/SpecialErroBasePage.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/SpecialErrorsPages/SpecialErroBasePage.cs
@@ -30,8 +30,8 @@ namespace Infomaniak.kDrive.Pages
 {
     public partial class SpecialErroBasePage : Page
     {
-        private AppModel _viewModel = App.ServiceProvider.GetRequiredService<AppModel>();
-        private List<SyncErrorStates> _handledErrorStates;
+        private readonly AppModel _viewModel = App.ServiceProvider.GetRequiredService<AppModel>();
+        private readonly List<SyncErrorStates> _handledErrorStates;
         public AppModel ViewModel => _viewModel;
         public SpecialErroBasePage(List<SyncErrorStates> syncErrorStates)
         {

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/StoragePage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/StoragePage.xaml.cs
@@ -33,7 +33,7 @@ namespace Infomaniak.kDrive.Pages
 {
     public sealed partial class StoragePage : Page
     {
-        private StoragePageViewModel _pageViewModel = new StoragePageViewModel();
+        private readonly StoragePageViewModel _pageViewModel = new StoragePageViewModel();
         public StoragePageViewModel PageViewModel => _pageViewModel;
         public StoragePage()
         {
@@ -42,7 +42,7 @@ namespace Infomaniak.kDrive.Pages
             Logger.Log(Logger.Level.Debug, "StoragePage components initialized");
         }
 
-        protected async override void OnNavigatedTo(NavigationEventArgs e)
+        protected override async void OnNavigatedTo(NavigationEventArgs e)
         {
             if (App.ServiceProvider.GetRequiredService<AppModel>().SelectedSync is null)
                 AppModel.UIThreadDispatcher.TryEnqueue(() => Frame.Navigate(typeof(SettingsPage)));

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Interfaces/IServerCommProtocol.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Interfaces/IServerCommProtocol.cs
@@ -35,7 +35,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Interfaces
             public ExitCause Cause { get; set; } = ExitCause.Unknown;
 
             // Parameters for requests or data for signals
-            public JsonObject Params { get; set; } = new JsonObject();
+            public JsonObject Params { get; set; } = [];
         }
 
         public Task<CommData> SendRequestAsync(RequestNum requestNum, JsonObject parameters, CancellationToken cancellationToken = default);

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/JsonConverters/ColorJsonConverter.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/JsonConverters/ColorJsonConverter.cs
@@ -12,8 +12,7 @@ namespace Infomaniak.kDrive.ServerCommunication.JsonConverters
             // Decode base64 strings
             if (reader.TokenType != JsonTokenType.String)
                 throw new JsonException("Expected string token type for ColorJsonConverter.");
-            string colorString = "";
-
+            string colorString;
             try
             {
                 byte[] bytes = reader.GetBytesFromBase64();

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/CommSharedJsonKeys.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/CommSharedJsonKeys.cs
@@ -21,81 +21,81 @@ namespace Infomaniak.kDrive.ServerCommunication.CommStruct
     // Shared JSON keys used in server communication
     public struct JsonKeys
     {
-        static public string ExitCode = "code";
-        static public string ExitCause = "cause";
+        public static string ExitCode = "code";
+        public static string ExitCause = "cause";
 
-        static public string OAuthCode = "code";
-        static public string OAuthCodeVerifier = "codeVerifier";
+        public static string OAuthCode = "code";
+        public static string OAuthCodeVerifier = "codeVerifier";
 
-        static public string UserDbId = "userDbId";
-        static public string UserDbIds = "userDbIds";
-        static public string UserInfoList = "userInfoList";
-        static public string UserInfo = "userInfo";
+        public static string UserDbId = "userDbId";
+        public static string UserDbIds = "userDbIds";
+        public static string UserInfoList = "userInfoList";
+        public static string UserInfo = "userInfo";
 
-        static public string AccountDbId = "accountDbId";
-        static public string AccountId = "accountId";
-        static public string AccountName = "accountName";
-        static public string AccountInfoList = "accountInfoList";
-        static public string AccountInfo = "accountInfo";
+        public static string AccountDbId = "accountDbId";
+        public static string AccountId = "accountId";
+        public static string AccountName = "accountName";
+        public static string AccountInfoList = "accountInfoList";
+        public static string AccountInfo = "accountInfo";
 
-        static public string DriveDbId = "driveDbId";
-        static public string DriveInfoList = "driveInfoList";
-        static public string DriveInfo = "driveInfo";
-        static public string DriveId = "driveId";
+        public static string DriveDbId = "driveDbId";
+        public static string DriveInfoList = "driveInfoList";
+        public static string DriveInfo = "driveInfo";
+        public static string DriveId = "driveId";
 
-        static public string SyncInfoList = "syncInfoList";
-        static public string SyncDbId = "syncDbId";
-        static public string SyncInfo = "syncInfo";
-        static public string SyncProgress = "syncProgress";
-        static public string SyncStep = "syncStep";
-        static public string SyncStatus = "syncStatus";
-        static public string SyncFileItemInfo = "itemInfo";
-        static public string RestartSync = "restartSync";
+        public static string SyncInfoList = "syncInfoList";
+        public static string SyncDbId = "syncDbId";
+        public static string SyncInfo = "syncInfo";
+        public static string SyncProgress = "syncProgress";
+        public static string SyncStep = "syncStep";
+        public static string SyncStatus = "syncStatus";
+        public static string SyncFileItemInfo = "itemInfo";
+        public static string RestartSync = "restartSync";
 
-        static public string ErrorDbId = "errorDbId";
-        static public string ErrorInfo = "errorInfo";
-        static public string ErrorInfoList = "errorInfoList";
-        static public string ErrorMessage = "errorMessage";
+        public static string ErrorDbId = "errorDbId";
+        public static string ErrorInfo = "errorInfo";
+        public static string ErrorInfoList = "errorInfoList";
+        public static string ErrorMessage = "errorMessage";
 
-        static public string NodeId = "nodeId";
-        static public string NodeInfo = "nodeInfo";
-        static public string NodeIdList = "nodeIdList";
-        static public string LocalFolderPath = "localFolderPath";
-        static public string ServerFolderPath = "serverFolderPath";
-        static public string ServerFolderNodeId = "serverFolderNodeId";
-        static public string LiteSync = "liteSync";
-        static public string BlackList = "blackList";
+        public static string NodeId = "nodeId";
+        public static string NodeInfo = "nodeInfo";
+        public static string NodeIdList = "nodeIdList";
+        public static string LocalFolderPath = "localFolderPath";
+        public static string ServerFolderPath = "serverFolderPath";
+        public static string ServerFolderNodeId = "serverFolderNodeId";
+        public static string LiteSync = "liteSync";
+        public static string BlackList = "blackList";
 
-        static public string SearchString = "searchString";
-        static public string SearchInfoList = "searchInfoList";
+        public static string SearchString = "searchString";
+        public static string SearchInfoList = "searchInfoList";
 
-        static public string NodeSubFolderInfoList = "nodeSubFolderInfoList";
-        static public string FolderSize = "folderSize";
-        static public string WithPath = "withPath";
-        static public string ParmsInfo = "parametersInfo";
+        public static string NodeSubFolderInfoList = "nodeSubFolderInfoList";
+        public static string FolderSize = "folderSize";
+        public static string WithPath = "withPath";
+        public static string ParmsInfo = "parametersInfo";
 
-        static public string ExclusionTemplatesList = "exclusionTemplateList";
-        static public string Default = "default";
+        public static string ExclusionTemplatesList = "exclusionTemplateList";
+        public static string Default = "default";
 
-        static public string Limit = "limit";
-        static public string IsValid = "isValid";
-        static public string Path = "path";
-        static public string BasePath = "basePath";
-        static public string GoodPath = "goodPath";
-        static public string BestMode = "bestMode";
-        static public string Value = "value";
-        static public string Size= "size";
+        public static string Limit = "limit";
+        public static string IsValid = "isValid";
+        public static string Path = "path";
+        public static string BasePath = "basePath";
+        public static string GoodPath = "goodPath";
+        public static string BestMode = "bestMode";
+        public static string Value = "value";
+        public static string Size = "size";
 
-        static public string LinkUrl = "linkUrl";
+        public static string LinkUrl = "linkUrl";
 
-        static public string VersionInfo = "versionInfo";
-        static public string DriveAvailableInfoList = "driveAvailableInfoList";
+        public static string VersionInfo = "versionInfo";
+        public static string DriveAvailableInfoList = "driveAvailableInfoList";
 
-        static public string UpdateChannel = "channel";
-        static public string UpdateState = "updateState";
-        static public string State = "state";
-        static public string Percentage = "percentage";
+        public static string UpdateChannel = "channel";
+        public static string UpdateState = "updateState";
+        public static string State = "state";
+        public static string Percentage = "percentage";
 
-        static public string IncludeArchivedLogs = "includeArchivedLogs";
+        public static string IncludeArchivedLogs = "includeArchivedLogs";
     }
 }

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/CommSharedStructs.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/CommSharedStructs.cs
@@ -69,7 +69,7 @@ namespace Infomaniak.kDrive.ServerCommunication.CommStruct
 
     public static partial class ConversionHelper
     {
-        static public void CopyToUser(UserInfo source, User target)
+        public static void CopyToUser(UserInfo source, User target)
         {
             CopyProperty(source, target, nameof(source.DbId), nameof(target.DbId));
             CopyProperty(source, target, nameof(source.UserId), nameof(target.UserId));
@@ -104,7 +104,7 @@ namespace Infomaniak.kDrive.ServerCommunication.CommStruct
 
     public static partial class ConversionHelper
     {
-        static public void CopyToAccount(AccountInfo source, Account target)
+        public static void CopyToAccount(AccountInfo source, Account target)
         {
             CopyProperty(source, target, nameof(source.DbId), nameof(target.DbId));
             CopyProperty(source, target, nameof(source.Id), nameof(target.Id));
@@ -137,7 +137,7 @@ namespace Infomaniak.kDrive.ServerCommunication.CommStruct
     }
     public static partial class ConversionHelper
     {
-        static public void CopyToDrive(DriveInfo source, Drive target)
+        public static void CopyToDrive(DriveInfo source, Drive target)
         {
             CopyProperty(source, target, nameof(source.DbId), nameof(target.DbId));
             CopyProperty(source, target, nameof(source.Id), nameof(target.DriveId));
@@ -162,7 +162,7 @@ namespace Infomaniak.kDrive.ServerCommunication.CommStruct
     }
     public static partial class ConversionHelper
     {
-        static public void CopyToDriveAvailable(DriveAvailableInfo source, DriveAvailable target)
+        public static void CopyToDriveAvailable(DriveAvailableInfo source, DriveAvailable target)
         {
             CopyProperty(source, target, nameof(source.DriveId), nameof(target.DriveId));
             CopyProperty(source, target, nameof(source.UserId), nameof(target.UserId));
@@ -186,7 +186,7 @@ namespace Infomaniak.kDrive.ServerCommunication.CommStruct
     }
     public static partial class ConversionHelper
     {
-        static public void CopyToSync(SyncInfo source, Sync target)
+        public static void CopyToSync(SyncInfo source, Sync target)
         {
             CopyProperty(source, target, nameof(source.DbId), nameof(target.DbId));
             CopyProperty(source, target, nameof(source.TargetPath), nameof(target.RemotePath));
@@ -213,7 +213,7 @@ namespace Infomaniak.kDrive.ServerCommunication.CommStruct
     }
     public static partial class ConversionHelper
     {
-        static public void CopyToProxyConfig(ProxyConfigInfo source, ProxyConfig target)
+        public static void CopyToProxyConfig(ProxyConfigInfo source, ProxyConfig target)
         {
             CopyProperty(source, target, nameof(source.Type), nameof(target.Type));
             CopyProperty(source, target, nameof(source.HostName), nameof(target.HostName));
@@ -222,7 +222,7 @@ namespace Infomaniak.kDrive.ServerCommunication.CommStruct
             CopyProperty(source, target, nameof(source.User), nameof(target.User));
             CopyProperty(source, target, nameof(source.Pwd), nameof(target.Pwd));
         }
-        static public void CopyToProxyConfigInfo(ProxyConfig source, ProxyConfigInfo target)
+        public static void CopyToProxyConfigInfo(ProxyConfig source, ProxyConfigInfo target)
         {
             CopyProperty(source, target, nameof(source.Type), nameof(target.Type));
             CopyProperty(source, target, nameof(source.HostName), nameof(target.HostName));
@@ -250,7 +250,7 @@ namespace Infomaniak.kDrive.ServerCommunication.CommStruct
     }
     public static partial class ConversionHelper
     {
-        static public void CopyToSettings(ParmsInfo source, Settings target)
+        public static void CopyToSettings(ParmsInfo source, Settings target)
         {
             CopyProperty(source, target, nameof(source.Language), nameof(target.Language));
             CopyProperty(source, target, nameof(source.AutoStart), nameof(target.AutoStart));
@@ -274,7 +274,7 @@ namespace Infomaniak.kDrive.ServerCommunication.CommStruct
             else
                 CopyProperty(source, target, nameof(source.LogLevel), nameof(target.LogLevel));
         }
-        static public void CopyToParmsInfo(Settings source, ParmsInfo target)
+        public static void CopyToParmsInfo(Settings source, ParmsInfo target)
         {
             CopyProperty(source, target, nameof(source.Language), nameof(target.Language));
             CopyProperty(source, target, nameof(source.AutoStart), nameof(target.AutoStart));
@@ -333,7 +333,7 @@ namespace Infomaniak.kDrive.ServerCommunication.CommStruct
 
     public static partial class ConversionHelper
     {
-        static public void CopyToSyncFileItem(SyncFileItemInfo source, SyncFileItem target)
+        public static void CopyToSyncFileItem(SyncFileItemInfo source, SyncFileItem target)
         {
             CopyProperty(source, target, nameof(source.Type), nameof(target.Type));
             CopyProperty(source, target, nameof(source.Path), nameof(target.Path));
@@ -365,7 +365,7 @@ namespace Infomaniak.kDrive.ServerCommunication.CommStruct
 
     public static partial class ConversionHelper
     {
-        static public void CopyToNode(NodeInfo source, Node target)
+        public static void CopyToNode(NodeInfo source, Node target)
         {
             CopyProperty(source, target, nameof(source.NodeId), nameof(target.NodeId));
             CopyProperty(source, target, nameof(source.Name), nameof(target.Name));
@@ -395,7 +395,7 @@ namespace Infomaniak.kDrive.ServerCommunication.CommStruct
 
     public static partial class ConversionHelper
     {
-        static public void CopyToError(ErrorInfo source, Error target)
+        public static void CopyToError(ErrorInfo source, Error target)
         {
             CopyProperty(source, target, nameof(source.DbId), nameof(target.DbId));
             CopyProperty(source, target, nameof(source.Time), nameof(target.Timestamp));
@@ -421,7 +421,7 @@ namespace Infomaniak.kDrive.ServerCommunication.CommStruct
 
     public static partial class ConversionHelper
     {
-        static public ExclusionTemplate FromExclusionTemplateInfo(ExclusionTemplateInfo source)
+        public static ExclusionTemplate FromExclusionTemplateInfo(ExclusionTemplateInfo source)
         {
             return new ExclusionTemplate(
                 template: source.Template ?? string.Empty,
@@ -430,7 +430,7 @@ namespace Infomaniak.kDrive.ServerCommunication.CommStruct
             );
         }
 
-        static public void CopyToExclusionTemplateInfo(ExclusionTemplate source, ExclusionTemplateInfo target)
+        public static void CopyToExclusionTemplateInfo(ExclusionTemplate source, ExclusionTemplateInfo target)
         {
             CopyProperty(source, target, nameof(source.Template), nameof(target.Template));
             CopyProperty(source, target, nameof(source.Default), nameof(target.Default));

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/MockServerCommProtocol.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/MockServerCommProtocol.cs
@@ -49,7 +49,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
         private Task? _customSignalsHandler;
         public MockServerCommProtocol()
         {
-            _ = Initialize();
+            Initialize();
         }
 
         public async Task<CommData> SendRequestAsync(RequestNum requestNum, JsonObject parameters, CancellationToken cancellationToken = default)
@@ -139,7 +139,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
         {
             var users = _mockData.Users;
 
-            JsonObject result = new JsonObject();
+            JsonObject result = [];
             foreach (var user in users)
             {
                 var userData = new JsonObject
@@ -172,7 +172,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
         {
             var accounts = _mockData.Users.SelectMany(u => u.Accounts).ToList();
 
-            JsonObject result = new JsonObject();
+            JsonObject result = [];
             foreach (var account in accounts)
             {
                 var accountData = new JsonObject
@@ -202,7 +202,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
         {
             var drives = _mockData.Users.SelectMany(u => u.Accounts).SelectMany(a => a.Drives).ToList();
 
-            JsonObject result = new JsonObject();
+            JsonObject result = [];
             foreach (var drive in drives)
             {
                 var driveData = new JsonObject
@@ -238,7 +238,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
         private Task<CommData> SyncInfoListRequest(JsonObject parameters)
         {
             var syncs = _mockData.Users.SelectMany(u => u.Accounts).SelectMany(a => a.Drives).SelectMany(d => d.Syncs).ToList();
-            JsonObject result = new JsonObject();
+            JsonObject result = [];
             foreach (var sync in syncs)
             {
                 var syncData = new JsonObject
@@ -277,7 +277,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 Type = CommMessageType.Request,
                 Id = (int)NextId,
                 RequestNum = RequestNum.UPDATER_START_INSTALLER,
-                Params = new JsonObject()
+                Params = []
             };
         }
 
@@ -320,13 +320,13 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 Logger.Log(Logger.Level.Warning, "No channel specified in UpdaterChangeChannel request, using current channel.");
 
             }
-            EnqueueSignal(SignalNum.UPDATER_STATE_CHANGED, new JsonObject());
+            EnqueueSignal(SignalNum.UPDATER_STATE_CHANGED, []);
             return new CommData
             {
                 Type = CommMessageType.Request,
                 Id = (int)NextId,
                 RequestNum = RequestNum.UPDATER_CHANGE_CHANNEL,
-                Params = new JsonObject()
+                Params = []
             };
         }
 
@@ -363,7 +363,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                     Type = CommMessageType.Request,
                     Id = (int)NextId,
                     RequestNum = RequestNum.PARAMETERS_UPDATE,
-                    Params = new JsonObject()
+                    Params = []
                 };
             }
 
@@ -385,7 +385,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 Type = CommMessageType.Request,
                 Id = (int)NextId,
                 RequestNum = RequestNum.PARAMETERS_UPDATE,
-                Params = new JsonObject()
+                Params = []
             };
         }
 
@@ -436,7 +436,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             System.IO.File.WriteAllText(path, json);
         }
 
-        public List<User> Users { get; set; } = new List<User>();
+        public List<User> Users { get; set; } = [];
         public AppVersion CurrentVersion { get; set; } = new AppVersion() { BuildVersion = 1, Tag = "3.7.6" };
         public ParmsInfo Settings { get; set; } = new ParmsInfo();
 
@@ -459,23 +459,23 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             Users.Add(new User(2) { UserId = 11, Name = "Alice", Email = "Alice.doe@infomaniak.com", IsConnected = false, IsStaff = false });
 
             // Create mock accounts
-            List<Account> accounts = new List<Account>();
-            accounts.Add(new Account(1, Users[0]));
-            accounts.Add(new Account(2, Users[1]));
+            List<Account> accounts = [new Account(1, Users[0]), new Account(2, Users[1])];
 
             Users[0].Accounts.Add(accounts[0]);
             Users[1].Accounts.Add(accounts[1]);
 
             // Create mock drives
-            List<Drive> drives = new List<Drive>();
-            drives.Add(new Drive(1, accounts[0]) { DriveId = 140946, Name = "Infomaniak", Color = Color.FromArgb(255, 0, 150, 136), IsFreeOffer = false });
-            drives.Add(new Drive(2, accounts[0]) { DriveId = 101, Name = "Etik corp", Color = Color.FromArgb(255, 156, 38, 176), IsFreeOffer = false });
-            drives.Add(new Drive(3, accounts[0]) { DriveId = 102, Name = "CH corp", Color = Color.FromArgb(255, 110, 168, 44), IsFreeOffer = true });
-            drives.Add(new Drive(4, accounts[0]) { DriveId = 103, Name = "The cloud", Color = Color.FromArgb(255, 255, 168, 110), IsFreeOffer = true });
-            drives.Add(new Drive(5, accounts[0]) { DriveId = 104, Name = "SwissCloud", Color = Color.FromArgb(255, 160, 168, 213), IsFreeOffer = true });
-            drives.Add(new Drive(6, accounts[0]) { DriveId = 105, Name = "FrenchCloud", Color = Color.FromArgb(255, 123, 179, 12), IsFreeOffer = true });
-            drives.Add(new Drive(7, accounts[1]) { DriveId = 106, Name = "EuropaCloud", Color = Color.FromArgb(255, 160, 12, 213), IsFreeOffer = true });
-            drives.Add(new Drive(8, accounts[1]) { DriveId = 107, Name = "WinUI cloud", Color = Color.FromArgb(255, 12, 168, 179), IsFreeOffer = true });
+            List<Drive> drives =
+            [
+                new Drive(1, accounts[0]) { DriveId = 140946, Name = "Infomaniak", Color = Color.FromArgb(255, 0, 150, 136), IsFreeOffer = false },
+                new Drive(2, accounts[0]) { DriveId = 101, Name = "Etik corp", Color = Color.FromArgb(255, 156, 38, 176), IsFreeOffer = false },
+                new Drive(3, accounts[0]) { DriveId = 102, Name = "CH corp", Color = Color.FromArgb(255, 110, 168, 44), IsFreeOffer = true },
+                new Drive(4, accounts[0]) { DriveId = 103, Name = "The cloud", Color = Color.FromArgb(255, 255, 168, 110), IsFreeOffer = true },
+                new Drive(5, accounts[0]) { DriveId = 104, Name = "SwissCloud", Color = Color.FromArgb(255, 160, 168, 213), IsFreeOffer = true },
+                new Drive(6, accounts[0]) { DriveId = 105, Name = "FrenchCloud", Color = Color.FromArgb(255, 123, 179, 12), IsFreeOffer = true },
+                new Drive(7, accounts[1]) { DriveId = 106, Name = "EuropaCloud", Color = Color.FromArgb(255, 160, 12, 213), IsFreeOffer = true },
+                new Drive(8, accounts[1]) { DriveId = 107, Name = "WinUI cloud", Color = Color.FromArgb(255, 12, 168, 179), IsFreeOffer = true },
+            ];
 
             Users[0].Accounts[0].Drives.Add(drives[0]);
             Users[0].Accounts[0].Drives.Add(drives[1]);
@@ -488,9 +488,10 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
 
 
             // Create mock syncs
-            List<Sync> syncs = new List<Sync>();
-
-            syncs.Add(new Sync(1, drives[0]) { LocalPath = "C:\\Users\\John\\Etik corp sync1", RemotePath = "", SupportOnlineMode = false });
+            List<Sync> syncs =
+            [
+                new Sync(1, drives[0]) { LocalPath = "C:\\Users\\John\\Etik corp sync1", RemotePath = "", SupportOnlineMode = false },
+            ];
             drives[0].Syncs.Add(syncs[0]);
 
             syncs.Add(new Sync(2, drives[1]) { LocalPath = "D:\\Users\\John\\CH corp\\kDrive Metier", RemotePath = "", SupportOnlineMode = false });

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/MockServerCommProtocolTestError.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/MockServerCommProtocolTestError.cs
@@ -40,7 +40,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
 
         public MockServerCommProtocolTestError() : base()
         {
-            _ = Task.Run(async () =>
+            Task.Run(async () =>
             {
                 while (!App.ServiceProvider.GetRequiredService<AppModel>().IsInitialized)
                 {
@@ -255,7 +255,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             options.Converters.Add(new IntToDateTimeConverter());
 
             var json = JsonSerializer.SerializeToNode(errorInfo, options);
-            var jsonObject = json as JsonObject ?? new JsonObject();
+            var jsonObject = json as JsonObject ?? [];
 
             return new JsonObject
             {

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -65,7 +65,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
         // Requests
         public async Task<List<DbId>?> GetUserDbIds(CancellationToken cancellationToken)
         {
-            CommData data = await _commClient.SendRequestAsync(RequestNum.USER_DBIDLIST, new JsonObject(), cancellationToken);
+            CommData data = await _commClient.SendRequestAsync(RequestNum.USER_DBIDLIST, [], cancellationToken);
             if (data.Params is null || !data.Params.ContainsKey(JsonKeys.UserDbIds))
             {
                 Logger.Log(Logger.Level.Error, $"{JsonKeys.UserDbIds} not found in response.");
@@ -122,9 +122,9 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
 
         public async Task<bool> RefreshUsers(CancellationToken cancellationToken)
         {
-            CommData data = await _commClient.SendRequestAsync(RequestNum.USER_INFOLIST, new JsonObject(), cancellationToken).ConfigureAwait(false);
+            CommData data = await _commClient.SendRequestAsync(RequestNum.USER_INFOLIST, [], cancellationToken).ConfigureAwait(false);
 
-            if (!CheckJobResultAndLogIfError(data, new JsonObject()))
+            if (!CheckJobResultAndLogIfError(data, []))
                 return false;
 
             if (!HasRequiredParam(data, JsonKeys.UserInfoList))
@@ -191,7 +191,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
 
         public async Task<bool> RefreshAccounts(CancellationToken cancellationToken)
         {
-            CommData data = await _commClient.SendRequestAsync(RequestNum.ACCOUNT_INFOLIST, new JsonObject(), cancellationToken).ConfigureAwait(false);
+            CommData data = await _commClient.SendRequestAsync(RequestNum.ACCOUNT_INFOLIST, [], cancellationToken).ConfigureAwait(false);
             if (!CheckJobResultAndLogIfError(data))
                 return false;
 
@@ -249,7 +249,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
 
         public async Task<bool> RefreshDrives(CancellationToken cancellationToken)
         {
-            CommData data = await _commClient.SendRequestAsync(RequestNum.DRIVE_INFOLIST, new JsonObject(), cancellationToken).ConfigureAwait(false);
+            CommData data = await _commClient.SendRequestAsync(RequestNum.DRIVE_INFOLIST, [], cancellationToken).ConfigureAwait(false);
             if (!CheckJobResultAndLogIfError(data))
                 return false;
 
@@ -398,7 +398,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
 
         public async Task<bool> RefreshSyncs(CancellationToken cancellationToken)
         {
-            CommData data = await _commClient.SendRequestAsync(RequestNum.SYNC_INFOLIST, new JsonObject(), cancellationToken).ConfigureAwait(false);
+            CommData data = await _commClient.SendRequestAsync(RequestNum.SYNC_INFOLIST, [], cancellationToken).ConfigureAwait(false);
             if (!CheckJobResultAndLogIfError(data))
                 return false;
 
@@ -912,13 +912,13 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
 
         public async Task<bool> StartUpdate(CancellationToken cancellationToken)
         {
-            CommData data = await _commClient.SendRequestAsync(RequestNum.UPDATER_START_INSTALLER, new JsonObject(), cancellationToken).ConfigureAwait(false);
+            CommData data = await _commClient.SendRequestAsync(RequestNum.UPDATER_START_INSTALLER, [], cancellationToken).ConfigureAwait(false);
             return CheckJobResultAndLogIfError(data);
         }
         public async Task<bool> RefreshUpdaterVersionInfo(CancellationToken cancellationToken)
         {
             // First check the update state
-            CommData data = await _commClient.SendRequestAsync(RequestNum.UPDATER_STATE, new JsonObject(), cancellationToken);
+            CommData data = await _commClient.SendRequestAsync(RequestNum.UPDATER_STATE, [], cancellationToken);
             if (!CheckJobResultAndLogIfError(data))
                 return false;
 
@@ -940,15 +940,15 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             }
             _viewModel.Settings.UpdateManager.UpdateEnabled = true;
 
-            List<UpdateState> notReadyStates = new List<UpdateState>
-            {
+            List<UpdateState> notReadyStates =
+            [
                 UpdateState.UpToDate,
                 UpdateState.Available,
                 UpdateState.Downloading,
                 UpdateState.CheckError,
                 UpdateState.DownloadError,
                 UpdateState.UpdateError
-            };
+            ];
 
             if (notReadyStates.Contains(updateState.Value))
             {
@@ -1010,13 +1010,13 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
 
         public async Task<bool> CancelLogUpload(CancellationToken cancellationToken)
         {
-            CommData data = await _commClient.SendRequestAsync(RequestNum.UTILITY_CANCEL_LOG_TO_SUPPORT, new JsonObject { }, cancellationToken);
+            CommData data = await _commClient.SendRequestAsync(RequestNum.UTILITY_CANCEL_LOG_TO_SUPPORT, [], cancellationToken);
             return CheckJobResultAndLogIfError(data);
         }
 
         public async Task<bool> RefreshSettings(CancellationToken cancellationToken)
         {
-            CommData data = await _commClient.SendRequestAsync(RequestNum.PARAMETERS_INFO, new JsonObject(), cancellationToken);
+            CommData data = await _commClient.SendRequestAsync(RequestNum.PARAMETERS_INFO, [], cancellationToken);
             if (!CheckJobResultAndLogIfError(data))
                 return false;
 
@@ -1040,14 +1040,14 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
 
         public async Task<bool> ActivateLoadInfo(CancellationToken cancellationToken)
         {
-            CommData data = await _commClient.SendRequestAsync(RequestNum.UTILITY_ACTIVATELOADINFO, new JsonObject { }, cancellationToken);
+            CommData data = await _commClient.SendRequestAsync(RequestNum.UTILITY_ACTIVATELOADINFO, [], cancellationToken);
             return CheckJobResultAndLogIfError(data);
         }
 
         public async Task Exit()
         {
             // Try and forget, no need to wait for response on exit
-            await _commClient.SendRequestAsync(RequestNum.UTILITY_QUIT, new JsonObject { }, CancellationToken.None);
+            await _commClient.SendRequestAsync(RequestNum.UTILITY_QUIT, [], CancellationToken.None);
         }
 
         public async Task<bool> SaveSettings(CancellationToken cancellationToken)
@@ -1081,7 +1081,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
 
         public async Task<List<ExclusionTemplate>?> GetExclusionTemplates(CancellationToken cancellationToken)
         {
-            List<ExclusionTemplate> result = new();
+            List<ExclusionTemplate> result = [];
 
             foreach (bool def in new bool[] { false, true })
             {
@@ -1526,7 +1526,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 }
 
                 // Remove any item with the same remote or local node id wich is not syncing or done (ie errored)
-                var toBeRemoved = activities.Where(a => (a.Status == fileItemInfo.Status || a.Status != SyncFileStatus.Success && ((!string.IsNullOrEmpty(a.LocalNodeId) && a.LocalNodeId == fileItemInfo.LocalNodeId) || (!string.IsNullOrEmpty(a.RemoteNodeId) && a.RemoteNodeId == fileItemInfo.RemoteNodeId))));
+                var toBeRemoved = activities.Where(a => a.Status == fileItemInfo.Status || (a.Status != SyncFileStatus.Success && ((!string.IsNullOrEmpty(a.LocalNodeId) && a.LocalNodeId == fileItemInfo.LocalNodeId) || (!string.IsNullOrEmpty(a.RemoteNodeId) && a.RemoteNodeId == fileItemInfo.RemoteNodeId))));
                 activities.RemoveMany(toBeRemoved);
 
                 // Create new item
@@ -1758,7 +1758,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
         {
             await AutoRetry(async Task<bool> () =>
             {
-                List<Drive> allDrives = new();
+                List<Drive> allDrives = [];
                 foreach (var user in _viewModel.Users)
                 {
                     allDrives.AddRange(user.Drives);

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/SocketServerCommProtocol.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/SocketServerCommProtocol.cs
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-using Infomaniak.kDrive.ServerCommunication.Interfaces;
 using Infomaniak.kDrive.ServerCommunication.JsonConverters;
 using Infomaniak.kDrive.Types;
 using System;
@@ -30,7 +29,6 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
-using Windows.Networking.Connectivity;
 using static Infomaniak.kDrive.ServerCommunication.Interfaces.IServerCommProtocol;
 
 
@@ -68,7 +66,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
 
         public Task Initialize()
         {
-            _ = Task.Run(ReconnectLoop);
+            Task.Run(ReconnectLoop);
             return Task.CompletedTask;
         }
 
@@ -335,7 +333,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 case CommMessageType.Signal:
                     // Signal
                     SignalNum signalNum = (SignalNum)data.Num;
-                    RaiseSignal(signalNum, data.Params ?? new JsonObject());
+                    RaiseSignal(signalNum, data.Params ?? []);
                     break;
                 default:
                     Logger.Log(Logger.Level.Warning, $"Unknown message type: {data.Type}");

--- a/src/gui4/windows/kDrive client/kDrive client/Utility/Types.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Utility/Types.cs
@@ -4,11 +4,8 @@ global using DriveId = System.Int64;
 global using NodeId = System.String;
 global using SyncPath = System.String;
 global using UserId = System.Int64;
-using Infomaniak.kDrive.ViewModels;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Threading.Tasks;
-using System.Windows.Documents;
 
 
 namespace Infomaniak.kDrive.Types

--- a/src/gui4/windows/kDrive client/kDrive client/Utility/UserDefaults.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Utility/UserDefaults.cs
@@ -21,16 +21,16 @@ namespace Infomaniak.kDrive
                 try
                 {
                     string jsonContent = File.ReadAllText(userDefaultsFilePath);
-                    userDefaults = JsonNode.Parse(jsonContent)?.AsObject() ?? new JsonObject();
+                    userDefaults = JsonNode.Parse(jsonContent)?.AsObject() ?? [];
                 }
                 catch (Exception)
                 {
-                    userDefaults = new JsonObject();
+                    userDefaults = [];
                 }
             }
             else
             {
-                userDefaults = new JsonObject();
+                userDefaults = [];
             }
         }
 

--- a/src/gui4/windows/kDrive client/kDrive client/Utility/Utility.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Utility/Utility.cs
@@ -181,14 +181,15 @@ namespace Infomaniak.kDrive
 
         public static ContentDialog GetContentDialog(XamlRoot xamlRoot, string translationKeyPreffix, ContentDialogButton defaultButton = ContentDialogButton.Primary)
         {
-            ContentDialog dialog = new ContentDialog();
-
-            dialog.XamlRoot = xamlRoot;
-            dialog.Title = Localizer.Instance.GetString($"{translationKeyPreffix}Title");
-            dialog.PrimaryButtonText = Localizer.Instance.GetString($"{translationKeyPreffix}PrimaryButtonText");
-            dialog.SecondaryButtonText = Localizer.Instance.GetString($"{translationKeyPreffix}SecondaryButtonText");
-            dialog.DefaultButton = defaultButton;
-            dialog.Content = Localizer.Instance.GetString($"{translationKeyPreffix}Content");
+            ContentDialog dialog = new ContentDialog
+            {
+                XamlRoot = xamlRoot,
+                Title = Localizer.Instance.GetString($"{translationKeyPreffix}Title"),
+                PrimaryButtonText = Localizer.Instance.GetString($"{translationKeyPreffix}PrimaryButtonText"),
+                SecondaryButtonText = Localizer.Instance.GetString($"{translationKeyPreffix}SecondaryButtonText"),
+                DefaultButton = defaultButton,
+                Content = Localizer.Instance.GetString($"{translationKeyPreffix}Content")
+            };
             return dialog;
         }
 

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/Account.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/Account.cs
@@ -25,7 +25,7 @@ namespace Infomaniak.kDrive.ViewModels
         private string _name = "";
         private DbId _dbId = -1;
         private AccountId _id = 0;
-        private ObservableCollection<Drive> _drives = new ObservableCollection<Drive>();
+        private ObservableCollection<Drive> _drives = [];
         private User _user;
         public Account(DbId dbId, User user)
         {

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/App.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/App.cs
@@ -191,7 +191,7 @@ namespace Infomaniak.kDrive.ViewModels
             {
                 Logger.Log(Logger.Level.Debug, "There are no syncs available, setting SelectedSync to null.");
                 SelectedSync = null;
-                (((App.Current as App)?.CurrentWindow as MainWindow)?.AppNavView?.Frame.Navigate(typeof(SettingsPage)));
+                ((App.Current as App)?.CurrentWindow as MainWindow)?.AppNavView?.Frame.Navigate(typeof(SettingsPage));
             }
             else if (_selectedSync == null || (_selectedSync != null && !AllSyncs.Contains(_selectedSync))) // If SelectedSync is null or not in AllSyncs, pick the first one
             {

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/App.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/App.cs
@@ -50,7 +50,7 @@ namespace Infomaniak.kDrive.ViewModels
         /** The list of users setup in the application.
          *  This is an observable collection, so the UI can bind to it and be notified of changes.
          */
-        private ObservableCollection<User> _users = new();
+        private ObservableCollection<User> _users = [];
 
         /** The dispatcher queue for the UI thread.
          *  This is used to marshal calls to the UI thread when updating observable item.
@@ -59,7 +59,7 @@ namespace Infomaniak.kDrive.ViewModels
         public static DispatcherQueue UIThreadDispatcher { get; set; } = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
 
         // The list of server level error
-        public ObservableCollection<Error> AppErrors = new();
+        public ObservableCollection<Error> AppErrors = [];
 
         // Helpers - Agregated collections
         /** The list of active syncs across all users.
@@ -191,7 +191,7 @@ namespace Infomaniak.kDrive.ViewModels
             {
                 Logger.Log(Logger.Level.Debug, "There are no syncs available, setting SelectedSync to null.");
                 SelectedSync = null;
-                ((App.Current as App)?.CurrentWindow as MainWindow)?.AppNavView?.Frame.Navigate(typeof(SettingsPage));
+                (((App.Current as App)?.CurrentWindow as MainWindow)?.AppNavView?.Frame.Navigate(typeof(SettingsPage)));
             }
             else if (_selectedSync == null || (_selectedSync != null && !AllSyncs.Contains(_selectedSync))) // If SelectedSync is null or not in AllSyncs, pick the first one
             {

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/Drive.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/Drive.cs
@@ -37,7 +37,7 @@ namespace Infomaniak.kDrive.ViewModels
         private string _name = "";
         private Color _color = Color.Blue;
         private bool _isFreeOffer = true; // Indicates if the drive is a free offer
-        private readonly  ObservableCollection<Sync> _syncs = new ObservableCollection<Sync>();
+        private readonly ObservableCollection<Sync> _syncs = [];
         private Sync? _mainSync;
         private bool _isConfigured = false; // Indicates if at least one sync (which is not an advanced sync) is set up for this drive
         private bool _isAdmin = false; // Indicates if the user is admin of this drive
@@ -48,7 +48,7 @@ namespace Infomaniak.kDrive.ViewModels
 
         // Drive UI properties
         private bool _displayRemoteSpaceWarning = false;
-        private readonly ObservableCollection<Sync> _advancedSyncs = new ObservableCollection<Sync>();
+        private readonly ObservableCollection<Sync> _advancedSyncs = [];
 
 
         public Drive(DbId dbId, Account account)

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/Node.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/Node.cs
@@ -17,9 +17,7 @@
  */
 
 using Infomaniak.kDrive.ServerCommunication.Interfaces;
-using Infomaniak.kDrive.Types;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/Sync.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/Sync.cs
@@ -46,7 +46,7 @@ namespace Infomaniak.kDrive.ViewModels
         // Sync UI properties
         private bool _showIncomingActivity = true;
         private SyncErrorStates _syncErrorState = SyncErrorStates.Undefined;
-        private readonly ObservableCollection<SyncFileItem> _syncActivities = new();
+        private readonly ObservableCollection<SyncFileItem> _syncActivities = [];
         private bool _syncTypeMigrationInProgress = false;
         private SyncFileItem? _lastActivity;
 
@@ -166,7 +166,7 @@ namespace Infomaniak.kDrive.ViewModels
         }
 
         // The list of sync and node errors
-        public ObservableCollection<Error> SyncErrors = new();
+        public ObservableCollection<Error> SyncErrors = [];
 
         public SyncErrorStates SyncErrorState
         {

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/User.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/User.cs
@@ -44,8 +44,8 @@ namespace Infomaniak.kDrive.ViewModels
         private ImageSource? _avatarImageSource = null;
         private bool _isConnected = false;
         private bool _isStaff = false;
-        private readonly ObservableCollection<Account> _accounts = new ObservableCollection<Account>();
-        private ObservableCollection<DriveAvailable> _drivesAvailable = new ObservableCollection<DriveAvailable>();
+        private readonly ObservableCollection<Account> _accounts = [];
+        private readonly ObservableCollection<DriveAvailable> _drivesAvailable = [];
         private bool _driveRefreshInProgress = false;
         private Task<bool>? _refreshAvailableDrivesTask;
         private readonly IDisposable _allDriveSubscribtion;
@@ -145,7 +145,7 @@ namespace Infomaniak.kDrive.ViewModels
         }
 
         // Combined collection of all drives (configured in db and available)
-        public ObservableCollection<IDrive> AllDrives { get; } = new();
+        public ObservableCollection<IDrive> AllDrives { get; } = [];
 
         public static async Task<ImageSource?> ByteArrayToImageSource(byte[]? imageData)
         {
@@ -193,9 +193,7 @@ namespace Infomaniak.kDrive.ViewModels
          */
         private void MergeDrives()
         {
-            List<IDrive> drives = new();
-            foreach (var drive in Drives)
-                drives.Add(drive);
+            List<IDrive> drives = [.. Drives];
 
             foreach (var drive in DrivesAvailable)
                 if (drives.FirstOrDefault(d => d.DriveId == drive.DriveId) is null)

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/Onboarding/NewSync.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/Onboarding/NewSync.cs
@@ -23,7 +23,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Windows.Documents;
 
 namespace Infomaniak.kDrive.ViewModels
 {
@@ -37,7 +36,7 @@ namespace Infomaniak.kDrive.ViewModels
         private NodeId _remoteNodeId = "";
         private SyncType _syncType = SyncType.Unknown;
         private IDrive? drive;
-        private ObservableCollection<NodeId> _excludedNodeIds = new ObservableCollection<NodeId>();
+        private ObservableCollection<NodeId> _excludedNodeIds = [];
 
         public NewSync() { }
         public NewSync(NewSync other)

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/Onboarding/Onboarding.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/Onboarding/Onboarding.cs
@@ -23,7 +23,7 @@ namespace Infomaniak.kDrive.ViewModels
 
         public event EventHandler? DrivesAvailable;
 
-        public ObservableCollection<NewSync> NewSyncs { get; } = new();
+        public ObservableCollection<NewSync> NewSyncs { get; } = [];
 
         public OAuth2State CurrentOAuth2State
         {
@@ -39,7 +39,7 @@ namespace Infomaniak.kDrive.ViewModels
 
         public void Dispose()
         {
-            _ = StopDriveAvailabilityWatcherAsync();
+            StopDriveAvailabilityWatcherAsync();
         }
 
         public void StartDriveAvailabilityWatcher()

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/Settings/AppVersion.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/Settings/AppVersion.cs
@@ -19,7 +19,7 @@ namespace Infomaniak.kDrive.ViewModels
             }
         }
 
-        static public AppVersion Current()
+        public static AppVersion Current()
         {
             var assembly = Assembly.GetExecutingAssembly();
             var version = assembly.GetName().Version;
@@ -72,7 +72,7 @@ namespace Infomaniak.kDrive.ViewModels
                     return thisTagParts.Length > otherTagParts.Length;
                 }
             }
-            catch (System.FormatException ex)
+            catch (System.FormatException)
             {
                 Logger.Log(Logger.Level.Error, "Unable to parse the version tag");
                 return false;

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/Settings/ExclusionTemplate.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/Settings/ExclusionTemplate.cs
@@ -1,11 +1,4 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Infomaniak.kDrive.ViewModels
+﻿namespace Infomaniak.kDrive.ViewModels
 {
     public class ExclusionTemplate : UISafeObservableObject
     {

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/Settings/ExclusionTemplateListModel.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/Settings/ExclusionTemplateListModel.cs
@@ -15,17 +15,17 @@ namespace Infomaniak.kDrive.ViewModels
     public partial class ExclusionTemplateListModel : UISafeObservableObject, IDisposable
     {
         // Collection of all the ExclusionTemplate objects
-        private ObservableCollection<ExclusionTemplate> _templates = new();
-        private ReadOnlyObservableCollection<ExclusionTemplate> _defaultTemplates;
-        private ReadOnlyObservableCollection<ExclusionTemplate> _userDefinedTemplates;
+        private ObservableCollection<ExclusionTemplate> _templates = [];
+        private readonly ReadOnlyObservableCollection<ExclusionTemplate> _defaultTemplates;
+        private readonly ReadOnlyObservableCollection<ExclusionTemplate> _userDefinedTemplates;
         private int _selectedCount;
         private bool _hasSelectedTemplates;
         private CancellationTokenSource? _saveDebounceCts;
         private readonly object _saveDebounceLock = new();
 
         // Subscription handlers
-        private IDisposable _defaultTemplatesSubscription;
-        private IDisposable _userDefinedTemplatesSubscription;
+        private readonly IDisposable _defaultTemplatesSubscription;
+        private readonly IDisposable _userDefinedTemplatesSubscription;
         public ExclusionTemplateListModel()
         {
             _defaultTemplatesSubscription = _templates.ToObservableChangeSet().Filter(t => t.Default).Bind(out _defaultTemplates).Subscribe();
@@ -46,7 +46,7 @@ namespace Infomaniak.kDrive.ViewModels
                 _saveDebounceCts = null;
             }
             if (hasPendingSave)
-                _ = SaveUserTemplatesImmediateAsync().ContinueWith(task =>
+                SaveUserTemplatesImmediateAsync().ContinueWith(task =>
                 {
                     if (task.Exception is not null)
                     {

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/Settings/ProxyConfig.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/Settings/ProxyConfig.cs
@@ -1,7 +1,4 @@
-﻿using DynamicData;
-using Infomaniak.kDrive.Types;
-using System;
-using System.Threading.Tasks;
+﻿using Infomaniak.kDrive.Types;
 
 namespace Infomaniak.kDrive.ViewModels
 {

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/Settings/VersionInfo.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/Settings/VersionInfo.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace Infomaniak.kDrive.ViewModels
 {
-    public class VersionInfo: UISafeObservableObject
+    public class VersionInfo : UISafeObservableObject
     {
         public VersionChannel Channel { get; set; } = VersionChannel.Unknown;
         public string Tag { get; set; } = string.Empty; // Version number. Example: 3.6.4


### PR DESCRIPTION
Refactor codebase to use C# 12 collection initializers (`[]`), add `readonly` where appropriate, and clean up unused usings and obsolete comments. Improves code clarity, immutability, and consistency across the project. Also standardizes object initialization and error handling.