### PR TITLE
feat(sync): improve VFS sync status

### DIFF
--- a/src/libsyncengine/syncpal/syncpalworker.cpp
+++ b/src/libsyncengine/syncpal/syncpalworker.cpp
@@ -27,6 +27,8 @@
 #include "propagation/operation_sorter/operationsorterworker.h"
 #include "propagation/executor/executorworker.h"
 #include "libcommonserver/utility/utility.h"
+#include "libcommonserver/io/iohelper.h"
+#include "libcommonserver/io/filestat.h"
 #include "libcommon/utility/utility.h"
 #include "libcommon/log/sentry/ptraces.h"
 #include "libcommon/log/sentry/utility.h"
@@ -575,6 +577,67 @@ bool SyncPalWorker::tryToFixDbNodeIdsAfterSyncDirChange() {
     return true;
 }
 
+bool SyncPalWorker::isLocalItemInSyncWithDb(const SyncPath &localAbsolutePath) {
+    // Ideally, this logic should be shared with ComputeFSOperationWorker::inferChangeFromDbNode,
+    // but for now it would require some refactoring to make it reusable, so we duplicate it here.
+
+    FileStat fileStat;
+    IoError ioError = IoError::Success;
+    if (!IoHelper::getFileStat(localAbsolutePath, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive)) {
+        LOGW_SYNCPAL_WARN(_logger, L"Error in IoHelper::getFileStat: " << Utility::formatIoError(localAbsolutePath, ioError));
+        return false;
+    }
+    if (ioError == IoError::NoSuchFileOrDirectory) {
+        LOGW_SYNCPAL_WARN(_logger, L"Item does not exist anymore: " << Utility::formatSyncPath(localAbsolutePath));
+        return false;
+    } else if (ioError == IoError::AccessDenied) {
+        LOGW_SYNCPAL_WARN(_logger, L"Item misses search permission: " << Utility::formatSyncPath(localAbsolutePath));
+        return false;
+    }
+
+    DbNode dbNode;
+    bool found = false;
+    if (!_syncPal->syncDb()->node(ReplicaSide::Local, std::to_string(fileStat.inode), dbNode, found)) {
+        LOGW_SYNCPAL_WARN(_logger, L"Error in SyncDb::node for " << Utility::formatSyncPath(localAbsolutePath));
+        return false;
+    }
+
+    if (!found) {
+        return false;
+    }
+
+    SyncPath localDbRelativePath;
+    SyncPath remoteDbRelativePath;
+    if (!_syncPal->syncDb()->path(dbNode.nodeId(), localDbRelativePath, remoteDbRelativePath, found)) {
+        LOGW_SYNCPAL_WARN(_logger, L"Error in SyncDb::path for " << Utility::formatSyncPath(localAbsolutePath));
+        return false;
+    }
+
+    if (!found) {
+        LOG_WARN(_logger, "dbNodeId " << dbNode.nodeId() << " not found in SyncDb");
+        return false;
+    }
+
+    SyncPath localRelativePath = CommonUtility::relativePath(_syncPal->localPath(), localAbsolutePath);
+
+    if (localDbRelativePath.lexically_normal() != localRelativePath.lexically_normal()) {
+        return false;
+    }
+
+    if (fileStat.nodeType == NodeType::Directory) {
+        return true;
+    }
+
+    if (dbNode.size() == fileStat.size && dbNode.lastModifiedLocal() == fileStat.modificationTime &&
+        (!dbNode.created().has_value() || dbNode.created().value() == fileStat.creationTime)) {
+        SyncFileItem syncItem;
+        syncItem.setLocalNodeId(std::to_string(fileStat.inode));
+        return true;
+    }
+
+    return false;
+}
+
 void SyncPalWorker::resetVfsFilesStatus() {
     if (_syncPal->vfsMode() == VirtualFileMode::Off) return;
     sentry::pTraces::scoped::ResetStatus perfMonitor1(syncDbId());
@@ -595,10 +658,17 @@ void SyncPalWorker::resetVfsFilesStatus() {
             }
             SyncPath absolutePath;
             try {
+                absolutePath = dirIt->path();
+
                 if (!dirIt->is_symlink() && dirIt->is_directory()) {
+                    // Fix directories sync status if needed to avoid having directories in false Syncing status.
+                    if (isLocalItemInSyncWithDb(absolutePath)) {
+                        VfsStatus status;
+                        status.isSyncing = false;
+                        _syncPal->vfs()->forceStatus(dirIt->path(), status);
+                    }
                     continue;
                 }
-                absolutePath = dirIt->path();
             } catch (std::filesystem::filesystem_error &) {
                 dirIt.disable_recursion_pending();
                 continue;
@@ -643,7 +713,41 @@ void SyncPalWorker::resetVfsFilesStatus() {
                 continue;
             }
 
-            if (!vfsStatus.isPlaceholder) continue;
+            if (!vfsStatus.isPlaceholder) {
+#if defined(KD_WINDOWS)
+                // Due to a bug introduced in kDrive 3.8.2.5, some files may have been reverted to regular files
+                // (i.e., no longer placeholders) while still being considered in sync with the database.
+                // As a corrective measure, we reconvert such files to placeholders when necessary to avoid misleading syncing
+                // status
+                if (!dirIt->is_symlink()) {
+                    SyncFileItem syncItem;
+                    FileStat fileStat;
+                    IoError ioError = IoError::Success;
+                    if (!IoHelper::getFileStat(absolutePath, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive)) {
+                        LOGW_SYNCPAL_WARN(_logger,
+                                          L"Error in IoHelper::getFileStat: " << Utility::formatIoError(absolutePath, ioError));
+                        continue;
+                    }
+                    if (ioError == IoError::NoSuchFileOrDirectory) {
+                        LOGW_SYNCPAL_WARN(_logger, L"Item does not exist anymore: " << Utility::formatSyncPath(absolutePath));
+                        continue;
+                    } else if (ioError == IoError::AccessDenied) {
+                        LOGW_SYNCPAL_WARN(_logger, L"Item misses search permission: " << Utility::formatSyncPath(absolutePath));
+                        continue;
+                    }
+                    if (isLocalItemInSyncWithDb(absolutePath)) {
+                        syncItem.setLocalNodeId(std::to_string(fileStat.inode));
+                        if (ExitInfo exitInfo = _syncPal->vfs()->convertToPlaceholder(absolutePath, syncItem); !exitInfo) {
+                            LOGW_SYNCPAL_WARN(_logger, L"Error in vfsConvertToPlaceholder : "
+                                                               << Utility::formatSyncPath(absolutePath) << L": " << exitInfo);
+                        }
+                    }
+                }
+                continue;
+#else
+                continue;
+#endif // WIN32
+            }
 
             const PinState pinState = _syncPal->vfs()->pinState(dirIt->path());
 #ifndef KD_WINDOWS // Handle by the API on windows.

--- a/src/libsyncengine/syncpal/syncpalworker.cpp
+++ b/src/libsyncengine/syncpal/syncpalworker.cpp
@@ -610,7 +610,7 @@ bool SyncPalWorker::isLocalItemInSyncWithDb(const SyncPath &localAbsolutePath, s
     SyncPath localDbRelativePath;
     SyncPath remoteDbRelativePath;
     if (!_syncPal->syncDb()->path(dbNode.nodeId(), localDbRelativePath, remoteDbRelativePath, found)) {
-        LOGW_SYNCPAL_WARN(_logger, L"Error in SyncDb::path for " << Utility::formatSyncPath(localAbsolutePath));
+        LOGW_SYNCPAL_WARN(_logger, L"Error in SyncDb::path for DbNodeID " << dbNode.nodeId());
         return false;
     }
 
@@ -619,7 +619,7 @@ bool SyncPalWorker::isLocalItemInSyncWithDb(const SyncPath &localAbsolutePath, s
         return false;
     }
 
-    SyncPath localRelativePath = CommonUtility::relativePath(_syncPal->localPath(), localAbsolutePath);
+    const SyncPath localRelativePath = CommonUtility::relativePath(_syncPal->localPath(), localAbsolutePath);
 
     if (localDbRelativePath.lexically_normal() != localRelativePath.lexically_normal()) {
         return false;
@@ -662,7 +662,7 @@ void SyncPalWorker::resetVfsFilesStatus() {
                 absolutePath = dirIt->path();
 
                 if (!dirIt->is_symlink() && dirIt->is_directory()) {
-                    // Fix directories sync status if needed to avoid having directories in false Syncing status.
+                    // Fix directories sync status if needed to avoid having directories in incorrect Syncing status.
                     std::optional<NodeId> localNodeId;
                     if (isLocalItemInSyncWithDb(absolutePath, localNodeId)) {
                         VfsStatus status;

--- a/src/libsyncengine/syncpal/syncpalworker.cpp
+++ b/src/libsyncengine/syncpal/syncpalworker.cpp
@@ -607,6 +607,10 @@ bool SyncPalWorker::isLocalItemInSyncWithDb(const SyncPath &localAbsolutePath, s
         return false;
     }
 
+    if (dbNode.type() != fileStat.nodeType) {
+        return false;
+    }
+
     SyncPath localDbRelativePath;
     SyncPath remoteDbRelativePath;
     if (!_syncPal->syncDb()->path(dbNode.nodeId(), localDbRelativePath, remoteDbRelativePath, found)) {
@@ -615,7 +619,7 @@ bool SyncPalWorker::isLocalItemInSyncWithDb(const SyncPath &localAbsolutePath, s
     }
 
     if (!found) {
-        LOG_WARN(_logger, "dbNodeId " << dbNode.nodeId() << " not found in SyncDb");
+        LOG_SYNCPAL_WARN(_logger, "dbNodeId " << dbNode.nodeId() << " not found in SyncDb");
         return false;
     }
 
@@ -660,13 +664,15 @@ void SyncPalWorker::resetVfsFilesStatus() {
                 absolutePath = dirIt->path();
                 std::optional<NodeId> localNodeId;
 
-                if (!dirIt->is_symlink() && dirIt->is_directory() && isLocalItemInSyncWithDb(absolutePath, localNodeId)) {
-                    // Fix directories sync status if needed to avoid having directories in incorrect Syncing status.
-                    VfsStatus status;
-                    status.isSyncing = false;
-                    if (const ExitInfo exitInfo = _syncPal->vfs()->forceStatus(dirIt->path(), status); !exitInfo) {
-                        LOGW_SYNCPAL_WARN(_logger, L"Error in vfsForceStatus : " << Utility::formatSyncPath(dirIt->path())
-                                                                                 << L": " << exitInfo);
+                if (!dirIt->is_symlink() && dirIt->is_directory()) {
+                    if (isLocalItemInSyncWithDb(absolutePath, localNodeId)) {
+                        // Fix directories sync status if needed to avoid having directories in incorrect Syncing status.
+                        VfsStatus status;
+                        status.isSyncing = false;
+                        if (const ExitInfo exitInfo = _syncPal->vfs()->forceStatus(dirIt->path(), status); !exitInfo) {
+                            LOGW_SYNCPAL_WARN(_logger, L"Error in vfsForceStatus : " << Utility::formatSyncPath(dirIt->path())
+                                                                                     << L": " << exitInfo);
+                        }
                     }
 
                     continue;
@@ -734,7 +740,7 @@ void SyncPalWorker::resetVfsFilesStatus() {
                 continue;
 #else
                 continue;
-#endif // WIN32
+#endif // KD_WINDOWS
             }
 
             const PinState pinState = _syncPal->vfs()->pinState(dirIt->path());

--- a/src/libsyncengine/syncpal/syncpalworker.cpp
+++ b/src/libsyncengine/syncpal/syncpalworker.cpp
@@ -631,8 +631,6 @@ bool SyncPalWorker::isLocalItemInSyncWithDb(const SyncPath &localAbsolutePath, s
 
     if (dbNode.size() == fileStat.size && dbNode.lastModifiedLocal() == fileStat.modificationTime &&
         (!dbNode.created().has_value() || dbNode.created().value() == fileStat.creationTime)) {
-        SyncFileItem syncItem;
-        syncItem.setLocalNodeId(std::to_string(fileStat.inode));
         return true;
     }
 

--- a/src/libsyncengine/syncpal/syncpalworker.cpp
+++ b/src/libsyncengine/syncpal/syncpalworker.cpp
@@ -658,19 +658,17 @@ void SyncPalWorker::resetVfsFilesStatus() {
             SyncPath absolutePath;
             try {
                 absolutePath = dirIt->path();
+                std::optional<NodeId> localNodeId;
 
-                if (!dirIt->is_symlink() && dirIt->is_directory()) {
+                if (!dirIt->is_symlink() && dirIt->is_directory() && isLocalItemInSyncWithDb(absolutePath, localNodeId)) {
                     // Fix directories sync status if needed to avoid having directories in incorrect Syncing status.
-                    std::optional<NodeId> localNodeId;
-                    if (isLocalItemInSyncWithDb(absolutePath, localNodeId)) {
-                        VfsStatus status;
-                        status.isSyncing = false;
-                        if (const ExitInfo exitInfo = _syncPal->vfs()->forceStatus(dirIt->path(), status); !exitInfo) {
-                            LOGW_SYNCPAL_WARN(_logger, L"Error in vfsForceStatus : " << Utility::formatSyncPath(dirIt->path())
-                                                                                     << L": " << exitInfo);
-                            continue;
-                        }
+                    VfsStatus status;
+                    status.isSyncing = false;
+                    if (const ExitInfo exitInfo = _syncPal->vfs()->forceStatus(dirIt->path(), status); !exitInfo) {
+                        LOGW_SYNCPAL_WARN(_logger, L"Error in vfsForceStatus : " << Utility::formatSyncPath(dirIt->path())
+                                                                                 << L": " << exitInfo);
                     }
+
                     continue;
                 }
             } catch (std::filesystem::filesystem_error &) {

--- a/src/libsyncengine/syncpal/syncpalworker.cpp
+++ b/src/libsyncengine/syncpal/syncpalworker.cpp
@@ -670,6 +670,7 @@ void SyncPalWorker::resetVfsFilesStatus() {
                 std::optional<NodeId> localNodeId;
 
                 if (!dirIt->is_symlink() && dirIt->is_directory()) {
+#ifdef KD_WINDOWS
                     if (isLocalItemInSyncWithDb(absolutePath, localNodeId)) {
                         // Fix directories sync status if needed to avoid having directories in incorrect Syncing status.
                         VfsStatus status;
@@ -679,7 +680,7 @@ void SyncPalWorker::resetVfsFilesStatus() {
                                                                                      << L": " << exitInfo);
                         }
                     }
-
+#endif // KD_WINDOWS
                     continue;
                 }
             } catch (std::filesystem::filesystem_error &) {

--- a/src/libsyncengine/syncpal/syncpalworker.cpp
+++ b/src/libsyncengine/syncpal/syncpalworker.cpp
@@ -580,7 +580,7 @@ bool SyncPalWorker::tryToFixDbNodeIdsAfterSyncDirChange() {
 bool SyncPalWorker::isLocalItemInSyncWithDb(const SyncPath &localAbsolutePath, std::optional<NodeId> &outLocalNodeId) {
     // Ideally, this logic should be shared with ComputeFSOperationWorker::inferChangeFromDbNode,
     // but for now it would require some refactoring to make it reusable, so we duplicate it here.
-
+    outLocalNodeId.reset();
     FileStat fileStat;
     IoError ioError = IoError::Success;
     if (!IoHelper::getFileStat(localAbsolutePath, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive)) {
@@ -593,7 +593,12 @@ bool SyncPalWorker::isLocalItemInSyncWithDb(const SyncPath &localAbsolutePath, s
     } else if (ioError == IoError::AccessDenied) {
         LOGW_SYNCPAL_WARN(_logger, L"Item misses search permission: " << Utility::formatSyncPath(localAbsolutePath));
         return false;
+    } else if (ioError != IoError::Success) {
+        LOGW_SYNCPAL_WARN(_logger, L"Error accessing item: " << Utility::formatSyncPath(localAbsolutePath)
+                                                             << L": " << Utility::formatIoError(ioError));
+        return false;
     }
+
     outLocalNodeId = std::to_string(fileStat.inode);
 
     DbNode dbNode;

--- a/src/libsyncengine/syncpal/syncpalworker.cpp
+++ b/src/libsyncengine/syncpal/syncpalworker.cpp
@@ -577,7 +577,7 @@ bool SyncPalWorker::tryToFixDbNodeIdsAfterSyncDirChange() {
     return true;
 }
 
-bool SyncPalWorker::isLocalItemInSyncWithDb(const SyncPath &localAbsolutePath) {
+bool SyncPalWorker::isLocalItemInSyncWithDb(const SyncPath &localAbsolutePath, std::optional<NodeId> &outLocalNodeId) {
     // Ideally, this logic should be shared with ComputeFSOperationWorker::inferChangeFromDbNode,
     // but for now it would require some refactoring to make it reusable, so we duplicate it here.
 
@@ -594,6 +594,7 @@ bool SyncPalWorker::isLocalItemInSyncWithDb(const SyncPath &localAbsolutePath) {
         LOGW_SYNCPAL_WARN(_logger, L"Item misses search permission: " << Utility::formatSyncPath(localAbsolutePath));
         return false;
     }
+    outLocalNodeId = std::to_string(fileStat.inode);
 
     DbNode dbNode;
     bool found = false;
@@ -662,10 +663,15 @@ void SyncPalWorker::resetVfsFilesStatus() {
 
                 if (!dirIt->is_symlink() && dirIt->is_directory()) {
                     // Fix directories sync status if needed to avoid having directories in false Syncing status.
-                    if (isLocalItemInSyncWithDb(absolutePath)) {
+                    std::optional<NodeId> localNodeId;
+                    if (isLocalItemInSyncWithDb(absolutePath, localNodeId)) {
                         VfsStatus status;
                         status.isSyncing = false;
-                        _syncPal->vfs()->forceStatus(dirIt->path(), status);
+                        if (const ExitInfo exitInfo = _syncPal->vfs()->forceStatus(dirIt->path(), status); !exitInfo) {
+                            LOGW_SYNCPAL_WARN(_logger, L"Error in vfsForceStatus : " << Utility::formatSyncPath(dirIt->path())
+                                                                                     << L": " << exitInfo);
+                            continue;
+                        }
                     }
                     continue;
                 }
@@ -719,28 +725,14 @@ void SyncPalWorker::resetVfsFilesStatus() {
                 // (i.e., no longer placeholders) while still being considered in sync with the database.
                 // As a corrective measure, we reconvert such files to placeholders when necessary to avoid misleading syncing
                 // status
-                if (!dirIt->is_symlink()) {
-                    SyncFileItem syncItem;
-                    FileStat fileStat;
-                    IoError ioError = IoError::Success;
-                    if (!IoHelper::getFileStat(absolutePath, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive)) {
-                        LOGW_SYNCPAL_WARN(_logger,
-                                          L"Error in IoHelper::getFileStat: " << Utility::formatIoError(absolutePath, ioError));
-                        continue;
-                    }
-                    if (ioError == IoError::NoSuchFileOrDirectory) {
-                        LOGW_SYNCPAL_WARN(_logger, L"Item does not exist anymore: " << Utility::formatSyncPath(absolutePath));
-                        continue;
-                    } else if (ioError == IoError::AccessDenied) {
-                        LOGW_SYNCPAL_WARN(_logger, L"Item misses search permission: " << Utility::formatSyncPath(absolutePath));
-                        continue;
-                    }
-                    if (isLocalItemInSyncWithDb(absolutePath)) {
-                        syncItem.setLocalNodeId(std::to_string(fileStat.inode));
-                        if (ExitInfo exitInfo = _syncPal->vfs()->convertToPlaceholder(absolutePath, syncItem); !exitInfo) {
-                            LOGW_SYNCPAL_WARN(_logger, L"Error in vfsConvertToPlaceholder : "
-                                                               << Utility::formatSyncPath(absolutePath) << L": " << exitInfo);
-                        }
+
+                SyncFileItem syncItem;
+                std::optional<NodeId> localNodeId;
+                if (!dirIt->is_symlink() && isLocalItemInSyncWithDb(absolutePath, localNodeId) && localNodeId.has_value()) {
+                    syncItem.setLocalNodeId(localNodeId.value());
+                    if (ExitInfo exitInfo = _syncPal->vfs()->convertToPlaceholder(absolutePath, syncItem); !exitInfo) {
+                        LOGW_SYNCPAL_WARN(_logger, L"Error in vfsConvertToPlaceholder : " << Utility::formatSyncPath(absolutePath)
+                                                                                          << L": " << exitInfo);
                     }
                 }
                 continue;

--- a/src/libsyncengine/syncpal/syncpalworker.h
+++ b/src/libsyncengine/syncpal/syncpalworker.h
@@ -65,7 +65,7 @@ class SyncPalWorker : public ISyncWorker {
          * Returns false if the item is not in sync, or if an error occurred while trying to determine it
          * (e.g., file not found, I/O error, etc.). 
          */
-        bool isLocalItemInSyncWithDb(const SyncPath &localPath, std::optional<NodeId> &outLocalNodeId);
+        bool isLocalItemInSyncWithDb(const SyncPath &localAbsolutePath, std::optional<NodeId> &outLocalNodeId);
         void resetVfsFilesStatus();
         /**
          * @brief Attempts to repair local node IDs in the SyncDb after the sync directory has changed its node ID.

--- a/src/libsyncengine/syncpal/syncpalworker.h
+++ b/src/libsyncengine/syncpal/syncpalworker.h
@@ -60,6 +60,7 @@ class SyncPalWorker : public ISyncWorker {
         void stopAndWaitForExitOfWorkers(std::shared_ptr<ISyncWorker> workers[2]);
         void stopAndWaitForExitOfAllWorkers(std::shared_ptr<ISyncWorker> fsoWorkers[2],
                                             std::shared_ptr<ISyncWorker> stepWorkers[2]);
+        bool isLocalItemInSyncWithDb(const SyncPath &localPath);
         void resetVfsFilesStatus();
         /**
          * @brief Attempts to repair local node IDs in the SyncDb after the sync directory has changed its node ID.

--- a/src/libsyncengine/syncpal/syncpalworker.h
+++ b/src/libsyncengine/syncpal/syncpalworker.h
@@ -60,7 +60,7 @@ class SyncPalWorker : public ISyncWorker {
         void stopAndWaitForExitOfWorkers(std::shared_ptr<ISyncWorker> workers[2]);
         void stopAndWaitForExitOfAllWorkers(std::shared_ptr<ISyncWorker> fsoWorkers[2],
                                             std::shared_ptr<ISyncWorker> stepWorkers[2]);
-        bool isLocalItemInSyncWithDb(const SyncPath &localPath);
+        bool isLocalItemInSyncWithDb(const SyncPath &localPath, std::optional<NodeId>& outLocalNodeId);
         void resetVfsFilesStatus();
         /**
          * @brief Attempts to repair local node IDs in the SyncDb after the sync directory has changed its node ID.

--- a/src/libsyncengine/syncpal/syncpalworker.h
+++ b/src/libsyncengine/syncpal/syncpalworker.h
@@ -60,7 +60,12 @@ class SyncPalWorker : public ISyncWorker {
         void stopAndWaitForExitOfWorkers(std::shared_ptr<ISyncWorker> workers[2]);
         void stopAndWaitForExitOfAllWorkers(std::shared_ptr<ISyncWorker> fsoWorkers[2],
                                             std::shared_ptr<ISyncWorker> stepWorkers[2]);
-        bool isLocalItemInSyncWithDb(const SyncPath &localPath, std::optional<NodeId>& outLocalNodeId);
+
+        /* Returns true if the local item is in sync with its state in the SyncDb.
+         * Returns false if the item is not in sync, or if an error occurred while trying to determine it
+         * (e.g., file not found, I/O error, etc.). 
+         */
+        bool isLocalItemInSyncWithDb(const SyncPath &localPath, std::optional<NodeId> &outLocalNodeId);
         void resetVfsFilesStatus();
         /**
          * @brief Attempts to repair local node IDs in the SyncDb after the sync directory has changed its node ID.


### PR DESCRIPTION
Add isLocalItemInSyncWithDb to check local/db sync and convert to VFS placeholder if needed. Update resetVfsFilesStatus to fix incorrect "Syncing" status and handle placeholder conversion on Windows.