### PR TITLE
feat(conflicts): add quick bulk resolve flow for file conflicts (WinUI)

### DIFF
--- a/src/gui4/windows/kDrive client/kDrive client/App.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/App.xaml.cs
@@ -156,7 +156,7 @@ namespace Infomaniak.kDrive
                 return;
             }
             CurrentWindow.Content = currentWindowContent;
-            (CurrentWindow as MainWindow)?.AppNavView?.Frame.Navigate(typeof(Pages.HomePage));
+            (CurrentWindow as MainWindow)?.AppNavView?.Frame?.Navigate(typeof(Pages.HomePage));
             StartOnboardingIfNeeded();
             appModel.AllSyncs.AsObservableChangeSet()
             .Subscribe(_ =>

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Dialogs/ConflictVersionPresenter.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Dialogs/ConflictVersionPresenter.xaml
@@ -63,7 +63,7 @@
                 <Border Grid.Column="2"
                         Background="{ThemeResource SystemFillColorSuccessBackgroundBrush}"
                         CornerRadius="{StaticResource Infomaniak.Style.CornerRadius.Uniform.S}"
-                        Padding="4,2"
+                        Padding="{StaticResource Infomaniak.Style.Thickness.TextBadge}"
                         VerticalAlignment="Center"
                         Visibility="{x:Bind ShowMostRecentBadge, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}">
                     <TextBlock Text="{x:Bind kDrive:Localizer.Instance.GetString('labelMostRecent')}"

--- a/src/gui4/windows/kDrive client/kDrive client/Localizer/Localizer.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Localizer/Localizer.cs
@@ -59,6 +59,11 @@ namespace Infomaniak.kDrive
             return GetString(key, new object?[] { arg1 });
         }
 
+        public string GetString1i(string key, int arg1)
+        {
+            return GetString(key, new object?[] { arg1 });
+        }
+
         public string GetString1i2i(string key, int arg1, int arg2)
         {
             return GetString(key, new object?[] { arg1, arg2 });

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Errors/ConflictQuickResolvePage.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Errors/ConflictQuickResolvePage.xaml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Page x:Class="Infomaniak.kDrive.Pages.Errors.ErrorPage"
+<Page x:Class="Infomaniak.kDrive.Pages.Errors.ConflictQuickResolvePage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:local="using:Infomaniak.kDrive"
@@ -31,7 +31,7 @@
             </Grid.ColumnDefinitions>
 
             <TextBlock Grid.Column="0"
-                       Text="{x:Bind kDrive:Localizer.Instance.GetString('tabTitleActivities')}"
+                       Text="{x:Bind kDrive:Localizer.Instance.GetString('errorPageTitle')}"
                        FontSize="{StaticResource TitleTextBlockFontSize}"
                        FontWeight="SemiBold"
                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
@@ -78,8 +78,7 @@
 
                 <StackPanel Grid.Row="1"
                             Spacing="{StaticResource Infomaniak.Style.Spacing.XS}"
-                            Margin="{StaticResource Infomaniak.Style.Thickness.Bottom.L}"
-                            Visibility="{x:Bind _errorPageVM.HasManyConflicts, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}">
+                            Margin="{StaticResource Infomaniak.Style.Thickness.Bottom.L}">
                     <TextBlock Style="{ThemeResource SubtitleTextBlockStyle}"
                                Text="{x:Bind kDrive:Localizer.Instance.GetString('conflictErrorTitle'), Mode=OneWay}" />
 

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Errors/ConflictQuickResolvePage.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Errors/ConflictQuickResolvePage.xaml
@@ -47,7 +47,7 @@
                       VerticalAlignment="Bottom" />
 
             <TextBlock Grid.Column="2"
-                       Text="{x:Bind kDrive:Localizer.Instance.GetString('errorPageTitle')}"
+                       Text="{x:Bind kDrive:Localizer.Instance.GetString('conflictErrorTitle')}"
                        FontSize="{StaticResource TitleTextBlockFontSize}"
                        FontWeight="SemiBold"
                        Foreground="{ThemeResource TextFillColorPrimaryBrush}"
@@ -58,54 +58,153 @@
         <ScrollView Grid.Row="1"
                     Padding="0"
                     Margin="0">
-            <Grid>
+            <Grid RowSpacing="{StaticResource Infomaniak.Style.Spacing.XXS}">
                 <Grid.RowDefinitions>
-                    <!-- SyncDir -->
                     <RowDefinition Height="Auto" />
-                    <!-- Conflicts -->
                     <RowDefinition Height="Auto" />
-                    <!-- Files -->
                     <RowDefinition Height="Auto" />
-                    <!-- Other -->
+                    <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
+                <StackPanel Grid.Row="0"
+                            Margin="{StaticResource Infomaniak.Style.Thickness.Bottom.S}">
+                    <TextBlock FontWeight="SemiBold"
+                               Text="{x:Bind kDrive:Localizer.Instance.GetString1i('labelManyConflictTitle', _errorPageVM.ConflictsCount), Mode=OneWay}" />
 
-                <errors:ErrorList Grid.Row="0"
-                                  Header="{x:Bind kDrive:Localizer.Instance.GetString('labelSyncFolder')}"
-                                  Errors="{x:Bind _errorPageVM.SyncDirErrors, Mode=OneWay}"
-                                  Margin="{StaticResource Infomaniak.Style.Thickness.Bottom.L}"
-                                  Visibility="{x:Bind _errorPageVM.SyncDirErrors.Count, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" />
-
-                <StackPanel Grid.Row="1"
-                            Spacing="{StaticResource Infomaniak.Style.Spacing.XS}"
-                            Margin="{StaticResource Infomaniak.Style.Thickness.Bottom.L}">
-                    <TextBlock Style="{ThemeResource SubtitleTextBlockStyle}"
-                               Text="{x:Bind kDrive:Localizer.Instance.GetString('conflictErrorTitle'), Mode=OneWay}" />
-
-                    <toolKit:SettingsCard Header="{x:Bind kDrive:Localizer.Instance.GetString1i('manyConflictErrorTitle', _errorPageVM.ConflictsCount), Mode=OneWay}"
-                                          Description="{x:Bind kDrive:Localizer.Instance.GetString('manyConflictErrorDescription'), Mode=OneWay}">
-                        <toolKit:SettingsCard.HeaderIcon>
-                            <controls:SvgIcon UriString="{StaticResource Infomaniak.DS.Icons.Documents.file-circle-cross}"
-                                              Height="32"
-                                              Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
-                        </toolKit:SettingsCard.HeaderIcon>
-                        <Button Content="{x:Bind kDrive:Localizer.Instance.GetString('buttonManage'), Mode=OneWay}"
-                                HorizontalAlignment="Left"
-                                Click="ManyConflicts_ActionClick" />
-                    </toolKit:SettingsCard>
+                    <TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                               Text="{x:Bind kDrive:Localizer.Instance.GetString('labelChooseConflictVersion'), Mode=OneWay}" />
                 </StackPanel>
 
-                <errors:ErrorList Grid.Row="2"
-                                  Header="{x:Bind kDrive:Localizer.Instance.GetString('errorListFilesToVerifyHeader')}"
-                                  Errors="{x:Bind _errorPageVM.FileErrors, Mode=OneWay}"
-                                  Margin="{StaticResource Infomaniak.Style.Thickness.Bottom.L}"
-                                  Visibility="{x:Bind _errorPageVM.FileErrors.Count, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" />
+                <Border Grid.Row="1"
+                        Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                        BorderThickness="1"
+                        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                        CornerRadius="{StaticResource Infomaniak.Style.CornerRadius.Uniform.S}"
+                        Padding="{StaticResource Infomaniak.Style.Thickness.Uniform.S}">
+                    <RadioButton x:Name="KeepMostRecentRadioButton"
+                                 GroupName="StrategySelectionRadioButtons"
+                                 Loaded="RadioButton_Loaded"
+                                 MinWidth="0"
+                                 Padding="0"
+                                 IsChecked="True"
+                                 HorizontalAlignment="Stretch">
 
-                <errors:ErrorList Grid.Row="3"
-                                  Header="{x:Bind kDrive:Localizer.Instance.GetString('errorListOthersHeader')}"
-                                  Errors="{x:Bind _errorPageVM.OtherErrors, Mode=OneWay}"
-                                  Margin="{StaticResource Infomaniak.Style.Thickness.Bottom.L}"
-                                  Visibility="{x:Bind _errorPageVM.OtherErrors.Count, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" />
+                        <Grid Grid.Column="1"
+                              Grid.Row="0"
+                              HorizontalAlignment="Left"
+                              Padding="{StaticResource Infomaniak.Style.Thickness.Left.S}">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="auto" />
+                                <RowDefinition Height="auto" />
+                            </Grid.RowDefinitions>
+                            <StackPanel Orientation="Horizontal"
+                                        Grid.Row="0">
+                                <TextBlock Text="{x:Bind kDrive:Localizer.Instance.GetString('labelConflictStrategyKeepMostRecentTitle')}"
+                                           VerticalAlignment="Center" />
+
+                                <Border Margin="{StaticResource Infomaniak.Style.Thickness.Left.XS}"
+                                        CornerRadius="{StaticResource Infomaniak.Style.CornerRadius.Uniform.S}"
+                                        Background="{ThemeResource SystemFillColorSuccessBackgroundBrush}"
+                                        Padding="{StaticResource Infomaniak.Style.Thickness.TextBadge}"
+                                        VerticalAlignment="Center"
+                                        HorizontalAlignment="Left">
+                                    <TextBlock Text="{x:Bind kDrive:Localizer.Instance.GetString('labelRecommended')}"
+                                               FontSize="12"
+                                               Foreground="DarkGreen"
+                                               VerticalAlignment="Center" />
+                                </Border>
+                            </StackPanel>
+                            <TextBlock Grid.Row="1"
+                                       FontSize="12"
+                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                       TextWrapping="WrapWholeWords"
+                                       Text="{x:Bind kDrive:Localizer.Instance.GetString('labelConflictStrategyKeepMostRecentDescription')}" />
+                        </Grid>
+                    </RadioButton>
+                </Border>
+                <Border Grid.Row="2"
+                        Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                        BorderThickness="1"
+                        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                        CornerRadius="{StaticResource Infomaniak.Style.CornerRadius.Uniform.S}"
+                        Padding="{StaticResource Infomaniak.Style.Thickness.Uniform.S}">
+
+                    <RadioButton x:Name="KeepRemoteRadioButton"
+                                 GroupName="StrategySelectionRadioButtons"
+                                 Loaded="RadioButton_Loaded"
+                                 MinWidth="0"
+                                 Padding="0"
+                                 HorizontalAlignment="Stretch">
+                        <Grid Grid.Column="1"
+                              Grid.Row="0"
+                              HorizontalAlignment="Left"
+                              Padding="{StaticResource Infomaniak.Style.Thickness.Left.S}">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="auto" />
+                                <RowDefinition Height="auto" />
+                            </Grid.RowDefinitions>
+
+                            <TextBlock Grid.Row="0"
+                                       Text="{x:Bind kDrive:Localizer.Instance.GetString('labelConflictStrategyKeepRemoteTitle')}"
+                                       VerticalAlignment="Center" />
+
+                            <TextBlock Grid.Row="1"
+                                       FontSize="12"
+                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                       TextWrapping="WrapWholeWords"
+                                       Text="{x:Bind kDrive:Localizer.Instance.GetString1i('labelConflictStrategyKeepRemoteDescription', _errorPageVM.ConflictsCount), Mode=OneWay}" />
+                        </Grid>
+                    </RadioButton>
+                </Border>
+
+                <Border Grid.Row="3"
+                        Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                        BorderThickness="1"
+                        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                        CornerRadius="{StaticResource Infomaniak.Style.CornerRadius.Uniform.S}"
+                        Padding="{StaticResource Infomaniak.Style.Thickness.Uniform.S}">
+
+                    <RadioButton x:Name="KeepLocalRadioButton"
+                                 GroupName="StrategySelectionRadioButtons"
+                                 Loaded="RadioButton_Loaded"
+                                 MinWidth="0"
+                                 Padding="0"
+                                 HorizontalAlignment="Stretch">
+                        <Grid Grid.Column="1"
+                              Grid.Row="0"
+                              Padding="{StaticResource Infomaniak.Style.Thickness.Left.S}">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="auto" />
+                                <RowDefinition Height="auto" />
+                            </Grid.RowDefinitions>
+
+                            <TextBlock Text="{x:Bind kDrive:Localizer.Instance.GetString('labelConflictStrategyKeepLocalTitle')}"
+                                       VerticalAlignment="Center" />
+
+                            <TextBlock Grid.Row="1"
+                                       FontSize="12"
+                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                       TextWrapping="WrapWholeWords"
+                                       Text="{x:Bind kDrive:Localizer.Instance.GetString1i('labelConflictStrategyKeepLocalDescription', _errorPageVM.ConflictsCount), Mode=OneWay}" />
+                        </Grid>
+                    </RadioButton>
+                </Border>
+
+                <StackPanel Grid.Row="4"
+                            Orientation="Horizontal"
+                            Spacing="{StaticResource Infomaniak.Style.Spacing.XS}"
+                            HorizontalAlignment="Right"
+                            Margin="{StaticResource Infomaniak.Style.Thickness.Top.S}">
+
+                    <Button x:Name="ApplyButton"
+                            Content="{x:Bind kDrive:Localizer.Instance.GetString1i('buttonApplyToXFiles', _errorPageVM.ConflictsCount), Mode=OneWay}"
+                            Style="{ThemeResource AccentButtonStyle}"
+                            Click="ApplyButton_Click" />
+
+                    <Button x:Name="ManageIndividuallyButton"
+                            Content="{x:Bind kDrive:Localizer.Instance.GetString('buttonManageIndividually')}" />
+
+                </StackPanel>
             </Grid>
         </ScrollView>
     </Grid>

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Errors/ConflictQuickResolvePage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Errors/ConflictQuickResolvePage.xaml.cs
@@ -101,9 +101,9 @@ namespace Infomaniak.kDrive.Pages.Errors
                 return;
             }
 
