### PR TITLE
feat(comm): add JSON helpers and dynamic struct parsing

### DIFF
--- a/src/gui4/linux/communicationlayer/ipcclient.cpp
+++ b/src/gui4/linux/communicationlayer/ipcclient.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "ipcclient.h"
+#include "libcommon/commjson.h"
 #include "libcommon/utility/utility.h"
 #include "libcommon/utility/types.h"
 
@@ -24,7 +25,6 @@
 #include <QLoggingCategory>
 
 #include <Poco/Dynamic/Struct.h>
-#include <Poco/JSON/Parser.h>
 
 #include <filesystem>
 #include <exception>
@@ -334,18 +334,10 @@ void IpcClient::handleServerSignal(const Poco::DynamicStruct &ipcMessage, const 
  * @note Any parsing or deserialization error is considered fatal: the client calls exit(EXIT_FAILURE).
  */
 void IpcClient::processBuffer() {
-    Poco::JSON::Parser parser;
     std::string raw;
     while (extractNextMessage(_readBuffer, raw)) {
         try {
-            parser.reset();
-            const Poco::Dynamic::Var var = parser.parse(raw);
-            const auto &objPtr = var.extract<Poco::JSON::Object::Ptr>();
-            if (!objPtr) {
-                qCCritical(lcIpcClient) << "Failed to parse the JSON message: \n'" << raw << "'\n";
-                exit(EXIT_FAILURE);
-            }
-            const Poco::DynamicStruct ipcMessage = *objPtr;
+            const Poco::DynamicStruct ipcMessage = CommJson::parseObject(raw);
 
             if (!ipcMessage.contains(MSG_TYPE) || !ipcMessage.contains(MSG_REQUEST_ID) || !ipcMessage.contains(MSG_REQUEST_NUM) ||
                 !ipcMessage.contains(MSG_REQUEST_PARAMS)) {

--- a/src/libcommon/AGENTS.md
+++ b/src/libcommon/AGENTS.md
@@ -10,6 +10,7 @@ Foundational shared library. **Everything depends on it** (`libcommonserver` →
 | `utility/cstypes.h` | All primitive enums — **no Qt/Poco dependency** |
 | `utility/types.h` | Type aliases, `ExitInfo`, concepts, bitwise ops, string conversion macros |
 | `comm.h` | Full IPC protocol: `RequestNum`, `SignalNum`, timeout constants |
+| `commjson.h` | Shared IPC JSON helpers for parsing the message envelope into `Poco::DynamicStruct` |
 | `info/*.h` | All DTO classes (UserInfo, DriveInfo, SyncInfo, ErrorInfo, …) |
 | `utility/utility.h` | `CommonUtility` — static helpers (paths, strings, UUID, disk space, URL, …) |
 | `utility/urlhelper.h` | `UrlHelper` — all Infomaniak API base URLs |
@@ -74,6 +75,7 @@ Defines every request/signal between GUI and server:
 - `RequestNum` — ~70 RPC calls, grouped by domain (`LOGIN_*`, `DRIVE_*`, `SYNC_*`, `NODE_*`, …)
 - `SignalNum` — ~30 async server→client notifications
 - Timeout constants: `COMM_SHORT_TIMEOUT` (1s), `COMM_AVERAGE_TIMEOUT` (10s), `COMM_LONG_TIMEOUT` (60s)
+- `commjson.h` — small shared helper for parsing raw IPC JSON strings into `Poco::DynamicStruct`
 
 **Adding a new IPC call:** add to `RequestNum` here, then handle symmetrically in `src/server/comm/guicommserver.cpp` and `src/libcommongui/commclient.cpp`.
 

--- a/src/libcommon/CMakeLists.txt
+++ b/src/libcommon/CMakeLists.txt
@@ -23,6 +23,7 @@ add_definitions(-D_UNICODE)
 # Sources
 set(libcommon_SRCS
     comm.h
+    commjson.h commjson.cpp
     utility/cstypes.h
     utility/types.h utility/types.cpp
     utility/utility_base.h utility/utility.h utility/utility.cpp

--- a/src/libcommon/commjson.cpp
+++ b/src/libcommon/commjson.cpp
@@ -27,16 +27,17 @@
 namespace KDC::CommJson {
 
 Poco::DynamicStruct parseObject(const std::string &json) {
-    Poco::JSON::Parser parser;
-    const Poco::Dynamic::Var parsedJson = parser.parse(json);
+    Poco::Dynamic::Var parsedJson;
+    try {
+        Poco::JSON::Parser parser;
+        parsedJson = parser.parse(json);
+    } catch (const Poco::Exception &) {
+        throw Poco::InvalidArgumentException("Failed to parse JSON");
+    }
     Poco::JSON::Object::Ptr jsonObject;
     try {
         jsonObject = parsedJson.extract<Poco::JSON::Object::Ptr>();
     } catch (const Poco::BadCastException &) {
-        throw Poco::InvalidArgumentException("Expected a JSON object");
-    }
-
-    if (!jsonObject) {
         throw Poco::InvalidArgumentException("Expected a JSON object");
     }
 

--- a/src/libcommon/commjson.cpp
+++ b/src/libcommon/commjson.cpp
@@ -29,7 +29,13 @@ namespace KDC::CommJson {
 Poco::DynamicStruct parseObject(const std::string &json) {
     Poco::JSON::Parser parser;
     const Poco::Dynamic::Var parsedJson = parser.parse(json);
-    const auto jsonObject = parsedJson.extract<Poco::JSON::Object::Ptr>();
+    Poco::JSON::Object::Ptr jsonObject;
+    try {
+        jsonObject = parsedJson.extract<Poco::JSON::Object::Ptr>();
+    } catch (const Poco::BadCastException &) {
+        throw Poco::InvalidArgumentException("Expected a JSON object");
+    }
+
     if (!jsonObject) {
         throw Poco::InvalidArgumentException("Expected a JSON object");
     }

--- a/src/libcommon/commjson.cpp
+++ b/src/libcommon/commjson.cpp
@@ -1,0 +1,50 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "commjson.h"
+
+#include "utility/utility.h"
+
+#include <Poco/Exception.h>
+#include <Poco/JSON/Object.h>
+#include <Poco/JSON/Parser.h>
+
+namespace KDC::CommJson {
+
+Poco::DynamicStruct parseObject(const std::string &json) {
+    Poco::JSON::Parser parser;
+    const Poco::Dynamic::Var parsedJson = parser.parse(json);
+    const auto jsonObject = parsedJson.extract<Poco::JSON::Object::Ptr>();
+    if (!jsonObject) {
+        throw Poco::InvalidArgumentException("Expected a JSON object");
+    }
+
+    return *jsonObject;
+}
+
+Poco::DynamicStruct parseCommObject(const CommString &json) {
+#ifdef KD_WINDOWS
+    // CommString is std::wstring on Windows, while Poco::JSON::Parser consumes UTF-8 std::string input.
+    return parseObject(CommonUtility::commString2Str(json));
+#else
+    // On Unix platforms CommString is already std::string, so avoid an unnecessary conversion/copy.
+    return parseObject(json);
+#endif
+}
+
+} // namespace KDC::CommJson

--- a/src/libcommon/commjson.h
+++ b/src/libcommon/commjson.h
@@ -1,0 +1,28 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "utility/types.h"
+
+namespace KDC::CommJson {
+
+Poco::DynamicStruct parseObject(const std::string &json);
+Poco::DynamicStruct parseCommObject(const CommString &json);
+
+} // namespace KDC::CommJson

--- a/src/libcommon/info/errorinfo.cpp
+++ b/src/libcommon/info/errorinfo.cpp
@@ -19,6 +19,8 @@
 #include "errorinfo.h"
 #include "utility/utility.h"
 
+#include <cstdint>
+
 static const auto outParamsDbId = "dbId";
 static const auto outParamsTime = "time";
 static const auto outParamsLevel = "level";
@@ -100,6 +102,50 @@ void ErrorInfo::toDynamicStruct(Poco::DynamicStruct &dstruct) const {
     CommonUtility::writeValueToStruct(dstruct, outParamsInconsistencyType, _inconsistencyType);
     CommonUtility::writeValueToStruct(dstruct, outParamsCancelType, _cancelType);
     CommonUtility::writeValueToStruct(dstruct, outParamsAutoResolved, _autoResolved);
+}
+
+void ErrorInfo::fromDynamicStruct(const Poco::DynamicStruct &dstruct) {
+    CommonUtility::readValueFromStruct(dstruct, outParamsDbId, _dbId);
+    CommonUtility::readValueFromStruct(dstruct, outParamsTime, _time);
+    CommonUtility::readValueFromStruct(dstruct, outParamsLevel, _level);
+
+    std::string functionName;
+    CommonUtility::readValueFromStruct(dstruct, outParamsFunctionName, functionName);
+    _functionName = QString::fromStdString(functionName);
+
+    CommonUtility::readValueFromStruct(dstruct, outParamsSyncDbId, _syncDbId);
+
+    std::string workerName;
+    CommonUtility::readValueFromStruct(dstruct, outParamsWorkerName, workerName);
+    _workerName = QString::fromStdString(workerName);
+
+    CommonUtility::readValueFromStruct(dstruct, outParamsExitCode, _exitCode);
+    CommonUtility::readValueFromStruct(dstruct, outParamsExitCause, _exitCause);
+
+    std::string localNodeId;
+    CommonUtility::readValueFromStruct(dstruct, outParamsLocalNodeId, localNodeId);
+    _localNodeId = QString::fromStdString(localNodeId);
+
+    std::string remoteNodeId;
+    CommonUtility::readValueFromStruct(dstruct, outParamsRemoteNodeId, remoteNodeId);
+    _remoteNodeId = QString::fromStdString(remoteNodeId);
+
+    CommonUtility::readValueFromStruct(dstruct, outParamsNodeType, _nodeType);
+
+    std::string path;
+    CommonUtility::readValueFromStruct(dstruct, outParamsPath, path);
+    _path = QString::fromStdString(path);
+
+    std::string destinationPath;
+    CommonUtility::readValueFromStruct(dstruct, outParamsDestinationPath, destinationPath);
+    _destinationPath = QString::fromStdString(destinationPath);
+
+    CommonUtility::readValueFromStruct(dstruct, outParamsConflictType, _conflictType);
+    int32_t inconsistencyTypeValue = 0;
+    CommonUtility::readValueFromStruct(dstruct, outParamsInconsistencyType, inconsistencyTypeValue);
+    _inconsistencyType = fromInt<InconsistencyType>(inconsistencyTypeValue);
+    CommonUtility::readValueFromStruct(dstruct, outParamsCancelType, _cancelType);
+    CommonUtility::readValueFromStruct(dstruct, outParamsAutoResolved, _autoResolved);
 }
 
 QDataStream &operator>>(QDataStream &in, ErrorInfo &errorInfo) {

--- a/src/libcommon/info/errorinfo.cpp
+++ b/src/libcommon/info/errorinfo.cpp
@@ -111,34 +111,34 @@ void ErrorInfo::fromDynamicStruct(const Poco::DynamicStruct &dstruct) {
 
     CommString functionName;
     CommonUtility::readValueFromStruct(dstruct, outParamsFunctionName, functionName);
-    _functionName = QString::fromStdString(functionName);
+    _functionName = CommonUtility::commString2QStr(functionName);
 
     CommonUtility::readValueFromStruct(dstruct, outParamsSyncDbId, _syncDbId);
 
     CommString workerName;
     CommonUtility::readValueFromStruct(dstruct, outParamsWorkerName, workerName);
-    _workerName = QString::fromStdString(workerName);
+    _workerName = CommonUtility::commString2QStr(workerName);
 
     CommonUtility::readValueFromStruct(dstruct, outParamsExitCode, _exitCode);
     CommonUtility::readValueFromStruct(dstruct, outParamsExitCause, _exitCause);
 
     CommString localNodeId;
     CommonUtility::readValueFromStruct(dstruct, outParamsLocalNodeId, localNodeId);
-    _localNodeId = QString::fromStdString(localNodeId);
+    _localNodeId = CommonUtility::commString2QStr(localNodeId);
 
     CommString remoteNodeId;
     CommonUtility::readValueFromStruct(dstruct, outParamsRemoteNodeId, remoteNodeId);
-    _remoteNodeId = QString::fromStdString(remoteNodeId);
+    _remoteNodeId = CommonUtility::commString2QStr(remoteNodeId);
 
     CommonUtility::readValueFromStruct(dstruct, outParamsNodeType, _nodeType);
 
     CommString path;
     CommonUtility::readValueFromStruct(dstruct, outParamsPath, path);
-    _path = QString::fromStdString(path);
+    _path = CommonUtility::commString2QStr(path);
 
     CommString destinationPath;
     CommonUtility::readValueFromStruct(dstruct, outParamsDestinationPath, destinationPath);
-    _destinationPath = QString::fromStdString(destinationPath);
+    _destinationPath = CommonUtility::commString2QStr(destinationPath);
 
     CommonUtility::readValueFromStruct(dstruct, outParamsConflictType, _conflictType);
     int32_t inconsistencyTypeValue = 0;

--- a/src/libcommon/info/errorinfo.cpp
+++ b/src/libcommon/info/errorinfo.cpp
@@ -109,34 +109,34 @@ void ErrorInfo::fromDynamicStruct(const Poco::DynamicStruct &dstruct) {
     CommonUtility::readValueFromStruct(dstruct, outParamsTime, _time);
     CommonUtility::readValueFromStruct(dstruct, outParamsLevel, _level);
 
-    std::string functionName;
+    CommString functionName;
     CommonUtility::readValueFromStruct(dstruct, outParamsFunctionName, functionName);
     _functionName = QString::fromStdString(functionName);
 
     CommonUtility::readValueFromStruct(dstruct, outParamsSyncDbId, _syncDbId);
 
-    std::string workerName;
+    CommString workerName;
     CommonUtility::readValueFromStruct(dstruct, outParamsWorkerName, workerName);
     _workerName = QString::fromStdString(workerName);
 
     CommonUtility::readValueFromStruct(dstruct, outParamsExitCode, _exitCode);
     CommonUtility::readValueFromStruct(dstruct, outParamsExitCause, _exitCause);
 
-    std::string localNodeId;
+    CommString localNodeId;
     CommonUtility::readValueFromStruct(dstruct, outParamsLocalNodeId, localNodeId);
     _localNodeId = QString::fromStdString(localNodeId);
 
-    std::string remoteNodeId;
+    CommString remoteNodeId;
     CommonUtility::readValueFromStruct(dstruct, outParamsRemoteNodeId, remoteNodeId);
     _remoteNodeId = QString::fromStdString(remoteNodeId);
 
     CommonUtility::readValueFromStruct(dstruct, outParamsNodeType, _nodeType);
 
-    std::string path;
+    CommString path;
     CommonUtility::readValueFromStruct(dstruct, outParamsPath, path);
     _path = QString::fromStdString(path);
 
-    std::string destinationPath;
+    CommString destinationPath;
     CommonUtility::readValueFromStruct(dstruct, outParamsDestinationPath, destinationPath);
     _destinationPath = QString::fromStdString(destinationPath);
 

--- a/src/libcommon/info/errorinfo.h
+++ b/src/libcommon/info/errorinfo.h
@@ -76,6 +76,7 @@ class ErrorInfo {
         inline void setAutoResolved(bool newAutoResolved) { _autoResolved = newAutoResolved; }
 
         void toDynamicStruct(Poco::DynamicStruct &dstruct) const;
+        void fromDynamicStruct(const Poco::DynamicStruct &dstruct);
 
         friend QDataStream &operator>>(QDataStream &in, ErrorInfo &errorInfo);
         friend QDataStream &operator<<(QDataStream &out, const ErrorInfo &errorInfo);

--- a/src/libcommon/info/nodeinfo.cpp
+++ b/src/libcommon/info/nodeinfo.cpp
@@ -50,6 +50,30 @@ void NodeInfo::toDynamicStruct(Poco::DynamicStruct &dstruct) const {
     CommonUtility::writeValueToStruct(dstruct, nodeInfoAccessDenied, _accessDenied);
 }
 
+void NodeInfo::fromDynamicStruct(const Poco::DynamicStruct &dstruct) {
+    CommString nodeId;
+    CommonUtility::readValueFromStruct(dstruct, nodeInfoNodeId, nodeId);
+    _nodeId = CommonUtility::commString2QStr(nodeId);
+
+    CommString name;
+    CommonUtility::readValueFromStruct(dstruct, nodeInfoName, name);
+    _name = CommonUtility::commString2QStr(name);
+
+    CommonUtility::readValueFromStruct(dstruct, nodeInfoSize, _size);
+
+    CommString parentNodeId;
+    CommonUtility::readValueFromStruct(dstruct, nodeInfoParentNodeId, parentNodeId);
+    _parentNodeId = CommonUtility::commString2QStr(parentNodeId);
+
+    CommonUtility::readValueFromStruct(dstruct, nodeInfoModtime, _modtime);
+
+    CommString path;
+    CommonUtility::readValueFromStruct(dstruct, nodeInfoPath, path);
+    _path = CommonUtility::commString2QStr(path);
+
+    CommonUtility::readValueFromStruct(dstruct, nodeInfoAccessDenied, _accessDenied);
+}
+
 QDataStream &operator>>(QDataStream &in, NodeInfo &info) {
     in >> info._nodeId >> info._name >> info._size >> info._parentNodeId >> info._modtime >> info._path >> info._accessDenied;
     return in;

--- a/src/libcommon/info/nodeinfo.h
+++ b/src/libcommon/info/nodeinfo.h
@@ -49,6 +49,7 @@ class NodeInfo {
         inline void setAccessDenied(bool accessDenied) { _accessDenied = accessDenied; }
 
         void toDynamicStruct(Poco::DynamicStruct &dstruct) const;
+        void fromDynamicStruct(const Poco::DynamicStruct &dstruct);
         friend QDataStream &operator>>(QDataStream &in, NodeInfo &info);
         friend QDataStream &operator<<(QDataStream &out, const NodeInfo &info);
 

--- a/src/libcommon/info/syncfileiteminfo.cpp
+++ b/src/libcommon/info/syncfileiteminfo.cpp
@@ -106,7 +106,7 @@ void SyncFileItemInfo::fromDynamicStruct(const Poco::DynamicStruct &dstruct) {
 
     CommString error;
     CommonUtility::readValueFromStruct(dstruct, outParamsError, error);
-    _error = QString::fromStdString(error);
+    _error = CommonUtility::commString2QStr(error);
 
     CommonUtility::readValueFromStruct(dstruct, outParamsSize, _size);
     CommonUtility::readValueFromStruct(dstruct, outParamsProgress, _progress);

--- a/src/libcommon/info/syncfileiteminfo.cpp
+++ b/src/libcommon/info/syncfileiteminfo.cpp
@@ -19,6 +19,8 @@
 #include "syncfileiteminfo.h"
 #include "utility/utility.h"
 
+#include <cstdint>
+
 static const auto outParamsType = "type";
 static const auto outParamsPath = "path";
 static const auto outParamsNewPath = "newPath";
@@ -72,6 +74,43 @@ void SyncFileItemInfo::toDynamicStruct(Poco::DynamicStruct &dstruct) const {
     CommonUtility::writeValueToStruct(dstruct, outParamsSize, _size);
     CommonUtility::writeValueToStruct(dstruct, outParamsProgress, _progress);
     CommonUtility::writeValueToStruct(dstruct, outParamsOperationId, _operationId);
+}
+
+void SyncFileItemInfo::fromDynamicStruct(const Poco::DynamicStruct &dstruct) {
+    CommonUtility::readValueFromStruct(dstruct, outParamsType, _type);
+
+    std::string path;
+    CommonUtility::readValueFromStruct(dstruct, outParamsPath, path);
+    _path = QString::fromStdString(path);
+
+    std::string newPath;
+    CommonUtility::readValueFromStruct(dstruct, outParamsNewPath, newPath);
+    _newPath = QString::fromStdString(newPath);
+
+    std::string localNodeId;
+    CommonUtility::readValueFromStruct(dstruct, outParamsLocalNodeId, localNodeId);
+    _localNodeId = QString::fromStdString(localNodeId);
+
+    std::string remoteNodeId;
+    CommonUtility::readValueFromStruct(dstruct, outParamsRemoteNodeId, remoteNodeId);
+    _remoteNodeId = QString::fromStdString(remoteNodeId);
+
+    CommonUtility::readValueFromStruct(dstruct, outParamsDirection, _direction);
+    CommonUtility::readValueFromStruct(dstruct, outParamsInstruction, _instruction);
+    CommonUtility::readValueFromStruct(dstruct, outParamsStatus, _status);
+    CommonUtility::readValueFromStruct(dstruct, outParamsConflict, _conflict);
+    int32_t inconsistencyValue = 0;
+    CommonUtility::readValueFromStruct(dstruct, outParamsInconsistency, inconsistencyValue);
+    _inconsistency = fromInt<InconsistencyType>(inconsistencyValue);
+    CommonUtility::readValueFromStruct(dstruct, outParamsCancelType, _cancelType);
+
+    std::string error;
+    CommonUtility::readValueFromStruct(dstruct, outParamsError, error);
+    _error = QString::fromStdString(error);
+
+    CommonUtility::readValueFromStruct(dstruct, outParamsSize, _size);
+    CommonUtility::readValueFromStruct(dstruct, outParamsProgress, _progress);
+    CommonUtility::readValueFromStruct(dstruct, outParamsOperationId, _operationId);
 }
 
 QDataStream &operator>>(QDataStream &in, SyncFileItemInfo &info) {

--- a/src/libcommon/info/syncfileiteminfo.cpp
+++ b/src/libcommon/info/syncfileiteminfo.cpp
@@ -79,19 +79,19 @@ void SyncFileItemInfo::toDynamicStruct(Poco::DynamicStruct &dstruct) const {
 void SyncFileItemInfo::fromDynamicStruct(const Poco::DynamicStruct &dstruct) {
     CommonUtility::readValueFromStruct(dstruct, outParamsType, _type);
 
-    std::string path;
+    CommString path;
     CommonUtility::readValueFromStruct(dstruct, outParamsPath, path);
     _path = QString::fromStdString(path);
 
-    std::string newPath;
+    CommString newPath;
     CommonUtility::readValueFromStruct(dstruct, outParamsNewPath, newPath);
     _newPath = QString::fromStdString(newPath);
 
-    std::string localNodeId;
+    CommString localNodeId;
     CommonUtility::readValueFromStruct(dstruct, outParamsLocalNodeId, localNodeId);
     _localNodeId = QString::fromStdString(localNodeId);
 
-    std::string remoteNodeId;
+    CommString remoteNodeId;
     CommonUtility::readValueFromStruct(dstruct, outParamsRemoteNodeId, remoteNodeId);
     _remoteNodeId = QString::fromStdString(remoteNodeId);
 
@@ -104,7 +104,7 @@ void SyncFileItemInfo::fromDynamicStruct(const Poco::DynamicStruct &dstruct) {
     _inconsistency = fromInt<InconsistencyType>(inconsistencyValue);
     CommonUtility::readValueFromStruct(dstruct, outParamsCancelType, _cancelType);
 
-    std::string error;
+    CommString error;
     CommonUtility::readValueFromStruct(dstruct, outParamsError, error);
     _error = QString::fromStdString(error);
 

--- a/src/libcommon/info/syncfileiteminfo.cpp
+++ b/src/libcommon/info/syncfileiteminfo.cpp
@@ -81,19 +81,19 @@ void SyncFileItemInfo::fromDynamicStruct(const Poco::DynamicStruct &dstruct) {
 
     CommString path;
     CommonUtility::readValueFromStruct(dstruct, outParamsPath, path);
-    _path = QString::fromStdString(path);
+    _path = CommonUtility::commString2QStr(path);
 
     CommString newPath;
     CommonUtility::readValueFromStruct(dstruct, outParamsNewPath, newPath);
-    _newPath = QString::fromStdString(newPath);
+    _newPath = CommonUtility::commString2QStr(newPath);
 
     CommString localNodeId;
     CommonUtility::readValueFromStruct(dstruct, outParamsLocalNodeId, localNodeId);
-    _localNodeId = QString::fromStdString(localNodeId);
+    _localNodeId = CommonUtility::commString2QStr(localNodeId);
 
     CommString remoteNodeId;
     CommonUtility::readValueFromStruct(dstruct, outParamsRemoteNodeId, remoteNodeId);
-    _remoteNodeId = QString::fromStdString(remoteNodeId);
+    _remoteNodeId = CommonUtility::commString2QStr(remoteNodeId);
 
     CommonUtility::readValueFromStruct(dstruct, outParamsDirection, _direction);
     CommonUtility::readValueFromStruct(dstruct, outParamsInstruction, _instruction);

--- a/src/libcommon/info/syncfileiteminfo.h
+++ b/src/libcommon/info/syncfileiteminfo.h
@@ -72,6 +72,7 @@ class SyncFileItemInfo {
         friend QDataStream &operator<<(QDataStream &out, const QList<SyncFileItemInfo> &list);
 
         void toDynamicStruct(Poco::DynamicStruct &dstruct) const;
+        void fromDynamicStruct(const Poco::DynamicStruct &dstruct);
 
     private:
         NodeType _type;

--- a/src/server/comm/guijobs/abstractguijob.cpp
+++ b/src/server/comm/guijobs/abstractguijob.cpp
@@ -17,10 +17,9 @@
  */
 
 #include "abstractguijob.h"
-#include "utility/jsonparserutility.h"
 #include "appserver.h"
+#include "libcommon/commjson.h"
 
-#include <Poco/JSON/Parser.h>
 #include <Poco/Exception.h>
 
 // Input parameters keys
@@ -97,10 +96,7 @@ ExitInfo AbstractGuiJob::runJob() {
 bool AbstractGuiJob::deserializeGenericInputParms(const CommString &inputParamsStr, int &requestId, RequestNum &requestNum,
                                                   Poco::DynamicStruct &inParams) {
     try {
-        Poco::JSON::Parser parser;
-        Poco::Dynamic::Var inputParamsVar = parser.parse(CommonUtility::commString2Str(inputParamsStr));
-
-        Poco::DynamicStruct paramsStruct = *inputParamsVar.extract<Poco::JSON::Object::Ptr>();
+        const Poco::DynamicStruct paramsStruct = CommJson::parseCommObject(inputParamsStr);
 
         CommonUtility::readValueFromStruct(paramsStruct, inRequestId, requestId);
         CommonUtility::readValueFromStruct(paramsStruct, inRequestNum, requestNum);

--- a/test/libcommon/CMakeLists.txt
+++ b/test/libcommon/CMakeLists.txt
@@ -23,6 +23,8 @@ set(testcommon_SRCS
         utility/testtypes.cpp utility/testtypes.h
         utility/testurlhelper.h utility/testurlhelper.cpp
         utility/testjsonparserutility.h utility/testjsonparserutility.cpp
+        utility/testcommjson.h utility/testcommjson.cpp
+        utility/testinfodynamicstruct.h utility/testinfodynamicstruct.cpp
         # Log
         log/sentry/testsentryhandler.h log/sentry/testsentryhandler.cpp
         log/testlog.h log/testlog.cpp

--- a/test/libcommon/test.cpp
+++ b/test/libcommon/test.cpp
@@ -23,6 +23,8 @@
 #include "utility/testtypes.h"
 #include "log/sentry/testsentryhandler.h"
 #include "utility/testurlhelper.h"
+#include "utility/testcommjson.h"
+#include "utility/testinfodynamicstruct.h"
 #include "utility/testjsonparserutility.h"
 #include "log/testlog.h"
 #include "io/testio.h"
@@ -33,6 +35,8 @@ CPPUNIT_TEST_SUITE_REGISTRATION(TestUtility);
 CPPUNIT_TEST_SUITE_REGISTRATION(TestTypes);
 CPPUNIT_TEST_SUITE_REGISTRATION(TestSentryHandler);
 CPPUNIT_TEST_SUITE_REGISTRATION(TestUrlHelper);
+CPPUNIT_TEST_SUITE_REGISTRATION(TestCommJson);
+CPPUNIT_TEST_SUITE_REGISTRATION(TestInfoDynamicStruct);
 CPPUNIT_TEST_SUITE_REGISTRATION(TestJsonParserUtility);
 CPPUNIT_TEST_SUITE_REGISTRATION(TestLog);
 CPPUNIT_TEST_SUITE_REGISTRATION(TestIo);

--- a/test/libcommon/utility/testcommjson.cpp
+++ b/test/libcommon/utility/testcommjson.cpp
@@ -1,0 +1,50 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "testcommjson.h"
+
+#include "libcommon/commjson.h"
+#include "libcommon/utility/utility.h"
+
+#include <Poco/Exception.h>
+
+#include <cstdint>
+
+namespace KDC {
+
+void TestCommJson::testParseObject() {
+    const Poco::DynamicStruct parsed = CommJson::parseObject(R"({"answer":42,"ok":true,"text":"hello"})");
+
+    CPPUNIT_ASSERT_EQUAL(int32_t{42}, parsed["answer"].convert<int32_t>());
+    CPPUNIT_ASSERT_EQUAL(true, parsed["ok"].convert<bool>());
+    CPPUNIT_ASSERT_EQUAL(std::string("hello"), parsed["text"].convert<std::string>());
+}
+
+void TestCommJson::testParseCommObject() {
+    const CommString json = CommonUtility::str2CommString(R"({"requestId":7,"scope":"gui4"})");
+    const Poco::DynamicStruct parsed = CommJson::parseCommObject(json);
+
+    CPPUNIT_ASSERT_EQUAL(int32_t{7}, parsed["requestId"].convert<int32_t>());
+    CPPUNIT_ASSERT_EQUAL(std::string("gui4"), parsed["scope"].convert<std::string>());
+}
+
+void TestCommJson::testParseObjectRejectsNonObject() {
+    CPPUNIT_ASSERT_THROW(CommJson::parseObject(R"([1,2,3])"), Poco::InvalidArgumentException);
+}
+
+} // namespace KDC

--- a/test/libcommon/utility/testcommjson.h
+++ b/test/libcommon/utility/testcommjson.h
@@ -22,7 +22,7 @@
 
 namespace KDC {
 
-class TestCommJson final : public CppUnit::TestFixture, public TestBase {
+class TestCommJson : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST_SUITE(TestCommJson);
         CPPUNIT_TEST(testParseObject);
         CPPUNIT_TEST(testParseCommObject);

--- a/test/libcommon/utility/testcommjson.h
+++ b/test/libcommon/utility/testcommjson.h
@@ -1,0 +1,42 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "testincludes.h"
+
+namespace KDC {
+
+class TestCommJson final : public CppUnit::TestFixture, public TestBase {
+        CPPUNIT_TEST_SUITE(TestCommJson);
+        CPPUNIT_TEST(testParseObject);
+        CPPUNIT_TEST(testParseCommObject);
+        CPPUNIT_TEST(testParseObjectRejectsNonObject);
+        CPPUNIT_TEST_SUITE_END();
+
+    public:
+        void setUp() override { TestBase::start(); }
+        void tearDown() override { TestBase::stop(); }
+
+    protected:
+        void testParseObject();
+        void testParseCommObject();
+        void testParseObjectRejectsNonObject();
+};
+
+} // namespace KDC

--- a/test/libcommon/utility/testinfodynamicstruct.cpp
+++ b/test/libcommon/utility/testinfodynamicstruct.cpp
@@ -29,8 +29,8 @@ namespace KDC {
 void TestInfoDynamicStruct::testErrorInfoRoundTrip() {
     const ErrorInfo source(ErrorDbId{41}, int64_t{1712345678}, ErrorLevel::SyncPal, QString("syncStep"), SyncDbId{99},
                            QString("workerA"), ExitCode::NetworkError, ExitCause::NetworkTimeout, QString("local-1"),
-                           QString("remote-2"), NodeType::File, QString("/tmp/file.txt"), ConflictType::EditEdit,
-                           InconsistencyType::ForbiddenChar, CancelType::Move, QString("/tmp/file-copy.txt"));
+                           QString("remote-2"), NodeType::File, QString("workspace/file.txt"), ConflictType::EditEdit,
+                           InconsistencyType::ForbiddenChar, CancelType::Move, QString("workspace/file-copy.txt"));
 
     Poco::DynamicStruct dstruct;
     source.toDynamicStruct(dstruct);
@@ -49,8 +49,8 @@ void TestInfoDynamicStruct::testErrorInfoRoundTrip() {
     CPPUNIT_ASSERT_EQUAL(std::string("local-1"), parsed.localNodeId().toStdString());
     CPPUNIT_ASSERT_EQUAL(std::string("remote-2"), parsed.remoteNodeId().toStdString());
     CPPUNIT_ASSERT_EQUAL(NodeType::File, parsed.nodeType());
-    CPPUNIT_ASSERT_EQUAL(std::string("/tmp/file.txt"), parsed.path().toStdString());
-    CPPUNIT_ASSERT_EQUAL(std::string("/tmp/file-copy.txt"), parsed.destinationPath().toStdString());
+    CPPUNIT_ASSERT_EQUAL(std::string("workspace/file.txt"), parsed.path().toStdString());
+    CPPUNIT_ASSERT_EQUAL(std::string("workspace/file-copy.txt"), parsed.destinationPath().toStdString());
     CPPUNIT_ASSERT_EQUAL(ConflictType::EditEdit, parsed.conflictType());
     CPPUNIT_ASSERT_EQUAL(InconsistencyType::ForbiddenChar, parsed.inconsistencyType());
     CPPUNIT_ASSERT_EQUAL(CancelType::Move, parsed.cancelType());
@@ -59,7 +59,7 @@ void TestInfoDynamicStruct::testErrorInfoRoundTrip() {
 
 void TestInfoDynamicStruct::testNodeInfoRoundTrip() {
     const NodeInfo source(QString("node-123"), QString("FolderA"), int64_t{4096}, QString("parent-99"), SyncTime{123456789},
-                          QString("/root/FolderA"));
+                          QString("workspace/FolderA"));
 
     Poco::DynamicStruct dstruct;
     source.toDynamicStruct(dstruct);
@@ -72,7 +72,7 @@ void TestInfoDynamicStruct::testNodeInfoRoundTrip() {
     CPPUNIT_ASSERT_EQUAL(qint64{4096}, parsed.size());
     CPPUNIT_ASSERT_EQUAL(std::string("parent-99"), parsed.parentNodeId().toStdString());
     CPPUNIT_ASSERT_EQUAL(qint64{123456789}, parsed.modtime());
-    CPPUNIT_ASSERT_EQUAL(std::string("/root/FolderA"), parsed.path().toStdString());
+    CPPUNIT_ASSERT_EQUAL(std::string("workspace/FolderA"), parsed.path().toStdString());
     CPPUNIT_ASSERT_EQUAL(false, parsed.accessDenied());
 }
 

--- a/test/libcommon/utility/testinfodynamicstruct.cpp
+++ b/test/libcommon/utility/testinfodynamicstruct.cpp
@@ -104,7 +104,7 @@ void TestInfoDynamicStruct::testSyncFileItemInfoRoundTrip() {
     CPPUNIT_ASSERT_EQUAL(CancelType::TmpBlacklisted, parsed.cancelType());
     CPPUNIT_ASSERT_EQUAL(std::string("temporary error"), parsed.error().toStdString());
     CPPUNIT_ASSERT_EQUAL(int64_t{2048}, parsed.size());
-    CPPUNIT_ASSERT_EQUAL(int32_t{73}, static_cast<int32_t>(parsed.progress()));
+    CPPUNIT_ASSERT_EQUAL(int32_t{73}, parsed.progress());
     CPPUNIT_ASSERT_EQUAL(UniqueId{555}, parsed.operationId());
 }
 

--- a/test/libcommon/utility/testinfodynamicstruct.cpp
+++ b/test/libcommon/utility/testinfodynamicstruct.cpp
@@ -1,0 +1,111 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "testinfodynamicstruct.h"
+
+#include "libcommon/info/errorinfo.h"
+#include "libcommon/info/nodeinfo.h"
+#include "libcommon/info/syncfileiteminfo.h"
+
+#include <cstdint>
+
+namespace KDC {
+
+void TestInfoDynamicStruct::testErrorInfoRoundTrip() {
+    const ErrorInfo source(ErrorDbId{41}, int64_t{1712345678}, ErrorLevel::SyncPal, QString("syncStep"), SyncDbId{99},
+                           QString("workerA"), ExitCode::NetworkError, ExitCause::NetworkTimeout, QString("local-1"),
+                           QString("remote-2"), NodeType::File, QString("/tmp/file.txt"), ConflictType::EditEdit,
+                           InconsistencyType::ForbiddenChar, CancelType::Move, QString("/tmp/file-copy.txt"));
+
+    Poco::DynamicStruct dstruct;
+    source.toDynamicStruct(dstruct);
+
+    ErrorInfo parsed;
+    parsed.fromDynamicStruct(dstruct);
+
+    CPPUNIT_ASSERT_EQUAL(ErrorDbId{41}, parsed.dbId());
+    CPPUNIT_ASSERT_EQUAL(qint64{1712345678}, parsed.getTime());
+    CPPUNIT_ASSERT_EQUAL(ErrorLevel::SyncPal, parsed.level());
+    CPPUNIT_ASSERT_EQUAL(std::string("syncStep"), parsed.functionName().toStdString());
+    CPPUNIT_ASSERT_EQUAL(SyncDbId{99}, parsed.syncDbId());
+    CPPUNIT_ASSERT_EQUAL(std::string("workerA"), parsed.workerName().toStdString());
+    CPPUNIT_ASSERT_EQUAL(ExitCode::NetworkError, parsed.exitCode());
+    CPPUNIT_ASSERT_EQUAL(ExitCause::NetworkTimeout, parsed.exitCause());
+    CPPUNIT_ASSERT_EQUAL(std::string("local-1"), parsed.localNodeId().toStdString());
+    CPPUNIT_ASSERT_EQUAL(std::string("remote-2"), parsed.remoteNodeId().toStdString());
+    CPPUNIT_ASSERT_EQUAL(NodeType::File, parsed.nodeType());
+    CPPUNIT_ASSERT_EQUAL(std::string("/tmp/file.txt"), parsed.path().toStdString());
+    CPPUNIT_ASSERT_EQUAL(std::string("/tmp/file-copy.txt"), parsed.destinationPath().toStdString());
+    CPPUNIT_ASSERT_EQUAL(ConflictType::EditEdit, parsed.conflictType());
+    CPPUNIT_ASSERT_EQUAL(InconsistencyType::ForbiddenChar, parsed.inconsistencyType());
+    CPPUNIT_ASSERT_EQUAL(CancelType::Move, parsed.cancelType());
+    CPPUNIT_ASSERT_EQUAL(false, parsed.autoResolved());
+}
+
+void TestInfoDynamicStruct::testNodeInfoRoundTrip() {
+    const NodeInfo source(QString("node-123"), QString("FolderA"), int64_t{4096}, QString("parent-99"), SyncTime{123456789},
+                          QString("/root/FolderA"));
+
+    Poco::DynamicStruct dstruct;
+    source.toDynamicStruct(dstruct);
+
+    NodeInfo parsed;
+    parsed.fromDynamicStruct(dstruct);
+
+    CPPUNIT_ASSERT_EQUAL(std::string("node-123"), parsed.nodeId().toStdString());
+    CPPUNIT_ASSERT_EQUAL(std::string("FolderA"), parsed.name().toStdString());
+    CPPUNIT_ASSERT_EQUAL(qint64{4096}, parsed.size());
+    CPPUNIT_ASSERT_EQUAL(std::string("parent-99"), parsed.parentNodeId().toStdString());
+    CPPUNIT_ASSERT_EQUAL(qint64{123456789}, parsed.modtime());
+    CPPUNIT_ASSERT_EQUAL(std::string("/root/FolderA"), parsed.path().toStdString());
+    CPPUNIT_ASSERT_EQUAL(false, parsed.accessDenied());
+}
+
+void TestInfoDynamicStruct::testSyncFileItemInfoRoundTrip() {
+    SyncFileItemInfo source(NodeType::Directory, QString("docs/report.txt"), QString("docs/report-final.txt"), QString("local-9"),
+                            QString("remote-10"), SyncDirection::Down, SyncFileInstruction::Update, SyncFileStatus::Syncing,
+                            ConflictType::MoveCreate, InconsistencyType::PathLength, CancelType::TmpBlacklisted);
+    source.setError(QString("temporary error"));
+    source.setSize(int64_t{2048});
+    source.setProgress(int32_t{73});
+    source.setOperationId(UniqueId{555});
+
+    Poco::DynamicStruct dstruct;
+    source.toDynamicStruct(dstruct);
+
+    SyncFileItemInfo parsed;
+    parsed.fromDynamicStruct(dstruct);
+
+    CPPUNIT_ASSERT_EQUAL(NodeType::Directory, parsed.type());
+    CPPUNIT_ASSERT_EQUAL(std::string("docs/report.txt"), parsed.path().toStdString());
+    CPPUNIT_ASSERT_EQUAL(std::string("docs/report-final.txt"), parsed.newPath().toStdString());
+    CPPUNIT_ASSERT_EQUAL(std::string("local-9"), parsed.localNodeId().toStdString());
+    CPPUNIT_ASSERT_EQUAL(std::string("remote-10"), parsed.remoteNodeId().toStdString());
+    CPPUNIT_ASSERT_EQUAL(SyncDirection::Down, parsed.direction());
+    CPPUNIT_ASSERT_EQUAL(SyncFileInstruction::Update, parsed.instruction());
+    CPPUNIT_ASSERT_EQUAL(SyncFileStatus::Syncing, parsed.status());
+    CPPUNIT_ASSERT_EQUAL(ConflictType::MoveCreate, parsed.conflict());
+    CPPUNIT_ASSERT_EQUAL(InconsistencyType::PathLength, parsed.inconsistency());
+    CPPUNIT_ASSERT_EQUAL(CancelType::TmpBlacklisted, parsed.cancelType());
+    CPPUNIT_ASSERT_EQUAL(std::string("temporary error"), parsed.error().toStdString());
+    CPPUNIT_ASSERT_EQUAL(int64_t{2048}, parsed.size());
+    CPPUNIT_ASSERT_EQUAL(int32_t{73}, static_cast<int32_t>(parsed.progress()));
+    CPPUNIT_ASSERT_EQUAL(UniqueId{555}, parsed.operationId());
+}
+
+} // namespace KDC

--- a/test/libcommon/utility/testinfodynamicstruct.h
+++ b/test/libcommon/utility/testinfodynamicstruct.h
@@ -22,7 +22,7 @@
 
 namespace KDC {
 
-class TestInfoDynamicStruct final : public CppUnit::TestFixture, public TestBase {
+class TestInfoDynamicStruct : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST_SUITE(TestInfoDynamicStruct);
         CPPUNIT_TEST(testErrorInfoRoundTrip);
         CPPUNIT_TEST(testNodeInfoRoundTrip);

--- a/test/libcommon/utility/testinfodynamicstruct.h
+++ b/test/libcommon/utility/testinfodynamicstruct.h
@@ -1,0 +1,42 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "testincludes.h"
+
+namespace KDC {
+
+class TestInfoDynamicStruct final : public CppUnit::TestFixture, public TestBase {
+        CPPUNIT_TEST_SUITE(TestInfoDynamicStruct);
+        CPPUNIT_TEST(testErrorInfoRoundTrip);
+        CPPUNIT_TEST(testNodeInfoRoundTrip);
+        CPPUNIT_TEST(testSyncFileItemInfoRoundTrip);
+        CPPUNIT_TEST_SUITE_END();
+
+    public:
+        void setUp() override { TestBase::start(); }
+        void tearDown() override { TestBase::stop(); }
+
+    protected:
+        void testErrorInfoRoundTrip();
+        void testNodeInfoRoundTrip();
+        void testSyncFileItemInfoRoundTrip();
+};
+
+} // namespace KDC


### PR DESCRIPTION
## Summary
This PR centralizes IPC JSON object parsing in `libcommon` and adds deserialization support for the shared info types exchanged through `Poco::DynamicStruct`. It also updates the existing IPC call sites to use the shared helper and adds unit coverage for the new parsing paths.

## Changes
- Added `CommJson::parseObject()` and `CommJson::parseCommObject()` in `src/libcommon/commjson.cpp` and `src/libcommon/commjson.h` to centralize JSON object parsing.
- Replaced ad hoc JSON parsing in `src/server/comm/guijobs/abstractguijob.cpp` and `src/gui4/linux/communicationlayer/ipcclient.cpp` with the shared helper.
- Implemented `fromDynamicStruct()` for `ErrorInfo`, `NodeInfo`, and `SyncFileItemInfo` so IPC payloads can be converted back into typed objects.
- Updated `src/libcommon/CMakeLists.txt` to build the new shared helper.
- Added unit tests for JSON parsing and `Poco::DynamicStruct` round trips in `test/libcommon/utility/testcommjson.cpp` and `test/libcommon/utility/testinfodynamicstruct.cpp`.
- Updated `test/libcommon/CMakeLists.txt` and `test/libcommon/test.cpp` to compile and register the new tests.

## Technical Details
`CommJson::parseObject()` validates that the parsed JSON payload is an object and throws `Poco::InvalidArgumentException` for non-object inputs. `parseCommObject()` keeps `CommString` handling aligned across Windows and Unix.

The new `fromDynamicStruct()` methods mirror the existing `toDynamicStruct()` serialization paths and restore string fields, enum-backed values, and typed identifiers from IPC payloads.
