### PR TITLE
fix(sync): fix sync item removal and add progress callback

### DIFF
--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -1637,8 +1637,8 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
 
                 Func<SyncFileItemInfo, SyncFileItem, bool> shouldBeRemoved = (info, item) =>
                 {
-                    // We never want to remove an item that as sucessfully completed
-                    if (item.Status == SyncFileStatus.Success)
+                    // We never want to remove an item that has successfully completed or is still syncing
+                    if (item.Status == SyncFileStatus.Success || item.Status == SyncFileStatus.Syncing)
                         return false;
 
 

--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -151,11 +151,23 @@ void ExecutorWorker::execute() {
         if (job) {
             job->setAdditionalCallback(std::bind_front(&ExecutorWorker::executorCallback, this));
 
-            const auto progressPercentCallback = [job, this](UniqueId,
-                                                             int progress // %
-                                                 ) {
+            // Use a weak_ptr to avoid a reference cycle:
+            // The job owns the progress callback, and capturing a shared_ptr<SyncJob> inside
+            // the callback would create a cycle (job → callback → job).
+            // This would prevent the job from being destroyed after completion and removal
+            // from the job map, resulting in a memory leak.
+            std::weak_ptr<SyncJob> weakJobPtr = job;
+            const auto progressPercentCallback = [weakJobPtr, this]([[maybe_unused]] UniqueId, int progress /* % */) {
+                auto job = weakJobPtr.lock();
+                if (!job) {
+                    LOG_SYNCPAL_WARN(_logger, "Job no longer exists in progress callback");
+                    return;
+                }
+
                 if (!_syncPal->setProgress(job->affectedFilePath(), progress)) {
-                    LOGW_SYNCPAL_WARN(_logger, L"Error in SyncPal::setProgress: " << Utility::formatSyncPath(job->affectedFilePath()));
+                    LOGW_SYNCPAL_WARN(_logger, L"Error in SyncPal::setProgress: path="
+                                                       << Utility::formatSyncPath(job->affectedFilePath()) << L", progress="
+                                                       << progress << L"%" << L", jobId=" << job->jobId());
                 }
             };
             job->setProgressPercentCallback(progressPercentCallback);

--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -150,6 +150,16 @@ void ExecutorWorker::execute() {
 
         if (job) {
             job->setAdditionalCallback(std::bind_front(&ExecutorWorker::executorCallback, this));
+
+            const auto progressPercentCallback = [job, this](UniqueId,
+                                                             int progress // %
+                                                 ) {
+                if (!_syncPal->setProgress(job->affectedFilePath(), progress)) {
+                    LOGW_SYNCPAL_WARN(_logger, L"Error in SyncPal::setProgress: " << Utility::formatSyncPath(job->affectedFilePath()));
+                }
+            };
+            job->setProgressPercentCallback(progressPercentCallback);
+
             SyncJobManagerSingleton::instance()->queueAsyncJob(job, Poco::Thread::PRIO_NORMAL);
             (void) _ongoingJobs.try_emplace(job->jobId(), job);
             (void) _jobToSyncOpMap.try_emplace(job->jobId(), syncOp);

--- a/src/libsyncengine/syncpal/syncpal.cpp
+++ b/src/libsyncengine/syncpal/syncpal.cpp
@@ -735,9 +735,22 @@ ExitCode SyncPal::addDlDirectJob(const SyncPath &relativePath, const SyncPath &a
     std::function<void(UniqueId)> callback = std::bind_front(&SyncPal::directDownloadCallback, this);
     job->setAdditionalCallback(callback);
 
-    const auto progressPercentCallback = [job, this](UniqueId,
-                                                     int progress // %
+
+    // Use a weak_ptr to avoid a reference cycle:
+    // The job owns the progress callback, and capturing a shared_ptr<SyncJob> inside
+    // the callback would create a cycle (job → callback → job).
+    // This would prevent the job from being destroyed after completion and removal
+    // from the job map, resulting in a memory leak.
+    std::weak_ptr<SyncJob> weakJobPtr = job;
+    const auto progressPercentCallback = [weakJobPtr, this](UniqueId,
+                                                            int progress // %
                                          ) {
+        auto job = weakJobPtr.lock();
+        if (!job) {
+            LOG_SYNCPAL_WARN(_logger, "Job no longer exists in progress callback");
+            return;
+        }
+
         if (!setProgress(job->affectedFilePath(), progress)) {
             LOGW_SYNCPAL_WARN(_logger, L"Error in SyncPal::setProgress: " << Utility::formatSyncPath(job->affectedFilePath()));
         }


### PR DESCRIPTION
Update sync item removal logic to also retain items with Syncing status. Add per-job progress callback in executorworker to update SyncPal and log warnings on failure.