### PR TITLE
feat(sync): open folder exclusion in dialog from advanced syncs

### DIFF
--- a/src/gui4/windows/kDrive client/kDrive client/Converters/BooleanToVisibilityConverter.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Converters/BooleanToVisibilityConverter.cs
@@ -13,6 +13,8 @@ namespace Infomaniak.kDrive.Converters
                 valueAsBool = boolValue;
             else if (value is int intValue)
                 valueAsBool = intValue != 0;
+            else if (value is null)
+                valueAsBool = false;
             else
                 throw new InvalidOperationException("Value must be a boolean or an integer.");
 

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/AdvancedSyncSetupContentDialog/AdvancedSyncSetupContentDialog.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/AdvancedSyncSetupContentDialog/AdvancedSyncSetupContentDialog.cs
@@ -24,9 +24,9 @@ namespace Infomaniak.kDrive.CustomControls
             base.MinWidth = 540;
             base.DataContext = _advancedSyncSetupContentDialogVM;
             base.XamlRoot = xamlRoot;
-            base.SecondaryButtonText = Localizer.Instance.GetString("buttonConfirm");
-            base.IsSecondaryButtonEnabled = false;
-            base.PrimaryButtonText = Localizer.Instance.GetString("buttonCancel");
+            base.PrimaryButtonText = Localizer.Instance.GetString("buttonConfirm");
+            base.IsPrimaryButtonEnabled = false;
+            base.CloseButtonText = Localizer.Instance.GetString("buttonCancel");
             base.DefaultButton = ContentDialogButton.Secondary;
             var frame = new Frame();
             base.Content = frame;
@@ -47,7 +47,7 @@ namespace Infomaniak.kDrive.CustomControls
         private void AdvancedSyncSetupContentDialogVM_PropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             if (e.PropertyName == nameof(AdvancedSyncSetupContentDialogVM.CanGoNext))
-                base.IsSecondaryButtonEnabled = _advancedSyncSetupContentDialogVM.CanGoNext;
+                base.IsPrimaryButtonEnabled = _advancedSyncSetupContentDialogVM.CanGoNext;
         }
 
         private void AdvancedSyncSetupContentDialogVM_SetupFinished(object? sender, AdvancedSyncSetupResult e)

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/AdvancedSyncSetupContentDialog/AdvancedSyncSetupContentDialog.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/AdvancedSyncSetupContentDialog/AdvancedSyncSetupContentDialog.cs
@@ -27,7 +27,7 @@ namespace Infomaniak.kDrive.CustomControls
             base.PrimaryButtonText = Localizer.Instance.GetString("buttonConfirm");
             base.IsPrimaryButtonEnabled = false;
             base.CloseButtonText = Localizer.Instance.GetString("buttonCancel");
-            base.DefaultButton = ContentDialogButton.Secondary;
+            base.DefaultButton = ContentDialogButton.Primary;
             var frame = new Frame();
             base.Content = frame;
             frame.Navigate(typeof(SyncSetupPage), _advancedSyncSetupContentDialogVM);

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/ConsentContentDialog.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/ConsentContentDialog.xaml
@@ -25,7 +25,7 @@
              xmlns:kDrive="using:Infomaniak.kDrive">
     <ContentDialog x:Name="Dialog"
                    PrimaryButtonText="{x:Bind kDrive:Localizer.Instance.GetString('buttonSave')}"
-                   SecondaryButtonText="{x:Bind kDrive:Localizer.Instance.GetString('buttonCancel')}"
+                   CloseButtonText="{x:Bind kDrive:Localizer.Instance.GetString('buttonCancel')}"
                    DefaultButton="Primary">
 
         <ContentDialog.TitleTemplate>

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/SyncExclusionPage.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/SyncExclusionPage.xaml
@@ -43,7 +43,7 @@
         <!-- Remote folder exclusion -->
         <controls:SyncExclusionSelector x:Name="ExclusionSelector"
                                         Grid.Row="3"
-                                        Sync="{x:Bind DriveSetupContentDialogVM.CurrentSync}"
+                                        Sync="{x:Bind Sync}"
                                         CanShowSaveMenu="False" />
     </Grid>
 </Page>

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/SyncExclusionPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/SyncExclusionPage.xaml.cs
@@ -43,7 +43,7 @@ namespace Infomaniak.kDrive.Pages.DriveSetupContentDialog
             else if (Sync is null)
             {
                 Logger.Log(Logger.Level.Fatal, "Invalid parameter type when navigating to SyncExclusionPage");
-                throw new Exception("Invalid parameter type when navigating to SyncSetupPage");
+                throw new Exception("Invalid parameter type when navigating to SyncExclusionPage");
             }
         }
         protected override void OnNavigatedFrom(NavigationEventArgs e)

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/SyncExclusionPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/SyncExclusionPage.xaml.cs
@@ -1,15 +1,11 @@
 using Infomaniak.kDrive.CustomControls;
-using Infomaniak.kDrive.ServerCommunication.Interfaces;
 using Infomaniak.kDrive.Types;
 using Infomaniak.kDrive.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
 using System;
