### PR TITLE
feat: Mac updater observer

### DIFF
--- a/src/gui4/macOS/kDrive.xcodeproj/project.pbxproj
+++ b/src/gui4/macOS/kDrive.xcodeproj/project.pbxproj
@@ -137,6 +137,7 @@
 				Cache/Observation/ObservedSynchroNodesTests.swift,
 				Cache/Observation/ObservedSynchrosTests.swift,
 				Cache/Observation/ObservedSynchroTests.swift,
+				Cache/Observation/ObservedUpdaterTests.swift,
 				Cache/Observation/ObservedUserTests.swift,
 				Jobs/LoginJobTests.swift,
 				Parsing/Base64CodedTests.swift,

--- a/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedAccount.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedAccount.swift
@@ -24,10 +24,10 @@ import OrderedCollections
 @MainActor
 @propertyWrapper
 final class ObservedAccount: ObservableObject {
-    @Published public private(set) var wrappedValue: Account?
+    @Published private(set) var wrappedValue: Account?
     private var cancellable: AnyCancellable?
 
-    public init(
+    init(
         userDbId: Int32,
         accountDbId: Int32,
         cacheObservation: CoherentCacheObservable? = nil
@@ -43,7 +43,7 @@ final class ObservedAccount: ObservableObject {
             }
     }
 
-    public init(
+    init(
         accountDbId: Int32,
         cacheObservation: CoherentCacheObservable? = nil
     ) {
@@ -60,7 +60,9 @@ final class ObservedAccount: ObservableObject {
 
     deinit { cancellable?.cancel() }
 
-    public var projectedValue: ObservedAccount { self }
+    var projectedValue: ObservedAccount {
+        self
+    }
 }
 
 public extension AnyPublisher where Output == IndexedUsers, Failure == Never {

--- a/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedAccount.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedAccount.swift
@@ -23,7 +23,7 @@ import OrderedCollections
 
 @MainActor
 @propertyWrapper
-public final class ObservedAccount: ObservableObject {
+final class ObservedAccount: ObservableObject {
     @Published public private(set) var wrappedValue: Account?
     private var cancellable: AnyCancellable?
 

--- a/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedAccount.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedAccount.swift
@@ -21,12 +21,14 @@ import Foundation
 import InfomaniakDI
 import OrderedCollections
 
+// periphery:ignore - Will be moved to the test target
 @MainActor
 @propertyWrapper
 final class ObservedAccount: ObservableObject {
     @Published private(set) var wrappedValue: Account?
     private var cancellable: AnyCancellable?
 
+    // periphery:ignore
     init(
         userDbId: Int32,
         accountDbId: Int32,
@@ -43,6 +45,7 @@ final class ObservedAccount: ObservableObject {
             }
     }
 
+    // periphery:ignore
     init(
         accountDbId: Int32,
         cacheObservation: CoherentCacheObservable? = nil

--- a/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedAvailableDrives.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedAvailableDrives.swift
@@ -28,7 +28,7 @@ public struct AvailableDriveContext: Sendable, Equatable {
 
 @MainActor
 @propertyWrapper
-public final class ObservedAvailableDrives: ObservableObject {
+final class ObservedAvailableDrives: ObservableObject {
     @Published public private(set) var wrappedValue: [AvailableDriveContext] = []
     private var cancellable: AnyCancellable?
 

--- a/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedAvailableDrives.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedAvailableDrives.swift
@@ -29,10 +29,10 @@ public struct AvailableDriveContext: Sendable, Equatable {
 @MainActor
 @propertyWrapper
 final class ObservedAvailableDrives: ObservableObject {
-    @Published public private(set) var wrappedValue: [AvailableDriveContext] = []
+    @Published private(set) var wrappedValue: [AvailableDriveContext] = []
     private var cancellable: AnyCancellable?
 
-    public init(
+    init(
         cacheObservation: CoherentCacheObservable? = nil
     ) {
         let cacheObservation =
@@ -48,7 +48,9 @@ final class ObservedAvailableDrives: ObservableObject {
 
     deinit { cancellable?.cancel() }
 
-    public var projectedValue: ObservedAvailableDrives { self }
+    var projectedValue: ObservedAvailableDrives {
+        self
+    }
 }
 
 public extension AnyPublisher where Output == IndexedUsers, Failure == Never {

--- a/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedAvailableDrives.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedAvailableDrives.swift
@@ -26,12 +26,14 @@ public struct AvailableDriveContext: Sendable, Equatable {
     public let user: User
 }
 
+// periphery:ignore - Will be moved to the test target
 @MainActor
 @propertyWrapper
 final class ObservedAvailableDrives: ObservableObject {
     @Published private(set) var wrappedValue: [AvailableDriveContext] = []
     private var cancellable: AnyCancellable?
 
+    // periphery:ignore
     init(
         cacheObservation: CoherentCacheObservable? = nil
     ) {

--- a/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedDrive.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedDrive.swift
@@ -21,12 +21,14 @@ import Foundation
 import InfomaniakDI
 import OrderedCollections
 
+// periphery:ignore - Will be moved to the test target
 @MainActor
 @propertyWrapper
 final class ObservedDrive: ObservableObject {
     @Published private(set) var wrappedValue: Drive?
     private var cancellable: AnyCancellable?
 
+    // periphery:ignore
     init(
         userDbId: Int32,
         accountDbId: Int32,

--- a/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedDrive.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedDrive.swift
@@ -24,10 +24,10 @@ import OrderedCollections
 @MainActor
 @propertyWrapper
 final class ObservedDrive: ObservableObject {
-    @Published public private(set) var wrappedValue: Drive?
+    @Published private(set) var wrappedValue: Drive?
     private var cancellable: AnyCancellable?
 
-    public init(
+    init(
         userDbId: Int32,
         accountDbId: Int32,
         driveDbId: Int32,
@@ -48,7 +48,7 @@ final class ObservedDrive: ObservableObject {
             }
     }
 
-    public init(
+    init(
         driveDbId: Int32,
         cacheObservation: CoherentCacheObservable? = nil
     ) {
@@ -65,7 +65,9 @@ final class ObservedDrive: ObservableObject {
 
     deinit { cancellable?.cancel() }
 
-    public var projectedValue: ObservedDrive { self }
+    var projectedValue: ObservedDrive {
+        self
+    }
 }
 
 public extension AnyPublisher where Output == IndexedUsers, Failure == Never {

--- a/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedDrive.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedDrive.swift
@@ -23,7 +23,7 @@ import OrderedCollections
 
 @MainActor
 @propertyWrapper
-public final class ObservedDrive: ObservableObject {
+final class ObservedDrive: ObservableObject {
     @Published public private(set) var wrappedValue: Drive?
     private var cancellable: AnyCancellable?
 

--- a/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedDrives.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedDrives.swift
@@ -27,12 +27,14 @@ public struct DriveContext: Sendable, Equatable {
     public let user: User
 }
 
+// periphery:ignore - Will be moved to the test target
 @MainActor
 @propertyWrapper
 final class ObservedDrives: ObservableObject {
     @Published private(set) var wrappedValue: [DriveContext] = []
     private var cancellable: AnyCancellable?
 
+    // periphery:ignore
     init(
         cacheObservation: CoherentCacheObservable? = nil
     ) {

--- a/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedDrives.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedDrives.swift
@@ -30,10 +30,10 @@ public struct DriveContext: Sendable, Equatable {
 @MainActor
 @propertyWrapper
 final class ObservedDrives: ObservableObject {
-    @Published public private(set) var wrappedValue: [DriveContext] = []
+    @Published private(set) var wrappedValue: [DriveContext] = []
     private var cancellable: AnyCancellable?
 
-    public init(
+    init(
         cacheObservation: CoherentCacheObservable? = nil
     ) {
         let cacheObservation =
@@ -49,7 +49,9 @@ final class ObservedDrives: ObservableObject {
 
     deinit { cancellable?.cancel() }
 
-    public var projectedValue: ObservedDrives { self }
+    var projectedValue: ObservedDrives {
+        self
+    }
 }
 
 public extension AnyPublisher where Output == IndexedUsers, Failure == Never {

--- a/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedDrives.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedDrives.swift
@@ -29,7 +29,7 @@ public struct DriveContext: Sendable, Equatable {
 
 @MainActor
 @propertyWrapper
-public final class ObservedDrives: ObservableObject {
+final class ObservedDrives: ObservableObject {
     @Published public private(set) var wrappedValue: [DriveContext] = []
     private var cancellable: AnyCancellable?
 

--- a/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedSynchro.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedSynchro.swift
@@ -24,10 +24,10 @@ import OrderedCollections
 @MainActor
 @propertyWrapper
 final class ObservedSynchro: ObservableObject {
-    @Published public private(set) var wrappedValue: Synchro?
+    @Published private(set) var wrappedValue: Synchro?
     private var cancellable: AnyCancellable?
 
-    public init(
+    init(
         userDbId: Int32,
         accountDbId: Int32,
         driveDbId: Int32,
@@ -45,7 +45,7 @@ final class ObservedSynchro: ObservableObject {
             }
     }
 
-    public init(
+    init(
         synchroDbId: Int32,
         cacheObservation: CoherentCacheObservable? = nil
     ) {
@@ -62,7 +62,9 @@ final class ObservedSynchro: ObservableObject {
 
     deinit { cancellable?.cancel() }
 
-    public var projectedValue: ObservedSynchro { self }
+    var projectedValue: ObservedSynchro {
+        self
+    }
 }
 
 public extension AnyPublisher where Output == IndexedUsers, Failure == Never {

--- a/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedSynchro.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedSynchro.swift
@@ -21,12 +21,14 @@ import Foundation
 import InfomaniakDI
 import OrderedCollections
 
+// periphery:ignore - Will be moved to the test target
 @MainActor
 @propertyWrapper
 final class ObservedSynchro: ObservableObject {
     @Published private(set) var wrappedValue: Synchro?
     private var cancellable: AnyCancellable?
 
+    // periphery:ignore
     init(
         userDbId: Int32,
         accountDbId: Int32,
@@ -45,6 +47,7 @@ final class ObservedSynchro: ObservableObject {
             }
     }
 
+    // periphery:ignore
     init(
         synchroDbId: Int32,
         cacheObservation: CoherentCacheObservable? = nil

--- a/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedSynchro.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedSynchro.swift
@@ -23,7 +23,7 @@ import OrderedCollections
 
 @MainActor
 @propertyWrapper
-public final class ObservedSynchro: ObservableObject {
+final class ObservedSynchro: ObservableObject {
     @Published public private(set) var wrappedValue: Synchro?
     private var cancellable: AnyCancellable?
 

--- a/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedSynchroNodes.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedSynchroNodes.swift
@@ -29,12 +29,14 @@ public struct SynchroNodeContext: Sendable, Equatable {
     public let user: User
 }
 
+// periphery:ignore - Will be moved to the test target
 @MainActor
 @propertyWrapper
 final class ObservedSynchroNodes: ObservableObject {
     @Published private(set) var wrappedValue: [SynchroNodeContext] = []
     private var cancellable: AnyCancellable?
 
+    // periphery:ignore
     init(
         synchroDbId: Int32,
         cacheObservation: CoherentCacheObservable? = nil

--- a/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedSynchroNodes.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedSynchroNodes.swift
@@ -31,7 +31,7 @@ public struct SynchroNodeContext: Sendable, Equatable {
 
 @MainActor
 @propertyWrapper
-public final class ObservedSynchroNodes: ObservableObject {
+final class ObservedSynchroNodes: ObservableObject {
     @Published public private(set) var wrappedValue: [SynchroNodeContext] = []
     private var cancellable: AnyCancellable?
 

--- a/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedSynchroNodes.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedSynchroNodes.swift
@@ -32,10 +32,10 @@ public struct SynchroNodeContext: Sendable, Equatable {
 @MainActor
 @propertyWrapper
 final class ObservedSynchroNodes: ObservableObject {
-    @Published public private(set) var wrappedValue: [SynchroNodeContext] = []
+    @Published private(set) var wrappedValue: [SynchroNodeContext] = []
     private var cancellable: AnyCancellable?
 
-    public init(
+    init(
         synchroDbId: Int32,
         cacheObservation: CoherentCacheObservable? = nil
     ) {
@@ -52,7 +52,7 @@ final class ObservedSynchroNodes: ObservableObject {
 
     deinit { cancellable?.cancel() }
 
-    public var projectedValue: ObservedSynchroNodes {
+    var projectedValue: ObservedSynchroNodes {
         self
     }
 }

--- a/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedSynchros.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedSynchros.swift
@@ -24,10 +24,10 @@ import OrderedCollections
 @MainActor
 @propertyWrapper
 final class ObservedSynchros: ObservableObject {
-    @Published public private(set) var wrappedValue: [SynchroContext] = []
+    @Published private(set) var wrappedValue: [SynchroContext] = []
     private var cancellable: AnyCancellable?
 
-    public init(
+    init(
         cacheObservation: CoherentCacheObservable? = nil
     ) {
         let cacheObservation =
@@ -43,7 +43,9 @@ final class ObservedSynchros: ObservableObject {
 
     deinit { cancellable?.cancel() }
 
-    public var projectedValue: ObservedSynchros { self }
+    var projectedValue: ObservedSynchros {
+        self
+    }
 }
 
 public extension AnyPublisher where Output == IndexedUsers, Failure == Never {

--- a/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedSynchros.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedSynchros.swift
@@ -23,7 +23,7 @@ import OrderedCollections
 
 @MainActor
 @propertyWrapper
-public final class ObservedSynchros: ObservableObject {
+final class ObservedSynchros: ObservableObject {
     @Published public private(set) var wrappedValue: [SynchroContext] = []
     private var cancellable: AnyCancellable?
 

--- a/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedSynchros.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedSynchros.swift
@@ -21,12 +21,14 @@ import Foundation
 import InfomaniakDI
 import OrderedCollections
 
+// periphery:ignore - Will be moved to the test target
 @MainActor
 @propertyWrapper
 final class ObservedSynchros: ObservableObject {
     @Published private(set) var wrappedValue: [SynchroContext] = []
     private var cancellable: AnyCancellable?
 
+    // periphery:ignore
     init(
         cacheObservation: CoherentCacheObservable? = nil
     ) {

--- a/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedUpdater.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedUpdater.swift
@@ -20,13 +20,14 @@ import Combine
 import Foundation
 import InfomaniakDI
 
-// periphery:ignore - Will be moved to the test target with the other ones
+// periphery:ignore - Will be moved to the test target
 @MainActor
 @propertyWrapper
 final class ObservedUpdater: ObservableObject {
     @Published private(set) var wrappedValue: KDC.UpdateState?
     private var cancellable: AnyCancellable?
 
+    // periphery:ignore
     init(updaterObservable: UpdaterCacheObservable? = nil) {
         let updaterObservable =
             updaterObservable ?? InjectService<UpdaterCacheObservable>().wrappedValue

--- a/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedUpdater.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedUpdater.swift
@@ -20,6 +20,7 @@ import Combine
 import Foundation
 import InfomaniakDI
 
+// periphery:ignore - Will be moved to the test target with the other ones
 @MainActor
 @propertyWrapper
 final class ObservedUpdater: ObservableObject {

--- a/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedUpdater.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedUpdater.swift
@@ -1,0 +1,46 @@
+/*
+ Infomaniak kDrive - Desktop
+ Copyright (C) 2023-2025 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Combine
+import Foundation
+import InfomaniakDI
+
+@MainActor
+@propertyWrapper
+public final class ObservedUpdater: ObservableObject {
+    @Published public private(set) var wrappedValue: KDC.UpdateState?
+    private var cancellable: AnyCancellable?
+
+    public init(updaterObservable: UpdaterCacheObservable? = nil) {
+        let updaterObservable =
+            updaterObservable ?? InjectService<UpdaterCacheObservable>().wrappedValue
+
+        cancellable = updaterObservable.updateStatePublisher
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] updateState in
+                self?.wrappedValue = updateState
+            }
+    }
+
+    deinit { cancellable?.cancel() }
+
+    public var projectedValue: ObservedUpdater {
+        self
+    }
+}

--- a/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedUpdater.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedUpdater.swift
@@ -22,16 +22,16 @@ import InfomaniakDI
 
 @MainActor
 @propertyWrapper
-public final class ObservedUpdater: ObservableObject {
-    @Published public private(set) var wrappedValue: KDC.UpdateState?
+final class ObservedUpdater: ObservableObject {
+    @Published private(set) var wrappedValue: KDC.UpdateState?
     private var cancellable: AnyCancellable?
 
-    public init(updaterObservable: UpdaterCacheObservable? = nil) {
+    init(updaterObservable: UpdaterCacheObservable? = nil) {
         let updaterObservable =
             updaterObservable ?? InjectService<UpdaterCacheObservable>().wrappedValue
 
         cancellable = updaterObservable.updateStatePublisher
-            .removeDuplicates()
+            .observableUpdaterPublisher()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] updateState in
                 self?.wrappedValue = updateState
@@ -40,7 +40,14 @@ public final class ObservedUpdater: ObservableObject {
 
     deinit { cancellable?.cancel() }
 
-    public var projectedValue: ObservedUpdater {
+    var projectedValue: ObservedUpdater {
         self
+    }
+}
+
+public extension AnyPublisher where Output == KDC.UpdateState, Failure == Never {
+    func observableUpdaterPublisher() -> AnyPublisher<KDC.UpdateState, Never> {
+        removeDuplicates()
+            .eraseToAnyPublisher()
     }
 }

--- a/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedUser.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedUser.swift
@@ -28,7 +28,7 @@ public enum ObservationEvent<Some: Equatable>: Equatable {
 
 @MainActor
 @propertyWrapper
-public final class ObservedUser: ObservableObject {
+final class ObservedUser: ObservableObject {
     @Published public private(set) var wrappedValue: User?
     private var cancellable: AnyCancellable?
 

--- a/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedUser.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedUser.swift
@@ -29,10 +29,10 @@ public enum ObservationEvent<Some: Equatable>: Equatable {
 @MainActor
 @propertyWrapper
 final class ObservedUser: ObservableObject {
-    @Published public private(set) var wrappedValue: User?
+    @Published private(set) var wrappedValue: User?
     private var cancellable: AnyCancellable?
 
-    public init(userDbId: Int32, cacheObservation: CoherentCacheObservable? = nil) {
+    init(userDbId: Int32, cacheObservation: CoherentCacheObservable? = nil) {
         let cacheObservation = cacheObservation ?? InjectService<CoherentCacheObservable>().wrappedValue
 
         cancellable = cacheObservation.usersPublisher
@@ -45,7 +45,9 @@ final class ObservedUser: ObservableObject {
 
     deinit { cancellable?.cancel() }
 
-    public var projectedValue: ObservedUser { self }
+    var projectedValue: ObservedUser {
+        self
+    }
 }
 
 public extension AnyPublisher where Output == IndexedUsers, Failure == Never {

--- a/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedUser.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/Cache/Observation/ObservedUser.swift
@@ -26,12 +26,14 @@ public enum ObservationEvent<Some: Equatable>: Equatable {
     case removed
 }
 
+// periphery:ignore - Will be moved to the test target
 @MainActor
 @propertyWrapper
 final class ObservedUser: ObservableObject {
     @Published private(set) var wrappedValue: User?
     private var cancellable: AnyCancellable?
 
+    // periphery:ignore
     init(userDbId: Int32, cacheObservation: CoherentCacheObservable? = nil) {
         let cacheObservation = cacheObservation ?? InjectService<CoherentCacheObservable>().wrappedValue
 

--- a/src/gui4/macOS/kDriveCore/ServerBridge/Cache/UpdaterStateCache.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/Cache/UpdaterStateCache.swift
@@ -1,0 +1,51 @@
+/*
+ Infomaniak kDrive - Desktop
+ Copyright (C) 2023-2025 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Combine
+import Foundation
+
+public protocol UpdaterObservable: Sendable {
+    var updateStatePublisher: AnyPublisher<KDC.UpdateState, Never> { get }
+}
+
+public actor UpdaterStateCache: UpdaterObservable {
+    private var updateState: KDC.UpdateState?
+
+    private nonisolated let updateStateSubject = PassthroughSubject<KDC.UpdateState, Never>()
+
+    public nonisolated var updateStatePublisher: AnyPublisher<KDC.UpdateState, Never> {
+        updateStateSubject
+            .subscribe(on: DispatchQueue.global(qos: .userInitiated))
+            .eraseToAnyPublisher()
+    }
+
+    public init() {}
+
+    public func setUpdateState(_ state: KDC.UpdateState) {
+        updateState = state
+        notifyUpdateStateChange(state)
+    }
+
+    public func getUpdateState() -> KDC.UpdateState? {
+        updateState
+    }
+
+    private func notifyUpdateStateChange(_ state: KDC.UpdateState) {
+        updateStateSubject.send(state)
+    }
+}

--- a/src/gui4/macOS/kDriveCore/ServerBridge/Cache/UpdaterStateCache.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/Cache/UpdaterStateCache.swift
@@ -19,11 +19,16 @@
 import Combine
 import Foundation
 
-public protocol UpdaterObservable: Sendable {
+public protocol UpdaterCacheObservable: Sendable {
     var updateStatePublisher: AnyPublisher<KDC.UpdateState, Never> { get }
 }
 
-public actor UpdaterStateCache: UpdaterObservable {
+public protocol UpdaterCache {
+    func setUpdateState(_ state: KDC.UpdateState) async
+    func getUpdateState() async -> KDC.UpdateState?
+}
+
+public actor UpdaterStateCache: UpdaterCache, UpdaterCacheObservable {
     private var updateState: KDC.UpdateState?
 
     private nonisolated let updateStateSubject = PassthroughSubject<KDC.UpdateState, Never>()

--- a/src/gui4/macOS/kDriveCore/ServerBridge/Signal/signal handlers/UpdaterSignalHandler.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/Signal/signal handlers/UpdaterSignalHandler.swift
@@ -21,6 +21,7 @@ import InfomaniakDI
 
 struct UpdaterSignalHandler {
     private let decoder = JSONDecoder()
+    @LazyInjectService private var updaterCache: UpdaterCache
 
     func handleShowDialog(_ signal: Data) async throws {
         guard let showDialogSignal = try? decoder.decode(SignalMessage<UpdaterShowDialogSignal>.self, from: signal) else {
@@ -43,6 +44,6 @@ struct UpdaterSignalHandler {
 
         IKLogger.xpc.log("[KD] Updater state changed: \(updateState)")
 
-        // TODO: Make the updater view refresh itself with a UpdaterJobs().updaterState()
+        await updaterCache.setUpdateState(updateState)
     }
 }

--- a/src/gui4/macOS/kDriveCore/Utils/TargetAssembly.swift
+++ b/src/gui4/macOS/kDriveCore/Utils/TargetAssembly.swift
@@ -43,6 +43,9 @@ open class TargetAssembly {
                                      factoryParameters: nil,
                                      resolver: resolver)
             },
+            Factory(type: UpdaterObservable.self) { _, _ in
+                UpdaterStateCache()
+            },
             Factory(type: XPCConnectionProvider.self) { _, _ in
                 if testing {
                     return XPCServerMock()

--- a/src/gui4/macOS/kDriveCore/Utils/TargetAssembly.swift
+++ b/src/gui4/macOS/kDriveCore/Utils/TargetAssembly.swift
@@ -43,8 +43,14 @@ open class TargetAssembly {
                                      factoryParameters: nil,
                                      resolver: resolver)
             },
-            Factory(type: UpdaterObservable.self) { _, _ in
+            Factory(type: UpdaterCache.self) { _, _ in
                 UpdaterStateCache()
+            },
+            Factory(type: UpdaterCacheObservable.self) { _, resolver in
+                try resolver.resolve(type: UpdaterCache.self,
+                                     forCustomTypeIdentifier: nil,
+                                     factoryParameters: nil,
+                                     resolver: resolver)
             },
             Factory(type: XPCConnectionProvider.self) { _, _ in
                 if testing {

--- a/src/gui4/macOS/kDriveTests/Cache/Observation/ObservedAccountTests.swift
+++ b/src/gui4/macOS/kDriveTests/Cache/Observation/ObservedAccountTests.swift
@@ -19,7 +19,7 @@
 import Combine
 import Foundation
 @testable import InfomaniakDI
-import kDriveCore
+@testable import kDriveCore
 import Testing
 
 extension ObservedAccount {

--- a/src/gui4/macOS/kDriveTests/Cache/Observation/ObservedDriveTests.swift
+++ b/src/gui4/macOS/kDriveTests/Cache/Observation/ObservedDriveTests.swift
@@ -19,7 +19,7 @@
 import Combine
 import Foundation
 @testable import InfomaniakDI
-import kDriveCore
+@testable import kDriveCore
 import Testing
 
 extension ObservedDrive {

--- a/src/gui4/macOS/kDriveTests/Cache/Observation/ObservedUpdaterTests.swift
+++ b/src/gui4/macOS/kDriveTests/Cache/Observation/ObservedUpdaterTests.swift
@@ -1,0 +1,188 @@
+/*
+ Infomaniak kDrive - Desktop
+ Copyright (C) 2023-2025 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Combine
+import Foundation
+@testable import kDriveCore
+import Testing
+
+extension ObservedUpdater {
+    var receivedValues: AsyncStream<KDC.UpdateState> {
+        AsyncStream { continuation in
+            let cancellable = $wrappedValue
+                .sink { value in
+                    if let value = value {
+                        continuation.yield(value)
+                    }
+                }
+
+            continuation.onTermination = { _ in cancellable.cancel() }
+        }
+    }
+}
+
+@MainActor
+struct ObservedUpdaterTests {
+    @Test(.timeLimit(.minutes(1)))
+    func setObservedUpdateState() async {
+        // GIVEN
+        let cache = UpdaterStateCache()
+        let initialState = await cache.getUpdateState()
+        #expect(initialState == nil, "Cache should initially be empty")
+
+        @ObservedUpdater(updaterObservable: cache) var observedState: KDC.UpdateState?
+        let receivedValues = $observedState.receivedValues // Start to save the received values
+
+        #expect(observedState == nil, "UpdateState should initially be nil")
+
+        // WHEN
+        let expectedState = KDC.UpdateState.Checking
+        await cache.setUpdateState(expectedState)
+
+        // THEN
+        _ = await receivedValues.first(where: { _ in true })
+
+        let cachedState = await cache.getUpdateState()
+        #expect(cachedState == expectedState, "The cache should have been updated with the state")
+        #expect(observedState == expectedState, "The observed state should match the one we just set")
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func updateObservedUpdateState() async {
+        // GIVEN
+        let cache = UpdaterStateCache()
+
+        @ObservedUpdater(updaterObservable: cache) var observedState: KDC.UpdateState?
+        let receivedValues = $observedState.receivedValues // Start to save the received values
+
+        let initialState = KDC.UpdateState.Checking
+        await cache.setUpdateState(initialState)
+
+        _ = await receivedValues.first(where: { _ in true })
+
+        let cachedState = await cache.getUpdateState()
+        #expect(cachedState == initialState, "The cache should have been updated with the initial state")
+        #expect(observedState == initialState, "The observed state should match the initial state")
+
+        // WHEN
+        let updatedState = KDC.UpdateState.Available
+        await cache.setUpdateState(updatedState)
+
+        // THEN
+        _ = await receivedValues.first(where: { _ in true })
+
+        let latestCachedState = await cache.getUpdateState()
+        #expect(latestCachedState == updatedState, "The cache should have been updated with the new state")
+        #expect(observedState == updatedState, "The observed state should match the updated one")
+        #expect(observedState != initialState, "The observed state should not match the old one")
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func multipleUpdateStateChanges() async {
+        // GIVEN
+        let cache = UpdaterStateCache()
+
+        @ObservedUpdater(updaterObservable: cache) var observedState: KDC.UpdateState?
+        let receivedValues = $observedState.receivedValues // Start to save the received values
+
+        #expect(observedState == nil, "UpdateState should initially be nil")
+
+        // WHEN - Set multiple states in sequence
+        let firstState = KDC.UpdateState.Checking
+        await cache.setUpdateState(firstState)
+
+        _ = await receivedValues.first(where: { _ in true })
+        #expect(observedState == firstState, "The observed state should be checking")
+
+        let secondState = KDC.UpdateState.Downloading
+        await cache.setUpdateState(secondState)
+
+        _ = await receivedValues.first(where: { _ in true })
+        #expect(observedState == secondState, "The observed state should be downloading")
+
+        let thirdState = KDC.UpdateState.Ready
+        await cache.setUpdateState(thirdState)
+
+        // THEN
+        _ = await receivedValues.first(where: { _ in true })
+
+        let finalCachedState = await cache.getUpdateState()
+        #expect(finalCachedState == thirdState, "The cache should have the final state")
+        #expect(observedState == thirdState, "The observed state should be ready")
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func setSameUpdateStateMultipleTimes() async {
+        // GIVEN
+        let cache = UpdaterStateCache()
+
+        @ObservedUpdater(updaterObservable: cache) var observedState: KDC.UpdateState?
+        let receivedValues = $observedState.receivedValues // Start to save the received values
+
+        let expectedState = KDC.UpdateState.UpToDate
+        await cache.setUpdateState(expectedState)
+
+        _ = await receivedValues.first(where: { _ in true })
+
+        #expect(observedState == expectedState, "The observed state should be upToDate")
+
+        // WHEN - Set the same state again
+        await cache.setUpdateState(expectedState)
+
+        try? await Task.sleep(nanoseconds: 200_000_000) // Thanks to deduplication, receivedValues are not mutated
+
+        // THEN - Value should still be correct
+        let cachedState = await cache.getUpdateState()
+        #expect(cachedState == expectedState, "The cache should still have the same state")
+        #expect(observedState == expectedState, "The observed state should still be upToDate")
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func allUpdateStateValues() async {
+        // GIVEN
+        let cache = UpdaterStateCache()
+
+        @ObservedUpdater(updaterObservable: cache) var observedState: KDC.UpdateState?
+        let receivedValues = $observedState.receivedValues // Start to save the received values
+
+        let states: [KDC.UpdateState] = [.UpToDate,
+                                         .Checking,
+                                         .Available,
+                                         .ManualUpdateAvailable,
+                                         .Downloading,
+                                         .Ready,
+                                         .CheckError,
+                                         .DownloadError,
+                                         .UpdateError,
+                                         .NoUpdate,
+                                         .Unknown,
+                                         .EnumEnd].shuffled()
+
+        for (index, expectedState) in states.enumerated() {
+            // WHEN
+            await cache.setUpdateState(expectedState)
+
+            // THEN
+            _ = await receivedValues.first(where: { _ in true })
+
+            let cachedState = await cache.getUpdateState()
+            #expect(cachedState == expectedState, "The cache should have state at index \(index)")
+            #expect(observedState == expectedState, "The observed state should match at index \(index)")
+        }
+    }
+}

--- a/src/gui4/macOS/kDriveTests/Cache/Observation/ObservedUpdaterTests.swift
+++ b/src/gui4/macOS/kDriveTests/Cache/Observation/ObservedUpdaterTests.swift
@@ -26,7 +26,7 @@ extension ObservedUpdater {
         AsyncStream { continuation in
             let cancellable = $wrappedValue
                 .sink { value in
-                    if let value = value {
+                    if let value {
                         continuation.yield(value)
                     }
                 }

--- a/src/gui4/macOS/kDriveTests/Cache/Observation/ObservedUserTests.swift
+++ b/src/gui4/macOS/kDriveTests/Cache/Observation/ObservedUserTests.swift
@@ -19,7 +19,7 @@
 import Combine
 import Foundation
 @testable import InfomaniakDI
-import kDriveCore
+@testable import kDriveCore
 import Testing
 
 extension ObservedUser {


### PR DESCRIPTION
New mechanism to observe the Updater status
- UpdaterStateCache to maintain last known state + tests