### PR TITLE
feat: Add dutch language

### DIFF
--- a/src/gui/custommessagebox.cpp
+++ b/src/gui/custommessagebox.cpp
@@ -195,13 +195,13 @@ void CustomMessageBox::setIcon() {
 
 QSize CustomMessageBox::sizeHint() const {
     // Get the size hint of all buttons
-    QSize buttonsSizeHint;
+    int buttonsWidthHint = 0;
     for (const auto &child: _buttonsHBox->children()) {
-        if (const auto *const button = qobject_cast<QPushButton *>(child); button) buttonsSizeHint += button->sizeHint();
+        if (const auto *const button = qobject_cast<QPushButton *>(child); button) buttonsWidthHint += button->sizeHint().width();
     }
     const auto labelWidthHint = std::max((_warningLabel ? _warningLabel->width() : 0), (_textLabel ? _textLabel->width() : 0));
-    const auto widthHint = contentsMargins().left() + contentsMargins().right() + 2 * boxHMargin +
-                           std::max(labelWidthHint, buttonsSizeHint.width());
+    const auto widthHint =
+            contentsMargins().left() + contentsMargins().right() + 2 * boxHMargin + std::max(labelWidthHint, buttonsWidthHint);
 
     const auto heightHint = contentsMargins().top() + contentsMargins().bottom() + messageVTMargin + 2 * messageVBMargin +
                             (_warningLabel ? _warningLabel->height() : 0) + (_textLabel ? _textLabel->height() : 0) +

--- a/src/gui/custommessagebox.cpp
+++ b/src/gui/custommessagebox.cpp
@@ -199,12 +199,15 @@ QSize CustomMessageBox::sizeHint() const {
     for (const auto &child: _buttonsHBox->children()) {
         if (const auto *const button = qobject_cast<QPushButton *>(child); button) buttonsSizeHint += button->sizeHint();
     }
-    const auto widthHint = std::max((_warningLabel ? _warningLabel->width() : 0) + (_textLabel ? _textLabel->width() : 0),
-                                    buttonsSizeHint.width());
-    return QSize(contentsMargins().left() + contentsMargins().right() + 2 * boxHMargin + widthHint,
-                 contentsMargins().top() + contentsMargins().bottom() + messageVTMargin + 2 * messageVBMargin +
-                         (_warningLabel ? _warningLabel->height() : 0) + (_textLabel ? _textLabel->height() : 0) +
-                         QPushButton().height());
+    const auto labelWidthHint = std::max((_warningLabel ? _warningLabel->width() : 0), (_textLabel ? _textLabel->width() : 0));
+    const auto widthHint = contentsMargins().left() + contentsMargins().right() + 2 * boxHMargin +
+                           std::max(labelWidthHint, buttonsSizeHint.width());
+
+    const auto heightHint = contentsMargins().top() + contentsMargins().bottom() + messageVTMargin + 2 * messageVBMargin +
+                            (_warningLabel ? _warningLabel->height() : 0) + (_textLabel ? _textLabel->height() : 0) +
+                            QPushButton().height();
+
+    return QSize(widthHint, heightHint);
 }
 
 void CustomMessageBox::showEvent(QShowEvent *event) {

--- a/src/gui/custommessagebox.cpp
+++ b/src/gui/custommessagebox.cpp
@@ -197,9 +197,10 @@ QSize CustomMessageBox::sizeHint() const {
     // Get the size hint of all buttons
     int buttonsWidthHint = 0;
     if (_buttonsHBox) {
-        for (const auto &child: _buttonsHBox->children()) {
-            if (const auto *const button = qobject_cast<QPushButton *>(child); button)
+        for (auto i = 0; i < _buttonsHBox->count(); ++i) {
+            if (const auto *const button = qobject_cast<QPushButton *>(_buttonsHBox->itemAt(i)->widget()); button) {
                 buttonsWidthHint += button->sizeHint().width();
+            }
         }
     }
     const auto labelWidthHint = std::max((_warningLabel ? _warningLabel->width() : 0), (_textLabel ? _textLabel->width() : 0));

--- a/src/gui/custommessagebox.cpp
+++ b/src/gui/custommessagebox.cpp
@@ -196,8 +196,11 @@ void CustomMessageBox::setIcon() {
 QSize CustomMessageBox::sizeHint() const {
     // Get the size hint of all buttons
     int buttonsWidthHint = 0;
-    for (const auto &child: _buttonsHBox->children()) {
-        if (const auto *const button = qobject_cast<QPushButton *>(child); button) buttonsWidthHint += button->sizeHint().width();
+    if (_buttonsHBox) {
+        for (const auto &child: _buttonsHBox->children()) {
+            if (const auto *const button = qobject_cast<QPushButton *>(child); button)
+                buttonsWidthHint += button->sizeHint().width();
+        }
     }
     const auto labelWidthHint = std::max((_warningLabel ? _warningLabel->width() : 0), (_textLabel ? _textLabel->width() : 0));
     const auto widthHint =

--- a/src/gui/custommessagebox.cpp
+++ b/src/gui/custommessagebox.cpp
@@ -195,17 +195,9 @@ void CustomMessageBox::setIcon() {
 
 QSize CustomMessageBox::sizeHint() const {
     // Get the size hint of all buttons
-    int buttonsWidthHint = 0;
-    if (_buttonsHBox) {
-        for (auto i = 0; i < _buttonsHBox->count(); ++i) {
-            if (const auto *const button = qobject_cast<QPushButton *>(_buttonsHBox->itemAt(i)->widget()); button) {
-                buttonsWidthHint += button->sizeHint().width();
-            }
-        }
-    }
     const auto labelWidthHint = std::max((_warningLabel ? _warningLabel->width() : 0), (_textLabel ? _textLabel->width() : 0));
-    const auto widthHint =
-            contentsMargins().left() + contentsMargins().right() + 2 * boxHMargin + std::max(labelWidthHint, buttonsWidthHint);
+    const auto widthHint = contentsMargins().left() + contentsMargins().right() + 2 * boxHMargin +
+                           std::max(labelWidthHint, _buttonsHBox ? _buttonsHBox->sizeHint().width() : 0);
 
     const auto heightHint = contentsMargins().top() + contentsMargins().bottom() + messageVTMargin + 2 * messageVBMargin +
                             (_warningLabel ? _warningLabel->height() : 0) + (_textLabel ? _textLabel->height() : 0) +

--- a/src/gui/custommessagebox.cpp
+++ b/src/gui/custommessagebox.cpp
@@ -197,7 +197,7 @@ QSize CustomMessageBox::sizeHint() const {
     // Get the size hint of all buttons
     QSize buttonsSizeHint;
     for (const auto &child: _buttonsHBox->children()) {
-        if (const auto *button = qobject_cast<QPushButton *>(child); button) buttonsSizeHint += button->sizeHint();
+        if (const auto *const button = qobject_cast<QPushButton *>(child); button) buttonsSizeHint += button->sizeHint();
     }
     const auto widthHint = std::max((_warningLabel ? _warningLabel->width() : 0) + (_textLabel ? _textLabel->width() : 0),
                                     buttonsSizeHint.width());

--- a/src/gui/custommessagebox.cpp
+++ b/src/gui/custommessagebox.cpp
@@ -44,7 +44,6 @@ CustomMessageBox::CustomMessageBox(QMessageBox::Icon icon, const QString &text, 
     _textLabel(nullptr),
     _iconLabel(nullptr),
     _buttonsHBox(nullptr),
-    _iconSize(QSize()),
     _buttonCount(0) {
     QVBoxLayout *mainLayout = this->mainLayout();
 
@@ -195,11 +194,17 @@ void CustomMessageBox::setIcon() {
 }
 
 QSize CustomMessageBox::sizeHint() const {
-    return QSize(
-            contentsMargins().left() + contentsMargins().right() + 2 * boxHMargin + (_warningLabel ? _warningLabel->width() : 0),
-            contentsMargins().top() + contentsMargins().bottom() + messageVTMargin + 2 * messageVBMargin +
-                    (_warningLabel ? _warningLabel->height() : 0) + (_textLabel ? _textLabel->height() : 0) +
-                    QPushButton().height());
+    // Get the size hint of all buttons
+    QSize buttonsSizeHint;
+    for (const auto &child: _buttonsHBox->children()) {
+        if (const auto *button = qobject_cast<QPushButton *>(child); button) buttonsSizeHint += button->sizeHint();
+    }
+    const auto widthHint = std::max((_warningLabel ? _warningLabel->width() : 0) + (_textLabel ? _textLabel->width() : 0),
+                                    buttonsSizeHint.width());
+    return QSize(contentsMargins().left() + contentsMargins().right() + 2 * boxHMargin + widthHint,
+                 contentsMargins().top() + contentsMargins().bottom() + messageVTMargin + 2 * messageVBMargin +
+                         (_warningLabel ? _warningLabel->height() : 0) + (_textLabel ? _textLabel->height() : 0) +
+                         QPushButton().height());
 }
 
 void CustomMessageBox::showEvent(QShowEvent *event) {

--- a/src/gui/guiutility.cpp
+++ b/src/gui/guiutility.cpp
@@ -624,6 +624,8 @@ QLocale GuiUtility::languageToQLocale(Language language) {
             return QLocale::German;
         case Language::Italian:
             return QLocale::Italian;
+        case Language::Dutch:
+            return QLocale::Dutch;
         default:
             return QLocale();
     }

--- a/src/gui/preferenceswidget.cpp
+++ b/src/gui/preferenceswidget.cpp
@@ -61,12 +61,6 @@ static constexpr int textHSpacing = 10;
 static const QString debuggingFolderLink = "debuggingFolderLink";
 static const QString moveToTrashFAQLink = "https://faq.infomaniak.com/2383#desktop";
 
-static const QString englishCode = "en";
-static const QString frenchCode = "fr";
-static const QString germanCode = "de";
-static const QString spanishCode = "es";
-static const QString italianCode = "it";
-
 Q_LOGGING_CATEGORY(lcPreferencesWidget, "gui.preferenceswidget", QtInfoMsg)
 
 PreferencesWidget::PreferencesWidget(std::shared_ptr<ClientGui> gui, QWidget *parent) :
@@ -508,6 +502,7 @@ void PreferencesWidget::retranslateUi() const {
     _languageSelectorComboBox->addItem(tr("German"), toInt(Language::German));
     _languageSelectorComboBox->addItem(tr("Spanish"), toInt(Language::Spanish));
     _languageSelectorComboBox->addItem(tr("Italian"), toInt(Language::Italian));
+    _languageSelectorComboBox->addItem(tr("Dutch"), toInt(Language::Dutch));
     const int languageIndex =
             _languageSelectorComboBox->findData(toInt(ParametersCache::instance()->parametersInfo().language()));
     _languageSelectorComboBox->setCurrentIndex(languageIndex);

--- a/src/libcommon/theme/theme.cpp
+++ b/src/libcommon/theme/theme.cpp
@@ -141,6 +141,7 @@ QString Theme::feedbackUrl(const Language language) const {
             return FEEDBACK_ES_URL;
         case Language::Italian:
             return FEEDBACK_IT_URL;
+        case Language::Dutch:
         default:
             break;
     }

--- a/src/libcommon/utility/cstypes.h
+++ b/src/libcommon/utility/cstypes.h
@@ -180,6 +180,7 @@ enum class Language {
     German,
     Spanish,
     Italian,
+    Dutch,
     EnumEnd
 };
 

--- a/src/libcommon/utility/types.cpp
+++ b/src/libcommon/utility/types.cpp
@@ -537,6 +537,8 @@ std::string toString(const Language e) {
             return "Spanish";
         case Language::Italian:
             return "Italian";
+        case Language::Dutch:
+            return "Dutch";
         default:
             return noConversionStr;
     }

--- a/src/libcommon/utility/utility.cpp
+++ b/src/libcommon/utility/utility.cpp
@@ -799,7 +799,7 @@ bool CommonUtility::languageCodeIsEnglish(const QString &languageCode) {
 }
 
 bool CommonUtility::isSupportedLanguage(const QString &languageCode) {
-    return strToLanguage(languageCode) == Language::Default;
+    return strToLanguage(languageCode) != Language::Default;
 }
 
 Language CommonUtility::strToLanguage(const QString &lang) {

--- a/src/libcommon/utility/utility.cpp
+++ b/src/libcommon/utility/utility.cpp
@@ -96,7 +96,7 @@ const QString CommonUtility::frenchCode = "fr";
 const QString CommonUtility::germanCode = "de";
 const QString CommonUtility::spanishCode = "es";
 const QString CommonUtility::italianCode = "it";
-
+const QString CommonUtility::dutchCode = "nl";
 static std::random_device rd;
 static std::default_random_engine gen(rd());
 
@@ -799,8 +799,25 @@ bool CommonUtility::languageCodeIsEnglish(const QString &languageCode) {
 }
 
 bool CommonUtility::isSupportedLanguage(const QString &languageCode) {
-    static const std::unordered_set<QString> supportedLanguages = {englishCode, frenchCode, germanCode, italianCode, spanishCode};
-    return supportedLanguages.contains(languageCode);
+    return strToLanguage(languageCode) == Language::Default;
+}
+
+Language CommonUtility::strToLanguage(const QString &lang) {
+    if (lang == CommonUtility::englishCode) {
+        return Language::English;
+    } else if (lang == CommonUtility::frenchCode) {
+        return Language::French;
+    } else if (lang == CommonUtility::germanCode) {
+        return Language::German;
+    } else if (lang == CommonUtility::spanishCode) {
+        return Language::Spanish;
+    } else if (lang == CommonUtility::italianCode) {
+        return Language::Italian;
+    } else if (lang == CommonUtility::dutchCode) {
+        return Language::Dutch;
+    }
+
+    return Language::Default;
 }
 
 QString CommonUtility::languageCode(const Language language) {
@@ -819,6 +836,8 @@ QString CommonUtility::languageCode(const Language language) {
             return italianCode;
         case Language::Spanish:
             return spanishCode;
+        case Language::Dutch:
+            return dutchCode;
         case Language::English:
             break;
         case Language::EnumEnd:

--- a/src/libcommon/utility/utility.h
+++ b/src/libcommon/utility/utility.h
@@ -110,6 +110,8 @@ struct COMMON_EXPORT CommonUtility {
         static const QString germanCode;
         static const QString spanishCode;
         static const QString italianCode;
+        static const QString dutchCode;
+        static Language strToLanguage(const QString &lang);
         static QString languageCode(Language language);
         static QStringList languageCodeList(Language enforcedLocale);
         static void setupTranslations(QCoreApplication *app, Language enforcedLocale);

--- a/src/server/migration/migrationparams.cpp
+++ b/src/server/migration/migrationparams.cpp
@@ -96,22 +96,6 @@ MigrationParams::MigrationParams() :
     _logger(Log::instance()->getLogger()),
     _proxyNotSupported(false) {}
 
-Language MigrationParams::strToLanguage(QString lang) {
-    if (lang == "en") {
-        return Language::English;
-    } else if (lang == "fr") {
-        return Language::French;
-    } else if (lang == "de") {
-        return Language::German;
-    } else if (lang == "es") {
-        return Language::Spanish;
-    } else if (lang == "it") {
-        return Language::Italian;
-    } else {
-        return Language::Default;
-    }
-}
-
 LogLevel MigrationParams::intToLogLevel(int log) {
     switch (log) {
         case 0:
@@ -215,7 +199,7 @@ ExitCode MigrationParams::migrateGeneralParams() {
     ParametersCache::instance()->parameters().setMonoIcons(monoIcons);
     ParametersCache::instance()->parameters().setUseLog(automaticLogDir);
     ParametersCache::instance()->parameters().setLogLevel(logLevel);
-    ParametersCache::instance()->parameters().setLanguage(strToLanguage(language));
+    ParametersCache::instance()->parameters().setLanguage(CommonUtility::strToLanguage(language));
     bool purgeOldLogs = false;
     if (deleteOldLogsAfterHours == QString() || deleteOldLogsAfterHours != "-1") {
         purgeOldLogs = true;

--- a/src/server/migration/migrationparams.h
+++ b/src/server/migration/migrationparams.h
@@ -53,7 +53,6 @@ class MigrationParams {
     private:
         ExitCode loadAccount(QSettings &settings);
 
-        Language strToLanguage(QString lang);
         LogLevel intToLogLevel(int log);
         VirtualFileMode modeFromString(const QString &str);
         int extractDriveIdFromUrl(std::string url);

--- a/test/libcommon/utility/testutility.cpp
+++ b/test/libcommon/utility/testutility.cpp
@@ -462,6 +462,7 @@ void TestUtility::testLanguageCode() {
     CPPUNIT_ASSERT_EQUAL(std::string("de"), CommonUtility::languageCode(Language::German).toStdString());
     CPPUNIT_ASSERT_EQUAL(std::string("es"), CommonUtility::languageCode(Language::Spanish).toStdString());
     CPPUNIT_ASSERT_EQUAL(std::string("it"), CommonUtility::languageCode(Language::Italian).toStdString());
+    CPPUNIT_ASSERT_EQUAL(std::string("nl"), CommonUtility::languageCode(Language::Dutch).toStdString());
 
     const auto systemLanguage = QLocale::languageToCode(QLocale::system().language());
     CPPUNIT_ASSERT_EQUAL(systemLanguage.toStdString(), CommonUtility::languageCode(Language::Default).toStdString());
@@ -476,6 +477,7 @@ void TestUtility::testIsSupportedLanguage() {
     CPPUNIT_ASSERT_EQUAL(true, CommonUtility::isSupportedLanguage("de"));
     CPPUNIT_ASSERT_EQUAL(true, CommonUtility::isSupportedLanguage("es"));
     CPPUNIT_ASSERT_EQUAL(true, CommonUtility::isSupportedLanguage("it"));
+    CPPUNIT_ASSERT_EQUAL(true, CommonUtility::isSupportedLanguage("nl"));
     CPPUNIT_ASSERT_EQUAL(false, CommonUtility::isSupportedLanguage("ita"));
     CPPUNIT_ASSERT_EQUAL(false, CommonUtility::isSupportedLanguage("zc"));
     CPPUNIT_ASSERT_EQUAL(false, CommonUtility::isSupportedLanguage(""));

--- a/translations/client_nl.ts
+++ b/translations/client_nl.ts
@@ -1,0 +1,3021 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="nl_NL">
+<context>
+    <name>KDC::AboutDialog</name>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="73"/>
+        <source>About</source>
+        <translation>Over</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="112"/>
+        <source>CLOSE</source>
+        <translation>SLUITEN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="123"/>
+        <source>Version %1. For more information visit &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
+        <translation>Versie %1. Voor meer informatie, bezoek &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="126"/>
+        <source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
+        <translation>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="127"/>
+        <source>Distributed by %1 and licensed under the &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
+        <translation>Gedistribueerd door %1 en gelicentieerd onder de &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 en het %2-logo zijn gedeponeerde handelsmerken van %1.&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="151"/>
+        <location filename="../src/gui/aboutdialog.cpp" line="162"/>
+        <location filename="../src/gui/aboutdialog.cpp" line="171"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Kan map %1 niet openen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="132"/>
+        <source>&lt;p&gt;&lt;small&gt;Built from &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
+        <translation>&lt;p&gt;&lt;small&gt;Gecompileerd vanuit &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git-bronnen&lt;/a&gt; op %2, %3 met Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AbstractFileItemWidget</name>
+    <message>
+        <location filename="../src/gui/abstractfileitemwidget.cpp" line="177"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Kan debugmap %1 niet openen.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AddDriveConfirmationWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55"/>
+        <source>Synchronization will start and you will be able to add files to your %1 folder.</source>
+        <translation>De synchronisatie begint en u kunt bestanden aan uw %1-map toevoegen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99"/>
+        <source>Your kDrive is ready!</source>
+        <translation>Uw kDrive is klaar!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123"/>
+        <source>OPEN FOLDER</source>
+        <translation>LOKALE MAP OPENEN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130"/>
+        <source>PARAMETERS</source>
+        <translation>INSTELLINGEN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138"/>
+        <source>Synchronize another drive</source>
+        <translation>Een andere kDrive synchroniseren</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AddDriveListWidget</name>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="170"/>
+        <source>Cancel</source>
+        <translation>Annuleren</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="177"/>
+        <source>NEXT</source>
+        <translation>VOLGENDE</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="196"/>
+        <source>Select the kDrive you want to synchronize</source>
+        <translation>Selecteer de kDrive die u wilt synchroniseren</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="234"/>
+        <source>Get kDrive for free</source>
+        <translation>Ontvang kDrive gratis</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="244"/>
+        <source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
+        <translation>Sla uw foto's, documenten en e-mails op in Zwitserland bij een onafhankelijk bedrijf dat de privacy respecteert. Meer informatie</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="263"/>
+        <source>Test for free</source>
+        <translation>Gratis testen</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AddDriveLiteSyncWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147"/>
+        <source>Conserve your computer space</source>
+        <translation>Bespaar ruimte op uw computer</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167"/>
+        <source>Decide which files should be available online or locally</source>
+        <translation>Bepaal welke bestanden online of lokaal beschikbaar moeten zijn</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187"/>
+        <source>LATER</source>
+        <translation>LATER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193"/>
+        <source>YES</source>
+        <translation>JA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
+        <source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Lite Sync synchroniseert al uw bestanden zonder de ruimte op uw computer te gebruiken. U kunt door de bestanden in uw kDrive bladeren en ze downloaden wanneer u wilt. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Meer informatie&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207"/>
+        <source>Unable to open link %1.</source>
+        <translation>Kan link %1 niet openen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112"/>
+        <source>Would you like to activate Lite Sync (Beta) ?</source>
+        <translation>Wilt u Lite Sync (Beta) activeren?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114"/>
+        <source>Would you like to activate Lite Sync ?</source>
+        <translation>Wilt u Lite Sync activeren?</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AddDriveLocalFolderWidget</name>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65"/>
+        <source>Location of your %1 kDrive</source>
+        <translation>Locatie van uw %1 kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155"/>
+        <source>Edit folder</source>
+        <translation>Map bewerken</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+        <source>END</source>
+        <translation>VOLTOOIEN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
+        <source>Select folder</source>
+        <translation>Map selecteren</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
+        <source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
+        <translation>De inhoud van de map &lt;b&gt;%1&lt;/b&gt; wordt gesynchroniseerd met uw kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212"/>
+        <source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
+        <translation>U vindt al uw bestanden in deze map wanneer de configuratie voltooid is. U kunt nieuwe bestanden hier naartoe slepen om ze te synchroniseren met uw kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284"/>
+        <source>This folder is not compatible with Lite Sync.&lt;br&gt;
+Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt;
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Deze map is niet compatibel met Lite Sync.&lt;br&gt;
+Selecteer een andere map. Als u doorgaat, wordt Lite Sync uitgeschakeld.&lt;br&gt;
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Meer informatie&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377"/>
+        <source>Unable to open link %1.</source>
+        <translation>Kan link %1 niet openen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+        <source>CONTINUE</source>
+        <translation>DOORGAAN</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AddDriveLoginWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="69"/>
+        <source>Log in from your browser</source>
+        <translation>Log in via uw browser</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="75"/>
+        <source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
+        <translation>Uw browser zou automatisch moeten openen om de verbinding te voltooien. Eenmaal verbonden, keert u automatisch terug naar kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
+        <source>Open the login page</source>
+        <translation>Open de inlogpagina</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="119"/>
+        <source>Token request failed: %1 - %2</source>
+        <translation>Token-aanvraag mislukt: %1 - %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="133"/>
+        <source>Login failed: %1 - %2</source>
+        <translation>Inloggen mislukt: %1 - %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="141"/>
+        <source>Failed to open the login page in your web browser</source>
+        <translation>Kan de inlogpagina niet openen in uw webbrowser</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AddDriveServerFoldersWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129"/>
+        <source>Select kDrive folders to synchronize on your desktop</source>
+        <translation>Selecteer kDrive-mappen om te synchroniseren op uw computer</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174"/>
+        <source>CONTINUE</source>
+        <translation>DOORGAAN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187"/>
+        <source>Space available on your computer : %1</source>
+        <translation>Beschikbare ruimte op uw computer: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206"/>
+        <source>An error occurred while loading the list of subfolders.</source>
+        <translation>Er is een fout opgetreden bij het laden van de lijst met submappen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210"/>
+        <source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>Kan de lijst met submappen niet laden. Uw kDrive is mogelijk in onderhoud.&lt;br&gt;Log in op de &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;webversie&lt;/a&gt; om de status van uw kDrive te controleren, of neem contact op met uw beheerder.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AddDriveWizard</name>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="221"/>
+        <source>Failed to create local folder %1</source>
+        <translation>Kan lokale map %1 niet aanmaken</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="232"/>
+        <source>Failed to create new synchronization</source>
+        <translation>Kan geen nieuwe synchronisatie aanmaken</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="265"/>
+        <source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
+        <translation>De kDrive %1 is al gesynchroniseerd op deze computer. Toch doorgaan?</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AppClient</name>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="100"/>
+        <source>kDrive client is run with bad parameters!</source>
+        <translation>kDrive-client wordt uitgevoerd met ongeldige parameters!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="109"/>
+        <source>kDrive client is already running!</source>
+        <translation>kDrive-client draait al!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="719"/>
+        <source>The user %1 is not connected. Please log in again.</source>
+        <translation>Gebruiker %1 is niet verbonden. Log opnieuw in.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AppServer</name>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="1638"/>
+        <source>Share link copied to clipboard</source>
+        <translation>Deellink gekopieerd naar klembord</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3668"/>
+        <source>%1 and %n other file(s) have been removed.</source>
+        <translation>
+            <numerusform>%1 is verwijderd.</numerusform>
+            <numerusform>%1 en %n andere bestanden zijn verwijderd.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3670"/>
+        <source>%1 has been removed.</source>
+        <comment>%1 names a file.</comment>
+        <translation>%1 is verwijderd.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3675"/>
+        <source>%1 and %n other file(s) have been added.</source>
+        <translation>
+            <numerusform>%1 en %n ander(e) bestand(en) zijn toegevoegd.</numerusform>
+            <numerusform>%1 en %n andere bestanden zijn toegevoegd.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3677"/>
+        <source>%1 has been added.</source>
+        <comment>%1 names a file.</comment>
+        <translation>%1 is toegevoegd.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3682"/>
+        <source>%1 and %n other file(s) have been updated.</source>
+        <translation>
+            <numerusform>%1 is bijgewerkt.</numerusform>
+            <numerusform>%1 en %n andere bestanden zijn bijgewerkt.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3684"/>
+        <source>%1 has been updated.</source>
+        <comment>%1 names a file.</comment>
+        <translation>%1 is bijgewerkt.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3689"/>
+        <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
+        <translation>
+            <numerusform>%1 is verplaatst naar %2.</numerusform>
+            <numerusform>%1 is verplaatst naar %2 en %n andere bestanden zijn verplaatst.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3692"/>
+        <source>%1 has been moved to %2.</source>
+        <translation>%1 is verplaatst naar %2.</translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3700"/>
+        <source>Sync Activity</source>
+        <translation>Synchronisatieactiviteit</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::BaseFolderTreeItemWidget</name>
+    <message>
+        <location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102"/>
+        <source>No subfolders currently on the server.</source>
+        <translation>Geen submappen op de server.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::BetaProgramDialog</name>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="69"/>
+        <source>Quit the beta program</source>
+        <translation>Bètaprogramma verlaten</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="69"/>
+        <source>Join the beta program</source>
+        <translation>Deelnemen aan het bètaprogramma</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="77"/>
+        <source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
+        <translation>Krijg vroeg toegang tot nieuwe versies van de applicatie voordat ze voor het grote publiek worden vrijgegeven, en help mee de applicatie te verbeteren door ons uw opmerkingen te sturen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="87"/>
+        <source>Benefit from application beta updates</source>
+        <translation>Profiteer van bèta-updates van de applicatie</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="91"/>
+        <source>No</source>
+        <translation>Nee</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="92"/>
+        <source>Public beta version</source>
+        <translation>Openbare bètaversie</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="93"/>
+        <source>Internal beta version</source>
+        <translation>Interne bètaversie</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="141"/>
+        <source>I understand</source>
+        <translation>Ik begrijp het</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="147"/>
+        <source>Are you sure you want to leave the beta program?</source>
+        <translation>Weet u zeker dat u het bètaprogramma wilt verlaten?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="161"/>
+        <source>Save</source>
+        <translation>Opslaan</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="167"/>
+        <source>Cancel</source>
+        <translation>Annuleren</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="228"/>
+        <source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
+        <translation>Uw huidige versie van de applicatie is mogelijk te recent, uw keuze wordt effectief wanneer de volgende update beschikbaar is.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="233"/>
+        <source>Beta versions may leave unexpectedly or cause instabilities.</source>
+        <translation>Bètaversies kunnen onverwacht stoppen of instabiliteit veroorzaken.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ClientGui</name>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="189"/>
+        <source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
+        <translation>Kan conflict(en) niet oplossen voor %1 item(s) in synchronisatiemap: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="242"/>
+        <source>Please sign in</source>
+        <translation>Log alstublieft in</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="292"/>
+        <source>Folder %1: %2</source>
+        <translation>Map %1: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="298"/>
+        <source>There are no sync folders configured.</source>
+        <translation>Er zijn geen synchronisatiemappen geconfigureerd.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1422"/>
+        <source>Synthesis</source>
+        <translation>Overzicht</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1423"/>
+        <source>Preferences</source>
+        <translatorcomment>Voorkeuren</translatorcomment>
+        <translation>Voorkeuren</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1424"/>
+        <source>Quit</source>
+        <translation>Afsluiten</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="673"/>
+        <source>Undefined State.</source>
+        <translation>Ongedefinieerde status.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="676"/>
+        <source>Waiting to start syncing.</source>
+        <translation>Wachten om synchronisatie te starten.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="679"/>
+        <source>Sync is running.</source>
+        <translation>Synchronisatie wordt uitgevoerd.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="683"/>
+        <source>Sync was successful, unresolved conflicts.</source>
+        <translation>Synchronisatie gelukt, niet-opgeloste conflicten.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="685"/>
+        <source>Last Sync was successful.</source>
+        <translation>Laatste synchronisatie was succesvol.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="692"/>
+        <source>User Abort.</source>
+        <translation>Afgebroken door gebruiker.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="696"/>
+        <source>Sync is paused.</source>
+        <translation>Synchronisatie is gepauzeerd.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="705"/>
+        <source>%1 (Sync is paused)</source>
+        <translation>%1 (Synchronisatie gepauzeerd)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1257"/>
+        <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+        <translation>Weet u zeker dat u de synchronisaties van het account &lt;i&gt;%1&lt;/i&gt; wilt verwijderen?&lt;br&gt;&lt;b&gt;Opmerking:&lt;/b&gt; Dit zal &lt;b&gt;geen&lt;/b&gt; bestanden verwijderen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1261"/>
+        <source>REMOVE ALL SYNCHRONIZATIONS</source>
+        <translation>ALLE SYNCHRONISATIES VERWIJDEREN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1262"/>
+        <source>CANCEL</source>
+        <translation>ANNULEREN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1590"/>
+        <source>Failed to start synchronizations!</source>
+        <translation>Kan synchronisaties niet starten!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="849"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Kan debugmap %1 niet openen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="116"/>
+        <source>Unable to initialize kDrive client</source>
+        <translation>Kan kDrive-client niet initialiseren</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="255"/>
+        <source>Synchronization is paused</source>
+        <translation>Synchronisatie is gepauzeerd</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ConfirmSynchronizationDialog</name>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="85"/>
+        <source>Summary of your local folder synchronization</source>
+        <translation>Samenvatting van uw lokale mapsynchronisatie</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="94"/>
+        <source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
+        <translation>De inhoud van de map op uw computer wordt gesynchroniseerd met de map van de geselecteerde kDrive en omgekeerd.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="183"/>
+        <source>CANCEL</source>
+        <translation>ANNULEREN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="190"/>
+        <source>SYNCHRONIZE</source>
+        <translation>SYNCHRONISEREN</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::CustomExtensionSetupWidget</name>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="96"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="120"/>
+        <source>Before finishing</source>
+        <translation>Voordat u voltooit</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="107"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="131"/>
+        <source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
+        <translation>Voer de volgende stappen uit om ervoor te zorgen dat Lite Sync correct werkt op uw computer en om de configuratie van de kDrive te voltooien.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="208"/>
+        <source>Open your Mac&apos;s &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Open de &lt;b&gt;Algemene instellingen&lt;/b&gt; van uw Mac of &lt;a style=%1 href=%2&gt;klik hier&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="212"/>
+        <source>Open your Mac&apos;s &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Open de &lt;b&gt;Privacy- en beveiligingsinstellingen&lt;/b&gt; van uw Mac of &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klik hier&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="216"/>
+        <source>Open your Mac&apos;s &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Open de &lt;b&gt;Beveiligings- en privacy-instellingen&lt;/b&gt; van uw Mac of &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klik hier&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="246"/>
+        <source>Go to &lt;b&gt;&quot;Login Items &amp; Extensions&quot;&lt;/b&gt; section and then to &lt;b&gt;&quot;Endpoint Security Extensions&quot;&lt;/b&gt;</source>
+        <translation>Ga naar de sectie &lt;b&gt;&quot;Inlogitems en extensies&quot;&lt;/b&gt; en vervolgens naar &lt;b&gt;&quot;Endpoint Security Extensions&quot;&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="263"/>
+        <source>Authorize the kDrive application</source>
+        <translation>Authoriseer de kDrive-applicatie</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="272"/>
+        <source>Go to &lt;b&gt;&quot;Security&quot;&lt;/b&gt; section</source>
+        <translation>Ga naar de sectie &lt;b&gt;&quot;Beveiliging&quot;&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="289"/>
+        <source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
+        <translation>Authoriseer de kDrive-applicatie in het vak dat aangeeft dat kDrive is geblokkeerd</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="299"/>
+        <source>Unlock the padlock &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; and authorize the kDrive application</source>
+        <translation>Ontgrendel het hangslot &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; en authoriseer de kDrive-applicatie</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="344"/>
+        <source>Go to &lt;b&gt;&quot;Privacy &amp; Security&quot;&lt;/b&gt; section and click on &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt; or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Ga naar de sectie &lt;b&gt;&quot;Privacy en beveiliging&quot;&lt;/b&gt; en klik op &lt;b&gt;&quot;Volledige schijftoegang&quot;&lt;/b&gt; of &lt;a style=%1 href=%2&gt;klik hier&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="348"/>
+        <source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;&quot;Privacy&quot;&lt;/b&gt; tab or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Nog steeds in de Beveiliging- en Privacy-instellingen, open het tabblad &lt;b&gt;&quot;Privacy&quot;&lt;/b&gt; of &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klik hier&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="376"/>
+        <source>Check the &quot;kDrive LiteSync Extension&quot; box then the &quot;kDrive.app&quot; box (if not already checked)</source>
+        <translation>Vink het vakje &quot;kDrive LiteSync Extension&quot; aan en vervolgens het vakje &quot;kDrive.app&quot; (indien nog niet aangevinkt)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="393"/>
+        <source>A restart of the app might be proposed, in this case accept it</source>
+        <translation>Een herstart van de app kan worden voorgesteld, accepteer dit in dat geval</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="399"/>
+        <source>Check the &quot;kDrive LiteSync Extension&quot; box (and &quot;kDrive.app&quot; if it exists) in &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt;</source>
+        <translation>Vink het vakje &quot;kDrive LiteSync Extension&quot; aan (en &quot;kDrive.app&quot; als het bestaat) bij &lt;b&gt;&quot;Volledige schijftoegang&quot;&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
+        <source>STEP 1</source>
+        <translation>STAP 1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="496"/>
+        <source>(Done)</source>
+        <translation>(Uitgevoerd)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="496"/>
+        <source>STEP 2</source>
+        <translation>STAP 2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="499"/>
+        <source>STEPS PERFORMED</source>
+        <translation>UITGEVOERDE STAPPEN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="501"/>
+        <source>END</source>
+        <translation>VOLTOOIEN</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::CustomMessageBox</name>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="101"/>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="111"/>
+        <source>CANCEL</source>
+        <translation>ANNULEREN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="121"/>
+        <source>YES</source>
+        <translation>JA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="131"/>
+        <source>NO</source>
+        <translation>NEE</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::DebugReporter</name>
+    <message>
+        <location filename="../src/gui/debugreporter.cpp" line="37"/>
+        <source>Sending of debugging information</source>
+        <translation>Verzenden van debuginformatie</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debugreporter.cpp" line="37"/>
+        <source>Cancel</source>
+        <translation>Annuleren</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::DebuggingDialog</name>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="46"/>
+        <source>Info</source>
+        <translation>Informatie</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="45"/>
+        <source>Debug</source>
+        <translation>Debuggen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="47"/>
+        <source>Warning</source>
+        <translation>Waarschuwing</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="48"/>
+        <source>Error</source>
+        <translation>Fout</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="49"/>
+        <source>Fatal</source>
+        <translation>Fataal</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="74"/>
+        <source>Debugging settings</source>
+        <translation>Debug-instellingen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="90"/>
+        <source>Save debugging information in a folder on my computer (Recommended)</source>
+        <translation>Debuginformatie opslaan in een map op mijn computer (aanbevolen)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="104"/>
+        <source>This information enables IT support to determine the origin of an incident.</source>
+        <translation>Deze informatie stelt IT-ondersteuning in staat de oorzaak van een incident te bepalen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="114"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Debugmap openen&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="143"/>
+        <source>Debug level</source>
+        <translation>Debug-niveau</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="152"/>
+        <source>The trace level lets you choose the extent of the debugging information recorded</source>
+        <translation>Het trace-niveau laat u de omvang van de vastgelegde debuginformatie kiezen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="179"/>
+        <source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
+        <translation>Het uitgebreide volledige logboek verzamelt een gedetailleerde geschiedenis die kan worden gebruikt voor debugging. Het activeren ervan kan de kDrive-applicatie vertragen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="183"/>
+        <source>Extended Full Log</source>
+        <translation>Uitgebreid volledig logboek</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="206"/>
+        <source>Delete logs older than %1 days</source>
+        <translation>Logboeken ouder dan %1 dagen verwijderen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="225"/>
+        <source>Share the debug folder with Infomaniak support.</source>
+        <translation>Deel de debugmap met Infomaniak-ondersteuning.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="249"/>
+        <source>The last session is the periode since the last kDrive start.</source>
+        <translation>De laatste sessie is de periode sinds de laatste kDrive-start.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="253"/>
+        <source>Share only the last kDrive session</source>
+        <translation>Deel alleen de laatste kDrive-sessie</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="284"/>
+        <source>  Loading</source>
+        <translation>  Laden</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="293"/>
+        <source>Cancel</source>
+        <translation>Annuleren</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="319"/>
+        <source>SAVE</source>
+        <translation>OPSLAAN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="326"/>
+        <source>CANCEL</source>
+        <translation>ANNULEREN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="470"/>
+        <source>Failed to share</source>
+        <translation>Delen mislukt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="480"/>
+        <source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
+        <translation>1. Controleer of u bent ingelogd &lt;br&gt;2. Controleer of u ten minste één kDrive heeft geconfigureerd</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="485"/>
+        <source> (Connexion interrupted)</source>
+        <translation> (Verbinding onderbroken)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="492"/>
+        <source>Share the folder with SwissTransfer &lt;br&gt;</source>
+        <translation>Deel de map met SwissTransfer &lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="493"/>
+        <source> 1. We automatically compressed your log &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;here&lt;/a&gt;.&lt;br&gt;</source>
+        <translation> 1. We hebben uw logboek automatisch gecomprimeerd &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;hier&lt;/a&gt;.&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="495"/>
+        <source> 2. Transfer the archive with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
+        <translation> 2. Verstuur het archief met &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="497"/>
+        <source> 3. Share the link with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
+        <translation> 3. Deel de link met &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="527"/>
+        <source>Last upload the %1</source>
+        <translation>Laatste upload op %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="555"/>
+        <source>Sharing has been cancelled</source>
+        <translation>Het delen is geannuleerd</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.h" line="70"/>
+        <source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
+        <translation>De hele map is groot (&gt; 100 MB) en het delen kan enige tijd duren. Om de deeltijd te verkorten, raden we aan alleen de laatste kDrive-sessie te delen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="600"/>
+        <source>%1/%2/%3 at %4h%5m and %6s</source>
+        <extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
+        <translation>%2/%1/%3 om %4u%5 en %6s</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="643"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Wilt u uw wijzigingen opslaan?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="698"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="704"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Kan map %1 niet openen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="711"/>
+        <source>  Share</source>
+        <translation>  Delen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="721"/>
+        <source>  Sharing | step 1/2 %1%</source>
+        <translation>  Delen | stap 1/2 %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="730"/>
+        <source>  Sharing | step 2/2 %1%</source>
+        <translation>  Delen | stap 2/2 %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="740"/>
+        <source>  Canceling...</source>
+        <translation>  Annuleren...</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::DrivePreferencesWidget</name>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
+        <source>Folders</source>
+        <translation>Mappen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
+        <source>Notifications</source>
+        <translation>Meldingen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
+        <source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
+        <translation>Een melding wordt weergegeven zodra een nieuwe map is gesynchroniseerd of gewijzigd</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
+        <source>Connected with</source>
+        <translation>Verbonden met</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
+        <source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+        <translation>Weet u zeker dat u wilt stoppen met het synchroniseren van de map &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Opmerking:&lt;/b&gt; Hierdoor worden &lt;b&gt;geen&lt;/b&gt; bestanden verwijderd.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="356"/>
+        <source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
+        <translation>Deze bewerking kan enkele seconden tot enkele minuten duren, afhankelijk van de grootte van de map.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="360"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="391"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="986"/>
+        <source>CANCEL</source>
+        <translation>ANNULEREN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
+        <source>New local folder synchronization failed!</source>
+        <translation>Synchronisatie van nieuwe lokale map mislukt!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
+        <source>Lite Sync activation failed.</source>
+        <translation>Activering van Lite Sync mislukt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
+        <source>Lite Sync deactivation failed.</source>
+        <translation>Deactivering van Lite Sync mislukt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
+        <source>REMOVE FOLDER SYNC CONNECTION</source>
+        <translation>MAP-SYNCHRONISATIE VERWIJDEREN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
+        <source>An error occurred while loading the list of subfolders.</source>
+        <translation>Er is een fout opgetreden bij het laden van de lijst met submappen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
+        <source>Enable the notifications for this kDrive</source>
+        <translation>Meldingen voor deze kDrive inschakelen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
+        <source>CONFIRM</source>
+        <translation>BEVESTIGEN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
+        <source>Synchronization errors and information.</source>
+        <translation>Synchronisatiefouten en informatie.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
+        <source>Synchronize a local folder</source>
+        <translation>Een lokale map synchroniseren</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
+        <source>Do you really want to turn on Lite Sync?</source>
+        <translation>Weet u zeker dat u Lite Sync wilt inschakelen?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="382"/>
+        <source>Do you really want to turn off Lite Sync?</source>
+        <translation>Weet u zeker dat u Lite Sync wilt uitschakelen?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="384"/>
+        <source>You don&apos;t have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
+        <translation>U heeft niet genoeg ruimte om alle bestanden op uw kDrive te synchroniseren (%1 ontbreekt). Als u Lite Sync uitschakelt, moet u selecteren welke mappen op uw computer moeten worden gesynchroniseerd. In de tussentijd wordt de synchronisatie van uw kDrive gepauzeerd.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="388"/>
+        <source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
+        <translation>Als u Lite Sync uitschakelt, worden alle bestanden naar uw computer gedownload.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="627"/>
+        <source>Failed to create new synchronization</source>
+        <translation>Kan geen nieuwe synchronisatie aanmaken</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="819"/>
+        <source>Lite Sync activated.</source>
+        <translation>Lite Sync geactiveerd.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="837"/>
+        <source>Lite Sync deactivated.</source>
+        <translation>Lite Sync gedeactiveerd.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="899"/>
+        <source>This drive is being deleted.</source>
+        <translation>Dit station wordt verwijderd.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="962"/>
+        <source>Impossible to open item %1</source>
+        <translation>Kan item %1 niet openen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1007"/>
+        <source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
+        <translation>Kan stoppen met synchroniseren van map &lt;i&gt;%1&lt;/i&gt; niet uitvoeren.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1125"/>
+        <source>Remove all synchronizations</source>
+        <translation>Alle synchronisaties verwijderen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1126"/>
+        <source>Search in your kDrive</source>
+        <translation>Zoeken in uw kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1127"/>
+        <source>Search</source>
+        <translation>Zoeken</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::DriveSelectionWidget</name>
+    <message>
+        <location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
+        <source>Synchronize a kDrive</source>
+        <translation>Een kDrive synchroniseren</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/driveselectionwidget.cpp" line="150"/>
+        <source>Add a kDrive</source>
+        <translation>Een kDrive toevoegen</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ErrorTabWidget</name>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="179"/>
+        <source>Resolve</source>
+        <translation>Oplossen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="180"/>
+        <source>Conflicted item(s)</source>
+        <translation>Item(s) met conflict</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="181"/>
+        <source>Item(s) with unsupported characters</source>
+        <translation>Item(s) met niet-ondersteunde tekens</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="92"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="135"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="178"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="186"/>
+        <source>Clear history</source>
+        <translation>Geschiedenis wissen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="176"/>
+        <source>To Resolve</source>
+        <translation>Op te lossen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="184"/>
+        <source>Automatically resolved</source>
+        <translation>Automatisch opgelost</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="185"/>
+        <source>problem(s) solved</source>
+        <translation>probleem(en) opgelost</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="177"/>
+        <source>problem(s) detected</source>
+        <translation>probleem(en) gedetecteerd</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ErrorsMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="84"/>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="103"/>
+        <source>Synchronization conflicts or errors</source>
+        <translation>Synchronisatieconflicten of fouten</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="86"/>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="105"/>
+        <source>Errors</source>
+        <translation>Fouten</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="101"/>
+        <source>Back to preferences</source>
+        <translation>Terug naar voorkeuren</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ErrorsPopup</name>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="75"/>
+        <source>Some files couldn&apos;t be synchronized on the following kDrive(s) :</source>
+        <translation>Sommige bestanden konden niet worden gesynchroniseerd op de volgende kDrive(s):</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="97"/>
+        <source> (%1 error(s))</source>
+        <translation> (%1 fout(en))</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="103"/>
+        <source> (%1 information(s))</source>
+        <translation> (%1 informatie(s))</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="109"/>
+        <source> (%1 error(s) and %2 information(s))</source>
+        <translation> (%1 fout(en) en %2 informatie(s))</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/errorspopup.cpp" line="150"/>
+        <source>Generic errors (%n warning(s) or error(s))</source>
+        <comment>Number of warnings or errors</comment>
+        <translation>
+            <numerusform>Algemene fouten (%n waarschuwing of fout)</numerusform>
+            <numerusform>Algemene fouten (%n waarschuwingen of fouten)</numerusform>
+        </translation>
+    </message>
+</context>
+<context>
+    <name>KDC::FileExclusionDialog</name>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="78"/>
+        <source>Excluded files</source>
+        <translation>Uitgesloten bestanden</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="86"/>
+        <source>Add files or folders that will not be synchronized on your computer.</source>
+        <translation>Voeg bestanden of mappen toe die niet op uw computer worden gesynchroniseerd.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="97"/>
+        <source>Add</source>
+        <translation>Toevoegen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="109"/>
+        <source>NAME</source>
+        <translation>NAAM</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="114"/>
+        <source>WARNING</source>
+        <translation>WAARSCHUWING</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="149"/>
+        <source>SAVE</source>
+        <translation>OPSLAAN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="156"/>
+        <source>CANCEL</source>
+        <translation>ANNULEREN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="304"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Wilt u uw wijzigingen opslaan?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="353"/>
+        <source>Exclusion template already exists!</source>
+        <translation>Uitsluitingssjabloon bestaat al!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="374"/>
+        <source>Do you really want to delete?</source>
+        <translation>Weet u zeker dat u wilt verwijderen?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="434"/>
+        <source>Cannot save changes!</source>
+        <translation>Kan wijzigingen niet opslaan!</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::FileExclusionNameDialog</name>
+    <message>
+        <location filename="../src/gui/fileexclusionnamedialog.cpp" line="58"/>
+        <source>VALIDATE</source>
+        <translation>VALIDEREN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusionnamedialog.cpp" line="65"/>
+        <source>CANCEL</source>
+        <translation>ANNULEREN</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::FixConflictingFilesDialog</name>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67"/>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73"/>
+        <source>Unable to open link %1.</source>
+        <translation>Kan link %1 niet openen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122"/>
+        <source>Solve conflict(s)</source>
+        <translation>Conflict(en) oplossen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140"/>
+        <source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
+        <translation>&lt;b&gt;Wat wilt u doen met de %1 item(s) met een conflict?&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143"/>
+        <source>Save my changes and replace other users&apos; versions.</source>
+        <translation>Mijn wijzigingen opslaan en de versies van andere gebruikers vervangen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147"/>
+        <source>Undo my changes and keep other users&apos; versions.</source>
+        <translation>Mijn wijzigingen ongedaan maken en de versies van andere gebruikers behouden.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169"/>
+        <source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
+        <translation>Uw wijzigingen kunnen permanent worden verwijderd. Ze kunnen niet worden hersteld vanuit de kDrive webapplicatie.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171"/>
+        <source>&lt;a style=%1 href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a style=%1 href=&quot;%2&quot;&gt;Meer informatie&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175"/>
+        <source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
+        <translation>Uw wijzigingen worden permanent verwijderd. Ze kunnen niet worden hersteld vanuit de kDrive webapplicatie.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191"/>
+        <source>Show item(s)</source>
+        <translation>Item(s) tonen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228"/>
+        <source>VALIDATE</source>
+        <translation>VALIDEREN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234"/>
+        <source>CANCEL</source>
+        <translation>ANNULEREN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251"/>
+        <source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
+        <translation>Er zijn wijzigingen aangebracht in deze bestanden door meerdere gebruikers op verschillende plaatsen (online op kDrive, een computer of een mobiel apparaat). Mappen die deze bestanden bevatten, kunnen ook zijn verwijderd.&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253"/>
+        <source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>De lokale versie van uw item &lt;b&gt;is niet gesynchroniseerd&lt;/b&gt; met kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Meer informatie&lt;/a&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::FolderItemWidget</name>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="458"/>
+        <source>More actions</source>
+        <translation>Meer acties</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="188"/>
+        <location filename="../src/gui/folderitemwidget.cpp" line="476"/>
+        <source>Synchronized into &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</source>
+        <translation>Gesynchroniseerd in &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="343"/>
+        <source>Activate Lite Sync</source>
+        <translation>Lite Sync activeren</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="345"/>
+        <source>Activate Lite Sync (Beta)</source>
+        <translation>Lite Sync (Beta) activeren</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="481"/>
+        <source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
+        <translation>Niet-geselecteerde mappen worden naar de prullenbak verplaatst als ze offline items bevatten. Mappen die met kDrive zijn gesynchroniseerd, blijven online beschikbaar.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="485"/>
+        <source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
+        <translation>Niet-geselecteerde mappen worden naar de prullenbak verplaatst. Mappen die met kDrive zijn gesynchroniseerd, blijven online beschikbaar.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="488"/>
+        <source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
+        <translation>Niet-geselecteerde mappen worden &lt;b&gt;permanent&lt;/b&gt; van de computer verwijderd. Mappen die met kDrive zijn gesynchroniseerd, blijven online beschikbaar.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="493"/>
+        <source>Cancel</source>
+        <translation>Annuleren</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="494"/>
+        <source>VALIDATE</source>
+        <translation>VALIDEREN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="365"/>
+        <source>Pause synchronization</source>
+        <translation>Synchronisatie pauzeren</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="354"/>
+        <source>Deactivate Lite Sync</source>
+        <translation>Lite Sync deactiveren</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="375"/>
+        <source>Resume synchronization</source>
+        <translation>Synchronisatie hervatten</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="386"/>
+        <source>Remove synchronization</source>
+        <translation>Synchronisatie verwijderen</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::GenericErrorItemWidget</name>
+    <message>
+        <location filename="../src/gui/genericerroritemwidget.cpp" line="85"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Kan mappad %1 niet openen.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::LiteSyncAppDialog</name>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="48"/>
+        <source>Application Id</source>
+        <translation>Applicatie-ID</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="98"/>
+        <source>Application Name</source>
+        <translation>Applicatienaam</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="121"/>
+        <source>VALIDATE</source>
+        <translation>VALIDEREN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="128"/>
+        <source>CANCEL</source>
+        <translation>ANNULEREN</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::LiteSyncDialog</name>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="91"/>
+        <source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are &quot;online&quot;. Add them in the list below to avoid this behaviour.</source>
+        <translation>Sommige apps (back-up, antivirus...) krijgen toegang tot uw bestanden, wat leidt tot hun download wanneer ze &quot;online&quot; zijn. Voeg ze toe aan de onderstaande lijst om dit gedrag te voorkomen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="103"/>
+        <source>Add</source>
+        <translation>Toevoegen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="115"/>
+        <source>APPLICATION ID</source>
+        <translation>APPLICATIE-ID</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="120"/>
+        <source>NAME</source>
+        <translation>NAAM</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="154"/>
+        <source>SAVE</source>
+        <translation>OPSLAAN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="161"/>
+        <source>CANCEL</source>
+        <translation>ANNULEREN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="295"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Wilt u uw wijzigingen opslaan?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="337"/>
+        <source>Do you really want to delete?</source>
+        <translation>Weet u zeker dat u wilt verwijderen?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="374"/>
+        <source>Cannot save changes!</source>
+        <translation>Kan wijzigingen niet opslaan!</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::LocalFolderDialog</name>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="63"/>
+        <source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
+        <translation>Welke map op uw computer wilt u&lt;br&gt;synchroniseren?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="72"/>
+        <source>The content of this folder will be synchronized on the kDrive</source>
+        <translation>De inhoud van deze map wordt gesynchroniseerd met de kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="91"/>
+        <source>Select a folder</source>
+        <translation>Selecteer een map</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="131"/>
+        <source>Edit folder</source>
+        <translation>Map bewerken</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="166"/>
+        <source>CANCEL</source>
+        <translation>ANNULEREN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="173"/>
+        <source>CONTINUE</source>
+        <translation>DOORGAAN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="210"/>
+        <source>This folder is not compatible with Lite Sync.&lt;br&gt;
+Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt;
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Deze map is niet compatibel met Lite Sync.&lt;br&gt;
+Selecteer een andere map. Als u doorgaat, wordt Lite Sync uitgeschakeld.&lt;br&gt;
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Meer informatie&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="233"/>
+        <source>Select folder</source>
+        <translation>Map selecteren</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="292"/>
+        <source>Unable to open link %1.</source>
+        <translation>Kan link %1 niet openen.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::Logger</name>
+    <message>
+        <location filename="../src/libcommongui/logger.cpp" line="189"/>
+        <source>Error</source>
+        <translation>Fout</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/logger.cpp" line="189"/>
+        <source>&lt;nobr&gt;File &apos;%1&apos;&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
+        <translation>&lt;nobr&gt;Bestand &apos;%1&apos;&lt;br/&gt;kan niet worden geopend om te schrijven.&lt;br/&gt;&lt;br/&gt;De loguitvoer kan &lt;b&gt;niet&lt;/b&gt; worden opgeslagen!&lt;/nobr&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::MainMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/mainmenubarwidget.cpp" line="115"/>
+        <source>Preferences</source>
+        <translation>Voorkeuren</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/mainmenubarwidget.cpp" line="116"/>
+        <source>Help</source>
+        <translation>Help</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ParametersDialog</name>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1082"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Kan mappad %1 niet openen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1096"/>
+        <source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
+        <translation>Verzending voltooid!&lt;br&gt;Gelieve te verwijzen naar identificatie &lt;b&gt;%1&lt;/b&gt; in bugrapporten.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1118"/>
+        <source>No kDrive configured!</source>
+        <translation>Geen kDrive geconfigureerd!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1097"/>
+        <source>Transmission failed!
+Please, use the following link to send the logs to the support: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</source>
+        <translation>Verzending mislukt!
+Gebruik de volgende link om de logs naar de ondersteuning te sturen: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="337"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="440"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="506"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="546"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="560"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>Er is een technische fout opgetreden (fout %1).&lt;br&gt;Wis de geschiedenis en neem contact op met ons ondersteuningsteam als de fout aanhoudt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="342"/>
+        <source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
+        <translation>Het lijkt erop dat uw netwerkverbinding is geconfigureerd met een te korte time-out waardoor de applicatie niet correct kan werken (fout %1).&lt;br&gt;Controleer uw netwerkconfiguratie.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="347"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="516"/>
+        <source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
+        <translation>Kan geen verbinding maken met kDrive-server (fout %1).&lt;br&gt;Opnieuw verbinden proberen. Controleer uw internetverbinding en uw firewall.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="352"/>
+        <source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
+        <translation>Er is een inlogprobleem opgetreden (fout %1).&lt;br&gt;Log opnieuw in en neem contact op met ons ondersteuningsteam als de fout aanhoudt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="356"/>
+        <source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
+        <translation>Een nieuwe versie van de applicatie is beschikbaar.&lt;br&gt;Update de applicatie om deze te blijven gebruiken.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="360"/>
+        <source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
+        <translation>Het uploaden van het logboek is mislukt (fout %1).&lt;br&gt;Probeer het later opnieuw.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="385"/>
+        <source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
+        <translation>De synchronisatiemap is niet langer toegankelijk (fout %1).&lt;br&gt;De synchronisatie wordt hervat zodra de map toegankelijk is.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="532"/>
+        <source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
+        <translation>De synchronisatiemap is vervangen of verplaatst op een manier die synchronisatie verhindert (fout %1).&lt;br&gt;Dit kan gebeuren na het kopiëren, verplaatsen of herstellen van de map.&lt;br&gt;Om dit op te lossen, maakt u een nieuwe synchronisatie met een nieuwe map.&lt;br&gt;Opmerking: als u niet-gesynchroniseerde wijzigingen in de oude map heeft, moet u deze handmatig naar de nieuwe map kopiëren.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="397"/>
+        <source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>Er is niet genoeg geheugen over op uw machine.&lt;br&gt;De synchronisatie is gestopt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="320"/>
+        <source>kDrive needs to have write access to your computer&apos;s temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
+        <translation>kDrive moet schrijftoegang hebben tot de tijdelijke map van uw computer.&lt;br&gt;Start de kDrive-app opnieuw op om dit probleem op te lossen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="330"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="487"/>
+        <source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>Er is een technische fout opgetreden.&lt;br&gt;De synchronisatie wordt zo snel mogelijk hervat. Neem contact op met ons ondersteuningsteam als de fout aanhoudt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="401"/>
+        <source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing &apos;/etc/sysctl.conf&apos;.</source>
+        <translation>Het aantal inotify-watches is onvoldoende (fout %1).&lt;br&gt;U kunt dit aantal verhogen door &apos;/etc/sysctl.conf&apos; te bewerken.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="406"/>
+        <source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
+        <translation>Kan synchronisatie niet starten (fout %1).&lt;br&gt;U moet toestaan:&lt;br&gt;- kDrive in Systeeminstellingen &gt;&gt; Algemeen &gt;&gt; Inlogitems en extensies &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in Systeeminstellingen &gt;&gt; Privacy en beveiliging &gt;&gt; Volledige schijftoegang.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="419"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Kan Lite Sync-plugin niet starten (fout %1).&lt;br&gt;Controleer of de Lite Sync-extensie is geïnstalleerd en de Windows Search-service is ingeschakeld.&lt;br&gt;Wis de geschiedenis, start opnieuw op en neem contact op met ons ondersteuningsteam als de fout aanhoudt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="424"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Kan Lite Sync-plugin niet starten (fout %1).&lt;br&gt;Controleer of de Lite Sync-extensie de juiste rechten heeft en actief is.&lt;br&gt;Wis de geschiedenis, start opnieuw op en neem contact op met ons ondersteuningsteam als de fout aanhoudt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="429"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Kan Lite Sync-plugin niet starten (fout %1).&lt;br&gt;Wis de geschiedenis, start opnieuw op en neem contact op met ons ondersteuningsteam als de fout aanhoudt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="435"/>
+        <source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>Een bestand of map in uw synchronisatiemap lijkt beschadigd te zijn.&lt;br&gt;De synchronisatie is gestopt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="449"/>
+        <source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>De kDrive is in onderhoudsmodus.&lt;br&gt;De synchronisatie wordt zo snel mogelijk hervat. Neem contact op met ons ondersteuningsteam als de fout aanhoudt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="455"/>
+        <source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+        <translation>De kDrive is geblokkeerd.&lt;br&gt;Verleng uw kDrive. Als er geen actie wordt ondernomen, worden de gegevens permanent verwijderd en is het onmogelijk ze te herstellen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="460"/>
+        <source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+        <translation>De kDrive is geblokkeerd.&lt;br&gt;Neem contact op met een beheerder om de kDrive te verlengen. Als er geen actie wordt ondernomen, worden de gegevens permanent verwijderd en is het onmogelijk ze te herstellen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="466"/>
+        <source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>De kDrive wordt wakker.&lt;br&gt;De synchronisatie wordt zo snel mogelijk hervat. Neem contact op met ons ondersteuningsteam als de fout aanhoudt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="475"/>
+        <source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>De kDrive slaapt.&lt;br&gt;Log in op de &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;webversie&lt;/a&gt; om de status van uw kDrive te controleren, of neem contact op met uw beheerder.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="479"/>
+        <source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>De kDrive slaapt.&lt;br&gt;Log in op de webversie om de status van uw kDrive te controleren, of neem contact op met uw beheerder.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="483"/>
+        <source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
+        <translation>U bent niet gemachtigd om toegang te krijgen tot deze kDrive.&lt;br&gt;De synchronisatie is gepauzeerd. Neem contact op met een beheerder.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="493"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>Er is een technische fout opgetreden (fout %1).&lt;br&gt;De synchronisatie wordt zo snel mogelijk hervat. Neem contact op met ons ondersteuningsteam als de fout aanhoudt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="512"/>
+        <source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>De netwerkverbindingen zijn verbroken door de kernel (fout %1).&lt;br&gt;Wis de geschiedenis en neem contact op met ons ondersteuningsteam als de fout aanhoudt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="522"/>
+        <source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
+        <translation>Helaas kon uw oude configuratie niet worden gemigreerd.&lt;br&gt;De applicatie zal een lege configuratie gebruiken.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="526"/>
+        <source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
+        <translation>Helaas kon uw oude proxy-configuratie niet worden gemigreerd, SOCKS5-proxies worden op dit moment niet ondersteund.&lt;br&gt;De applicatie zal in plaats daarvan de systeem-proxy-instellingen gebruiken.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="539"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
+        <translation>Er is een technische fout opgetreden (fout %1).&lt;br&gt;De synchronisatie is opnieuw gestart. Wis de geschiedenis en neem contact op met ons ondersteuningsteam als de fout aanhoudt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="550"/>
+        <source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
+        <translation>Er is een fout opgetreden bij het toegang krijgen tot de synchronisatiedatabase (fout %1).&lt;br&gt;De synchronisatie is gestopt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="564"/>
+        <source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
+        <translation>Er is een inlogprobleem opgetreden (fout %1).&lt;br&gt;Token ongeldig of ingetrokken.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="569"/>
+        <source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
+        <translation>Geneste synchronisaties zijn verboden (fout %1).&lt;br&gt;U moet alleen synchronisaties behouden waarvan de mappen niet genest zijn.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="573"/>
+        <source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
+        <translation>De synchronisatiemap op de externe kDrive bestaat niet meer of is niet langer toegankelijk (fout %1).&lt;br&gt;U moet deze herstellen of opnieuw toegangsrechten geven, of de synchronisatie verwijderen/opnieuw aanmaken.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="580"/>
+        <source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
+        <translation>Fout bij het ontleden van bestandsnamen (fout %1).&lt;br&gt;Speciale tekens zoals aanhalingstekens, backslashes of regeleinden kunnen ontledingsfouten veroorzaken.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="722"/>
+        <source>You are not allowed to move item to &quot;%1&quot;.&lt;br&gt;It will be restored into its original parent folder.</source>
+        <translation>U mag het item niet verplaatsen naar &quot;%1&quot;.&lt;br&gt;Het wordt hersteld in de oorspronkelijke bovenliggende map.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="814"/>
+        <source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
+        <translation>Er is niet genoeg ruimte over op uw computer.&lt;br&gt;De download is geannuleerd.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="609"/>
+        <source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>Dit element is ergens anders naartoe verplaatst.&lt;br&gt;De lokale bewerking is geannuleerd.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="618"/>
+        <source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
+        <translation>Er bestaat al een element met dezelfde naam op deze locatie.&lt;br&gt;Het lokale element is hernoemd.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="614"/>
+        <source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>Er bestaat al een element met dezelfde naam op deze locatie.&lt;br&gt;De lokale bewerking is geannuleerd.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="393"/>
+        <source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>Er is niet genoeg ruimte over op uw computer.&lt;br&gt;De synchronisatie is gestopt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="622"/>
+        <source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
+        <translation>Het bestand is op hetzelfde moment gewijzigd door een andere gebruiker.&lt;br&gt;Uw wijzigingen zijn opgeslagen in een kopie.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="626"/>
+        <source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>Een andere gebruiker heeft een bovenliggende map van de bestemming verplaatst.&lt;br&gt;De lokale bewerking is geannuleerd.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="692"/>
+        <source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>De itemnaam bevat alleen spaties.&lt;br&gt;Het is tijdelijk op de zwarte lijst gezet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="703"/>
+        <source>Either you are not allowed to create an item, or another item already exists with the same name.&lt;br&gt;The item has been excluded from synchronization.</source>
+        <translation>Ofwel mag u geen item aanmaken, ofwel bestaat er al een ander item met dezelfde naam.&lt;br&gt;Het item is uitgesloten van synchronisatie.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="708"/>
+        <source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
+        <translation>U mag het item niet bewerken.&lt;br&gt;Het bestand met uw wijzigingen is hernoemd en uitgesloten van synchronisatie.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="716"/>
+        <source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
+        <translation>U mag het item niet hernoemen.&lt;br&gt;Het wordt hersteld met zijn oorspronkelijke naam.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="727"/>
+        <source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
+        <translation>U mag het item niet verwijderen.&lt;br&gt;Het wordt hersteld naar zijn oorspronkelijke locatie.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="732"/>
+        <source>Failed to move this item to trash, it has been blacklisted.</source>
+        <translation>Kan dit item niet naar de prullenbak verplaatsen, het is op de zwarte lijst gezet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="748"/>
+        <source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
+        <translation>Het bestand is lokaal gewijzigd terwijl het op de externe kDrive is verwijderd.&lt;br&gt;De lokale kopie is opgeslagen in de reddingsmap.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="765"/>
+        <source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
+        <translation>De uitgevoerde bewerking op het item is verboden.&lt;br&gt;Het item is tijdelijk op de zwarte lijst gezet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="771"/>
+        <source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
+        <translation>De uitgevoerde bewerking op dit item is mislukt.&lt;br&gt;Het item is tijdelijk op de zwarte lijst gezet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="776"/>
+        <source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
+        <translation>Het bestand is te groot om te uploaden. Het is tijdelijk op de zwarte lijst gezet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="782"/>
+        <source>Impossible to download the file.</source>
+        <translation>Onmogelijk om het bestand te downloaden.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="779"/>
+        <source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
+        <translation>U heeft uw quotum overschreden. Verhoog uw ruimtequotum om het uploaden van bestanden opnieuw in te schakelen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="389"/>
+        <source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
+        <translation>Het station dat uw synchronisatiemap bevat, is niet langer verbonden (fout %1).&lt;br&gt;Sluit het opnieuw aan om de synchronisatie te hervatten.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="413"/>
+        <source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
+        <translation>Kan synchronisatie niet starten (fout %1).&lt;br&gt;Het LiteSyncExt-proces wordt momenteel niet uitgevoerd. De synchronisatie wordt hervat zodra het wordt gestart.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="649"/>
+        <source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Een bestaand item heeft een identieke naam met dezelfde hoofdletteropties (dezelfde hoofd- en kleine letters).&lt;br&gt;Het is tijdelijk op de zwarte lijst gezet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="656"/>
+        <source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>De itemnaam bevat een niet-ondersteund teken.&lt;br&gt;Het is tijdelijk op de zwarte lijst gezet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="662"/>
+        <source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>De itemnaam eindigt met een spatie, wat verboden is op uw besturingssysteem.&lt;br&gt;Het is tijdelijk op de zwarte lijst gezet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="668"/>
+        <source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Deze itemnaam is gereserveerd door uw besturingssysteem.&lt;br&gt;Het is tijdelijk op de zwarte lijst gezet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="674"/>
+        <source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>De itemnaam is te lang.&lt;br&gt;Het is tijdelijk op de zwarte lijst gezet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="680"/>
+        <source>The item path is too long.&lt;br&gt;It has been ignored.</source>
+        <translation>Het itempad is te lang.&lt;br&gt;Het is genegeerd.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="686"/>
+        <source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+        <translation>De itemnaam bevat een recent UNICODE-teken dat nog niet wordt ondersteund door uw bestandssysteem.&lt;br&gt;Het is uitgesloten van synchronisatie.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="735"/>
+        <source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
+        <translation>Kan dit item niet synchroniseren. Het is tijdelijk op de zwarte lijst gezet.&lt;br&gt;Er wordt over een uur of bij de volgende start van de applicatie opnieuw geprobeerd het te synchroniseren.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="740"/>
+        <source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
+        <translation>Dit item is uitgesloten van synchronisatie door een aangepast sjabloon.&lt;br&gt;U kunt dit type melding uitschakelen in de Voorkeuren</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="745"/>
+        <source>This item has been excluded from sync because it is a hard link.</source>
+        <translation>Dit item is uitgesloten van synchronisatie omdat het een harde link is.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="785"/>
+        <source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
+        <translation>Dit item is momenteel vergrendeld door een andere gebruiker online.&lt;br&gt;We zullen later opnieuw proberen uw wijzigingen te uploaden.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="790"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="834"/>
+        <source>Synchronization error.</source>
+        <translation>Synchronisatiefout.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="810"/>
+        <source>Can&apos;t access item.&lt;br&gt;Please fix the read and write permissions.</source>
+        <translation>Kan geen toegang krijgen tot item.&lt;br&gt;Corrigeer de lees- en schrijfrechten.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="818"/>
+        <source>System error.</source>
+        <translation>Systeemfout.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="825"/>
+        <source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Item bestaat al aan de andere kant.&lt;br&gt;Het is tijdelijk op de zwarte lijst gezet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="840"/>
+        <source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>Er is een technische fout opgetreden.&lt;br&gt;Wis de geschiedenis en neem contact op met ons ondersteuningsteam als de fout aanhoudt.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::PreferencesBlocWidget</name>
+    <message>
+        <location filename="../src/gui/preferencesblocwidget.cpp" line="187"/>
+        <source>This synchronization is being deleted.</source>
+        <translation>Deze synchronisatie wordt verwijderd.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::PreferencesMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/preferencesmenubarwidget.cpp" line="63"/>
+        <source>Back to drive list</source>
+        <translation>Terug naar de drivelijst</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferencesmenubarwidget.cpp" line="64"/>
+        <source>Preferences</source>
+        <translation>Voorkeuren</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::PreferencesWidget</name>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="491"/>
+        <source>General</source>
+        <translation>Algemeen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="493"/>
+        <source>Activate dark theme</source>
+        <translation>Donker thema activeren</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="495"/>
+        <source>Activate monochrome icons</source>
+        <translation>Monochrome pictogrammen activeren</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="496"/>
+        <source>Launch kDrive at startup</source>
+        <translation>kDrive starten bij het opstarten</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="516"/>
+        <source>Advanced</source>
+        <translation>Geavanceerd</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="517"/>
+        <source>Debugging information</source>
+        <translation>Debuginformatie</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="519"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Debugmap openen&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="520"/>
+        <source>Files to exclude</source>
+        <translation>Bestanden om uit te sluiten</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="521"/>
+        <source>Proxy server</source>
+        <translation>Proxyserver</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="466"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Kan map %1 niet openen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferences.cpp" line="478"/>
+        <source>Unable to open link %1.</source>
+        <translation>Kan link %1 niet openen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="483"/>
+        <source>Invalid link %1.</source>
+        <translation>Ongeldige link %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="523"/>
+        <source>Lite Sync</source>
+        <translation>Lite Sync</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="497"/>
+        <source>Language</source>
+        <translation>Taal</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="490"/>
+        <source>Some process failed to run.</source>
+        <translation>Sommige processen konden niet worden uitgevoerd.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="498"/>
+        <source>Move deleted files to my computer&apos;s trash</source>
+        <translation>Verwijderde bestanden naar de prullenbak van mijn computer verplaatsen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="499"/>
+        <source>Some files or folders may not be moved to the computer&apos;s trash.</source>
+        <translation>Sommige bestanden of mappen kunnen mogelijk niet naar de prullenbak van de computer worden verplaatst.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="500"/>
+        <source>You can always retrieve already synced files from the kDrive web application trash.</source>
+        <translation>U kunt altijd reeds gesynchroniseerde bestanden ophalen uit de prullenbak van de kDrive webapplicatie.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="502"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a style=%1 href=&quot;%2&quot;&gt;Meer informatie&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="506"/>
+        <source>English</source>
+        <translation>Engels</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="507"/>
+        <source>French</source>
+        <translation>Frans</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="508"/>
+        <source>German</source>
+        <translation>Duits</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="509"/>
+        <source>Spanish</source>
+        <translation>Spaans</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="510"/>
+        <source>Italian</source>
+        <translation>Italiaans</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="505"/>
+        <source>Default</source>
+        <translation>Standaard</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ProgressBarWidget</name>
+    <message>
+        <location filename="../src/gui/progressbarwidget.cpp" line="70"/>
+        <source>%1 in use</source>
+        <translation>%1 in gebruik</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ProxyServerDialog</name>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="50"/>
+        <source>HTTP(S) Proxy</source>
+        <translation>HTTP(S) Proxy</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="73"/>
+        <source>Proxy server</source>
+        <translation>Proxyserver</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="85"/>
+        <source>No proxy server</source>
+        <translation>Geen proxyserver</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="90"/>
+        <source>Use system parameters</source>
+        <translation>Systeeminstellingen gebruiken</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="95"/>
+        <source>Indicate a proxy manually</source>
+        <translation>Proxy handmatig opgeven</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="131"/>
+        <source>Port</source>
+        <translation>Poort</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="144"/>
+        <source>Address of the proxy server</source>
+        <translation>Adres van de proxyserver</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="150"/>
+        <source>Authentication needed</source>
+        <translation>Authenticatie vereist</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="165"/>
+        <source>User</source>
+        <translation>Gebruiker</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="171"/>
+        <source>Password</source>
+        <translation>Wachtwoord</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="185"/>
+        <source>SAVE</source>
+        <translation>OPSLAAN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="192"/>
+        <source>CANCEL</source>
+        <translation>ANNULEREN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="286"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Wilt u uw wijzigingen opslaan?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="295"/>
+        <source>Unable to save, all mandatory fields are not completed!</source>
+        <translation>Opslaan niet mogelijk, niet alle verplichte velden zijn ingevuld!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="316"/>
+        <source>Proxy not found, save anyway?</source>
+        <translation>Proxy niet gevonden, toch opslaan?</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ResourcesManagerDialog</name>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="55"/>
+        <source>Resources Manager</source>
+        <translation>Resources Beheer</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="65"/>
+        <source>Maximum CPU usage allowed</source>
+        <translation>Maximaal toegestaan CPU-gebruik</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="96"/>
+        <source>SAVE</source>
+        <translation>OPSLAAN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="103"/>
+        <source>CANCEL</source>
+        <translation>ANNULEREN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="122"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Wilt u uw wijzigingen opslaan?</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ServerBaseFolderDialog</name>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="81"/>
+        <source>Select a folder on your kDrive</source>
+        <translation>Selecteer een map op uw kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="90"/>
+        <source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
+        <translation>De inhoud van de geselecteerde map wordt gesynchroniseerd naar de map &lt;b&gt;%1&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="134"/>
+        <source>CONTINUE</source>
+        <translation>DOORGAAN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="150"/>
+        <source>Space available on your computer for the current folder : %1</source>
+        <translation>Beschikbare ruimte op uw computer voor de huidige map: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="190"/>
+        <source>This folder is already being synced.</source>
+        <translation>Deze map wordt al gesynchroniseerd.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="204"/>
+        <source>CONFIRM</source>
+        <translation>BEVESTIGEN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="205"/>
+        <source>CANCEL</source>
+        <translation>ANNULEREN</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ServerFoldersDialog</name>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="80"/>
+        <source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
+        <translation>De map &lt;b&gt;%1&lt;/b&gt; bevat submappen,&lt;br&gt; selecteer degene die u wilt synchroniseren</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="110"/>
+        <source>CONTINUE</source>
+        <translation>DOORGAAN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="146"/>
+        <source>No subfolders currently on the server.</source>
+        <translation>Geen submappen op de server.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::StatusBarWidget</name>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="178"/>
+        <source>Resume kDrive &quot;%1&quot; synchronization</source>
+        <translation>Hervat kDrive &quot;%1&quot; synchronisatie</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="180"/>
+        <source>Resume all kDrives synchronization</source>
+        <translation>Hervat alle kDrives synchronisatie</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="183"/>
+        <source>Pause kDrive &quot;%1&quot; synchronization</source>
+        <translation>Pauzeer kDrive &quot;%1&quot; synchronisatie</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="184"/>
+        <location filename="../src/gui/statusbarwidget.cpp" line="321"/>
+        <source>Pause synchronization</source>
+        <translation>Synchronisatie pauzeren</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="185"/>
+        <source>Pause all kDrives synchronization</source>
+        <translation>Pauzeer alle kDrives synchronisatie</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="179"/>
+        <location filename="../src/gui/statusbarwidget.cpp" line="322"/>
+        <source>Resume synchronization</source>
+        <translation>Synchronisatie hervatten</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::SynchronizedItemWidget</name>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
+        <source>Copy share link</source>
+        <translation>Deellink kopiëren</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
+        <source>Display on kdrive.infomaniak.com</source>
+        <translation>Weergeven op kdrive.infomaniak.com</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
+        <source>Show in folder</source>
+        <translation>Tonen in map</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
+        <source>More actions</source>
+        <translation>Meer acties</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="317"/>
+        <source>Open</source>
+        <translation>Openen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
+        <source>Add to favorites</source>
+        <translation>Toevoegen aan favorieten</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::SynthesisBar</name>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="43"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="54"/>
+        <source>Never</source>
+        <translation>Nooit</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="44"/>
+        <source>During 1 hour</source>
+        <translation>Gedurende 1 uur</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="45"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="56"/>
+        <source>Until tomorrow 8:00AM</source>
+        <translation>Tot morgen 08:00</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="46"/>
+        <source>During 3 days</source>
+        <translation>Gedurende 3 dagen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="47"/>
+        <source>During 1 week</source>
+        <translation>Gedurende 1 week</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="48"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="59"/>
+        <source>Always</source>
+        <translation>Altijd</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="55"/>
+        <source>For 1 more hour</source>
+        <translation>Voor 1 uur extra</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="57"/>
+        <source>For 3 more days</source>
+        <translation>Voor 3 dagen extra</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="58"/>
+        <source>For 1 more week</source>
+        <translation>Voor 1 week extra</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="171"/>
+        <source>Unable to open folder url %1.</source>
+        <translation>Kan map-URL %1 niet openen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="241"/>
+        <source>Open in folder</source>
+        <translation>Openen in map</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="279"/>
+        <source>Open %1 web version</source>
+        <translation>Open %1 webversie</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="289"/>
+        <source>Drive parameters</source>
+        <translation>Drive-instellingen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="302"/>
+        <source>Notifications disabled until %1</source>
+        <translation>Meldingen uitgeschakeld tot %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="303"/>
+        <source>Disable Notifications</source>
+        <translation>Meldingen uitschakelen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="336"/>
+        <source>Application preferences</source>
+        <translation>Applicatievoorkeuren</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="344"/>
+        <source>Need help</source>
+        <translation>Hulp nodig</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="352"/>
+        <source>Send feedbacks</source>
+        <translation>Feedback sturen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="360"/>
+        <source>Quit kDrive</source>
+        <translation>kDrive afsluiten</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="423"/>
+        <source>Unable to access web site %1.</source>
+        <translation>Kan geen toegang krijgen tot website %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="514"/>
+        <source>Show errors and informations</source>
+        <translation>Fouten en informatie tonen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="515"/>
+        <source>Show informations</source>
+        <translation>Informatie tonen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="516"/>
+        <source>More actions</source>
+        <translation>Meer acties</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::SynthesisPopover</name>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1171"/>
+        <source>Update kDrive App</source>
+        <translation>kDrive App bijwerken</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1172"/>
+        <source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
+        <translation>Deze versie van de kDrive-app wordt niet meer ondersteund. Update om toegang te krijgen tot de nieuwste functies en verbeteringen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="967"/>
+        <source>Update</source>
+        <translation>Bijwerken</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1175"/>
+        <source>Please download the latest version on the website.</source>
+        <translation>Download de nieuwste versie op de website.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="970"/>
+        <source>Update download in progress</source>
+        <translation>Update-download bezig</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="973"/>
+        <source>Looking for update...</source>
+        <translation>Zoeken naar update...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="976"/>
+        <source>Manual update</source>
+        <translation>Handmatige update</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="979"/>
+        <source>Unavailable</source>
+        <translation>Niet beschikbaar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1188"/>
+        <source>You can synchronize files &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;from your computer&lt;/a&gt; or on &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
+        <translation>U kunt bestanden synchroniseren &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;vanaf uw computer&lt;/a&gt; of op &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="446"/>
+        <source>Synchronized</source>
+        <translation>Gesynchroniseerd</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="450"/>
+        <source>Favorites</source>
+        <translation>Favorieten</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="454"/>
+        <source>Activity</source>
+        <translation>Activiteit</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1123"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1170"/>
+        <source>Not implemented!</source>
+        <translation>Niet geïmplementeerd!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1181"/>
+        <source>No synchronized folder for this Drive!</source>
+        <translation>Geen gesynchroniseerde map voor deze Drive!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1184"/>
+        <source>No kDrive configured!</source>
+        <translation>Geen kDrive geconfigureerd!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1151"/>
+        <source>Unable to open link %1.</source>
+        <translation>Kan link %1 niet openen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1163"/>
+        <source>Invalid link %1.</source>
+        <translation>Ongeldige link %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="575"/>
+        <source>Unable to open folder url %1.</source>
+        <translation>Kan map-URL %1 niet openen.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::UpdateDialog</name>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="61"/>
+        <source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;De nieuwe versie &lt;b&gt;%1&lt;/b&gt; van de %2 Client is beschikbaar en is gedownload.&lt;/p&gt;&lt;p&gt;De geïnstalleerde versie is %3.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="95"/>
+        <source>Skip this version</source>
+        <translation>Deze versie overslaan</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="103"/>
+        <source>Remind me later</source>
+        <translation>Herinner me later</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="109"/>
+        <source>Install update</source>
+        <translation>Update installeren</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::UpdateManager</name>
+    <message>
+        <location filename="../src/server/updater/updatemanager.cpp" line="86"/>
+        <source>New update available.</source>
+        <translation>Nieuwe update beschikbaar.</translation>
+    </message>
+    <message>
+        <location filename="../src/server/updater/updatemanager.cpp" line="87"/>
+        <source>Version %1 is available for download.</source>
+        <translation>Versie %1 is beschikbaar om te downloaden.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::UserSelectionWidget</name>
+    <message>
+        <location filename="../src/gui/userselectionwidget.cpp" line="131"/>
+        <source>Add an account</source>
+        <translation>Een account toevoegen</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::VersionWidget</name>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="295"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="169"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Show release note&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Release-opmerking tonen&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="172"/>
+        <source>Version</source>
+        <translation>Versie</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="173"/>
+        <source>UPDATE</source>
+        <translation>BIJWERKEN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="197"/>
+        <source>%1 is up to date!</source>
+        <translation>%1 is up-to-date!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="201"/>
+        <source>Checking update on server...</source>
+        <translation>Controleren op update op server...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="205"/>
+        <source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;here&lt;/a&gt;.</source>
+        <translation>Een update is beschikbaar: %1.&lt;br&gt;Download het van &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;hier&lt;/a&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="212"/>
+        <source>An update is available: %1</source>
+        <translation>Een update is beschikbaar: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="218"/>
+        <source>Downloading %1. Please wait...</source>
+        <translation>%1 downloaden. Even geduld...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="223"/>
+        <source>Could not check for new updates.</source>
+        <translation>Kon niet controleren op nieuwe updates.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="227"/>
+        <source>An error occurred during update.</source>
+        <translation>Er is een fout opgetreden tijdens de update.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="231"/>
+        <source>Could not download update.</source>
+        <translation>Kon update niet downloaden.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="235"/>
+        <source>Update disabled.</source>
+        <translation>Update uitgeschakeld.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="251"/>
+        <source>Beta program</source>
+        <translation>Bètaprogramma</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="252"/>
+        <source>Get early access to new versions of the application</source>
+        <translation>Krijg vroeg toegang tot nieuwe versies van de applicatie</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="256"/>
+        <source>Join</source>
+        <translation>Deelnemen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="259"/>
+        <source>Modify</source>
+        <translation>Wijzigen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="259"/>
+        <source>Quit</source>
+        <translation>Verlaten</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/gui/parameterscache.cpp" line="59"/>
+        <source>Unable to save parameters, please retry later.</source>
+        <translation>Kan parameters niet opslaan, probeer het later opnieuw.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parameterscache.cpp" line="60"/>
+        <source>Unable to save parameters!</source>
+        <translation>Kan parameters niet opslaan!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="391"/>
+        <source>The parent folder is a sync folder or contained in one</source>
+        <translation>De bovenliggende map is een synchronisatiemap of zit erin</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="412"/>
+        <source>Can&apos;t find a valid path</source>
+        <translation>Kan geen geldig pad vinden</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="1981"/>
+        <source>No valid folder selected!</source>
+        <translation>Geen geldige map geselecteerd!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="1992"/>
+        <source>The selected path does not exist!</source>
+        <translation>Het geselecteerde pad bestaat niet!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="1997"/>
+        <source>The selected path is not a folder!</source>
+        <translation>Het geselecteerde pad is geen map!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2002"/>
+        <source>You have no permission to write to the selected folder!</source>
+        <translation>U heeft geen schrijfrechten voor de geselecteerde map!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2032"/>
+        <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
+        <translation>De lokale map %1 bevat een map die al gesynchroniseerd is. Kies een andere!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2040"/>
+        <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
+        <translation>De lokale map %1 zit in een map die al gesynchroniseerd is. Kies een andere!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2048"/>
+        <source>The local folder %1 is already synced. Please pick another one!</source>
+        <translation>De lokale map %1 is al gesynchroniseerd. Kies een andere!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="42"/>
+        <source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
+        <translation>Lite sync (Beta) is ingeschakeld. Bestanden van kDrive blijven in de Cloud en gebruiken geen opslagruimte op uw computer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="45"/>
+        <source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
+        <translation>Lite sync (Beta) is uitgeschakeld. De kDrive-bestanden gebruiken de opslagruimte van uw computer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="48"/>
+        <source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
+        <translation>Lite sync is ingeschakeld. Bestanden van kDrive blijven in de Cloud en gebruiken geen opslagruimte op uw computer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="50"/>
+        <source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
+        <translation>Lite sync is uitgeschakeld. De kDrive-bestanden gebruiken de opslagruimte van uw computer.</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1164"/>
+        <source>Make available locally</source>
+        <translation>Lokaal beschikbaar maken</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1168"/>
+        <source>Free up local space</source>
+        <translation>Lokale ruimte vrijmaken</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1172"/>
+        <source>Cancel free up local space</source>
+        <translation>Annuleer lokale ruimte vrijmaken</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1176"/>
+        <source>Cancel make available locally</source>
+        <translation>Annuleer lokaal beschikbaar maken</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1180"/>
+        <source>Resharing this file is not allowed</source>
+        <translation>Opnieuw delen van dit bestand is niet toegestaan</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1181"/>
+        <source>Resharing this folder is not allowed</source>
+        <translation>Opnieuw delen van deze map is niet toegestaan</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1185"/>
+        <source>Copy public share link</source>
+        <translation>Openbare deellink kopiëren</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1189"/>
+        <source>Copy private share link</source>
+        <translation>Privé deellink kopiëren</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1193"/>
+        <source>Open in browser</source>
+        <translation>Openen in browser</translation>
+    </message>
+</context>
+<context>
+    <name>SharedTools::QtSingleApplication</name>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="134"/>
+        <source>kDrive application will close due to a fatal error.</source>
+        <translation>kDrive-applicatie wordt afgesloten vanwege een fatale fout.</translation>
+    </message>
+</context>
+<context>
+    <name>Utility</name>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="93"/>
+        <source>%L1 GB</source>
+        <translation>%L1 GB</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="97"/>
+        <source>%L1 MB</source>
+        <translation>%L1 MB</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="101"/>
+        <source>%L1 KB</source>
+        <translation>%L1 KB</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="104"/>
+        <source>%L1 B</source>
+        <translation>%L1 B</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="37"/>
+        <source>%n year(s)</source>
+        <translation>
+            <numerusform>%n jaar</numerusform>
+            <numerusform>%n jaar</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="38"/>
+        <source>%n month(s)</source>
+        <translation>
+            <numerusform>%n maand</numerusform>
+            <numerusform>%n maanden</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="39"/>
+        <source>%n day(s)</source>
+        <translation>
+            <numerusform>%n dag</numerusform>
+            <numerusform>%n dagen</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="40"/>
+        <source>%n hour(s)</source>
+        <translation>
+            <numerusform>%n uur</numerusform>
+            <numerusform>%n uur</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="41"/>
+        <source>%n minute(s)</source>
+        <translation>
+            <numerusform>%n minuut</numerusform>
+            <numerusform>%n minuten</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="42"/>
+        <source>%n second(s)</source>
+        <translation>
+            <numerusform>%n seconde</numerusform>
+            <numerusform>%n seconden</numerusform>
+        </translation>
+    </message>
+</context>
+<context>
+    <name>main.cpp</name>
+    <message>
+        <location filename="../src/gui/mainclient.cpp" line="47"/>
+        <source>System Tray not available</source>
+        <translation>Systeemvak niet beschikbaar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/mainclient.cpp" line="48"/>
+        <source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as &apos;trayer&apos; and try again.</source>
+        <translation>%1 vereist een werkend systeemvak. Als u XFCE gebruikt, volg dan &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;deze instructies&lt;/a&gt;. Installeer anders een systeemvak-toepassing zoals &apos;trayer&apos; en probeer het opnieuw.</translation>
+    </message>
+</context>
+<context>
+    <name>utility</name>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="84"/>
+        <source>Could not open browser</source>
+        <translation>Kon browser niet openen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="85"/>
+        <source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
+        <translation>Er trad een fout op bij het starten van de browser om naar URL %1 te gaan. Misschien is er geen standaardbrowser geconfigureerd?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="104"/>
+        <source>Could not open email client</source>
+        <translation>Kon e-mailclient niet openen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="105"/>
+        <source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
+        <translation>Er trad een fout op bij het starten van de e-mailclient om een nieuw bericht te maken. Misschien is er geen standaard e-mailclient geconfigureerd?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="324"/>
+        <source>You are not connected anymore. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Log in&lt;/a&gt;</source>
+        <translation>U bent niet meer verbonden. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Inloggen&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="347"/>
+        <source>Sync in progress (Step %1/%2).</source>
+        <translation>Synchronisatie bezig (Stap %1/%2).</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="353"/>
+        <source>Sync in progress.</source>
+        <translation>Synchronisatie bezig.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="364"/>
+        <source>Some files couldn&apos;t be synchronized. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Sommige bestanden konden niet worden gesynchroniseerd. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Meer informatie&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="370"/>
+        <source>Synchronization pausing ...</source>
+        <translation>Synchronisatie wordt gepauzeerd...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="570"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
+        <translation>Map &lt;b&gt;%1&lt;/b&gt; kan niet worden geselecteerd omdat een andere synchronisatie dezelfde map gebruikt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="576"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+        <translation>Map &lt;b&gt;%1&lt;/b&gt; kan niet worden geselecteerd omdat deze de gesynchroniseerde map &lt;b&gt;%2&lt;/b&gt; bevat.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="584"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+        <translation>Map &lt;b&gt;%1&lt;/b&gt; kan niet worden geselecteerd omdat deze bevat is in de gesynchroniseerde map &lt;b&gt;%2&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="595"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
+        <translation>Map &lt;b&gt;%1&lt;/b&gt; kan niet worden geselecteerd als synchronisatiemap. Selecteer een andere map.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="599"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
+        <translation>Map &lt;b&gt;%1&lt;/b&gt; kan niet worden geselecteerd als synchronisatiemap. Selecteer een andere map. Voorgestelde map: &lt;b&gt;%2&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="641"/>
+        <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
+        <translation>U heeft meer dan %1 mappen uitgesloten, houd er rekening mee dat dit de synchronisatieprestaties beïnvloedt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="650"/>
+        <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
+        <translation>U kunt niet meer dan %1 mappen uitsluiten. Vink mappen op een hoger niveau uit.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="351"/>
+        <source>Synchronization starting</source>
+        <translation>Synchronisatie start</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="374"/>
+        <source>Synchronization paused.</source>
+        <translation>Synchronisatie gepauzeerd.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="336"/>
+        <source>Sync in progress (%1 of %2)</source>
+        <translation>Synchronisatie bezig (%1 van %2)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="340"/>
+        <source>Sync in progress (%1 of %2)
+%3 left...</source>
+        <translation>Synchronisatie bezig (%1 van %2)
+%3 resterend...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="358"/>
+        <source>You are up to date, unresolved conflicts.</source>
+        <translation>U bent up-to-date, niet-opgeloste conflicten.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="360"/>
+        <source>You are up to date!</source>
+        <translation>U bent up-to-date!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="329"/>
+        <source>No folder to synchronize
+You can add one from the kDrive settings.</source>
+        <translation>Geen map om te synchroniseren
+U kunt er een toevoegen via de kDrive-instellingen.</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
## Summary

This PR adds Dutch (Netherlands) language support to kDrive and includes a UI fix for message box button widths.

### Changes

#### New Features
- **Dutch language support** - Full translation file (`translations/client_nl.ts`) with 3,021 lines
- Added `Language::Dutch` enum value
- Language code `"nl"` support in `CommonUtility`
- QLocale integration for Dutch locale
- Dutch option in language preferences selector

#### UI Fixes  
- **Fixed button width calculation** in `CustomMessageBox` - dialog now properly sizes based on actual button widths instead of content width alone

#### Code Improvements
- **Refactoring**: Moved `strToLanguage()` function from `MigrationParams` to `CommonUtility` to eliminate code duplication (DRY principle)
- Updated unit tests for new language support

### Files Modified
- `src/gui/custommessagebox.cpp` - Button width fix
- `src/gui/guiutility.cpp` - Dutch locale support
- `src/gui/preferenceswidget.cpp` - Language selector update
- `src/libcommon/theme/theme.cpp` - Theme support
- `src/libcommon/utility/cstypes.h` - Language enum
- `src/libcommon/utility/types.cpp` - Type utilities
- `src/libcommon/utility/utility.cpp/.h` - Language utilities
- `src/server/migration/migrationparams.cpp/.h` - Refactoring
- `test/libcommon/utility/testutility.cpp` - Unit tests
- `translations/client_nl.ts` - Dutch translations (new file)

### Testing
- [x] Unit tests updated and passing
- [x] Translation file validated
- [x] UI rendering tested

---
**Note**: This branch contains 3 commits that should be squashed on merge if preferred.
