### PR TITLE
feat(sync): add isAdvancedSync param for folder validation

### DIFF
--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/SyncExclusionPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/SyncExclusionPage.xaml.cs
@@ -1,5 +1,6 @@
 using Infomaniak.kDrive.CustomControls;
 using Infomaniak.kDrive.ServerCommunication.Interfaces;
+using Infomaniak.kDrive.Types;
 using Infomaniak.kDrive.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml;
@@ -115,7 +116,7 @@ namespace Infomaniak.kDrive.Pages.DriveSetupContentDialog
             }
 
             var commServices = App.ServiceProvider.GetRequiredService<IServerCommService>();
-            bool? result = await commServices.IsPathValidForNewSync(folder.Path, false, CancellationToken.None);
+            bool? result = await commServices.IsPathValidForNewSync(folder.Path, SyncConfiguration.Classic, CancellationToken.None);
             if (result is null)
             {
                 Utility.ShowUnexpectedErrorTeachingTip();

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/SyncExclusionPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/SyncExclusionPage.xaml.cs
@@ -115,7 +115,7 @@ namespace Infomaniak.kDrive.Pages.DriveSetupContentDialog
             }
 
             var commServices = App.ServiceProvider.GetRequiredService<IServerCommService>();
-            bool? result = await commServices.IsPathValidForNewSync(folder.Path, CancellationToken.None);
+            bool? result = await commServices.IsPathValidForNewSync(folder.Path, false, CancellationToken.None);
             if (result is null)
             {
                 Utility.ShowUnexpectedErrorTeachingTip();

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/SyncSetupPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/SyncSetupPage.xaml.cs
@@ -1,5 +1,6 @@
 using Infomaniak.kDrive.CustomControls;
 using Infomaniak.kDrive.ServerCommunication.Interfaces;
+using Infomaniak.kDrive.Types;
 using Infomaniak.kDrive.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml;
@@ -129,7 +130,7 @@ namespace Infomaniak.kDrive.Pages.DriveSetupContentDialog
             }
 
             var commServices = App.ServiceProvider.GetRequiredService<IServerCommService>();
-            bool? result = await commServices.IsPathValidForNewSync(folder.Path, false, CancellationToken.None);
+            bool? result = await commServices.IsPathValidForNewSync(folder.Path, SyncConfiguration.Classic, CancellationToken.None);
             if (result is null)
             {
                 Utility.ShowUnexpectedErrorTeachingTip();

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/SyncSetupPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/SyncSetupPage.xaml.cs
@@ -129,7 +129,7 @@ namespace Infomaniak.kDrive.Pages.DriveSetupContentDialog
             }
 
             var commServices = App.ServiceProvider.GetRequiredService<IServerCommService>();
-            bool? result = await commServices.IsPathValidForNewSync(folder.Path, CancellationToken.None);
+            bool? result = await commServices.IsPathValidForNewSync(folder.Path, false, CancellationToken.None);
             if (result is null)
             {
                 Utility.ShowUnexpectedErrorTeachingTip();

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Interfaces/IServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Interfaces/IServerCommService.cs
@@ -65,7 +65,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Interfaces
 
         // Returns a valid path for a new sync as close as possible to the desiredPath, if not known, the driveDbId can be set to -1
         Task<string?> GetGoodPathForNewSync(IDrive? drive, string desiredPath, CancellationToken cancellationToken);
-        Task<bool?> IsPathValidForNewSync(string path, bool isAdvancedSync, CancellationToken cancellationToken);
+        Task<bool?> IsPathValidForNewSync(string path, SyncConfiguration syncConfiguration, CancellationToken cancellationToken);
         Task<List<SearchItem>?> SearchItem(DbId syncDbId, string searchString, CancellationToken cancellationToken);
         Task<UInt64?> GetSyncOfflineFilesSize(DbId syncDbId, CancellationToken cancellationToken);
 

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Interfaces/IServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Interfaces/IServerCommService.cs
@@ -65,7 +65,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Interfaces
 
         // Returns a valid path for a new sync as close as possible to the desiredPath, if not known, the driveDbId can be set to -1
         Task<string?> GetGoodPathForNewSync(IDrive? drive, string desiredPath, CancellationToken cancellationToken);
-        Task<bool?> IsPathValidForNewSync(string path, CancellationToken cancellationToken);
+        Task<bool?> IsPathValidForNewSync(string path, bool isAdvancedSync, CancellationToken cancellationToken);
         Task<List<SearchItem>?> SearchItem(DbId syncDbId, string searchString, CancellationToken cancellationToken);
         Task<UInt64?> GetSyncOfflineFilesSize(DbId syncDbId, CancellationToken cancellationToken);
 

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/CommSharedEnums.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/CommSharedEnums.cs
@@ -353,4 +353,9 @@ namespace Infomaniak.kDrive.Types
         KeepLocal,
         KeepRemote
     }
+    public enum SyncConfiguration
+    {
+        Classic,
+        Advanced
+    };
 }

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/CommSharedJsonKeys.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/CommSharedJsonKeys.cs
@@ -84,7 +84,7 @@ namespace Infomaniak.kDrive.ServerCommunication.CommStruct
         static public string Limit = "limit";
         static public string IsValid = "isValid";
         static public string Path = "path";
-        static public string IsAdvancedSync = "isAdvancedSync";
+        static public string SyncConfiguration = "syncConfiguration";
         static public string BasePath = "basePath";
         static public string GoodPath = "goodPath";
         static public string BestMode = "bestMode";

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/CommSharedJsonKeys.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/CommSharedJsonKeys.cs
@@ -84,6 +84,7 @@ namespace Infomaniak.kDrive.ServerCommunication.CommStruct
         static public string Limit = "limit";
         static public string IsValid = "isValid";
         static public string Path = "path";