-using System.Linq;
-using System.Threading;
-using Windows.Storage.Pickers;
+using System.Threading.Tasks;
 
 namespace Infomaniak.kDrive.Pages.DriveSetupContentDialog
 {
@@ -19,9 +15,17 @@ namespace Infomaniak.kDrive.Pages.DriveSetupContentDialog
         public AppModel ViewModel { get { return _viewModel; } }
 
         private DriveSetupContentDialogVM? DriveSetupContentDialogVM { get; set; }
+        private ISync? Sync { get; set; }
         public SyncExclusionPage()
         {
             Logger.Log(Logger.Level.Info, "Navigated to DriveSetupContentDialog.SyncExclusionPage - Initializing DriveSetupContentDialog.SyncExclusionPage components");
+            InitializeComponent();
+            Logger.Log(Logger.Level.Debug, "DriveSetupContentDialog.SyncExclusionPage components initialized");
+        }
+        public SyncExclusionPage(ISync sync)
+        {
+            Logger.Log(Logger.Level.Info, "Navigated to DriveSetupContentDialog.SyncExclusionPage - Initializing DriveSetupContentDialog.SyncExclusionPage components");
+            Sync = sync;
             InitializeComponent();
             Logger.Log(Logger.Level.Debug, "DriveSetupContentDialog.SyncExclusionPage components initialized");
         }
@@ -32,10 +36,11 @@ namespace Infomaniak.kDrive.Pages.DriveSetupContentDialog
             if (e.Parameter is DriveSetupContentDialogVM viewModel)
             {
                 DriveSetupContentDialogVM = viewModel;
+                Sync = DriveSetupContentDialogVM.CurrentSync;
                 DriveSetupContentDialogVM.CurrentStepCancelled += DriveSetupContentDialogVM_CurrentStepCancelled;
                 DriveSetupContentDialogVM.CurrentStepConfirmed += DriveSetupContentDialogVM_CurrentStepConfirmed;
             }
-            else
+            else if (Sync is null)
             {
                 Logger.Log(Logger.Level.Fatal, "Invalid parameter type when navigating to SyncExclusionPage");
                 throw new Exception("Invalid parameter type when navigating to SyncSetupPage");
@@ -43,10 +48,20 @@ namespace Infomaniak.kDrive.Pages.DriveSetupContentDialog
         }
         protected override void OnNavigatedFrom(NavigationEventArgs e)
         {
-            DriveSetupContentDialogVM!.CurrentStepCancelled -= DriveSetupContentDialogVM_CurrentStepCancelled;
-            DriveSetupContentDialogVM!.CurrentStepConfirmed -= DriveSetupContentDialogVM_CurrentStepConfirmed;
+            if (DriveSetupContentDialogVM is not null)
+            {
+                DriveSetupContentDialogVM.CurrentStepCancelled -= DriveSetupContentDialogVM_CurrentStepCancelled;
+                DriveSetupContentDialogVM.CurrentStepConfirmed -= DriveSetupContentDialogVM_CurrentStepConfirmed;
+            }
         }
 
+        // Public methods
+        public async Task SaveChanges()
+        {
+            await ExclusionSelector.SaveChanges();
+        }
+
+        // Private methods
         private async void DriveSetupContentDialogVM_CurrentStepConfirmed(object? sender, EventArgs e)
         {
             if (DriveSetupContentDialogVM is null)

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DriveSetupContentDialog.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DriveSetupContentDialog.cs
@@ -29,7 +29,7 @@ namespace Infomaniak.kDrive.CustomControls
             base.Content = frame;
             frame.Navigate(typeof(DriveSelectionPage), _driveSetupContentDialogVM);
             base.PrimaryButtonClick += DriveSetupContentDialog_PrimaryButtonClick;
-            base.SecondaryButtonClick += DriveSetupContentDialog_SecondaryButtonClick;
+            base.CloseButtonClick += DriveSetupContentDialog_SecondaryButtonClick;
             _driveSetupContentDialogVM.SetupFinished += DriveSetupContentDialogVM_SetupFinished;
         }
 

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DriveSetupContentDialog.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DriveSetupContentDialog.cs
@@ -22,9 +22,9 @@ namespace Infomaniak.kDrive.CustomControls
             _driveSetupContentDialogVM = new DriveSetupContentDialogVM(newSyncs);
             base.DataContext = _driveSetupContentDialogVM;
             base.XamlRoot = xamlRoot;
-            base.SecondaryButtonText = Localizer.Instance.GetString("buttonConfirm");
-            base.PrimaryButtonText = Localizer.Instance.GetString("buttonCancel");
-            base.DefaultButton = ContentDialogButton.Secondary;
+            base.PrimaryButtonText = Localizer.Instance.GetString("buttonConfirm");
+            base.CloseButtonText = Localizer.Instance.GetString("buttonCancel");
+            base.DefaultButton = ContentDialogButton.Primary;
             var frame = new Frame();
             base.Content = frame;
             frame.Navigate(typeof(DriveSelectionPage), _driveSetupContentDialogVM);

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/LocalAccessError.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/LocalAccessError.xaml.cs
@@ -38,7 +38,7 @@ namespace Infomaniak.kDrive.CustomControls.Errors.Templates.Node
                 Title = Localizer.Instance.GetString("localFileAccessErrorTitle"),
                 Content = Localizer.Instance.GetString("localFileAccessErrorDialogOpenParentFolder"),
                 DefaultButton = ContentDialogButton.Primary,
-                SecondaryButtonText = Localizer.Instance.GetString("buttonClose"),
+                CloseButtonText = Localizer.Instance.GetString("buttonClose"),
                 PrimaryButtonText = Localizer.Instance.GetString("buttonOpenParentFolder"),
             };
             dialog.Content = new LocalAccessErrorDialog(_error) { XamlRoot = xamlRoot };

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/SyncPal/DataErrorSyncDirChanged.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/SyncPal/DataErrorSyncDirChanged.xaml.cs
@@ -35,7 +35,7 @@ namespace Infomaniak.kDrive.CustomControls.Errors.Templates.SyncPal
                 XamlRoot = xamlRoot,
                 Title = Localizer.Instance.GetString("dialogDataErrorSyncDirChangedTitle"),
                 DefaultButton = ContentDialogButton.Primary,
-                SecondaryButtonText = Localizer.Instance.GetString("buttonClose"),
+                CloseButtonText = Localizer.Instance.GetString("buttonClose"),
                 PrimaryButtonText = Localizer.Instance.GetString("buttonCreateNewSync"),
                 Content = new SystemErrorSyncDirChangedErrorDialog(Error) { XamlRoot = xamlRoot }
             };

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/SyncPal/SystemErrorSyncDirAccessError.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/SyncPal/SystemErrorSyncDirAccessError.xaml.cs
@@ -36,7 +36,7 @@ namespace Infomaniak.kDrive.CustomControls.Errors.Templates.SyncPal
                 XamlRoot = xamlRoot,
                 Title = Localizer.Instance.GetString("systemErrorSyncDirAccessErrorTitle"),
                 DefaultButton = ContentDialogButton.Primary,
