### PR TITLE
fix: Crash in operation sorter worker 2

### DIFF
--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -349,8 +349,8 @@ ExitInfo ExecutorWorker::handleCreateOp(SyncOpPtr syncOp, std::shared_ptr<SyncJo
         }
 
         if (ExitInfo exitInfo = generateCreateJob(syncOp, job, hydrating); !exitInfo) {
-            LOGW_SYNCPAL_WARN(_logger, L"Failed to generate create job for: " << SyncName2WStr(syncOp->affectedNode()->name())
-                                                                              << L" " << exitInfo);
+            LOGW_SYNCPAL_WARN(_logger, L"Failed to generate create job for: "
+                                               << Utility::formatSyncName(syncOp->affectedNode()->name()) << L" " << exitInfo);
             return exitInfo;
         }
 
@@ -574,7 +574,7 @@ ExitInfo ExecutorWorker::generateCreateJob(SyncOpPtr syncOp, std::shared_ptr<Syn
                 _syncPal->setRestart(true);
 
                 if (!_syncPal->updateTree(ReplicaSide::Local)->deleteNode(syncOp->affectedNode())) {
-                    LOGW_SYNCPAL_WARN(_logger, L"Error in UpdateTree::deleteNode: node name="
+                    LOGW_SYNCPAL_WARN(_logger, L"Error in UpdateTree::deleteNode: node "
                                                        << Utility::formatSyncName(syncOp->affectedNode()->name()) << L" "
                                                        << exitInfo);
                 }
@@ -779,8 +779,8 @@ ExitInfo ExecutorWorker::handleEditOp(SyncOpPtr syncOp, std::shared_ptr<SyncJob>
     }
 
     if (ExitInfo exitInfo = generateEditJob(syncOp, job); !exitInfo) {
-        LOGW_SYNCPAL_WARN(_logger, L"Failed to generate edit job for: " << SyncName2WStr(syncOp->affectedNode()->name()) << L" "
-                                                                        << exitInfo);
+        LOGW_SYNCPAL_WARN(_logger, L"Failed to generate edit job for: " << Utility::formatSyncName(syncOp->affectedNode()->name())
+                                                                        << L" " << exitInfo);
         return exitInfo;
     }
     return ExitCode::Ok;
@@ -1901,16 +1901,9 @@ ExitInfo ExecutorWorker::propagateMoveToDbAndTree(SyncOpPtr syncOp) {
 
         correspondingNode->setName(syncOp->newName());
 
-        if (!correspondingNode->setParentNode(parentNode)) {
-            LOGW_SYNCPAL_WARN(_logger, L"Error in Node::setParentNode: node name="
-                                               << Utility::formatSyncName(correspondingNode->name()) << L" parent node name="
-                                               << Utility::formatSyncName(parentNode->name()));
-            return ExitCode::DataError;
-        }
-
         if (!correspondingNode->parentNode()->insertChildren(correspondingNode)) {
-            LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node name="
-                                               << Utility::formatSyncName(correspondingNode->name()) << L" parent node name="
+            LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node "
+                                               << Utility::formatSyncName(correspondingNode->name()) << L" parent node "
                                                << Utility::formatSyncName(correspondingNode->parentNode()->name()));
             return ExitCode::DataError;
         }

--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -1903,8 +1903,8 @@ ExitInfo ExecutorWorker::propagateMoveToDbAndTree(SyncOpPtr syncOp) {
 
         if (!correspondingNode->setParentNode(parentNode)) {
             LOGW_SYNCPAL_WARN(_logger, L"Error in Node::setParentNode: node name="
-                                               << Utility::formatSyncName(parentNode->name()) << L" parent node name="
-                                               << Utility::formatSyncName(correspondingNode->name()));
+                                               << Utility::formatSyncName(correspondingNode->name()) << L" parent node name="
+                                               << Utility::formatSyncName(parentNode->name()));
             return ExitCode::DataError;
         }
 

--- a/src/libsyncengine/propagation/operation_sorter/operationsorterworker.cpp
+++ b/src/libsyncengine/propagation/operation_sorter/operationsorterworker.cpp
@@ -124,7 +124,7 @@ void OperationSorterWorker::fixDeleteBeforeMove() {
         const auto moveNodeParent = moveNode->parentNode();
         LOG_IF_FAIL(moveNodeParent)
         if (!moveNodeParent->id().has_value()) {
-            LOGW_SYNCPAL_WARN(_logger, L"Node without id: " << SyncName2WStr(moveNodeParent->name()));
+            LOGW_SYNCPAL_WARN(_logger, L"Node without id: " << Utility::formatSyncName(moveNodeParent->name()));
             continue;
         }
 
@@ -157,7 +157,7 @@ void OperationSorterWorker::fixMoveBeforeCreate() {
         const auto createParentNode = createNode->parentNode();
         LOG_IF_FAIL(createParentNode)
         if (!createParentNode->id().has_value()) {
-            LOGW_SYNCPAL_WARN(_logger, L"Node without id: " << SyncName2WStr(createParentNode->normalizedName()));
+            LOGW_SYNCPAL_WARN(_logger, L"Node without id: " << Utility::formatSyncName(createParentNode->normalizedName()));
             continue;
         }
 
@@ -477,9 +477,9 @@ bool OperationSorterWorker::breakCycle(SyncOperationList &cycle, const SyncOpPtr
     renameResolutionOp->setNewName(correspondingNode->name() + Str("-") +
                                    Str2SyncName(CommonUtility::generateRandomStringAlphaNum()));
     // and we only execute Opr follow by restart sync
-    LOGW_SYNCPAL_INFO(_logger, L"Breaking cycle by renaming temporarily item " << SyncName2WStr(correspondingNode->name())
-                                                                               << L" to "
-                                                                               << SyncName2WStr(renameResolutionOp->newName()));
+    LOGW_SYNCPAL_INFO(_logger, L"Breaking cycle by renaming temporarily item "
+                                       << Utility::formatSyncName(correspondingNode->name()) << L" to "
+                                       << Utility::formatSyncName(renameResolutionOp->newName()));
     // After breaking a cycle, the update tree is not up to date anymore and needs to be rebuilt.
     _syncPal->setUpdateTreesNeedToBeCleared(true);
     return true;

--- a/src/libsyncengine/reconciliation/operation_generator/operationgeneratorworker.cpp
+++ b/src/libsyncengine/reconciliation/operation_generator/operationgeneratorworker.cpp
@@ -66,18 +66,18 @@ void OperationGeneratorWorker::execute() {
         LOG_IF_FAIL(currentNode->id().has_value());
 
         // Explore children even if node is processed
-        for (const auto &child: currentNode->children()) {
-            _queuedToExplore.push(child.second);
-            LOG_IF_FAIL(child.second->parentNode() == currentNode);
-            if (child.second->parentNode() != currentNode) {
+        for (const auto &[_, child]: currentNode->children()) {
+            _queuedToExplore.push(child);
+            LOG_IF_FAIL(child->parentNode() == currentNode);
+            if (child->parentNode() != currentNode) {
                 // Only occurs if there is a bug before.
                 sentry::Handler::captureMessage(sentry::Level::Warning, "OperationGeneratorWorker::execute",
                                                 "Invalid parent node");
                 // Fix the issue
-                LOGW_SYNCPAL_WARN(_logger, L"Update the node's parent: " << SyncName2WStr(child.second->name()));
-                if (!child.second->setParentNode(currentNode)) {
-                    LOGW_SYNCPAL_WARN(_logger, L"Error in Node::setParentNode: node name="
-                                                       << Utility::formatSyncName(child.second->name()) << L" parent node name="
+                LOGW_SYNCPAL_WARN(_logger, L"Update the node's parent: " << Utility::formatSyncName(child->name()));
+                if (!child->setParentNode(currentNode)) {
+                    LOGW_SYNCPAL_WARN(_logger, L"Error in Node::setParentNode: node "
+                                                       << Utility::formatSyncName(child->name()) << L" parent node "
                                                        << Utility::formatSyncName(currentNode->name()));
                     continue;
                 }
@@ -92,7 +92,7 @@ void OperationGeneratorWorker::execute() {
         if (!correspondingNode &&
             (currentNode->hasChangeEvent(OperationType::Delete) || currentNode->hasChangeEvent(OperationType::Edit) ||
              currentNode->hasChangeEvent(OperationType::Move))) {
-            LOGW_SYNCPAL_WARN(_logger, L"Failed to get corresponding node: " << SyncName2WStr(currentNode->name()));
+            LOGW_SYNCPAL_WARN(_logger, L"Failed to get corresponding node: " << Utility::formatSyncName(currentNode->name()));
             exitCode = ExitCode::DataError;
             break;
         }

--- a/src/libsyncengine/reconciliation/operation_generator/operationgeneratorworker.cpp
+++ b/src/libsyncengine/reconciliation/operation_generator/operationgeneratorworker.cpp
@@ -75,7 +75,12 @@ void OperationGeneratorWorker::execute() {
                                                 "Invalid parent node");
                 // Fix the issue
                 LOGW_SYNCPAL_WARN(_logger, L"Update the node's parent: " << SyncName2WStr(child.second->name()));
-                child.second->setParentNode(currentNode);
+                if (!child.second->setParentNode(currentNode)) {
+                    LOGW_SYNCPAL_WARN(_logger, L"Error in Node::setParentNode: node name="
+                                                       << Utility::formatSyncName(child.second->name()) << L" parent node name="
+                                                       << Utility::formatSyncName(currentNode->name()));
+                    continue;
+                }
             }
         }
 

--- a/src/libsyncengine/reconciliation/operation_generator/operationgeneratorworker.cpp
+++ b/src/libsyncengine/reconciliation/operation_generator/operationgeneratorworker.cpp
@@ -63,12 +63,16 @@ void OperationGeneratorWorker::execute() {
             continue;
         }
 
-        assert(currentNode->id().has_value());
+        LOG_IF_FAIL(currentNode->id().has_value());
 
         // Explore children even if node is processed
         for (const auto &child: currentNode->children()) {
             _queuedToExplore.push(child.second);
-            assert(child.second->parentNode() == currentNode);
+            if (child.second->parentNode() != currentNode) {
+                assert(false);
+                LOGW_SYNCPAL_WARN(_logger, L"Update of the node's father: " << SyncName2WStr(child.second->name()));
+                child.second->setParentNode(currentNode);
+            }
         }
 
         if (currentNode->status() == NodeStatus::Processed) {
@@ -239,7 +243,10 @@ void OperationGeneratorWorker::generateEditOperation(std::shared_ptr<Node> curre
 void OperationGeneratorWorker::generateMoveOperation(std::shared_ptr<Node> currentNode, std::shared_ptr<Node> correspondingNode) {
     SyncOpPtr op = std::make_shared<SyncOperation>();
 
-    assert(correspondingNode);
+    LOG_IF_FAIL(currentNode->parentNode());
+    LOG_IF_FAIL(currentNode->id().has_value());
+
+    LOG_IF_FAIL(correspondingNode);
 
     // Check for Move-Move (Source) pseudo conflict
     if (isPseudoConflict(currentNode, correspondingNode)) {

--- a/src/libsyncengine/reconciliation/operation_generator/operationgeneratorworker.cpp
+++ b/src/libsyncengine/reconciliation/operation_generator/operationgeneratorworker.cpp
@@ -68,9 +68,13 @@ void OperationGeneratorWorker::execute() {
         // Explore children even if node is processed
         for (const auto &child: currentNode->children()) {
             _queuedToExplore.push(child.second);
+            LOG_IF_FAIL(child.second->parentNode() == currentNode);
             if (child.second->parentNode() != currentNode) {
-                assert(false);
-                LOGW_SYNCPAL_WARN(_logger, L"Update of the node's father: " << SyncName2WStr(child.second->name()));
+                // Only occurs if there is a bug before.
+                sentry::Handler::captureMessage(sentry::Level::Warning, "OperationGeneratorWorker::execute",
+                                                "Invalid parent node");
+                // Fix the issue
+                LOGW_SYNCPAL_WARN(_logger, L"Update the node's parent: " << SyncName2WStr(child.second->name()));
                 child.second->setParentNode(currentNode);
             }
         }
@@ -243,6 +247,7 @@ void OperationGeneratorWorker::generateEditOperation(std::shared_ptr<Node> curre
 void OperationGeneratorWorker::generateMoveOperation(std::shared_ptr<Node> currentNode, std::shared_ptr<Node> correspondingNode) {
     SyncOpPtr op = std::make_shared<SyncOperation>();
 
+    LOG_IF_FAIL(currentNode);
     LOG_IF_FAIL(currentNode->parentNode());
     LOG_IF_FAIL(currentNode->id().has_value());
 

--- a/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerworker.cpp
+++ b/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerworker.cpp
@@ -142,8 +142,7 @@ ExitCode PlatformInconsistencyCheckerWorker::checkLocalTree(std::shared_ptr<Node
     return ExitCode::Ok;
 }
 
-void PlatformInconsistencyCheckerWorker::blacklistNode(const std::shared_ptr<Node> node,
-                                                       const InconsistencyType inconsistencyType) {
+void PlatformInconsistencyCheckerWorker::blacklistNode(std::shared_ptr<Node> node, const InconsistencyType inconsistencyType) {
     // Local node needs to be excluded before call to blacklistTemporarily because
     // we need the DB entry to retrieve the corresponding node
     NodeIdPair nodeIDs;

--- a/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerworker.h
+++ b/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerworker.h
@@ -35,7 +35,7 @@ class PlatformInconsistencyCheckerWorker : public OperationProcessor {
         ExitCode checkRemoteTree(std::shared_ptr<Node> remoteNode, const SyncPath &parentPath);
         ExitCode checkLocalTree(std::shared_ptr<Node> localNode, const SyncPath &parentPath);
 
-        void blacklistNode(const std::shared_ptr<Node> node, const InconsistencyType inconsistencyType);
+        void blacklistNode(std::shared_ptr<Node> node, const InconsistencyType inconsistencyType);
         bool checkPathAndName(std::shared_ptr<Node> remoteNode);
         void checkNameClashAgainstSiblings(const std::shared_ptr<Node> remoteParentNode);
 

--- a/src/libsyncengine/update_detection/update_detector/node.cpp
+++ b/src/libsyncengine/update_detection/update_detector/node.cpp
@@ -178,6 +178,10 @@ bool Node::insertChildren(std::shared_ptr<Node> child) {
         }
     }
 
+    if (child->parentNode() != shared_from_this()) {
+        child->setParentNode(shared_from_this());
+    }
+
     _childrenById[*child->id()] = child;
 
     return true;

--- a/src/libsyncengine/update_detection/update_detector/node.cpp
+++ b/src/libsyncengine/update_detection/update_detector/node.cpp
@@ -180,8 +180,8 @@ bool Node::insertChildren(std::shared_ptr<Node> child) {
 
     if (child->parentNode() != shared_from_this()) {
         if (!child->setParentNode(shared_from_this())) {
-            LOGW_WARN(Log::instance()->getLogger(), L"Error in Node::setParentNode: node name="
-                                                            << Utility::formatSyncName(child->name()) << L" parent node name="
+            LOGW_WARN(Log::instance()->getLogger(), L"Error in Node::setParentNode: node "
+                                                            << Utility::formatSyncName(child->name()) << L" parent node "
                                                             << Utility::formatSyncName(name()));
 
             return false;

--- a/src/libsyncengine/update_detection/update_detector/node.cpp
+++ b/src/libsyncengine/update_detection/update_detector/node.cpp
@@ -179,7 +179,13 @@ bool Node::insertChildren(std::shared_ptr<Node> child) {
     }
 
     if (child->parentNode() != shared_from_this()) {
-        child->setParentNode(shared_from_this());
+        if (!child->setParentNode(shared_from_this())) {
+            LOGW_WARN(Log::instance()->getLogger(), L"Error in Node::setParentNode: node name="
+                                                            << Utility::formatSyncName(child->name()) << L" parent node name="
+                                                            << Utility::formatSyncName(name()));
+
+            return false;
+        }
     }
 
     _childrenById[*child->id()] = child;

--- a/src/libsyncengine/update_detection/update_detector/node.h
+++ b/src/libsyncengine/update_detection/update_detector/node.h
@@ -32,7 +32,7 @@ namespace KDC {
 static const SyncPath defaultInvalidPath = ":\0/:\0"; // Invalid path for increased safety
 static const NodeId defaultInvalidNodeId = "-1"; // Invalid node id for increased safety
 
-class Node {
+class Node : public std::enable_shared_from_this<Node> {
     public:
         class MoveOriginInfos {
             public:

--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
@@ -1400,7 +1400,6 @@ ExitCode UpdateTreeWorker::updateTmpNode(const std::shared_ptr<Node> tmpNode) {
     if (prevNode) {
         // Update children list
         for (const auto &[_, childNode]: prevNode->children()) {
-            // set new parent
             if (!tmpNode->insertChildren(childNode)) {
                 LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node name=" << SyncName2WStr(childNode->name())
                                                                                         << L" parent node name="

--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
@@ -952,15 +952,6 @@ ExitCode UpdateTreeWorker::createMoveNodes(const NodeType &nodeType) {
                 return ExitCode::DataError;
             }
 
-
-            // set new parent
-            if (!currentNode->setParentNode(parentNode)) {
-                LOGW_SYNCPAL_WARN(_logger, L"Error in Node::setParentNode: node name=" << SyncName2WStr(parentNode->name())
-                                                                                       << L" parent node name="
-                                                                                       << SyncName2WStr(currentNode->name()));
-                return ExitCode::DataError;
-            }
-
             // insert currentNode into children list of new parent
             if (!parentNode->insertChildren(currentNode)) {
                 LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node name=" << SyncName2WStr(currentNode->name())
@@ -1140,13 +1131,6 @@ bool UpdateTreeWorker::mergingTempNodeToRealNode(std::shared_ptr<Node> tmpNode, 
 
     // merging tmpNode's children to realNode
     for (auto &child: tmpNode->children()) {
-        if (!child.second->setParentNode(realNode)) {
-            LOGW_SYNCPAL_WARN(_logger, L"Error in Node::setParentNode: node name=" << SyncName2WStr(realNode->name())
-                                                                                   << L" parent node name="
-                                                                                   << SyncName2WStr(child.second->name()));
-            return false;
-        }
-
         if (!realNode->insertChildren(child.second)) {
             LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node name=" << SyncName2WStr(child.second->name())
                                                                                     << L" parent node name="
@@ -1361,7 +1345,7 @@ ExitCode UpdateTreeWorker::mergeNodeToParentChildren(std::shared_ptr<Node> paren
     }
 
     if (!parentNode->insertChildren(node)) {
-        LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node name=" << SyncName2WStr(node->name()).c_str()
+        LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node name=" << SyncName2WStr(node->name())
                                                                                 << L" parent node name="
                                                                                 << SyncName2WStr(parentNode->name()));
         return ExitCode::DataError;
@@ -1416,18 +1400,11 @@ ExitCode UpdateTreeWorker::updateTmpNode(const std::shared_ptr<Node> tmpNode) {
     if (prevNode) {
         // Update children list
         for (const auto &[_, childNode]: prevNode->children()) {
+            // set new parent
             if (!tmpNode->insertChildren(childNode)) {
                 LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node name=" << SyncName2WStr(childNode->name())
                                                                                         << L" parent node name="
                                                                                         << SyncName2WStr(tmpNode->name()));
-                return ExitCode::DataError;
-            }
-
-            // set new parent
-            if (!childNode->setParentNode(tmpNode)) {
-                LOGW_SYNCPAL_WARN(_logger, L"Error in Node::setParentNode: node name=" << SyncName2WStr(tmpNode->name())
-                                                                                       << L" parent node name="
-                                                                                       << SyncName2WStr(childNode->name()));
                 return ExitCode::DataError;
             }
 

--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
@@ -249,9 +249,9 @@ ExitCode UpdateTreeWorker::step3DeleteDirectory() {
                 }
 
                 if (!parentNode->insertChildren(existingNode)) {
-                    LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node name=" << SyncName2WStr(existingNode->name())
-                                                                                            << L" parent node name="
-                                                                                            << SyncName2WStr(parentNode->name()));
+                    LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node "
+                                                       << Utility::formatSyncName(existingNode->name()) << L" parent node "
+                                                       << Utility::formatSyncName(parentNode->name()));
                     return ExitCode::DataError;
                 }
 
@@ -502,9 +502,9 @@ ExitCode UpdateTreeWorker::step4DeleteFile() {
                 }
 
                 if (!parentNode->insertChildren(newNode)) {
-                    LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node name=" << SyncName2WStr(newNode->name())
-                                                                                            << L" parent node name="
-                                                                                            << SyncName2WStr(parentNode->name()));
+                    LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node "
+                                                       << Utility::formatSyncName(newNode->name()) << L" parent node "
+                                                       << Utility::formatSyncName(parentNode->name()));
                     return ExitCode::DataError;
                 }
 
@@ -650,9 +650,9 @@ ExitCode UpdateTreeWorker::step6CreateFile() {
         }
 
         if (!parentNode->insertChildren(newNode)) {
-            LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node name=" << SyncName2WStr(newNode->name())
-                                                                                    << L" parent node name="
-                                                                                    << SyncName2WStr(parentNode->name()));
+            LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node " << Utility::formatSyncName(newNode->name())
+                                                                               << L" parent node "
+                                                                               << Utility::formatSyncName(parentNode->name()));
             return ExitCode::DataError;
         }
 
@@ -737,9 +737,9 @@ ExitCode UpdateTreeWorker::step7EditFile() {
         }
 
         if (!parentNode->insertChildren(newNode)) {
-            LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node name=" << SyncName2WStr(newNode->name()).c_str()
-                                                                                    << L" parent node name="
-                                                                                    << SyncName2WStr(parentNode->name()));
+            LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node " << Utility::formatSyncName(newNode->name()).c_str()
+                                                                               << L" parent node "
+                                                                               << Utility::formatSyncName(parentNode->name()));
             return ExitCode::DataError;
         }
 
@@ -862,9 +862,9 @@ ExitCode UpdateTreeWorker::step8CompleteUpdateTree() {
             }
 
             if (!parentNode->insertChildren(newNode)) {
-                LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node name=" << SyncName2WStr(newNode->name())
-                                                                                        << L" parent node name="
-                                                                                        << SyncName2WStr(parentNode->name()));
+                LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node "
+                                                   << Utility::formatSyncName(newNode->name()) << L" parent node "
+                                                   << Utility::formatSyncName(parentNode->name()));
                 return ExitCode::DataError;
             }
 
@@ -954,9 +954,9 @@ ExitCode UpdateTreeWorker::createMoveNodes(const NodeType &nodeType) {
 
             // insert currentNode into children list of new parent
             if (!parentNode->insertChildren(currentNode)) {
-                LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node name=" << SyncName2WStr(currentNode->name())
-                                                                                        << L" parent node name="
-                                                                                        << SyncName2WStr(parentNode->name()));
+                LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node "
+                                                   << Utility::formatSyncName(currentNode->name()) << L" parent node "
+                                                   << Utility::formatSyncName(parentNode->name()));
                 return ExitCode::DataError;
             }
 
@@ -1132,9 +1132,9 @@ bool UpdateTreeWorker::mergingTempNodeToRealNode(std::shared_ptr<Node> tmpNode, 
     // merging tmpNode's children to realNode
     for (auto &child: tmpNode->children()) {
         if (!realNode->insertChildren(child.second)) {
-            LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node name=" << SyncName2WStr(child.second->name())
-                                                                                    << L" parent node name="
-                                                                                    << SyncName2WStr(realNode->name()));
+            LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node " << Utility::formatSyncName(child.second->name())
+                                                                               << L" parent node "
+                                                                               << Utility::formatSyncName(realNode->name()));
             return false;
         }
     }
@@ -1145,9 +1145,9 @@ bool UpdateTreeWorker::mergingTempNodeToRealNode(std::shared_ptr<Node> tmpNode, 
 
     // Real node added as child of parent node
     if (!realNode->parentNode()->insertChildren(realNode)) {
-        LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node name=" << SyncName2WStr(realNode->name())
-                                                                                << L" parent node name="
-                                                                                << SyncName2WStr(realNode->parentNode()->name()));
+        LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node "
+                                           << Utility::formatSyncName(realNode->name()) << L" parent node "
+                                           << Utility::formatSyncName(realNode->parentNode()->name()));
         return false;
     }
 
@@ -1345,9 +1345,9 @@ ExitCode UpdateTreeWorker::mergeNodeToParentChildren(std::shared_ptr<Node> paren
     }
 
     if (!parentNode->insertChildren(node)) {
-        LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node name=" << SyncName2WStr(node->name())
-                                                                                << L" parent node name="
-                                                                                << SyncName2WStr(parentNode->name()));
+        LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node " << Utility::formatSyncName(node->name())
+                                                                           << L" parent node "
+                                                                           << Utility::formatSyncName(parentNode->name()));
         return ExitCode::DataError;
     }
 
@@ -1401,9 +1401,9 @@ ExitCode UpdateTreeWorker::updateTmpNode(const std::shared_ptr<Node> tmpNode) {
         // Update children list
         for (const auto &[_, childNode]: prevNode->children()) {
             if (!tmpNode->insertChildren(childNode)) {
-                LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node name=" << SyncName2WStr(childNode->name())
-                                                                                        << L" parent node name="
-                                                                                        << SyncName2WStr(tmpNode->name()));
+                LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node " << SyncName2WStr(childNode->name())
+                                                                                   << L" parent node "
+                                                                                   << SyncName2WStr(tmpNode->name()));
                 return ExitCode::DataError;
             }
 


### PR DESCRIPTION
Fix of a crash in `OperationSorterWorker::fixDeleteBeforeMove` because the equality `moveNodeParent == null` holds true.
The cause could be the insertion of a node without parent by `UpdateTreeWorker::mergeNodeToParentChildren`.
This issue has been fixed and additional protections have been added.