+        static public string IsAdvancedSync = "isAdvancedSync";
         static public string BasePath = "basePath";
         static public string GoodPath = "goodPath";
         static public string BestMode = "bestMode";

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -650,11 +650,12 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
 
             return result;
         }
-        public async Task<bool?> IsPathValidForNewSync(string path, CancellationToken cancellationToken)
+        public async Task<bool?> IsPathValidForNewSync(string path, bool isAdvancedSync, CancellationToken cancellationToken)
         {
             var parms = new JsonObject
             {
-                [JsonKeys.Path] = Utility.ToBase64String(path)
+                [JsonKeys.Path] = Utility.ToBase64String(path),
+                [JsonKeys.IsAdvancedSync] = isAdvancedSync
             };
 
             CommData data = await _commClient.SendRequestAsync(RequestNum.UTILITY_ISPATHVALIDFORNEWSYNC, parms, cancellationToken);

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -650,12 +650,12 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
 
             return result;
         }
-        public async Task<bool?> IsPathValidForNewSync(string path, bool isAdvancedSync, CancellationToken cancellationToken)
+        public async Task<bool?> IsPathValidForNewSync(string path, , SyncConfiguration syncConfiguration, CancellationToken cancellationToken)
         {
             var parms = new JsonObject
             {
                 [JsonKeys.Path] = Utility.ToBase64String(path),
-                [JsonKeys.IsAdvancedSync] = isAdvancedSync
+                [JsonKeys.SyncConfiguration] = (int)syncConfiguration
             };
 
             CommData data = await _commClient.SendRequestAsync(RequestNum.UTILITY_ISPATHVALIDFORNEWSYNC, parms, cancellationToken);

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -650,7 +650,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
 
             return result;
         }
-        public async Task<bool?> IsPathValidForNewSync(string path, , SyncConfiguration syncConfiguration, CancellationToken cancellationToken)
+        public async Task<bool?> IsPathValidForNewSync(string path, SyncConfiguration syncConfiguration, CancellationToken cancellationToken)
         {
             var parms = new JsonObject
             {

--- a/src/libcommon/utility/cstypes.h
+++ b/src/libcommon/utility/cstypes.h
@@ -320,4 +320,10 @@ enum class ConflictResolutionStrategy {
     EnumEnd
 };
 
+enum class SyncConfiguration {
+    Classic,
+    Advanced,
+    EnumEnd
+};
+
 } // namespace KDC

--- a/src/libcommon/utility/types.cpp
+++ b/src/libcommon/utility/types.cpp
@@ -893,6 +893,17 @@ std::string toString(const ConflictResolutionStrategy e) {
     }
 }
 