-                SecondaryButtonText = Localizer.Instance.GetString("buttonClose"),
+                CloseButtonText = Localizer.Instance.GetString("buttonClose"),
                 PrimaryButtonText = Localizer.Instance.GetString("buttonOpenParentFolder"),
                 Content = new SystemErrorSyncDirAccessErrorDialog(Error) { XamlRoot = xamlRoot }
             };

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/SyncPal/SystemErrorSyncDirDiskMissing.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/SyncPal/SystemErrorSyncDirDiskMissing.xaml.cs
@@ -36,7 +36,7 @@ namespace Infomaniak.kDrive.CustomControls.Errors.Templates.SyncPal
                 XamlRoot = xamlRoot,
                 Title = Localizer.Instance.GetString("systemErrorSyncDirMissingErrorTitle"),
                 DefaultButton = ContentDialogButton.Primary,
-                SecondaryButtonText = Localizer.Instance.GetString("buttonClose"),
+                CloseButtonText = Localizer.Instance.GetString("buttonClose"),
                 PrimaryButtonText = Localizer.Instance.GetString("buttonRestartSync"),
                 Content = new SystemErrorSyncDirDiskMissingErrorDialog(Error) { XamlRoot = xamlRoot }
             };

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/LogUploadSettingsCard.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/LogUploadSettingsCard.xaml.cs
@@ -30,7 +30,7 @@ namespace Infomaniak.kDrive.CustomControls
                 Title = Localizer.Instance.GetString("logUploadPopupTitle"),
                 DefaultButton = ContentDialogButton.Primary,
                 PrimaryButtonText = Localizer.Instance.GetString("buttonSend"),
-                SecondaryButtonText = Localizer.Instance.GetString("buttonCancel")
+                CloseButtonText = Localizer.Instance.GetString("buttonCancel")
             };
             var popupPage = new Pages.Popup.LogUploadPopup();
             dialog.Content = popupPage;

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/SyncExclusionSelector.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/SyncExclusionSelector.xaml
@@ -58,12 +58,13 @@
                                          HorizontalAlignment="Right"
                                          IsLoading="{x:Bind Node.IsLoadingSize, Mode=OneWay}"
                                          CornerRadius="{StaticResource Infomaniak.Style.CornerRadius.Uniform.S}"
-                                         MinWidth="60"
+                                         LoaderMinWidth="60"
+                                         LoaderMinHeight="16"
                                          Margin="{StaticResource Infomaniak.Style.Thickness.Right.M}"
                                          DataContextChanged="SizeContentLoader_DataContextChanged">
                         <local:ContentLoader.LoaderContent>
                             <TextBlock Text="{x:Bind Node.Size, Converter={StaticResource BytesToHumanReadableStringConverter}, Mode=OneWay}"
