### PR TITLE
docs(readme): add direct download link for latest platform-specific URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Collaborate online on Office documents, organise meetings, share your work. Anyt
 Protect your data in a sovereign cloud exclusively developed and hosted in Switzerland. Infomaniak doesn’t analyze or resell your data.
 
 ### [Download the kDrive app here](https://www.infomaniak.com/en/apps/download-kdrive)
+Alternatively, you can retrieve the latest platform-specific direct download URLs here: https://www.infomaniak.com/drive/latest
 
 ## License & Contributions
 This project is under GPLv3 license.  


### PR DESCRIPTION
Included a direct download link in the README for users to easily access the latest platform-specific download URLs for the kDrive app.