### PR TITLE
fix(unit-tests): Merge fixed Linux implementation of the `isInTrash` helper method

### DIFF
--- a/src/libcommonserver/io/iohelper_linux.cpp
+++ b/src/libcommonserver/io/iohelper_linux.cpp
@@ -36,8 +36,6 @@
 
 #include <QFile>
 
-#include <QFile>
-
 namespace KDC {
 
 bool IoHelper::checkIfFileIsDehydrated(const SyncPath &itemPath, bool &isDehydrated, IoError &ioError) noexcept {

--- a/src/libcommonserver/io/iohelper_linux.cpp
+++ b/src/libcommonserver/io/iohelper_linux.cpp
@@ -36,6 +36,8 @@
 
 #include <QFile>
 
+#include <QFile>
+
 namespace KDC {
 
 bool IoHelper::checkIfFileIsDehydrated(const SyncPath &itemPath, bool &isDehydrated, IoError &ioError) noexcept {

--- a/test/libsyncengine/integration/testintegration.cpp
+++ b/test/libsyncengine/integration/testintegration.cpp
@@ -304,7 +304,7 @@ void TestIntegration::testBlacklist() {
 
     CPPUNIT_ASSERT(!std::filesystem::exists(dirpath));
 #if defined(KD_LINUX)
-    testhelpers::isInTrash(dirpath);
+    CPPUNIT_ASSERT(testhelpers::isInTrash(dirpath));
 #else
     CPPUNIT_ASSERT(testhelpers::isInTrash(filename));
 #endif
@@ -320,7 +320,7 @@ void TestIntegration::testBlacklist() {
 
     CPPUNIT_ASSERT(!std::filesystem::exists(_syncPal->localPath() / filename));
 #if defined(KD_LINUX)
-    testhelpers::isInTrash(_syncPal->localPath() / filename);
+    CPPUNIT_ASSERT(testhelpers::isInTrash(_syncPal->localPath() / filename));
 #else
     CPPUNIT_ASSERT(testhelpers::isInTrash(filename));
 #endif
@@ -481,7 +481,7 @@ void TestIntegration::testExclusionTemplates() {
                                             filename)); // The local file has been moved to trash.
     CPPUNIT_ASSERT(!std::filesystem::exists(filename));
 #if defined(KD_LINUX)
-    testhelpers::isInTrash(_syncPal->localPath() / tmpRemoteDir.name() / filename);
+    CPPUNIT_ASSERT(testhelpers::isInTrash(_syncPal->localPath() / tmpRemoteDir.name() / filename));
 #else
     CPPUNIT_ASSERT(testhelpers::isInTrash(filename));
 #endif

--- a/test/libsyncengine/integration/testintegration.cpp
+++ b/test/libsyncengine/integration/testintegration.cpp
@@ -303,7 +303,12 @@ void TestIntegration::testBlacklist() {
     waitForSyncToBeIdle(SourceLocation::currentLoc());
 
     CPPUNIT_ASSERT(!std::filesystem::exists(dirpath));
-    CPPUNIT_ASSERT(testhelpers::isInTrash(dirpath.filename()));
+#if defined(KD_LINUX)
+    testhelpers::isInTrash(dirpath);
+#else
+    CPPUNIT_ASSERT(testhelpers::isInTrash(filename));
+#endif
+
 #if defined(KD_MACOS) || defined(KD_LINUX)
     testhelpers::eraseFromTrash(dirpath.filename());
 #endif
@@ -314,7 +319,12 @@ void TestIntegration::testBlacklist() {
     waitForSyncToBeIdle(SourceLocation::currentLoc());
 
     CPPUNIT_ASSERT(!std::filesystem::exists(_syncPal->localPath() / filename));
+#if defined(KD_LINUX)
+    testhelpers::isInTrash(_syncPal->localPath() / filename);
+#else
     CPPUNIT_ASSERT(testhelpers::isInTrash(filename));
+#endif
+
 #if defined(KD_MACOS) || defined(KD_LINUX)
     testhelpers::eraseFromTrash(filename);
 #endif
@@ -469,9 +479,13 @@ void TestIntegration::testExclusionTemplates() {
     CPPUNIT_ASSERT(!_syncPal->liveSnapshot(ReplicaSide::Remote).exists(fileRemoteId));
     CPPUNIT_ASSERT(!std::filesystem::exists(_syncPal->localPath() / tmpRemoteDir.name() /
                                             filename)); // The local file has been moved to trash.
-
     CPPUNIT_ASSERT(!std::filesystem::exists(filename));
+#if defined(KD_LINUX)
+    testhelpers::isInTrash(_syncPal->localPath() / tmpRemoteDir.name() / filename);
+#else
     CPPUNIT_ASSERT(testhelpers::isInTrash(filename));
+#endif
+
 #if defined(KD_MACOS) || defined(KD_LINUX)
     testhelpers::eraseFromTrash(filename);
 #endif

--- a/test/libsyncengine/integration/testintegration_basics.cpp
+++ b/test/libsyncengine/integration/testintegration_basics.cpp
@@ -100,7 +100,7 @@ void TestIntegration::testLocalChanges() {
     CPPUNIT_ASSERT(!remoteTestFileInfo.isValid());
 
 #if defined(KD_LINUX)
-    testhelpers::isInTrash(subDirPath);
+    CPPUNIT_ASSERT(testhelpers::isInTrash(subDirPath));
 #else
     CPPUNIT_ASSERT(testhelpers::isInTrash(subDirPath.filename()));
 #endif
@@ -178,7 +178,7 @@ void TestIntegration::testRemoteChanges() {
     CPPUNIT_ASSERT(!std::filesystem::exists(subDirPath));
     CPPUNIT_ASSERT(!std::filesystem::exists(filePath));
 #if defined(KD_LINUX)
-    testhelpers::isInTrash(subDirPath);
+    CPPUNIT_ASSERT(testhelpers::isInTrash(subDirPath));
 #else
     CPPUNIT_ASSERT(testhelpers::isInTrash(subDirPath.filename()));
 #endif

--- a/test/libsyncengine/integration/testintegration_basics.cpp
+++ b/test/libsyncengine/integration/testintegration_basics.cpp
@@ -99,7 +99,12 @@ void TestIntegration::testLocalChanges() {
     remoteTestFileInfo = getRemoteFileInfoByName(_driveDbId, remoteTestDirInfo.id, filePath.filename());
     CPPUNIT_ASSERT(!remoteTestFileInfo.isValid());
 
+#if defined(KD_LINUX)
+    testhelpers::isInTrash(subDirPath);
+#else
     CPPUNIT_ASSERT(testhelpers::isInTrash(subDirPath.filename()));
+#endif
+
 #if defined(KD_MACOS) || defined(KD_LINUX)
     testhelpers::eraseFromTrash(subDirPath.filename());
 #endif
@@ -172,7 +177,12 @@ void TestIntegration::testRemoteChanges() {
 
     CPPUNIT_ASSERT(!std::filesystem::exists(subDirPath));
     CPPUNIT_ASSERT(!std::filesystem::exists(filePath));
+#if defined(KD_LINUX)
+    testhelpers::isInTrash(subDirPath);
+#else
     CPPUNIT_ASSERT(testhelpers::isInTrash(subDirPath.filename()));
+#endif
+
 #if defined(KD_MACOS) || defined(KD_LINUX)
     testhelpers::eraseFromTrash(subDirPath.filename());
 #endif

--- a/test/libsyncengine/integration/testintegration_conflicts.cpp
+++ b/test/libsyncengine/integration/testintegration_conflicts.cpp
@@ -254,7 +254,13 @@ void TestIntegration::testEditDeleteConflict() {
         // ... but the edited file has been rescued.
         CPPUNIT_ASSERT(std::filesystem::exists(_syncPal->localPath() / FileRescuer::rescueFolderName() / filepath.filename()));
 
+#if defined(KD_LINUX)
+        testhelpers::isInTrash(dirpath);
+#else
         CPPUNIT_ASSERT(testhelpers::isInTrash(dirpath.filename()));
+#endif
+
+
 #if defined(KD_MACOS) || defined(KD_LINUX)
         testhelpers::eraseFromTrash(dirpath.filename());
 #endif

--- a/test/libsyncengine/integration/testintegration_conflicts.cpp
+++ b/test/libsyncengine/integration/testintegration_conflicts.cpp
@@ -255,7 +255,7 @@ void TestIntegration::testEditDeleteConflict() {
         CPPUNIT_ASSERT(std::filesystem::exists(_syncPal->localPath() / FileRescuer::rescueFolderName() / filepath.filename()));
 
 #if defined(KD_LINUX)
-        testhelpers::isInTrash(dirpath);
+        CPPUNIT_ASSERT(testhelpers::isInTrash(dirpath));
 #else
         CPPUNIT_ASSERT(testhelpers::isInTrash(dirpath.filename()));
 #endif

--- a/test/libsyncengine/jobs/local/testlocaljobs.cpp
+++ b/test/libsyncengine/jobs/local/testlocaljobs.cpp
@@ -39,7 +39,7 @@ namespace KDC {
 class LocalDeleteJobMockingTrash : public SyncLocalDeleteJob {
     public:
         explicit LocalDeleteJobMockingTrash(const std::shared_ptr<SyncPal> syncPal, const SyncPath &absolutePath) :
-            SyncLocalDeleteJob(syncPal, absolutePath) {};
+            SyncLocalDeleteJob(syncPal, absolutePath){};
         void setMoveToTrashFailed(const bool failed) { _moveToTrashFailed = failed; };
         void setLiteSyncEnabled(const bool enabled) { _liteSyncIsEnabled = enabled; };
         void setMockMoveToTrash(const bool mocked) { _moveToTrashIsMocked = mocked; }
@@ -176,10 +176,13 @@ void KDC::TestLocalJobs::testLocalJobs() {
     LOGW_INFO(Log::instance()->getLogger(),
               L"copyDirPath in TestLocalJobs::testLocalJobs: " << Utility::formatSyncPath(copyDirPath));
 #if defined(KD_MACOS) || defined(KD_WINDOWS)
-    // testhelpers::isInTrash is not reliable on Linux if previous tests have failed and have left a polluted trash.
     CPPUNIT_ASSERT(testhelpers::isInTrash(copyDirPath.filename()));
     CPPUNIT_ASSERT(testhelpers::isInTrash(copyDirPath.filename() / testDirName / "tmp_picture.jpg"));
     CPPUNIT_ASSERT(!testhelpers::isInTrash(copyDirPath.filename() / testDirName / "dehydrated_placeholder.jpg"));
+#else
+    CPPUNIT_ASSERT(testhelpers::isInTrash(copyDirPath));
+    CPPUNIT_ASSERT(testhelpers::isInTrash(copyDirPath / testDirName / "tmp_picture.jpg"));
+    CPPUNIT_ASSERT(!testhelpers::isInTrash(copyDirPath / testDirName / "dehydrated_placeholder.jpg"));
 #endif
 #if defined(KD_MACOS) || defined(KD_LINUX)
     testhelpers::eraseFromTrash(copyDirPath.filename());
@@ -266,7 +269,7 @@ void KDC::TestLocalJobs::testLocalDeleteJob() {
         public:
             LocalDeleteJobMock(const std::shared_ptr<SyncPal> syncPal, const SyncPath &relativePath, bool isDehydratedPlaceholder,
                                NodeId remoteId, bool forceToTrash = false) :
-                SyncLocalDeleteJob(syncPal, relativePath, isDehydratedPlaceholder, remoteId, forceToTrash) {
+                SyncLocalDeleteJob(syncPal, relativePath, isDehydratedPlaceholder, remoteId, forceToTrash){
 
                 };
             void setRemoteItemPath(const SyncPath &remoteItemPath) { _remoteItemPath = remoteItemPath; }

--- a/test/test_utility/testhelpers.h
+++ b/test/test_utility/testhelpers.h
@@ -89,11 +89,11 @@ struct RightsSet {
         RightsSet(int rights) :
             read(rights & 4),
             write(rights & 2),
-            execute(rights & 1) {};
+            execute(rights & 1){};
         RightsSet(bool read, bool write, bool execute) :
             read(read),
             write(write),
-            execute(execute) {};
+            execute(execute){};
         bool read;
         bool write;
         bool execute;
@@ -128,10 +128,11 @@ void eraseFromTrash(const SyncPath &relativePath);
 #endif
 /**
  * Check whether a path indicates an item located in the trash.
- * @param relativePath SyncPath relative to the trash directory path.
- * @return true if `relativePath` indicated an existing item of the trash, false otherwise.
+ * @param path SyncPath relative to the trash directory path on Windows and MacOS, absolute path on Linux.
+ * @return true if `path` indicated an existing item of the trash, false otherwise.
  */
-bool isInTrash(const SyncPath &relativePath);
+bool isInTrash(const SyncPath &path);
+
 // Create two symbolic links that refer to each other:
 // filepath1 -> filepath2,
 // filepath2 -> filepath1

--- a/test/test_utility/testhelpers_linux.cpp
+++ b/test/test_utility/testhelpers_linux.cpp
@@ -106,7 +106,7 @@ bool isSubPath(const SyncPath &path1, const SyncPath &path2) {
         const auto [path1It, path2It] =
                 std::mismatch(canonicalPath1.begin(), canonicalPath1.end(), canonicalPath2.begin(), canonicalPath2.end());
 
-        return (path2It == canonicalPath2.end());
+        return (path1It == canonicalPath1.end());
     } catch (const std::filesystem::filesystem_error &e) {
         std::cerr << "Filesystem error in isSubPath: " << e.what() << std::endl;
         return false;
@@ -154,10 +154,10 @@ bool isInTrash(const SyncPath &absoluteFilePath) {
             if (originalPathStr.empty()) continue;
 
             const auto originalPath = std::filesystem::absolute(originalPathStr);
-            if (!isSubPath(absoluteFilePath, originalPath)) continue;
+            if (!isSubPath(originalPath, absoluteFilePath)) continue;
 
             const SyncPath relativePath = std::filesystem::relative(absoluteFilePath, originalPath);
-            if (relativePath.begin() == relativePath.end()) return true;
+            if (relativePath.begin() == relativePath.end() || relativePath == ".") return true;
 
             const auto fileTrashParentName = entry.path().filename().stem();
             return std::filesystem::exists(getTrashSubDir(TrashSubDirectory::Files) / fileTrashParentName / relativePath);

--- a/test/test_utility/testhelpers_linux.cpp
+++ b/test/test_utility/testhelpers_linux.cpp
@@ -32,7 +32,7 @@
 #include <utime.h>
 
 namespace KDC::testhelpers {
-
+namespace {
 SyncPath removeNumericSuffix(const SyncPath &relativePath) {
     if (relativePath.empty()) return {};
 
@@ -61,6 +61,59 @@ SyncPath removeNumericSuffix(const SyncPath &relativePath) {
     return SyncPath{ss.str()};
 }
 
+enum class TrashSubDirectory {
+    Info,
+    Files
+};
+
+// Get the user's home trash  subdirectory
+SyncPath getTrashSubDir(const TrashSubDirectory trashSubDir) {
+    switch (trashSubDir) {
+        case TrashSubDirectory::Info:
+            return SyncPath{Utility::getTrashPath()}.parent_path().parent_path() / "info";
+            break;
+        case TrashSubDirectory::Files:
+            return Utility::getTrashPath();
+            break;
+        default:
+            throw std::invalid_argument("Unrecognized trash subdirectory type.");
+    }
+
+    return {};
+}
+
+
+// Parse the mandatory `Path` entry from a .trashinfo file
+std::string getOriginalPath(const SyncPath &infoFile) {
+    std::ifstream file(infoFile);
+    if (!file.is_open()) return "";
+
+    std::string line;
+    while (std::getline(file, line)) {
+        if (line.rfind("Path=", 0) != 0) continue;
+        return line.substr(5); // Remove the "Path=" prefix.
+    }
+
+    return "";
+}
+
+bool isSubPath(const SyncPath &path1, const SyncPath &path2) {
+    try {
+        const SyncPath canonicalPath1 = std::filesystem::weakly_canonical(path1);
+        const SyncPath canonicalPath2 = std::filesystem::weakly_canonical(path2);
+
+        const auto [path1It, path2It] =
+                std::mismatch(canonicalPath1.begin(), canonicalPath1.end(), canonicalPath2.begin(), canonicalPath2.end());
+
+        return (path2It == canonicalPath2.end());
+    } catch (const std::filesystem::filesystem_error &e) {
+        std::cerr << "Filesystem error in isSubPath: " << e.what() << std::endl;
+        return false;
+    }
+}
+
+} // namespace
+
 void eraseFromTrash(const KDC::SyncPath &relativePath) {
     const auto trashPath = Utility::getTrashPath();
     std::error_code ec;
@@ -81,28 +134,40 @@ void eraseFromTrash(const KDC::SyncPath &relativePath) {
         if (relativePath == suffixFreedirectorEntryPath) itemsToErase.push_back(dirIt->path());
     }
 
-    for (const auto &pathToErase: itemsToErase) (void) std::filesystem::remove_all(pathToErase, ec);
+
+    auto ioError = IoError::Success;
+    for (const auto &pathToErase: itemsToErase) (void) IoHelper::deleteItem(pathToErase, ioError);
 }
 
-bool isInTrash(const SyncPath &relativePath) {
-    const auto trashPath = Utility::getTrashPath();
-    std::error_code ec;
+// Check if a file is in the trash
+bool isInTrash(const SyncPath &filePath) {
+    try {
+        const SyncPath trashInfoDir = getTrashSubDir(TrashSubDirectory::Info);
+        if (!std::filesystem::exists(trashInfoDir)) return false;
 
-    auto dirIt = std::filesystem::recursive_directory_iterator(trashPath,
-                                                               std::filesystem::directory_options::skip_permission_denied, ec);
-    if (ec) {
-        LOGW_WARN(Log::instance()->getLogger(), L"Error in testhelpers::isInTrash: " << Utility::formatStdError(ec));
-        return false;
-    }
+        const SyncPath targetPath = std::filesystem::absolute(filePath);
 
-    for (; dirIt != std::filesystem::recursive_directory_iterator(); ++dirIt) {
-        const auto dirItemRelativePath = std::filesystem::relative(dirIt->path(), trashPath, ec);
-        // Filter out the numerical suffix of the root directory name, e.g.: `dirname.15` is replaced with `dirname`.
-        const auto suffixFreedirectorEntryPath = removeNumericSuffix(dirItemRelativePath);
-        if (relativePath == suffixFreedirectorEntryPath) return true;
+        for (const auto &entry: std::filesystem::directory_iterator(trashInfoDir)) {
+            if (entry.path().extension() != ".trashinfo") continue;
+
+            const std::string originalPathStr = getOriginalPath(entry.path());
+            if (originalPathStr.empty()) continue;
+
+            const auto originalPath = std::filesystem::absolute(originalPathStr);
+            if (!isSubPath(filePath, originalPath)) continue;
+
+            const SyncPath relativePath = std::filesystem::relative(filePath, originalPath);
+            if (relativePath.begin() == relativePath.end()) return true;
+
+            const auto fileTrashParentName = entry.path().filename().stem();
+            return std::filesystem::exists(getTrashSubDir(TrashSubDirectory::Files) / fileTrashParentName / relativePath);
+        }
+    } catch (const std::exception &e) {
+        std::cerr << "Exception caught in `isInTrash`: " << e.what() << std::endl;
     }
 
     return false;
 }
+
 
 } // namespace KDC::testhelpers

--- a/test/test_utility/testhelpers_linux.cpp
+++ b/test/test_utility/testhelpers_linux.cpp
@@ -66,7 +66,7 @@ enum class TrashSubDirectory {
     Files
 };
 
-// Get the user's home trash  subdirectory
+// Get the user trash subdirectory
 SyncPath getTrashSubDir(const TrashSubDirectory trashSubDir) {
     switch (trashSubDir) {
         case TrashSubDirectory::Info:
@@ -89,9 +89,10 @@ std::string getOriginalPath(const SyncPath &infoFile) {
     if (!file.is_open()) return "";
 
     std::string line;
+    static const std::string pathKey = "Path=";
     while (std::getline(file, line)) {
-        if (line.rfind("Path=", 0) != 0) continue;
-        return line.substr(5); // Remove the "Path=" prefix.
+        if (line.rfind(pathKey, 0) != 0) continue;
+        return line.substr(pathKey.size());
     }
 
     return "";

--- a/test/test_utility/testhelpers_linux.cpp
+++ b/test/test_utility/testhelpers_linux.cpp
@@ -134,18 +134,17 @@ void eraseFromTrash(const KDC::SyncPath &relativePath) {
         if (relativePath == suffixFreedirectorEntryPath) itemsToErase.push_back(dirIt->path());
     }
 
-
     auto ioError = IoError::Success;
     for (const auto &pathToErase: itemsToErase) (void) IoHelper::deleteItem(pathToErase, ioError);
 }
 
 // Check if a file is in the trash
-bool isInTrash(const SyncPath &filePath) {
+bool isInTrash(const SyncPath &absoluteFilePath) {
     try {
         const SyncPath trashInfoDir = getTrashSubDir(TrashSubDirectory::Info);
         if (!std::filesystem::exists(trashInfoDir)) return false;
 
-        const SyncPath targetPath = std::filesystem::absolute(filePath);
+        const SyncPath targetPath = std::filesystem::absolute(absoluteFilePath);
 
         for (const auto &entry: std::filesystem::directory_iterator(trashInfoDir)) {
             if (entry.path().extension() != ".trashinfo") continue;
@@ -154,9 +153,9 @@ bool isInTrash(const SyncPath &filePath) {
             if (originalPathStr.empty()) continue;
 
             const auto originalPath = std::filesystem::absolute(originalPathStr);
-            if (!isSubPath(filePath, originalPath)) continue;
+            if (!isSubPath(absoluteFilePath, originalPath)) continue;
 
-            const SyncPath relativePath = std::filesystem::relative(filePath, originalPath);
+            const SyncPath relativePath = std::filesystem::relative(absoluteFilePath, originalPath);
             if (relativePath.begin() == relativePath.end()) return true;
 
             const auto fileTrashParentName = entry.path().filename().stem();

--- a/test/test_utility/testhelpers_linux.cpp
+++ b/test/test_utility/testhelpers_linux.cpp
@@ -161,8 +161,8 @@ bool isInTrash(const SyncPath &absoluteFilePath) {
             const auto fileTrashParentName = entry.path().filename().stem();
             return std::filesystem::exists(getTrashSubDir(TrashSubDirectory::Files) / fileTrashParentName / relativePath);
         }
-    } catch (const std::exception &e) {
-        std::cerr << "Exception caught in `isInTrash`: " << e.what() << std::endl;
+    } catch (const std::filesystem::filesystem_error &e) {
+        std::cerr << "File system exception caught in `isInTrash`: " << e.what() << std::endl;
     }
 
     return false;


### PR DESCRIPTION
This pull-request re-implements on Linux the helper function `IoHelper::isInTrash` that checks whether an item is located in the user trash in a reliable way. This new implementation follows the [Freedesktop specifications](https://specifications.freedesktop.org/trash/latest/).
This helper is used in unit tests to check whether some clean up tasks are executed successfully. With these changes, the related tests will not fail anymore for unclear and seemingly random reasons.