-                                       MinWidth="60" />
+                                       HorizontalAlignment="Right" />
                         </local:ContentLoader.LoaderContent>
                     </local:ContentLoader>
                 </Grid>

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/SyncExclusionSelector.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/SyncExclusionSelector.xaml.cs
@@ -191,8 +191,7 @@ namespace Infomaniak.kDrive.CustomControls
             if (Sync is ViewModels.Sync dbSync)
             {
                 IsLoading = true;
-                var commService = App.ServiceProvider.GetRequiredService<IServerCommService>();
-                if (!await commService.SetBlacklistedNodeIdList(dbSync.DbId, GetExcludedNodeIds(), CancellationToken.None))
+                if (!await dbSync.SetExcludedNodeIds(GetExcludedNodeIds()))
                 {
                     Logger.Log(Logger.Level.Warning, "Failed to save BlacklistedNodeIdList");
                     Utility.ShowUnexpectedErrorTeachingTip();

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/DriveAdvancedSyncsPage.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/DriveAdvancedSyncsPage.xaml
@@ -16,6 +16,7 @@
         <converters:StringPathToFileNameConverter x:Key="StringPathToFileNameConverter" />
         <converters:BooleanToInvertedBooleanConverter x:Key="BooleanToInvertedBooleanConverter" />
         <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+        <converters:IsNullToBoolOrVisibilityConverter x:Key="IsNullToBoolOrVisibilityConverter" />
 
         <!-- Data template -->
         <DataTemplate x:Key="AdvancedSyncItemTemplate"
@@ -49,11 +50,37 @@
                         <StackPanel Orientation="Horizontal"
                                     Spacing="{StaticResource Infomaniak.Style.Spacing.XS}">
 
-                            <controls:ContentLoader IsLoading="True"
-                                                    LoaderMinHeight="16"
-                                                    LoaderMinWidth="80">
+                            <controls:ContentLoader IsLoading="{x:Bind HasExcludedFodler, Converter={StaticResource IsNullToBoolOrVisibilityConverter}, Mode=OneWay}"
+                                                    CornerRadius="{StaticResource Infomaniak.Style.CornerRadius.Uniform.S}"
+                                                    LoaderMinHeight="12"
+                                                    Height="24"
+                                                    LoaderMinWidth="120">
                                 <controls:ContentLoader.LoaderContent>
-                                    <TextBlock Text="Tous les dossiers" />
+                                    <Grid>
+                                        <!-- No exclusion -->
+                                        <StackPanel Orientation="Horizontal"
+                                                    Visibility="{x:Bind HasExcludedFodler, Converter={StaticResource BooleanToVisibilityConverter}, ConverterParameter='Inverted=True', Mode=OneWay}"
+                                                    Spacing="{StaticResource Infomaniak.Style.Spacing.XXS}"
+                                                    VerticalAlignment="Center">
+                                            <controls:SvgIcon UriString="{StaticResource Infomaniak.DS.Icons.Actions.circle-check-outline}"
+                                                              Style="{StaticResource Infomaniak.Style.Icon.Size.XS}"
+                                                              Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                                            <TextBlock Text="{x:Bind kDrive:Localizer.Instance.GetString('labelAllFolders')}"
+                                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                                        </StackPanel>
+
+                                        <StackPanel Orientation="Horizontal"
+                                                    Visibility="{x:Bind HasExcludedFodler, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}"
+                                                    Spacing="{StaticResource Infomaniak.Style.Spacing.XXS}"
+                                                    VerticalAlignment="Center">
+
+                                            <controls:SvgIcon UriString="{StaticResource Infomaniak.DS.Icons.Actions.circle-maybe-check}"
+                                                              Style="{StaticResource Infomaniak.Style.Icon.Size.XS}"
+                                                              Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                                            <TextBlock Text="{x:Bind kDrive:Localizer.Instance.GetString('onboardingExclusionSummarySome')}"
+                                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                                        </StackPanel>
+                                    </Grid>
                                 </controls:ContentLoader.LoaderContent>
                             </controls:ContentLoader>
                             <Button Content="{x:Bind kDrive:Localizer.Instance.GetString('buttonSelect')}"

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/DriveAdvancedSyncsPage.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/DriveAdvancedSyncsPage.xaml
@@ -27,13 +27,31 @@
                                       Height="32" />
                 </toolKit:SettingsExpander.HeaderIcon>
                 <toolKit:SettingsExpander.Items>
+                    <!-- Local path -->
                     <toolKit:SettingsCard Header="{x:Bind kDrive:Localizer.Instance.GetString('localLocation')}">
                         <HyperlinkButton Content="{x:Bind LocalPath}"
                                          Click="LocalPathLink_Click" />
                     </toolKit:SettingsCard>
+
+                    <!-- Remote path -->
                     <toolKit:SettingsCard Header="{x:Bind kDrive:Localizer.Instance.GetString('remoteLocation')}">
-                        <HyperlinkButton Content="{x:Bind RemotePath}"
-                                         Click="RemotePathLink_Click" />
+                        <HyperlinkButton Content="{x:Bind RemotePath, Converter={StaticResource StringPathToFileNameConverter}}"
+                                         Click="RemotePathLink_Click">
+                            <ToolTipService.ToolTip>
+                                <TextBlock Text="{x:Bind RemotePath}" />
+                            </ToolTipService.ToolTip>
+                        </HyperlinkButton>
+                    </toolKit:SettingsCard>
+
+                    <!--- Folder selection -->
+                    <toolKit:SettingsCard Header="Dossiers synchronisés">
+                        <!-- Presentation -->
+                        <StackPanel Orientation="Horizontal"
+                                    Spacing="{StaticResource Infomaniak.Style.Spacing.XS}">
+
+                            <Button Content="{x:Bind kDrive:Localizer.Instance.GetString('buttonSelect')}"
+                                    Click="SyncExclusionButton_Click" />
+                        </StackPanel>
                     </toolKit:SettingsCard>
 
                     <!-- Lite sync -->
@@ -106,33 +124,6 @@
                         </Grid>
                     </toolKit:SettingsCard>
 
-                    <!--- Folder selection -->
-                    <toolKit:SettingsCard HorizontalAlignment="Stretch"
-                                          HorizontalContentAlignment="Stretch"
-                                          ContentAlignment="Vertical">
-                        <!-- Presentation -->
-                        <Grid RowSpacing="{StaticResource Infomaniak.Style.Spacing.M}">
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="Auto" />
-                                <RowDefinition Height="*" />
-                            </Grid.RowDefinitions>
-                            <StackPanel Grid.Row="0"
-                                        Spacing="{StaticResource Infomaniak.Style.Spacing.XXS}">
-                                <TextBlock Text="{x:Bind kDrive:Localizer.Instance.GetString('selectFoldersToSync')}"
-                                           Style="{StaticResource Infomaniak.Style.TextBlock.Body}"
-                                           TextWrapping="Wrap" />
-
-                                <TextBlock Text="{x:Bind kDrive:Localizer.Instance.GetString('selectFoldersToSyncDescription')}"
-                                           Style="{StaticResource Infomaniak.Style.TextBlock.Caption}"
-                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                           TextWrapping="Wrap" />
-                            </StackPanel>
-                            <controls:SyncExclusionSelector Grid.Row="1"
-                                                            Sync="{x:Bind Mode=OneWay}"
-                                                            CanShowSaveMenu="True"
-                                                            HorizontalAlignment="Stretch" />
-                        </Grid>
-                    </toolKit:SettingsCard>
                     <toolKit:SettingsCard Header="{x:Bind kDrive:Localizer.Instance.GetString('removeSync')}"
                                           Foreground="{ThemeResource SystemFillColorCriticalBrush}"
                                           PointerExited="FixForegroundOnPointerExited"
@@ -196,7 +187,7 @@
                     </ListView.ItemContainerStyle>
                 </ListView>
                 <Button Content="{x:Bind kDrive:Localizer.Instance.GetString('buttonAddAdvancedSync')}"
-                        Click="AddAdvancedSyncButton_Click"/>
+                        Click="AddAdvancedSyncButton_Click" />
                 <!-- TODO: Bind the button logic once the UI/UX is ready -->
             </StackPanel>
         </ScrollView>

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/DriveAdvancedSyncsPage.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/DriveAdvancedSyncsPage.xaml
@@ -46,7 +46,6 @@
 
                     <!--- Folder selection -->
                     <toolKit:SettingsCard Header="{x:Bind kDrive:Localizer.Instance.GetString('labelSyncedFolders')}">
-                        <!-- Presentation -->
                         <StackPanel Orientation="Horizontal"
                                     Spacing="{StaticResource Infomaniak.Style.Spacing.XS}">
 
@@ -222,7 +221,6 @@
                 </ListView>
                 <Button Content="{x:Bind kDrive:Localizer.Instance.GetString('buttonAddAdvancedSync')}"
                         Click="AddAdvancedSyncButton_Click" />
-                <!-- TODO: Bind the button logic once the UI/UX is ready -->
             </StackPanel>
         </ScrollView>
     </Grid>

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/DriveAdvancedSyncsPage.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/DriveAdvancedSyncsPage.xaml
@@ -50,7 +50,7 @@
                         <StackPanel Orientation="Horizontal"
                                     Spacing="{StaticResource Infomaniak.Style.Spacing.XS}">
 
-                            <controls:ContentLoader IsLoading="{x:Bind HasExcludedFodler, Converter={StaticResource IsNullToBoolOrVisibilityConverter}, Mode=OneWay}"
+                            <controls:ContentLoader IsLoading="{x:Bind HasExcludedFolder, Converter={StaticResource IsNullToBoolOrVisibilityConverter}, Mode=OneWay}"
                                                     CornerRadius="{StaticResource Infomaniak.Style.CornerRadius.Uniform.S}"
                                                     LoaderMinHeight="12"
                                                     Height="24"
@@ -59,7 +59,7 @@
                                     <Grid>
                                         <!-- No exclusion -->
                                         <StackPanel Orientation="Horizontal"
-                                                    Visibility="{x:Bind HasExcludedFodler, Converter={StaticResource BooleanToVisibilityConverter}, ConverterParameter='Inverted=True', Mode=OneWay}"
+                                                    Visibility="{x:Bind HasExcludedFolder, Converter={StaticResource BooleanToVisibilityConverter}, ConverterParameter='Inverted=True', Mode=OneWay}"
                                                     Spacing="{StaticResource Infomaniak.Style.Spacing.XXS}"
                                                     VerticalAlignment="Center">
                                             <controls:SvgIcon UriString="{StaticResource Infomaniak.DS.Icons.Actions.circle-check-outline}"
@@ -70,7 +70,7 @@
                                         </StackPanel>
 
                                         <StackPanel Orientation="Horizontal"
-                                                    Visibility="{x:Bind HasExcludedFodler, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}"
+                                                    Visibility="{x:Bind HasExcludedFolder, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}"
                                                     Spacing="{StaticResource Infomaniak.Style.Spacing.XXS}"
                                                     VerticalAlignment="Center">
 

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/DriveAdvancedSyncsPage.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/DriveAdvancedSyncsPage.xaml
@@ -49,6 +49,13 @@
                         <StackPanel Orientation="Horizontal"
                                     Spacing="{StaticResource Infomaniak.Style.Spacing.XS}">
 
+                            <controls:ContentLoader IsLoading="True"
+                                                    LoaderMinHeight="16"
+                                                    LoaderMinWidth="80">
+                                <controls:ContentLoader.LoaderContent>
+                                    <TextBlock Text="Tous les dossiers" />
+                                </controls:ContentLoader.LoaderContent>
+                            </controls:ContentLoader>
                             <Button Content="{x:Bind kDrive:Localizer.Instance.GetString('buttonSelect')}"
                                     Click="SyncExclusionButton_Click" />
                         </StackPanel>

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/DriveAdvancedSyncsPage.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/DriveAdvancedSyncsPage.xaml
@@ -44,7 +44,7 @@
                     </toolKit:SettingsCard>
 
                     <!--- Folder selection -->
-                    <toolKit:SettingsCard Header="Dossiers synchronisés">
+                    <toolKit:SettingsCard Header="{x:Bind kDrive:Localizer.Instance.GetString('labelSyncedFolders')}">
                         <!-- Presentation -->
                         <StackPanel Orientation="Horizontal"
                                     Spacing="{StaticResource Infomaniak.Style.Spacing.XS}">

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/DriveAdvancedSyncsPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/DriveAdvancedSyncsPage.xaml.cs
@@ -274,9 +274,9 @@ public sealed partial class DriveAdvancedSyncsPage : Page
         ContentDialog dialog = new ContentDialog
         {
             XamlRoot = this.XamlRoot,
-            SecondaryButtonText = Localizer.Instance.GetString("buttonConfirm"),
-            PrimaryButtonText = Localizer.Instance.GetString("buttonCancel"),
-            DefaultButton = ContentDialogButton.Secondary
+            CloseButtonText = Localizer.Instance.GetString("buttonCancel"),
+            PrimaryButtonText = Localizer.Instance.GetString("ButtonConfirm"),
+            DefaultButton = ContentDialogButton.Primary
         };
         var exclusionPage = new SyncExclusionPage(sync);
         dialog.Content = exclusionPage;

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/DriveAdvancedSyncsPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/DriveAdvancedSyncsPage.xaml.cs
@@ -263,7 +263,7 @@ public sealed partial class DriveAdvancedSyncsPage : Page
             return;
         }
 
-        Sync? sync = control.DataContext as Sync;
+        ISync? sync = control.DataContext as ISync;
         if (sync is null)
         {
             Logger.Log(Logger.Level.Error, "Could not get sync from DataContext when clicking on sync exclusion button");

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/DriveAdvancedSyncsPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/DriveAdvancedSyncsPage.xaml.cs
@@ -282,7 +282,7 @@ public sealed partial class DriveAdvancedSyncsPage : Page
         dialog.Content = exclusionPage;
 
         var result = await dialog.ShowAsync();
-        if (result == ContentDialogResult.Secondary)
+        if (result == ContentDialogResult.Primary)
         {
             Logger.Log(Logger.Level.Info, "User confirmed sync exclusion changes");
             await exclusionPage.SaveChanges();

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/DriveAdvancedSyncsPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/DriveAdvancedSyncsPage.xaml.cs
@@ -1,4 +1,5 @@
 using Infomaniak.kDrive.CustomControls;
+using Infomaniak.kDrive.Pages.DriveSetupContentDialog;
 using Infomaniak.kDrive.ServerCommunication.Interfaces;
 using Infomaniak.kDrive.Types;
 using Infomaniak.kDrive.ViewModels;
@@ -250,5 +251,46 @@ public sealed partial class DriveAdvancedSyncsPage : Page
 
         if (control is not null)
             control.IsEnabled = true;
+    }
+
+    private async void SyncExclusionButton_Click(object sender, RoutedEventArgs e)
+    {
+        Control? control = sender as Control;
+        if (control is null)
+        {
+            Logger.Log(Logger.Level.Error, "Sync exclusion button is null when clicking on sync exclusion button");
+            Utility.ShowUnexpectedErrorTeachingTip();
+            return;
+        }
+
+        Sync? sync = control.DataContext as Sync;
+        if (sync is null)
+        {
+            Logger.Log(Logger.Level.Error, "Could not get sync from DataContext when clicking on sync exclusion button");
+            Utility.ShowUnexpectedErrorTeachingTip();
+            return;
+        }
+
+        ContentDialog dialog = new ContentDialog
+        {
+            XamlRoot = this.XamlRoot,
+            SecondaryButtonText = Localizer.Instance.GetString("buttonConfirm"),
+            PrimaryButtonText = Localizer.Instance.GetString("buttonCancel"),
+            DefaultButton = ContentDialogButton.Secondary
+        };
+        var exclusionPage = new SyncExclusionPage(sync);
+        dialog.Content = exclusionPage;
+
+        var result = await dialog.ShowAsync();
+        if (result == ContentDialogResult.Secondary)
+        {
+            Logger.Log(Logger.Level.Info, "User confirmed sync exclusion changes");
+            await exclusionPage.SaveChanges();
+        }
+        else
+        {
+            Logger.Log(Logger.Level.Info, "User canceled sync exclusion changes");
+        }
+
     }
 }

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/DriveAdvancedSyncsPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/DriveAdvancedSyncsPage.xaml.cs
@@ -275,7 +275,7 @@ public sealed partial class DriveAdvancedSyncsPage : Page
         {
             XamlRoot = this.XamlRoot,
             CloseButtonText = Localizer.Instance.GetString("buttonCancel"),
-            PrimaryButtonText = Localizer.Instance.GetString("ButtonConfirm"),
+            PrimaryButtonText = Localizer.Instance.GetString("buttonConfirm"),
             DefaultButton = ContentDialogButton.Primary
         };
         var exclusionPage = new SyncExclusionPage(sync);

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/TemplateExclusionPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/TemplateExclusionPage.xaml.cs
@@ -59,7 +59,7 @@ namespace Infomaniak.kDrive.Pages.Settings
                 XamlRoot = this.XamlRoot,
                 Content = popupPage,
                 PrimaryButtonText = Localizer.Instance.GetString("dialogNewExclusionRulePrimaryButton"),
-                SecondaryButtonText = Localizer.Instance.GetString("buttonCancel"),
+                CloseButtonText = Localizer.Instance.GetString("buttonCancel"),
                 DefaultButton = ContentDialogButton.Primary
             };
 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/de-DE/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/de-DE/Resources.resw
