### PR TITLE
fix(winui): always display current version in update expander

### DIFF
--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/UpdateExpander.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/UpdateExpander.xaml
@@ -35,13 +35,10 @@
 
     <toolKit:SettingsExpander.Items>
         <toolKit:SettingsCard Background="{ThemeResource LayerFillColorDefault}"
-                              Header="{x:Bind kDrive:Localizer.Instance.GetString1s('labelKDriveVersion', DisplayedVersion.Tag), Mode=OneWay}"
-                              Visibility="{x:Bind ViewModel.Settings.UpdateManager.AvailableUpdate, Converter={StaticResource IsNullToBoolOrVisibilityConverter}, ConverterParameter='Inverted=True', Mode=OneWay}">
+                              Header="{x:Bind kDrive:Localizer.Instance.GetString1s('labelKDriveVersion', ViewModel.Settings.AppVersion.Tag), Mode=OneWay}">
             <toolKit:SettingsCard.Description>
-                <local:LicensesHyperlink DisplayedVersion="{x:Bind DisplayedVersion, Mode=OneWay}" />
+                <local:LicensesHyperlink DisplayedVersion="{x:Bind ViewModel.Settings.AppVersion, Mode=OneWay}" />
             </toolKit:SettingsCard.Description>
-            <HyperlinkButton Content="{x:Bind kDrive:Localizer.Instance.GetString('buttonReleaseNotes'), Mode=OneWay}"
-                             NavigateUri="{x:Bind DisplayedVersion.ChangeLogUrl, Mode=OneWay}" />
         </toolKit:SettingsCard>
         <toolKit:SettingsCard Header="{x:Bind kDrive:Localizer.Instance.GetString('automaticUpdatesSetting'), Mode=OneWay}"
                               Background="{ThemeResource LayerFillColorDefault}"

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/UpdateExpander.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/UpdateExpander.xaml.cs
@@ -60,21 +60,6 @@ namespace Infomaniak.kDrive.CustomControls
                 Refresh();
         }
 
-        // The version to display in the expander either the current app version or the available update version
-        public static readonly DependencyProperty DisplayedVersionProperty =
-         DependencyProperty.Register(
-             nameof(DisplayedVersion),
-             typeof(AppVersion),
-             typeof(UpdateExpander),
-             new PropertyMetadata(null));
-
-        public AppVersion? DisplayedVersion
-        {
-            get => (AppVersion?)GetValue(DisplayedVersionProperty);
-            set => SetValue(DisplayedVersionProperty, value);
-
-        }
-
         public void Refresh()
         {
             if (ViewModel.Settings is null)
@@ -85,13 +70,11 @@ namespace Infomaniak.kDrive.CustomControls
 
             if (ViewModel.Settings.UpdateManager.AvailableUpdate is AppVersion updateVersion)
             {
-                base.Description = Localizer.Instance.GetString("updateAvailable", updateVersion.Tag);
-                DisplayedVersion = updateVersion;
+                base.Description = Localizer.Instance.GetString("updateAvailable", $"{updateVersion.Tag}.{updateVersion.BuildVersion}");
             }
             else if (ViewModel.Settings.AppVersion is AppVersion AppVersionInfo)
             {
                 base.Description = Localizer.Instance.GetString("appUpToDate");
-                DisplayedVersion = AppVersionInfo;
             }
             UpdateInternalChannelComboBoxVisibility();
         }


### PR DESCRIPTION
depends on #1593 

## Summary

This PR improves the **kDrive client UI**, **version/update display**, and **localization**, while applying a few UI tweaks and project cleanup.

## Changes

### UI & UX
- Refactored `UpdateExpander`: removed `DisplayedVersion` and bind directly to `AppVersion`.
- Update description now shows **version tag + build version**.
- Improved alignment/orientation of `LicensesHyperlink` and related elements.

### Maintenance
- Removed an **obsolete dependency section** from the Visual Studio solution.

## Result
Improves **UI clarity**, **translation quality**, and **code maintainability**.