### PR TITLE
fix(macOS UI): App crashes when opening settings several times

### DIFF
--- a/src/gui4/macOS/kDrive/AppDelegate.swift
+++ b/src/gui4/macOS/kDrive/AppDelegate.swift
@@ -22,7 +22,7 @@ import kDriveCore
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
     private lazy var mainWindow = MainWindowController()
-    private lazy var preferencesWindow = PreferencesWindowController()
+    private var preferencesWindow: PreferencesWindowController?
 
     private static var isRunningTests: Bool {
         ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
@@ -56,8 +56,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    @objc func openPreferencesWindow(_ sender: Any?) {
-        preferencesWindow.showWindow(sender)
-        preferencesWindow.window?.makeKeyAndOrderFront(sender)
+    @objc func openPreferencesWindow() {
+        if preferencesWindow == nil {
+            preferencesWindow = PreferencesWindowController()
+        }
+        preferencesWindow?.showWindow(nil)
+        preferencesWindow?.window?.makeKeyAndOrderFront(nil)
+        preferencesWindow?.window?.isReleasedWhenClosed = false
     }
 }

--- a/src/gui4/macOS/kDrive/KDriveApp.swift
+++ b/src/gui4/macOS/kDrive/KDriveApp.swift
@@ -21,7 +21,7 @@ import Cocoa
 @main
 struct KDriveApp {
     @MainActor
-    static func main() async {
+    static func main() {
         let delegate = AppDelegate()
         NSApplication.shared.delegate = delegate
 

--- a/src/gui4/macOS/kDrive/UI/Controllers/MainWindow/MainView/MainViewController.swift
+++ b/src/gui4/macOS/kDrive/UI/Controllers/MainWindow/MainView/MainViewController.swift
@@ -215,7 +215,7 @@ extension MainViewController {
         settingsButton.image = KDriveResources.cog.image
         settingsButton.label = KDriveLocalizable.buttonSettings
         settingsButton.target = nil
-        settingsButton.action = #selector(AppDelegate.openPreferencesWindow(_:))
+        settingsButton.action = #selector(AppDelegate.openPreferencesWindow)
 
         let group = NSToolbarItemGroup(itemIdentifier: .syncControlsGroup)
         group.subitems = [pauseResumeButton, settingsButton]


### PR DESCRIPTION
The app crashes if you open, close then re-open the settings window