-            if (_viewModel is null)
+            if (_errorPageVM is null)
             {
-                Logger.Log(Logger.Level.Error, "ViewModel is null when Apply button clicked. This should never happen, but if it does, we log the error and re-enable the buttons to allow the user to try again or choose to manage conflicts individually.");
+                Logger.Log(Logger.Level.Error, "_errorPageVM is null when Apply button clicked. This should never happen, but if it does, we log the error and re-enable the buttons to allow the user to try again or choose to manage conflicts individually.");
                 Utility.ShowUnexpectedErrorTeachingTip();
                 return;
             }
@@ -115,6 +115,10 @@ namespace Infomaniak.kDrive.Pages.Errors
             {
                 Logger.Log(Logger.Level.Error, "Failed to resolve conflicts quickly. Re-enabling buttons to allow user to try again or manage individually.");
                 Utility.ShowUnexpectedErrorTeachingTip();
+            }
+            else
+            {
+                Frame.Navigate(typeof(ActivityPage));
             }
             ApplyButton.IsEnabled = true;
             ManageIndividuallyButton.IsEnabled = true;

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Errors/ConflictQuickResolvePage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Errors/ConflictQuickResolvePage.xaml.cs
@@ -1,6 +1,9 @@
+using Infomaniak.kDrive.Types;
 using Infomaniak.kDrive.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Navigation;
 using System;
 using static Infomaniak.kDrive.ViewModels.AppModel;