@@ -6,7 +6,7 @@
   Locale: de, German
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Thu, 19 Mar 2026 13:02:15 +0100 
+  Exported at: Thu, 19 Mar 2026 14:03:38 +0100 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -979,6 +979,9 @@ Es wird in Ihrem Browser geöffnet.</value>
   </data> 
   <data name="labelSyncLocation" xml:space="preserve"> 
     <value>Standort</value> 
+  </data> 
+  <data name="labelSyncedFolders" xml:space="preserve"> 
+    <value /> 
   </data> 
   <data name="labelSynchronisation" xml:space="preserve"> 
     <value>Synchronisierung</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/de-DE/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/de-DE/Resources.resw
@@ -6,7 +6,7 @@
   Locale: de, German
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Thu, 19 Mar 2026 15:25:27 +0100 
+  Exported at: Thu, 19 Mar 2026 16:46:04 +0100 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -984,7 +984,7 @@ Es wird in Ihrem Browser geöffnet.</value>
     <value>Standort</value> 
   </data> 
   <data name="labelSyncedFolders" xml:space="preserve"> 
-    <value /> 
+    <value>Synchronisierte Ordner</value> 
   </data> 
   <data name="labelSynchronisation" xml:space="preserve"> 
     <value>Synchronisierung</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/de-DE/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/de-DE/Resources.resw
