### PR TITLE
feat(cmake): set default value for KDRIVE_THEME_DIR

### DIFF
--- a/THEME.cmake
+++ b/THEME.cmake
@@ -1,4 +1,4 @@
-set(KDRIVE_THEME_DIR "" CACHE STRING "Define directory containing a custom theme")
+set(KDRIVE_THEME_DIR "${CMAKE_CURRENT_LIST_DIR}/infomaniak" CACHE STRING "Define directory containing a custom theme")
 include("${KDRIVE_THEME_DIR}/kDrive.cmake")
 
 # Default dbus name and path

--- a/infomaniak-build-tools/linux/Readme.md
+++ b/infomaniak-build-tools/linux/Readme.md
@@ -230,7 +230,6 @@ The project requires additional CMake variables for a correct build. To inject t
 1. Create or open `~/.conan2/profiles/debug_vars.cmake` and add the cache entries, for example:
    ```cmake
    set(APPLICATION_CLIENT_EXECUTABLE "kdrive_client")
-   set(KDRIVE_THEME_DIR "$ENV{HOME}/Projects/desktop-kDrive/infomaniak")
    set(BUILD_UNIT_TESTS "ON")      # Set to "OFF" to skip tests
    set(CMAKE_PREFIX_PATH "$ENV{HOME}/Qt/6.7.2/gcc_arm64")
    set(CMAKE_INSTALL_PREFIX "$ENV{HOME}/Projects/CLion-build-debug/bin")
@@ -301,7 +300,6 @@ CMake options:
 ```
 -DCMAKE_BUILD_TYPE:STRING=Debug
 -DAPPLICATION_CLIENT_EXECUTABLE=kdrive_client
--DKDRIVE_THEME_DIR=/home/<user>/Projects/desktop-kDrive/infomaniak
 -DCMAKE_INSTALL_PREFIX=/home/<user>/Projects/CLion-build-debug/bin
 -DBUILD_UNIT_TESTS:BOOL=ON
 -DCMAKE_PREFIX_PATH:STRING=/home/<user>/Qt/6.7.2/gcc_arm64
@@ -325,7 +323,6 @@ In the project build settings, paste the following lines in the Initial Configur
 -DCMAKE_C_COMPILER:STRING=%{Compiler:Executable:C}
 -DCMAKE_CXX_COMPILER:STRING=%{Compiler:Executable:Cxx}
 -DAPPLICATION_CLIENT_EXECUTABLE=kdrive
--DKDRIVE_THEME_DIR=/home/<user>/Projects/desktop-kDrive/infomaniak
 -DCMAKE_INSTALL_PREFIX=/home/<user>/Projects/build-desktop-kDrive-Desktop_Qt_6_2_3_GCC_64bit-Debug/bin
 -DBUILD_TESTING=OFF
 ```

--- a/infomaniak-build-tools/macos/Readme.md
+++ b/infomaniak-build-tools/macos/Readme.md
@@ -244,7 +244,6 @@ The project requires additional CMake variables for a correct build. To inject t
 1. Create or open `~/.conan2/profiles/debug_vars.cmake` and add the cache entries, for example:
    ```cmake
    set(APPLICATION_CLIENT_EXECUTABLE "kdrive_client")
-   set(KDRIVE_THEME_DIR "$ENV{HOME}/Projects/desktop-kDrive/infomaniak")
    set(BUILD_UNIT_TESTS "ON")      # Set to "OFF" to skip tests
    set(TEAM_IDENTIFIER_PREFIX "864VDCS2QY")
    set(CMAKE_PREFIX_PATH "$ENV{HOME}/Qt/6.2.3/macos")
