### PR TITLE
fix(executor): handle parent move operations in complex sequences

### DIFF
--- a/src/libsyncengine/db/dbnode.cpp
+++ b/src/libsyncengine/db/dbnode.cpp
@@ -49,22 +49,6 @@ DbNode::DbNode(std::optional<DbNodeId> parentNodeId, const SyncName &nameLocal, 
     DbNode(0, parentNodeId, nameLocal, nameRemote, nodeIdLocal, nodeIdRemote, created, lastModifiedLocal, lastModifiedRemote,
            type, size, checksum, status, syncing) {}
 
-DbNode::DbNode() :
-    _nodeId(0),
-    _parentNodeId(0),
-    _nameLocal(SyncName()),
-    _nameRemote(SyncName()),
-    _nodeIdLocal(std::string()),
-    _nodeIdRemote(std::string()),
-    _created(0),
-    _lastModifiedLocal(0),
-    _lastModifiedRemote(0),
-    _type(NodeType::Unknown),
-    _size(0),
-    _checksum(std::string()),
-    _status(SyncFileStatus::Unknown),
-    _syncing(false) {}
-
 void DbNode::setNameLocal(const SyncName &name) {
     _nameLocal = name;
 }

--- a/src/libsyncengine/db/dbnode.h
+++ b/src/libsyncengine/db/dbnode.h
@@ -41,7 +41,7 @@ class DbNode {
                const std::optional<std::string> &checksum = std::nullopt, SyncFileStatus status = SyncFileStatus::Unknown,
                bool syncing = false);
 
-        DbNode();
+        DbNode() = default;
         virtual ~DbNode() = default;
 
         inline DbNodeId nodeId() const { return _nodeId; }
@@ -96,7 +96,7 @@ class DbNode {
         }
 
     protected:
-        DbNodeId _nodeId;
+        DbNodeId _nodeId{0};
         std::optional<DbNodeId> _parentNodeId;
         SyncName _nameLocal; // /!\ Must be in NFC form
         SyncName _nameRemote; // /!\ Must be in NFC form
@@ -105,11 +105,11 @@ class DbNode {
         std::optional<SyncTime> _created;
         std::optional<SyncTime> _lastModifiedLocal;
         std::optional<SyncTime> _lastModifiedRemote;
-        NodeType _type;
-        int64_t _size;
+        NodeType _type{NodeType::Unknown};
+        int64_t _size{0};
         std::optional<std::string> _checksum;
-        SyncFileStatus _status;
-        bool _syncing;
+        SyncFileStatus _status{SyncFileStatus::Unknown};
+        bool _syncing{false};
 };
 
 } // namespace KDC

--- a/src/libsyncengine/db/syncdb.cpp
+++ b/src/libsyncengine/db/syncdb.cpp
@@ -1728,7 +1728,7 @@ bool SyncDb::lastModified(ReplicaSide side, const NodeId &nodeId, std::optional<
 }
 
 // Returns the parent directory ID of the object with ID nodeId