@@ -6,7 +6,7 @@
   Locale: de, German
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Thu, 19 Mar 2026 14:03:38 +0100 
+  Exported at: Thu, 19 Mar 2026 15:25:27 +0100 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -809,6 +809,9 @@ Es wird in Ihrem Browser geöffnet.</value>
   </data> 
   <data name="labelAgo" xml:space="preserve"> 
     <value>vor %@</value> 
+  </data> 
+  <data name="labelAllFolders" xml:space="preserve"> 
+    <value>Alle Ordner</value> 
   </data> 
   <data name="labelAuthor" xml:space="preserve"> 
     <value>Autor</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/en-US/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/en-US/Resources.resw
@@ -6,7 +6,7 @@
   Locale: en, English
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Thu, 19 Mar 2026 13:02:15 +0100 
+  Exported at: Thu, 19 Mar 2026 14:03:38 +0100 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -979,6 +979,9 @@ It will open in your browser.</value>
   </data> 
   <data name="labelSyncLocation" xml:space="preserve"> 
     <value>Location</value> 
+  </data> 
+  <data name="labelSyncedFolders" xml:space="preserve"> 
+    <value /> 
   </data> 
   <data name="labelSynchronisation" xml:space="preserve"> 
     <value>Synchronization</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/en-US/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/en-US/Resources.resw
@@ -6,7 +6,7 @@
   Locale: en, English
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Thu, 19 Mar 2026 14:03:38 +0100 
+  Exported at: Thu, 19 Mar 2026 15:25:26 +0100 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -809,6 +809,9 @@ It will open in your browser.</value>
   </data> 
   <data name="labelAgo" xml:space="preserve"> 
     <value>%@ ago</value> 
+  </data> 
+  <data name="labelAllFolders" xml:space="preserve"> 
+    <value>All files</value> 
   </data> 
   <data name="labelAuthor" xml:space="preserve"> 
     <value>Author</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/en-US/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/en-US/Resources.resw
@@ -6,7 +6,7 @@
   Locale: en, English
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Thu, 19 Mar 2026 15:25:26 +0100 
+  Exported at: Thu, 19 Mar 2026 16:46:04 +0100 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -984,7 +984,7 @@ It will open in your browser.</value>
     <value>Location</value> 
   </data> 
   <data name="labelSyncedFolders" xml:space="preserve"> 
