### PR TITLE
fix: Mac tests

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -10,9 +10,7 @@ macOS UI:
 
 XPC:
   - changed-files:
-    - any-glob-to-any-file: 'src/gui4/macOS/kDriveCore/ServerBridge/**'
-    - any-glob-to-any-file: 'extensions/MacOSX/kDriveFinderSync/**'
-    - any-glob-to-any-file: 'src/server/comm/**'
+    - any-glob-to-any-file: ['src/gui4/macOS/kDriveCore/ServerBridge/**', 'extensions/MacOSX/kDriveFinderSync/**', 'src/server/comm/**']
 
 GUI job:
   - changed-files:

--- a/src/gui4/macOS/kDriveTests/XPC/JSON/QuotaExceededError.json
+++ b/src/gui4/macOS/kDriveTests/XPC/JSON/QuotaExceededError.json
@@ -1,5 +1,5 @@
 {
-  "cause": 38,
+  "cause": 39,
   "code": 6,
   "id": 42,
   "params": { }


### PR DESCRIPTION
Bump labeler conf
Bump a sample JSON to new XPC error codes