### PR TITLE
refactor: decouple drive creation from account creation

### DIFF
--- a/src/libsyncengine/jobs/network/kDrive_API/getinfodrivejob.h
+++ b/src/libsyncengine/jobs/network/kDrive_API/getinfodrivejob.h
@@ -32,7 +32,7 @@ class GetInfoDriveJob : public AbstractTokenNetworkJob {
         [[nodiscard]] const std::string &name() const { return _name; }
         [[nodiscard]] int64_t size() const { return _size; }
         [[nodiscard]] bool isAdmin() const { return _isAdmin; }
-        [[nodiscard]] int accountId() const { return _accountId; }
+        [[nodiscard]] uint64_t accountId() const { return _accountId; }
         [[nodiscard]] const std::string &colorHex() const { return _colorHex; }
         [[nodiscard]] bool isInMaintenance() const { return _isInMaintenance; }
         [[nodiscard]] int64_t maintenanceFrom() const { return _maintenanceFrom; }
@@ -51,7 +51,7 @@ class GetInfoDriveJob : public AbstractTokenNetworkJob {
         std::string _name;
         int64_t _size{0};
         bool _isAdmin{false};
-        int _accountId{0};
+        uint64_t _accountId{0};
         std::string _colorHex;
         bool _isInMaintenance{false};
         int64_t _maintenanceFrom{0};

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -2797,34 +2797,8 @@ ExitInfo AppServer::updateUserInfo(User &user) {
     if (user.keychainKey().empty()) {
         return ExitCode::Ok;
     }
-    bool updated = false;
-    if (const auto exitInfo = ServerRequests::loadUserInfo(user, updated); !exitInfo) {
-        LOG_WARN(_logger, "Error in Requests::loadUserInfo: " << exitInfo);
-        if (exitInfo.code() == ExitCode::InvalidToken) {
-            // Notify client app that the user is disconnected
-            UserInfo userInfo;
-            ServerRequests::userToUserInfo(user, userInfo);
-            sendUserUpdated(userInfo);
-        }
 
-        return exitInfo;
-    }
-
-    if (updated) {
-        bool found = false;
-        if (!ParmsDb::instance()->updateUser(user, found)) {
-            LOG_WARN(_logger, "Error in ParmsDb::updateUser");
-            return ExitCode::DbError;
-        }
-        if (!found) {
-            LOG_WARN(_logger, "User not found for userDbId=" << user.dbId());
-            return ExitCode::DataError;
-        }
-
-        UserInfo userInfo;
-        ServerRequests::userToUserInfo(user, userInfo);
-        sendUserUpdated(userInfo);
-    }
+    if (const auto exitInfo = updateUser(user); !exitInfo) return exitInfo;
 
     std::vector<Account> accounts;
     if (!ParmsDb::instance()->selectAllAccounts(user.dbId(), accounts)) {
@@ -2833,26 +2807,7 @@ ExitInfo AppServer::updateUserInfo(User &user) {
     }
 
     for (auto &account: accounts) {
-        bool accountUpdated = false;
-        if (const auto exitInfo = ServerRequests::loadAccountInfo(account, accountUpdated); !exitInfo) {
-            LOG_WARN(_logger, "Error in Requests::loadDriveInfo: " << exitInfo);
-            return exitInfo;
-        }
-        if (accountUpdated) {
-            AccountInfo accountInfo;
-            ServerRequests::accountToAccountInfo(account, accountInfo);
-            sendAccountUpdated(accountInfo);
-
-            bool found = false;
-            if (!ParmsDb::instance()->updateAccount(account, found)) {
-                LOG_WARN(_logger, "Error in ParmsDb::updateAccount");
-                return ExitCode::DbError;
-            }
-            if (!found) {
-                LOG_WARN(_logger, "Account not found for accountDbId=" << account.dbId());
-                return ExitCode::DataError;
-            }
-        }
+        if (const auto exitInfo = updateAccount(account); !exitInfo) return exitInfo;
 
         std::vector<Drive> drives;
         if (!ParmsDb::instance()->selectAllDrives(account.dbId(), drives)) {
@@ -2987,6 +2942,65 @@ ExitInfo AppServer::updateUserInfo(User &user) {
 
     return ExitCode::Ok;
 }
+
+ExitInfo AppServer::updateUser(User &user) {
+    bool updated = false;
+    if (const auto exitInfo = ServerRequests::loadUserInfo(user, updated); !exitInfo) {
+        LOG_WARN(_logger, "Error in Requests::loadUserInfo: " << exitInfo);
+        if (exitInfo.code() == ExitCode::InvalidToken) {
+            // Notify client app that the user is disconnected
+            UserInfo userInfo;
+            ServerRequests::userToUserInfo(user, userInfo);
+            sendUserUpdated(userInfo);
+        }
+
+        return exitInfo;
+    }
+
+    if (updated) {
+        bool found = false;
+        if (!ParmsDb::instance()->updateUser(user, found)) {
+            LOG_WARN(_logger, "Error in ParmsDb::updateUser");
+            return ExitCode::DbError;
+        }
+        if (!found) {
+            LOG_WARN(_logger, "User not found for userDbId=" << user.dbId());
+            return ExitCode::DataError;
+        }
+
+        UserInfo userInfo;
+        ServerRequests::userToUserInfo(user, userInfo);
+        sendUserUpdated(userInfo);
+    }
+    return ExitCode::Ok;
+}
+
+ExitInfo AppServer::updateAccount(Account &account) {
+    bool accountUpdated = false;
+    if (const auto exitInfo = ServerRequests::loadAccountInfo(account, accountUpdated); !exitInfo) {
+        LOG_WARN(_logger, "Error in Requests::loadDriveInfo: " << exitInfo);
+        return exitInfo;
+    }
+    if (accountUpdated) {
+        AccountInfo accountInfo;
+        ServerRequests::accountToAccountInfo(account, accountInfo);
+        sendAccountUpdated(accountInfo);
+
+        bool found = false;
+        if (!ParmsDb::instance()->updateAccount(account, found)) {
+            LOG_WARN(_logger, "Error in ParmsDb::updateAccount");
+            return ExitCode::DbError;
+        }
+        if (!found) {
+            LOG_WARN(_logger, "Account not found for accountDbId=" << account.dbId());
+            return ExitCode::DataError;
+        }
+    }
+    return ExitCode::Ok;
+}
+
+ExitInfo AppServer::updateDrive(Drive &drive){TODO}
+
 
 ExitInfo AppServer::startSyncs() {
     // Load user list

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -115,15 +115,6 @@ namespace KDC {
 std::vector<AppServer::Notification> AppServer::_notifications;
 std::unique_ptr<UpdateManager> AppServer::_updateManager;
 
-std::function<ExitInfo(User &user, bool &updated)> AppServer::_loadUserInfo =
-        static_cast<ExitInfo (*)(User &user, bool &updated)>(&ServerRequests::loadUserInfo);
-std::function<ExitInfo(Account &account, bool &updated)> AppServer::_loadAccountInfo =
-        static_cast<ExitInfo (*)(Account &account, bool &updated)>(&ServerRequests::loadAccountInfo);
-std::function<ExitInfo(Drive &drive, const uint64_t previousAccountId, uint64_t &newAccountId, bool &updated, bool &quotaUpdated)>
-        AppServer::_loadDriveInfo =
-                static_cast<ExitInfo (*)(Drive &drive, const uint64_t previousAccountId, uint64_t &newAccountId, bool &updated,
-                                         bool &quotaUpdated)>(&ServerRequests::loadDriveInfo);
-
 namespace {
 
 static const char optionsC[] =

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -2978,7 +2978,6 @@ ExitInfo AppServer::updateDrive(const User &user, const Account &account, Drive 
         DriveInfo driveInfo;
         ServerRequests::driveToDriveInfo(drive, driveInfo);
         sendDriveUpdated(driveInfo);
-        if (_commManager) _commManager->sendGuiSignal(std::make_shared<SignalDriveUpdatedJob>(driveInfo));
     }
     return ExitCode::Ok;
 }

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -2883,21 +2883,6 @@ ExitInfo AppServer::createAccount(Account &newAccount) {
         return ExitCode::DbError;
     }
 
-    // Retrieve account DB ID
-    std::vector<Account> accountList;
-    if (!ParmsDb::instance()->selectAllAccounts(newAccount.userDbId(), accountList)) {
-        LOG_WARN(_logger, "Error in ParmsDb::selectAllAccounts");
-        return ExitCode::DbError;
-    }
-    for (const auto &account: accountList) {
-        if (account.accountId() == newAccount.accountId()) {
-            newAccount.setDbId(account.dbId());
-            break;
-        }
-    }
-
-    assert(newAccount.dbId()); // At this point, newAccount should have a valid DB ID
-
     return ExitCode::Ok;
 }
 
@@ -2930,8 +2915,8 @@ ExitInfo AppServer::updateDrive(const User &user, const Account &account, Drive 
     bool driveUpdated = false;
     bool quotaUpdated = false;
     uint64_t newAccountId = 0;
-    if (const auto exitInfo = ServerRequests::loadDriveInfo(drive, static_cast<uint64_t>(account.accountId()), newAccountId,
-                                                            driveUpdated, quotaUpdated);
+    if (const auto exitInfo =
+                _loadDriveInfo(drive, static_cast<uint64_t>(account.accountId()), newAccountId, driveUpdated, quotaUpdated);
         !exitInfo) {
         LOG_WARN(_logger, "Error in Requests::loadDriveInfo: " << exitInfo);
         return exitInfo;
@@ -3006,6 +2991,14 @@ ExitInfo AppServer::manageDriveMovedToAnotherAccount(const User &user, const Acc
 
     if (!accountIdAlreadyExists) {
         // The account does not exist yet for this user, create it
+        int accountDbId = 0;
+        if (!ParmsDb::instance()->getNewAccountDbId(accountDbId)) {
+            LOG_WARN(Log::instance()->getLogger(), "Error in ParmsDb::getNewAccountDbId");
+            return ExitCode::DbError;
+        }
+        newAccount.setDbId(accountDbId);
+        newAccount.setAccountId(static_cast<int>(newAccountId));
+        newAccount.setUserDbId(user.dbId());
         if (const auto exitInfo = createAccount(newAccount); !exitInfo) return exitInfo;
     }
 

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -2923,30 +2923,7 @@ ExitInfo AppServer::updateDrive(const User &user, const Account &account, Drive 
     }
 
     if (drive.accessDenied() || drive.maintenanceInfo()._maintenance) {
-        LOG_WARN(_logger, "Access denied for driveId=" << drive.driveId());
-
-        std::vector<Sync> syncs;
-        if (!ParmsDb::instance()->selectAllSyncs(drive.dbId(), syncs)) {
-            LOG_WARN(_logger, "Error in ParmsDb::selectAllSyncs");
-            return ExitCode::DbError;
-        }
-
-        for (auto &sync: syncs) {
-            // Pause sync
-            sync.setPaused(true);
-            ExitCause exitCause = ExitCause::DriveAccessError;
-            if (drive.maintenanceInfo()._maintenance) {
-                if (drive.maintenanceInfo()._notRenew)
-                    exitCause = ExitCause::DriveNotRenew;
-                else if (drive.maintenanceInfo()._asleep)
-                    exitCause = ExitCause::DriveAsleep;
-                else if (drive.maintenanceInfo()._wakingUp)
-                    exitCause = ExitCause::DriveWakingUp;
-                else
-                    exitCause = ExitCause::DriveMaintenance;
-            }
-            addError(Error(sync.dbId(), ERR_ID, ExitCode::BackError, exitCause));
-        }
+        if (const auto exitInfo = handleDriveAccessDenied(drive); !exitInfo) return exitInfo;
     }
 
     if (driveUpdated) {
@@ -2972,6 +2949,34 @@ ExitInfo AppServer::updateDrive(const User &user, const Account &account, Drive 
         DriveInfo driveInfo;
         ServerRequests::driveToDriveInfo(drive, driveInfo);
         sendDriveUpdated(driveInfo);
+    }
+    return ExitCode::Ok;
+}
+
+ExitInfo AppServer::handleDriveAccessDenied(const Drive &drive) {
+    LOG_WARN(_logger, "Access denied for driveId=" << drive.driveId());
+
+    std::vector<Sync> syncs;
+    if (!ParmsDb::instance()->selectAllSyncs(drive.dbId(), syncs)) {
+        LOG_WARN(_logger, "Error in ParmsDb::selectAllSyncs");
+        return ExitCode::DbError;
+    }
+
+    for (auto &sync: syncs) {
+        // Pause sync
+        sync.setPaused(true);
+        ExitCause exitCause = ExitCause::DriveAccessError;
+        if (drive.maintenanceInfo()._maintenance) {
+            if (drive.maintenanceInfo()._notRenew)
+                exitCause = ExitCause::DriveNotRenew;
+            else if (drive.maintenanceInfo()._asleep)
+                exitCause = ExitCause::DriveAsleep;
+            else if (drive.maintenanceInfo()._wakingUp)
+                exitCause = ExitCause::DriveWakingUp;
+            else
+                exitCause = ExitCause::DriveMaintenance;
+        }
+        addError(Error(sync.dbId(), ERR_ID, ExitCode::BackError, exitCause));
     }
     return ExitCode::Ok;
 }

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -115,6 +115,15 @@ namespace KDC {
 std::vector<AppServer::Notification> AppServer::_notifications;
 std::unique_ptr<UpdateManager> AppServer::_updateManager;
 
+std::function<ExitInfo(User &user, bool &updated)> AppServer::_loadUserInfo =
+        static_cast<ExitInfo (*)(User &user, bool &updated)>(&ServerRequests::loadUserInfo);
+std::function<ExitInfo(Account &account, bool &updated)> AppServer::_loadAccountInfo =
+        static_cast<ExitInfo (*)(Account &account, bool &updated)>(&ServerRequests::loadAccountInfo);
+std::function<ExitInfo(Drive &drive, const uint64_t previousAccountId, uint64_t &newAccountId, bool &updated, bool &quotaUpdated)>
+        AppServer::_loadDriveInfo =
+                static_cast<ExitInfo (*)(Drive &drive, const uint64_t previousAccountId, uint64_t &newAccountId, bool &updated,
+                                         bool &quotaUpdated)>(&ServerRequests::loadDriveInfo);
+
 namespace {
 
 static const char optionsC[] =
@@ -2825,7 +2834,7 @@ ExitInfo AppServer::updateUserInfo(User &user) {
 
 ExitInfo AppServer::updateUser(User &user) {
     bool updated = false;
-    if (const auto exitInfo = ServerRequests::loadUserInfo(user, updated); !exitInfo) {
+    if (const auto exitInfo = _loadUserInfo(user, updated); !exitInfo) {
         LOG_WARN(_logger, "Error in Requests::loadUserInfo: " << exitInfo);
         if (exitInfo.code() == ExitCode::InvalidToken) {
             // Notify client app that the user is disconnected
@@ -2858,7 +2867,7 @@ ExitInfo AppServer::updateUser(User &user) {
 ExitInfo AppServer::createAccount(Account &newAccount) {
     // Make sure all information are up to date
     bool accountUpdated = false;
-    if (const auto exitInfo = ServerRequests::loadAccountInfo(newAccount, accountUpdated); !exitInfo) {
+    if (const auto exitInfo = _loadAccountInfo(newAccount, accountUpdated); !exitInfo) {
         LOG_WARN(_logger, "Error in Requests::loadDriveInfo: " << exitInfo);
         return exitInfo;
     }
@@ -2894,7 +2903,7 @@ ExitInfo AppServer::createAccount(Account &newAccount) {
 
 ExitInfo AppServer::updateAccount(Account &account) {
     bool accountUpdated = false;
-    if (const auto exitInfo = ServerRequests::loadAccountInfo(account, accountUpdated); !exitInfo) {
+    if (const auto exitInfo = _loadAccountInfo(account, accountUpdated); !exitInfo) {
         LOG_WARN(_logger, "Error in Requests::loadDriveInfo: " << exitInfo);
         return exitInfo;
     }

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -2816,127 +2816,7 @@ ExitInfo AppServer::updateUserInfo(User &user) {
         }
 
         for (auto &drive: drives) {
-            bool quotaUpdated = false;
-            bool accountChanged = false;
-            Account modifiedAccount = account;
-            if (const auto exitInfo =
-                        ServerRequests::loadDriveInfo(drive, modifiedAccount, updated, quotaUpdated, accountChanged);
-                !exitInfo) {
-                LOG_WARN(_logger, "Error in Requests::loadDriveInfo: " << exitInfo);
-                return exitInfo;
-            }
-
-            if (drive.accessDenied() || drive.maintenanceInfo()._maintenance) {
-                LOG_WARN(_logger, "Access denied for driveId=" << drive.driveId());
-
-                std::vector<Sync> syncs;
-                if (!ParmsDb::instance()->selectAllSyncs(drive.dbId(), syncs)) {
-                    LOG_WARN(_logger, "Error in ParmsDb::selectAllSyncs");
-                    return ExitCode::DbError;
-                }
-
-                for (auto &sync: syncs) {
-                    // Pause sync
-                    sync.setPaused(true);
-                    ExitCause exitCause = ExitCause::DriveAccessError;
-                    if (drive.maintenanceInfo()._maintenance) {
-                        if (drive.maintenanceInfo()._notRenew)
-                            exitCause = ExitCause::DriveNotRenew;
-                        else if (drive.maintenanceInfo()._asleep)
-                            exitCause = ExitCause::DriveAsleep;
-                        else if (drive.maintenanceInfo()._wakingUp)
-                            exitCause = ExitCause::DriveWakingUp;
-                        else
-                            exitCause = ExitCause::DriveMaintenance;
-                    }
-                    addError(Error(sync.dbId(), ERR_ID, ExitCode::BackError, exitCause));
-                }
-            }
-
-            if (updated) {
-                bool found = false;
-                if (!ParmsDb::instance()->updateDrive(drive, found)) {
-                    LOG_WARN(_logger, "Error in ParmsDb::updateDrive");
-                    return ExitCode::DbError;
-                }
-                if (!found) {
-                    LOG_WARN(_logger, "Drive not found for driveDbId=" << drive.dbId());
-                    return ExitCode::DataError;
-                }
-            }
-
-            if (quotaUpdated) {
-                sendDriveQuotaUpdated(drive.dbId(), drive.size(), drive.usedSize());
-            }
-
-            bool accountRemoved = false;
-            if (accountChanged) {
-                bool accountIdAlreadyExists = false;
-                Account dummyAccount;
-                bool found = false;
-                if (!ParmsDb::instance()->accountFromUserDbIdAndAccountId(user.dbId(), modifiedAccount.accountId(), dummyAccount,
-                                                                          found)) {
-                    LOG_WARN(_logger, "Error in ParmsDb::accountDbId");
-                    return ExitCode::DbError;
-                }
-                accountIdAlreadyExists = found;
-
-                // Update account
-                if (!ParmsDb::instance()->updateAccount(modifiedAccount, found)) {
-                    LOG_WARN(_logger, "Error in ParmsDb::updateAccount");
-                    return ExitCode::DbError;
-                }
-                if (!found) {
-                    LOG_WARN(_logger, "Account not found for accountDbId=" << account.dbId());
-                    return ExitCode::DataError;
-                }
-
-                AccountInfo accountInfo;
-                ServerRequests::accountToAccountInfo(account, accountInfo);
-                sendAccountUpdated(accountInfo);
-
-                if (modifiedAccount.accountId() != account.accountId() && accountIdAlreadyExists) {
-                    // An account already exists with the new accountId, link the drive to it
-                    drive.setAccountDbId(modifiedAccount.dbId());
-                    if (!ParmsDb::instance()->updateDrive(drive, found)) {
-                        LOG_WARN(_logger, "Error in ParmsDb::updateDrive");
-                        return ExitCode::DbError;
-                    }
-                    if (!found) {
-                        LOG_WARN(_logger, "Drive not found for driveDbId=" << drive.dbId());
-                        return ExitCode::DataError;
-                    }
-
-                    updated = true;
-
-                    // Delete the old account if not used anymore
-                    std::vector<Drive> driveList;
-                    if (!ParmsDb::instance()->selectAllDrives(account.dbId(), driveList)) {
-                        LOG_WARN(_logger, "Error in ParmsDb::selectAllDrives");
-                        return ExitCode::DbError;
-                    }
-
-                    if (driveList.empty()) {
-                        if (const auto exitInfo = ServerRequests::deleteAccount(account.dbId()); !exitInfo) {
-                            LOG_WARN(_logger, "Error in Requests::deleteAccount: code=" << exitInfo);
-                            return exitInfo;
-                        }
-                        sendAccountRemoved(account.accountId());
-                        accountRemoved = true;
-                    }
-                }
-            }
-
-            if (updated || quotaUpdated) {
-                DriveInfo driveInfo;
-                ServerRequests::driveToDriveInfo(drive, driveInfo);
-                sendDriveUpdated(driveInfo);
-                if (_commManager) _commManager->sendGuiSignal(std::make_shared<SignalDriveUpdatedJob>(driveInfo));
-            }
-
-            if (accountRemoved) {
-                sendAccountRemoved(account.dbId());
-            }
+            if (const auto exitInfo = updateDrive(user, account, drive); !exitInfo) return exitInfo;
         }
     }
 
@@ -2975,12 +2855,50 @@ ExitInfo AppServer::updateUser(User &user) {
     return ExitCode::Ok;
 }
 
+ExitInfo AppServer::createAccount(Account &newAccount) {
+    // Make sure all information are up to date
+    bool accountUpdated = false;
+    if (const auto exitInfo = ServerRequests::loadAccountInfo(newAccount, accountUpdated); !exitInfo) {
+        LOG_WARN(_logger, "Error in Requests::loadDriveInfo: " << exitInfo);
+        return exitInfo;
+    }
+
+    // Notify the UI
+    AccountInfo accountInfo;
+    ServerRequests::accountToAccountInfo(newAccount, accountInfo);
+    sendAccountAdded(accountInfo);
+
+    // Insert account in DB
+    if (!ParmsDb::instance()->insertAccount(newAccount)) {
+        LOG_WARN(_logger, "Error in ParmsDb::insertAccount");
+        return ExitCode::DbError;
+    }
+
+    // Retrieve account DB ID
+    std::vector<Account> accountList;
+    if (!ParmsDb::instance()->selectAllAccounts(newAccount.userDbId(), accountList)) {
+        LOG_WARN(_logger, "Error in ParmsDb::selectAllAccounts");
+        return ExitCode::DbError;
+    }
+    for (const auto &account: accountList) {
+        if (account.accountId() == newAccount.accountId()) {
+            newAccount.setDbId(account.dbId());
+            break;
+        }
+    }
+
+    assert(newAccount.dbId()); // At this point, newAccount should have a valid DB ID
+
+    return ExitCode::Ok;
+}
+
 ExitInfo AppServer::updateAccount(Account &account) {
     bool accountUpdated = false;
     if (const auto exitInfo = ServerRequests::loadAccountInfo(account, accountUpdated); !exitInfo) {
         LOG_WARN(_logger, "Error in Requests::loadDriveInfo: " << exitInfo);
         return exitInfo;
     }
+
     if (accountUpdated) {
         AccountInfo accountInfo;
         ServerRequests::accountToAccountInfo(account, accountInfo);
@@ -2999,8 +2917,119 @@ ExitInfo AppServer::updateAccount(Account &account) {
     return ExitCode::Ok;
 }
 
-ExitInfo AppServer::updateDrive(Drive &drive){TODO}
+ExitInfo AppServer::updateDrive(const User &user, const Account &account, Drive &drive) {
+    bool driveUpdated = false;
+    bool quotaUpdated = false;
+    uint64_t newAccountId = 0;
+    if (const auto exitInfo = ServerRequests::loadDriveInfo(drive, static_cast<uint64_t>(account.accountId()), newAccountId,
+                                                            driveUpdated, quotaUpdated);
+        !exitInfo) {
+        LOG_WARN(_logger, "Error in Requests::loadDriveInfo: " << exitInfo);
+        return exitInfo;
+    }
 
+    if (drive.accessDenied() || drive.maintenanceInfo()._maintenance) {
+        LOG_WARN(_logger, "Access denied for driveId=" << drive.driveId());
+
+        std::vector<Sync> syncs;
+        if (!ParmsDb::instance()->selectAllSyncs(drive.dbId(), syncs)) {
+            LOG_WARN(_logger, "Error in ParmsDb::selectAllSyncs");
+            return ExitCode::DbError;
+        }
+
+        for (auto &sync: syncs) {
+            // Pause sync
+            sync.setPaused(true);
+            ExitCause exitCause = ExitCause::DriveAccessError;
+            if (drive.maintenanceInfo()._maintenance) {
+                if (drive.maintenanceInfo()._notRenew)
+                    exitCause = ExitCause::DriveNotRenew;
+                else if (drive.maintenanceInfo()._asleep)
+                    exitCause = ExitCause::DriveAsleep;
+                else if (drive.maintenanceInfo()._wakingUp)
+                    exitCause = ExitCause::DriveWakingUp;
+                else
+                    exitCause = ExitCause::DriveMaintenance;
+            }
+            addError(Error(sync.dbId(), ERR_ID, ExitCode::BackError, exitCause));
+        }
+    }
+
+    if (driveUpdated) {
+        bool found = false;
+        if (!ParmsDb::instance()->updateDrive(drive, found)) {
+            LOG_WARN(_logger, "Error in ParmsDb::updateDrive");
+            return ExitCode::DbError;
+        }
+        if (!found) {
+            LOG_WARN(_logger, "Drive not found for driveDbId=" << drive.dbId());
+            return ExitCode::DataError;
+        }
+    }
+
+    if (quotaUpdated) {
+        sendDriveQuotaUpdated(drive.dbId(), drive.size(), drive.usedSize());
+    }
+
+    if (const auto exitInfo = manageDriveMovedToAnotherAccount(user, account, newAccountId, drive, driveUpdated); !exitInfo)
+        return exitInfo;
+
+    if (driveUpdated || quotaUpdated) {
+        DriveInfo driveInfo;
+        ServerRequests::driveToDriveInfo(drive, driveInfo);
+        sendDriveUpdated(driveInfo);
+        if (_commManager) _commManager->sendGuiSignal(std::make_shared<SignalDriveUpdatedJob>(driveInfo));
+    }
+    return ExitCode::Ok;
+}
+
+ExitInfo AppServer::manageDriveMovedToAnotherAccount(const User &user, const Account &oldAccount, const uint64_t newAccountId,
+                                                     Drive &drive, bool &driveUpdated) {
+    if (newAccountId <= 0) return ExitCode::Ok; // The account has not changed
+
+    // Check if new account already exist in DB for this user
+    Account newAccount;
+    bool accountIdAlreadyExists = false;
+    if (!ParmsDb::instance()->accountFromUserDbIdAndAccountId(user.dbId(), static_cast<int>(newAccountId), newAccount,
+                                                              accountIdAlreadyExists)) {
+        LOG_WARN(_logger, "Error in ParmsDb::accountDbId");
+        return ExitCode::DbError;
+    }
+
+    if (!accountIdAlreadyExists) {
+        // The account does not exist yet for this user, create it
+        if (const auto exitInfo = createAccount(newAccount); !exitInfo) return exitInfo;
+    }
+
+    // Update the account DB ID in drive table
+    drive.setAccountDbId(newAccount.dbId());
+    bool found = false;
+    if (!ParmsDb::instance()->updateDrive(drive, found)) {
+        LOG_WARN(_logger, "Error in ParmsDb::updateDrive");
+        return ExitCode::DbError;
+    }
+    if (!found) {
+        LOG_WARN(_logger, "Drive not found for driveDbId=" << drive.dbId());
+        return ExitCode::DataError;
+    }
+    driveUpdated = true;
+
+    // Delete the old account if not used anymore
+    std::vector<Drive> driveList;
+    if (!ParmsDb::instance()->selectAllDrives(oldAccount.dbId(), driveList)) {
+        LOG_WARN(_logger, "Error in ParmsDb::selectAllDrives");
+        return ExitCode::DbError;
+    }
+
+    if (driveList.empty()) {
+        if (const auto exitInfo = ServerRequests::deleteAccount(oldAccount.dbId()); !exitInfo) {
+            LOG_WARN(_logger, "Error in Requests::deleteAccount: code=" << exitInfo);
+            return ExitCode::DataError;
+        }
+        sendAccountRemoved(oldAccount.dbId());
+    }
+    return ExitCode::Ok;
+}
 
 ExitInfo AppServer::startSyncs() {
     // Load user list

--- a/src/server/appserver.h
+++ b/src/server/appserver.h
@@ -227,6 +227,13 @@ class AppServer : public SharedTools::QtSingleApplication {
 #endif
         }
 
+    protected:
+        static std::function<ExitInfo(User &user, bool &updated)> _loadUserInfo;
+        static std::function<ExitInfo(Account &account, bool &updated)> _loadAccountInfo;
+        static std::function<ExitInfo(Drive &drive, const uint64_t previousAccountId, uint64_t &newAccountId, bool &updated,
+                                      bool &quotaUpdated)>
+                _loadDriveInfo;
+
     private:
         AuthorizationCodeEventFilter _eventFilter;
 

--- a/src/server/appserver.h
+++ b/src/server/appserver.h
@@ -278,8 +278,11 @@ class AppServer : public SharedTools::QtSingleApplication {
         ExitInfo updateAllUsersInfo();
         ExitInfo updateUserInfo(User &user);
         ExitInfo updateUser(User &user);
+        ExitInfo createAccount(Account &newAccount);
         ExitInfo updateAccount(Account &account);
-        ExitInfo updateDrive(Drive &drive);
+        ExitInfo updateDrive(const User &user, const Account &account, Drive &drive);
+        ExitInfo manageDriveMovedToAnotherAccount(const User &user, const Account &oldAccount, const uint64_t newAccountId,
+                                                  Drive &drive, bool &driveUpdated);
 
         [[nodiscard]] ExitInfo initSyncPal(const Sync &sync, const QSet<QString> &blackList, bool start = true,
                                            const std::chrono::seconds &startDelay = std::chrono::seconds(0),

--- a/src/server/appserver.h
+++ b/src/server/appserver.h
@@ -228,11 +228,15 @@ class AppServer : public SharedTools::QtSingleApplication {
         }
 
     protected:
-        static std::function<ExitInfo(User &user, bool &updated)> _loadUserInfo;
-        static std::function<ExitInfo(Account &account, bool &updated)> _loadAccountInfo;
-        static std::function<ExitInfo(Drive &drive, const uint64_t previousAccountId, uint64_t &newAccountId, bool &updated,
-                                      bool &quotaUpdated)>
-                _loadDriveInfo;
+        // ServerRequests methods are accessible through std::function pointers in order to be mocked in tests
+        std::function<ExitInfo(User &user, bool &updated)> _loadUserInfo =
+                static_cast<ExitInfo (*)(User &user, bool &updated)>(&ServerRequests::loadUserInfo);
+        std::function<ExitInfo(Account &account, bool &updated)> _loadAccountInfo =
+                static_cast<ExitInfo (*)(Account &account, bool &updated)>(&ServerRequests::loadAccountInfo);
+        std::function<ExitInfo(Drive &drive, const uint64_t previousAccountId, uint64_t &newAccountId, bool &updated,
+                               bool &quotaUpdated)>
+                _loadDriveInfo = static_cast<ExitInfo (*)(Drive &drive, const uint64_t previousAccountId, uint64_t &newAccountId,
+                                                          bool &updated, bool &quotaUpdated)>(&ServerRequests::loadDriveInfo);
 
     private:
         AuthorizationCodeEventFilter _eventFilter;

--- a/src/server/appserver.h
+++ b/src/server/appserver.h
@@ -288,6 +288,7 @@ class AppServer : public SharedTools::QtSingleApplication {
         ExitInfo createAccount(Account &newAccount);
         ExitInfo updateAccount(Account &account);
         ExitInfo updateDrive(const User &user, const Account &account, Drive &drive);
+        ExitInfo handleDriveAccessDenied(const Drive &drive);
         ExitInfo manageDriveMovedToAnotherAccount(const User &user, const Account &oldAccount, const uint64_t newAccountId,
                                                   Drive &drive, bool &driveUpdated);
 

--- a/src/server/appserver.h
+++ b/src/server/appserver.h
@@ -303,28 +303,28 @@ class AppServer : public SharedTools::QtSingleApplication {
         [[nodiscard]] ExitInfo processMigratedSyncOnceConnected(int userDbId, int driveId, Sync &sync, QSet<QString> &blackList,
                                                                 bool &syncUpdated);
 
-        void sendUserAdded(const UserInfo &userInfo) const;
-        void sendUserUpdated(const UserInfo &userInfo) const;
-        void sendUserStatusChanged(int userDbId, bool connected, QString connexionError) const;
-        void sendUserRemoved(int userDbId) const;
-        void sendAccountAdded(const AccountInfo &accountInfo) const;
-        void sendAccountUpdated(const AccountInfo &accountInfo) const;
-        void sendAccountRemoved(int accountDbId) const;
-        void sendDriveAdded(const DriveInfo &driveInfo) const;
-        void sendDriveUpdated(const DriveInfo &driveInfo) const;
-        void sendDriveQuotaUpdated(int driveDbId, qint64 total, qint64 used) const;
-        void sendDriveRemoved(int driveDbId) const;
-        void sendDriveDeletionFailed(int driveDbId) const;
-        void sendSyncProgressInfo(int syncDbId, SyncStatus status, SyncStep step, const SyncProgress &progress) const;
-        void sendSyncAdded(const SyncInfo &syncInfo) const;
-        void sendSyncUpdated(const SyncInfo &syncInfo) const;
-        void sendSyncRemoved(int syncDbId) const;
-        void sendSyncDeletionFailed(int syncDbId) const;
-        void sendGetFolderSizeCompleted(const QString &nodeId, qint64 size) const;
-        void sendErrorsCleared(int syncDbId) const;
-        void sendQuit() const; // Ask client to quit
-        void sendLogUploadStatusUpdated(LogUploadState status, int percent) const;
-        void sendNodeFixConflictedFilesCompleted(int syncDbId, qint64 nbErrors) const;
+        virtual void sendUserAdded(const UserInfo &userInfo) const;
+        virtual void sendUserUpdated(const UserInfo &userInfo) const;
+        virtual void sendUserStatusChanged(int userDbId, bool connected, QString connexionError) const;
+        virtual void sendUserRemoved(int userDbId) const;
+        virtual void sendAccountAdded(const AccountInfo &accountInfo) const;
+        virtual void sendAccountUpdated(const AccountInfo &accountInfo) const;
+        virtual void sendAccountRemoved(int accountDbId) const;
+        virtual void sendDriveAdded(const DriveInfo &driveInfo) const;
+        virtual void sendDriveUpdated(const DriveInfo &driveInfo) const;
+        virtual void sendDriveQuotaUpdated(int driveDbId, qint64 total, qint64 used) const;
+        virtual void sendDriveRemoved(int driveDbId) const;
+        virtual void sendDriveDeletionFailed(int driveDbId) const;
+        virtual void sendSyncProgressInfo(int syncDbId, SyncStatus status, SyncStep step, const SyncProgress &progress) const;
+        virtual void sendSyncAdded(const SyncInfo &syncInfo) const;
+        virtual void sendSyncUpdated(const SyncInfo &syncInfo) const;
+        virtual void sendSyncRemoved(int syncDbId) const;
+        virtual void sendSyncDeletionFailed(int syncDbId) const;
+        virtual void sendGetFolderSizeCompleted(const QString &nodeId, qint64 size) const;
+        virtual void sendErrorsCleared(int syncDbId) const;
+        virtual void sendQuit() const; // Ask client to quit
+        virtual void sendLogUploadStatusUpdated(LogUploadState status, int percent) const;
+        virtual void sendNodeFixConflictedFilesCompleted(int syncDbId, qint64 nbErrors) const;
 
         void deleteAccount(int accountDbId);
         void sendErrorAdded(const ErrorInfo &errorInfo) const;

--- a/src/server/appserver.h
+++ b/src/server/appserver.h
@@ -275,8 +275,12 @@ class AppServer : public SharedTools::QtSingleApplication {
         void processInterruptedLogsUpload();
 
         ExitCode migrateConfiguration(bool &proxyNotSupported);
-        ExitInfo updateUserInfo(User &user);
         ExitInfo updateAllUsersInfo();
+        ExitInfo updateUserInfo(User &user);
+        ExitInfo updateUser(User &user);
+        ExitInfo updateAccount(Account &account);
+        ExitInfo updateDrive(Drive &drive);
+
         [[nodiscard]] ExitInfo initSyncPal(const Sync &sync, const QSet<QString> &blackList, bool start = true,
                                            const std::chrono::seconds &startDelay = std::chrono::seconds(0),
                                            bool resumedByUser = false, bool firstInit = false);

--- a/src/server/requests/serverrequests.cpp
+++ b/src/server/requests/serverrequests.cpp
@@ -1061,12 +1061,13 @@ ExitCode ServerRequests::createDrive(const Drive &drive, DriveInfo &driveInfo) {
     Drive driveUpdated(drive);
     Account account;
     bool updated = false;
-    bool accountUpdated = false;
     bool quotaUpdated = false;
-    ExitCode exitCode = loadDriveInfo(driveUpdated, account, updated, quotaUpdated, accountUpdated);
-    if (exitCode != ExitCode::Ok) {
+    uint64_t newAccountId = 0;
+    if (const auto exitInfo =
+                loadDriveInfo(driveUpdated, static_cast<uint64_t>(account.accountId()), newAccountId, updated, quotaUpdated);
+        !exitInfo) {
         LOG_WARN(Log::instance()->getLogger(), "Error in User::loadDriveInfo");
-        return exitCode;
+        return exitInfo;
     }
 
     if (updated) {
@@ -1724,9 +1725,10 @@ ExitInfo ServerRequests::loadAccountInfo(Account &account, bool &updated) {
     return ExitCode::Ok;
 }
 
-ExitInfo ServerRequests::loadDriveInfo(Drive &drive, Account &account, bool &updated, bool &quotaUpdated, bool &accountUpdated) {
+ExitInfo ServerRequests::loadDriveInfo(Drive &drive, const uint64_t previousAccountId, uint64_t &newAccountId, bool &updated,
+                                       bool &quotaUpdated) {
+    newAccountId = 0;
     updated = false;
-    accountUpdated = false;
     quotaUpdated = false; // TODO: variable to be removed once migrated to the new UI
     // Get drive data
     std::shared_ptr<GetInfoDriveJob> job = nullptr;
@@ -1774,9 +1776,8 @@ ExitInfo ServerRequests::loadDriveInfo(Drive &drive, Account &account, bool &upd
         updated = true;
     }
 
-    if (account.accountId() != job->accountId()) {
-        account.setAccountId(job->accountId());
-        accountUpdated = true;
+    if (previousAccountId != job->accountId()) {
+        newAccountId = job->accountId();
     }
 
     if (!job->colorHex().empty()) {

--- a/src/server/requests/serverrequests.h
+++ b/src/server/requests/serverrequests.h
@@ -141,7 +141,8 @@ struct SYNCENGINE_EXPORT ServerRequests {
 
         // Server requests
         static ExitInfo loadAccountInfo(Account &account, bool &updated);
-        static ExitInfo loadDriveInfo(Drive &drive, Account &account, bool &updated, bool &quotaUpdated, bool &accountUpdated);
+        static ExitInfo loadDriveInfo(Drive &drive, const uint64_t previousAccountId, uint64_t &newAccountId, bool &updated,
+                                      bool &quotaUpdated);
         static ExitInfo loadUserInfo(User &user, bool &updated);
         static ExitInfo loadUserAvatar(User &user);
         static ExitInfo getThumbnail(int driveDbId, const NodeId &nodeId, int width, std::string &thumbnail);

--- a/test/server/appserver/testappserver.cpp
+++ b/test/server/appserver/testappserver.cpp
@@ -196,7 +196,12 @@ void TestAppServer::testCleanup() {
     CPPUNIT_ASSERT(true);
 }
 
-ExitInfo mockLoadUserInfo(User &user, bool &updated) {
+/**
+ * Test:
+ * - "driveA" has been moved from "accountA" to "accountB"
+ */
+
+ExitInfo mockLoadUserInfo([[maybe_unused]] User &user, bool &updated) {
     updated = false;
     return ExitCode::Ok;
 }
@@ -227,11 +232,6 @@ void TestAppServer::testUpdateUserInfo() {
     _appPtr->setLoadAccountInfoFunction(mockLoadAccountInfo);
     _appPtr->setLoadDriveInfoFunction(mockLoadDriveInfo);
 
-    /**
-     * Test:
-     * - "driveA" has been moved from "accountA" to "accountB"
-     * - "userA" is in both "accountA" and "accountB"
-     */
     // Insert user, account, drive & sync
     User userA(11, 111, "dummy", "userA", "userA@mail.com");
     (void) ParmsDb::instance()->insertUser(userA);
@@ -245,7 +245,7 @@ void TestAppServer::testUpdateUserInfo() {
     _appPtr->updateUserInfo(userA);
 
     std::vector<Account> accounts;
-    ParmsDb::instance()->selectAllAccounts(accounts);
+    (void) ParmsDb::instance()->selectAllAccounts(accounts);
     bool foundAccountA = false;
     bool foundAccountB = false;
     uint64_t accountDbIdB = 0;
@@ -261,7 +261,7 @@ void TestAppServer::testUpdateUserInfo() {
 
     Drive drive;
     bool found = false;
-    ParmsDb::instance()->selectDrive(driveA.dbId(), drive, found);
+    (void) ParmsDb::instance()->selectDrive(driveA.dbId(), drive, found);
     CPPUNIT_ASSERT(found);
     CPPUNIT_ASSERT(drive.accountDbId() != 11);
     CPPUNIT_ASSERT_EQUAL(accountDbIdB, static_cast<uint64_t>(drive.accountDbId()));

--- a/test/server/appserver/testappserver.cpp
+++ b/test/server/appserver/testappserver.cpp
@@ -195,6 +195,46 @@ void TestAppServer::testCleanup() {
     CPPUNIT_ASSERT(true);
 }
 
+ExitInfo mockLoadUserInfo(User &user, bool &updated) {
+    return ExitCode::Ok;
+}
+
+ExitInfo mockLoadAccountInfo(Account &account, bool &updated) {
+    return ExitCode::Ok;
+}
+
+ExitInfo mockLoadDriveInfo(Drive &drive, const uint64_t previousAccountId, uint64_t &newAccountId, bool &updated,
+                           bool &quotaUpdated) {
+    return ExitCode::Ok;
+}
+
+void TestAppServer::testUpdateUserInfo() {
+    _appPtr->setLoadUserInfoFunction(mockLoadUserInfo);
+    _appPtr->setLoadAccountInfoFunction(mockLoadAccountInfo);
+    _appPtr->setLoadDriveInfoFunction(mockLoadDriveInfo);
+
+    /**
+     * Test:
+     * - "driveA" has been moved from "accountA" to "accountB"
+     * - "userA" is in both "accountA" and "accountB"
+     */
+    // Insert user, account, drive & sync
+    User userA(1, 11, "dummy");
+    (void) ParmsDb::instance()->insertUser(userA);
+
+    Account accountA(1, 111, userA.dbId(), "accountA");
+    (void) ParmsDb::instance()->insertAccount(accountA);
+    Account accountB(1, 222, userA.dbId(), "accountB");
+    (void) ParmsDb::instance()->insertAccount(accountB);
+
+    Drive driveA(1, 1111, accountA.dbId(), "driveA", 123, "#FF0000");
+    (void) ParmsDb::instance()->insertDrive(driveA);
+    // const Drive driveB(1, 1111, accountB.dbId(), "driveB", 123, "#FF0000");
+    // (void) ParmsDb::instance()->insertDrive(driveB);
+
+    _appPtr->updateUserInfo(userA);
+}
+
 bool TestAppServer::waitForSyncStatus(int syncDbId, SyncStatus targetStatus) const {
     int count = 0;
     while (count++ < 100) {

--- a/test/server/appserver/testappserver.cpp
+++ b/test/server/appserver/testappserver.cpp
@@ -18,6 +18,7 @@
 
 #include "testappserver.h"
 
+#include "comm/guijobmanager.h"
 #include "utility/types.h"
 #include "requests/parameterscache.h"
 #include "libcommonserver/keychainmanager/keychainmanager.h"
@@ -196,15 +197,28 @@ void TestAppServer::testCleanup() {
 }
 
 ExitInfo mockLoadUserInfo(User &user, bool &updated) {
+    updated = false;
     return ExitCode::Ok;
 }
 
+const std::string accountNameA = "accountA";
+const std::string accountNameB = "accountB";
+const uint64_t accountIdA = 111;
+const uint64_t accountIdB = 222;
 ExitInfo mockLoadAccountInfo(Account &account, bool &updated) {
+    const auto accountName = account.dbId() == 11 ? accountNameA : accountNameB;
+    updated = account.name() == accountName;
+    account.setName(accountName);
     return ExitCode::Ok;
 }
 
 ExitInfo mockLoadDriveInfo(Drive &drive, const uint64_t previousAccountId, uint64_t &newAccountId, bool &updated,
                            bool &quotaUpdated) {
+    if (drive.dbId() == 11 && previousAccountId == accountIdA) {
+        newAccountId = accountIdB;
+        updated = true;
+    }
+    quotaUpdated = false;
     return ExitCode::Ok;
 }
 
@@ -219,20 +233,38 @@ void TestAppServer::testUpdateUserInfo() {
      * - "userA" is in both "accountA" and "accountB"
      */
     // Insert user, account, drive & sync
-    User userA(1, 11, "dummy");
+    User userA(11, 111, "dummy", "userA", "userA@mail.com");
     (void) ParmsDb::instance()->insertUser(userA);
 
-    Account accountA(1, 111, userA.dbId(), "accountA");
+    Account accountA(11, accountIdA, userA.dbId(), accountNameA);
     (void) ParmsDb::instance()->insertAccount(accountA);
-    Account accountB(1, 222, userA.dbId(), "accountB");
-    (void) ParmsDb::instance()->insertAccount(accountB);
 
-    Drive driveA(1, 1111, accountA.dbId(), "driveA", 123, "#FF0000");
+    Drive driveA(11, 111, accountA.dbId(), "driveA", 123, "#FF0000");
     (void) ParmsDb::instance()->insertDrive(driveA);
-    // const Drive driveB(1, 1111, accountB.dbId(), "driveB", 123, "#FF0000");
-    // (void) ParmsDb::instance()->insertDrive(driveB);
 
     _appPtr->updateUserInfo(userA);
+
+    std::vector<Account> accounts;
+    ParmsDb::instance()->selectAllAccounts(accounts);
+    bool foundAccountA = false;
+    bool foundAccountB = false;
+    uint64_t accountDbIdB = 0;
+    for (const auto &account: accounts) {
+        if (account.accountId() == accountIdA) foundAccountA = true;
+        if (account.accountId() == accountIdB) {
+            foundAccountB = true;
+            accountDbIdB = static_cast<uint64_t>(account.dbId());
+        }
+    }
+    CPPUNIT_ASSERT(!foundAccountA);
+    CPPUNIT_ASSERT(foundAccountB);
+
+    Drive drive;
+    bool found = false;
+    ParmsDb::instance()->selectDrive(driveA.dbId(), drive, found);
+    CPPUNIT_ASSERT(found);
+    CPPUNIT_ASSERT(drive.accountDbId() != 11);
+    CPPUNIT_ASSERT_EQUAL(accountDbIdB, static_cast<uint64_t>(drive.accountDbId()));
 }
 
 bool TestAppServer::waitForSyncStatus(int syncDbId, SyncStatus targetStatus) const {

--- a/test/server/appserver/testappserver.h
+++ b/test/server/appserver/testappserver.h
@@ -53,10 +53,10 @@ class MockAppServer : public AppServer {
 
 class TestAppServer : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST_SUITE(TestAppServer);
-        // CPPUNIT_TEST(testInitAndStopSyncPal);
-        // CPPUNIT_TEST(testStartAndStopSync);
+        CPPUNIT_TEST(testInitAndStopSyncPal);
+        CPPUNIT_TEST(testStartAndStopSync);
         CPPUNIT_TEST(testUpdateUserInfo);
-        // CPPUNIT_TEST(testCleanup); // Must be the last test
+        CPPUNIT_TEST(testCleanup); // Must be the last test
         CPPUNIT_TEST_SUITE_END();
 
     public:

--- a/test/server/appserver/testappserver.h
+++ b/test/server/appserver/testappserver.h
@@ -33,15 +33,30 @@ class MockAppServer : public AppServer {
 
         void setParmsDbPath(const std::filesystem::path &path) { _parmsDbPath = path; }
 
+        void setLoadUserInfoFunction(std::function<ExitInfo(User &user, bool &updated)> f) { _loadUserInfo = f; };
+        void setLoadAccountInfoFunction(std::function<ExitInfo(Account &account, bool &updated)> f) { _loadAccountInfo = f; };
+        void setLoadDriveInfoFunction(std::function<ExitInfo(Drive &drive, const uint64_t previousAccountId,
+                                                             uint64_t &newAccountId, bool &updated, bool &quotaUpdated)>
+                                              f) {
+            _loadDriveInfo = f;
+        };
+
     private:
+        // Do not try to notify the client
+        void sendUserUpdated(const UserInfo &) const override {};
+        void sendAccountAdded(const AccountInfo &) const override {};
+        void sendAccountUpdated(const AccountInfo &) const override {};
+        void sendDriveUpdated(const DriveInfo &) const override {};
+
         std::filesystem::path _parmsDbPath;
 };
 
 class TestAppServer : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST_SUITE(TestAppServer);
-        CPPUNIT_TEST(testInitAndStopSyncPal);
-        CPPUNIT_TEST(testStartAndStopSync);
-        CPPUNIT_TEST(testCleanup); // Must be the last test
+        // CPPUNIT_TEST(testInitAndStopSyncPal);
+        // CPPUNIT_TEST(testStartAndStopSync);
+        CPPUNIT_TEST(testUpdateUserInfo);
+        // CPPUNIT_TEST(testCleanup); // Must be the last test
         CPPUNIT_TEST_SUITE_END();
 
     public:
@@ -51,6 +66,7 @@ class TestAppServer : public CppUnit::TestFixture, public TestBase {
         void testInitAndStopSyncPal();
         void testStartAndStopSync();
         void testCleanup();
+        void testUpdateUserInfo();
 
     private:
         MockAppServer *_appPtr;

--- a/test/server/appserver/testappserver.h
+++ b/test/server/appserver/testappserver.h
@@ -33,20 +33,21 @@ class MockAppServer : public AppServer {
 
         void setParmsDbPath(const std::filesystem::path &path) { _parmsDbPath = path; }
 
-        void setLoadUserInfoFunction(std::function<ExitInfo(User &user, bool &updated)> f) { _loadUserInfo = f; };
-        void setLoadAccountInfoFunction(std::function<ExitInfo(Account &account, bool &updated)> f) { _loadAccountInfo = f; };
-        void setLoadDriveInfoFunction(std::function<ExitInfo(Drive &drive, const uint64_t previousAccountId,
-                                                             uint64_t &newAccountId, bool &updated, bool &quotaUpdated)>
-                                              f) {
+        void setLoadUserInfoFunction(const std::function<ExitInfo(User &user, bool &updated)> &f) { _loadUserInfo = f; };
+        void setLoadAccountInfoFunction(const std::function<ExitInfo(Account &account, bool &updated)> &f) {
+            _loadAccountInfo = f;
+        };
+        void setLoadDriveInfoFunction(
+                const std::function<ExitInfo(Drive &drive, const uint64_t previousAccountId, uint64_t &newAccountId,
+                                             bool &updated, bool &quotaUpdated)> &f) {
             _loadDriveInfo = f;
         };
 
     private:
-        // Do not try to notify the client
-        void sendUserUpdated(const UserInfo &) const override {};
-        void sendAccountAdded(const AccountInfo &) const override {};
-        void sendAccountUpdated(const AccountInfo &) const override {};
-        void sendDriveUpdated(const DriveInfo &) const override {};
+        void sendUserUpdated(const UserInfo &) const override { /* Do not try to notify the client */ };
+        void sendAccountAdded(const AccountInfo &) const override { /* Do not try to notify the client */ };
+        void sendAccountUpdated(const AccountInfo &) const override { /* Do not try to notify the client */ };
+        void sendDriveUpdated(const DriveInfo &) const override { /* Do not try to notify the client */ };
 
         std::filesystem::path _parmsDbPath;
 };


### PR DESCRIPTION
## Summary

This PR refactors the user info update mechanism to properly handle drives that are moved between accounts and improves testability by introducing dependency injection for `ServerRequests` methods.

## Changes

### Refactoring
- Split `updateUserInfo()` into smaller, focused methods:
  - `updateUser()`
  - `updateAccount()`  
  - `updateDrive()`
  - `manageDriveMovedToAnotherAccount()`

### Bug Fixes
- **Fixed duplicate SignalDriveUpdatedJob signal**: Ensure the drive update signal is only sent once per update cycle
- **Fixed DB updates on drive transfer**: Properly update the database when a drive is moved from one account to another

### Architecture Improvements
- Made `ServerRequests` methods accessible through `std::function` pointers for better testability
- Enabled dependency injection pattern for mocking network jobs in unit tests

### Testing
- Added comprehensive unit tests for `AppServer::updateUserInfo()`
- Implemented mocks for `GetUserInfoJob`, `GetAccountInfoJob`, and `GetDriveInfoJob`
- Added test case for the "drive moved between accounts" scenario