### PR TITLE
fix: crashes in KDC::CustomRollingFileAppender::append

### DIFF
--- a/src/libsyncengine/jobs/jobmanager.cpp
+++ b/src/libsyncengine/jobs/jobmanager.cpp
@@ -38,7 +38,7 @@ namespace KDC {
 void JobManager::startMainThreadIfNeeded() {
     if (!_mainThread) {
         const std::function<void()> runFunction = std::bind_front(&JobManager::run, this);
-        _mainThread = std::make_unique<std::thread>(runFunction);
+        _mainThread = std::make_unique<StdLoggingThread>(runFunction);
     }
 }
 

--- a/src/libsyncengine/jobs/jobmanager.h
+++ b/src/libsyncengine/jobs/jobmanager.h
@@ -81,7 +81,7 @@ class JobManager {
         Poco::ThreadPool _threadPool;
 
         log4cplus::Logger _logger;
-        std::unique_ptr<std::thread> _mainThread;
+        std::unique_ptr<StdLoggingThread> _mainThread{nullptr};
 
         friend class TestSyncJobManagerSingleton;
 };

--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -262,8 +262,8 @@ void ExecutorWorker::setProgressComplete(const SyncOpPtr syncOp, SyncFileStatus 
         relativeLocalFilePath = syncOp->affectedNode()->getPath();
     }
 
-    if (syncOp->hasConflict() && status == SyncFileStatus::Success && (syncOp->conflict().type() == ConflictType::CreateCreate) ||
-        syncOp->conflict().type() == ConflictType::EditEdit) {
+    if (syncOp->hasConflict() && status == SyncFileStatus::Success &&
+        (syncOp->conflict().type() == ConflictType::CreateCreate || syncOp->conflict().type() == ConflictType::EditEdit)) {
         status = SyncFileStatus::Conflict;
     }
 

--- a/src/libsyncengine/syncpal/isyncworker.cpp
+++ b/src/libsyncengine/syncpal/isyncworker.cpp
@@ -37,7 +37,6 @@ ISyncWorker::~ISyncWorker() {
     }
     waitForExit();
     LOG_SYNCPAL_DEBUG(_logger, "Worker " << _name << " destroyed");
-    log4cplus::threadCleanup();
 }
 
 void ISyncWorker::start() {
@@ -50,7 +49,8 @@ void ISyncWorker::start() {
 
     init();
     _isRunning = true;
-    _thread = (std::make_unique<std::thread>(executeFunc, this));
+    auto executeFunc = std::function<void()>([this]() { execute(); });
+    _thread = (std::make_unique<StdLoggingThread>(executeFunc));
 }
 
 
@@ -120,12 +120,6 @@ void ISyncWorker::setDone(const ExitCode exitCode) {
     _isRunning = false;
     _stopAsked = false;
     _exitCode = exitCode;
-    log4cplus::threadCleanup();
-}
-
-void ISyncWorker::executeFunc(void *thisWorker) {
-    ((ISyncWorker *) thisWorker)->execute();
-    log4cplus::threadCleanup();
 }
 
 } // namespace KDC

--- a/src/libsyncengine/syncpal/isyncworker.h
+++ b/src/libsyncengine/syncpal/isyncworker.h
@@ -73,12 +73,10 @@ class ISyncWorker {
         inline int syncDbId() const { return _syncPal ? _syncPal->syncDbId() : -1; }
 
     private:
-        static void executeFunc(void *thisWorker);
-
         const std::string _name;
         const std::string _shortName;
         const std::chrono::seconds _startDelay{0};
-        std::unique_ptr<std::thread> _thread;
+        std::unique_ptr<StdLoggingThread> _thread{nullptr};
         bool _stopAsked{false};
         bool _isRunning{false};
         ExitCode _exitCode{ExitCode::Unknown};

--- a/src/libsyncengine/syncpal/syncpalworker.cpp
+++ b/src/libsyncengine/syncpal/syncpalworker.cpp
@@ -97,7 +97,7 @@ void SyncPalWorker::execute() {
     if (_syncPal->vfsMode() != VirtualFileMode::Off) {
 #if defined(KD_WINDOWS)
         auto resetFunc = std::function<void()>([this]() { resetVfsFilesStatus(); });
-        _resetVfsFilesStatusThread = StdLoggingThread(resetFunc);
+        _resetVfsFilesStatusThread = std::make_unique<StdLoggingThread>(resetFunc);
 #else
         resetVfsFilesStatus();
 #endif
@@ -282,9 +282,11 @@ void SyncPalWorker::stop() {
     _pauseAsked = false;
     _unpauseAsked = true;
     ISyncWorker::stop();
-    if (_resetVfsFilesStatusThread.joinable()) {
-        _resetVfsFilesStatusThread.join();
+#if defined(KD_WINDOWS)
+    if (_resetVfsFilesStatusThread->joinable()) {
+        _resetVfsFilesStatusThread->join();
     }
+#endif
 }
 
 void SyncPalWorker::pause() {

--- a/src/libsyncengine/syncpal/syncpalworker.cpp
+++ b/src/libsyncengine/syncpal/syncpalworker.cpp
@@ -283,7 +283,7 @@ void SyncPalWorker::stop() {
     _unpauseAsked = true;
     ISyncWorker::stop();
 #if defined(KD_WINDOWS)
-    if (_resetVfsFilesStatusThread->joinable()) {
+    if (_resetVfsFilesStatusThread && _resetVfsFilesStatusThread->joinable()) {
         _resetVfsFilesStatusThread->join();
     }
 #endif

--- a/src/libsyncengine/syncpal/syncpalworker.h
+++ b/src/libsyncengine/syncpal/syncpalworker.h
@@ -47,7 +47,9 @@ class SyncPalWorker : public ISyncWorker {
         bool _pauseAsked{false};
         bool _unpauseAsked{false};
         bool _isPaused{false};
-        std::thread _resetVfsFilesStatusThread;
+#if defined(KD_WINDOWS)
+        std::unique_ptr<StdLoggingThread> _resetVfsFilesStatusThread{nullptr};
+#endif
         void initStep(SyncStep step, std::shared_ptr<ISyncWorker> (&workers)[2],
                       std::shared_ptr<SharedObject> (&inputSharedObject)[2]);
         void initStepFirst(std::shared_ptr<ISyncWorker> (&workers)[2], std::shared_ptr<SharedObject> (&inputSharedObject)[2],

--- a/src/libsyncengine/update_detection/file_system_observer/folderwatcher.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/folderwatcher.cpp
@@ -33,7 +33,8 @@ void FolderWatcher::start() {
     _stop = false;
     _ready = false;
 
-    _thread = std::make_unique<std::thread>(executeFunc, this);
+    auto startWatchingFunc = std::function<void()>([this]() { startWatching(); });
+    _thread = std::make_unique<StdLoggingThread>(startWatchingFunc);
 
 #if defined(KD_MACOS)
     _thread->detach();
@@ -59,11 +60,6 @@ void FolderWatcher::stop() {
 #endif
 
     _thread = nullptr;
-}
-
-void FolderWatcher::executeFunc(void *thisWorker) {
-    ((FolderWatcher *) thisWorker)->startWatching();
-    log4cplus::threadCleanup();
 }
 
 } // namespace KDC

--- a/src/libsyncengine/update_detection/file_system_observer/folderwatcher.h
+++ b/src/libsyncengine/update_detection/file_system_observer/folderwatcher.h
@@ -54,9 +54,7 @@ class FolderWatcher {
         bool _ready{false};
 
     private:
-        static void executeFunc(void *thisWorker);
-
-        std::unique_ptr<std::thread> _thread = nullptr;
+        std::unique_ptr<StdLoggingThread> _thread{nullptr};
         ExitInfo _exitInfo = ExitCode::Ok;
 };
 

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -1863,8 +1863,11 @@ void AppServer::onRequestReceived(int id, RequestNum num, const QByteArray &para
             paramsStream >> driveId;
             paramsStream >> nodeId;
 
-            std::thread getFolderSize(ServerRequests::getFolderSizeWithCallback, userDbId, driveId, nodeId.toStdString(),
-                                      std::bind_front(&AppServer::sendGetFolderSizeCompleted, this));
+            auto getFolderSizeWithCallbackFunc = std::function<void()>([userDbId, driveId, nodeId, this]() {
+                (void) ServerRequests::getFolderSizeWithCallback(userDbId, driveId, nodeId.toStdString(),
+                                                                 std::bind_front(&AppServer::sendGetFolderSizeCompleted, this));
+            });
+            StdLoggingThread getFolderSize(getFolderSizeWithCallbackFunc);
             getFolderSize.detach();
 
             resultStream << ExitCode::Ok;
@@ -4859,7 +4862,7 @@ void AppServer::onRestartSyncs() {
 #endif
 
     const std::scoped_lock lock(syncPalMapMutex);
-    for (const auto [_, syncPal]: syncPalMap) {
+    for (const auto &[_, syncPal]: syncPalMap) {
         if (!syncPal) continue;
         if ((syncPal->isPaused() || syncPal->pauseAsked()) &&
             syncPal->pauseTime() + std::chrono::minutes(1) < std::chrono::steady_clock::now()) {

--- a/src/server/comm/abstractcommserver.h
+++ b/src/server/comm/abstractcommserver.h
@@ -32,7 +32,6 @@ class AbstractCommServer {
 
         virtual ~AbstractCommServer() {
             LOG_DEBUG(Log::instance()->getLogger(), _name << " destroyed");
-            log4cplus::threadCleanup();
         }
 
         std::string name() { return _name; }

--- a/src/server/comm/socketcommserver.cpp
+++ b/src/server/comm/socketcommserver.cpp
@@ -25,7 +25,8 @@ namespace KDC {
 SocketCommChannel::SocketCommChannel(const Poco::Net::StreamSocket &socket) :
     AbstractCommChannel(),
     _socket(socket) {
-    _callbackThread = std::thread(&SocketCommChannel::callbackHandler, this);
+    auto callbackHandlerFunc = std::function<void()>([this]() { callbackHandler(); });
+    _callbackThread = std::make_unique<StdLoggingThread>(callbackHandlerFunc);
 }
 
 SocketCommChannel::~SocketCommChannel() {
@@ -36,8 +37,8 @@ SocketCommChannel::~SocketCommChannel() {
         LOG_ERROR(Log::instance()->getLogger(), "Exception in SocketCommChannel::close: " << ex.what());
     }
 
-    if (_callbackThread.joinable()) {
-        _callbackThread.join();
+    if (_callbackThread->joinable()) {
+        _callbackThread->join();
     }
 }
 
@@ -200,7 +201,8 @@ bool SocketCommServer::listen() {
     }
 
     LOG_DEBUG(Log::instance()->getLogger(), name() << " start");
-    _serverSocketThread = std::make_unique<std::thread>(&SocketCommServer::execute, this);
+    auto executeFunc = std::function<void()>([this]() { execute(); });
+    _serverSocketThread = std::make_unique<StdLoggingThread>(executeFunc);
 
     // Wait until the server socket is listening (or timeout after 20s)
     int remainTries = 500;
@@ -267,6 +269,5 @@ void SocketCommServer::execute() {
         newConnectionCbk();
     }
     _isListening = false;
-    log4cplus::threadCleanup();
 }
 } // namespace KDC

--- a/src/server/comm/socketcommserver.cpp
+++ b/src/server/comm/socketcommserver.cpp
@@ -37,7 +37,7 @@ SocketCommChannel::~SocketCommChannel() {
         LOG_ERROR(Log::instance()->getLogger(), "Exception in SocketCommChannel::close: " << ex.what());
     }
 
-    if (_callbackThread->joinable()) {
+    if (_callbackThread && _callbackThread->joinable()) {
         _callbackThread->join();
     }
 }

--- a/src/server/comm/socketcommserver.h
+++ b/src/server/comm/socketcommserver.h
@@ -20,6 +20,7 @@
 
 #include "abstractcommserver.h"
 #include "libcommon/utility/types.h"
+#include "libcommon/utility/utility.h"
 
 #include <Poco/Net/Socket.h>
 #include <Poco/Net/ServerSocket.h>
@@ -44,7 +45,7 @@ class SocketCommChannel : public AbstractCommChannel {
     private:
         bool _isClosing = false;
         bool _pendingRead = false;
-        std::thread _callbackThread;
+        std::unique_ptr<StdLoggingThread> _callbackThread{nullptr};
         Poco::Net::StreamSocket _socket;
 
         void callbackHandler();
@@ -69,7 +70,7 @@ class SocketCommServer : public AbstractCommServer {
         std::list<std::shared_ptr<AbstractCommChannel>> _channels;
         bool _isListening = false;
         bool _stopAsked = false;
-        std::unique_ptr<std::thread> _serverSocketThread;
+        std::unique_ptr<StdLoggingThread> _serverSocketThread{nullptr};
         void execute();
 };
 


### PR DESCRIPTION
There may be a missing call to `log4cplus::threadCleanup()` when closing a thread.