@@ -317,7 +316,6 @@ CMake options:
 ```
 -DCMAKE_BUILD_TYPE:STRING=Debug
 -DAPPLICATION_CLIENT_EXECUTABLE=kdrive_client
--DKDRIVE_THEME_DIR=/Users/<user_name>/Projects/desktop-kDrive/infomaniak
 -DCMAKE_INSTALL_PREFIX=/Users/<user_name>/Projects/CLion-build-debug/install
 -DBUILD_UNIT_TESTS:BOOL=ON
 -DCMAKE_PREFIX_PATH:STRING=/Users/<user_name>/Qt/6.2.3/macos
@@ -382,7 +380,6 @@ In the project build settings, paste the following lines in the `Initial Configu
 -DCMAKE_CXX_COMPILER:STRING=%{Compiler:Executable:Cxx}
 -DAPPLICATION_CLIENT_EXECUTABLE=kdrive
 -DTEAM_IDENTIFIER_PREFIX=<team id>
--DKDRIVE_THEME_DIR=/Users/<user>/Projects/desktop-kDrive/infomaniak
 -DCMAKE_INSTALL_PREFIX=/Users/<user>/Projects/build-desktop-kDrive-Qt_6_2_3_for_macOS-Debug/install
 -DBUILD_TESTING=OFF
 %{CMAKE_OSX_ARCHITECTURES:DefaultFlag}

--- a/infomaniak-build-tools/windows/Readme.md
+++ b/infomaniak-build-tools/windows/Readme.md
@@ -294,7 +294,6 @@ The project requires additional CMake variables for a correct build. To inject t
 1. Create or open `%USERPROFILE%/.conan2/profiles/debug_vars.cmake` and add the cache entries adapted to your installation, for example:
    ```cmake
    set(APPLICATION_CLIENT_EXECUTABLE "kdrive_client")
-   set(KDRIVE_THEME_DIR "F:/Projects/desktop-kDrive/infomaniak")
    set(BUILD_UNIT_TESTS "ON")      # Set to "OFF" to skip tests
    set(CMAKE_PREFIX_PATH "C:/Qt/6.2.3/msvc2019_64")
    set(CMAKE_BUILD_TYPE "Debug")
@@ -383,7 +382,6 @@ Then copy the following list of `CMake` variables in "Initial CMake Parameters" 
 -DCMAKE_EXE_LINKER_FLAGS_DEBUG:STRING=/debug /INCREMENTAL
 -DCMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO:STRING=/debug /INCREMENTAL
 -DCMAKE_INSTALL_PREFIX:PATH=%{ActiveProject:RunConfig:Executable:Path}/..
--DKDRIVE_THEME_DIR:STRING=F:/projects/desktop-kDrive/infomaniak
 -DPLUGINDIR:STRING=C:/Program Files (x86)/kDrive/lib/kDrive/plugins
 -DZLIB_INCLUDE_DIR:PATH=C:/Program Files (x86)/zlib-1.2.11/include
 -DZLIB_LIBRARY_RELEASE:FILEPATH=C:/Program Files (x86)/zlib-1.2.11/lib/zlib.lib
@@ -427,7 +425,6 @@ Open `Visual Studio 2019` and select `Open local folder`. Then choose `F:\Projec
    - CMake command args:
     ```
     -DAPPLICATION_CLIENT_EXECUTABLE=kdrive_client
-    -DKDRIVE_THEME_DIR=F:/Projects/desktop-kDrive/infomaniak
     -DBUILD_UNIT_TESTS:BOOL=ON
     -DCMAKE_PREFIX_PATH:STRING=C:/Qt/6.2.3/msvc2019_64
     -DZLIB_INCLUDE_DIR:PATH="C:/Program Files (x86)/zlib-1.2.11/include"


### PR DESCRIPTION
This PR sets a default value for `KDRIVE_THEME_DIR` in `THEME.cmake`, pointing to the `infomaniak` theme directory within the repository. This removes the need to manually define the variable when configuring the project.

The documentation for Linux, macOS, and Windows has also been updated to remove instructions that previously required users to set `KDRIVE_THEME_DIR` manually.