+std::string toString(const SyncConfiguration e) {
+    switch (e) {
+        case SyncConfiguration::Classic:
+            return "Classic";
+        case SyncConfiguration::Advanced:
+            return "Advanced";
+        default:
+            return noConversionStr;
+    }
+}
+
 void ExitInfo::merge(const ExitInfo &exitInfoToMerge, const std::vector<ExitCode> &exitCodeList) {
     const long index = indexInList(exitInfoToMerge.code(), exitCodeList);
     const long thisIndex = indexInList(this->code(), exitCodeList);

--- a/src/libcommon/utility/types.h
+++ b/src/libcommon/utility/types.h
@@ -470,6 +470,7 @@ std::string toString(UploadSessionType e);
 std::string toString(UpdateState e);
 std::string toString(VersionChannel e);
 std::string toString(VirtualFileMode e);
+std::string toString(SyncConfiguration e);
 
 inline ReplicaSide otherSide(const ReplicaSide side) {
     if (side == ReplicaSide::Unknown) return ReplicaSide::Unknown;

--- a/src/server/comm/guijobs/utilityispathvalidfornewsyncjob.cpp
+++ b/src/server/comm/guijobs/utilityispathvalidfornewsyncjob.cpp
@@ -23,6 +23,7 @@
 
 // Input parameters keys
 static const auto inParamsPath = "path";
+static const auto inParamsIsAdvancedSync = "isAdvancedSync";
 
 // Output parameters keys
 static const auto outParamsIsValid = "isValid";
@@ -41,6 +42,8 @@ ExitInfo UtilityIsPathValidForNewSyncJob::deserializeInputParms() {
     CommString pathStr;
     try {
         readParamValue(inParamsPath, pathStr);
+        readParamValue(inParamsIsAdvancedSync, _isAdvancedSync);
+
     } catch (const Poco::Exception &pocoException) {
         LOG_WARN(_logger, logMessage << pocoException.message());
         return ExitCode::LogicError;
@@ -56,7 +59,7 @@ ExitInfo UtilityIsPathValidForNewSyncJob::serializeOutputParms() {
 }
 
 ExitInfo UtilityIsPathValidForNewSyncJob::process() {
-    if (const auto exitInfo = ServerRequests::isPathValidForNewSync(_path, _isValid); !exitInfo) {
+    if (const auto exitInfo = ServerRequests::isPathValidForNewSync(_path, _isAdvancedSync, _isValid); !exitInfo) {
         LOGW_WARN(_logger, L"isPathValidForNewSync failed: " << Utility::formatSyncPath(_path));
         return exitInfo;
     }

--- a/src/server/comm/guijobs/utilityispathvalidfornewsyncjob.cpp
+++ b/src/server/comm/guijobs/utilityispathvalidfornewsyncjob.cpp
@@ -23,7 +23,7 @@
 
 // Input parameters keys
 static const auto inParamsPath = "path";
-static const auto inParamsIsAdvancedSync = "isAdvancedSync";
+static const auto inParamsSyncConfiguration = "syncConfiguration";
 
 // Output parameters keys
 static const auto outParamsIsValid = "isValid";
@@ -42,7 +42,7 @@ ExitInfo UtilityIsPathValidForNewSyncJob::deserializeInputParms() {
     CommString pathStr;
     try {
         readParamValue(inParamsPath, pathStr);
-        readParamValue(inParamsIsAdvancedSync, _isAdvancedSync);
+        readParamValue(inParamsSyncConfiguration, _syncConfig);
 
     } catch (const Poco::Exception &pocoException) {
         LOG_WARN(_logger, logMessage << pocoException.message());
@@ -59,7 +59,7 @@ ExitInfo UtilityIsPathValidForNewSyncJob::serializeOutputParms() {
 }
 
 ExitInfo UtilityIsPathValidForNewSyncJob::process() {
-    if (const auto exitInfo = ServerRequests::isPathValidForNewSync(_path, _isAdvancedSync, _isValid); !exitInfo) {
+    if (const auto exitInfo = ServerRequests::isPathValidForNewSync(_path, _syncConfig, _isValid); !exitInfo) {
         LOGW_WARN(_logger, L"isPathValidForNewSync failed: " << Utility::formatSyncPath(_path));
         return exitInfo;
     }

--- a/src/server/comm/guijobs/utilityispathvalidfornewsyncjob.h
+++ b/src/server/comm/guijobs/utilityispathvalidfornewsyncjob.h
@@ -30,7 +30,7 @@ class UtilityIsPathValidForNewSyncJob : public AbstractGuiJob {
     private:
         // Input parameters
         SyncPath _path;
-        bool _isAdvancedSync = false;
+        SyncConfiguration _syncConfig = SyncConfiguration::Classic;
 
         // Output parameters
         bool _isValid = false;

--- a/src/server/comm/guijobs/utilityispathvalidfornewsyncjob.h
+++ b/src/server/comm/guijobs/utilityispathvalidfornewsyncjob.h
@@ -30,6 +30,7 @@ class UtilityIsPathValidForNewSyncJob : public AbstractGuiJob {
     private:
         // Input parameters
         SyncPath _path;
+        bool _isAdvancedSync = false;
 
         // Output parameters
         bool _isValid = false;

--- a/src/server/requests/serverrequests.cpp
+++ b/src/server/requests/serverrequests.cpp
@@ -312,7 +312,7 @@ ExitCode ServerRequests::updateParameters(const ParametersInfo &parametersInfo) 
     return exitCode;
 }
 
-ExitInfo ServerRequests::isPathValidForNewSync(const SyncPath &path, bool &valid) {
+ExitInfo ServerRequests::isPathValidForNewSync(const SyncPath &path, bool isAdvancedSync, bool &valid) {
     // Check for nested syncs
     std::vector<Sync> syncList;
     valid = false;
@@ -350,12 +350,48 @@ ExitInfo ServerRequests::isPathValidForNewSync(const SyncPath &path, bool &valid
         }
     }
 
-    if (!isEmpty && CommonUtility::envVarValue("KD_ALLOW_NON_EMPTY_SYNC_FOLDER") != "1") {
-        LOGW_WARN(Log::instance()->getLogger(), L"The path exists but is not empty: " << Utility::formatSyncPath(path));
-        return ExitCode::Ok;
+    if (!isAdvancedSync && !isEmpty && CommonUtility::envVarValue("KD_ALLOW_NON_EMPTY_SYNC_FOLDER") != "1") {
+        bool containsNonExcludedFile = false;
+        if (exitInfo = folderContainsNonExcludedItem(path, containsNonExcludedFile); !exitInfo) {
+            LOG_WARN(Log::instance()->getLogger(), "Error in folderContainsNonExcludedItem: " << exitInfo);
+            return exitInfo;
+        }
+        if (containsNonExcludedFile) {
+            LOGW_WARN(Log::instance()->getLogger(), L"The directory is not empty: " << Utility::formatSyncPath(path));
+            return ExitCode::Ok;
+        }
     }
 
     valid = true;
+    return ExitCode::Ok;
+}
+
+ExitInfo ServerRequests::folderContainsNonExcludedItem(const SyncPath &path, bool &containsNonExcludedFile) {
+    IoError ioError = IoError::Unknown;
+    IoHelper::DirectoryIterator dirIt(path, false, ioError);
+    if (ioError != IoError::Success) {
+        LOG_WARN(Log::instance()->getLogger(),
+                 "Error in IoHelper::DirectoryIterator for path=" << Path2Str(path) << " error=" << ioError);
+        return ExitCode::SystemError;
+    }
+
+    containsNonExcludedFile = false;
+
+    DirectoryEntry entry;
+    bool endOfDirectory = false;
+    while (dirIt.next(entry, endOfDirectory, ioError) && !endOfDirectory && ioError == IoError::Success) {
+        if (!ExclusionTemplateCache::instance()->isExcluded(entry.path())) {
+            containsNonExcludedFile = true;
+            return ExitCode::Ok;
+        }
+    }
+
+    if (!endOfDirectory || ioError != IoError::Success) {
+        LOG_WARN(Log::instance()->getLogger(), "Error iterating directory with IoHelper::DirectoryIterator for path="
+                                                       << Path2Str(path) << " error=" << ioError);
+        return ExitCode::SystemError;
+    }
+
     return ExitCode::Ok;
 }
 
@@ -2053,21 +2089,6 @@ ExitInfo ServerRequests::checkPathValidityForNewFolder(const std::vector<Sync> &
 
     const QString userDir = QDir::cleanPath(canonicalPath(path)) + '/';
 
-    // Check if the local directory already exists
-    IoError ioError = IoError::Success;
-    bool found = false;
-    const bool success = IoHelper::checkIfPathExists(QStr2Path(userDir), found, ioError, IoHelper::PathCheckOption::Insensitive);
-    if (!success) {
-        LOGW_WARN(Log::instance()->getLogger(), L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(ioError));
-        error = QObject::tr("An error occurred while checking the local folder. Please try again.");
-        return ExitCode::SystemError;
-    }
-
-    if (found) {
-        error = QObject::tr("The local folder %1 already exists. Please pick another one!").arg(QDir::toNativeSeparators(path));
-        return {ExitCode::SystemError, ExitCause::DirExists};
-    }
-
     // check if the local directory isn't used yet in another sync
     QList<std::filesystem::path> existingSyncFolderList;
     for (const Sync &sync: syncList) {
@@ -2099,6 +2120,21 @@ ExitInfo ServerRequests::checkPathValidityForNewFolder(const std::vector<Sync> &
                             .arg(QDir::toNativeSeparators(path));
             return {ExitCode::InvalidSync, ExitCause::DirExists};
         }
+    }
+
+    // Check if the local directory already exists
+    IoError ioError = IoError::Success;
+    bool found = false;
+    const bool success = IoHelper::checkIfPathExists(QStr2Path(userDir), found, ioError, IoHelper::PathCheckOption::Insensitive);
+    if (!success) {
+        LOGW_WARN(Log::instance()->getLogger(), L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(ioError));
+        error = QObject::tr("An error occurred while checking the local folder. Please try again.");
+        return ExitCode::SystemError;
+    }
+
+    if (found) {
+        error = QObject::tr("The local folder %1 already exists. Please pick another one!").arg(QDir::toNativeSeparators(path));
+        return {ExitCode::SystemError, ExitCause::DirExists};
     }
 
     return ExitCode::Ok;

--- a/src/server/requests/serverrequests.cpp
+++ b/src/server/requests/serverrequests.cpp
@@ -349,7 +349,7 @@ ExitInfo ServerRequests::isPathValidForNewSync(const SyncPath &path, SyncConfigu
         return ExitCode::Ok;
     }
 
-    if (CommonUtility::envVarValue("KD_ALLOW_NON_EMPTY_SYNC_FOLDER") != "1") {
+    if (CommonUtility::envVarValue("KD_ALLOW_NON_EMPTY_SYNC_FOLDER") == "1") {
         valid = true;
         return ExitCode::Ok;
     }

--- a/src/server/requests/serverrequests.cpp
+++ b/src/server/requests/serverrequests.cpp
@@ -323,14 +323,23 @@ ExitInfo ServerRequests::isPathValidForNewSync(const SyncPath &path, bool isAdva
 
     const QString qPath = Path2QStr(path);
     QString qError;
-    ExitInfo exitInfo = checkPathValidityForNewFolder(syncList, qPath, qError);
-    bool alreadyExists = exitInfo == ExitInfo(ExitCode::SystemError, ExitCause::DirExists);
-    if (!exitInfo && !alreadyExists) {
-        LOG_WARN(Log::instance()->getLogger(), "Error in checkPathValidityForNewFolder: " << exitInfo << qError.toStdString());
+
+    if (ExitInfo exitInfo = checkSyncNesting(syncList, qPath, qError); !exitInfo) {
+        LOG_WARN(Log::instance()->getLogger(), "Error in checkSyncNesting: " << exitInfo << qError.toStdString());
         return ExitCode::Ok;
     }
 
     // If the directory exists, check if it is empty
+
+    // Check if the local directory already exists
+    IoError ioError = IoError::Success;
+    bool alreadyExists = false;
+    const bool success = IoHelper::checkIfPathExists(path, alreadyExists, ioError, IoHelper::PathCheckOption::Insensitive);
+    if (!success) {
+        LOGW_WARN(Log::instance()->getLogger(), L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(ioError));
+        return ExitCode::SystemError;
+    }
+
     bool isEmpty = true;
     std::error_code ec;
     if (alreadyExists) {
@@ -352,7 +361,7 @@ ExitInfo ServerRequests::isPathValidForNewSync(const SyncPath &path, bool isAdva
 
     if (!isAdvancedSync && !isEmpty && CommonUtility::envVarValue("KD_ALLOW_NON_EMPTY_SYNC_FOLDER") != "1") {
         bool containsNonExcludedFile = false;
-        if (exitInfo = folderContainsNonExcludedItem(path, containsNonExcludedFile); !exitInfo) {
+        if (ExitInfo exitInfo = folderContainsNonExcludedItem(path, containsNonExcludedFile); !exitInfo) {
             LOG_WARN(Log::instance()->getLogger(), "Error in folderContainsNonExcludedItem: " << exitInfo);
             return exitInfo;
         }
@@ -432,23 +441,38 @@ ExitInfo ServerRequests::findGoodPathForNewSync(const QString &basePath, QString
 
     int attempt = 1;
     forever {
-        const auto exitInfo = checkPathValidityForNewFolder(syncList, folder, error);
-        if (!exitInfo && exitInfo.cause() != ExitCause::DirExists) {
-            LOG_WARN(Log::instance()->getLogger(), "Error in checkPathValidityForNewFolder:" << exitInfo);
+        const ExitInfo exitInfo = checkSyncNesting(syncList, folder, error);
+        if (!exitInfo && (exitInfo.code() != ExitCode::InvalidSync ||
+                          attempt >= 100)) { // If the error is a sync nesting error, we can try another
+                                             // as the folder can just be already used by another sync
+            LOG_WARN(Log::instance()->getLogger(), "Error in checkSyncNesting:" << exitInfo);
             return exitInfo;
         }
 
-        if (exitInfo.cause() != ExitCause::DirExists) {
-            break;
+        if (exitInfo) {
+            // Check if the local directory already exists
+            IoError ioError = IoError::Success;
+            bool alreadyExists = false;
+            const bool success = IoHelper::checkIfPathExists(QStr2Path(folder), alreadyExists, ioError,
+                                                             IoHelper::PathCheckOption::Insensitive);
+            if (!success) {
+                LOGW_WARN(Log::instance()->getLogger(),
+                          L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(ioError));
+                return ExitCode::SystemError;
+            }
+
+            if (!alreadyExists) {
+                break;
+            }
         }
 
         // Count attempts and give up eventually
-        attempt++;
-        if (attempt > 100) {
+        if (attempt >= 100) {
             LOG_WARN(Log::instance()->getLogger(), "Can't find a valid path");
             error = QObject::tr("Can't find a valid path");
             return ExitCode::SystemError;
         }
+        attempt++;
 
         folder = basePath + " " + QString::number(attempt);
     }
@@ -2077,7 +2101,7 @@ ExitCode ServerRequests::checkPathValidityRecursive(const QString &path, QString
     return ExitCode::Ok;
 }
 
-ExitInfo ServerRequests::checkPathValidityForNewFolder(const std::vector<Sync> &syncList, const QString &path, QString &error) {
+ExitInfo ServerRequests::checkSyncNesting(const std::vector<Sync> &syncList, const QString &path, QString &error) {
     error.clear();
     ExitCode exitCode = checkPathValidityRecursive(path, error);
     if (exitCode != ExitCode::Ok) {
@@ -2118,23 +2142,8 @@ ExitInfo ServerRequests::checkPathValidityForNewFolder(const std::vector<Sync> &
         if (!differentPaths) {
             error = QObject::tr("The local folder %1 is already synced. Please pick another one!")
                             .arg(QDir::toNativeSeparators(path));
-            return {ExitCode::InvalidSync, ExitCause::DirExists};
+            return {ExitCode::InvalidSync, ExitCause::SyncDirNestingError};
         }
-    }
-
-    // Check if the local directory already exists
-    IoError ioError = IoError::Success;
-    bool found = false;
-    const bool success = IoHelper::checkIfPathExists(QStr2Path(userDir), found, ioError, IoHelper::PathCheckOption::Insensitive);
-    if (!success) {
-        LOGW_WARN(Log::instance()->getLogger(), L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(ioError));
-        error = QObject::tr("An error occurred while checking the local folder. Please try again.");
-        return ExitCode::SystemError;
-    }
-
-    if (found) {
-        error = QObject::tr("The local folder %1 already exists. Please pick another one!").arg(QDir::toNativeSeparators(path));
-        return {ExitCode::SystemError, ExitCause::DirExists};
     }
 
     return ExitCode::Ok;

--- a/src/server/requests/serverrequests.cpp
+++ b/src/server/requests/serverrequests.cpp
@@ -312,7 +312,7 @@ ExitCode ServerRequests::updateParameters(const ParametersInfo &parametersInfo) 
     return exitCode;
 }
 
-ExitInfo ServerRequests::isPathValidForNewSync(const SyncPath &path, bool isAdvancedSync, bool &valid) {
+ExitInfo ServerRequests::isPathValidForNewSync(const SyncPath &path, SyncConfiguration syncConfig, bool &valid) {
     // Check for nested syncs
     std::vector<Sync> syncList;
     valid = false;
@@ -329,58 +329,73 @@ ExitInfo ServerRequests::isPathValidForNewSync(const SyncPath &path, bool isAdva
         return exitInfo.code() == ExitCode::InvalidSync ? ExitInfo(ExitCode::Ok) : exitInfo;
     }
 
-    // If the directory exists, check if it is empty
+    if (syncConfig == SyncConfiguration::Advanced) {
+        valid = true;
+        return ExitCode::Ok;
+    }
 
     // Check if the local directory already exists
-    IoError ioError = IoError::Success;
+    auto ioError = IoError::Success;
     bool alreadyExists = false;
-    const bool success = IoHelper::checkIfPathExists(path, alreadyExists, ioError, IoHelper::PathCheckOption::Insensitive);
-    if (!success) {
+    if (const bool success = IoHelper::checkIfPathExists(path, alreadyExists, ioError, IoHelper::PathCheckOption::Insensitive);
+        !success) {
         LOGW_WARN(Log::instance()->getLogger(), L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(ioError));
         return ExitCode::SystemError;
     }
 
+    // If the directory exists, check if it is empty
+    if (!alreadyExists) {
+        valid = true;
+        return ExitCode::Ok;
+    }
+
+    if (CommonUtility::envVarValue("KD_ALLOW_NON_EMPTY_SYNC_FOLDER") != "1") {
+        valid = true;
+        return ExitCode::Ok;
+    }
+
     bool isEmpty = true;
     std::error_code ec;
-    if (alreadyExists) {
-        if (!std::filesystem::is_directory(path, ec)) {
-            LOGW_WARN(Log::instance()->getLogger(), L"The path exists but is not a directory: " << Utility::formatSyncPath(path));
-            return ExitCode::Ok;
-        }
-        if (ec) {
-            LOG_WARN(Log::instance()->getLogger(), "Error checking if path is a directory: " << ec.message());
-            return ExitCode::SystemError;
-        }
-
-        isEmpty = std::filesystem::is_empty(path, ec);
-        if (ec) {
-            LOG_WARN(Log::instance()->getLogger(), "Error checking if path is empty: " << ec.message());
-            return ExitCode::SystemError;
-        }
+    if (!std::filesystem::is_directory(path, ec)) {
+        LOGW_WARN(Log::instance()->getLogger(), L"The path exists but is not a directory: " << Utility::formatSyncPath(path));
+        return ExitCode::Ok;
+    }
+    if (ec) {
+        LOG_WARN(Log::instance()->getLogger(), "Error checking if path is a directory: " << ec.message());
+        return ExitCode::SystemError;
     }
 
-    if (!isAdvancedSync && !isEmpty && CommonUtility::envVarValue("KD_ALLOW_NON_EMPTY_SYNC_FOLDER") != "1") {
-        bool containsNonExcludedFile = false;
-        if (ExitInfo exitInfo = folderContainsNonExcludedItem(path, containsNonExcludedFile); !exitInfo) {
-            LOG_WARN(Log::instance()->getLogger(), "Error in folderContainsNonExcludedItem: " << exitInfo);
-            return exitInfo;
-        }
-        if (containsNonExcludedFile) {
-            LOGW_WARN(Log::instance()->getLogger(), L"The directory is not empty: " << Utility::formatSyncPath(path));
-            return ExitCode::Ok;
-        }
+    isEmpty = std::filesystem::is_empty(path, ec);
+    if (ec) {
+        LOG_WARN(Log::instance()->getLogger(), "Error checking if path is empty: " << ec.message());
+        return ExitCode::SystemError;
     }
 
-    valid = true;
+    if (isEmpty) {
+        valid = true;
+        return ExitCode::Ok;
+    }
+
+    bool containsNonExcludedItem = false;
+    if (ExitInfo exitInfo = folderContainsNonExcludedItem(path, containsNonExcludedItem); !exitInfo) {
+        LOG_WARN(Log::instance()->getLogger(), "Error in folderContainsNonExcludedItem: " << exitInfo);
+        return exitInfo;
+    }
+    if (!containsNonExcludedItem) {
+        valid = true;
+        return ExitCode::Ok;
+    }
+
+    LOGW_WARN(Log::instance()->getLogger(), L"The directory is not empty: " << Utility::formatSyncPath(path));
     return ExitCode::Ok;
 }
 
 ExitInfo ServerRequests::folderContainsNonExcludedItem(const SyncPath &path, bool &containsNonExcludedFile) {
-    IoError ioError = IoError::Unknown;
+    auto ioError = IoError::Unknown;
     IoHelper::DirectoryIterator dirIt(path, false, ioError);
     if (ioError != IoError::Success) {
-        LOG_WARN(Log::instance()->getLogger(),
-                 "Error in IoHelper::DirectoryIterator for path=" << Path2Str(path) << " error=" << ioError);
+        LOGW_WARN(Log::instance()->getLogger(),
+                  L"Error in IoHelper::DirectoryIterator " << Utility::formatIoError(path, ioError));
         return ExitCode::SystemError;
     }
 
@@ -388,7 +403,7 @@ ExitInfo ServerRequests::folderContainsNonExcludedItem(const SyncPath &path, boo
 
     DirectoryEntry entry;
     bool endOfDirectory = false;
-    while (dirIt.next(entry, endOfDirectory, ioError) && !endOfDirectory && ioError == IoError::Success) {
+    while (dirIt.next(entry, endOfDirectory, ioError) && !endOfDirectory) {
         if (!ExclusionTemplateCache::instance()->isExcluded(entry.path())) {
             containsNonExcludedFile = true;
             return ExitCode::Ok;
@@ -396,8 +411,8 @@ ExitInfo ServerRequests::folderContainsNonExcludedItem(const SyncPath &path, boo
     }
 
     if (!endOfDirectory || ioError != IoError::Success) {
-        LOG_WARN(Log::instance()->getLogger(), "Error iterating directory with IoHelper::DirectoryIterator for path="
-                                                       << Path2Str(path) << " error=" << ioError);
+        LOGW_WARN(Log::instance()->getLogger(),
+                  L"Error iterating directory with IoHelper::DirectoryIterator " << Utility::formatIoError(path, ioError));
         return ExitCode::SystemError;
     }
 
@@ -451,13 +466,13 @@ ExitInfo ServerRequests::findGoodPathForNewSync(const QString &basePath, QString
 
         if (exitInfo) {
             // Check if the local directory already exists
-            IoError ioError = IoError::Success;
+            auto ioError = IoError::Success;
             bool alreadyExists = false;
             const bool success = IoHelper::checkIfPathExists(QStr2Path(folder), alreadyExists, ioError,
                                                              IoHelper::PathCheckOption::Insensitive);
             if (!success) {
                 LOGW_WARN(Log::instance()->getLogger(),
-                          L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(ioError));
+                          L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(folder, ioError));
                 return ExitCode::SystemError;
             }
 

--- a/src/server/requests/serverrequests.cpp
+++ b/src/server/requests/serverrequests.cpp
@@ -326,7 +326,7 @@ ExitInfo ServerRequests::isPathValidForNewSync(const SyncPath &path, bool isAdva
 
     if (ExitInfo exitInfo = checkSyncNesting(syncList, qPath, qError); !exitInfo) {
         LOG_WARN(Log::instance()->getLogger(), "Error in checkSyncNesting: " << exitInfo << qError.toStdString());
-        return ExitCode::Ok;
+        return exitInfo.code() == ExitCode::InvalidSync ? ExitInfo(ExitCode::Ok) : exitInfo;
     }
 
     // If the directory exists, check if it is empty

--- a/src/server/requests/serverrequests.h
+++ b/src/server/requests/serverrequests.h
@@ -67,7 +67,8 @@ struct SYNCENGINE_EXPORT ServerRequests {
         static ExitCode getSyncInfoList(std::vector<SyncInfo> &list);
         static ExitCode getParameters(ParametersInfo &parametersInfo);
         static ExitCode updateParameters(const ParametersInfo &parametersInfo);
-        static ExitInfo isPathValidForNewSync(const SyncPath &path, bool &valid);
+        static ExitInfo isPathValidForNewSync(const SyncPath &path, bool isAdvancedSync, bool &valid);
+        static ExitInfo folderContainsNonExcludedItem(const SyncPath &path, bool &containsNonExcludedFile);
         static ExitInfo findGoodPathForNewSync(const SyncPath &basePath, SyncPath &path, std::string &error);
         static ExitInfo findGoodPathForNewSync(const QString &basePath, QString &path, QString &error);
         static ExitCode getPrivateLinkUrl(int driveDbId, const std::string &fileId, std::string &linkUrl);

--- a/src/server/requests/serverrequests.h
+++ b/src/server/requests/serverrequests.h
@@ -67,7 +67,7 @@ struct SYNCENGINE_EXPORT ServerRequests {
         static ExitCode getSyncInfoList(std::vector<SyncInfo> &list);
         static ExitCode getParameters(ParametersInfo &parametersInfo);
         static ExitCode updateParameters(const ParametersInfo &parametersInfo);
-        static ExitInfo isPathValidForNewSync(const SyncPath &path, bool isAdvancedSync, bool &valid);
+        static ExitInfo isPathValidForNewSync(const SyncPath &path, SyncConfiguration syncConfig, bool &valid);
         static ExitInfo folderContainsNonExcludedItem(const SyncPath &path, bool &containsNonExcludedFile);
         static ExitInfo findGoodPathForNewSync(const SyncPath &basePath, SyncPath &path, std::string &error);
         static ExitInfo findGoodPathForNewSync(const QString &basePath, QString &path, QString &error);

--- a/src/server/requests/serverrequests.h
+++ b/src/server/requests/serverrequests.h
@@ -177,7 +177,7 @@ struct SYNCENGINE_EXPORT ServerRequests {
         static ExitCode processRequestTokenFinished(const Login &login, UserInfo &userInfo, bool &userCreated);
         static QString canonicalPath(const QString &path);
         static ExitCode checkPathValidityRecursive(const QString &path, QString &error);
-        static ExitInfo checkPathValidityForNewFolder(const std::vector<Sync> &syncList, const QString &path, QString &error);
+        static ExitInfo checkSyncNesting(const std::vector<Sync> &syncList, const QString &path, QString &error);
         static ExitCode syncForPath(const std::vector<Sync> &syncList, const QString &path, int &syncDbId);
         static QString excludeFile(bool liteSync);
         static ExitCode createUser(const User &user, UserInfo &userInfo);

--- a/test/libcommon/utility/testtypes.cpp
+++ b/test/libcommon/utility/testtypes.cpp
@@ -233,6 +233,7 @@ void TestTypes::testToString() {
     testToStringIntValues<Platform>();
     testToStringIntValues<ConflictResolutionStrategy>();
     testToStringIntValues<sentry::ConfidentialityLevel>();
+    testToStringIntValues<SyncConfiguration>();
 }
 
 } // namespace KDC

--- a/test/server/comm/guicommchannel/testutility.cpp
+++ b/test/server/comm/guicommchannel/testutility.cpp
@@ -161,7 +161,7 @@ void TestGuiCommChannel::testUtilityIsPathValidForNewSyncJob() {
 
     Poco::JSON::Object queryParamsObj;
     (void) queryParamsObj.set("path", "");
-    (void) queryParamsObj.set("isAdvancedSync", false);
+    (void) queryParamsObj.set("syncConfiguration", toInt(SyncConfiguration::Classic));
     (void) queryObj.set("params", queryParamsObj);
     const auto queryStr = stringifyQueryObj(queryObj);
 

--- a/test/server/comm/guicommchannel/testutility.cpp
+++ b/test/server/comm/guicommchannel/testutility.cpp
@@ -161,6 +161,7 @@ void TestGuiCommChannel::testUtilityIsPathValidForNewSyncJob() {
 
     Poco::JSON::Object queryParamsObj;
     (void) queryParamsObj.set("path", "");
+    (void) queryParamsObj.set("isAdvancedSync", false);
     (void) queryObj.set("params", queryParamsObj);
     const auto queryStr = stringifyQueryObj(queryObj);
 

--- a/test/server/requests/testserverrequests.cpp
+++ b/test/server/requests/testserverrequests.cpp
@@ -24,6 +24,7 @@
 
 #include "libcommonserver/keychainmanager/keychainmanager.h"
 #include "libsyncengine/jobs/network/abstracttokennetworkjob.h"
+#include "libsyncengine/requests/exclusiontemplatecache.h"
 
 #include "libparms/db/parmsdb.h"
 
@@ -69,6 +70,7 @@ void TestServerRequests::tearDown() {
     ParmsDb::instance()->close();
     ParmsDb::reset();
     ParametersCache::reset();
+    ExclusionTemplateCache::reset();
     TestBase::stop();
 }
 
@@ -227,5 +229,51 @@ void TestServerRequests::testDeleteDrive() {
     CPPUNIT_ASSERT(!AbstractTokenNetworkJob::_driveToApiKeyMap.contains(1));
 }
 
+void TestServerRequests::testFolderContainsNonExcludedItemInvalidPath() {
+    // A non-existent path cannot be opened by the directory iterator.
+    const SyncPath nonExistentPath = _localTempDir.path() / "non_existent_dir";
+    bool containsNonExcludedFile = false;
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::SystemError),
+                         ServerRequests::folderContainsNonExcludedItem(nonExistentPath, containsNonExcludedFile));
+    CPPUNIT_ASSERT(!containsNonExcludedFile);
+}
+
+void TestServerRequests::testFolderContainsNonExcludedItemEmptyDir() {
+    LocalTemporaryDirectory emptyDir("folderContainsEmpty");
+    bool containsNonExcludedFile = false;
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok),
+                         ServerRequests::folderContainsNonExcludedItem(emptyDir.path(), containsNonExcludedFile));
+    CPPUNIT_ASSERT(!containsNonExcludedFile);
+}
+
+void TestServerRequests::testFolderContainsNonExcludedItemOnlyExcludedFiles() {
+    // Files whose names end with "~" are matched by the "*~" default exclusion template.
+    LocalTemporaryDirectory dir("folderContainsExcluded");
+    testhelpers::generateTestFile(dir.path() / "excluded_file~");
+    bool containsNonExcludedFile = false;
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok),
+                         ServerRequests::folderContainsNonExcludedItem(dir.path(), containsNonExcludedFile));
+    CPPUNIT_ASSERT(!containsNonExcludedFile);
+}
+
+void TestServerRequests::testFolderContainsNonExcludedItemWithNonExcludedFile() {
+    LocalTemporaryDirectory dir("folderContainsNonExcluded");
+    testhelpers::generateTestFile(dir.path() / "regular_file.txt");
+    bool containsNonExcludedFile = false;
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok),
+                         ServerRequests::folderContainsNonExcludedItem(dir.path(), containsNonExcludedFile));
+    CPPUNIT_ASSERT(containsNonExcludedFile);
+}
+
+void TestServerRequests::testFolderContainsNonExcludedItemMixed() {
+    // Directory containing both an excluded file and a regular one.
+    LocalTemporaryDirectory dir("folderContainsMixed");
+    testhelpers::generateTestFile(dir.path() / "excluded_file~");  // matched by "*~" exclusion template
+    testhelpers::generateTestFile(dir.path() / "regular_file.txt");
+    bool containsNonExcludedFile = false;
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok),
+                         ServerRequests::folderContainsNonExcludedItem(dir.path(), containsNonExcludedFile));
+    CPPUNIT_ASSERT(containsNonExcludedFile);
+}
 
 } // namespace KDC

--- a/test/server/requests/testserverrequests.cpp
+++ b/test/server/requests/testserverrequests.cpp
@@ -162,10 +162,11 @@ void TestServerRequests::testFindGoodPathForNewSync() {
     // Check with a non-existing path containing an already synced child
     SyncPath returnedPath;
     std::string error;
-    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::InvalidSync, ExitCause::SyncDirNestingError),
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok, ExitCause::Unknown),
                          ServerRequests::findGoodPathForNewSync(localTempDirPath, returnedPath, error));
-    CPPUNIT_ASSERT(returnedPath.empty());
-    CPPUNIT_ASSERT(!error.empty());
+    CPPUNIT_ASSERT(!returnedPath.empty());
+    CPPUNIT_ASSERT(returnedPath.filename().string().find('2') != std::string::npos);
+    CPPUNIT_ASSERT(error.empty());
 }
 
 void TestServerRequests::testDeleteUser() {

--- a/test/server/requests/testserverrequests.h
+++ b/test/server/requests/testserverrequests.h
@@ -29,6 +29,11 @@ class TestServerRequests : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST(testDeleteUser);
         CPPUNIT_TEST(testDeleteAccount);
         CPPUNIT_TEST(testDeleteDrive);
+        CPPUNIT_TEST(testFolderContainsNonExcludedItemInvalidPath);
+        CPPUNIT_TEST(testFolderContainsNonExcludedItemEmptyDir);
+        CPPUNIT_TEST(testFolderContainsNonExcludedItemOnlyExcludedFiles);
+        CPPUNIT_TEST(testFolderContainsNonExcludedItemWithNonExcludedFile);
+        CPPUNIT_TEST(testFolderContainsNonExcludedItemMixed);
         CPPUNIT_TEST_SUITE_END();
 
     public:
@@ -41,6 +46,11 @@ class TestServerRequests : public CppUnit::TestFixture, public TestBase {
         void testDeleteUser();
         void testDeleteAccount();
         void testDeleteDrive();
+        void testFolderContainsNonExcludedItemInvalidPath();
+        void testFolderContainsNonExcludedItemEmptyDir();
+        void testFolderContainsNonExcludedItemOnlyExcludedFiles();
+        void testFolderContainsNonExcludedItemWithNonExcludedFile();
+        void testFolderContainsNonExcludedItemMixed();
 
     private:
         int _driveDbId{0};


### PR DESCRIPTION
depends on #1639 

## ✨ Overview

This PR refactors folder creation and improves sync path validation, mainly to better support **advanced sync scenarios** and missing folders.

---

## 📁 Folder Creation

* Reworked the *create missing folders* flow
* Introduced a new request (`NODE_CREATEMISSINGFOLDERS_LEGACY`) with a cleaner API
* Improved overall process:

  * pauses sync
  * creates folders
  * updates blacklist if needed
  * resumes sync
* Simplified server inputs (`userDbId`, `driveId`, `relativePath`, `parentNodeId`) and now returns `nodeId`
* Updated related jobs and constructors to match the new flow

---

## 🔍 Sync Path Validation

* Added `isAdvancedSync` flag to path validation
* Allows proper distinction between **standard** and **advanced** sync
* Propagated the new parameter through client, server, and core logic

---

## 🧹 Misc

* Added `isAdvancedSync` in JSON
* Minor cleanup and better error handling

---

## ✅ Result

Cleaner APIs, more robust folder creation, and proper support for advanced sync.
