### PR TITLE
fix(unit-tests): Fixes Linux implementation of the `isInTrash` helper method

### DIFF
--- a/src/libcommonserver/io/iohelper_linux.cpp
+++ b/src/libcommonserver/io/iohelper_linux.cpp
@@ -1,6 +1,6 @@
 /*
  * Infomaniak kDrive - Desktop
- * Copyright (C) 2023-2025 Infomaniak Network SA
+ * Copyright (C) 2023-2026 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,15 +16,18 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "libcommonserver/io/filestat.h"
-#include "libcommonserver/io/iohelper.h"
-#include "libcommonserver/log/log.h"
+#include "io/iohelper.h"
+
+#include "io/filestat.h"
+#include "log/log.h"
 #include "libcommonserver/utility/utility.h"
 
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>
 #include <fcntl.h>
+#include <filesystem>
+#include <mntent.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/xattr.h>
@@ -33,6 +36,7 @@
 #include <log4cplus/loggingmacros.h>
 
 #include <Poco/File.h>
+#include "utility/utility.h"
 
 #include <QFile>
 
@@ -51,6 +55,7 @@ bool IoHelper::_getFileStatFn(const SyncPath &path, FileStat *buf, IoError &ioEr
     ioError = IoError::Success;
 
     struct statx sb;
+
     if (statx(AT_FDCWD, path.string().c_str(), AT_SYMLINK_NOFOLLOW, STATX_BASIC_STATS | STATX_BTIME, &sb) < 0) {
         ioError = posixError2ioError(errno);
         return isExpectedError(ioError);
@@ -128,8 +133,61 @@ IoError IoHelper::isLocked(const SyncPath &, bool &locked) noexcept {
 }
 
 bool IoHelper::moveItemToTrash(const SyncPath &itemPath) {
-    QFile file(itemPath);
-    return file.moveToTrash();
+    return QFile(itemPath).moveToTrash();
 }
 
+bool IoHelper::isPathOnMountedDisk(const SyncPath &path, bool &isMounted, IoError &ioError) noexcept {
+    isMounted = false;
+    ioError = IoError::Success;
+    std::error_code ec;
+    std::string absPath = std::filesystem::absolute(path, ec).string();
+    if (ec) {
+        ioError = IoHelper::stdError2ioError(ec);
+        LOGW_WARN(logger(), L"Error in std::filesystem::absolute - " << Utility::formatStdError(ec));
+        return false;
+    }
+
+    FILE *mtab = setmntent("/proc/mounts", "r");
+    if (!mtab) {
+        ioError = posixError2ioError(errno);
+        LOGW_WARN(logger(), L"Error in setmntent: " << Utility::formatIoError(path, ioError));
+        return false;
+    }
+
+    struct mntent *ent = nullptr;
+    size_t bestMatchLen = 0;
+    std::string bestMount;
+
+    while ((ent = getmntent(mtab)) != nullptr) {
+        std::string mountPoint = ent->mnt_dir;
+        bool matches = false;
+        if (mountPoint == "/" || (absPath.compare(0, mountPoint.size(), mountPoint) == 0 &&
+                                  (absPath.size() == mountPoint.size() || absPath[mountPoint.size()] == '/'))) {
+            matches = true;
+        }
+
+        if (matches && mountPoint.size() > bestMatchLen) {
+            bestMatchLen = mountPoint.size();
+            bestMount = std::move(mountPoint);
+        }
+    }
+
+    if (endmntent(mtab) != 1) {
+        LOGW_WARN(logger(), L"Error in endmntent: " << Utility::formatSyncPath(path));
+    }
+
+    if (bestMatchLen == 0) {
+        isMounted = false;
+        return true;
+    }
+
+    if (bestMount == "/" &&
+        (absPath.starts_with("/mnt/") || absPath.starts_with("/media/") || absPath.starts_with("/run/media/"))) {
+        isMounted = false;
+        return true;
+    }
+
+    isMounted = true;
+    return true;
+}
 } // namespace KDC

--- a/test/libsyncengine/integration/testintegration.cpp
+++ b/test/libsyncengine/integration/testintegration.cpp
@@ -29,21 +29,6 @@
 #include "jobs/network/kDrive_API/upload/uploadjob.h"
 #include "requests/syncnodecache.h"
 #include "requests/exclusiontemplatecache.h"
-#include "libcommon/utility/utility.h"
-#include "libcommon/keychainmanager/keychainmanager.h"
-#include "libcommonserver/io/filestat.h"
-#include "libcommonserver/io/iohelper.h"
-#include "libcommonserver/utility/utility.h"
-#include "libcommonserver/network/proxy.h"
-#include "libsyncengine/jobs/network/kDrive_API/copytodirectoryjob.h"
-#include "libsyncengine/jobs/network/kDrive_API/createdirjob.h"
-#include "libsyncengine/jobs/network/kDrive_API/deletejob.h"
-#include "libsyncengine/jobs/network/kDrive_API/duplicatejob.h"
-#include "libsyncengine/jobs/network/kDrive_API/getfileinfojob.h"
-#include "libsyncengine/jobs/network/kDrive_API/getfilelistjob.h"
-#include "libsyncengine/jobs/network/kDrive_API/movejob.h"
-#include "libsyncengine/jobs/network/kDrive_API/renamejob.h"
-#include "libsyncengine/update_detection/file_system_observer/filesystemobserverworker.h"
 #include "requests/syncnodecache.h"
 #include "requests/exclusiontemplatecache.h"
 #include "mocks/libcommonserver/db/mockdb.h"
@@ -53,6 +38,24 @@
 #include "syncpal/excludelistpropagator.h"
 #include "test_utility/remotetemporarydirectory.h"
 #include "update_detection/blacklist_changes_propagator/blacklistpropagator.h"
+
+#include "libcommon/utility/utility.h"
+
+#include "libcommonserver/keychainmanager/keychainmanager.h"
+#include "libcommonserver/io/filestat.h"
+#include "libcommonserver/io/iohelper.h"
+#include "libcommonserver/utility/utility.h"
+#include "libcommonserver/network/proxy.h"
+
+#include "libsyncengine/jobs/network/kDrive_API/copytodirectoryjob.h"
+#include "libsyncengine/jobs/network/kDrive_API/createdirjob.h"
+#include "libsyncengine/jobs/network/kDrive_API/deletejob.h"
+#include "libsyncengine/jobs/network/kDrive_API/duplicatejob.h"
+#include "libsyncengine/jobs/network/kDrive_API/getfileinfojob.h"
+#include "libsyncengine/jobs/network/kDrive_API/getfilelistjob.h"
+#include "libsyncengine/jobs/network/kDrive_API/movejob.h"
+#include "libsyncengine/jobs/network/kDrive_API/renamejob.h"
+#include "libsyncengine/update_detection/file_system_observer/filesystemobserverworker.h"
 
 using namespace CppUnit;
 using namespace std::chrono;
@@ -88,7 +91,7 @@ void TestIntegration::setUp() {
     const User user(1, 12321, keychainKey);
     (void) ParmsDb::instance()->insertUser(user);
 
-    const Account account(1, atoi(testVariables.accountId.c_str()), user.dbId());
+    const Account account(1, atoi(testVariables.accountId.c_str()), user.dbId(), "account1");
     (void) ParmsDb::instance()->insertAccount(account);
 
     _driveDbId = 1;
@@ -113,7 +116,7 @@ void TestIntegration::setUp() {
 
     FileStat fileStat;
     IoError ioError = IoError::Unknown;
-    (void) IoHelper::getFileStat(_localSyncDir.path(), &fileStat, ioError, IoHelper::PathCheckOption::Insensitive);
+    (void) IoHelper::getFileStat(_localSyncDir.path(), &fileStat, ioError);
 
     // This is an advanced sync. Define remote target path and remote target node ID.
     const Sync sync(1, drive.dbId(), _localSyncDir.path(), std::to_string(fileStat.inode),
@@ -134,7 +137,7 @@ void TestIntegration::setUp() {
 }
 
 void TestIntegration::tearDown() {
-    if (_syncPal) _syncPal->stop(SyncPal::PauseCaller::Sync, SyncPal::DbBehaviorAfterStop::Remove);
+    if (_syncPal) _syncPal->stop(false, true, false);
     _remoteSyncDir.deleteDirectory();
 
     ParmsDb::instance()->close();
@@ -215,7 +218,7 @@ void TestIntegration::inconsistencyTests() {
     testhelpers::generateOrEditTestFile(nameClashLocalPath);
     FileStat filestat;
     IoError ioError = IoError::Unknown;
-    (void) IoHelper::getFileStat(nameClashLocalPath, &filestat, ioError, IoHelper::PathCheckOption::Insensitive);
+    (void) IoHelper::getFileStat(nameClashLocalPath, &filestat, ioError);
     waitForSyncToBeIdle(SourceLocation::currentLoc());
 
     auto remoteFileInfo = getRemoteFileInfoByName(_driveDbId, _remoteSyncDir.id(), Str("testnameclash"));
@@ -231,8 +234,7 @@ void TestIntegration::inconsistencyTests() {
     // and a new edit operation, with the new path, is generated.
     waitForSyncToBeIdle(SourceLocation::currentLoc());
 
-    (void) IoHelper::getFileStat(_syncPal->localPath() / "testnameclash2", &filestat, ioError,
-                                 IoHelper::PathCheckOption::Insensitive);
+    (void) IoHelper::getFileStat(_syncPal->localPath() / "testnameclash2", &filestat, ioError);
     remoteFileInfo = getRemoteFileInfoByName(_driveDbId, _remoteSyncDir.id(), Str("testnameclash2"));
 
     CPPUNIT_ASSERT(remoteFileInfo.isValid());
@@ -303,7 +305,12 @@ void TestIntegration::testBlacklist() {
     waitForSyncToBeIdle(SourceLocation::currentLoc());
 
     CPPUNIT_ASSERT(!std::filesystem::exists(dirpath));
-    CPPUNIT_ASSERT(testhelpers::isInTrash(dirpath.filename()));
+#if defined(KD_LINUX)
+    CPPUNIT_ASSERT(testhelpers::isInTrash(dirpath));
+#else
+    CPPUNIT_ASSERT(testhelpers::isInTrash(filename));
+#endif
+
 #if defined(KD_MACOS) || defined(KD_LINUX)
     testhelpers::eraseFromTrash(dirpath.filename());
 #endif
@@ -314,7 +321,12 @@ void TestIntegration::testBlacklist() {
     waitForSyncToBeIdle(SourceLocation::currentLoc());
 
     CPPUNIT_ASSERT(!std::filesystem::exists(_syncPal->localPath() / filename));
+#if defined(KD_LINUX)
+    CPPUNIT_ASSERT(testhelpers::isInTrash(_syncPal->localPath() / filename));
+#else
     CPPUNIT_ASSERT(testhelpers::isInTrash(filename));
+#endif
+
 #if defined(KD_MACOS) || defined(KD_LINUX)
     testhelpers::eraseFromTrash(filename);
 #endif
@@ -383,8 +395,7 @@ void TestIntegration::testExclusionTemplates() {
     const RemoteTemporaryDirectory exclusionTemplatesTestDir(_driveDbId, tmpRemoteDir.id(), "testDir");
     FileStat filestat;
     bool found = false;
-    IoHelper::getFileStat(_syncPal->localPath() / tmpRemoteDir.name() / exclusionTemplatesTestDir.name(), &filestat, found,
-                          IoHelper::PathCheckOption::Insensitive);
+    IoHelper::getFileStat(_syncPal->localPath() / tmpRemoteDir.name() / exclusionTemplatesTestDir.name(), &filestat, found);
     const auto dirLocalId = std::to_string(filestat.inode);
 
     const auto filename = "testExclusionTemplates";
@@ -394,7 +405,7 @@ void TestIntegration::testExclusionTemplates() {
     waitForSyncToBeIdle(SourceLocation::currentLoc());
 
     const auto excludedFilePath = _syncPal->localPath() / tmpRemoteDir.name() / testName;
-    IoHelper::getFileStat(excludedFilePath, &filestat, found, IoHelper::PathCheckOption::Insensitive);
+    IoHelper::getFileStat(excludedFilePath, &filestat, found);
     auto fileLocalId = std::to_string(filestat.inode);
     CPPUNIT_ASSERT(std::filesystem::exists(excludedFilePath));
 
@@ -419,8 +430,7 @@ void TestIntegration::testExclusionTemplates() {
     CPPUNIT_ASSERT(_syncPal->liveSnapshot(ReplicaSide::Remote).exists(fileRemoteId));
     // ... but the local file is still excluded. A new file is therefore downloaded.
     CPPUNIT_ASSERT(!_syncPal->liveSnapshot(ReplicaSide::Local).exists(fileLocalId));
-    IoHelper::getFileStat(_syncPal->localPath() / tmpRemoteDir.name() / filename, &filestat, found,
-                          IoHelper::PathCheckOption::Insensitive);
+    IoHelper::getFileStat(_syncPal->localPath() / tmpRemoteDir.name() / filename, &filestat, found);
     fileLocalId = std::to_string(filestat.inode);
     CPPUNIT_ASSERT(_syncPal->liveSnapshot(ReplicaSide::Local).exists(fileLocalId));
 
@@ -448,8 +458,7 @@ void TestIntegration::testExclusionTemplates() {
     CPPUNIT_ASSERT(std::filesystem::exists(_syncPal->localPath() / tmpRemoteDir.name() / filename));
     // Local file ID has changed again.
     CPPUNIT_ASSERT(!_syncPal->liveSnapshot(ReplicaSide::Local).exists(fileLocalId));
-    IoHelper::getFileStat(_syncPal->localPath() / tmpRemoteDir.name() / filename, &filestat, found,
-                          IoHelper::PathCheckOption::Insensitive);
+    IoHelper::getFileStat(_syncPal->localPath() / tmpRemoteDir.name() / filename, &filestat, found);
     fileLocalId = std::to_string(filestat.inode);
     CPPUNIT_ASSERT(_syncPal->liveSnapshot(ReplicaSide::Local).exists(fileLocalId));
 
@@ -469,9 +478,13 @@ void TestIntegration::testExclusionTemplates() {
     CPPUNIT_ASSERT(!_syncPal->liveSnapshot(ReplicaSide::Remote).exists(fileRemoteId));
     CPPUNIT_ASSERT(!std::filesystem::exists(_syncPal->localPath() / tmpRemoteDir.name() /
                                             filename)); // The local file has been moved to trash.
-
     CPPUNIT_ASSERT(!std::filesystem::exists(filename));
+#if defined(KD_LINUX)
+    CPPUNIT_ASSERT(testhelpers::isInTrash(_syncPal->localPath() / tmpRemoteDir.name() / filename));
+#else
     CPPUNIT_ASSERT(testhelpers::isInTrash(filename));
+#endif
+
 #if defined(KD_MACOS) || defined(KD_LINUX)
     testhelpers::eraseFromTrash(filename);
 #endif
@@ -486,8 +499,7 @@ void TestIntegration::testExclusionTemplates() {
     CPPUNIT_ASSERT(_syncPal->liveSnapshot(ReplicaSide::Remote).exists(fileRemoteId));
     // Local file ID has changed again.
     CPPUNIT_ASSERT(!_syncPal->liveSnapshot(ReplicaSide::Local).exists(fileLocalId));
-    IoHelper::getFileStat(_syncPal->localPath() / tmpRemoteDir.name() / testName, &filestat, found,
-                          IoHelper::PathCheckOption::Insensitive);
+    IoHelper::getFileStat(_syncPal->localPath() / tmpRemoteDir.name() / testName, &filestat, found);
     fileLocalId = std::to_string(filestat.inode);
     CPPUNIT_ASSERT(_syncPal->liveSnapshot(ReplicaSide::Local).exists(fileLocalId));
 
@@ -565,7 +577,7 @@ void TestIntegration::testNegativeModificationTime() {
         testhelpers::generateOrEditTestFile(filepath);
         FileStat fileStat;
         bool found = false;
-        IoHelper::getFileStat(filepath, &fileStat, found, IoHelper::PathCheckOption::Insensitive);
+        IoHelper::getFileStat(filepath, &fileStat, found);
         (void) IoHelper::setFileDates(filepath, fileStat.creationTime, timeInput, false);
         waitForSyncToBeIdle(SourceLocation::currentLoc());
 
@@ -584,7 +596,7 @@ void TestIntegration::testNegativeModificationTime() {
         testhelpers::generateOrEditTestFile(filepath);
         FileStat fileStat;
         bool found = false;
-        IoHelper::getFileStat(filepath, &fileStat, found, IoHelper::PathCheckOption::Insensitive);
+        IoHelper::getFileStat(filepath, &fileStat, found);
         (void) IoHelper::setFileDates(filepath, timeInput, fileStat.modificationTime, false);
         waitForSyncToBeIdle(SourceLocation::currentLoc());
 
@@ -610,7 +622,7 @@ void TestIntegration::testNegativeModificationTime() {
         testhelpers::generateOrEditTestFile(filepath);
         FileStat fileStat;
         bool found = false;
-        IoHelper::getFileStat(filepath, &fileStat, found, IoHelper::PathCheckOption::Insensitive);
+        IoHelper::getFileStat(filepath, &fileStat, found);
         (void) IoHelper::setFileDates(filepath, timeInput, timeInput, false);
         waitForSyncToBeIdle(SourceLocation::currentLoc());
 
@@ -890,7 +902,7 @@ SyncPath TestIntegration::findLocalFileByNamePrefix(const SyncPath &parentAbsolu
     IoHelper::DirectoryIterator dirIt(parentAbsolutePath, false, ioError);
     bool endOfDir = false;
     DirectoryEntry entry;
-    while (dirIt.next(entry, endOfDir, ioError) && !endOfDir && ioError == IoError::Success) {
+    while (dirIt.next(entry, endOfDir, ioError) && !endOfDir) {
         if (CommonUtility::startsWith(entry.path().filename(), namePrefix)) return entry.path();
     }
     return {};

--- a/test/libsyncengine/integration/testintegration_basics.cpp
+++ b/test/libsyncengine/integration/testintegration_basics.cpp
@@ -48,7 +48,7 @@ void TestIntegration::testLocalChanges() {
 
     FileStat fileStat;
     bool exists = false;
-    IoHelper::getFileStat(filePath, &fileStat, exists, IoHelper::PathCheckOption::Insensitive);
+    IoHelper::getFileStat(filePath, &fileStat, exists);
     waitForSyncToBeIdle(SourceLocation::currentLoc());
 
     auto remoteTestFileInfo = getRemoteFileInfoByName(_driveDbId, _remoteSyncDir.id(), filePath.filename());
@@ -62,7 +62,7 @@ void TestIntegration::testLocalChanges() {
 
     // Generate an edit operation.
     testhelpers::generateOrEditTestFile(filePath);
-    IoHelper::getFileStat(filePath, &fileStat, exists, IoHelper::PathCheckOption::Insensitive);
+    IoHelper::getFileStat(filePath, &fileStat, exists);
     waitForSyncToBeIdle(SourceLocation::currentLoc());
 
     const auto prevRemoteTestFileInfo = remoteTestFileInfo;
@@ -99,7 +99,12 @@ void TestIntegration::testLocalChanges() {
     remoteTestFileInfo = getRemoteFileInfoByName(_driveDbId, remoteTestDirInfo.id, filePath.filename());
     CPPUNIT_ASSERT(!remoteTestFileInfo.isValid());
 
+#if defined(KD_LINUX)
+    CPPUNIT_ASSERT(testhelpers::isInTrash(subDirPath));
+#else
     CPPUNIT_ASSERT(testhelpers::isInTrash(subDirPath.filename()));
+#endif
+
 #if defined(KD_MACOS) || defined(KD_LINUX)
     testhelpers::eraseFromTrash(subDirPath.filename());
 #endif
@@ -132,7 +137,7 @@ void TestIntegration::testRemoteChanges() {
 
     FileStat fileStat;
     bool exists = false;
-    IoHelper::getFileStat(filePath, &fileStat, exists, IoHelper::PathCheckOption::Insensitive);
+    IoHelper::getFileStat(filePath, &fileStat, exists);
     CPPUNIT_ASSERT_EQUAL(fileInfoJob.size(), fileStat.size);
     CPPUNIT_ASSERT_EQUAL(fileInfoJob.modificationTime(), fileStat.modificationTime);
 
@@ -147,7 +152,7 @@ void TestIntegration::testRemoteChanges() {
 
     FileStat filestat;
     IoError ioError = IoError::Unknown;
-    (void) IoHelper::getFileStat(filePath, &filestat, ioError, IoHelper::PathCheckOption::Insensitive);
+    (void) IoHelper::getFileStat(filePath, &filestat, ioError);
     CPPUNIT_ASSERT_EQUAL(modificationTime, filestat.modificationTime);
     CPPUNIT_ASSERT_EQUAL(size, filestat.size);
     logStep("test edit remote file");
@@ -172,7 +177,12 @@ void TestIntegration::testRemoteChanges() {
 
     CPPUNIT_ASSERT(!std::filesystem::exists(subDirPath));
     CPPUNIT_ASSERT(!std::filesystem::exists(filePath));
+#if defined(KD_LINUX)
+    CPPUNIT_ASSERT(testhelpers::isInTrash(subDirPath));
+#else
     CPPUNIT_ASSERT(testhelpers::isInTrash(subDirPath.filename()));
+#endif
+
 #if defined(KD_MACOS) || defined(KD_LINUX)
     testhelpers::eraseFromTrash(subDirPath.filename());
 #endif
@@ -209,7 +219,7 @@ void TestIntegration::testUploadBigFile() {
 
     bool found = false;
     FileStat fileStat;
-    IoHelper::getFileStat(localFilePath, &fileStat, found, IoHelper::PathCheckOption::Insensitive);
+    IoHelper::getFileStat(localFilePath, &fileStat, found);
 
     waitForSyncToBeIdle(SourceLocation::currentLoc());
 

--- a/test/libsyncengine/integration/testintegration_conflicts.cpp
+++ b/test/libsyncengine/integration/testintegration_conflicts.cpp
@@ -105,8 +105,7 @@ void TestIntegration::testEditEditPseudoConflict() {
     // Check that the modification time has been updated in DB.
     FileStat fileStat;
     bool exists = false;
-    IoHelper::getFileStat(_syncPal->localPath() / dbNode.name(ReplicaSide::Local), &fileStat, exists,
-                          IoHelper::PathCheckOption::Insensitive);
+    IoHelper::getFileStat(_syncPal->localPath() / dbNode.name(ReplicaSide::Local), &fileStat, exists);
     std::optional<SyncTime> lastModified = std::nullopt;
     CPPUNIT_ASSERT_EQUAL(true,
                          _syncPal->syncDb()->lastModified(ReplicaSide::Remote, _testFileRemoteId, lastModified, found) && found);
@@ -217,7 +216,7 @@ void TestIntegration::testEditDeleteConflict() {
         // Edit operation has won.
         CPPUNIT_ASSERT(std::filesystem::exists(filepath));
         FileStat fileStat;
-        (void) IoHelper::getFileStat(filepath, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive);
+        (void) IoHelper::getFileStat(filepath, &fileStat, ioError);
         CPPUNIT_ASSERT_EQUAL(modificationTime, fileStat.modificationTime);
         CPPUNIT_ASSERT_EQUAL(size, fileStat.size);
         logStep("testEditDeleteConflict1");
@@ -254,7 +253,13 @@ void TestIntegration::testEditDeleteConflict() {
         // ... but the edited file has been rescued.
         CPPUNIT_ASSERT(std::filesystem::exists(_syncPal->localPath() / FileRescuer::rescueFolderName() / filepath.filename()));
 
+#if defined(KD_LINUX)
+        CPPUNIT_ASSERT(testhelpers::isInTrash(dirpath));
+#else
         CPPUNIT_ASSERT(testhelpers::isInTrash(dirpath.filename()));
+#endif
+
+
 #if defined(KD_MACOS) || defined(KD_LINUX)
         testhelpers::eraseFromTrash(dirpath.filename());
 #endif

--- a/test/libsyncengine/jobs/local/testlocaljobs.cpp
+++ b/test/libsyncengine/jobs/local/testlocaljobs.cpp
@@ -39,7 +39,7 @@ namespace KDC {
 class LocalDeleteJobMockingTrash : public SyncLocalDeleteJob {
     public:
         explicit LocalDeleteJobMockingTrash(const std::shared_ptr<SyncPal> syncPal, const SyncPath &absolutePath) :
-            SyncLocalDeleteJob(syncPal, absolutePath) {};
+            SyncLocalDeleteJob(syncPal, absolutePath){};
         void setMoveToTrashFailed(const bool failed) { _moveToTrashFailed = failed; };
         void setLiteSyncEnabled(const bool enabled) { _liteSyncIsEnabled = enabled; };
         void setMockMoveToTrash(const bool mocked) { _moveToTrashIsMocked = mocked; }
@@ -47,7 +47,7 @@ class LocalDeleteJobMockingTrash : public SyncLocalDeleteJob {
     protected:
         ExitInfo moveToTrash() final {
             if (_moveToTrashIsMocked) {
-                std::filesystem::remove_all(absolutePath());
+                (void) IoHelper::deleteItem(absolutePath());
                 moveToTrashOrHardDeleteIfNeeded(absolutePath());
                 return _moveToTrashFailed ? ExitCode::SystemError : ExitCode::Ok;
             }
@@ -80,7 +80,7 @@ void KDC::TestLocalJobs::setUp() {
     (void) ParmsDb::instance()->insertUser(user);
 
     int accountId(atoi(testVariables.accountId.c_str()));
-    Account account(1, accountId, user.dbId());
+    Account account(1, accountId, user.dbId(), "account1");
     (void) ParmsDb::instance()->insertAccount(account);
 
     int driveId = atoi(testVariables.driveId.c_str());
@@ -176,10 +176,13 @@ void KDC::TestLocalJobs::testLocalJobs() {
     LOGW_INFO(Log::instance()->getLogger(),
               L"copyDirPath in TestLocalJobs::testLocalJobs: " << Utility::formatSyncPath(copyDirPath));
 #if defined(KD_MACOS) || defined(KD_WINDOWS)
-    // testhelpers::isInTrash is not reliable on Linux if previous tests have failed and have left a polluted trash.
     CPPUNIT_ASSERT(testhelpers::isInTrash(copyDirPath.filename()));
     CPPUNIT_ASSERT(testhelpers::isInTrash(copyDirPath.filename() / testDirName / "tmp_picture.jpg"));
     CPPUNIT_ASSERT(!testhelpers::isInTrash(copyDirPath.filename() / testDirName / "dehydrated_placeholder.jpg"));
+#else
+    CPPUNIT_ASSERT(testhelpers::isInTrash(copyDirPath));
+    CPPUNIT_ASSERT(testhelpers::isInTrash(copyDirPath / testDirName / "tmp_picture.jpg"));
+    CPPUNIT_ASSERT(!testhelpers::isInTrash(copyDirPath / testDirName / "dehydrated_placeholder.jpg"));
 #endif
 #if defined(KD_MACOS) || defined(KD_LINUX)
     testhelpers::eraseFromTrash(copyDirPath.filename());
@@ -266,7 +269,7 @@ void KDC::TestLocalJobs::testLocalDeleteJob() {
         public:
             LocalDeleteJobMock(const std::shared_ptr<SyncPal> syncPal, const SyncPath &relativePath, bool isDehydratedPlaceholder,
                                NodeId remoteId, bool forceToTrash = false) :
-                SyncLocalDeleteJob(syncPal, relativePath, isDehydratedPlaceholder, remoteId, forceToTrash) {
+                SyncLocalDeleteJob(syncPal, relativePath, isDehydratedPlaceholder, remoteId, forceToTrash){
 
                 };
             void setRemoteItemPath(const SyncPath &remoteItemPath) { _remoteItemPath = remoteItemPath; }
@@ -290,7 +293,7 @@ void KDC::TestLocalJobs::testLocalDeleteJob() {
     {
         LocalDeleteJobMock deleteJob(_syncPal, SyncPath{_localTempDir.path().filename()}, false, NodeId{"1234"});
 
-        CPPUNIT_ASSERT(deleteJob.canRun());
+        CPPUNIT_ASSERT(deleteJob.checkIfRemoteFileHasBeenMoved());
     }
 
     // Local and remote item paths are the same: cannot run
@@ -298,7 +301,7 @@ void KDC::TestLocalJobs::testLocalDeleteJob() {
         LocalDeleteJobMock deleteJob(_syncPal, SyncPath{_localTempDir.path().filename()}, false, NodeId{"1234"});
         deleteJob.setRemoteItemPath(_syncPal->syncInfo().targetPath / SyncPath{_localTempDir.path().filename()});
 
-        CPPUNIT_ASSERT(!deleteJob.canRun());
+        CPPUNIT_ASSERT(!deleteJob.checkIfRemoteFileHasBeenMoved());
     }
 
     // Advanced synchronisation, local and remote item paths are the same: cannot run
@@ -307,7 +310,7 @@ void KDC::TestLocalJobs::testLocalDeleteJob() {
         LocalDeleteJobMock deleteJob(_syncPal, SyncPath{_localTempDir.path().filename()}, false, NodeId{"1234"});
         deleteJob.setRemoteItemPath(SyncPath{_localTempDir.path().filename()});
 
-        CPPUNIT_ASSERT(!deleteJob.canRun());
+        CPPUNIT_ASSERT(!deleteJob.checkIfRemoteFileHasBeenMoved());
     }
 
     // Advanced synchronisation, local and remote item paths are different: cannot run
@@ -315,7 +318,7 @@ void KDC::TestLocalJobs::testLocalDeleteJob() {
         LocalDeleteJobMock deleteJob(_syncPal, SyncPath{_localTempDir.path().filename()}, false, NodeId{"1234"});
         deleteJob.setRemoteItemPath(SyncPath{"tmp_dir_diff"});
 
-        CPPUNIT_ASSERT(deleteJob.canRun());
+        CPPUNIT_ASSERT(deleteJob.checkIfRemoteFileHasBeenMoved());
 
         deleteJob.runSynchronously();
 

--- a/test/test_utility/testhelpers.h
+++ b/test/test_utility/testhelpers.h
@@ -89,11 +89,11 @@ struct RightsSet {
         RightsSet(int rights) :
             read(rights & 4),
             write(rights & 2),
-            execute(rights & 1) {};
+            execute(rights & 1){};
         RightsSet(bool read, bool write, bool execute) :
             read(read),
             write(write),
-            execute(execute) {};
+            execute(execute){};
         bool read;
         bool write;
         bool execute;
@@ -128,10 +128,11 @@ void eraseFromTrash(const SyncPath &relativePath);
 #endif
 /**
  * Check whether a path indicates an item located in the trash.
- * @param relativePath SyncPath relative to the trash directory path.
- * @return true if `relativePath` indicated an existing item of the trash, false otherwise.
+ * @param path SyncPath relative to the trash directory path on Windows and MacOS, absolute path on Linux.
+ * @return true if `path` indicated an existing item of the trash, false otherwise.
  */
