### PR TITLE
fix(unit-tests): Fixes relative path empty check within `isInTrash` Linux implementation

### DIFF
--- a/test/test_utility/testhelpers_linux.cpp
+++ b/test/test_utility/testhelpers_linux.cpp
@@ -131,8 +131,8 @@ void eraseFromTrash(const KDC::SyncPath &relativePath) {
         const auto p = dirIt->path();
         const auto dirItemRelativePath = std::filesystem::relative(dirIt->path(), trashPath, ec);
         // Filter out the numerical suffix of the root directory name, e.g: `dirname.15` is replaced with `dirname`.
-        const auto suffixFreedirectorEntryPath = removeNumericSuffix(dirItemRelativePath);
-        if (relativePath == suffixFreedirectorEntryPath) itemsToErase.push_back(dirIt->path());
+        const auto suffixFreeDirectorEntryPath = removeNumericSuffix(dirItemRelativePath);
+        if (relativePath == suffixFreeDirectorEntryPath) itemsToErase.push_back(dirIt->path());
     }
 
     auto ioError = IoError::Success;

--- a/test/test_utility/testhelpers_linux.cpp
+++ b/test/test_utility/testhelpers_linux.cpp
@@ -1,6 +1,6 @@
 /*
  * Infomaniak kDrive - Desktop
- * Copyright (C) 2023-2025 Infomaniak Network SA
+ * Copyright (C) 2023-2026 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/test/test_utility/testhelpers_linux.cpp
+++ b/test/test_utility/testhelpers_linux.cpp
@@ -1,6 +1,6 @@
 /*
  * Infomaniak kDrive - Desktop
- * Copyright (C) 2023-2026 Infomaniak Network SA
+ * Copyright (C) 2023-2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -106,7 +106,7 @@ bool isSubPath(const SyncPath &path1, const SyncPath &path2) {
         const auto [path1It, path2It] =
                 std::mismatch(canonicalPath1.begin(), canonicalPath1.end(), canonicalPath2.begin(), canonicalPath2.end());
 
-        return (path2It == canonicalPath2.end());
+        return (path1It == canonicalPath1.end());
     } catch (const std::filesystem::filesystem_error &e) {
         std::cerr << "Filesystem error in isSubPath: " << e.what() << std::endl;
         return false;
@@ -131,8 +131,8 @@ void eraseFromTrash(const KDC::SyncPath &relativePath) {
         const auto p = dirIt->path();
         const auto dirItemRelativePath = std::filesystem::relative(dirIt->path(), trashPath, ec);
         // Filter out the numerical suffix of the root directory name, e.g: `dirname.15` is replaced with `dirname`.
-        const auto suffixFreeDirectorEntryPath = removeNumericSuffix(dirItemRelativePath);
-        if (relativePath == suffixFreeDirectorEntryPath) itemsToErase.push_back(dirIt->path());
+        const auto suffixFreedirectorEntryPath = removeNumericSuffix(dirItemRelativePath);
+        if (relativePath == suffixFreedirectorEntryPath) itemsToErase.push_back(dirIt->path());
     }
 
     auto ioError = IoError::Success;
@@ -154,10 +154,10 @@ bool isInTrash(const SyncPath &absoluteFilePath) {
             if (originalPathStr.empty()) continue;
 
             const auto originalPath = std::filesystem::absolute(originalPathStr);
-            if (!isSubPath(absoluteFilePath, originalPath)) continue;
+            if (!isSubPath(originalPath, absoluteFilePath)) continue;
 
             const SyncPath relativePath = std::filesystem::relative(absoluteFilePath, originalPath);
-            if (relativePath.begin() == relativePath.end()) return true;
+            if (relativePath.begin() == relativePath.end() || relativePath == ".") return true;
 
             const auto fileTrashParentName = entry.path().filename().stem();
             return std::filesystem::exists(getTrashSubDir(TrashSubDirectory::Files) / fileTrashParentName / relativePath);

--- a/test/test_utility/testhelpers_linux.cpp
+++ b/test/test_utility/testhelpers_linux.cpp
@@ -98,21 +98,6 @@ std::string getOriginalPath(const SyncPath &infoFile) {
     return "";
 }
 
-bool isSubPath(const SyncPath &path1, const SyncPath &path2) {
-    try {
-        const SyncPath canonicalPath1 = std::filesystem::weakly_canonical(path1);
-        const SyncPath canonicalPath2 = std::filesystem::weakly_canonical(path2);
-
-        const auto [path1It, path2It] =
-                std::mismatch(canonicalPath1.begin(), canonicalPath1.end(), canonicalPath2.begin(), canonicalPath2.end());
-
-        return (path1It == canonicalPath1.end());
-    } catch (const std::filesystem::filesystem_error &e) {
-        std::cerr << "Filesystem error in isSubPath: " << e.what() << std::endl;
-        return false;
-    }
-}
-
 } // namespace
 
 void eraseFromTrash(const KDC::SyncPath &relativePath) {
@@ -154,9 +139,9 @@ bool isInTrash(const SyncPath &absoluteFilePath) {
             if (originalPathStr.empty()) continue;
 
             const auto originalPath = std::filesystem::absolute(originalPathStr);
-            if (!isSubPath(originalPath, absoluteFilePath)) continue;
+            if (!CommonUtility::isSubDir(originalPath, absoluteFilePath)) continue;
 
-            const SyncPath relativePath = std::filesystem::relative(absoluteFilePath, originalPath);
+            const auto relativePath = std::filesystem::relative(absoluteFilePath, originalPath);
             if (relativePath.begin() == relativePath.end() || relativePath == ".") return true;
 
             const auto fileTrashParentName = entry.path().filename().stem();


### PR DESCRIPTION
These changes make sure that a relative path of the form `"."` is correctly interpreted when comparing two paths and trying to figure out if the first indicates a parent item of the item indicated by the second path.