-    <value /> 
+    <value>Synchronized folders</value> 
   </data> 
   <data name="labelSynchronisation" xml:space="preserve"> 
     <value>Synchronization</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/es-ES/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/es-ES/Resources.resw
@@ -6,7 +6,7 @@
   Locale: es, Spanish
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Thu, 19 Mar 2026 15:25:27 +0100 
+  Exported at: Thu, 19 Mar 2026 16:46:04 +0100 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -984,7 +984,7 @@ Se abrirá en su navegador.</value>
     <value>Ubicación</value> 
   </data> 
   <data name="labelSyncedFolders" xml:space="preserve"> 
-    <value /> 
+    <value>Carpetas sincronizadas</value> 
   </data> 
   <data name="labelSynchronisation" xml:space="preserve"> 
     <value>Sincronización</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/es-ES/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/es-ES/Resources.resw
@@ -6,7 +6,7 @@
   Locale: es, Spanish
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Thu, 19 Mar 2026 13:02:15 +0100 
+  Exported at: Thu, 19 Mar 2026 14:03:38 +0100 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -979,6 +979,9 @@ Se abrirá en su navegador.</value>
   </data> 
   <data name="labelSyncLocation" xml:space="preserve"> 
     <value>Ubicación</value> 
+  </data> 
+  <data name="labelSyncedFolders" xml:space="preserve"> 
+    <value /> 
   </data> 
   <data name="labelSynchronisation" xml:space="preserve"> 
     <value>Sincronización</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/es-ES/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/es-ES/Resources.resw
@@ -6,7 +6,7 @@
   Locale: es, Spanish
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Thu, 19 Mar 2026 14:03:38 +0100 
+  Exported at: Thu, 19 Mar 2026 15:25:27 +0100 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -809,6 +809,9 @@ Se abrirá en su navegador.</value>
   </data> 
   <data name="labelAgo" xml:space="preserve"> 
     <value>hace %@</value> 
+  </data> 
+  <data name="labelAllFolders" xml:space="preserve"> 
+    <value>Todos los archivos</value> 
   </data> 
   <data name="labelAuthor" xml:space="preserve"> 
     <value>Autor</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/fr-FR/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/fr-FR/Resources.resw
@@ -6,7 +6,7 @@
   Locale: fr, French
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Thu, 19 Mar 2026 15:25:27 +0100 
+  Exported at: Thu, 19 Mar 2026 16:46:04 +0100 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/fr-FR/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/fr-FR/Resources.resw
@@ -6,7 +6,7 @@
   Locale: fr, French
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Thu, 19 Mar 2026 14:03:38 +0100 
+  Exported at: Thu, 19 Mar 2026 15:25:27 +0100 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -807,6 +807,9 @@ Il s’ouvrira dans votre navigateur.</value>
   </data> 
   <data name="labelAgo" xml:space="preserve"> 
     <value>il y a %@</value> 
+  </data> 
+  <data name="labelAllFolders" xml:space="preserve"> 
+    <value>Tous les dossiers</value> 
   </data> 
   <data name="labelAuthor" xml:space="preserve"> 
     <value>Auteur</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/fr-FR/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/fr-FR/Resources.resw
@@ -6,7 +6,7 @@
   Locale: fr, French
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Thu, 19 Mar 2026 13:02:15 +0100 
+  Exported at: Thu, 19 Mar 2026 14:03:38 +0100 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -977,6 +977,9 @@ Il s’ouvrira dans votre navigateur.</value>
   </data> 
   <data name="labelSyncLocation" xml:space="preserve"> 
     <value>Emplacement</value> 
+  </data> 
+  <data name="labelSyncedFolders" xml:space="preserve"> 
+    <value>Dossiers synchronisés</value> 
   </data> 
   <data name="labelSynchronisation" xml:space="preserve"> 
     <value>Synchronisation</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/it-IT/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/it-IT/Resources.resw
@@ -6,7 +6,7 @@
   Locale: it, Italian
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Thu, 19 Mar 2026 15:25:27 +0100 
+  Exported at: Thu, 19 Mar 2026 16:46:04 +0100 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -982,7 +982,7 @@ Si aprirà nel browser.</value>
     <value>Posizione</value> 
   </data> 
   <data name="labelSyncedFolders" xml:space="preserve"> 
-    <value /> 
+    <value>Cartelle sincronizzate</value> 
   </data> 
   <data name="labelSynchronisation" xml:space="preserve"> 
     <value>Sincronizzazione</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/it-IT/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/it-IT/Resources.resw
@@ -6,7 +6,7 @@
   Locale: it, Italian
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Thu, 19 Mar 2026 13:02:15 +0100 
+  Exported at: Thu, 19 Mar 2026 14:03:38 +0100 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -977,6 +977,9 @@ Si aprirà nel browser.</value>
   </data> 
   <data name="labelSyncLocation" xml:space="preserve"> 
     <value>Posizione</value> 
+  </data> 
+  <data name="labelSyncedFolders" xml:space="preserve"> 
+    <value /> 
   </data> 
   <data name="labelSynchronisation" xml:space="preserve"> 
     <value>Sincronizzazione</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/it-IT/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/it-IT/Resources.resw
@@ -6,7 +6,7 @@
   Locale: it, Italian
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Thu, 19 Mar 2026 14:03:38 +0100 
+  Exported at: Thu, 19 Mar 2026 15:25:27 +0100 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -807,6 +807,9 @@ Si aprirà nel browser.</value>
   </data> 
   <data name="labelAgo" xml:space="preserve"> 
     <value>%@ fa</value> 
+  </data> 
+  <data name="labelAllFolders" xml:space="preserve"> 
+    <value>Tutti i file</value> 
   </data> 
   <data name="labelAuthor" xml:space="preserve"> 
     <value>Autore</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/Sync.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/Sync.cs
