### PR TITLE
fix: invalid abstract token network job cache

### DIFF
--- a/src/libsyncengine/jobs/network/abstracttokennetworkjob.cpp
+++ b/src/libsyncengine/jobs/network/abstracttokennetworkjob.cpp
@@ -84,6 +84,7 @@ ExitCause AbstractTokenNetworkJob::getExitCause() const {
 }
 
 void AbstractTokenNetworkJob::updateLoginByUserDbId(const Login &login, const int userDbId) {
+    std::scoped_lock lock(_cacheMutex);
     if (const auto it = _userToApiKeyMap.find(userDbId); it != _userToApiKeyMap.end()) {
         const std::shared_ptr<Login> currentLogin = it->second.first;
         // get new credentials
@@ -333,6 +334,7 @@ ApiToken AbstractTokenNetworkJob::loadApiToken() {
         case ApiType::Drive:
         case ApiType::Desktop:
         case ApiType::NotifyDrive: {
+            std::scoped_lock lock(_cacheMutex);
             if (_driveDbId) {
                 if (const auto it = _driveToApiKeyMap.find(_driveDbId); it != _driveToApiKeyMap.end()) {
                     // driveDbId found in Drive cache
@@ -424,6 +426,7 @@ ApiToken AbstractTokenNetworkJob::loadApiToken() {
         }
         case ApiType::Profile:
         case ApiType::DriveByUser: {
+            std::scoped_lock lock(_cacheMutex);
             if (const auto it = _userToApiKeyMap.find(_userDbId); it != _userToApiKeyMap.end()) {
                 // userDbId found in User cache
                 _userId = it->second.second;
@@ -478,6 +481,8 @@ std::string AbstractTokenNetworkJob::contentType() {
 }
 
 ExitInfo AbstractTokenNetworkJob::refreshToken() {
+    std::scoped_lock lock(_cacheMutex);
+
     _accessTokenAlreadyRefreshed = true;
     const auto it = _userToApiKeyMap.find(_userDbId);
     if (it == _userToApiKeyMap.end()) {
@@ -522,6 +527,7 @@ ExitInfo AbstractTokenNetworkJob::refreshToken() {
 }
 
 long AbstractTokenNetworkJob::tokenUpdateDurationFromNow() {
+    std::scoped_lock lock(_cacheMutex);
     const auto it = _userToApiKeyMap.find(_userDbId);
     if (it == _userToApiKeyMap.end()) {
         LOG_WARN(_logger, "User cache not set for userDbId=" << _userDbId);

--- a/src/libsyncengine/jobs/network/abstracttokennetworkjob.cpp
+++ b/src/libsyncengine/jobs/network/abstracttokennetworkjob.cpp
@@ -84,7 +84,7 @@ ExitCause AbstractTokenNetworkJob::getExitCause() const {
 }
 
 void AbstractTokenNetworkJob::updateLoginByUserDbId(const Login &login, const int userDbId) {
-    std::scoped_lock lock(_cacheMutex);
+    const std::scoped_lock lock(_cacheMutex);
     if (const auto it = _userToApiKeyMap.find(userDbId); it != _userToApiKeyMap.end()) {
         const std::shared_ptr<Login> currentLogin = it->second.first;
         // get new credentials
@@ -94,6 +94,12 @@ void AbstractTokenNetworkJob::updateLoginByUserDbId(const Login &login, const in
         currentLogin->setApiToken(newApiToken);
         currentLogin->setKeychainKey(newKeychainKey);
     }
+}
+
+void AbstractTokenNetworkJob::clearCache() {
+    const std::scoped_lock lock(_cacheMutex);
+    _driveToApiKeyMap.clear();
+    _userToApiKeyMap.clear();
 }
 
 std::string AbstractTokenNetworkJob::getSpecificUrl() {
@@ -334,7 +340,7 @@ ApiToken AbstractTokenNetworkJob::loadApiToken() {
         case ApiType::Drive:
         case ApiType::Desktop:
         case ApiType::NotifyDrive: {
-            std::scoped_lock lock(_cacheMutex);
+            const std::scoped_lock lock(_cacheMutex);
             if (_driveDbId) {
                 if (const auto it = _driveToApiKeyMap.find(_driveDbId); it != _driveToApiKeyMap.end()) {
                     // driveDbId found in Drive cache
@@ -426,7 +432,7 @@ ApiToken AbstractTokenNetworkJob::loadApiToken() {
         }
         case ApiType::Profile:
         case ApiType::DriveByUser: {
-            std::scoped_lock lock(_cacheMutex);
+            const std::scoped_lock lock(_cacheMutex);
             if (const auto it = _userToApiKeyMap.find(_userDbId); it != _userToApiKeyMap.end()) {
                 // userDbId found in User cache
                 _userId = it->second.second;
@@ -481,7 +487,7 @@ std::string AbstractTokenNetworkJob::contentType() {
 }
 
 ExitInfo AbstractTokenNetworkJob::refreshToken() {
-    std::scoped_lock lock(_cacheMutex);
+    const std::scoped_lock lock(_cacheMutex);
 
     _accessTokenAlreadyRefreshed = true;
     const auto it = _userToApiKeyMap.find(_userDbId);
@@ -527,7 +533,7 @@ ExitInfo AbstractTokenNetworkJob::refreshToken() {
 }
 
 long AbstractTokenNetworkJob::tokenUpdateDurationFromNow() {
-    std::scoped_lock lock(_cacheMutex);
+    const std::scoped_lock lock(_cacheMutex);
     const auto it = _userToApiKeyMap.find(_userDbId);
     if (it == _userToApiKeyMap.end()) {
         LOG_WARN(_logger, "User cache not set for userDbId=" << _userDbId);

--- a/src/libsyncengine/jobs/network/abstracttokennetworkjob.cpp
+++ b/src/libsyncengine/jobs/network/abstracttokennetworkjob.cpp
@@ -39,7 +39,7 @@ constexpr int TOKEN_LIFETIME = 7200; // 2 hours
 namespace KDC {
 std::unordered_map<int, std::pair<std::shared_ptr<Login>, int>> AbstractTokenNetworkJob::_userToApiKeyMap;
 std::unordered_map<int, std::pair<int, int>> AbstractTokenNetworkJob::_driveToApiKeyMap;
-
+std::recursive_mutex AbstractTokenNetworkJob::_cacheMutex;
 AbstractTokenNetworkJob::AbstractTokenNetworkJob(const ApiType apiType, const int userDbId, const int userId, const int driveDbId,
                                                  const int driveId, const bool returnJson /*= true*/) :
     _apiType(apiType),

--- a/src/libsyncengine/jobs/network/abstracttokennetworkjob.h
+++ b/src/libsyncengine/jobs/network/abstracttokennetworkjob.h
@@ -65,11 +65,7 @@ class AbstractTokenNetworkJob : public AbstractNetworkJob {
 
         static void updateLoginByUserDbId(const Login &login, int userDbId);
 
-        inline static void clearCache() {
-            std::scoped_lock lock(_cacheMutex);
-            _driveToApiKeyMap.clear();
-            _userToApiKeyMap.clear();
-        }
+        static void clearCache();
 
         ExitInfo refreshToken();
         long tokenUpdateDurationFromNow();

--- a/src/libsyncengine/jobs/network/abstracttokennetworkjob.h
+++ b/src/libsyncengine/jobs/network/abstracttokennetworkjob.h
@@ -112,6 +112,8 @@ class AbstractTokenNetworkJob : public AbstractNetworkJob {
         std::string getUrl() override;
         ExitInfo handleUnauthorizedResponse();
         void defaultBackErrorHandling(NetworkErrorCode errorCode, const Poco::URI &uri, ExitCause &exitCause);
+
+        friend class TestServerRequests;
 };
 
 } // namespace KDC

--- a/src/libsyncengine/jobs/network/abstracttokennetworkjob.h
+++ b/src/libsyncengine/jobs/network/abstracttokennetworkjob.h
@@ -65,8 +65,11 @@ class AbstractTokenNetworkJob : public AbstractNetworkJob {
 
         static void updateLoginByUserDbId(const Login &login, int userDbId);
 
-        inline static void clearCacheForUser(int userDbId) { _userToApiKeyMap.erase(userDbId); }
-        inline static void clearCacheForDrive(int driveDbId) { _driveToApiKeyMap.erase(driveDbId); }
+        inline static void clearCache() {
+            std::scoped_lock lock(_cacheMutex);
+            _driveToApiKeyMap.clear();
+            _userToApiKeyMap.clear();
+        }
 
         ExitInfo refreshToken();
         long tokenUpdateDurationFromNow();
@@ -92,6 +95,7 @@ class AbstractTokenNetworkJob : public AbstractNetworkJob {
 
         // Drive cache: <driveDbId, <userDbId, driveId>>
         static std::unordered_map<int, std::pair<int, int>> _driveToApiKeyMap;
+        static std::recursive_mutex _cacheMutex;
 
         ApiType _apiType;
         int _userDbId;

--- a/src/server/requests/serverrequests.cpp
+++ b/src/server/requests/serverrequests.cpp
@@ -142,7 +142,7 @@ ExitInfo ServerRequests::deleteAccount(int accountDbId) {
     return ExitCode::Ok;
 }
 
-ExitCode ServerRequests::deleteDrive(int driveDbId) {
+ExitInfo ServerRequests::deleteDrive(int driveDbId) {
     // Delete drive (and linked syncs by cascade)
     bool found;
     if (!ParmsDb::instance()->deleteDrive(driveDbId, found)) {

--- a/src/server/requests/serverrequests.cpp
+++ b/src/server/requests/serverrequests.cpp
@@ -142,7 +142,7 @@ ExitInfo ServerRequests::deleteAccount(int accountDbId) {
     return ExitCode::Ok;
 }
 
-ExitInfo ServerRequests::deleteDrive(int driveDbId) {
+ExitInfo ServerRequests::deleteDrive(int32_t driveDbId) {
     // Delete drive (and linked syncs by cascade)
     bool found;
     if (!ParmsDb::instance()->deleteDrive(driveDbId, found)) {

--- a/src/server/requests/serverrequests.cpp
+++ b/src/server/requests/serverrequests.cpp
@@ -121,7 +121,7 @@ ExitInfo ServerRequests::deleteUser(int userDbId) {
         return {ExitCode::DataError, ExitCause::DbEntryNotFound};
     }
 
-    AbstractTokenNetworkJob::clearCacheForUser(userDbId);
+    AbstractTokenNetworkJob::clearCache();
 
     return ExitCode::Ok;
 }
@@ -137,6 +137,7 @@ ExitInfo ServerRequests::deleteAccount(int accountDbId) {
         LOG_WARN(Log::instance()->getLogger(), "Account with id=" << accountDbId << " not found");
         return ExitCode::DataError;
     }
+    AbstractTokenNetworkJob::clearCache();
 
     return ExitCode::Ok;
 }
@@ -152,8 +153,7 @@ ExitCode ServerRequests::deleteDrive(int driveDbId) {
         LOG_WARN(Log::instance()->getLogger(), "Drive with id=" << driveDbId << " not found");
         return ExitCode::DataError;
     }
-
-    AbstractTokenNetworkJob::clearCacheForDrive(driveDbId);
+    AbstractTokenNetworkJob::clearCache();
 
     return ExitCode::Ok;
 }

--- a/src/server/requests/serverrequests.h
+++ b/src/server/requests/serverrequests.h
@@ -136,7 +136,7 @@ struct SYNCENGINE_EXPORT ServerRequests {
         // C/S requests (others)
         static ExitInfo deleteUser(int userDbId); // !!! Use COMM_LONG_TIMEOUT !!!
         static ExitInfo deleteAccount(int accountDbId); // !!! Use COMM_LONG_TIMEOUT !!!
-        static ExitInfo deleteDrive(int driveDbId); // !!! Use COMM_LONG_TIMEOUT !!!
+        static ExitInfo deleteDrive(int32_t driveDbId); // !!! Use COMM_LONG_TIMEOUT !!!
         static ExitCode deleteSync(int syncDbId); // !!! Use COMM_LONG_TIMEOUT !!!
 
         // Server requests

--- a/src/server/requests/serverrequests.h
+++ b/src/server/requests/serverrequests.h
@@ -136,7 +136,7 @@ struct SYNCENGINE_EXPORT ServerRequests {
         // C/S requests (others)
         static ExitInfo deleteUser(int userDbId); // !!! Use COMM_LONG_TIMEOUT !!!
         static ExitInfo deleteAccount(int accountDbId); // !!! Use COMM_LONG_TIMEOUT !!!
-        static ExitCode deleteDrive(int driveDbId); // !!! Use COMM_LONG_TIMEOUT !!!
+        static ExitInfo deleteDrive(int driveDbId); // !!! Use COMM_LONG_TIMEOUT !!!
         static ExitCode deleteSync(int syncDbId); // !!! Use COMM_LONG_TIMEOUT !!!
 
         // Server requests

--- a/test/server/requests/testserverrequests.cpp
+++ b/test/server/requests/testserverrequests.cpp
@@ -23,6 +23,7 @@
 #include "utility/types.h"
 
 #include "libcommonserver/keychainmanager/keychainmanager.h"
+#include "libsyncengine/jobs/network/abstracttokennetworkjob.h"
 
 #include "libparms/db/parmsdb.h"
 
@@ -94,5 +95,67 @@ void TestServerRequests::testGetPublicLink() {
     CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, ServerRequests::getPublicLinkUrl(_driveDbId, remoteTmpDir.id(), url));
     CPPUNIT_ASSERT(!url.empty());
 }
+
+void TestServerRequests::testDeleteUser() {
+    AbstractTokenNetworkJob::_userToApiKeyMap[1] = {nullptr, 0};
+    AbstractTokenNetworkJob::_driveToApiKeyMap[1] = {0, 0};
+
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), ServerRequests::deleteUser(1));
+
+    // Check that user/account/drive have been removed from db
+    User user;
+    bool found = false;
+    CPPUNIT_ASSERT(ParmsDb::instance()->selectUser(1, user, found));
+    CPPUNIT_ASSERT(!found);
+
+    Account account;
+    CPPUNIT_ASSERT(ParmsDb::instance()->selectAccount(1, account, found));
+    CPPUNIT_ASSERT(!found);
+
+    Drive drive;
+    CPPUNIT_ASSERT(ParmsDb::instance()->selectDrive(1, drive, found));
+    CPPUNIT_ASSERT(!found);
+
+    // Check that user and drive have been removed from cache
+    CPPUNIT_ASSERT(!AbstractTokenNetworkJob::_userToApiKeyMap.contains(1));
+    CPPUNIT_ASSERT(!AbstractTokenNetworkJob::_driveToApiKeyMap.contains(1));
+}
+
+void TestServerRequests::testDeleteAccount() {
+    AbstractTokenNetworkJob::_userToApiKeyMap[1] = {nullptr, 0};
+    AbstractTokenNetworkJob::_driveToApiKeyMap[1] = {0, 0};
+
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), ServerRequests::deleteAccount(1));
+
+    // Check that account/drive have been removed from db
+    Account account;
+    bool found = false;
+    CPPUNIT_ASSERT(ParmsDb::instance()->selectAccount(1, account, found));
+    CPPUNIT_ASSERT(!found);
+
+    Drive drive;
+    CPPUNIT_ASSERT(ParmsDb::instance()->selectDrive(1, drive, found));
+    CPPUNIT_ASSERT(!found);
+
+    // Check that drive has been removed from cache but not user
+    CPPUNIT_ASSERT(!AbstractTokenNetworkJob::_driveToApiKeyMap.contains(1));
+}
+
+void TestServerRequests::testDeleteDrive() {
+    AbstractTokenNetworkJob::_userToApiKeyMap[1] = {nullptr, 0};
+    AbstractTokenNetworkJob::_driveToApiKeyMap[1] = {0, 0};
+
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), ServerRequests::deleteDrive(1));
+
+    // Check that drive has been removed from db
+    Drive drive;
+    bool found = false;
+    CPPUNIT_ASSERT(ParmsDb::instance()->selectDrive(1, drive, found));
+    CPPUNIT_ASSERT(!found);
+
+    // Check that drive has been removed from cache
+    CPPUNIT_ASSERT(!AbstractTokenNetworkJob::_driveToApiKeyMap.contains(1));
+}
+
 
 } // namespace KDC

--- a/test/server/requests/testserverrequests.h
+++ b/test/server/requests/testserverrequests.h
@@ -25,6 +25,9 @@ class TestServerRequests : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST_SUITE(TestServerRequests);
         CPPUNIT_TEST(testFixProxyConfig);
         CPPUNIT_TEST(testGetPublicLink);
+        CPPUNIT_TEST(testDeleteUser);
+        CPPUNIT_TEST(testDeleteAccount);
+        CPPUNIT_TEST(testDeleteDrive);
         CPPUNIT_TEST_SUITE_END();
 
     public:
@@ -33,6 +36,9 @@ class TestServerRequests : public CppUnit::TestFixture, public TestBase {
 
         void testFixProxyConfig();
         void testGetPublicLink();
+        void testDeleteUser();
+        void testDeleteAccount();
+        void testDeleteDrive();
 
     private:
         int _driveDbId{0};


### PR DESCRIPTION
## Summary

When a user is deleted via `ServerRequests::deleteUser`, all related `accounts / drives / syncs` are removed **directly by database cascade** (foreign keys).

Because of this, `ServerRequests::deleteDrive` is **not called**, which means the `AbstractTokenNetworkJob` cache is not cleaned.

As a result, when the user later creates a new drive, it may reuse a previous `driveDbId`, and `AbstractTokenNetworkJob` can incorrectly retrieve the **cached ID of the old drive**.

This issue did not occur previously because the only way to remove a user was by deleting all their drives first. However, the **new GUI introduces a direct “disconnect account” action**, which exposes this problem.