-bool isInTrash(const SyncPath &relativePath);
+bool isInTrash(const SyncPath &path);
+
 // Create two symbolic links that refer to each other:
 // filepath1 -> filepath2,
 // filepath2 -> filepath1

--- a/test/test_utility/testhelpers_linux.cpp
+++ b/test/test_utility/testhelpers_linux.cpp
@@ -1,6 +1,6 @@
 /*
  * Infomaniak kDrive - Desktop
- * Copyright (C) 2023-2025 Infomaniak Network SA
+ * Copyright (C) 2023-2026 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -32,7 +32,7 @@
 #include <utime.h>
 
 namespace KDC::testhelpers {
-
+namespace {
 SyncPath removeNumericSuffix(const SyncPath &relativePath) {
     if (relativePath.empty()) return {};
 
@@ -61,6 +61,60 @@ SyncPath removeNumericSuffix(const SyncPath &relativePath) {
     return SyncPath{ss.str()};
 }
 
+enum class TrashSubDirectory {
+    Info,
+    Files
+};
+
+// Get the user trash subdirectory
+SyncPath getTrashSubDir(const TrashSubDirectory trashSubDir) {
+    switch (trashSubDir) {
+        case TrashSubDirectory::Info:
+            return SyncPath{Utility::getTrashPath()}.parent_path().parent_path() / "info";
+            break;
+        case TrashSubDirectory::Files:
+            return Utility::getTrashPath();
+            break;
+        default:
+            throw std::invalid_argument("Unrecognized trash subdirectory type.");
+    }
+
+    return {};
+}
+
+
+// Parse the mandatory `Path` entry from a .trashinfo file
+std::string getOriginalPath(const SyncPath &infoFile) {
+    std::ifstream file(infoFile);
+    if (!file.is_open()) return "";
+
+    std::string line;
+    static const std::string pathKey = "Path=";
+    while (std::getline(file, line)) {
+        if (line.rfind(pathKey, 0) != 0) continue;
+        return line.substr(pathKey.size());
+    }
+
+    return "";
+}
+
+bool isSubPath(const SyncPath &path1, const SyncPath &path2) {
+    try {
+        const SyncPath canonicalPath1 = std::filesystem::weakly_canonical(path1);
+        const SyncPath canonicalPath2 = std::filesystem::weakly_canonical(path2);
+
+        const auto [path1It, path2It] =
+                std::mismatch(canonicalPath1.begin(), canonicalPath1.end(), canonicalPath2.begin(), canonicalPath2.end());
+
+        return (path2It == canonicalPath2.end());
+    } catch (const std::filesystem::filesystem_error &e) {
+        std::cerr << "Filesystem error in isSubPath: " << e.what() << std::endl;
+        return false;
+    }
+}
+
+} // namespace
+
 void eraseFromTrash(const KDC::SyncPath &relativePath) {
     const auto trashPath = Utility::getTrashPath();
     std::error_code ec;
@@ -77,32 +131,43 @@ void eraseFromTrash(const KDC::SyncPath &relativePath) {
         const auto p = dirIt->path();
         const auto dirItemRelativePath = std::filesystem::relative(dirIt->path(), trashPath, ec);
         // Filter out the numerical suffix of the root directory name, e.g: `dirname.15` is replaced with `dirname`.
-        const auto suffixFreedirectorEntryPath = removeNumericSuffix(dirItemRelativePath);
-        if (relativePath == suffixFreedirectorEntryPath) itemsToErase.push_back(dirIt->path());
+        const auto suffixFreeDirectorEntryPath = removeNumericSuffix(dirItemRelativePath);
+        if (relativePath == suffixFreeDirectorEntryPath) itemsToErase.push_back(dirIt->path());
     }
 
-    for (const auto &pathToErase: itemsToErase) (void) std::filesystem::remove_all(pathToErase, ec);
+    auto ioError = IoError::Success;
+    for (const auto &pathToErase: itemsToErase) (void) IoHelper::deleteItem(pathToErase, ioError);
 }
 
-bool isInTrash(const SyncPath &relativePath) {
-    const auto trashPath = Utility::getTrashPath();
-    std::error_code ec;
+// Check if a file is in the trash
+bool isInTrash(const SyncPath &absoluteFilePath) {
+    try {
+        const SyncPath trashInfoDir = getTrashSubDir(TrashSubDirectory::Info);
+        if (!std::filesystem::exists(trashInfoDir)) return false;
 
-    auto dirIt = std::filesystem::recursive_directory_iterator(trashPath,
-                                                               std::filesystem::directory_options::skip_permission_denied, ec);
-    if (ec) {
-        LOGW_WARN(Log::instance()->getLogger(), L"Error in testhelpers::isInTrash: " << Utility::formatStdError(ec));
-        return false;
-    }
+        const SyncPath targetPath = std::filesystem::absolute(absoluteFilePath);
 
-    for (; dirIt != std::filesystem::recursive_directory_iterator(); ++dirIt) {
-        const auto dirItemRelativePath = std::filesystem::relative(dirIt->path(), trashPath, ec);
-        // Filter out the numerical suffix of the root directory name, e.g.: `dirname.15` is replaced with `dirname`.
-        const auto suffixFreedirectorEntryPath = removeNumericSuffix(dirItemRelativePath);
-        if (relativePath == suffixFreedirectorEntryPath) return true;
+        for (const auto &entry: std::filesystem::directory_iterator(trashInfoDir)) {
+            if (entry.path().extension() != ".trashinfo") continue;
+
+            const std::string originalPathStr = getOriginalPath(entry.path());
+            if (originalPathStr.empty()) continue;
+
+            const auto originalPath = std::filesystem::absolute(originalPathStr);
+            if (!isSubPath(absoluteFilePath, originalPath)) continue;
+
+            const SyncPath relativePath = std::filesystem::relative(absoluteFilePath, originalPath);
+            if (relativePath.begin() == relativePath.end()) return true;
+
+            const auto fileTrashParentName = entry.path().filename().stem();
+            return std::filesystem::exists(getTrashSubDir(TrashSubDirectory::Files) / fileTrashParentName / relativePath);
+        }
+    } catch (const std::filesystem::filesystem_error &e) {
+        std::cerr << "File system exception caught in `isInTrash`: " << e.what() << std::endl;
     }
 
     return false;
 }
+
 
 } // namespace KDC::testhelpers


### PR DESCRIPTION
This pull-request re-implements on Linux the helper function `IoHelper::isInTrash` that checks whether an item is located in the user trash in a reliable way. This new implementation follows the [Freedesktop specifications](https://specifications.freedesktop.org/trash/latest/).
This helper is used in unit tests to check whether some clean up tasks are executed successfully. With these changes, the related tests will not fail anymore for unclear and seemingly random reasons.