@@ -50,6 +50,8 @@ namespace Infomaniak.kDrive.ViewModels
         private readonly ObservableCollection<SyncFileItem> _syncActivities = [];
         private bool _syncTypeMigrationInProgress = false;
         private SyncFileItem? _lastActivity;
+        private bool? _hasExcludedFolder = null;
+        private Task? _hasExcludedFolderLoadingTask = null;
 
 
         public SyncStatus SyncStatus
@@ -199,6 +201,17 @@ namespace Infomaniak.kDrive.ViewModels
             set => SetPropertyInUIThread(ref _showIncomingActivity, value);
         }
 
+        public bool? HasExcludedFodler
+        {
+            get
+            {
+                if (_hasExcludedFolder is null) // If the value is not loaded yet, trigger the loading, UI will be updated once the loading is done
+                    RefreshHasExcludedFolder();
+                return _hasExcludedFolder;
+            }
+            set => SetPropertyInUIThread(ref _hasExcludedFolder, value);
+        }
+
         public async Task<bool> Start()
         {
             var commService = App.ServiceProvider.GetRequiredService<IServerCommService>();
@@ -327,11 +340,38 @@ namespace Infomaniak.kDrive.ViewModels
             return await commService.GetBlacklistedNodeIdList(DbId, CancellationToken.None);
         }
 
+        public async Task<bool> SetExcludedNodeIds(List<NodeId> excludedNodeIds)
+        {
+            var commService = App.ServiceProvider.GetRequiredService<IServerCommService>();
+            if (!await commService.SetBlacklistedNodeIdList(DbId, excludedNodeIds, CancellationToken.None))
+            {
+                Logger.Log(Logger.Level.Warning, "Failed to save BlacklistedNodeIdList");
+                return false;
+            }
+            HasExcludedFodler = excludedNodeIds.Count > 0;
+            return true;
+        }
+
         public void ClearOngoingActivities()
         {
             var toBeRemoved = SyncActivities.Where(a => a.Status == SyncFileStatus.Syncing);
             SyncActivities.RemoveMany(toBeRemoved);
         }
 
+        public void RefreshHasExcludedFolder()
+        {
+            if (_hasExcludedFolderLoadingTask is not null && !_hasExcludedFolderLoadingTask.IsCompleted)
+            {
+                Logger.Log(Logger.Level.Info, $"Sync {DbId}: Already loading excluded folders, skipping refresh.");
+                return;
+            }
+            _hasExcludedFolderLoadingTask = Task.Run(async () =>
+            {
+                var excludedNodeIds = await GetExcludedNodeIds();
+                HasExcludedFodler = excludedNodeIds is not null && excludedNodeIds.Count > 0;
+                Logger.Log(Logger.Level.Info, $"Sync {DbId}: RefreshHasExcludedFolder completed. HasExcludedFolder set to {HasExcludedFodler}");
+            });
+
+        }
     }
 }

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/Sync.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/Sync.cs
@@ -104,6 +104,8 @@ namespace Infomaniak.kDrive.ViewModels
                     LastActivity = null;
                 }
             };
+
+            RefreshHasExcludedFolder();
         }
 
         public DbId DbId
@@ -203,12 +205,7 @@ namespace Infomaniak.kDrive.ViewModels
 
         public bool? HasExcludedFolder
         {
-            get
-            {
-                if (_hasExcludedFolder is null) // If the value is not loaded yet, trigger the loading, UI will be updated once the loading is done
-                    RefreshHasExcludedFolder();
-                return _hasExcludedFolder;
-            }
+            get => _hasExcludedFolder;
             set => SetPropertyInUIThread(ref _hasExcludedFolder, value);
         }
 
@@ -358,7 +355,7 @@ namespace Infomaniak.kDrive.ViewModels
             SyncActivities.RemoveMany(toBeRemoved);
         }
 
-        public void RefreshHasExcludedFolder()
+        private void RefreshHasExcludedFolder()
         {
             if (_hasExcludedFolderLoadingTask is not null && !_hasExcludedFolderLoadingTask.IsCompleted)
             {

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/Sync.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/Sync.cs
@@ -201,7 +201,7 @@ namespace Infomaniak.kDrive.ViewModels
             set => SetPropertyInUIThread(ref _showIncomingActivity, value);
         }
 
-        public bool? HasExcludedFodler
+        public bool? HasExcludedFolder
         {
             get
             {
@@ -348,7 +348,7 @@ namespace Infomaniak.kDrive.ViewModels
                 Logger.Log(Logger.Level.Warning, "Failed to save BlacklistedNodeIdList");
                 return false;
             }
-            HasExcludedFodler = excludedNodeIds.Count > 0;
+            HasExcludedFolder = excludedNodeIds.Count > 0;
             return true;
         }
 
@@ -368,8 +368,8 @@ namespace Infomaniak.kDrive.ViewModels
             _hasExcludedFolderLoadingTask = Task.Run(async () =>
             {
                 var excludedNodeIds = await GetExcludedNodeIds();
-                HasExcludedFodler = excludedNodeIds is not null && excludedNodeIds.Count > 0;
-                Logger.Log(Logger.Level.Info, $"Sync {DbId}: RefreshHasExcludedFolder completed. HasExcludedFolder set to {HasExcludedFodler}");
+                HasExcludedFolder = excludedNodeIds is not null && excludedNodeIds.Count > 0;
+                Logger.Log(Logger.Level.Info, $"Sync {DbId}: RefreshHasExcludedFolder completed. HasExcludedFolder set to {HasExcludedFolder}");
             });
 
         }


### PR DESCRIPTION
depends on #1648 

Refactor folder exclusion management in DriveAdvancedSyncsPage: replace inline SyncExclusionSelector with a "Select" button that opens SyncExclusionPage in a ContentDialog. Allow SyncExclusionPage to be constructed with a Sync object and expose SaveChanges for external save. Improve remote path display with tooltip. Clean up event handling and logging for robustness.

<img width="523" height="89" alt="image" src="https://github.com/user-attachments/assets/16569236-0de7-4f38-aced-57c080a0dfce" />