-bool SyncDb::parent(ReplicaSide side, const NodeId &nodeId, NodeId &parentNodeid, bool &found) {
+bool SyncDb::parentId(ReplicaSide side, const NodeId &nodeId, NodeId &parentNodeid, bool &found) {
     const std::scoped_lock lock(_mutex);
 
     std::string id = (side == ReplicaSide::Local ? SELECT_NODE_BY_NODEIDLOCAL_ID : SELECT_NODE_BY_NODEIDDRIVE_ID);

--- a/src/libsyncengine/db/syncdb.h
+++ b/src/libsyncengine/db/syncdb.h
@@ -61,7 +61,7 @@ class SyncDb : public Db {
         bool size(ReplicaSide side, const NodeId &nodeId, int64_t &size, bool &found);
         bool created(ReplicaSide side, const NodeId &nodeId, std::optional<SyncTime> &time, bool &found);
         bool lastModified(ReplicaSide side, const NodeId &nodeId, std::optional<SyncTime> &time, bool &found);
-        bool parent(ReplicaSide side, const NodeId &nodeId, NodeId &parentNodeid, bool &found);
+        bool parentId(ReplicaSide side, const NodeId &nodeId, NodeId &parentNodeid, bool &found);
         bool path(ReplicaSide side, const NodeId &nodeId, SyncPath &path, bool &found);
         bool name(ReplicaSide side, const NodeId &nodeId, SyncName &name, bool &found);
         bool checksum(ReplicaSide side, const NodeId &nodeId, std::optional<std::string> &cs, bool &found);

--- a/src/libsyncengine/db/syncdbreadonlycache.cpp
+++ b/src/libsyncengine/db/syncdbreadonlycache.cpp
@@ -89,10 +89,10 @@ bool SyncDbReadOnlyCache::reloadIfNeeded() {
     return true;
 }
 
-bool SyncDbReadOnlyCache::parent(ReplicaSide side, const NodeId &nodeId, NodeId &parentNodeId, bool &found) {
+bool SyncDbReadOnlyCache::parentId(ReplicaSide side, const NodeId &nodeId, NodeId &parentNodeId, bool &found) {
     const std::scoped_lock lock(_mutex);
     LOG_IF_FAIL(Log::instance()->getLogger(), _cachedRevision != 0);
-    if (_cachedRevision == 0) return _syncDb.parent(side, nodeId, parentNodeId, found); // Fallback to a call in db.
+    if (_cachedRevision == 0) return _syncDb.parentId(side, nodeId, parentNodeId, found); // Fallback to a call in db.
     if (side == ReplicaSide::Unknown) return false;
 
     found = false;

--- a/src/libsyncengine/db/syncdbreadonlycache.h
+++ b/src/libsyncengine/db/syncdbreadonlycache.h
@@ -32,7 +32,7 @@ class SyncDbReadOnlyCache {
         bool reloadIfNeeded();
         void clear();
         // Getters with replica IDs
-        bool parent(ReplicaSide side, const NodeId &nodeId, NodeId &parentNodeid, bool &found);
+        bool parentId(ReplicaSide side, const NodeId &nodeId, NodeId &parentNodeid, bool &found);
         bool correspondingNodeId(ReplicaSide side, const NodeId &nodeIdIn, NodeId &nodeIdOut, bool &found);
         // Returns database ID for the ID nodeId of the snapshot from replica `side`
         bool dbId(ReplicaSide side, const NodeId &nodeId, DbNodeId &dbNodeId, bool &found);

--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -931,6 +931,33 @@ ExitInfo ExecutorWorker::handleMoveOp(SyncOpPtr syncOp, bool &ignored, bool &byp
     return ExitCode::Ok;
 }
 
+ExitInfo ExecutorWorker::getPathFromDb(const std::shared_ptr<Node> node, SyncPath &path) {
+    bool found = false;
+    if (!_syncPal->syncDb()->path(node->side(), node->id().value(), path, found)) {
+        LOG_SYNCPAL_WARN(_logger, "Error in SyncDb:: path");
+        return ExitCode::DbError;
+    }
+    if (!found) {
+        LOGW_SYNCPAL_WARN(_logger, L"Path not in DB for item ID " << CommonUtility::s2ws(node->id().value()) << L" on side "
+                                                                  << node->side());
+        return {ExitCode::DataError, ExitCause::NotFound};
+    }
+    return ExitCode::Ok;
+}
+
+bool checkIfAnyParentHasMoveOperation(const std::shared_ptr<Node> affectedNode) {
+    bool res = false;
+    auto parentNode = affectedNode->parentNode();
+    while (parentNode) {
+        if (parentNode->hasChangeEvent(OperationType::Move)) {
+            res = true;
+            break;
+        }
+        parentNode = parentNode->parentNode();
+    }
+    return res;
+}
+
 ExitInfo ExecutorWorker::generateMoveJob(SyncOpPtr syncOp, bool &ignored, bool &bypassProgressComplete) {
     bypassProgressComplete = false;
 
@@ -961,10 +988,20 @@ ExitInfo ExecutorWorker::generateMoveJob(SyncOpPtr syncOp, bool &ignored, bool &
             return ExitCode::DataError;
         }
 
-        relativeDestLocalFilePath = parentNode->getPath() / syncOp->newName();
         relativeOriginLocalFilePath = correspondingNode->getPath();
-        absoluteDestLocalFilePath = _syncPal->localPath() / relativeDestLocalFilePath;
         absoluteOriginLocalFilePath = _syncPal->localPath() / relativeOriginLocalFilePath;
+
+        if (checkIfAnyParentHasMoveOperation(syncOp->affectedNode())) {
+            // Get the parent corresponding node
+            SyncPath relativeParentPath;
+            if (const auto exitInfo = getPathFromDb(syncOp->affectedNode()->parentNode(), relativeParentPath); !exitInfo) {
+                return exitInfo;
+            }
+            relativeDestLocalFilePath = relativeParentPath / syncOp->newName();
+        } else {
+            relativeDestLocalFilePath = parentNode->getPath() / syncOp->newName();
+        }
+        absoluteDestLocalFilePath = _syncPal->localPath() / relativeDestLocalFilePath;
 
         job = std::make_shared<LocalMoveJob>(absoluteOriginLocalFilePath, absoluteDestLocalFilePath);
     } else {
@@ -985,12 +1022,24 @@ ExitInfo ExecutorWorker::generateMoveJob(SyncOpPtr syncOp, bool &ignored, bool &
             return ExitCode::DataError;
         }
 
-        relativeDestLocalFilePath = parentNode->getPath() / syncOp->newName();
         relativeOriginLocalFilePath = correspondingNode->getPath();
-        absoluteDestLocalFilePath = _syncPal->localPath() / relativeDestLocalFilePath;
         absoluteOriginLocalFilePath = _syncPal->localPath() / relativeOriginLocalFilePath;
 
-        if (syncOp->isBreakingCycleOp() || relativeOriginLocalFilePath.parent_path() == relativeDestLocalFilePath.parent_path()) {
+        bool bypassCheck = false;
+        if (checkIfAnyParentHasMoveOperation(syncOp->affectedNode())) {
+            // Get the parent corresponding node
+            SyncPath relativeParentPath;
+            if (const auto exitInfo = getPathFromDb(syncOp->affectedNode()->parentNode(), relativeParentPath); !exitInfo) {
+                return exitInfo;
+            }
+            relativeDestLocalFilePath = relativeParentPath / syncOp->newName();
+            bypassCheck = true;
+        } else {
+            relativeDestLocalFilePath = parentNode->getPath() / syncOp->newName();
+        }
+        absoluteDestLocalFilePath = _syncPal->localPath() / relativeDestLocalFilePath;
+
+        if (syncOp->isBreakingCycleOp() || absoluteOriginLocalFilePath.parent_path() == absoluteDestLocalFilePath.parent_path()) {
             // This is just a rename
             try {
                 job = std::make_shared<RenameJob>(_syncPal->vfs(), _syncPal->driveDbId(), correspondingNode->id().value_or(""),

--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -46,7 +46,6 @@
 #include <log4cplus/loggingmacros.h>
 
 namespace KDC {
-
 #define SEND_PROGRESS_DELAY 1 // 1 sec
 #define SNAPSHOT_INVALIDATION_THRESHOLD 100 // Changes
 
@@ -945,6 +944,7 @@ ExitInfo ExecutorWorker::getPathFromDb(const std::shared_ptr<Node> node, SyncPat
     return ExitCode::Ok;
 }
 
+namespace {
 bool checkIfAnyParentHasMoveOperation(const std::shared_ptr<Node> affectedNode) {
     bool res = false;
     auto parentNode = affectedNode->parentNode();
@@ -957,6 +957,7 @@ bool checkIfAnyParentHasMoveOperation(const std::shared_ptr<Node> affectedNode) 
     }
     return res;
 }
+} // namespace
 
 ExitInfo ExecutorWorker::generateMoveJob(SyncOpPtr syncOp, bool &ignored, bool &bypassProgressComplete) {
     bypassProgressComplete = false;

--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -1025,7 +1025,7 @@ ExitInfo ExecutorWorker::generateMoveJob(SyncOpPtr syncOp, bool &ignored, bool &
         relativeOriginLocalFilePath = correspondingNode->getPath();
         absoluteOriginLocalFilePath = _syncPal->localPath() / relativeOriginLocalFilePath;
 
-        bool bypassCheck = false;
+        bool bypassCheck = true;
         if (checkIfAnyParentHasMoveOperation(syncOp->affectedNode())) {
             // Get the parent corresponding node
             SyncPath relativeParentPath;
@@ -1075,7 +1075,7 @@ ExitInfo ExecutorWorker::generateMoveJob(SyncOpPtr syncOp, bool &ignored, bool &
             }
         }
 
-        if (syncOp->hasConflict() || syncOp->isBreakingCycleOp()) {
+        if (syncOp->hasConflict() || syncOp->isBreakingCycleOp() || bypassCheck) {
             job->setBypassCheck(true);
         }
     }

--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -1635,14 +1635,14 @@ ExitInfo ExecutorWorker::propagateCreateToDbAndTree(SyncOpPtr syncOp, const Node
                   syncOp->omit() ? SyncFileStatus::Success : SyncFileStatus::Unknown);
 
     if (ParametersCache::isExtendedLogEnabled()) {
-        LOGW_SYNCPAL_DEBUG(_logger, L"Inserting in DB: " << L" localName=" << Utility::quotedSyncName(localName)
-                                                         << L" / remoteName=" << Utility::quotedSyncName(remoteName)
-                                                         << L" / localId=" << CommonUtility::s2ws(localId) << L" / remoteId="
-                                                         << CommonUtility::s2ws(remoteId) << L" / parent DB ID="
-                                                         << newCorrespondingParentNode->idb().value_or(-1) << L" / createdAt="
-                                                         << newCreationTime.value_or(-1) << L" / lastModTime="
-                                                         << newLastModificationTime.value_or(-1) << L" / type="
-                                                         << syncOp->affectedNode()->type() << L" / size=" << size);
+        LOGW_SYNCPAL_DEBUG(_logger,
+                           L"Inserting in DB: "
+                                   << L" localName=" << Utility::quotedSyncName(localName) << L" / remoteName="
+                                   << Utility::quotedSyncName(remoteName) << L" / DB ID=" << dbNode.nodeId() << L" / localId="
+                                   << CommonUtility::s2ws(localId) << L" / remoteId=" << CommonUtility::s2ws(remoteId)
+                                   << L" / parent DB ID=" << newCorrespondingParentNode->idb().value_or(-1) << L" / createdAt="
+                                   << newCreationTime.value_or(-1) << L" / lastModTime=" << newLastModificationTime.value_or(-1)
+                                   << L" / type=" << syncOp->affectedNode()->type() << L" / size=" << size);
     }
 
     if (dbNode.nameLocal().empty() || dbNode.nameRemote().empty() || !dbNode.nodeIdLocal().has_value() ||
@@ -1655,11 +1655,11 @@ ExitInfo ExecutorWorker::propagateCreateToDbAndTree(SyncOpPtr syncOp, const Node
     DbNodeId newDbNodeId;
     bool constraintError = false;
     if (!_syncPal->syncDb()->insertNode(dbNode, newDbNodeId, constraintError)) {
-        LOGW_SYNCPAL_WARN(_logger, L"Failed to insert node into DB:" << L" local ID: " << CommonUtility::s2ws(localId)
-                                                                     << L", remote ID: " << CommonUtility::s2ws(remoteId)
-                                                                     << L", local name: " << Utility::quotedSyncName(localName)
-                                                                     << L", remote name: " << Utility::quotedSyncName(remoteName)
-                                                                     << L", parent DB ID: "
+        LOGW_SYNCPAL_WARN(_logger, L"Failed to insert node into DB:" << L" DB ID=" << dbNode.nodeId() << L", local ID: "
+                                                                     << CommonUtility::s2ws(localId) << L", remote ID: "
+                                                                     << CommonUtility::s2ws(remoteId) << L", local name: "
+                                                                     << Utility::quotedSyncName(localName) << L", remote name: "
+                                                                     << Utility::quotedSyncName(remoteName) << L", parent DB ID: "
                                                                      << (newCorrespondingParentNode->idb().value_or(-1)));
 
         if (!constraintError) {
@@ -1778,9 +1778,9 @@ ExitInfo ExecutorWorker::propagateEditToDbAndTree(SyncOpPtr syncOp, const NodeId
 
     if (ParametersCache::isExtendedLogEnabled()) {
         LOGW_SYNCPAL_DEBUG(_logger, L"Updating DB: " << L" / localName=" << Utility::quotedSyncName(localName)
-                                                     << L" / remoteName=" << Utility::quotedSyncName(remoteName) << L" / localId="
-                                                     << CommonUtility::s2ws(localId) << L" / remoteId="
-                                                     << CommonUtility::s2ws(remoteId) << L" / parent DB ID="
+                                                     << L" / remoteName=" << Utility::quotedSyncName(remoteName) << L" / DB ID="
+                                                     << dbNode.nodeId() << L" / localId=" << CommonUtility::s2ws(localId)
+                                                     << L" / remoteId=" << CommonUtility::s2ws(remoteId) << L" / parent DB ID="
                                                      << dbNode.parentNodeId().value_or(-1) << L" / createdAt="
                                                      << newCreationTime.value_or(-1) << L" / lastModTime="
                                                      << newLastModificationTime.value_or(-1) << L" / type="
@@ -1788,12 +1788,12 @@ ExitInfo ExecutorWorker::propagateEditToDbAndTree(SyncOpPtr syncOp, const NodeId
     }
 
     if (!_syncPal->syncDb()->updateNode(dbNode, found)) {
-        LOGW_SYNCPAL_WARN(_logger, L"Failed to update node into DB: " << L"local ID: " << CommonUtility::s2ws(localId)
-                                                                      << L", remote ID: " << CommonUtility::s2ws(remoteId)
-                                                                      << L", local name: " << Utility::quotedSyncName(localName)
-                                                                      << L", remote name: " << Utility::quotedSyncName(remoteName)
-                                                                      << L", parent DB ID: "
-                                                                      << dbNode.parentNodeId().value_or(-1));
+        LOGW_SYNCPAL_WARN(_logger, L"Failed to update node into DB: "
+                                           << L" DB ID=" << dbNode.nodeId() << L", local ID: " << CommonUtility::s2ws(localId)
+                                           << L", remote ID: " << CommonUtility::s2ws(remoteId) << L", local name: "
+                                           << Utility::quotedSyncName(localName) << L", remote name: "
+                                           << Utility::quotedSyncName(remoteName) << L", parent DB ID: "
+                                           << dbNode.parentNodeId().value_or(-1));
         return {ExitCode::DbError, ExitCause::DbAccessError};
     }
     if (!found) {
@@ -1871,7 +1871,8 @@ ExitInfo ExecutorWorker::propagateMoveToDbAndTree(SyncOpPtr syncOp) {
     if (ParametersCache::isExtendedLogEnabled()) {
         LOGW_SYNCPAL_DEBUG(_logger, L"Updating DB: " << L" localName=" << Utility::quotedSyncName(syncOp->newName())
                                                      << L" / remoteName=" << Utility::quotedSyncName(syncOp->newName())
-                                                     << L" / localId=" << CommonUtility::s2ws(localId) << L" / remoteId="
+                                                     << L" / DB ID=" << dbNode.nodeId() << L" / localId="
+                                                     << CommonUtility::s2ws(localId) << L" / remoteId="
                                                      << CommonUtility::s2ws(remoteId) << L" / parent DB ID="
                                                      << dbNode.parentNodeId().value_or(-1) << L" / createdAt="
                                                      << syncOp->affectedNode()->createdAt().value_or(-1) << L" / lastModTime="
@@ -1881,8 +1882,8 @@ ExitInfo ExecutorWorker::propagateMoveToDbAndTree(SyncOpPtr syncOp) {
 
     if (!_syncPal->syncDb()->updateNode(dbNode, found)) {
         LOGW_SYNCPAL_WARN(_logger, L"Failed to update node into DB: "
-                                           << L"local ID: " << CommonUtility::s2ws(localId) << L", remote ID: "
-                                           << CommonUtility::s2ws(remoteId) << L", local name: "
+                                           << L" DB ID=" << dbNode.nodeId() << L", local ID: " << CommonUtility::s2ws(localId)
+                                           << L", remote ID: " << CommonUtility::s2ws(remoteId) << L", local name: "
                                            << Utility::quotedSyncName(syncOp->newName()) << L", remote name: "
                                            << Utility::quotedSyncName(syncOp->newName()) << L", parent DB ID: "
                                            << dbNode.parentNodeId().value_or(-1));
@@ -1946,7 +1947,8 @@ ExitInfo ExecutorWorker::deleteFromDb(std::shared_ptr<Node> node) {
     }
 
     if (ParametersCache::isExtendedLogEnabled()) {
-        LOGW_SYNCPAL_DEBUG(_logger, L"Item \"" << Utility::formatSyncName(node->name()) << L"\" removed from DB");
+        LOGW_SYNCPAL_DEBUG(_logger, L"Item " << Utility::formatSyncName(node->name()) << L" (DB ID=" << *node->idb()
+                                             << L") removed from DB");
     }
 
     return ExitCode::Ok;

--- a/src/libsyncengine/propagation/executor/executorworker.h
+++ b/src/libsyncengine/propagation/executor/executorworker.h
@@ -91,6 +91,7 @@ class ExecutorWorker : public OperationProcessor {
 
         ExitInfo handleMoveOp(SyncOpPtr syncOp, bool &ignored, bool &bypassProgressComplete);
         ExitInfo generateMoveJob(SyncOpPtr syncOp, bool &ignored, bool &bypassProgressComplete);
+        ExitInfo getPathFromDb(const std::shared_ptr<Node> node, SyncPath &dbPath);
 
         ExitInfo handleDeleteOp(SyncOpPtr syncOp, bool &ignored, bool &bypassProgressComplete);
         ExitInfo generateDeleteJob(SyncOpPtr syncOp, bool &ignored, bool &bypassProgressComplete);

--- a/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
@@ -340,16 +340,17 @@ ExitCode ComputeFSOperationWorker::inferChangeFromDbNode(const ReplicaSide side,
                     return ExitCode::Ok;
                 }
 
-                if (!_fixImpossibleMove.isActive) {
-                    opSet->clear(); // Ignore all other operations for now
-                    _fixImpossibleMove = {.side = side, .parentNodeId = parentNodeId, .isActive = true};
-                    LOGW_SYNCPAL_DEBUG(_logger, L"Impossible operation sequence detected. Propagating only move operation inside "
-                                                        << Utility::formatSyncPath(parentDbPath));
-                }
-                if (_fixImpossibleMove.parentNodeId == parentNodeId) {
-                    // Fix only move operations whose direct parent is _fixImpossibleMove.parentNodeId
-                    fixingMoveOp = true;
-                }
+                // if (!_fixImpossibleMove.isActive) {
+                //     opSet->clear(); // Ignore all other operations for now
+                //     _fixImpossibleMove = {.side = side, .parentNodeId = parentNodeId, .isActive = true};
+                //     LOGW_SYNCPAL_DEBUG(_logger, L"Impossible operation sequence detected. Propagating only move operation
+                //     inside "
+                //                                         << Utility::formatSyncPath(parentDbPath));
+                // }
+                // if (_fixImpossibleMove.parentNodeId == parentNodeId) {
+                //     // Fix only move operations whose direct parent is _fixImpossibleMove.parentNodeId
+                //     fixingMoveOp = true;
+                // }
 
                 destinationPath = parentDbPath / snapshotName;
             }

--- a/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
@@ -332,17 +332,22 @@ ExitCode ComputeFSOperationWorker::inferChangeFromDbNode(const ReplicaSide side,
                     return ExitCode::DbError;
                 }
                 if (!found) {
-                    LOG_SYNCPAL_DEBUG(_logger, "Failed to retrieve node parent path for node ID=" << nodeId);
-                    setExitCause(ExitCause::DbEntryNotFound);
-                    return ExitCode::DataError;
+                    // The parent does not exist yet, ignore this move operation for now
+                    // LOG_SYNCPAL_DEBUG(_logger, "Failed to retrieve node parent path for node ID=" << nodeId);
+                    // setExitCause(ExitCause::DbEntryNotFound);
+                    // return ExitCode::DataError;
+                    LOG_SYNCPAL_DEBUG(_logger, "Ignoring move operation for now");
+                    return ExitCode::Ok;
                 }
 
                 if (!_fixImpossibleMove.isActive) {
                     opSet->clear(); // Ignore all other operations for now
                     _fixImpossibleMove = {.side = side, .parentNodeId = parentNodeId, .isActive = true};
+                    LOGW_SYNCPAL_DEBUG(_logger, L"Impossible operation sequence detected. Propagating only move operation inside "
+                                                        << Utility::formatSyncPath(parentDbPath));
                 }
                 if (_fixImpossibleMove.parentNodeId == parentNodeId) {
-                    // Fix only move operations whose parent is _fixImpossibleMove.parentNodeId
+                    // Fix only move operations whose direct parent is _fixImpossibleMove.parentNodeId
                     fixingMoveOp = true;
                 }
 

--- a/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
@@ -163,13 +163,13 @@ ExitCode ComputeFSOperationWorker::inferChangeFromDbNode(const ReplicaSide side,
 
     NodeId parentNodeid;
     bool parentNodeIsFoundInDb = false;
-    if (!_syncDbReadOnlyCache.parent(side, nodeId, parentNodeid, parentNodeIsFoundInDb)) {
-        LOG_SYNCPAL_WARN(_logger, "Error in SyncDb::parent");
+    if (!_syncDbReadOnlyCache.parentId(side, nodeId, parentNodeid, parentNodeIsFoundInDb)) {
+        LOG_SYNCPAL_WARN(_logger, "Error in SyncDb::parentId");
         setExitCause(ExitCause::DbAccessError);
         return ExitCode::DbError;
     }
     if (!parentNodeIsFoundInDb) {
-        LOG_SYNCPAL_DEBUG(_logger, "Failed to retrieve node for dbId=" << nodeId);
+        LOG_SYNCPAL_DEBUG(_logger, "Failed to retrieve node parent ID for node ID=" << nodeId);
         setExitCause(ExitCause::DbEntryNotFound);
         return ExitCode::DataError;
     }
@@ -313,8 +313,27 @@ ExitCode ComputeFSOperationWorker::inferChangeFromDbNode(const ReplicaSide side,
                                                  snapshotModificationTime, snapshot->size(nodeId), dbPath);
         } else {
             // Move operation
+            auto destinationPath = snapshotPath;
+            if (dbPath == snapshotPath) {
+                // The parents are different but the path is the same (new parent has been renamed with the name of a deleted
+                // folder)
+                SyncPath parentDbPath;
+                bool found = false;
+                if (!_syncDbReadOnlyCache.path(side, snapshot->parentId(nodeId), parentDbPath, found)) {
+                    LOG_SYNCPAL_WARN(_logger, "Error in SyncDb::parentDbPath");
+                    setExitCause(ExitCause::DbAccessError);
+                    return ExitCode::DbError;
+                }
+                if (!found) {
+                    LOG_SYNCPAL_DEBUG(_logger, "Failed to retrieve node parent path for node ID=" << nodeId);
+                    setExitCause(ExitCause::DbEntryNotFound);
+                    return ExitCode::DataError;
+                }
+
+                destinationPath = parentDbPath / snapshotName;
+            }
             fsOp = std::make_shared<FSOperation>(OperationType::Move, nodeId, dbNode.type(), snapshot->createdAt(nodeId),
-                                                 snapshotModificationTime, snapshot->size(nodeId), dbPath, snapshotPath);
+                                                 snapshotModificationTime, snapshot->size(nodeId), dbPath, destinationPath);
         }
 
         opSet->insertOp(fsOp);
@@ -357,7 +376,6 @@ ExitCode ComputeFSOperationWorker::inferChangesFromDb(const NodeType nodeType, N
             nodesIdsIt = remainingNodesIds.erase(nodesIdsIt);
             continue;
         }
-
 
         if (dbNode.type() != nodeType) {
             ++nodesIdsIt;
@@ -648,7 +666,7 @@ bool ComputeFSOperationWorker::isInUnsyncedListParentSearchInDb(const NodeId &no
             return true;
         }
 
-        if (!_syncDbReadOnlyCache.parent(side, tmpNodeId, tmpNodeId, found)) {
+        if (!_syncDbReadOnlyCache.parentId(side, tmpNodeId, tmpNodeId, found)) {
             LOG_WARN(_logger, "Error in SyncDb::parent");
             break;
         }

--- a/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
@@ -60,7 +60,6 @@ void ComputeFSOperationWorker::postponeOperationsOnReusedIds() {
 
 void ComputeFSOperationWorker::execute() {
     ExitCode exitCode(ExitCode::Unknown);
-    _fixImpossibleMove = {};
 
     LOG_SYNCPAL_DEBUG(_logger, "Worker started: name=" << name());
     auto start = std::chrono::steady_clock::now();
@@ -101,13 +100,13 @@ void ComputeFSOperationWorker::execute() {
         ok = exitCode == ExitCode::Ok;
         if (ok) perfMonitor.stop();
     }
-    if (ok && !stopAsked() && !_fixImpossibleMove.isActive) {
+    if (ok && !stopAsked()) {
         sentry::pTraces::scoped::ExploreLocalSnapshot perfMonitor(syncDbId());
         exitCode = exploreSnapshotTree(ReplicaSide::Local, localIdsSet);
         ok = exitCode == ExitCode::Ok;
         if (ok) perfMonitor.stop();
     }
-    if (ok && !stopAsked() && !_fixImpossibleMove.isActive) {
+    if (ok && !stopAsked()) {
         sentry::pTraces::scoped::ExploreRemoteSnapshot perfMonitor(syncDbId());
         exitCode = exploreSnapshotTree(ReplicaSide::Remote, remoteIdsSet);
         ok = exitCode == ExitCode::Ok;
@@ -248,20 +247,18 @@ ExitCode ComputeFSOperationWorker::inferChangeFromDbNode(const ReplicaSide side,
         if (checkTemplate && ExclusionTemplateCache::instance()->isExcluded(dbPath)) return ExitCode::Ok;
 
         // Delete operation
-        if (!_fixImpossibleMove.isActive) {
-            const auto fsOp = std::make_shared<FSOperation>(OperationType::Delete, nodeId, dbNode.type(),
-                                                            dbNode.created().has_value() ? dbNode.created().value() : 0,
-                                                            dbModificationTime, dbNode.size(), dbPath);
-            opSet->insertOp(fsOp);
-            logOperationGeneration(snapshot->side(), fsOp);
+        const auto fsOp = std::make_shared<FSOperation>(OperationType::Delete, nodeId, dbNode.type(),
+                                                        dbNode.created().has_value() ? dbNode.created().value() : 0,
+                                                        dbModificationTime, dbNode.size(), dbPath);
+        opSet->insertOp(fsOp);
+        logOperationGeneration(snapshot->side(), fsOp);
 
-            if (nodeIdReused) (void) _localReusedIds.insert(nodeId);
+        if (nodeIdReused) (void) _localReusedIds.insert(nodeId);
 
-            if (dbNode.type() == NodeType::Directory && !addFolderToDelete(dbPath)) {
-                LOGW_SYNCPAL_WARN(_logger,
-                                  L"Error in ComputeFSOperationWorker::addFolderToDelete: " << Utility::formatSyncPath(dbPath));
-                return ExitCode::SystemError;
-            }
+        if (dbNode.type() == NodeType::Directory && !addFolderToDelete(dbPath)) {
+            LOGW_SYNCPAL_WARN(_logger,
+                              L"Error in ComputeFSOperationWorker::addFolderToDelete: " << Utility::formatSyncPath(dbPath));
+            return ExitCode::SystemError;
         }
         return ExitCode::Ok;
     }
@@ -300,18 +297,14 @@ ExitCode ComputeFSOperationWorker::inferChangeFromDbNode(const ReplicaSide side,
     if (dbNode.type() == NodeType::File &&
         (modifiedTimeDiffIsEnough || !sameSize || (snapshotCreatedAt != dbCreatedAt && side == ReplicaSide::Local))) {
         // Edit operation
-        if (!_fixImpossibleMove.isActive) {
-            const auto fsOp =
-                    std::make_shared<FSOperation>(OperationType::Edit, nodeId, NodeType::File, snapshot->createdAt(nodeId),
-                                                  snapshotModificationTime, snapshot->size(nodeId), snapshotPath);
-            opSet->insertOp(fsOp);
-            logOperationGeneration(snapshot->side(), fsOp);
-        }
+        const auto fsOp = std::make_shared<FSOperation>(OperationType::Edit, nodeId, NodeType::File, snapshot->createdAt(nodeId),
+                                                        snapshotModificationTime, snapshot->size(nodeId), snapshotPath);
+        opSet->insertOp(fsOp);
+        logOperationGeneration(snapshot->side(), fsOp);
     }
 
     // Detect MOVE
     if (const auto snapshotName = snapshot->name(nodeId); dbName != snapshotName || parentNodeid != snapshot->parentId(nodeId)) {
-        bool fixingMoveOp = false;
         FSOpPtr fsOp = nullptr;
         if (isInUnsyncedListParentSearchInSnapshot(snapshot, nodeId, side)) {
             // Delete operation
@@ -333,24 +326,9 @@ ExitCode ComputeFSOperationWorker::inferChangeFromDbNode(const ReplicaSide side,
                 }
                 if (!found) {
                     // The parent does not exist yet, ignore this move operation for now
-                    // LOG_SYNCPAL_DEBUG(_logger, "Failed to retrieve node parent path for node ID=" << nodeId);
-                    // setExitCause(ExitCause::DbEntryNotFound);
-                    // return ExitCode::DataError;
-                    LOG_SYNCPAL_DEBUG(_logger, "Ignoring move operation for now");
+                    LOGW_SYNCPAL_DEBUG(_logger, L"Ignoring move operation for now : " << Utility::formatSyncPath(snapshotPath));
                     return ExitCode::Ok;
                 }
-
-                // if (!_fixImpossibleMove.isActive) {
-                //     opSet->clear(); // Ignore all other operations for now
-                //     _fixImpossibleMove = {.side = side, .parentNodeId = parentNodeId, .isActive = true};
-                //     LOGW_SYNCPAL_DEBUG(_logger, L"Impossible operation sequence detected. Propagating only move operation
-                //     inside "
-                //                                         << Utility::formatSyncPath(parentDbPath));
-                // }
-                // if (_fixImpossibleMove.parentNodeId == parentNodeId) {
-                //     // Fix only move operations whose direct parent is _fixImpossibleMove.parentNodeId
-                //     fixingMoveOp = true;
-                // }
 
                 destinationPath = parentDbPath / snapshotName;
             }
@@ -358,10 +336,8 @@ ExitCode ComputeFSOperationWorker::inferChangeFromDbNode(const ReplicaSide side,
                                                  snapshotModificationTime, snapshot->size(nodeId), dbPath, destinationPath);
         }
 
-        if (!_fixImpossibleMove.isActive || fixingMoveOp) {
-            opSet->insertOp(fsOp);
-            logOperationGeneration(snapshot->side(), fsOp);
-        }
+        opSet->insertOp(fsOp);
+        logOperationGeneration(snapshot->side(), fsOp);
     }
 
     return ExitCode::Ok;

--- a/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
@@ -160,9 +160,9 @@ ExitCode ComputeFSOperationWorker::inferChangeFromDbNode(const ReplicaSide side,
     const auto snapshot = _syncPal->snapshot(side);
     const auto opSet = _syncPal->operationSet(side);
 
-    NodeId parentNodeid;
+    NodeId parentNodeId;
     bool parentNodeIsFoundInDb = false;
-    if (!_syncDbReadOnlyCache.parentId(side, nodeId, parentNodeid, parentNodeIsFoundInDb)) {
+    if (!_syncDbReadOnlyCache.parentId(side, nodeId, parentNodeId, parentNodeIsFoundInDb)) {
         LOG_SYNCPAL_WARN(_logger, "Error in SyncDb::parentId");
         setExitCause(ExitCause::DbAccessError);
         return ExitCode::DbError;
@@ -186,7 +186,7 @@ ExitCode ComputeFSOperationWorker::inferChangeFromDbNode(const ReplicaSide side,
         // In case of a move inside an excluded folder, the item must be removed in this sync
         if (isInUnsyncedListParentSearchInDb(nodeId, ReplicaSide::Remote)) {
             remoteItemUnsynced = true;
-            if (nodeExistsInSnapshot && parentNodeid != snapshot->parentId(nodeId)) {
+            if (nodeExistsInSnapshot && parentNodeId != snapshot->parentId(nodeId)) {
                 movedIntoUnsyncedFolder = true;
             }
         }
@@ -304,7 +304,7 @@ ExitCode ComputeFSOperationWorker::inferChangeFromDbNode(const ReplicaSide side,
     }
 
     // Detect MOVE
-    if (const auto snapshotName = snapshot->name(nodeId); dbName != snapshotName || parentNodeid != snapshot->parentId(nodeId)) {
+    if (const auto snapshotName = snapshot->name(nodeId); dbName != snapshotName || parentNodeId != snapshot->parentId(nodeId)) {
         FSOpPtr fsOp = nullptr;
         if (isInUnsyncedListParentSearchInSnapshot(snapshot, nodeId, side)) {
             // Delete operation
@@ -313,25 +313,11 @@ ExitCode ComputeFSOperationWorker::inferChangeFromDbNode(const ReplicaSide side,
         } else {
             // Move operation
             auto destinationPath = snapshotPath;
-            if (dbPath == snapshotPath) {
-                // The parents are different but the path is the same (new parent has been renamed with the name of a deleted
-                // folder)
-                SyncPath parentDbPath;
-                bool found = false;
-                const auto parentNodeId = snapshot->parentId(nodeId);
-                if (!_syncDbReadOnlyCache.path(side, parentNodeId, parentDbPath, found)) {
-                    LOG_SYNCPAL_WARN(_logger, "Error in SyncDb::parentDbPath");
-                    setExitCause(ExitCause::DbAccessError);
-                    return ExitCode::DbError;
-                }
-                if (!found) {
-                    // The parent does not exist yet, ignore this move operation for now
-                    LOGW_SYNCPAL_DEBUG(_logger, L"Ignoring move operation for now : " << Utility::formatSyncPath(snapshotPath));
-                    return ExitCode::Ok;
-                }
-
-                destinationPath = parentDbPath / snapshotName;
+            if (const auto exitInfo = fixDestinationPathIfNeeded(destinationPath, dbPath, snapshot, nodeId, side, snapshotName);
+                !exitInfo) {
+                return exitInfo;
             }
+
             fsOp = std::make_shared<FSOperation>(OperationType::Move, nodeId, dbNode.type(), snapshot->createdAt(nodeId),
                                                  snapshotModificationTime, snapshot->size(nodeId), dbPath, destinationPath);
         }
@@ -340,6 +326,31 @@ ExitCode ComputeFSOperationWorker::inferChangeFromDbNode(const ReplicaSide side,
         logOperationGeneration(snapshot->side(), fsOp);
     }
 
+    return ExitCode::Ok;
+}
+
+ExitInfo ComputeFSOperationWorker::fixDestinationPathIfNeeded(SyncPath &destinationPath, const SyncPath &dbPath,
+                                                              const std::shared_ptr<ConstSnapshot> snapshot, const NodeId &nodeId,
+                                                              const ReplicaSide side, const SyncName &snapshotName) {
+    if (dbPath == destinationPath) {
+        // The parents are different but the path is the same (new parent has been renamed with the name of a deleted folder)
+        SyncPath parentDbPath;
+        bool found = false;
+        if (const auto snapshotParentNodeId = snapshot->parentId(nodeId);
+            !_syncDbReadOnlyCache.path(side, snapshotParentNodeId, parentDbPath, found)) {
+            LOG_SYNCPAL_WARN(_logger, "Error in SyncDb::parentDbPath");
+            setExitCause(ExitCause::DbAccessError);
+            return ExitCode::DbError;
+        }
+        if (!found) {
+            // The parent does not exist yet, ignore this move operation for now
+            LOGW_SYNCPAL_DEBUG(_logger,
+                               L"Ignoring move operation on item " << Utility::formatSyncName(snapshotName) << L" for now");
+            return ExitCode::Ok;
+        }
+
+        destinationPath = parentDbPath / snapshotName;
+    }
     return ExitCode::Ok;
 }
 

--- a/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
@@ -60,6 +60,7 @@ void ComputeFSOperationWorker::postponeOperationsOnReusedIds() {
 
 void ComputeFSOperationWorker::execute() {
     ExitCode exitCode(ExitCode::Unknown);
+    _fixImpossibleMove = {};
 
     LOG_SYNCPAL_DEBUG(_logger, "Worker started: name=" << name());
     auto start = std::chrono::steady_clock::now();
@@ -100,13 +101,13 @@ void ComputeFSOperationWorker::execute() {
         ok = exitCode == ExitCode::Ok;
         if (ok) perfMonitor.stop();
     }
-    if (ok && !stopAsked()) {
+    if (ok && !stopAsked() && !_fixImpossibleMove.isActive) {
         sentry::pTraces::scoped::ExploreLocalSnapshot perfMonitor(syncDbId());
         exitCode = exploreSnapshotTree(ReplicaSide::Local, localIdsSet);
         ok = exitCode == ExitCode::Ok;
         if (ok) perfMonitor.stop();
     }
-    if (ok && !stopAsked()) {
+    if (ok && !stopAsked() && !_fixImpossibleMove.isActive) {
         sentry::pTraces::scoped::ExploreRemoteSnapshot perfMonitor(syncDbId());
         exitCode = exploreSnapshotTree(ReplicaSide::Remote, remoteIdsSet);
         ok = exitCode == ExitCode::Ok;
@@ -120,7 +121,6 @@ void ComputeFSOperationWorker::execute() {
         _syncPal->operationSet(ReplicaSide::Local)->clear();
         _syncPal->operationSet(ReplicaSide::Remote)->clear();
         LOG_SYNCPAL_INFO(_logger, "FS operation aborted after: " << elapsedSeconds.count() << "s");
-
     } else {
         /* If the current snapshot state does not reveal any operation, we store the current revision number.
          * On the next call to compute filesystem operations, only items from the snapshot that were modified in a higher
@@ -248,18 +248,20 @@ ExitCode ComputeFSOperationWorker::inferChangeFromDbNode(const ReplicaSide side,
         if (checkTemplate && ExclusionTemplateCache::instance()->isExcluded(dbPath)) return ExitCode::Ok;
 
         // Delete operation
-        const auto fsOp = std::make_shared<FSOperation>(OperationType::Delete, nodeId, dbNode.type(),
-                                                        dbNode.created().has_value() ? dbNode.created().value() : 0,
-                                                        dbModificationTime, dbNode.size(), dbPath);
-        opSet->insertOp(fsOp);
-        logOperationGeneration(snapshot->side(), fsOp);
+        if (!_fixImpossibleMove.isActive) {
+            const auto fsOp = std::make_shared<FSOperation>(OperationType::Delete, nodeId, dbNode.type(),
+                                                            dbNode.created().has_value() ? dbNode.created().value() : 0,
+                                                            dbModificationTime, dbNode.size(), dbPath);
+            opSet->insertOp(fsOp);
+            logOperationGeneration(snapshot->side(), fsOp);
 
-        if (nodeIdReused) (void) _localReusedIds.insert(nodeId);
+            if (nodeIdReused) (void) _localReusedIds.insert(nodeId);
 
-        if (dbNode.type() == NodeType::Directory && !addFolderToDelete(dbPath)) {
-            LOGW_SYNCPAL_WARN(_logger,
-                              L"Error in ComputeFSOperationWorker::addFolderToDelete: " << Utility::formatSyncPath(dbPath));
-            return ExitCode::SystemError;
+            if (dbNode.type() == NodeType::Directory && !addFolderToDelete(dbPath)) {
+                LOGW_SYNCPAL_WARN(_logger,
+                                  L"Error in ComputeFSOperationWorker::addFolderToDelete: " << Utility::formatSyncPath(dbPath));
+                return ExitCode::SystemError;
+            }
         }
         return ExitCode::Ok;
     }
@@ -298,14 +300,18 @@ ExitCode ComputeFSOperationWorker::inferChangeFromDbNode(const ReplicaSide side,
     if (dbNode.type() == NodeType::File &&
         (modifiedTimeDiffIsEnough || !sameSize || (snapshotCreatedAt != dbCreatedAt && side == ReplicaSide::Local))) {
         // Edit operation
-        const auto fsOp = std::make_shared<FSOperation>(OperationType::Edit, nodeId, NodeType::File, snapshot->createdAt(nodeId),
-                                                        snapshotModificationTime, snapshot->size(nodeId), snapshotPath);
-        opSet->insertOp(fsOp);
-        logOperationGeneration(snapshot->side(), fsOp);
+        if (!_fixImpossibleMove.isActive) {
+            const auto fsOp =
+                    std::make_shared<FSOperation>(OperationType::Edit, nodeId, NodeType::File, snapshot->createdAt(nodeId),
+                                                  snapshotModificationTime, snapshot->size(nodeId), snapshotPath);
+            opSet->insertOp(fsOp);
+            logOperationGeneration(snapshot->side(), fsOp);
+        }
     }
 
     // Detect MOVE
     if (const auto snapshotName = snapshot->name(nodeId); dbName != snapshotName || parentNodeid != snapshot->parentId(nodeId)) {
+        bool fixingMoveOp = false;
         FSOpPtr fsOp = nullptr;
         if (isInUnsyncedListParentSearchInSnapshot(snapshot, nodeId, side)) {
             // Delete operation
@@ -319,7 +325,8 @@ ExitCode ComputeFSOperationWorker::inferChangeFromDbNode(const ReplicaSide side,
                 // folder)
                 SyncPath parentDbPath;
                 bool found = false;
-                if (!_syncDbReadOnlyCache.path(side, snapshot->parentId(nodeId), parentDbPath, found)) {
+                const auto parentNodeId = snapshot->parentId(nodeId);
+                if (!_syncDbReadOnlyCache.path(side, parentNodeId, parentDbPath, found)) {
                     LOG_SYNCPAL_WARN(_logger, "Error in SyncDb::parentDbPath");
                     setExitCause(ExitCause::DbAccessError);
                     return ExitCode::DbError;
@@ -330,14 +337,25 @@ ExitCode ComputeFSOperationWorker::inferChangeFromDbNode(const ReplicaSide side,
                     return ExitCode::DataError;
                 }
 
+                if (!_fixImpossibleMove.isActive) {
+                    opSet->clear(); // Ignore all other operations for now
+                    _fixImpossibleMove = {.side = side, .parentNodeId = parentNodeId, .isActive = true};
+                }
+                if (_fixImpossibleMove.parentNodeId == parentNodeId) {
+                    // Fix only move operations whose parent is _fixImpossibleMove.parentNodeId
+                    fixingMoveOp = true;
+                }
+
                 destinationPath = parentDbPath / snapshotName;
             }
             fsOp = std::make_shared<FSOperation>(OperationType::Move, nodeId, dbNode.type(), snapshot->createdAt(nodeId),
                                                  snapshotModificationTime, snapshot->size(nodeId), dbPath, destinationPath);
         }
 
-        opSet->insertOp(fsOp);
-        logOperationGeneration(snapshot->side(), fsOp);
+        if (!_fixImpossibleMove.isActive || fixingMoveOp) {
+            opSet->insertOp(fsOp);
+            logOperationGeneration(snapshot->side(), fsOp);
+        }
     }
 
     return ExitCode::Ok;

--- a/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.h
+++ b/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.h
@@ -56,6 +56,9 @@ class ComputeFSOperationWorker : public ISyncWorker {
                                     NodeIdsSet &remainingNodesIds); // Restrict change detection to a node type.
         ExitCode inferChangeFromDbNode(const ReplicaSide side, const DbNode &dbNode, const SyncPath &localDbPath,
                                        const SyncPath &remoteDbPath); // Detect change for a single node on a specific side.
+        ExitInfo fixDestinationPathIfNeeded(SyncPath &destinationPath, const SyncPath &dbPath,
+                                            const std::shared_ptr<ConstSnapshot> snapshot, const NodeId &nodeId,
+                                            const ReplicaSide side, const SyncName &snapshotName);
 
         // Detect changes based on the snapshot records: create operations
         ExitCode exploreSnapshotTree(ReplicaSide side, const NodeSet &idsSet);

--- a/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.h
+++ b/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.h
@@ -25,6 +25,12 @@
 
 namespace KDC {
 
+struct FixImpossibleMove {
+        ReplicaSide side{ReplicaSide::Unknown};
+        NodeId parentNodeId;
+        bool isActive{false};
+};
+
 class ComputeFSOperationWorker : public ISyncWorker {
     public:
         ComputeFSOperationWorker(std::shared_ptr<SyncPal> syncPal, const std::string &name, const std::string &shortName);
@@ -109,6 +115,7 @@ class ComputeFSOperationWorker : public ISyncWorker {
         NodeIdSet _remoteTmpUnsyncedList;
         NodeIdSet _localTmpUnsyncedList;
         NodeIdSet _localReusedIds;
+        FixImpossibleMove _fixImpossibleMove;
 
         std::unordered_set<SyncPath, PathHashFunction> _dirPathToDeleteSet;
         std::unordered_map<NodeId, SyncPath> _fileSizeMismatchMap; // File size mismatch checks are only enabled when env var:

--- a/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.h
+++ b/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.h
@@ -25,12 +25,6 @@
 
 namespace KDC {
 
-struct FixImpossibleMove {
-        ReplicaSide side{ReplicaSide::Unknown};
-        NodeId parentNodeId;
-        bool isActive{false};
-};
-
 class ComputeFSOperationWorker : public ISyncWorker {
     public:
         ComputeFSOperationWorker(std::shared_ptr<SyncPal> syncPal, const std::string &name, const std::string &shortName);
@@ -115,7 +109,6 @@ class ComputeFSOperationWorker : public ISyncWorker {
         NodeIdSet _remoteTmpUnsyncedList;
         NodeIdSet _localTmpUnsyncedList;
         NodeIdSet _localReusedIds;
-        FixImpossibleMove _fixImpossibleMove;
 
         std::unordered_set<SyncPath, PathHashFunction> _dirPathToDeleteSet;
         std::unordered_map<NodeId, SyncPath> _fileSizeMismatchMap; // File size mismatch checks are only enabled when env var:

--- a/src/libsyncengine/update_detection/file_system_observer/snapshot/livesnapshot.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/snapshot/livesnapshot.cpp
@@ -64,7 +64,7 @@ bool LiveSnapshot::updateItem(const SnapshotItem &newItem) {
         return false;
     }
 
-    // Check if `newItem` already exists with the same path but a different Id
+    // Check if `newItem` already exists with the same path but a different ID
     if (const auto newParent = findItem(newItem.parentId()); newParent) {
         for (const auto &child: newParent->children()) {
             if (child->normalizedName() == newItem.normalizedName() && child->id() != newItem.id()) {

--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
@@ -818,7 +818,7 @@ ExitCode UpdateTreeWorker::step8CompleteUpdateTree() {
         if (_updateTree->nodes().find(newNodeId) == _updateTree->nodes().end()) {
             // create node
             NodeId parentId;
-            if (!_syncDbReadOnlyCache.parent(_side, previousNodeId, parentId, found)) {
+            if (!_syncDbReadOnlyCache.parentId(_side, previousNodeId, parentId, found)) {
                 LOG_SYNCPAL_WARN(_logger, "Error in SyncDb::parent");
                 return ExitCode::DbError;
             }

--- a/test/libsyncengine/db/testsyncdb.cpp
+++ b/test/libsyncengine/db/testsyncdb.cpp
@@ -720,14 +720,14 @@ void TestSyncDb::testNodesTemplate(SyncDb &db, T &testObj) {
     }
     // parent
     NodeId parentNodeidFile3;
-    CPPUNIT_ASSERT(testObj.parent(ReplicaSide::Local, nodeFile3.nodeIdLocal().value(), parentNodeidFile3, found) && found);
+    CPPUNIT_ASSERT(testObj.parentId(ReplicaSide::Local, nodeFile3.nodeIdLocal().value(), parentNodeidFile3, found) && found);
     CPPUNIT_ASSERT(nodeDir1.nodeIdLocal() == parentNodeidFile3);
-    CPPUNIT_ASSERT(testObj.parent(ReplicaSide::Remote, nodeFile3.nodeIdRemote().value(), parentNodeidFile3, found) && found);
+    CPPUNIT_ASSERT(testObj.parentId(ReplicaSide::Remote, nodeFile3.nodeIdRemote().value(), parentNodeidFile3, found) && found);
     CPPUNIT_ASSERT(nodeDir1.nodeIdRemote() == parentNodeidFile3);
     NodeId parentNodeidDir1;
-    CPPUNIT_ASSERT(testObj.parent(ReplicaSide::Local, nodeDir1.nodeIdLocal().value(), parentNodeidDir1, found) && found);
+    CPPUNIT_ASSERT(testObj.parentId(ReplicaSide::Local, nodeDir1.nodeIdLocal().value(), parentNodeidDir1, found) && found);
     CPPUNIT_ASSERT(testObj.rootNode().nodeIdLocal() == parentNodeidDir1);
-    CPPUNIT_ASSERT(testObj.parent(ReplicaSide::Remote, nodeDir1.nodeIdRemote().value(), parentNodeidDir1, found) && found);
+    CPPUNIT_ASSERT(testObj.parentId(ReplicaSide::Remote, nodeDir1.nodeIdRemote().value(), parentNodeidDir1, found) && found);
     CPPUNIT_ASSERT(testObj.rootNode().nodeIdRemote() == parentNodeidDir1);
 
     // path

--- a/test/libsyncengine/integration/testintegration.cpp
+++ b/test/libsyncengine/integration/testintegration.cpp
@@ -169,6 +169,8 @@ void TestIntegration::testAll() {
     testNegativeModificationTime();
     testDeleteAndRecreateBranch();
     testDeleteAndMoveCase();
+    testMoveDeleteRename();
+    testCreateMoveDeleteRename();
     testSymLinkWithTooManySymbolicLevels();
     testDirSymLinkWithTooManySymbolicLevels();
     testSynchronizationOfSymLinks();
@@ -778,6 +780,155 @@ void TestIntegration::testDeleteAndMoveCase() {
     CPPUNIT_ASSERT(_syncPal->updateTree(ReplicaSide::Remote)->exists(nodeIdBBB));
 
     logStep("testDeleteAndMoveCase");
+}
+
+void TestIntegration::initTestMoveDeleteRename(const RemoteTemporaryDirectory &remoteTempDir, NodeId &nodeIdA, NodeId &nodeIdAA,
+                                               NodeId &nodeIdAAA, NodeId &nodeIdB) {
+    // Setup initial situation:
+    // .
+    // ├── A (a)
+    // │   └── AA (aa)
+    // │       └── AAA (aaa)
+    // └── B (b)
+
+    _syncPal->pause(); // We need to pause the sync because the back might take some time to notify all the events.
+
+    {
+        CreateDirJob jobA(nullptr, _driveDbId, remoteTempDir.id(), Str("A"));
+        (void) jobA.runSynchronously();
+        nodeIdA = jobA.nodeId();
+        CreateDirJob jobAA(nullptr, _driveDbId, jobA.nodeId(), Str("AA"));
+        (void) jobAA.runSynchronously();
+        nodeIdAA = jobAA.nodeId();
+        CreateDirJob jobB(nullptr, _driveDbId, remoteTempDir.id(), Str("B"));
+        (void) jobB.runSynchronously();
+        nodeIdB = jobB.nodeId();
+
+        const auto filename = Str("AAA");
+        nodeIdAAA = testhelpers::duplicateRemoteItem(_driveDbId, _testFileRemoteId, filename);
+        testhelpers::moveRemoteItem(_driveDbId, nodeIdAAA, nodeIdAA);
+    }
+    _syncPal->_remoteFSObserverWorker->forceUpdate(); // Make sure that the remote change is detected immediately
+    _syncPal->unpause(); // Synchronize the initial situation
+    waitForSyncToBeIdle(SourceLocation::currentLoc());
+
+    _syncPal->pause();
+}
+
+
+void TestIntegration::testMoveDeleteRename() {
+    waitForSyncToBeIdle(SourceLocation::currentLoc());
+
+    // Test: operations done on remote side
+    {
+        const RemoteTemporaryDirectory tmpRemoteDir(_driveDbId, _remoteSyncDir.id(), "testMoveDeleteRename1");
+        NodeId nodeIdA;
+        NodeId nodeIdAA;
+        NodeId nodeIdAAA;
+        NodeId nodeIdB;
+        initTestMoveDeleteRename(tmpRemoteDir, nodeIdA, nodeIdAA, nodeIdAAA, nodeIdB);
+        // Generate final situation on remote side:
+        // .
+        // └── A (b)
+        //     └── AA (aa)
+        //         └── AAA (aaa)
+
+        // Move aa
+        testhelpers::moveRemoteItem(_driveDbId, nodeIdAA, nodeIdB);
+        // Delete a
+        testhelpers::deleteRemoteItem(_driveDbId, nodeIdA);
+        // Rename b
+        testhelpers::renameRemoteItem(_driveDbId, nodeIdB, Str("A"));
+        _syncPal->unpause();
+        waitForSyncToBeIdle(SourceLocation::currentLoc());
+
+        CPPUNIT_ASSERT(!_syncPal->liveSnapshot(ReplicaSide::Remote).exists(nodeIdA));
+        CPPUNIT_ASSERT(_syncPal->liveSnapshot(ReplicaSide::Remote).exists(nodeIdAA));
+        CPPUNIT_ASSERT(_syncPal->liveSnapshot(ReplicaSide::Remote).exists(nodeIdAAA));
+        CPPUNIT_ASSERT(_syncPal->liveSnapshot(ReplicaSide::Remote).exists(nodeIdB));
+        CPPUNIT_ASSERT(std::filesystem::exists(_syncPal->localPath() / tmpRemoteDir.name() / "A" / "AA" / "AAA"));
+    }
+
+    // Test: operations done on local side
+    {
+        const RemoteTemporaryDirectory tmpRemoteDir(_driveDbId, _remoteSyncDir.id(), "testMoveDeleteRename2");
+        NodeId nodeIdA;
+        NodeId nodeIdAA;
+        NodeId nodeIdAAA;
+        NodeId nodeIdB;
+        initTestMoveDeleteRename(tmpRemoteDir, nodeIdA, nodeIdAA, nodeIdAAA, nodeIdB);
+        // Generate final situation on local side:
+        // .
+        // └── A (b)
+        //     └── AA (aa)
+        //         └── AAA (aaa)
+        // Move aa
+        const auto moveSourcePath = _syncPal->localPath() / tmpRemoteDir.name() / "A" / "AA";
+        const auto moveDestPath = _syncPal->localPath() / tmpRemoteDir.name() / "B" / "AA";
+        (void) LocalMoveJob(moveSourcePath, moveDestPath).runSynchronously();
+        // Delete a
+        const auto deletedPath = _syncPal->localPath() / tmpRemoteDir.name() / "A";
+        (void) GenericLocalDeleteJob(deletedPath, true).runSynchronously();
+        // Rename b
+        const auto renameSourcePath = _syncPal->localPath() / tmpRemoteDir.name() / "B";
+        const auto renameDestPath = _syncPal->localPath() / tmpRemoteDir.name() / "A";
+        (void) LocalMoveJob(renameSourcePath, renameDestPath).runSynchronously();
+
+        _syncPal->unpause();
+        waitForSyncToBeIdle(SourceLocation::currentLoc());
+
+        CPPUNIT_ASSERT(!_syncPal->liveSnapshot(ReplicaSide::Remote).exists(nodeIdA));
+        CPPUNIT_ASSERT(_syncPal->liveSnapshot(ReplicaSide::Remote).exists(nodeIdAA));
+        CPPUNIT_ASSERT(_syncPal->liveSnapshot(ReplicaSide::Remote).exists(nodeIdAAA));
+        CPPUNIT_ASSERT(_syncPal->liveSnapshot(ReplicaSide::Remote).exists(nodeIdB));
+        CPPUNIT_ASSERT(std::filesystem::exists(_syncPal->localPath() / tmpRemoteDir.name() / "A" / "AA" / "AAA"));
+    }
+
+    logStep("testMoveDeleteRename");
+}
+
+void TestIntegration::testCreateMoveDeleteRename() {
+    waitForSyncToBeIdle(SourceLocation::currentLoc());
+
+    // Test: move grand children on remote side
+    const RemoteTemporaryDirectory tmpRemoteDir(_driveDbId, _remoteSyncDir.id(), "testMoveDeleteRename3");
+    NodeId nodeIdA;
+    NodeId nodeIdAA;
+    NodeId nodeIdAAA;
+    NodeId nodeIdB;
+    initTestMoveDeleteRename(tmpRemoteDir, nodeIdA, nodeIdAA, nodeIdAAA, nodeIdB);
+
+    // Generate final situation on remote side:
+    // .
+    // └── A (b)
+    //     └── AA (bb)
+    //         └── AAA (aaa)
+
+    // Create bb
+    NodeId nodeIdBB;
+    CreateDirJob jobBB(nullptr, _driveDbId, nodeIdB, Str("AA"));
+    (void) jobBB.runSynchronously();
+    nodeIdBB = jobBB.nodeId();
+    // Move aaa
+    testhelpers::moveRemoteItem(_driveDbId, nodeIdAAA, nodeIdBB);
+    // Delete a
+    testhelpers::deleteRemoteItem(_driveDbId, nodeIdA);
+    // Rename b
+    testhelpers::renameRemoteItem(_driveDbId, nodeIdB, Str("A"));
+
+    _syncPal->updateTree(ReplicaSide::Remote)->clear();
+    _syncPal->updateTree(ReplicaSide::Local)->clear();
+    _syncPal->unpause();
+    waitForSyncToBeIdle(SourceLocation::currentLoc());
+
+    CPPUNIT_ASSERT(!_syncPal->liveSnapshot(ReplicaSide::Remote).exists(nodeIdA));
+    CPPUNIT_ASSERT(!_syncPal->liveSnapshot(ReplicaSide::Remote).exists(nodeIdAA));
+    CPPUNIT_ASSERT(_syncPal->liveSnapshot(ReplicaSide::Remote).exists(nodeIdAAA));
+    CPPUNIT_ASSERT(_syncPal->liveSnapshot(ReplicaSide::Remote).exists(nodeIdB));
+    CPPUNIT_ASSERT(_syncPal->liveSnapshot(ReplicaSide::Remote).exists(nodeIdBB));
+    CPPUNIT_ASSERT(std::filesystem::exists(_syncPal->localPath() / tmpRemoteDir.name() / "A" / "AA" / "AAA"));
+
+    logStep("testCreateMoveDeleteRename");
 }
 
 void TestIntegration::waitForSyncToBeIdle(

--- a/test/libsyncengine/integration/testintegration.h
+++ b/test/libsyncengine/integration/testintegration.h
@@ -85,6 +85,10 @@ class TestIntegration : public CppUnit::TestFixture, public TestBase {
 
         void testDeleteAndRecreateBranch();
         void testDeleteAndMoveCase();
+        void initTestMoveDeleteRename(const RemoteTemporaryDirectory &remoteTempDir, NodeId &nodeIdA, NodeId &nodeIdAA,
+                                      NodeId &nodeIdAAA, NodeId &nodeIdB);
+        void testMoveDeleteRename();
+        void testCreateMoveDeleteRename();
 
         void testSynchronizationOfSymLinks();
         void testSymLinkWithTooManySymbolicLevels();

--- a/test/test_utility/testhelpers_requests.cpp
+++ b/test/test_utility/testhelpers_requests.cpp
@@ -18,6 +18,8 @@
 
 #include "testhelpers_requests.h"
 
+#include "jobs/network/kDrive_API/renamejob.h"
+
 namespace KDC::testhelpers {
 
 NodeId createRemoteDir(const DriveDbId driveDbId, const NodeId &remoteParentId, const SyncName &name) {
@@ -54,7 +56,14 @@ void moveRemoteItem(const DriveDbId driveDbId, const NodeId &remoteFileId, const
     (void) job.runSynchronously();
 }
 
-NodeId duplicateRemoteItem(const DriveDbId driveDbId, const NodeId &id, const SyncName &newName) {
+void renameRemoteItem(const DriveDbId driveDbId, const NodeId &remoteFileId, const SyncName &name) {
+    RenameJob job(nullptr, driveDbId, remoteFileId, name);
+    job.setBypassCheck(true);
+    (void) job.runSynchronously();
+}
+
+
+NodeId duplicateRemoteItem(const int driveDbId, const NodeId &id, const SyncName &newName) {
     DuplicateJob job(nullptr, driveDbId, id, newName);
     (void) job.runSynchronously();
     return job.nodeId();

--- a/test/test_utility/testhelpers_requests.cpp
+++ b/test/test_utility/testhelpers_requests.cpp
@@ -62,8 +62,7 @@ void renameRemoteItem(const DriveDbId driveDbId, const NodeId &remoteFileId, con
     (void) job.runSynchronously();
 }
 
-
-NodeId duplicateRemoteItem(const int driveDbId, const NodeId &id, const SyncName &newName) {
+NodeId duplicateRemoteItem(const DriveDbId driveDbId, const NodeId &id, const SyncName &newName) {
     DuplicateJob job(nullptr, driveDbId, id, newName);
     (void) job.runSynchronously();
     return job.nodeId();

--- a/test/test_utility/testhelpers_requests.h
+++ b/test/test_utility/testhelpers_requests.h
@@ -38,7 +38,9 @@ void editRemoteFile(const DriveDbId driveDbId, const NodeId &remoteFileId, SyncT
                     SyncTime *modificationTime = nullptr, int64_t *size = nullptr);
 void moveRemoteItem(const DriveDbId driveDbId, const NodeId &remoteFileId, const NodeId &destinationRemoteParentId,
                     const SyncName &name = {});
+void renameRemoteItem(const DriveDbId driveDbId, const NodeId &remoteFileId, const SyncName &name = {});
 NodeId duplicateRemoteItem(const DriveDbId driveDbId, const NodeId &id, const SyncName &newName);
 void deleteRemoteItem(const DriveDbId driveDbId, const NodeId &id);
+SyncPath findLocalFileByNamePrefix(const SyncPath &parentAbsolutePath, const SyncName &namePrefix);
 
 } // namespace KDC::testhelpers


### PR DESCRIPTION
## Summary

Fixes a critical bug where file operations in complex sequences (move-delete-rename and create-move-delete-rename) could lead to incorrect file deletion.

## Problem

When a parent folder is moved/renamed while simultaneously performing operations on its children, the executor was using stale path information from the update tree instead of querying the current database state. This could cause file operations to target wrong paths.

## Solution

1. **ExecutorWorker**: Added `checkIfAnyParentHasMoveOperation()` to detect when a parent has a pending move operation. When detected, paths are retrieved from the database instead of the update tree to ensure correctness.

2. **ComputeFsOperationWorker**: Handle edge case where a parent is renamed with the name of a deleted folder - now ignores the move operation temporarily until parent exists.

3. **Code Quality**: 
   - Renamed `parent()` → `parentId()` for clarity
   - Modernized `DbNode` constructor with default member initializers
   - Enhanced logging with DB IDs for better debugging

## Tests

- Added integration test `testMoveDeleteRename` and `testCreateMoveDeleteRename()` covering the exact failure scenario
- All existing tests pass

## Files Changed

- `src/libsyncengine/propagation/executor/executorworker.cpp/h`
- `src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp`
- `src/libsyncengine/db/dbnode.cpp/h`
- `src/libsyncengine/db/syncdb.cpp/h`
- `src/libsyncengine/db/syncdbreadonlycache.cpp/h`
- Test files

Fixes file deletion bug in complex remote operation sequences.