### PR TITLE
fix(jobs): ensure additional callback is called even for cancelled jobs

### DIFF
--- a/src/libsyncengine/jobs/abstractjob.cpp
+++ b/src/libsyncengine/jobs/abstractjob.cpp
@@ -74,7 +74,7 @@ bool AbstractJob::isAborted() const {
 void AbstractJob::callback(const UniqueId id) {
     try {
         const std::scoped_lock lock(_additionalCallbackMutex);
-        if (_mainCallback && _additionalCallback && !_aborted) {
+        if (_mainCallback && _additionalCallback) {
             _additionalCallback(id); // Call the "additional" callback first since the main callback might delete the last
                                      // reference on the job
         }


### PR DESCRIPTION
## Description

Fixes an issue where the additional callback was not being called when a job was cancelled.

## Changes

- Removed the `!_aborted` check from the condition
- This ensures the additional callback is invoked even when the job has been cancelled
- The callback is called before the main callback as the main callback might delete the last reference on the job

## Related

Prevents missing cleanup or tracking operations that should occur on job cancellation.

Regression introduced following : https://github.com/Infomaniak/desktop-kDrive/pull/1443