### PR TITLE
chore(QtWebEngine): remove Qt WebEngine references from Windows build configuration

### DIFF
--- a/installer/windows/kDriveInstaller/Components/QTComponents.wxs
+++ b/installer/windows/kDriveInstaller/Components/QTComponents.wxs
@@ -5,18 +5,8 @@
                 <File Source="$(desktop-kDriveDir)/build-windows/install/bin/Qt6Core.dll" />
                 <File Source="$(desktop-kDriveDir)/build-windows/install/bin/Qt6Gui.dll" />
                 <File Source="$(desktop-kDriveDir)/build-windows/install/bin/Qt6Network.dll" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/Qt6OpenGL.dll" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/Qt6Positioning.dll" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/Qt6PrintSupport.dll" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/Qt6Qml.dll" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/Qt6QmlModels.dll" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/Qt6Quick.dll" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/Qt6QuickWidgets.dll" />
                 <File Source="$(desktop-kDriveDir)/build-windows/install/bin/Qt6Svg.dll" />
                 <File Source="$(desktop-kDriveDir)/build-windows/install/bin/Qt6SvgWidgets.dll" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/Qt6WebChannel.dll" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/Qt6WebEngineCore.dll" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/Qt6WebEngineWidgets.dll" />
                 <File Source="$(desktop-kDriveDir)/build-windows/install/bin/Qt6Widgets.dll" />
             </Component>
         </ComponentGroup>
@@ -58,62 +48,6 @@
                 <File Source="$(desktop-kDriveDir)/build-windows/install/bin/tls/qschannelbackend.dll" />
             </Component>
         </ComponentGroup>
-        <ComponentGroup Id="WebEngineLocalesComponents" Directory="QTWEBENGINE_LOCALES">
-            <Component Guid="{A1E5423C-A71D-4009-ACF2-3466A78FBFCB}">
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/am.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/ar.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/bg.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/bn.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/ca.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/cs.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/da.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/de.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/el.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/en-GB.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/en-US.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/es.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/es-419.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/et.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/fa.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/fi.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/fil.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/fr.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/gu.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/he.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/hi.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/hr.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/hu.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/id.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/it.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/ja.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/kn.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/ko.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/lt.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/lv.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/ml.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/mr.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/ms.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/nb.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/nl.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/pl.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/pt-BR.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/pt-PT.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/ro.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/ru.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/sk.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/sl.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/sr.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/sv.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/sw.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/ta.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/te.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/th.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/uk.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/vi.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/zh-CN.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qtwebengine_locales/zh-TW.pak" />
-            </Component>
-        </ComponentGroup>
         <ComponentGroup Id="TranslationsComponents" Directory="TRANSLATIONSFOLDER">
             <Component Guid="C1757675-3E9C-40C3-8E87-37A706D26527">
                 <File Source="$(desktop-kDriveDir)/build-windows/install/bin/translations/qt_ar.qm" />
@@ -150,22 +84,6 @@
         <ComponentGroup Id="StyleComponents" Directory="STYLEFOLDER">
             <Component Guid="5B4DBA6B-B232-442D-A862-6B05B742B6F3">
                 <File Source="$(desktop-kDriveDir)/build-windows/install/bin/styles/qwindowsvistastyle.dll" />
-            </Component>
-        </ComponentGroup>
-        <ComponentGroup Id="RessourcesComponents" Directory="RESOURCESFOLDER">
-            <Component Guid="036D567E-F605-4525-A690-0CF6FEFB0684">
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/resources/icudtl.dat" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/resources/qtwebengine_devtools_resources.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/resources/qtwebengine_resources.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/resources/qtwebengine_resources_100p.pak" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/resources/qtwebengine_resources_200p.pak" />
-            </Component>
-        </ComponentGroup>
-        <ComponentGroup Id="PositionComponents" Directory="POSITIONFOLDER">
-            <Component Guid="D4ABAAC3-61D0-46E4-B4A9-FD199981EA82">
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/position/qtposition_nmea.dll" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/position/qtposition_positionpoll.dll" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/position/qtposition_winrt.dll" />
             </Component>
         </ComponentGroup>
     </Fragment>

--- a/installer/windows/kDriveInstaller/Components/thirdPartyExeComponents.wxs
+++ b/installer/windows/kDriveInstaller/Components/thirdPartyExeComponents.wxs
@@ -3,7 +3,6 @@
         <ComponentGroup Id="thirdPartyExeComponents" Directory="INSTALLFOLDER">
             <Component Guid="A48CFB93-825E-4F75-ACAD-2DFB7A9FFF4E">
                 <File Source="$(desktop-kDriveDir)/build-windows/install/bin/crashpad_handler.exe" />
-                <File Source="$(desktop-kDriveDir)/build-windows/install/bin/QtWebEngineProcess.exe" />
             </Component>
         </ComponentGroup>
     </Fragment>

--- a/installer/windows/kDriveInstaller/Package.wxs
+++ b/installer/windows/kDriveInstaller/Package.wxs
@@ -18,9 +18,6 @@
             <ComponentGroupRef Id="PlatformsComponents" />
             <ComponentGroupRef Id="TLSComponents" />
             <ComponentGroupRef Id="TranslationsComponents" />
-            <ComponentGroupRef Id="WebEngineLocalesComponents" />
-            <ComponentGroupRef Id="PositionComponents" />
-            <ComponentGroupRef Id="RessourcesComponents" />
             <ComponentGroupRef Id="StyleComponents" />
             <ComponentGroupRef Id="ShellExtComponents" />
         </Feature>


### PR DESCRIPTION
Removing the last trace of webengine, found thanks to this [run failed](https://github.com/Infomaniak/desktop-kDrive/actions/runs/22628238359/job/65573309548#step:3:7329).