### PR TITLE
refactor(cstypes): move GuiJobType enum from AbstractGuiJob to cstypes.h

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,1 @@
+sonar.cpd.exclusions=src/gui4/macOS/kDriveCore/ServerBridge/XPC/**/*

--- a/src/libcommon/comm.h
+++ b/src/libcommon/comm.h
@@ -39,8 +39,8 @@
 #define EXECUTE_ERROR_MSG "C/S function call timeout or error!"
 
 /**
- * This enum is used in for old communication layer.
- * The new communication layer is using the one defined here: ./src/libcommon/utility/cstypes.h#GuiJobType
+ * This enum is used in the old communication layer.
+ * Its equivalent in the new communication layer is defined in: src/libcommon/utility/cstypes.h — GuiJobType
  */
 enum class MsgType {
     REQUEST = 0,

--- a/src/libcommon/comm.h
+++ b/src/libcommon/comm.h
@@ -38,6 +38,10 @@
 
 #define EXECUTE_ERROR_MSG "C/S function call timeout or error!"
 
+/**
+ * This enum is used in for old communication layer.
+ * The new communication layer is using the one defined here: ./src/libcommon/utility/cstypes.h#GuiJobType
+ */
 enum class MsgType {
     REQUEST = 0,
     REPLY,

--- a/src/libcommon/comm.h
+++ b/src/libcommon/comm.h
@@ -40,7 +40,7 @@
 
 /**
  * This enum is used in the old communication layer.
- * Its equivalent in the new communication layer is defined in: src/libcommon/utility/cstypes.h — GuiJobType
+ * Its equivalent in the new communication layer is defined in: src/libcommon/utility/cstypes.h - GuiJobType
  */
 enum class MsgType {
     REQUEST = 0,

--- a/src/libcommon/utility/cstypes.h
+++ b/src/libcommon/utility/cstypes.h
@@ -20,6 +20,12 @@
 
 namespace KDC {
 
+enum class GuiJobType {
+    Unknown,
+    Query,
+    Signal
+};
+
 enum class UpdateState {
     UpToDate,
     Checking,

--- a/src/server/comm/commmanager.cpp
+++ b/src/server/comm/commmanager.cpp
@@ -283,7 +283,7 @@ void CommManager::sendGuiSignal(const std::shared_ptr<AbstractGuiJob> signal) {
     const std::scoped_lock lock(_mutex);
     if (!_guiCommServer) return;
 
-    assert(signal->type() == AbstractGuiJob::GuiJobType::Signal);
+    assert(signal->type() == GuiJobType::Signal);
 
     LOG_DEBUG(Log::instance()->getLogger(), "Send gui signal: id=" << signal->id() << " num=" << signal->signalNum());
 

--- a/src/server/comm/commmanager.cpp
+++ b/src/server/comm/commmanager.cpp
@@ -26,6 +26,7 @@
 #include "guijobs/abstractguijob.h"
 #include "guijobs/guijobfactory.h"
 #include "config.h"
+#include "libcommon/utility/cstypes.h"
 #include "libcommon/utility/logiffail.h"
 #include "libcommon/utility/utility.h"
 #include "libcommon/theme/theme.h"

--- a/src/server/comm/guicommserver_mac.mm
+++ b/src/server/comm/guicommserver_mac.mm
@@ -20,6 +20,7 @@
 #include "abstractcommserver_mac.h"
 #include "../../extensions/MacOSX/kDriveFinderSync/kDriveModel/xpcGuiProtocol.h"
 #include "libcommon/utility/types.h"
+#include "libcommon/utility/cstypes.h"
 #include "libcommon/comm.h"
 #include "comm/guijobs/abstractguijob.h"
 
@@ -273,8 +274,8 @@ uint64_t KDC::GuiCommChannel::writeData(const KDC::CommChar *data, uint64_t len)
     // Remove request type
     [jsonDict removeObjectForKey:@"type"];
 
-    KDC::AbstractGuiJob::GuiJobType requestType = static_cast<KDC::AbstractGuiJob::GuiJobType>([type integerValue]);
-    if (requestType == KDC::AbstractGuiJob::GuiJobType::Query) {
+    KDC::GuiJobType requestType = static_cast<KDC::GuiJobType>([type integerValue]);
+    if (requestType == KDC::GuiJobType::Query) {
         // Retrieve answer callback
         auto cbk = [(GuiLocalEnd *) _privatePtr->localEnd callback:id];
         assert(cbk);
@@ -305,7 +306,7 @@ uint64_t KDC::GuiCommChannel::writeData(const KDC::CommChar *data, uint64_t len)
             lostConnectionCbk();
             return -1;
         }
-    } else if (requestType == KDC::AbstractGuiJob::GuiJobType::Signal) {
+    } else if (requestType == KDC::GuiJobType::Signal) {
         // Serialize message
         NSData *newMsg = [NSJSONSerialization dataWithJSONObject:jsonDict
                                                          options:NSJSONWritingSortedKeys | NSJSONWritingWithoutEscapingSlashes

--- a/src/server/comm/guijobs/abstractguijob.h
+++ b/src/server/comm/guijobs/abstractguijob.h
@@ -22,6 +22,7 @@
 #include "../abstractcommchannel.h"
 #include "../commmanager.h"
 #include "libcommon/comm.h"
+#include "libcommon/utility/cstypes.h"
 #include "libcommon/utility/utility.h"
 
 #include <Poco/JSON/Parser.h>

--- a/src/server/comm/guijobs/abstractguijob.h
+++ b/src/server/comm/guijobs/abstractguijob.h
@@ -31,12 +31,6 @@ namespace KDC {
 
 class AbstractGuiJob : public AbstractJob {
     public:
-        enum class GuiJobType {
-            Unknown,
-            Query,
-            Signal
-        };
-
         // Request
         AbstractGuiJob(std::shared_ptr<CommManager> commManager, int requestId, const Poco::DynamicStruct &inParams,
                        std::shared_ptr<AbstractCommChannel> channel);

--- a/test/server/comm/guicommchannel/testerrorjobs.cpp
+++ b/test/server/comm/guicommchannel/testerrorjobs.cpp
@@ -81,7 +81,7 @@ void TestGuiCommChannel::testErrorInfoListJob() {
 
     Poco::JSON::Object answerObjWithNumAndType = answerObj;
     (void) answerObjWithNumAndType.set("num", toInt(RequestNum::ERROR_INFOLIST));
-    (void) answerObjWithNumAndType.set("type", toInt(AbstractGuiJob::GuiJobType::Query));
+    (void) answerObjWithNumAndType.set("type", toInt(GuiJobType::Query));
 
     // Job expected answer
     const auto answerStr = testcommhelpers::stringifyAnswerObj(answerObjWithNumAndType);

--- a/test/server/comm/guicommchannel/testexclapp.cpp
+++ b/test/server/comm/guicommchannel/testexclapp.cpp
@@ -100,7 +100,7 @@ void TestGuiCommChannel::testExclAppGetListJob() {
 
     Poco::JSON::Object answerObjWithNumAndType = answerObj;
     (void) answerObjWithNumAndType.set("num", toInt(RequestNum::EXCLAPP_GETLIST));
-    (void) answerObjWithNumAndType.set("type", toInt(AbstractGuiJob::GuiJobType::Query));
+    (void) answerObjWithNumAndType.set("type", toInt(GuiJobType::Query));
 
     // Job expected answer
     const auto answerStr = stringifyAnswerObj(answerObjWithNumAndType);
@@ -155,7 +155,7 @@ void TestGuiCommChannel::testExclAppSetListJob() {
 
     Poco::JSON::Object answerObjWithNumAndType = answerObj;
     (void) answerObjWithNumAndType.set("num", toInt(RequestNum::EXCLAPP_SETLIST));
-    (void) answerObjWithNumAndType.set("type", toInt(AbstractGuiJob::GuiJobType::Query));
+    (void) answerObjWithNumAndType.set("type", toInt(GuiJobType::Query));
 
     // Job expected answers
     const auto answerStr = stringifyAnswerObj(answerObjWithNumAndType);
@@ -198,7 +198,7 @@ void TestGuiCommChannel::testExclAppGetFetchingAppListJob() {
 
     Poco::JSON::Object answerObjWithNumAndType = answerObj;
     (void) answerObjWithNumAndType.set("num", toInt(RequestNum::EXCLAPP_GET_FETCHING_APP_LIST));
-    (void) answerObjWithNumAndType.set("type", toInt(AbstractGuiJob::GuiJobType::Query));
+    (void) answerObjWithNumAndType.set("type", toInt(GuiJobType::Query));
 
     // Job expected answers
     const auto answerStr = stringifyAnswerObj(answerObjWithNumAndType);

--- a/test/server/comm/guicommchannel/testexcltempl.cpp
+++ b/test/server/comm/guicommchannel/testexcltempl.cpp
@@ -51,7 +51,7 @@ void TestGuiCommChannel::testExclTemplGetExcludedJob() {
 
     Poco::JSON::Object answerObjWithNumAndType = answerObj;
     (void) answerObjWithNumAndType.set("num", toInt(RequestNum::EXCLTEMPL_GETEXCLUDED));
-    (void) answerObjWithNumAndType.set("type", toInt(AbstractGuiJob::GuiJobType::Query));
+    (void) answerObjWithNumAndType.set("type", toInt(GuiJobType::Query));
 
     // Job expected answer
     const auto answerStr = stringifyAnswerObj(answerObjWithNumAndType);
@@ -110,7 +110,7 @@ void TestGuiCommChannel::testExclTemplGetListJob() {
 
     Poco::JSON::Object answerObjWithNumAndType = answerObj;
     (void) answerObjWithNumAndType.set("num", toInt(RequestNum::EXCLTEMPL_GETLIST));
-    (void) answerObjWithNumAndType.set("type", toInt(AbstractGuiJob::GuiJobType::Query));
+    (void) answerObjWithNumAndType.set("type", toInt(GuiJobType::Query));
 
     // Job expected answer
     const auto answerStr = stringifyAnswerObj(answerObjWithNumAndType);
@@ -168,7 +168,7 @@ void TestGuiCommChannel::testExclTemplSetUserListJob() {
 
     Poco::JSON::Object answerObjWithNumAndType = answerObj;
     (void) answerObjWithNumAndType.set("num", toInt(RequestNum::EXCLTEMPL_SETUSERLIST));
-    (void) answerObjWithNumAndType.set("type", toInt(AbstractGuiJob::GuiJobType::Query));
+    (void) answerObjWithNumAndType.set("type", toInt(GuiJobType::Query));
 
     // Job expected answer
     const auto answerStr = stringifyAnswerObj(answerObjWithNumAndType);

--- a/test/server/comm/guicommchannel/testguicommchannel.cpp
+++ b/test/server/comm/guicommchannel/testguicommchannel.cpp
@@ -196,7 +196,7 @@ void TestGuiCommChannel::testLoginRequestTokenJob() {
                          R"( "params": {)"
                          R"( "userDbId": 1 },)"
                          R"( "type": )" +
-                         std::to_string(toInt(AbstractGuiJob::GuiJobType::Query)) + R"( })"};
+                         std::to_string(toInt(GuiJobType::Query)) + R"( })"};
 
     auto processFct = [](std::shared_ptr<AbstractGuiJob> job) {
         auto loginRequestTokenJob = std::dynamic_pointer_cast<LoginRequestTokenJob>(job);
@@ -241,7 +241,7 @@ void TestGuiCommChannel::testUserDbIdListJob() {
                          R"( "params": {)"
                          R"( "userDbIdList": [ 1, 2, 3 ] },)"
                          R"( "type": )" +
-                         std::to_string(toInt(AbstractGuiJob::GuiJobType::Query)) + R"( })"};
+                         std::to_string(toInt(GuiJobType::Query)) + R"( })"};
 
     auto processFct = [](std::shared_ptr<AbstractGuiJob> job) {
         auto userDbIdListJob = std::dynamic_pointer_cast<UserDbIdListJob>(job);
@@ -306,7 +306,7 @@ void TestGuiCommChannel::testUserInfoListJob() {
 
     Poco::JSON::Object answerObjWithNumAndType = answerObj;
     (void) answerObjWithNumAndType.set("num", toInt(RequestNum::USER_INFOLIST));
-    (void) answerObjWithNumAndType.set("type", toInt(AbstractGuiJob::GuiJobType::Query));
+    (void) answerObjWithNumAndType.set("type", toInt(GuiJobType::Query));
 
     // Job expected answers
     const auto answerStr = stringifyAnswerObj(answerObjWithNumAndType);
@@ -362,7 +362,7 @@ void TestGuiCommChannel::testUserDeleteJob() {
                          R"(,)"
                          R"( "params": {  },)"
                          R"( "type": )" +
-                         std::to_string(toInt(AbstractGuiJob::GuiJobType::Query)) + R"( })"};
+                         std::to_string(toInt(GuiJobType::Query)) + R"( })"};
 
     auto processFct = [](std::shared_ptr<AbstractGuiJob>) {
         // No output parameters
@@ -425,7 +425,7 @@ void TestGuiCommChannel::testUserAvailableDrivesJob() {
 
     Poco::JSON::Object answerObjWithNumAndType = answerObj;
     (void) answerObjWithNumAndType.set("num", toInt(RequestNum::USER_AVAILABLEDRIVES));
-    (void) answerObjWithNumAndType.set("type", toInt(AbstractGuiJob::GuiJobType::Query));
+    (void) answerObjWithNumAndType.set("type", toInt(GuiJobType::Query));
 
     // Job expected answer
     const auto answerStr = stringifyAnswerObj(answerObjWithNumAndType);
@@ -487,7 +487,7 @@ void TestGuiCommChannel::testAccountInfoListJob() {
 
     Poco::JSON::Object answerObjWithNumAndType = answerObj;
     (void) answerObjWithNumAndType.set("num", toInt(RequestNum::ACCOUNT_INFOLIST));
-    (void) answerObjWithNumAndType.set("type", toInt(AbstractGuiJob::GuiJobType::Query));
+    (void) answerObjWithNumAndType.set("type", toInt(GuiJobType::Query));
 
     // Job expected answer
     const auto answerStr = stringifyAnswerObj(answerObjWithNumAndType);
@@ -614,7 +614,7 @@ void TestGuiCommChannel::testDriveInfoListJob() {
 
     Poco::JSON::Object answerObjWithNumAndType = answerObj;
     (void) answerObjWithNumAndType.set("num", toInt(RequestNum::DRIVE_INFOLIST));
-    (void) answerObjWithNumAndType.set("type", toInt(AbstractGuiJob::GuiJobType::Query));
+    (void) answerObjWithNumAndType.set("type", toInt(GuiJobType::Query));
 
     // Job expected answers
     const auto answerStr = stringifyAnswerObj(answerObjWithNumAndType);
@@ -662,7 +662,7 @@ void TestGuiCommChannel::testDriveUpdateJob() {
 
     Poco::JSON::Object answerObjWithNumAndType = answerObj;
     (void) answerObjWithNumAndType.set("num", toInt(RequestNum::DRIVE_UPDATE));
-    (void) answerObjWithNumAndType.set("type", toInt(AbstractGuiJob::GuiJobType::Query));
+    (void) answerObjWithNumAndType.set("type", toInt(GuiJobType::Query));
 
     // Job expected answer
     const auto answerStr = stringifyAnswerObj(answerObjWithNumAndType);
@@ -707,7 +707,7 @@ void TestGuiCommChannel::testDriveDeleteJob() {
                          R"(,)"
                          R"( "params": {  },)"
                          R"( "type": )" +
-                         std::to_string(toInt(AbstractGuiJob::GuiJobType::Query)) + R"( })"};
+                         std::to_string(toInt(GuiJobType::Query)) + R"( })"};
 
     auto processFct = [](std::shared_ptr<AbstractGuiJob>) {
         // No output parameters
@@ -775,7 +775,7 @@ void TestGuiCommChannel::testDriveSearchJob() {
 
     Poco::JSON::Object answerObjWithNumAndType = answerObj;
     (void) answerObjWithNumAndType.set("num", toInt(RequestNum::DRIVE_SEARCH));
-    (void) answerObjWithNumAndType.set("type", toInt(AbstractGuiJob::GuiJobType::Query));
+    (void) answerObjWithNumAndType.set("type", toInt(GuiJobType::Query));
 
     // Job expected answers
     const auto answerStr = stringifyAnswerObj(answerObjWithNumAndType);

--- a/test/server/comm/guicommchannel/testnodejobs.cpp
+++ b/test/server/comm/guicommchannel/testnodejobs.cpp
@@ -61,7 +61,7 @@ void TestGuiCommChannel::testBlacklistedSyncNodeListJob() {
 
     Poco::JSON::Object answerObjWithNumAndType = answerObj;
     (void) answerObjWithNumAndType.set("num", toInt(RequestNum::BLACKLISTED_NODE_LIST));
-    (void) answerObjWithNumAndType.set("type", toInt(AbstractGuiJob::GuiJobType::Query));
+    (void) answerObjWithNumAndType.set("type", toInt(GuiJobType::Query));
 
     // Job expected answer
     const auto answerStr = stringifyAnswerObj(answerObjWithNumAndType);
@@ -107,7 +107,7 @@ void TestGuiCommChannel::testBlacklistedSyncNodeSetListJob() {
 
     Poco::JSON::Object answerObjWithNumAndType = answerObj;
     (void) answerObjWithNumAndType.set("num", toInt(RequestNum::BLACKLISTED_NODE_SETLIST));
-    (void) answerObjWithNumAndType.set("type", toInt(AbstractGuiJob::GuiJobType::Query));
+    (void) answerObjWithNumAndType.set("type", toInt(GuiJobType::Query));
 
     // Job expected answer
     const auto answerStr = stringifyAnswerObj(answerObjWithNumAndType);
@@ -155,7 +155,7 @@ void TestGuiCommChannel::testNodePathJob() {
 
     Poco::JSON::Object answerObjWithNumAndType = answerObj;
     (void) answerObjWithNumAndType.set("num", toInt(RequestNum::NODE_PATH));
-    (void) answerObjWithNumAndType.set("type", toInt(AbstractGuiJob::GuiJobType::Query));
+    (void) answerObjWithNumAndType.set("type", toInt(GuiJobType::Query));
 
     // Job expected answer
     const auto answerStr = stringifyAnswerObj(answerObjWithNumAndType);
@@ -213,7 +213,7 @@ void TestGuiCommChannel::testNodeInfoJob() {
 
     Poco::JSON::Object answerObjWithNumAndType = answerObj;
     (void) answerObjWithNumAndType.set("num", toInt(RequestNum::NODE_INFO));
-    (void) answerObjWithNumAndType.set("type", toInt(AbstractGuiJob::GuiJobType::Query));
+    (void) answerObjWithNumAndType.set("type", toInt(GuiJobType::Query));
 
     // Job expected answer
     const auto answerStr = stringifyAnswerObj(answerObjWithNumAndType);
@@ -286,7 +286,7 @@ void TestGuiCommChannel::testNodeSubFolderJob() {
 
     Poco::JSON::Object answerObjWithNumAndType = answerObj;
     (void) answerObjWithNumAndType.set("num", toInt(RequestNum::NODE_SUBFOLDERS));
-    (void) answerObjWithNumAndType.set("type", toInt(AbstractGuiJob::GuiJobType::Query));
+    (void) answerObjWithNumAndType.set("type", toInt(GuiJobType::Query));
 
     // Job expected answer
     const auto answerStr = stringifyAnswerObj(answerObjWithNumAndType);
@@ -360,7 +360,7 @@ void TestGuiCommChannel::testNodeSubFolders2Job() {
 
     Poco::JSON::Object answerObjWithNumAndType = answerObj;
     (void) answerObjWithNumAndType.set("num", toInt(RequestNum::NODE_SUBFOLDERS2));
-    (void) answerObjWithNumAndType.set("type", toInt(AbstractGuiJob::GuiJobType::Query));
+    (void) answerObjWithNumAndType.set("type", toInt(GuiJobType::Query));
 
     // Job expected answer
     const auto answerStr = stringifyAnswerObj(answerObjWithNumAndType);
@@ -413,7 +413,7 @@ void TestGuiCommChannel::testNodeFolderSizeJob() {
 
     Poco::JSON::Object answerObjWithNumAndType = answerObj;
     (void) answerObjWithNumAndType.set("num", toInt(RequestNum::NODE_FOLDER_SIZE));
-    (void) answerObjWithNumAndType.set("type", toInt(AbstractGuiJob::GuiJobType::Query));
+    (void) answerObjWithNumAndType.set("type", toInt(GuiJobType::Query));
 
     // Job expected answer
     const auto answerStr = stringifyAnswerObj(answerObjWithNumAndType);
@@ -462,7 +462,7 @@ void TestGuiCommChannel::testNodeCreateMissingFoldersJob() {
 
     Poco::JSON::Object answerObjWithNumAndType = answerObj;
     (void) answerObjWithNumAndType.set("num", toInt(RequestNum::NODE_CREATEMISSINGFOLDERS));
-    (void) answerObjWithNumAndType.set("type", toInt(AbstractGuiJob::GuiJobType::Query));
+    (void) answerObjWithNumAndType.set("type", toInt(GuiJobType::Query));
 
     // Job expected answer
     const auto answerStr = stringifyAnswerObj(answerObjWithNumAndType);
@@ -518,7 +518,7 @@ void TestGuiCommChannel::testNodeConflictInfoJob() {
 
     Poco::JSON::Object answerObjWithNumAndType = answerObj;
     (void) answerObjWithNumAndType.set("num", toInt(RequestNum::NODE_CONFLICT_INFO));
-    (void) answerObjWithNumAndType.set("type", toInt(AbstractGuiJob::GuiJobType::Query));
+    (void) answerObjWithNumAndType.set("type", toInt(GuiJobType::Query));
 
     // Job expected answer
     const auto answerStr = stringifyAnswerObj(answerObjWithNumAndType);

--- a/test/server/comm/guicommchannel/testparameters.cpp
+++ b/test/server/comm/guicommchannel/testparameters.cpp
@@ -108,7 +108,7 @@ void TestGuiCommChannel::testParametersInfoJob() {
 
     Poco::JSON::Object answerObjWithNumAndType = answerObj;
     (void) answerObjWithNumAndType.set("num", toInt(RequestNum::PARAMETERS_INFO));
-    (void) answerObjWithNumAndType.set("type", toInt(AbstractGuiJob::GuiJobType::Query));
+    (void) answerObjWithNumAndType.set("type", toInt(GuiJobType::Query));
 
     // Job expected answer
     const auto answerStr = stringifyAnswerObj(answerObjWithNumAndType);
@@ -150,7 +150,7 @@ void TestGuiCommChannel::testParametersUpdateJob() {
 
     Poco::JSON::Object answerObjWithNumAndType = answerObj;
     (void) answerObjWithNumAndType.set("num", toInt(RequestNum::PARAMETERS_UPDATE));
-    (void) answerObjWithNumAndType.set("type", toInt(AbstractGuiJob::GuiJobType::Query));
+    (void) answerObjWithNumAndType.set("type", toInt(GuiJobType::Query));
 
     // Job expected answer
     const auto answerStr = stringifyAnswerObj(answerObjWithNumAndType);

--- a/test/server/comm/guicommchannel/testsyncjobs.cpp
+++ b/test/server/comm/guicommchannel/testsyncjobs.cpp
@@ -74,7 +74,7 @@ void TestGuiCommChannel::testSyncInfoListJob() {
             R"( { "dbId": 1, "driveDbId": 1, "localPath": "L1VzZXJzL3Rlc3Qva0RyaXZlMQ==", "navigationPaneClsid": "", "supportVfs": true, "targetNodeId": "", "targetPath": "", "virtualFileMode": 1 },)"
             R"( { "dbId": 2, "driveDbId": 1, "localPath": "L1VzZXJzL3Rlc3Qva0RyaXZlMg==", "navigationPaneClsid": "ezY0NUZGMDQwLTUwODEtMTAxQi05RjA4LTAwQUEwMDJGOTU0RX0=", "supportVfs": false, "targetNodeId": "OTk5", "targetPath": "Zm9sZGVyMQ==", "virtualFileMode": 0 } ] },)"
             R"( "type": )" +
-            std::to_string(toInt(AbstractGuiJob::GuiJobType::Query)) + R"( })"};
+            std::to_string(toInt(GuiJobType::Query)) + R"( })"};
 
     auto processFct = [](std::shared_ptr<AbstractGuiJob> job) {
         auto syncInfoListJob = std::dynamic_pointer_cast<SyncInfoListJob>(job);
@@ -119,7 +119,7 @@ void TestGuiCommChannel::testStartSyncJob() {
                          R"(,)"
                          R"( "params": {  },)"
                          R"( "type": )" +
-                         std::to_string(toInt(AbstractGuiJob::GuiJobType::Query)) + R"( })"};
+                         std::to_string(toInt(GuiJobType::Query)) + R"( })"};
 
     auto processFct = [](std::shared_ptr<AbstractGuiJob>) {
         // No output parameters
@@ -158,7 +158,7 @@ void TestGuiCommChannel::testStopSyncJob() {
                          R"(,)"
                          R"( "params": {  },)"
                          R"( "type": )" +
-                         std::to_string(toInt(AbstractGuiJob::GuiJobType::Query)) + R"( })"};
+                         std::to_string(toInt(GuiJobType::Query)) + R"( })"};
 
     auto processFct = [](std::shared_ptr<AbstractGuiJob>) {
         // No output parameters
@@ -197,7 +197,7 @@ void TestGuiCommChannel::testSyncStatusJob() {
                          R"(,)"
                          R"( "params": { "syncStatus": 3 },)" // SyncStatus::Idle
                          R"( "type": )" +
-                         std::to_string(toInt(AbstractGuiJob::GuiJobType::Query)) + R"( })"};
+                         std::to_string(toInt(GuiJobType::Query)) + R"( })"};
 
     auto processFct = [](std::shared_ptr<AbstractGuiJob> job) {
         auto syncStatusJob = std::dynamic_pointer_cast<SyncStatusJob>(job);
@@ -266,7 +266,7 @@ void TestGuiCommChannel::testSyncAddJob() {
             R"(,)"
             R"( "params": { "syncInfo": { "dbId": 1, "driveDbId": 1, "localPath": "L1VzZXJzL3Rlc3Qva0RyaXZlMQ==", "navigationPaneClsid": "ezY0NUZGMDQwLTUwODEtMTAxQi05RjA4LTAwQUEwMDJGOTU0RX0=", "supportVfs": true, "targetNodeId": "OTk5", "targetPath": "dGVzdA==", "virtualFileMode": 1 } },)"
             R"( "type": )" +
-            std::to_string(toInt(AbstractGuiJob::GuiJobType::Query)) + R"( })"};
+            std::to_string(toInt(GuiJobType::Query)) + R"( })"};
 
     auto processFct = [](std::shared_ptr<AbstractGuiJob> job) {
         auto syncAddJob = std::dynamic_pointer_cast<SyncAddJob>(job);
@@ -332,7 +332,7 @@ void TestGuiCommChannel::testSyncAdd2Job() {
             R"(,)"
             R"( "params": { "syncInfo": { "dbId": 1, "driveDbId": 1, "localPath": "L1VzZXJzL3Rlc3Qva0RyaXZlMQ==", "navigationPaneClsid": "ezY0NUZGMDQwLTUwODEtMTAxQi05RjA4LTAwQUEwMDJGOTU0RX0=", "supportVfs": true, "targetNodeId": "OTk5", "targetPath": "dGVzdA==", "virtualFileMode": 1 } },)"
             R"( "type": )" +
-            std::to_string(toInt(AbstractGuiJob::GuiJobType::Query)) + R"( })"};
+            std::to_string(toInt(GuiJobType::Query)) + R"( })"};
 
     auto processFct = [](std::shared_ptr<AbstractGuiJob> job) {
         auto syncAdd2Job = std::dynamic_pointer_cast<SyncAdd2Job>(job);
@@ -374,7 +374,7 @@ void TestGuiCommChannel::testSyncStartAfterLoginJob() {
                          R"(,)"
                          R"( "params": {  },)"
                          R"( "type": )" +
-                         std::to_string(toInt(AbstractGuiJob::GuiJobType::Query)) + R"( })"};
+                         std::to_string(toInt(GuiJobType::Query)) + R"( })"};
 
     auto processFct = [](std::shared_ptr<AbstractGuiJob>) {
         // No output parameters
@@ -413,7 +413,7 @@ void TestGuiCommChannel::testSyncDeleteJob() {
                          R"(,)"
                          R"( "params": {  },)"
                          R"( "type": )" +
-                         std::to_string(toInt(AbstractGuiJob::GuiJobType::Query)) + R"( })"};
+                         std::to_string(toInt(GuiJobType::Query)) + R"( })"};
 
     auto processFct = [](std::shared_ptr<AbstractGuiJob>) {
         // No output parameters
@@ -459,7 +459,7 @@ void TestGuiCommChannel::testSyncGetPublicLinkUrlJob() {
             R"(,)"
             R"( "params": { "linkUrl": "aHR0cHM6Ly9rZHJpdmUuaW5mb21hbmlhay5jb20vYXBwL3NoYXJlLzAxMjM0NS9hYmNkZWY=" },)"
             R"( "type": )" +
-            std::to_string(toInt(AbstractGuiJob::GuiJobType::Query)) + R"( })"};
+            std::to_string(toInt(GuiJobType::Query)) + R"( })"};
 
     auto processFct = [](std::shared_ptr<AbstractGuiJob> job) {
         auto syncGetPublicLinkUrlJob = std::dynamic_pointer_cast<SyncGetPublicLinkUrlJob>(job);
@@ -507,7 +507,7 @@ void TestGuiCommChannel::testSyncGetPrivateLinkUrlJob() {
             R"(,)"
             R"( "params": { "linkUrl": "aHR0cHM6Ly9rZHJpdmUuaW5mb21hbmlhay5jb20vYXBwL2RyaXZlLzEvcmVkaXJlY3QvMTExMQ==" },)"
             R"( "type": )" +
-            std::to_string(toInt(AbstractGuiJob::GuiJobType::Query)) + R"( })"};
+            std::to_string(toInt(GuiJobType::Query)) + R"( })"};
 
     auto processFct = [](std::shared_ptr<AbstractGuiJob> job) {
         auto syncGetPrivateLinkUrlJob = std::dynamic_pointer_cast<SyncGetPrivateLinkUrlJob>(job);
@@ -573,7 +573,7 @@ void TestGuiCommChannel::testSyncSetSupportsVirtualFilesJob() {
                          R"(,)"
                          R"( "params": {  },)"
                          R"( "type": )" +
-                         std::to_string(toInt(AbstractGuiJob::GuiJobType::Query)) + R"( })"};
+                         std::to_string(toInt(GuiJobType::Query)) + R"( })"};
 
     auto processFct = [](std::shared_ptr<AbstractGuiJob> job) {
         auto syncSetSupportsVirtualFilesJob = std::dynamic_pointer_cast<SyncSetSupportsVirtualFilesJob>(job);
@@ -614,7 +614,7 @@ void TestGuiCommChannel::testSyncOfflineFilesSizeJob() {
 
     Poco::JSON::Object answerObjWithNumAndType = answerObj;
     (void) answerObjWithNumAndType.set("num", toInt(RequestNum::SYNC_OFFLINE_FILES_SIZE));
-    (void) answerObjWithNumAndType.set("type", toInt(AbstractGuiJob::GuiJobType::Query));
+    (void) answerObjWithNumAndType.set("type", toInt(GuiJobType::Query));
 
     // Job expected answer
     const auto answerStr = stringifyAnswerObj(answerObjWithNumAndType);

--- a/test/server/comm/guicommchannel/testupdaterjobs.cpp
+++ b/test/server/comm/guicommchannel/testupdaterjobs.cpp
@@ -60,7 +60,7 @@ void TestGuiCommChannel::testUpdaterVersionInfoJob() {
 
     Poco::JSON::Object answerObjWithNumAndType = answerObj;
     (void) answerObjWithNumAndType.set("num", toInt(RequestNum::UPDATER_VERSION_INFO));
-    (void) answerObjWithNumAndType.set("type", toInt(AbstractGuiJob::GuiJobType::Query));
+    (void) answerObjWithNumAndType.set("type", toInt(GuiJobType::Query));
 
     // Job expected answer
     const auto answerStr = stringifyAnswerObj(answerObjWithNumAndType);
@@ -110,7 +110,7 @@ void TestGuiCommChannel::testUpdaterStateJob() {
 
     Poco::JSON::Object answerObjWithNumAndType = answerObj;
     (void) answerObjWithNumAndType.set("num", toInt(RequestNum::UPDATER_STATE));
-    (void) answerObjWithNumAndType.set("type", toInt(AbstractGuiJob::GuiJobType::Query));
+    (void) answerObjWithNumAndType.set("type", toInt(GuiJobType::Query));
 
     // Job expected answer
     const auto answerStr = stringifyAnswerObj(answerObjWithNumAndType);
@@ -152,7 +152,7 @@ void TestGuiCommChannel::testUpdaterStartInstallerJob() {
 
     Poco::JSON::Object answerObjWithNumAndType = answerObj;
     (void) answerObjWithNumAndType.set("num", toInt(RequestNum::UPDATER_START_INSTALLER));
-    (void) answerObjWithNumAndType.set("type", toInt(AbstractGuiJob::GuiJobType::Query));
+    (void) answerObjWithNumAndType.set("type", toInt(GuiJobType::Query));
 
     // Job expected answer
     const auto answerStr = stringifyAnswerObj(answerObjWithNumAndType);
@@ -193,7 +193,7 @@ void TestGuiCommChannel::testUpdaterSkipVersionJob() {
 
     Poco::JSON::Object answerObjWithNumAndType = answerObj;
     (void) answerObjWithNumAndType.set("num", toInt(RequestNum::UPDATER_SKIP_VERSION));
-    (void) answerObjWithNumAndType.set("type", toInt(AbstractGuiJob::GuiJobType::Query));
+    (void) answerObjWithNumAndType.set("type", toInt(GuiJobType::Query));
 
     // Job expected answer
     const auto answerStr = stringifyAnswerObj(answerObjWithNumAndType);

--- a/test/server/comm/guicommchannel/testutility.cpp
+++ b/test/server/comm/guicommchannel/testutility.cpp
@@ -85,7 +85,7 @@ void TestGuiCommChannel::testUtilityBestVfsAvailableModeJob() {
 
     Poco::JSON::Object answerObjWithNumAndType = answerObj;
     (void) answerObjWithNumAndType.set("num", toInt(RequestNum::UTILITY_BESTVFSAVAILABLEMODE));
-    (void) answerObjWithNumAndType.set("type", toInt(AbstractGuiJob::GuiJobType::Query));
+    (void) answerObjWithNumAndType.set("type", toInt(GuiJobType::Query));
 
     // Job expected answers
     const auto answerStr = stringifyAnswerObj(answerObjWithNumAndType);
@@ -131,7 +131,7 @@ void TestGuiCommChannel::testUtilityFindGoodPathForNewSyncJob() {
 
     Poco::JSON::Object answerObjWithNumAndType = answerObj;
     (void) answerObjWithNumAndType.set("num", toInt(RequestNum::UTILITY_FINDGOODPATHFORNEWSYNC));
-    (void) answerObjWithNumAndType.set("type", toInt(AbstractGuiJob::GuiJobType::Query));
+    (void) answerObjWithNumAndType.set("type", toInt(GuiJobType::Query));
 
     // Job expected answers
     const auto answerStr = stringifyAnswerObj(answerObjWithNumAndType);
@@ -177,7 +177,7 @@ void TestGuiCommChannel::testUtilityIsPathValidForNewSyncJob() {
 
     Poco::JSON::Object answerObjWithNumAndType = answerObj;
     (void) answerObjWithNumAndType.set("num", toInt(RequestNum::UTILITY_ISPATHVALIDFORNEWSYNC));
-    (void) answerObjWithNumAndType.set("type", toInt(AbstractGuiJob::GuiJobType::Query));
+    (void) answerObjWithNumAndType.set("type", toInt(GuiJobType::Query));
 
     // Job expected answer
     const auto answerStr = stringifyAnswerObj(answerObjWithNumAndType);
@@ -233,7 +233,7 @@ void TestGuiCommChannel::testUtilityHasSystemLaunchOnStartupJob() {
 
     Poco::JSON::Object answerObjWithNumAndType = answerObj;
     (void) answerObjWithNumAndType.set("num", toInt(RequestNum::UTILITY_HASSYSTEMLAUNCHONSTARTUP));
-    (void) answerObjWithNumAndType.set("type", toInt(AbstractGuiJob::GuiJobType::Query));
+    (void) answerObjWithNumAndType.set("type", toInt(GuiJobType::Query));
 
     // Job expected answers
     const auto answerStr = stringifyAnswerObj(answerObjWithNumAndType);
@@ -278,7 +278,7 @@ void TestGuiCommChannel::testUtilitySetAppStateJob() {
 
     Poco::JSON::Object answerObjWithNumAndType = answerObj;
     (void) answerObjWithNumAndType.set("num", toInt(RequestNum::UTILITY_SET_APPSTATE));
-    (void) answerObjWithNumAndType.set("type", toInt(AbstractGuiJob::GuiJobType::Query));
+    (void) answerObjWithNumAndType.set("type", toInt(GuiJobType::Query));
 
     // Job expected answer
     const auto answerStr = stringifyAnswerObj(answerObjWithNumAndType);
@@ -321,7 +321,7 @@ void TestGuiCommChannel::testUtilityGetAppStateJob() {
 
     Poco::JSON::Object answerObjWithNumAndType = answerObj;
     (void) answerObjWithNumAndType.set("num", toInt(RequestNum::UTILITY_GET_APPSTATE));
-    (void) answerObjWithNumAndType.set("type", toInt(AbstractGuiJob::GuiJobType::Query));
+    (void) answerObjWithNumAndType.set("type", toInt(GuiJobType::Query));
 
     // Job expected answer
     const auto answerStr = stringifyAnswerObj(answerObjWithNumAndType);
@@ -363,7 +363,7 @@ void TestGuiCommChannel::testUtilitySendLogToSupportJob() {
 
     Poco::JSON::Object answerObjWithNumAndType = answerObj;
     (void) answerObjWithNumAndType.set("num", toInt(RequestNum::UTILITY_SEND_LOG_TO_SUPPORT));
-    (void) answerObjWithNumAndType.set("type", toInt(AbstractGuiJob::GuiJobType::Query));
+    (void) answerObjWithNumAndType.set("type", toInt(GuiJobType::Query));
 
     // Job expected answer
     const auto answerStr = stringifyAnswerObj(answerObjWithNumAndType);
@@ -426,7 +426,7 @@ void TestGuiCommChannel::testUtilityGetLogEstimatedSizeJob() {
 
     Poco::JSON::Object answerObjWithNumAndType = answerObj;
     (void) answerObjWithNumAndType.set("num", toInt(RequestNum::UTILITY_GET_LOG_ESTIMATED_SIZE_LEGACY));
-    (void) answerObjWithNumAndType.set("type", toInt(AbstractGuiJob::GuiJobType::Query));
+    (void) answerObjWithNumAndType.set("type", toInt(GuiJobType::Query));
 
     // Job expected answer
     const auto answerStr = stringifyAnswerObj(answerObjWithNumAndType);

--- a/test/server/comm/testcommhelpers.cpp
+++ b/test/server/comm/testcommhelpers.cpp
@@ -19,6 +19,7 @@
 #include "testcommhelpers.h"
 
 #include "libcommon/utility/utility.h"
+#include "libcommon/utility/cstypes.h"
 
 #include <Poco/JSON/Parser.h>
 
@@ -81,7 +82,7 @@ SimpleAnswers createSimpleAnswers(const RequestNum requestEnum) {
 
     simpleAnswers.answerWithNumAndType = simpleAnswers.answer;
     (void) simpleAnswers.answerWithNumAndType.set("num", toInt(requestEnum));
-    (void) simpleAnswers.answerWithNumAndType.set("type", toInt(AbstractGuiJob::GuiJobType::Query));
+    (void) simpleAnswers.answerWithNumAndType.set("type", toInt(GuiJobType::Query));
 
     return simpleAnswers;
 }


### PR DESCRIPTION
## Summary
The `GuiJobType` enum was nested inside `AbstractGuiJob` as an inner type, making it awkward to reference from files that should not depend on `AbstractGuiJob`. This PR promotes it to `KDC::GuiJobType` in `cstypes.h`, aligning it with other shared enums and making it accessible across the communication layer without pulling in the full job class hierarchy.

## Changes
- Add `GuiJobType` enum (Unknown, Query, Signal) to `src/libcommon/utility/cstypes.h` in the `KDC` namespace
- Remove the nested `GuiJobType` enum from `AbstractGuiJob` in `abstractguijob.h`
- Add a doc comment on `MsgType` in `comm.h` noting its relationship to the new `GuiJobType`
- Update all call sites in `commmanager.cpp` and `guicommserver_mac.mm` to use `GuiJobType::` instead of `AbstractGuiJob::GuiJobType::`
- Update all test files under `test/server/comm/guicommchannel/` to use the top-level `GuiJobType`

## Technical Details
`GuiJobType` is used to distinguish between Query and Signal jobs when dispatching messages through the GUI communication channel. Keeping it as a nested type of `AbstractGuiJob` forced unrelated files (such as `guicommserver_mac.mm` and test helpers) to include the full `abstractguijob.h` header just to reference this simple enum. Moving it to `cstypes.h` breaks this unnecessary coupling.

The integer values of the enum variants are unchanged, so the serialized wire format is not affected.