### PR TITLE
feat(build-release): add dylib version check for macOS deployment target

### DIFF
--- a/infomaniak-build-tools/conan/build_dependencies.sh
+++ b/infomaniak-build-tools/conan/build_dependencies.sh
@@ -148,6 +148,9 @@ if [[ $use_release_profile == true ]]; then
     if grep -q 'os=Macos' "$profile_path" && ! grep -q 'arch=armv8|x86_64' "$profile_path"; then
       error "Profile '$release_profile' must set arch=armv8|x86_64 for MacOS"
     fi
+    if grep -q 'os=Macos' "$profile_path" && ! grep -q 'os.version=10.15' "$profile_path"; then
+      error "Profile '$release_profile' must set os.version=10.15 for MacOS"
+    fi
 
     log "Using '$release_profile' profile for Conan."
     conan_profile="$release_profile"

--- a/infomaniak-build-tools/macos/build-release.sh
+++ b/infomaniak-build-tools/macos/build-release.sh
@@ -100,6 +100,29 @@ make -j6 all install
 dsymutil ./install/kDrive.app/Contents/MacOS/kDrive -o ./install/kDrive.dSYM
 dsymutil ./bin/kDrive_client -o ./install/kDrive_client.dSYM
 
+# Verify that no dylib targets a macOS version higher than expected.
+# arm64 requires at least 11.0, so even with MACOSX_DEPLOYMENT_TARGET=10.15,
+# universal binaries will have minos=11.0 for the arm64 slice.
+check_dylibs_minos() {
+  local max_allowed="$1"
+  local search_dir="$2"
+
+  local highest
+  highest=$(otool -l $(find "$search_dir" -iname '*.dylib') \
+    | awk '/minos/{print $2}' \
+    | sort -Vu \
+    | tail -1)
+
+  local greatest
+  greatest=$(printf '%s\n' "$max_allowed" "$highest" | sort -V | tail -1)
+
+  if [ "$greatest" != "$max_allowed" ]; then
+    echo "Error: found dylib(s) with minos > $max_allowed:" >&2
+    return 1
+  fi
+}
+
+check_dylibs_minos "11.0" "."
 popd
 
 # Sign

--- a/infomaniak-build-tools/macos/build-release.sh
+++ b/infomaniak-build-tools/macos/build-release.sh
@@ -101,28 +101,42 @@ dsymutil ./install/kDrive.app/Contents/MacOS/kDrive -o ./install/kDrive.dSYM
 dsymutil ./bin/kDrive_client -o ./install/kDrive_client.dSYM
 
 # Verify that no dylib targets a macOS version higher than expected.
-# arm64 requires at least 11.0, so even with MACOSX_DEPLOYMENT_TARGET=10.15,
-# universal binaries will have minos=11.0 for the arm64 slice.
-check_dylibs_minos() {
+# Each architecture slice is checked independently: arm64 requires at least 11.0,
+# so the effective max for arm64 is max(max_allowed, 11.0).
+check_dylibs_minos() (
+  set +x
   local max_allowed="$1"
   local search_dir="$2"
+  local failed=0
 
-  local highest
-  highest=$(otool -l $(find "$search_dir" -iname '*.dylib') \
-    | awk '/minos/{print $2}' \
-    | sort -Vu \
-    | tail -1)
+  # Effective max per arch: arm64 can't go below 11.0
+  local max_x86_64="$max_allowed"
+  local max_arm64
+  max_arm64=$(printf '%s\n' "$max_allowed" "11.0" | sort -V | tail -1)
 
-  local greatest
-  greatest=$(printf '%s\n' "$max_allowed" "$highest" | sort -V | tail -1)
+  while IFS= read -r dylib; do
+    for arch in x86_64 arm64; do
+      local minos
+      minos=$(otool -arch "$arch" -l "$dylib" 2>/dev/null | awk '/minos/{print $2}' | sort -Vu | tail -1)
+      [ -z "$minos" ] && continue
 
-  if [ "$greatest" != "$max_allowed" ]; then
-    echo "Error: found dylib(s) with minos > $max_allowed:" >&2
+      local arch_max
+      [ "$arch" = "arm64" ] && arch_max="$max_arm64" || arch_max="$max_x86_64"
+
+      if [ "$(printf '%s\n' "$arch_max" "$minos" | sort -V | tail -1)" != "$arch_max" ]; then
+        echo "  $dylib ($arch minos=$minos > $arch_max)" >&2
+        failed=1
+      fi
+    done
+  done < <(find "$search_dir" -iname '*.dylib')
+
+  if [ "$failed" -eq 1 ]; then
+    echo "Error: dylib(s) above have a minos exceeding the allowed maximum" >&2
     return 1
   fi
-}
+)
 
-check_dylibs_minos "11.0" "."
+check_dylibs_minos "$MACOSX_DEPLOYMENT_TARGET" "."
 popd
 
 # Sign


### PR DESCRIPTION
This pull request adds a verification step to the macOS build script to ensure that no dynamic libraries (`.dylib` files) target a minimum macOS version higher than expected. This helps catch compatibility issues early.

Build validation improvements:

* Added the `check_dylibs_minos` function to `infomaniak-build-tools/macos/build-release.sh`, which checks all `.dylib` files in the build directory to ensure their minimum OS version (`minos`) does not exceed the specified maximum (e.g., 11.0). If any `.dylib` exceeds this, the script outputs an error and returns a failure.
* Invoked `check_dylibs_minos` after building and before signing, to enforce this validation step in the build process.