@@ -50,6 +53,71 @@ namespace Infomaniak.kDrive.Pages.Errors
         private void ManyConflicts_ActionClick(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
         {
 
+        }
+
+        private void RadioButton_Loaded(object sender, RoutedEventArgs e)
+        {
+            if (sender is RadioButton radioButton)
+            {
+                var glyphGrid = FindChild<Grid>(radioButton, "OuterEllipse");
+                if (glyphGrid is not null)
+                    glyphGrid.VerticalAlignment = VerticalAlignment.Center;
+            }
+        }
+
+        private static T? FindChild<T>(DependencyObject parent, string childNameInside) where T : FrameworkElement
+        {
+            for (var i = 0; i < VisualTreeHelper.GetChildrenCount(parent); i++)
+            {
+                var child = VisualTreeHelper.GetChild(parent, i);
+                if (child is FrameworkElement fe && fe.Name == childNameInside)
+                    return fe.Parent as T;
+
+                var result = FindChild<T>(child, childNameInside);
+                if (result is not null)
+                    return result;
+            }
+            return null;
+        }
+
+        private async void ApplyButton_Click(object sender, RoutedEventArgs e)
+        {
+            ConflictResolutionStrategy resolutionStrategy;
+            if (KeepMostRecentRadioButton.IsChecked == true)
+            {
+                resolutionStrategy = ConflictResolutionStrategy.KeepMostRecent;
+            }
+            else if (KeepLocalRadioButton.IsChecked == true)
+            {
+                resolutionStrategy = ConflictResolutionStrategy.KeepLocal;
+            }
+            else if (KeepRemoteRadioButton.IsChecked == true)
+            {
+                resolutionStrategy = ConflictResolutionStrategy.KeepRemote;
+            }
+            else
+            {
+                Logger.Log(Logger.Level.Warning, "Apply button clicked without a resolution strategy selected. No action will be taken.");
+                return;
+            }
+
+            if (_viewModel is null)
+            {
+                Logger.Log(Logger.Level.Error, "ViewModel is null when Apply button clicked. This should never happen, but if it does, we log the error and re-enable the buttons to allow the user to try again or choose to manage conflicts individually.");
+                Utility.ShowUnexpectedErrorTeachingTip();
+                return;
+            }
+
+            ApplyButton.IsEnabled = false;
+            ManageIndividuallyButton.IsEnabled = false;
+
+            if (!await _errorPageVM.SolveConflictsQuick(resolutionStrategy))
+            {
+                Logger.Log(Logger.Level.Error, "Failed to resolve conflicts quickly. Re-enabling buttons to allow user to try again or manage individually.");
+                Utility.ShowUnexpectedErrorTeachingTip();
+            }
+            ApplyButton.IsEnabled = true;
+            ManageIndividuallyButton.IsEnabled = true;
         }
     }
 }

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Errors/ConflictQuickResolvePage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Errors/ConflictQuickResolvePage.xaml.cs
@@ -7,16 +7,16 @@ using static Infomaniak.kDrive.ViewModels.AppModel;
 
 namespace Infomaniak.kDrive.Pages.Errors
 {
-    public sealed partial class ErrorPage : Page
+    public sealed partial class ConflictQuickResolvePage : Page
     {
-        private readonly AppModel _viewModel = App.ServiceProvider.GetRequiredService<AppModel>();
+        private AppModel _viewModel = App.ServiceProvider.GetRequiredService<AppModel>();
         public AppModel ViewModel { get { return _viewModel; } }
         private ErrorPageVM? _errorPageVM;
-        public ErrorPage()
+        public ConflictQuickResolvePage()
         {
-            Logger.Log(Logger.Level.Info, "Navigated to ErrorPage - Initializing ErrorPage components");
+            Logger.Log(Logger.Level.Info, "Navigated to ConflictQuickResolvePage - Initializing components");
             InitializeComponent();
-            Logger.Log(Logger.Level.Debug, "ErrorPage components initialized");
+            Logger.Log(Logger.Level.Debug, "ConflictQuickResolvePage components initialized");
         }
 
         protected override async void OnNavigatedTo(NavigationEventArgs e)
@@ -49,7 +49,7 @@ namespace Infomaniak.kDrive.Pages.Errors
 
         private void ManyConflicts_ActionClick(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
         {
-            Frame.Navigate(typeof(ConflictQuickResolvePage));
+
         }
     }
 }

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Errors/ErrorPageVM.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Errors/ErrorPageVM.cs
@@ -3,15 +3,18 @@ using DynamicData.Binding;
 using Infomaniak.kDrive.CustomControls.Errors;
 using Infomaniak.kDrive.Types;
 using Infomaniak.kDrive.ViewModels;
+using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using static Infomaniak.kDrive.ViewModels.AppModel;
 
 namespace Infomaniak.kDrive.Pages.Errors
 {
     partial class ErrorPageVM : UISafeObservableObject, IDisposable
     {
+        private AppModel _viewModel = App.ServiceProvider.GetRequiredService<AppModel>();
 
         private Sync? _sync;
         private const int _maxConflictsForIndividualDisplay = 5;
@@ -19,9 +22,10 @@ namespace Infomaniak.kDrive.Pages.Errors
         private int _conflictsCount;
         private readonly List<IDisposable?> _errorsSubscription = new();
 
-        public ReadOnlyObservableCollection<Error> FileErrors { get; private set; }
-        public ReadOnlyObservableCollection<Error> SyncDirErrors { get; private set; }
-        public ReadOnlyObservableCollection<Error> OtherErrors { get; private set; }
+        public ReadOnlyObservableCollection<Error> FileErrors { get; private set; } = new ReadOnlyObservableCollection<Error>(new ObservableCollection<Error>());
+        public ReadOnlyObservableCollection<Error> SyncDirErrors { get; private set; } = new ReadOnlyObservableCollection<Error>(new ObservableCollection<Error>());
+        public ReadOnlyObservableCollection<Error> OtherErrors { get; private set; } = new ReadOnlyObservableCollection<Error>(new ObservableCollection<Error>());
+
         public Sync? Sync
         {
             get => _sync;
@@ -46,6 +50,14 @@ namespace Infomaniak.kDrive.Pages.Errors
 
         public ErrorPageVM()
         {
+            _viewModel.SelectedSyncChanged += OnSelectedSyncChanged;
+            Sync = _viewModel.SelectedSync;
+            InitErrorLists();
+        }
+
+        private void OnSelectedSyncChanged(object? sender, SelectedSyncChangedEventArgs e)
+        {
+            Sync = e.NewValue;
             InitErrorLists();
         }
 
@@ -59,9 +71,15 @@ namespace Infomaniak.kDrive.Pages.Errors
 
             if (Sync is null)
             {
-                FileErrors = new ReadOnlyObservableCollection<Error>([]);
-                SyncDirErrors = new ReadOnlyObservableCollection<Error>([]);
-                OtherErrors = new ReadOnlyObservableCollection<Error>([]);
+                OnPropertyChangingInUIThread(nameof(FileErrors));
+                OnPropertyChangingInUIThread(nameof(SyncDirErrors));
+                OnPropertyChangingInUIThread(nameof(OtherErrors));
+                FileErrors = new ReadOnlyObservableCollection<Error>(new ObservableCollection<Error>());
+                SyncDirErrors = new ReadOnlyObservableCollection<Error>(new ObservableCollection<Error>());
+                OtherErrors = new ReadOnlyObservableCollection<Error>(new ObservableCollection<Error>());
+                OnPropertyChangedInUIThread(nameof(FileErrors));
+                OnPropertyChangedInUIThread(nameof(SyncDirErrors));
+                OnPropertyChangedInUIThread(nameof(OtherErrors));
                 return;
             }
             ConflictsCount = Sync.SyncErrors.Where(e => IsConflictUserResolvable(e)).Count();
@@ -143,6 +161,7 @@ namespace Infomaniak.kDrive.Pages.Errors
             {
                 subscription?.Dispose();
             }
+            _viewModel.SelectedSyncChanged -= OnSelectedSyncChanged;
         }
     }
 }

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Errors/ErrorPageVM.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Errors/ErrorPageVM.cs
@@ -1,6 +1,7 @@
 ﻿using DynamicData;
 using DynamicData.Binding;
 using Infomaniak.kDrive.CustomControls.Errors;
+using Infomaniak.kDrive.ServerCommunication.Interfaces;
 using Infomaniak.kDrive.Types;
 using Infomaniak.kDrive.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
@@ -8,6 +9,8 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using static Infomaniak.kDrive.ViewModels.AppModel;
 
 namespace Infomaniak.kDrive.Pages.Errors
@@ -53,6 +56,25 @@ namespace Infomaniak.kDrive.Pages.Errors
             _viewModel.SelectedSyncChanged += OnSelectedSyncChanged;
             Sync = _viewModel.SelectedSync;
             InitErrorLists();
+        }
+
+        public async Task<bool> SolveConflictsQuick(ConflictResolutionStrategy resolutionStrategy)
+        {
+            if (Sync is null)
+            {
+                Logger.Log(Logger.Level.Warning, "Attempted to resolve conflicts quickly, but no sync is currently selected.");
+            }
+
+            List<DbId> conflictsToResolve = Sync?.SyncErrors.Where(e => IsConflictUserResolvable(e)).Select(e => e.DbId).ToList() ?? new List<DbId>();
+
+            if (conflictsToResolve.Count == 0)
+            {
+                Logger.Log(Logger.Level.Info, "No user-resolvable conflicts found to resolve.");
+                return true;
+            }
+
+            var commService = App.ServiceProvider.GetRequiredService<IServerCommService>();
+            return await commService.ResolveConflictsQuick(conflictsToResolve, resolutionStrategy, CancellationToken.None);
         }
 
         private void OnSelectedSyncChanged(object? sender, SelectedSyncChangedEventArgs e)

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Errors/ErrorPageVM.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Errors/ErrorPageVM.cs
@@ -6,31 +6,42 @@ using Infomaniak.kDrive.ViewModels;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace Infomaniak.kDrive.Pages.Errors
 {
     partial class ErrorPageVM : UISafeObservableObject, IDisposable
     {
-        private Sync _syncVM;
-        private readonly List<IDisposable?> _errorsSubscription = [];
 
-        public Sync SyncVM
-        {
-            get => _syncVM;
-            set => SetPropertyInUIThread(ref _syncVM, value);
-        }
+        private Sync? _sync;
+        private const int _maxConflictsForIndividualDisplay = 5;
+        private bool _hasManyConflicts;
+        private int _conflictsCount;
+        private readonly List<IDisposable?> _errorsSubscription = new();
 
         public ReadOnlyObservableCollection<Error> FileErrors { get; private set; }
         public ReadOnlyObservableCollection<Error> SyncDirErrors { get; private set; }
         public ReadOnlyObservableCollection<Error> OtherErrors { get; private set; }
         public Sync? Sync
         {
-            get => _syncVM;
+            get => _sync;
             set
             {
-                SetPropertyInUIThread(ref _syncVM, value);
+                SetPropertyInUIThread(ref _sync, value);
                 InitErrorLists();
             }
+        }
+
+        public bool HasManyConflicts
+        {
+            get => _hasManyConflicts;
+            private set => SetPropertyInUIThread(ref _hasManyConflicts, value);
+        }
+
+        public int ConflictsCount
+        {
+            get => _conflictsCount;
+            private set => SetPropertyInUIThread(ref _conflictsCount, value);
         }
 
         public ErrorPageVM()
@@ -53,8 +64,10 @@ namespace Infomaniak.kDrive.Pages.Errors
                 OtherErrors = new ReadOnlyObservableCollection<Error>([]);
                 return;
             }
+            ConflictsCount = Sync.SyncErrors.Where(e => IsConflictUserResolvable(e)).Count();
+            HasManyConflicts = ConflictsCount > _maxConflictsForIndividualDisplay;
 
-            _errorsSubscription.Add(_syncVM.SyncErrors
+            _errorsSubscription.Add(Sync.SyncErrors
                 .ToObservableChangeSet()
                 .Filter(e => IsInFileErrorsList(e))
                 .Sort(SortExpressionComparer<Error>.Ascending(e => e.DbId))
@@ -64,7 +77,7 @@ namespace Infomaniak.kDrive.Pages.Errors
             FileErrors = fileErrors;
             OnPropertyChangedInUIThread(nameof(FileErrors));
 
-            _errorsSubscription.Add(_syncVM.SyncErrors
+            _errorsSubscription.Add(Sync.SyncErrors
                 .ToObservableChangeSet()
                 .Filter(e => IsInSyncDirErrorList(e))
                 .Sort(SortExpressionComparer<Error>.Ascending(e => e.DbId))
@@ -74,7 +87,7 @@ namespace Infomaniak.kDrive.Pages.Errors
             SyncDirErrors = syncDirErrors;
             OnPropertyChangedInUIThread(nameof(SyncDirErrors));
 
-            _errorsSubscription.Add(_syncVM.SyncErrors
+            _errorsSubscription.Add(Sync.SyncErrors
                 .ToObservableChangeSet()
                 .Filter(e => IsInOtherErrorList(e))
                 .Sort(SortExpressionComparer<Error>.Ascending(e => e.DbId))
@@ -85,9 +98,20 @@ namespace Infomaniak.kDrive.Pages.Errors
             OnPropertyChangedInUIThread(nameof(OtherErrors));
         }
 
-        private static bool IsInFileErrorsList(Error error)
+        private bool IsInFileErrorsList(Error error)
         {
-            return error.ErrorLevel == ErrorLevel.Node;
+            if (error.ErrorLevel != ErrorLevel.Node)
+                return false;
+
+            if (HasManyConflicts && IsConflictUserResolvable(error))
+                return false;
+
+            return true;
+        }
+
+        private static bool IsConflictUserResolvable(Error error)
+        {
+            return error.ErrorLevel == ErrorLevel.Node && (error.ConflictType == ConflictType.CreateCreate || error.ConflictType == ConflictType.EditEdit);
         }
 
         private static bool IsInSyncDirErrorList(Error error)
@@ -108,9 +132,9 @@ namespace Infomaniak.kDrive.Pages.Errors
             return syncDirErrorTypes.Contains(errorType);
         }
 
-        private static bool IsInOtherErrorList(Error error)
+        private bool IsInOtherErrorList(Error error)
         {
-            return !IsInFileErrorsList(error) && !IsInSyncDirErrorList(error);
+            return !IsInFileErrorsList(error) && !IsInSyncDirErrorList(error) && !IsConflictUserResolvable(error);
         }
 
         public void Dispose()

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/SettingsPage.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/SettingsPage.xaml
@@ -286,7 +286,7 @@
                                         </DataTemplate>
                                     </toolKit:SettingsExpander.ItemTemplate>
                                     <toolKit:SettingsExpander.ItemsFooter>
-                                        <toolKit:SettingsCard Header="{x:Bind kDrive:Localizer.Instance.GetString('disconnectAccount'), Mode=OneWay}"
+                                        <toolKit:SettingsCard Header="{x:Bind kDrive:Localizer.Instance.GetString('buttonDisconnectAccount'), Mode=OneWay}"
                                                               Style="{StaticResource DefaultSettingsExpanderItemStyle}"
                                                               IsClickEnabled="True"
                                                               Click="DisconectUser_Click" />

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -1591,7 +1591,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 if (newItem.Status != SyncFileStatus.Syncing || newItem.Size < MinFileSizeForTopSticking)
                 {
                     // Insert item after all syncing items
-                    activities.Insert(Math.Clamp((destIndex == 0) ? 0 : destIndex + 1, 0, activities.Count), newItem);
+                    activities.Insert(Math.Clamp(destIndex + 1, 0, activities.Count), newItem);
                 }
                 else
                 {

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -1591,7 +1591,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 if (newItem.Status != SyncFileStatus.Syncing || newItem.Size < MinFileSizeForTopSticking)
                 {
                     // Insert item after all syncing items
-                    activities.Insert(Math.Clamp(destIndex + 1, 0, activities.Count), newItem);
+                    activities.Insert(Math.Clamp((destIndex == 0) ? 0 : destIndex + 1, 0, activities.Count), newItem);
                 }
                 else
                 {

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/de-DE/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/de-DE/Resources.resw
@@ -6,7 +6,7 @@
   Locale: de, German
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Wed, 04 Mar 2026 12:59:04 +0100 
+  Exported at: Fri, 06 Mar 2026 11:35:46 +0100 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -182,11 +182,11 @@ Sie können sie jederzeit öffnen, auch ohne Internetzugang.</value>
   <data name="buttonConfigure" xml:space="preserve"> 
     <value>Konfigurieren Sie</value> 
   </data> 
-  <data name="buttonConfigureMainSync" xml:space="preserve"> 
-    <value>Aktivieren Sie</value> 
-  </data> 
   <data name="buttonConfirm" xml:space="preserve"> 
     <value>Bestätigen Sie</value> 
+  </data> 
+  <data name="buttonConnectAccount" xml:space="preserve"> 
+    <value>Ein Konto verbinden</value> 
   </data> 
   <data name="buttonCopyShareLink" xml:space="preserve"> 
     <value>Link zur Freigabe kopieren</value> 
@@ -199,6 +199,12 @@ Sie können sie jederzeit öffnen, auch ohne Internetzugang.</value>
   </data> 
   <data name="buttonDefaultLocation" xml:space="preserve"> 
     <value>Standard-Speicherort</value> 
+  </data> 
+  <data name="buttonDisconnectAccount" xml:space="preserve"> 
+    <value>Trennen Sie dieses Konto</value> 
+  </data> 
+  <data name="buttonEnable" xml:space="preserve"> 
+    <value>Aktivieren Sie</value> 
   </data> 
   <data name="buttonErrorResolutionTip" xml:space="preserve"> 
     <value>Das Problem verstehen</value> 
@@ -214,6 +220,12 @@ Sie können sie jederzeit öffnen, auch ohne Internetzugang.</value>
   </data> 
   <data name="buttonKDriveOnline" xml:space="preserve"> 
     <value>kDrive Online</value> 
+  </data> 
+  <data name="buttonKeepAccount" xml:space="preserve"> 
+    <value>Behalten Sie das Konto</value> 
+  </data> 
+  <data name="buttonLogOut" xml:space="preserve"> 
+    <value>Abmelden</value> 
   </data> 
   <data name="buttonLogin" xml:space="preserve"> 
     <value>Sich anmelden</value> 
@@ -340,9 +352,6 @@ Sie können sie jederzeit öffnen, auch ohne Internetzugang.</value>
   <data name="conflictErrorTitle" xml:space="preserve"> 
     <value>Versionskonflikte</value> 
   </data> 
-  <data name="connectAccount" xml:space="preserve"> 
-    <value>Ein Konto verbinden</value> 
-  </data> 
   <data name="creatingShareLink" xml:space="preserve"> 
     <value>Freigabelink erstellen…</value> 
   </data> 
@@ -410,17 +419,12 @@ Dieser Ordner darf nicht in einem anderen Synchronisationsordner enthalten sein 
   <data name="dialogNewExclusionRuleTitle" xml:space="preserve"> 
     <value>Eine Ausschlussregel hinzufügen</value> 
   </data> 
-  <data name="dialogRemoveAccountContent" xml:space="preserve"> 
-    <value>Sie sind dabei, sich von der App abzumelden {0}.
-Dateien, die von allen kDrives dieses Kontos synchronisiert wurden, werden von Ihrem Computer entfernt.
+  <data name="dialogRemoveAccountContentWindows" xml:space="preserve"> 
+    <value>Sie werden {0} von der Anwendung abmelden.
+
+Der Synchronisationsordner bleibt auf Ihrem Computer, wird aber nicht mehr mit kDrive synchronisiert.
 
 Alle Ihre Daten bleiben online auf kDrive zugänglich.</value> 
-  </data> 
-  <data name="dialogRemoveAccountPrimaryButton" xml:space="preserve"> 
-    <value>Behalten Sie das Konto</value> 
-  </data> 
-  <data name="dialogRemoveAccountSecondaryButton" xml:space="preserve"> 
-    <value>Abmelden</value> 
   </data> 
   <data name="dialogRemoveAccountTitle" xml:space="preserve"> 
     <value>Von diesem Konto abmelden?</value> 
@@ -473,9 +477,6 @@ Schliessen Sie die Anwendung während des Vorgangs nicht.</value>
   </data> 
   <data name="disableNotificationsSetting" xml:space="preserve"> 
     <value>Benachrichtigungen deaktivieren</value> 
-  </data> 
-  <data name="disconnectAccount" xml:space="preserve"> 
-    <value>Trennen Sie dieses Konto</value> 
   </data> 
   <data name="doNotJoin" xml:space="preserve"> 
     <value>Nicht beitreten</value> 
@@ -985,6 +986,12 @@ Bitte überprüfen Sie alle Dateien mit ungewöhnlichen Zeichen, benennen Sie si
   </data> 
   <data name="logsUploadErrorTooltip" xml:space="preserve"> 
     <value>Die letzte Übertragung ist fehlgeschlagen. Bitte überprüfen Sie Ihre Internetverbindung und stellen Sie sicher, dass mindestens ein kDrive-Benutzer eingeloggt ist. Die Anzahl der Übertragungen ist auf 10 pro Tag begrenzt.</value> 
+  </data> 
+  <data name="manyConflictErrorDescription" xml:space="preserve"> 
+    <value>Des versions différentes de ces fichiers ont été détectées.</value> 
+  </data> 
+  <data name="manyConflictErrorTitle" xml:space="preserve"> 
+    <value>%@ Versionskonflikte entdeckt</value> 
   </data> 
   <data name="matomoDescription" xml:space="preserve"> 
     <value>Matomo ist ein Analysetool, das ausschliesslich von Infomaniak gehostet und verwaltet wird, um zu verstehen, wie die Anwendung genutzt wird.</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/de-DE/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/de-DE/Resources.resw
@@ -6,7 +6,7 @@
   Locale: de, German
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Fri, 06 Mar 2026 11:35:46 +0100 
+  Exported at: Fri, 06 Mar 2026 14:25:39 +0100 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -170,6 +170,9 @@ Sie können sie jederzeit öffnen, auch ohne Internetzugang.</value>
   <data name="buttonAdvancedParameters" xml:space="preserve"> 
     <value>Erweiterte Einstellungen</value> 
   </data> 
+  <data name="buttonApplyToXFiles" xml:space="preserve"> 
+    <value>Anwenden auf %@ Dateien</value> 
+  </data> 
   <data name="buttonCancel" xml:space="preserve"> 
     <value>Abbrechen</value> 
   </data> 
@@ -235,6 +238,9 @@ Sie können sie jederzeit öffnen, auch ohne Internetzugang.</value>
   </data> 
   <data name="buttonManageDiskSpace" xml:space="preserve"> 
     <value>Speicherplatz verwalten</value> 
+  </data> 
+  <data name="buttonManageIndividually" xml:space="preserve"> 
+    <value>Dateien einzeln behandeln</value> 
   </data> 
   <data name="buttonOpenDebugFolder" xml:space="preserve"> 
     <value>Debug-Ordner öffnen</value> 
@@ -770,11 +776,32 @@ Bitte stellen Sie den Ordner wieder her, vergewissern Sie sich, dass Sie die not
   <data name="labelBytes" xml:space="preserve"> 
     <value>b</value> 
   </data> 
+  <data name="labelChooseConflictVersion" xml:space="preserve"> 
+    <value>Wählen Sie die Version Ihrer Dateien, die Sie behalten möchten.</value> 
+  </data> 
   <data name="labelConflictDialogQuestion" xml:space="preserve"> 
     <value>Welche Version möchten Sie behalten?</value> 
   </data> 
   <data name="labelConflictDialogTitle" xml:space="preserve"> 
     <value>Wählen Sie die Version, die Sie behalten möchten</value> 
+  </data> 
+  <data name="labelConflictStrategyKeepLocalDescription" xml:space="preserve"> 
+    <value /> 
+  </data> 
+  <data name="labelConflictStrategyKeepLocalTitle" xml:space="preserve"> 
+    <value /> 
+  </data> 
+  <data name="labelConflictStrategyKeepMostRecentDescription" xml:space="preserve"> 
+    <value>Bei jedem Konflikt behalten wir automatisch die Version (lokal oder online) bei, die zuletzt geändert wurde. Dies ist in den meisten Fällen die sicherste Wahl.</value> 
+  </data> 
+  <data name="labelConflictStrategyKeepMostRecentTitle" xml:space="preserve"> 
+    <value>Behalten Sie die neuesten Versionen</value> 
+  </data> 
+  <data name="labelConflictStrategyKeepRemoteDescription" xml:space="preserve"> 
+    <value /> 
+  </data> 
+  <data name="labelConflictStrategyKeepRemoteTitle" xml:space="preserve"> 
+    <value /> 
   </data> 
   <data name="labelCreateNewSync" xml:space="preserve"> 
     <value>Erstellen Sie eine %@.</value> 
@@ -825,6 +852,9 @@ Bitte stellen Sie den Ordner wieder her, vergewissern Sie sich, dass Sie die not
   <data name="labelLocal" xml:space="preserve"> 
     <value>Lokal</value> 
   </data> 
+  <data name="labelManyConflictTitle" xml:space="preserve"> 
+    <value>256 fichiers ont été modifiés à la fois sur votre ordinateur et sur kDrive. </value> 
+  </data> 
   <data name="labelMegaBytes" xml:space="preserve"> 
     <value>Mb</value> 
   </data> 
@@ -852,6 +882,9 @@ Bitte stellen Sie den Ordner wieder her, vergewissern Sie sich, dass Sie die not
   </data> 
   <data name="labelOriginalLocation" xml:space="preserve"> 
     <value>Ursprünglicher Standort :</value> 
+  </data> 
+  <data name="labelRecommended" xml:space="preserve"> 
+    <value>Recommandé</value> 
   </data> 
   <data name="labelRestoreToOriginalLocation" xml:space="preserve"> 
     <value>Legen Sie es wieder an seinen ursprünglichen Platz zurück.</value> 
@@ -988,7 +1021,7 @@ Bitte überprüfen Sie alle Dateien mit ungewöhnlichen Zeichen, benennen Sie si
     <value>Die letzte Übertragung ist fehlgeschlagen. Bitte überprüfen Sie Ihre Internetverbindung und stellen Sie sicher, dass mindestens ein kDrive-Benutzer eingeloggt ist. Die Anzahl der Übertragungen ist auf 10 pro Tag begrenzt.</value> 
   </data> 
   <data name="manyConflictErrorDescription" xml:space="preserve"> 
-    <value>Des versions différentes de ces fichiers ont été détectées.</value> 
+    <value>Es wurden unterschiedliche Versionen dieser Dateien entdeckt.</value> 
   </data> 
   <data name="manyConflictErrorTitle" xml:space="preserve"> 
     <value>%@ Versionskonflikte entdeckt</value> 
@@ -1027,7 +1060,7 @@ Wenn das Problem weiterhin besteht, kontaktieren Sie unser Support-Team.</value>
     <value>Sie haben kein angemeldetes Konto</value> 
   </data> 
   <data name="noResultsFound" xml:space="preserve"> 
-    <value>Keine Ergebnisse gefunden"</value> 
+    <value>Keine Ergebnisse gefunden</value> 
   </data> 
   <data name="notEnoughDiskSpaceErrorTitle" xml:space="preserve"> 
     <value>Nicht genügend Speicherplatz</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/en-US/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/en-US/Resources.resw
@@ -6,7 +6,7 @@
   Locale: en, English
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Wed, 04 Mar 2026 12:59:04 +0100 
+  Exported at: Fri, 06 Mar 2026 11:35:46 +0100 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -182,11 +182,11 @@ You can open them at any time, even without Internet access.</value>
   <data name="buttonConfigure" xml:space="preserve"> 
     <value>Configure</value> 
   </data> 
-  <data name="buttonConfigureMainSync" xml:space="preserve"> 
-    <value>Enable</value> 
-  </data> 
   <data name="buttonConfirm" xml:space="preserve"> 
     <value>Confirm</value> 
+  </data> 
+  <data name="buttonConnectAccount" xml:space="preserve"> 
+    <value>Connect an account</value> 
   </data> 
   <data name="buttonCopyShareLink" xml:space="preserve"> 
     <value>Copy share link</value> 
@@ -199,6 +199,12 @@ You can open them at any time, even without Internet access.</value>
   </data> 
   <data name="buttonDefaultLocation" xml:space="preserve"> 
     <value>Default location</value> 
+  </data> 
+  <data name="buttonDisconnectAccount" xml:space="preserve"> 
+    <value>Disconnect this account</value> 
+  </data> 
+  <data name="buttonEnable" xml:space="preserve"> 
+    <value>Enable</value> 
   </data> 
   <data name="buttonErrorResolutionTip" xml:space="preserve"> 
     <value>Understanding the problem</value> 
@@ -214,6 +220,12 @@ You can open them at any time, even without Internet access.</value>
   </data> 
   <data name="buttonKDriveOnline" xml:space="preserve"> 
     <value>kDrive Online</value> 
+  </data> 
+  <data name="buttonKeepAccount" xml:space="preserve"> 
+    <value>Keep the account</value> 
+  </data> 
+  <data name="buttonLogOut" xml:space="preserve"> 
+    <value>Sign out</value> 
   </data> 
   <data name="buttonLogin" xml:space="preserve"> 
     <value>Login</value> 
@@ -340,9 +352,6 @@ You can open them at any time, even without Internet access.</value>
   <data name="conflictErrorTitle" xml:space="preserve"> 
     <value>Conflicting versions</value> 
   </data> 
-  <data name="connectAccount" xml:space="preserve"> 
-    <value>Connect an account</value> 
-  </data> 
   <data name="creatingShareLink" xml:space="preserve"> 
     <value>Creating share link…</value> 
   </data> 
@@ -410,17 +419,12 @@ This folder must not be included in any other synchronization folder and must no
   <data name="dialogNewExclusionRuleTitle" xml:space="preserve"> 
     <value>Add an exclusion rule</value> 
   </data> 
-  <data name="dialogRemoveAccountContent" xml:space="preserve"> 
-    <value>You are about to sign out {0} from the app.
-Files synced from all kDrives on this account will be removed from your computer.
+  <data name="dialogRemoveAccountContentWindows" xml:space="preserve"> 
+    <value>You will disconnect %@ from the application.
+
+The synchronization folder will remain on your computer, but will no longer be synchronized with kDrive.
 
 All your data will remain accessible online on kDrive.</value> 
-  </data> 
-  <data name="dialogRemoveAccountPrimaryButton" xml:space="preserve"> 
-    <value>Keep the account</value> 
-  </data> 
-  <data name="dialogRemoveAccountSecondaryButton" xml:space="preserve"> 
-    <value>Sign out</value> 
   </data> 
   <data name="dialogRemoveAccountTitle" xml:space="preserve"> 
     <value>Sign out of this account?</value> 
@@ -473,9 +477,6 @@ Do not close the application during the process.</value>
   </data> 
   <data name="disableNotificationsSetting" xml:space="preserve"> 
     <value>Disable notifications</value> 
-  </data> 
-  <data name="disconnectAccount" xml:space="preserve"> 
-    <value>Disconnect this account</value> 
   </data> 
   <data name="doNotJoin" xml:space="preserve"> 
     <value>Do not join</value> 
@@ -985,6 +986,12 @@ Please check and rename any files with unusual characters, then try again.</valu
   </data> 
   <data name="logsUploadErrorTooltip" xml:space="preserve"> 
     <value>The last transfer failed. Please check your Internet connection and make sure at least one kDrive user is logged in. Transfers are limited to 10 per day.</value> 
+  </data> 
+  <data name="manyConflictErrorDescription" xml:space="preserve"> 
+    <value>Des versions différentes de ces fichiers ont été détectées.</value> 
+  </data> 
+  <data name="manyConflictErrorTitle" xml:space="preserve"> 
+    <value>%@ version conflicts detected</value> 
   </data> 
   <data name="matomoDescription" xml:space="preserve"> 
     <value>Matomo is an analytics tool hosted and managed exclusively by Infomaniak to understand how the application is used.</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/en-US/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/en-US/Resources.resw
@@ -6,7 +6,7 @@
   Locale: en, English
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Fri, 06 Mar 2026 11:35:46 +0100 
+  Exported at: Fri, 06 Mar 2026 14:25:39 +0100 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -170,6 +170,9 @@ You can open them at any time, even without Internet access.</value>
   <data name="buttonAdvancedParameters" xml:space="preserve"> 
     <value>Advanced settings</value> 
   </data> 
+  <data name="buttonApplyToXFiles" xml:space="preserve"> 
+    <value>Apply to %@ files</value> 
+  </data> 
   <data name="buttonCancel" xml:space="preserve"> 
     <value>Cancel</value> 
   </data> 
@@ -235,6 +238,9 @@ You can open them at any time, even without Internet access.</value>
   </data> 
   <data name="buttonManageDiskSpace" xml:space="preserve"> 
     <value>Manage disk space</value> 
+  </data> 
+  <data name="buttonManageIndividually" xml:space="preserve"> 
+    <value>Process files individually</value> 
   </data> 
   <data name="buttonOpenDebugFolder" xml:space="preserve"> 
     <value>Open debug folder</value> 
@@ -770,11 +776,32 @@ Please restore the folder, make sure you have the necessary access rights, or de
   <data name="labelBytes" xml:space="preserve"> 
     <value>b</value> 
   </data> 
+  <data name="labelChooseConflictVersion" xml:space="preserve"> 
+    <value>Choose the version of your files you wish to keep.</value> 
+  </data> 
   <data name="labelConflictDialogQuestion" xml:space="preserve"> 
     <value>Which version do you want to keep?</value> 
   </data> 
   <data name="labelConflictDialogTitle" xml:space="preserve"> 
     <value>Choose the version to keep</value> 
+  </data> 
+  <data name="labelConflictStrategyKeepLocalDescription" xml:space="preserve"> 
+    <value /> 
+  </data> 
+  <data name="labelConflictStrategyKeepLocalTitle" xml:space="preserve"> 
+    <value /> 
+  </data> 
+  <data name="labelConflictStrategyKeepMostRecentDescription" xml:space="preserve"> 
+    <value>For each conflict, we automatically keep the most recently modified version (local or online). This is the safest choice in most cases.</value> 
+  </data> 
+  <data name="labelConflictStrategyKeepMostRecentTitle" xml:space="preserve"> 
+    <value>Keep the most recent versions</value> 
+  </data> 
+  <data name="labelConflictStrategyKeepRemoteDescription" xml:space="preserve"> 
+    <value /> 
+  </data> 
+  <data name="labelConflictStrategyKeepRemoteTitle" xml:space="preserve"> 
+    <value /> 
   </data> 
   <data name="labelCreateNewSync" xml:space="preserve"> 
     <value>Create a %@.</value> 
@@ -825,6 +852,9 @@ Please restore the folder, make sure you have the necessary access rights, or de
   <data name="labelLocal" xml:space="preserve"> 
     <value>Local</value> 
   </data> 
+  <data name="labelManyConflictTitle" xml:space="preserve"> 
+    <value>256 fichiers ont été modifiés à la fois sur votre ordinateur et sur kDrive. </value> 
+  </data> 
   <data name="labelMegaBytes" xml:space="preserve"> 
     <value>Mb</value> 
   </data> 
@@ -852,6 +882,9 @@ Please restore the folder, make sure you have the necessary access rights, or de
   </data> 
   <data name="labelOriginalLocation" xml:space="preserve"> 
     <value>Original location :</value> 
+  </data> 
+  <data name="labelRecommended" xml:space="preserve"> 
+    <value>Recommandé</value> 
   </data> 
   <data name="labelRestoreToOriginalLocation" xml:space="preserve"> 
     <value>Return it to its original position.</value> 
@@ -988,7 +1021,7 @@ Please check and rename any files with unusual characters, then try again.</valu
     <value>The last transfer failed. Please check your Internet connection and make sure at least one kDrive user is logged in. Transfers are limited to 10 per day.</value> 
   </data> 
   <data name="manyConflictErrorDescription" xml:space="preserve"> 
-    <value>Des versions différentes de ces fichiers ont été détectées.</value> 
+    <value>Different versions of these files have been detected.</value> 
   </data> 
   <data name="manyConflictErrorTitle" xml:space="preserve"> 
     <value>%@ version conflicts detected</value> 
@@ -1027,7 +1060,7 @@ If the problem continues, contact our support team.</value>
     <value>You are not logged in</value> 
   </data> 
   <data name="noResultsFound" xml:space="preserve"> 
-    <value>No results found”</value> 
+    <value>No results found</value> 
   </data> 
   <data name="notEnoughDiskSpaceErrorTitle" xml:space="preserve"> 
     <value>Not enough disk space</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/es-ES/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/es-ES/Resources.resw
@@ -6,7 +6,7 @@
   Locale: es, Spanish
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Fri, 06 Mar 2026 11:35:46 +0100 
+  Exported at: Fri, 06 Mar 2026 14:25:39 +0100 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -170,6 +170,9 @@ Podrás abrirlos en cualquier momento, incluso sin acceso a Internet.</value>
   <data name="buttonAdvancedParameters" xml:space="preserve"> 
     <value>Configuración avanzada</value> 
   </data> 
+  <data name="buttonApplyToXFiles" xml:space="preserve"> 
+    <value>Aplicar a archivos %@</value> 
+  </data> 
   <data name="buttonCancel" xml:space="preserve"> 
     <value>Cancelar</value> 
   </data> 
@@ -235,6 +238,9 @@ Podrás abrirlos en cualquier momento, incluso sin acceso a Internet.</value>
   </data> 
   <data name="buttonManageDiskSpace" xml:space="preserve"> 
     <value>Gestionar el espacio en disco</value> 
+  </data> 
+  <data name="buttonManageIndividually" xml:space="preserve"> 
+    <value>Tratar los archivos individualmente</value> 
   </data> 
   <data name="buttonOpenDebugFolder" xml:space="preserve"> 
     <value>Abrir carpeta de depuración</value> 
@@ -770,11 +776,32 @@ Por favor, restaure la carpeta, asegúrese de que tiene los derechos de acceso n
   <data name="labelBytes" xml:space="preserve"> 
     <value>b</value> 
   </data> 
+  <data name="labelChooseConflictVersion" xml:space="preserve"> 
+    <value>Elige la versión de tus archivos que quieres conservar.</value> 
+  </data> 
   <data name="labelConflictDialogQuestion" xml:space="preserve"> 
     <value>¿Qué versión desea conservar?</value> 
   </data> 
   <data name="labelConflictDialogTitle" xml:space="preserve"> 
     <value>Elija la versión que desea conservar</value> 
+  </data> 
+  <data name="labelConflictStrategyKeepLocalDescription" xml:space="preserve"> 
+    <value /> 
+  </data> 
+  <data name="labelConflictStrategyKeepLocalTitle" xml:space="preserve"> 
+    <value /> 
+  </data> 
+  <data name="labelConflictStrategyKeepMostRecentDescription" xml:space="preserve"> 
+    <value>Para cada conflicto, guardaremos automáticamente la versión modificada más recientemente (local u online). Esta es la opción más segura en la mayoría de los casos.</value> 
+  </data> 
+  <data name="labelConflictStrategyKeepMostRecentTitle" xml:space="preserve"> 
+    <value>Conserve las versiones más recientes</value> 
+  </data> 
+  <data name="labelConflictStrategyKeepRemoteDescription" xml:space="preserve"> 
+    <value /> 
+  </data> 
+  <data name="labelConflictStrategyKeepRemoteTitle" xml:space="preserve"> 
+    <value /> 
   </data> 
   <data name="labelCreateNewSync" xml:space="preserve"> 
     <value>Crear un %@.</value> 
@@ -825,6 +852,9 @@ Por favor, restaure la carpeta, asegúrese de que tiene los derechos de acceso n
   <data name="labelLocal" xml:space="preserve"> 
     <value>Local</value> 
   </data> 
+  <data name="labelManyConflictTitle" xml:space="preserve"> 
+    <value>256 fichiers ont été modifiés à la fois sur votre ordinateur et sur kDrive. </value> 
+  </data> 
   <data name="labelMegaBytes" xml:space="preserve"> 
     <value>Mb</value> 
   </data> 
@@ -852,6 +882,9 @@ Por favor, restaure la carpeta, asegúrese de que tiene los derechos de acceso n
   </data> 
   <data name="labelOriginalLocation" xml:space="preserve"> 
     <value>Ubicación original :</value> 
+  </data> 
+  <data name="labelRecommended" xml:space="preserve"> 
+    <value>Recommandé</value> 
   </data> 
   <data name="labelRestoreToOriginalLocation" xml:space="preserve"> 
     <value>Vuelva a colocarlo en su posición original.</value> 
@@ -988,7 +1021,7 @@ Compruebe y cambie el nombre de los archivos que contengan caracteres inusuales 
     <value>La última transferencia ha fallado. Por favor, compruebe su conexión a Internet y asegúrese de que al menos un usuario de kDrive está conectado. Las transferencias están limitadas a 10 por día.</value> 
   </data> 
   <data name="manyConflictErrorDescription" xml:space="preserve"> 
-    <value>Des versions différentes de ces fichiers ont été détectées.</value> 
+    <value>Se han detectado diferentes versiones de estos archivos.</value> 
   </data> 
   <data name="manyConflictErrorTitle" xml:space="preserve"> 
     <value>%@ conflictos de versión detectados</value> 
@@ -1027,7 +1060,7 @@ Si el problema continúa, póngase en contacto con nuestro equipo de soporte.</v
     <value>No tiene cuenta</value> 
   </data> 
   <data name="noResultsFound" xml:space="preserve"> 
-    <value>No se han encontrado resultados"</value> 
+    <value>No se han encontrado resultados</value> 
   </data> 
   <data name="notEnoughDiskSpaceErrorTitle" xml:space="preserve"> 
     <value>No hay suficiente espacio en disco</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/es-ES/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/es-ES/Resources.resw
@@ -6,7 +6,7 @@
   Locale: es, Spanish
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Wed, 04 Mar 2026 12:59:04 +0100 
+  Exported at: Fri, 06 Mar 2026 11:35:46 +0100 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -182,11 +182,11 @@ Podrás abrirlos en cualquier momento, incluso sin acceso a Internet.</value>
   <data name="buttonConfigure" xml:space="preserve"> 
     <value>Configure</value> 
   </data> 
-  <data name="buttonConfigureMainSync" xml:space="preserve"> 
-    <value>Activar</value> 
-  </data> 
   <data name="buttonConfirm" xml:space="preserve"> 
     <value>Confirme</value> 
+  </data> 
+  <data name="buttonConnectAccount" xml:space="preserve"> 
+    <value>Conectar una cuenta</value> 
   </data> 
   <data name="buttonCopyShareLink" xml:space="preserve"> 
     <value>Copiar enlace compartido</value> 
@@ -199,6 +199,12 @@ Podrás abrirlos en cualquier momento, incluso sin acceso a Internet.</value>
   </data> 
   <data name="buttonDefaultLocation" xml:space="preserve"> 
     <value>Ubicación por defecto</value> 
+  </data> 
+  <data name="buttonDisconnectAccount" xml:space="preserve"> 
+    <value>Desconectar esta cuenta</value> 
+  </data> 
+  <data name="buttonEnable" xml:space="preserve"> 
+    <value>Activar</value> 
   </data> 
   <data name="buttonErrorResolutionTip" xml:space="preserve"> 
     <value>Entender el problema</value> 
@@ -214,6 +220,12 @@ Podrás abrirlos en cualquier momento, incluso sin acceso a Internet.</value>
   </data> 
   <data name="buttonKDriveOnline" xml:space="preserve"> 
     <value>kDrive en línea</value> 
+  </data> 
+  <data name="buttonKeepAccount" xml:space="preserve"> 
+    <value>Mantener la cuenta</value> 
+  </data> 
+  <data name="buttonLogOut" xml:space="preserve"> 
+    <value>Cerrar sesión</value> 
   </data> 
   <data name="buttonLogin" xml:space="preserve"> 
     <value>Iniciar sesión</value> 
@@ -340,9 +352,6 @@ Podrás abrirlos en cualquier momento, incluso sin acceso a Internet.</value>
   <data name="conflictErrorTitle" xml:space="preserve"> 
     <value>Versiones contradictorias</value> 
   </data> 
-  <data name="connectAccount" xml:space="preserve"> 
-    <value>Conectar una cuenta</value> 
-  </data> 
   <data name="creatingShareLink" xml:space="preserve"> 
     <value>Crear enlace para compartir…</value> 
   </data> 
@@ -410,17 +419,12 @@ Esta carpeta no debe estar incluida en ninguna otra carpeta de sincronización y
   <data name="dialogNewExclusionRuleTitle" xml:space="preserve"> 
     <value>Añadir una regla de exclusión</value> 
   </data> 
-  <data name="dialogRemoveAccountContent" xml:space="preserve"> 
-    <value>Está a punto de cerrar la sesión {0} de la aplicación.
-Los archivos sincronizados desde todos los kDrives de esta cuenta se eliminarán de su ordenador.
+  <data name="dialogRemoveAccountContentWindows" xml:space="preserve"> 
+    <value>Desconectarás {0} de la aplicación.
 
-Todos tus datos permanecerán accesibles online en kDrive.</value> 
-  </data> 
-  <data name="dialogRemoveAccountPrimaryButton" xml:space="preserve"> 
-    <value>Mantener la cuenta</value> 
-  </data> 
-  <data name="dialogRemoveAccountSecondaryButton" xml:space="preserve"> 
-    <value>Cerrar sesión</value> 
+La carpeta de sincronización permanecerá en su ordenador, pero ya no se sincronizará con kDrive.
+
+Todos sus datos seguirán siendo accesibles en línea en kDrive.</value> 
   </data> 
   <data name="dialogRemoveAccountTitle" xml:space="preserve"> 
     <value>¿Salir de esta cuenta?</value> 
@@ -473,9 +477,6 @@ No cierre la aplicación durante el proceso.</value>
   </data> 
   <data name="disableNotificationsSetting" xml:space="preserve"> 
     <value>Desactivar notificaciones</value> 
-  </data> 
-  <data name="disconnectAccount" xml:space="preserve"> 
-    <value>Desconectar esta cuenta</value> 
   </data> 
   <data name="doNotJoin" xml:space="preserve"> 
     <value>No se afilie</value> 
@@ -985,6 +986,12 @@ Compruebe y cambie el nombre de los archivos que contengan caracteres inusuales 
   </data> 
   <data name="logsUploadErrorTooltip" xml:space="preserve"> 
     <value>La última transferencia ha fallado. Por favor, compruebe su conexión a Internet y asegúrese de que al menos un usuario de kDrive está conectado. Las transferencias están limitadas a 10 por día.</value> 
+  </data> 
+  <data name="manyConflictErrorDescription" xml:space="preserve"> 
+    <value>Des versions différentes de ces fichiers ont été détectées.</value> 
+  </data> 
+  <data name="manyConflictErrorTitle" xml:space="preserve"> 
+    <value>%@ conflictos de versión detectados</value> 
   </data> 
   <data name="matomoDescription" xml:space="preserve"> 
     <value>Matomo es una herramienta de análisis alojada y gestionada exclusivamente por Infomaniak para comprender cómo se utiliza la aplicación.</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/fr-FR/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/fr-FR/Resources.resw
@@ -6,7 +6,7 @@
   Locale: fr, French
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Wed, 04 Mar 2026 12:59:04 +0100 
+  Exported at: Fri, 06 Mar 2026 11:35:46 +0100 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -182,11 +182,11 @@ Vous pouvez les ouvrir à tout moment, même sans accès à Internet.</value>
   <data name="buttonConfigure" xml:space="preserve"> 
     <value>Configurer</value> 
   </data> 
-  <data name="buttonConfigureMainSync" xml:space="preserve"> 
-    <value>Activer</value> 
-  </data> 
   <data name="buttonConfirm" xml:space="preserve"> 
     <value>Confirmer</value> 
+  </data> 
+  <data name="buttonConnectAccount" xml:space="preserve"> 
+    <value>Connecter un compte</value> 
   </data> 
   <data name="buttonCopyShareLink" xml:space="preserve"> 
     <value>Copier le lien de partage</value> 
@@ -199,6 +199,12 @@ Vous pouvez les ouvrir à tout moment, même sans accès à Internet.</value>
   </data> 
   <data name="buttonDefaultLocation" xml:space="preserve"> 
     <value>Emplacement par défaut</value> 
+  </data> 
+  <data name="buttonDisconnectAccount" xml:space="preserve"> 
+    <value>Déconnecter ce compte</value> 
+  </data> 
+  <data name="buttonEnable" xml:space="preserve"> 
+    <value>Activer</value> 
   </data> 
   <data name="buttonErrorResolutionTip" xml:space="preserve"> 
     <value>Comprendre le problème</value> 
@@ -214,6 +220,12 @@ Vous pouvez les ouvrir à tout moment, même sans accès à Internet.</value>
   </data> 
   <data name="buttonKDriveOnline" xml:space="preserve"> 
     <value>kDrive en ligne</value> 
+  </data> 
+  <data name="buttonKeepAccount" xml:space="preserve"> 
+    <value>Garder le compte</value> 
+  </data> 
+  <data name="buttonLogOut" xml:space="preserve"> 
+    <value>Déconnecter</value> 
   </data> 
   <data name="buttonLogin" xml:space="preserve"> 
     <value>Se connecter</value> 
@@ -340,9 +352,6 @@ Vous pouvez les ouvrir à tout moment, même sans accès à Internet.</value>
   <data name="conflictErrorTitle" xml:space="preserve"> 
     <value>Conflits de versions</value> 
   </data> 
-  <data name="connectAccount" xml:space="preserve"> 
-    <value>Connecter un compte</value> 
-  </data> 
   <data name="creatingShareLink" xml:space="preserve"> 
     <value>Création d’un lien de partage…</value> 
   </data> 
@@ -410,17 +419,12 @@ Ce dossier ne doit pas être inclus dans un autre dossier de synchronisation et 
   <data name="dialogNewExclusionRuleTitle" xml:space="preserve"> 
     <value>Ajouter une règle d’exclusion</value> 
   </data> 
-  <data name="dialogRemoveAccountContent" xml:space="preserve"> 
-    <value>Vous êtes sur le point de vous déconnecter {0} de l’application.
-Les fichiers synchronisés à partir de tous les kDrives de ce compte seront supprimés de votre ordinateur.
+  <data name="dialogRemoveAccountContentWindows" xml:space="preserve"> 
+    <value>Vous allez déconnecter {0} de l’application.
+
+Le dossier de synchronisation restera sur votre ordinateur, mais ne sera plus synchronisé avec kDrive.
 
 Toutes vos données resteront accessibles en ligne sur kDrive.</value> 
-  </data> 
-  <data name="dialogRemoveAccountPrimaryButton" xml:space="preserve"> 
-    <value>Conserver le compte</value> 
-  </data> 
-  <data name="dialogRemoveAccountSecondaryButton" xml:space="preserve"> 
-    <value>Déconnecter</value> 
   </data> 
   <data name="dialogRemoveAccountTitle" xml:space="preserve"> 
     <value>Se déconnecter de ce compte ?</value> 
@@ -473,9 +477,6 @@ Ne fermez pas l’application pendant la procédure.</value>
   </data> 
   <data name="disableNotificationsSetting" xml:space="preserve"> 
     <value>Désactiver les notifications</value> 
-  </data> 
-  <data name="disconnectAccount" xml:space="preserve"> 
-    <value>Déconnecter ce compte</value> 
   </data> 
   <data name="doNotJoin" xml:space="preserve"> 
     <value>Ne pas adhérer</value> 
@@ -983,6 +984,12 @@ Veuillez vérifier et renommer les fichiers contenant des caractères inhabituel
   </data> 
   <data name="logsUploadErrorTooltip" xml:space="preserve"> 
     <value>Le dernier transfert a échoué. Veuillez vérifier votre connexion Internet et vous assurer qu’au moins un utilisateur de kDrive est connecté. Les transferts sont limités à 10 par jour.</value> 
+  </data> 
+  <data name="manyConflictErrorDescription" xml:space="preserve"> 
+    <value>Des versions différentes de ces fichiers ont été détectées.</value> 
+  </data> 
+  <data name="manyConflictErrorTitle" xml:space="preserve"> 
+    <value>%@ conflits de versions détectés</value> 
   </data> 
   <data name="matomoDescription" xml:space="preserve"> 
     <value>Matomo est un outil d’analyse hébergé et géré exclusivement par Infomaniak pour comprendre comment l’application est utilisée.</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/fr-FR/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/fr-FR/Resources.resw
@@ -6,7 +6,7 @@
   Locale: fr, French
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Fri, 06 Mar 2026 11:35:46 +0100 
+  Exported at: Fri, 06 Mar 2026 14:25:39 +0100 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -170,6 +170,9 @@ Vous pouvez les ouvrir à tout moment, même sans accès à Internet.</value>
   <data name="buttonAdvancedParameters" xml:space="preserve"> 
     <value>Paramètres avancés</value> 
   </data> 
+  <data name="buttonApplyToXFiles" xml:space="preserve"> 
+    <value>Appliquer aux %@ fichiers</value> 
+  </data> 
   <data name="buttonCancel" xml:space="preserve"> 
     <value>Annuler</value> 
   </data> 
@@ -235,6 +238,9 @@ Vous pouvez les ouvrir à tout moment, même sans accès à Internet.</value>
   </data> 
   <data name="buttonManageDiskSpace" xml:space="preserve"> 
     <value>Gérer l’espace disque</value> 
+  </data> 
+  <data name="buttonManageIndividually" xml:space="preserve"> 
+    <value>Traiter les fichiers individuellement</value> 
   </data> 
   <data name="buttonOpenDebugFolder" xml:space="preserve"> 
     <value>Ouvrir le dossier de débogage</value> 
@@ -768,11 +774,32 @@ Veuillez restaurer le dossier, vous assurer que vous avez les droits d'accès n�
   <data name="labelBytes" xml:space="preserve"> 
     <value>b</value> 
   </data> 
+  <data name="labelChooseConflictVersion" xml:space="preserve"> 
+    <value>Choisissez la version de vos fichiers que vous souhaitez conserver.</value> 
+  </data> 
   <data name="labelConflictDialogQuestion" xml:space="preserve"> 
     <value>Quelle version souhaitez-vous garder ?</value> 
   </data> 
   <data name="labelConflictDialogTitle" xml:space="preserve"> 
     <value>Choisir la version à conserver</value> 
+  </data> 
+  <data name="labelConflictStrategyKeepLocalDescription" xml:space="preserve"> 
+    <value>Les versions en ligne de ces %@ fichiers seront remplacées par vos versions locales.  Attention, cela peut écraser le travail de vos collaborateurs.</value> 
+  </data> 
+  <data name="labelConflictStrategyKeepLocalTitle" xml:space="preserve"> 
+    <value>Conserver uniquement les versions locales</value> 
+  </data> 
+  <data name="labelConflictStrategyKeepMostRecentDescription" xml:space="preserve"> 
+    <value>Pour chaque conflit, nous conserverons automatiquement la version (locale ou en ligne) modifiée le plus récemment. C'est le choix le plus sûr dans la plupart des cas.</value> 
+  </data> 
+  <data name="labelConflictStrategyKeepMostRecentTitle" xml:space="preserve"> 
+    <value>Conserver les versions les plus récentes</value> 
+  </data> 
+  <data name="labelConflictStrategyKeepRemoteDescription" xml:space="preserve"> 
+    <value>Toutes les modifications locales pour ces %@ fichiers seront annulées.  Utile si vous savez que le travail important est en ligne sur kDrive.</value> 
+  </data> 
+  <data name="labelConflictStrategyKeepRemoteTitle" xml:space="preserve"> 
+    <value>Conserver uniquement les versions en ligne</value> 
   </data> 
   <data name="labelCreateNewSync" xml:space="preserve"> 
     <value>Créez une %@.</value> 
@@ -823,6 +850,9 @@ Veuillez restaurer le dossier, vous assurer que vous avez les droits d'accès n�
   <data name="labelLocal" xml:space="preserve"> 
     <value>Locale</value> 
   </data> 
+  <data name="labelManyConflictTitle" xml:space="preserve"> 
+    <value>%@ fichiers ont été modifiés à la fois sur votre ordinateur et sur kDrive. </value> 
+  </data> 
   <data name="labelMegaBytes" xml:space="preserve"> 
     <value>Mb</value> 
   </data> 
@@ -850,6 +880,9 @@ Veuillez restaurer le dossier, vous assurer que vous avez les droits d'accès n�
   </data> 
   <data name="labelOriginalLocation" xml:space="preserve"> 
     <value>Emplacement d’origine :</value> 
+  </data> 
+  <data name="labelRecommended" xml:space="preserve"> 
+    <value>Recommandé</value> 
   </data> 
   <data name="labelRestoreToOriginalLocation" xml:space="preserve"> 
     <value>Remettez-le à son emplacement d’origine.</value> 
@@ -1025,7 +1058,7 @@ Si le problème persiste, contactez notre équipe d'assistance.</value>
     <value>Vous n’avez aucun compte connecté</value> 
   </data> 
   <data name="noResultsFound" xml:space="preserve"> 
-    <value>Aucun résultat trouvé"</value> 
+    <value>Aucun résultat trouvé</value> 
   </data> 
   <data name="notEnoughDiskSpaceErrorTitle" xml:space="preserve"> 
     <value>Espace disque insuffisant</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/it-IT/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/it-IT/Resources.resw
@@ -6,7 +6,7 @@
   Locale: it, Italian
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Fri, 06 Mar 2026 11:35:46 +0100 
+  Exported at: Fri, 06 Mar 2026 14:25:39 +0100 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -170,6 +170,9 @@
   <data name="buttonAdvancedParameters" xml:space="preserve"> 
     <value>Impostazioni avanzate</value> 
   </data> 
+  <data name="buttonApplyToXFiles" xml:space="preserve"> 
+    <value>Applicare a %@ file</value> 
+  </data> 
   <data name="buttonCancel" xml:space="preserve"> 
     <value>Annulla</value> 
   </data> 
@@ -235,6 +238,9 @@
   </data> 
   <data name="buttonManageDiskSpace" xml:space="preserve"> 
     <value>Gestire lo spazio su disco</value> 
+  </data> 
+  <data name="buttonManageIndividually" xml:space="preserve"> 
+    <value>Trattare i file singolarmente</value> 
   </data> 
   <data name="buttonOpenDebugFolder" xml:space="preserve"> 
     <value>Aprire la cartella di debug</value> 
@@ -768,11 +774,32 @@ Ripristinare la cartella, assicurarsi di avere i diritti di accesso necessari o 
   <data name="labelBytes" xml:space="preserve"> 
     <value>b</value> 
   </data> 
+  <data name="labelChooseConflictVersion" xml:space="preserve"> 
+    <value>Scegliere la versione dei file che si desidera conservare.</value> 
+  </data> 
   <data name="labelConflictDialogQuestion" xml:space="preserve"> 
     <value>Quale versione si vuole mantenere?</value> 
   </data> 
   <data name="labelConflictDialogTitle" xml:space="preserve"> 
     <value>Scegliere la versione da conservare</value> 
+  </data> 
+  <data name="labelConflictStrategyKeepLocalDescription" xml:space="preserve"> 
+    <value /> 
+  </data> 
+  <data name="labelConflictStrategyKeepLocalTitle" xml:space="preserve"> 
+    <value /> 
+  </data> 
+  <data name="labelConflictStrategyKeepMostRecentDescription" xml:space="preserve"> 
+    <value>Per ogni conflitto, verrà mantenuta automaticamente la versione modificata più di recente (locale o online). Questa è la scelta più sicura nella maggior parte dei casi.</value> 
+  </data> 
+  <data name="labelConflictStrategyKeepMostRecentTitle" xml:space="preserve"> 
+    <value>Conservare le versioni più recenti</value> 
+  </data> 
+  <data name="labelConflictStrategyKeepRemoteDescription" xml:space="preserve"> 
+    <value /> 
+  </data> 
+  <data name="labelConflictStrategyKeepRemoteTitle" xml:space="preserve"> 
+    <value /> 
   </data> 
   <data name="labelCreateNewSync" xml:space="preserve"> 
     <value>Creare un %@.</value> 
@@ -823,6 +850,9 @@ Ripristinare la cartella, assicurarsi di avere i diritti di accesso necessari o 
   <data name="labelLocal" xml:space="preserve"> 
     <value>Locale</value> 
   </data> 
+  <data name="labelManyConflictTitle" xml:space="preserve"> 
+    <value>256 fichiers ont été modifiés à la fois sur votre ordinateur et sur kDrive. </value> 
+  </data> 
   <data name="labelMegaBytes" xml:space="preserve"> 
     <value>Mb</value> 
   </data> 
@@ -850,6 +880,9 @@ Ripristinare la cartella, assicurarsi di avere i diritti di accesso necessari o 
   </data> 
   <data name="labelOriginalLocation" xml:space="preserve"> 
     <value>Posizione originale :</value> 
+  </data> 
+  <data name="labelRecommended" xml:space="preserve"> 
+    <value>Recommandé</value> 
   </data> 
   <data name="labelRestoreToOriginalLocation" xml:space="preserve"> 
     <value>Riportarlo nella posizione originale.</value> 
@@ -986,7 +1019,7 @@ Controllare e rinominare i file con caratteri insoliti, quindi riprovare.</value
     <value>L’ultimo trasferimento non è riuscito. Controllare la connessione a Internet e assicurarsi che almeno un utente di kDrive sia connesso. I trasferimenti sono limitati a 10 al giorno.</value> 
   </data> 
   <data name="manyConflictErrorDescription" xml:space="preserve"> 
-    <value>Des versions différentes de ces fichiers ont été détectées.</value> 
+    <value>Sono state rilevate diverse versioni di questi file.</value> 
   </data> 
   <data name="manyConflictErrorTitle" xml:space="preserve"> 
     <value>%@ conflitti di versione rilevati</value> 
@@ -1025,7 +1058,7 @@ Se il problema persiste, contattate il nostro team di assistenza.</value>
     <value>Non si dispone di un account</value> 
   </data> 
   <data name="noResultsFound" xml:space="preserve"> 
-    <value>Nessun risultato trovato"</value> 
+    <value>Nessun risultato trovato</value> 
   </data> 
   <data name="notEnoughDiskSpaceErrorTitle" xml:space="preserve"> 
     <value>Spazio su disco insufficiente</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/it-IT/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/it-IT/Resources.resw
@@ -6,7 +6,7 @@
   Locale: it, Italian
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Wed, 04 Mar 2026 12:59:04 +0100 
+  Exported at: Fri, 06 Mar 2026 11:35:46 +0100 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -182,11 +182,11 @@
   <data name="buttonConfigure" xml:space="preserve"> 
     <value>Configurare</value> 
   </data> 
-  <data name="buttonConfigureMainSync" xml:space="preserve"> 
-    <value>Abilitazione</value> 
-  </data> 
   <data name="buttonConfirm" xml:space="preserve"> 
     <value>Confermare</value> 
+  </data> 
+  <data name="buttonConnectAccount" xml:space="preserve"> 
+    <value>Collegare un account</value> 
   </data> 
   <data name="buttonCopyShareLink" xml:space="preserve"> 
     <value>Copiare il link di condivisione</value> 
@@ -199,6 +199,12 @@
   </data> 
   <data name="buttonDefaultLocation" xml:space="preserve"> 
     <value>Posizione predefinita</value> 
+  </data> 
+  <data name="buttonDisconnectAccount" xml:space="preserve"> 
+    <value>Disconnettere questo account</value> 
+  </data> 
+  <data name="buttonEnable" xml:space="preserve"> 
+    <value>Abilitazione</value> 
   </data> 
   <data name="buttonErrorResolutionTip" xml:space="preserve"> 
     <value>Comprendere il problema</value> 
@@ -214,6 +220,12 @@
   </data> 
   <data name="buttonKDriveOnline" xml:space="preserve"> 
     <value>kDrive online</value> 
+  </data> 
+  <data name="buttonKeepAccount" xml:space="preserve"> 
+    <value>Mantenere il conto</value> 
+  </data> 
+  <data name="buttonLogOut" xml:space="preserve"> 
+    <value>Esci</value> 
   </data> 
   <data name="buttonLogin" xml:space="preserve"> 
     <value>Accedi</value> 
@@ -340,9 +352,6 @@
   <data name="conflictErrorTitle" xml:space="preserve"> 
     <value>Versioni in conflitto</value> 
   </data> 
-  <data name="connectAccount" xml:space="preserve"> 
-    <value>Collegare un account</value> 
-  </data> 
   <data name="creatingShareLink" xml:space="preserve"> 
     <value>Creazione del link di condivisione…</value> 
   </data> 
@@ -410,17 +419,12 @@ Questa cartella non deve essere inclusa in altre cartelle di sincronizzazione e 
   <data name="dialogNewExclusionRuleTitle" xml:space="preserve"> 
     <value>Aggiungere una regola di esclusione</value> 
   </data> 
-  <data name="dialogRemoveAccountContent" xml:space="preserve"> 
-    <value>Si sta per uscire {0} dall’applicazione.
-I file sincronizzati da tutte le unità kDrive di questo account verranno rimossi dal computer.
+  <data name="dialogRemoveAccountContentWindows" xml:space="preserve"> 
+    <value>Si disconnette {0} dall'applicazione.
+
+La cartella di sincronizzazione rimarrà sul computer, ma non sarà più sincronizzata con kDrive.
 
 Tutti i dati rimarranno accessibili online su kDrive.</value> 
-  </data> 
-  <data name="dialogRemoveAccountPrimaryButton" xml:space="preserve"> 
-    <value>Mantenere il conto</value> 
-  </data> 
-  <data name="dialogRemoveAccountSecondaryButton" xml:space="preserve"> 
-    <value>Esci</value> 
   </data> 
   <data name="dialogRemoveAccountTitle" xml:space="preserve"> 
     <value>Uscire da questo account?</value> 
@@ -473,9 +477,6 @@ Non chiudere l’applicazione durante il processo.</value>
   </data> 
   <data name="disableNotificationsSetting" xml:space="preserve"> 
     <value>Disattivare le notifiche</value> 
-  </data> 
-  <data name="disconnectAccount" xml:space="preserve"> 
-    <value>Disconnettere questo account</value> 
   </data> 
   <data name="doNotJoin" xml:space="preserve"> 
     <value>Non aderire</value> 
@@ -983,6 +984,12 @@ Controllare e rinominare i file con caratteri insoliti, quindi riprovare.</value
   </data> 
   <data name="logsUploadErrorTooltip" xml:space="preserve"> 
     <value>L’ultimo trasferimento non è riuscito. Controllare la connessione a Internet e assicurarsi che almeno un utente di kDrive sia connesso. I trasferimenti sono limitati a 10 al giorno.</value> 
+  </data> 
+  <data name="manyConflictErrorDescription" xml:space="preserve"> 
+    <value>Des versions différentes de ces fichiers ont été détectées.</value> 
+  </data> 
+  <data name="manyConflictErrorTitle" xml:space="preserve"> 
+    <value>%@ conflitti di versione rilevati</value> 
   </data> 
   <data name="matomoDescription" xml:space="preserve"> 
     <value>Matomo è uno strumento di analisi ospitato e gestito esclusivamente da Infomaniak per capire come viene utilizzata l’applicazione.</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Styles/InfomaniakStyles.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/Styles/InfomaniakStyles.xaml
@@ -64,6 +64,7 @@
     <x:Double x:Key="Infomaniak.Style.Spacing.XXXL">48</x:Double>
 
     <!-- Thickness -->
+    <Thickness x:Key="Infomaniak.Style.Thickness.Uniform.XXXS">2</Thickness>
     <Thickness x:Key="Infomaniak.Style.Thickness.Uniform.XXS">4</Thickness>
     <Thickness x:Key="Infomaniak.Style.Thickness.Uniform.XS">8</Thickness>
     <Thickness x:Key="Infomaniak.Style.Thickness.Uniform.S">12</Thickness>
@@ -85,7 +86,7 @@
     <Thickness x:Key="Infomaniak.Style.Thickness.Sides.Vertical.M">0,16</Thickness>
     <Thickness x:Key="Infomaniak.Style.Thickness.Sides.Vertical.L">0,24</Thickness>
     <Thickness x:Key="Infomaniak.Style.Thickness.Sides.Vertical.XL">0,32</Thickness>
-    
+
     <Thickness x:Key="Infomaniak.Style.Thickness.Top.XXS">0,4,0,0</Thickness>
     <Thickness x:Key="Infomaniak.Style.Thickness.Top.XS">0,8,0,0</Thickness>
     <Thickness x:Key="Infomaniak.Style.Thickness.Top.S">0,12,0,0</Thickness>
@@ -109,6 +110,9 @@
     <Thickness x:Key="Infomaniak.Style.Thickness.Right.M">0,0,16,0</Thickness>
     <Thickness x:Key="Infomaniak.Style.Thickness.Right.L">0,0,24,0</Thickness>
     <Thickness x:Key="Infomaniak.Style.Thickness.Right.XL">0,0,32,0</Thickness>
+
+    <Thickness x:Key="Infomaniak.Style.Thickness.TextBadge">4,2</Thickness>
+
     <!-- Corner Radius -->
     <CornerRadius x:Key="Infomaniak.Style.CornerRadius.Uniform.XS">2</CornerRadius>
     <CornerRadius x:Key="Infomaniak.Style.CornerRadius.Uniform.S">4</CornerRadius>

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/App.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/App.cs
@@ -191,7 +191,7 @@ namespace Infomaniak.kDrive.ViewModels
             {
                 Logger.Log(Logger.Level.Debug, "There are no syncs available, setting SelectedSync to null.");
                 SelectedSync = null;
-                ((App.Current as App)?.CurrentWindow as MainWindow)?.AppNavView?.Frame.Navigate(typeof(SettingsPage));
+                ((App.Current as App)?.CurrentWindow as MainWindow)?.AppNavView?.Frame?.Navigate(typeof(SettingsPage));
             }
             else if (_selectedSync == null || (_selectedSync != null && !AllSyncs.Contains(_selectedSync))) // If SelectedSync is null or not in AllSyncs, pick the first one
             {

--- a/src/libcommon/info/nodeconflictinfo.h
+++ b/src/libcommon/info/nodeconflictinfo.h
@@ -30,7 +30,7 @@ class NodeConflictInfo {
         NodeConflictInfo(const std::string &authorName, const int64_t fileSize, const SyncTime lastModificationDate);
 
         [[nodiscard]] std::string_view authorName() const { return _authorName; }
-        void setAuthorName(std::string_view authorName) { _authorName = authorName; }
+        void setAuthorName(const std::string_view authorName) { _authorName = authorName; }
 
         [[nodiscard]] int64_t fileSize() const { return _fileSize; }
         void setFileSize(const int64_t fileSize) { _fileSize = fileSize; }

--- a/src/libcommon/info/nodeconflictinfo.h
+++ b/src/libcommon/info/nodeconflictinfo.h
@@ -29,8 +29,8 @@ class NodeConflictInfo {
         NodeConflictInfo() = default;
         NodeConflictInfo(const std::string &authorName, const int64_t fileSize, const SyncTime lastModificationDate);
 
-        [[nodiscard]] const std::string_view &authorName() const { return _authorName; }
-        void setAuthorName(const std::string_view &authorName) { _authorName = authorName; }
+        [[nodiscard]] std::string_view authorName() const { return _authorName; }
+        void setAuthorName(std::string_view authorName) { _authorName = authorName; }
 
         [[nodiscard]] int64_t fileSize() const { return _fileSize; }
         void setFileSize(const int64_t fileSize) { _fileSize = fileSize; }

--- a/src/libsyncengine/syncpal/syncpal.cpp
+++ b/src/libsyncengine/syncpal/syncpal.cpp
@@ -1084,11 +1084,13 @@ ExitCode SyncPal::fixConflictingFiles(const std::vector<Error> &keepLocalErrorLi
                                       std::vector<int32_t> &removedErrorsDbIds) {
     setUpConflictingFilesCorrector(keepLocalErrorList, keepRemoteErrorList);
     _conflictingFilesCorrector->setMainCallback(std::bind_front(&SyncPal::syncPalStartCallback, this));
-    if (ExitInfo exitInfo = _conflictingFilesCorrector->runSynchronously(); !exitInfo) {
+    auto conflictingFilesCorrectorPtr = _conflictingFilesCorrector; // Keep a local copy of the shared_ptr to ensure the object is
+                                                                    // not destroyed while running synchronously
+    if (ExitInfo exitInfo = conflictingFilesCorrectorPtr->runSynchronously(); !exitInfo) {
         LOG_SYNCPAL_WARN(_logger, "Error in ConflictingFilesCorrector::runSynchronously: " << exitInfo);
         return exitInfo.code();
     }
-    removedErrorsDbIds = _conflictingFilesCorrector->removedErrorsDbIds();
+    removedErrorsDbIds = conflictingFilesCorrectorPtr->removedErrorsDbIds();
     return ExitCode::Ok;
 }
 

--- a/src/libsyncengine/syncpal/syncpal.cpp
+++ b/src/libsyncengine/syncpal/syncpal.cpp
@@ -322,15 +322,10 @@ ExitCode SyncPal::clearNodes() {
 }
 
 void SyncPal::syncPalStartCallback([[maybe_unused]] UniqueId jobId) {
-    auto jobPtr = SyncJobManagerSingleton::instance()->getJob(jobId);
+    handlePropagatorJobsCompletion(SyncJobManagerSingleton::instance()->getJob(jobId));
+}
 
-    // _conflictingFilesCorrector may run synchronously (i.e. without SyncJobManager).
-    // If other jobs also move to synchronous execution, SyncPal should maintain
-    // an internal map to associate jobId with the actual job instance.
-    if (!jobPtr && _conflictingFilesCorrector) {
-        jobPtr = _conflictingFilesCorrector;
-    }
-
+void SyncPal::handlePropagatorJobsCompletion(const std::shared_ptr<AbstractJob> jobPtr) {
     if (jobPtr) {
         if (jobPtr->exitInfo().code() != ExitCode::Ok) {
             LOG_SYNCPAL_WARN(_logger, "Error in PropagatorJob");
@@ -1083,14 +1078,15 @@ ExitCode SyncPal::fixConflictingFilesAsync(const std::vector<Error> &keepLocalEr
 ExitCode SyncPal::fixConflictingFiles(const std::vector<Error> &keepLocalErrorList, const std::vector<Error> &keepRemoteErrorList,
                                       std::vector<int32_t> &removedErrorsDbIds) {
     setUpConflictingFilesCorrector(keepLocalErrorList, keepRemoteErrorList);
-    _conflictingFilesCorrector->setMainCallback(std::bind_front(&SyncPal::syncPalStartCallback, this));
-    auto conflictingFilesCorrectorPtr = _conflictingFilesCorrector; // Keep a local copy of the shared_ptr to ensure the object is
-                                                                    // not destroyed while running synchronously
-    if (ExitInfo exitInfo = conflictingFilesCorrectorPtr->runSynchronously(); !exitInfo) {
+    ExitInfo exitInfo = _conflictingFilesCorrector->runSynchronously();
+
+    if (exitInfo) removedErrorsDbIds = _conflictingFilesCorrector->removedErrorsDbIds();
+
+    handlePropagatorJobsCompletion(_conflictingFilesCorrector);
+    if (!exitInfo) {
         LOG_SYNCPAL_WARN(_logger, "Error in ConflictingFilesCorrector::runSynchronously: " << exitInfo);
         return exitInfo.code();
     }
-    removedErrorsDbIds = conflictingFilesCorrectorPtr->removedErrorsDbIds();
     return ExitCode::Ok;
 }
 

--- a/src/libsyncengine/syncpal/syncpal.h
+++ b/src/libsyncengine/syncpal/syncpal.h
@@ -202,6 +202,7 @@ class SYNCENGINE_EXPORT SyncPal : public std::enable_shared_from_this<SyncPal> {
         ExitCode clearNodes();
 
         void syncPalStartCallback(UniqueId jobId);
+        void handlePropagatorJobsCompletion(const std::shared_ptr<AbstractJob> jobPtr);
 
         //! Start SyncPal.
         /*!


### PR DESCRIPTION
depends on #1586 

## Quick Resolve Flow for File Conflicts

Introduces a dedicated `ConflictQuickResolvePage` enabling bulk resolution of file conflicts via three strategies: keep most recent, keep local, or keep remote. Integrated into the error page with a "Manage" button for high-volume conflicts.

### Changes
- **New Feature**: Bulk conflict resolution UI with strategy selection
- **Localization**: Added `GetString1i` method for dynamic integer arguments
- **UI Polish**: Refined padding, margins, and typography in error lists and dialogs
- **Stability**: Null-safety in navigation, proper ViewModel disposal

### Testing
Verify bulk resolution strategies apply correctly across multiple conflicts and that the error page displays the new management card when conflicts exceed the threshold.