### PR TITLE
feat(linux): add ServerCommService to handle server-initiated signals

### DIFF
--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -18,6 +18,8 @@ set(GUI_SOURCE_FILES # C++ files for the GUI application
         communicationlayer/ipcclient.h
         communicationlayer/signaldispatcher.cpp
         communicationlayer/signaldispatcher.h
+        app/services/servercommservice.cpp
+        app/services/servercommservice.h
 )
 
 set(GUI_QML_SINGLETON_FILES # QML singletons (tokens, theme, etc.)

--- a/src/gui4/linux/app/services/servercommservice.cpp
+++ b/src/gui4/linux/app/services/servercommservice.cpp
@@ -1,0 +1,98 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "servercommservice.h"
+
+#include "libcommon/utility/utility.h"
+
+#include <QLoggingCategory>
+
+Q_LOGGING_CATEGORY(lcServerCommService, "gui.v4.servercommservice", QtInfoMsg)
+
+namespace KDC {
+
+// Param keys ─ mirrors the server-side signal job static constants.
+namespace {
+// User
+constexpr auto kUserInfo = "userInfo";
+constexpr auto kUserDbId = "userDbId";
+// Account
+constexpr auto kAccountInfo = "accountInfo";
+constexpr auto kAccountDbId = "accountDbId";
+// Drive
+constexpr auto kDriveInfo = "driveInfo";
+constexpr auto kDriveDbId = "driveDbId";
+// Sync
+constexpr auto kSyncInfo = "syncInfo";
+constexpr auto kSyncDbId = "syncDbId";
+constexpr auto kSyncStatus = "syncStatus";
+constexpr auto kSyncStep = "syncStep";
+constexpr auto kSyncProgress = "SyncProgress";
+constexpr auto kCurrentFile = "currentFile";
+constexpr auto kTotalFiles = "totalFiles";
+constexpr auto kCompletedSize = "completedSize";
+constexpr auto kTotalSize = "totalSize";
+constexpr auto kEstimatedRemainingTime = "estimatedRemainingTime";
+constexpr auto kItemInfo = "itemInfo";
+// Error
+constexpr auto kErrorInfo = "errorInfo";
+constexpr auto kErrorDbId = "errorDbId";
+// Updater
+constexpr auto kUpdateState = "updateState";
+constexpr auto kVersionInfo = "versionInfo";
+// Utility
+constexpr auto kTitle = "title";
+constexpr auto kMessage = "message";
+constexpr auto kLogUploadState = "state";
+constexpr auto kPercentage = "percentage";
+} // namespace
+
+ServerCommService::ServerCommService(SignalDispatcher &dispatcher, QObject *parent) :
+    QObject(parent) {
+    registerUserHandlers(dispatcher);
+    registerAccountHandlers(dispatcher);
+    registerDriveHandlers(dispatcher);
+    registerSyncHandlers(dispatcher);
+    registerErrorHandlers(dispatcher);
+    registerUpdaterHandlers(dispatcher);
+    registerUtilityHandlers(dispatcher);
+}
+
+// -- User ---------------------------------------------------------------------
+
+void ServerCommService::registerUserHandlers(SignalDispatcher &dispatcher) {
+    dispatcher.registerHandler(SignalNum::USER_ADDED, [this](const Poco::DynamicStruct &params) {
+        UserInfo info;
+        info.fromDynamicStruct(params[kUserInfo].extract<Poco::DynamicStruct>());
+        emit userAdded(info);
+    });
+
+    dispatcher.registerHandler(SignalNum::USER_UPDATED, [this](const Poco::DynamicStruct &params) {
+        UserInfo info;
+        info.fromDynamicStruct(params[kUserInfo].extract<Poco::DynamicStruct>());
+        emit userUpdated(info);
+    });
+
+    dispatcher.registerHandler(SignalNum::USER_REMOVED, [this](const Poco::DynamicStruct &params) {
+        UserDbId userDbId = 0;
+        CommonUtility::readValueFromStruct(params, kUserDbId, userDbId);
+        emit userRemoved(userDbId);
+    });
+}
+
+} // namespace KDC

--- a/src/gui4/linux/app/services/servercommservice.cpp
+++ b/src/gui4/linux/app/services/servercommservice.cpp
@@ -22,11 +22,24 @@
 #include "libcommon/utility/utility.h"
 
 #include <QLoggingCategory>
+#include <QPointer>
 
 Q_LOGGING_CATEGORY(lcServerCommService, "gui.v4.servercommservice", QtInfoMsg)
 
-namespace KDC {
+namespace {
 
+bool checkSelf(const QPointer<KDC::ServerCommService> &self, SignalNum num) {
+    if (!self) {
+        qCWarning(lcServerCommService) << "Signal" << toString(num).c_str()
+                                       << "received after ServerCommService destruction - ignoring";
+        return true;
+    }
+    return false;
+}
+
+} // namespace
+
+namespace KDC {
 
 ServerCommService::ServerCommService(SignalDispatcher &dispatcher, QObject *parent) :
     QObject(parent) {

--- a/src/gui4/linux/app/services/servercommservice.cpp
+++ b/src/gui4/linux/app/services/servercommservice.cpp
@@ -139,5 +139,58 @@ void ServerCommService::registerDriveHandlers(SignalDispatcher &dispatcher) {
     });
 }
 
+// -- Sync ----------------------------------------------------------------------
+
+void ServerCommService::registerSyncHandlers(SignalDispatcher &dispatcher) {
+    dispatcher.registerHandler(SignalNum::SYNC_ADDED, [this](const Poco::DynamicStruct &params) {
+        SyncInfo info;
+        info.fromDynamicStruct(params[kSyncInfo].extract<Poco::DynamicStruct>());
+        emit syncAdded(info);
+    });
+
+    dispatcher.registerHandler(SignalNum::SYNC_UPDATED, [this](const Poco::DynamicStruct &params) {
+        SyncInfo info;
+        info.fromDynamicStruct(params[kSyncInfo].extract<Poco::DynamicStruct>());
+        emit syncUpdated(info);
+    });
+
+    dispatcher.registerHandler(SignalNum::SYNC_REMOVED, [this](const Poco::DynamicStruct &params) {
+        SyncDbId syncDbId = 0;
+        CommonUtility::readValueFromStruct(params, kSyncDbId, syncDbId);
+        emit syncRemoved(syncDbId);
+    });
+
+    dispatcher.registerHandler(SignalNum::SYNC_PROGRESSINFO, [this](const Poco::DynamicStruct &params) {
+        SyncDbId syncDbId = 0;
+        auto status = SyncStatus::Undefined;
+        auto step = SyncStep::Idle;
+        CommonUtility::readValueFromStruct(params, kSyncDbId, syncDbId);
+        CommonUtility::readValueFromStruct(params, kSyncStatus, status);
+        CommonUtility::readValueFromStruct(params, kSyncStep, step);
+
+        const Poco::DynamicStruct progressStruct = params[kSyncProgress].extract<Poco::DynamicStruct>();
+        int64_t currentFile = 0;
+        int64_t totalFiles = 0;
+        int64_t completedSize = 0;
+        int64_t totalSize = 0;
+        int64_t estimatedRemainingTime = 0;
+        CommonUtility::readValueFromStruct(progressStruct, kCurrentFile, currentFile);
+        CommonUtility::readValueFromStruct(progressStruct, kTotalFiles, totalFiles);
+        CommonUtility::readValueFromStruct(progressStruct, kCompletedSize, completedSize);
+        CommonUtility::readValueFromStruct(progressStruct, kTotalSize, totalSize);
+        CommonUtility::readValueFromStruct(progressStruct, kEstimatedRemainingTime, estimatedRemainingTime);
+
+        emit syncProgressInfo(syncDbId, status, step, currentFile, totalFiles, completedSize, totalSize, estimatedRemainingTime);
+    });
+
+    dispatcher.registerHandler(SignalNum::SYNC_COMPLETEDITEM, [this](const Poco::DynamicStruct &params) {
+        SyncDbId syncDbId = 0;
+        CommonUtility::readValueFromStruct(params, kSyncDbId, syncDbId);
+        SyncFileItemInfo info;
+        info.fromDynamicStruct(params[kItemInfo].extract<Poco::DynamicStruct>());
+        emit itemCompleted(syncDbId, info);
+    });
+}
+
 
 } // namespace KDC

--- a/src/gui4/linux/app/services/servercommservice.cpp
+++ b/src/gui4/linux/app/services/servercommservice.cpp
@@ -55,178 +55,230 @@ ServerCommService::ServerCommService(SignalDispatcher &dispatcher, QObject *pare
 // -- User ---------------------------------------------------------------------
 
 void ServerCommService::registerUserHandlers(SignalDispatcher &dispatcher) {
-    dispatcher.registerHandler(SignalNum::USER_ADDED, [this](const Poco::DynamicStruct &params) {
-        UserInfo info;
-        info.fromDynamicStruct(params[MSG_PARAM_USER_INFO].extract<Poco::DynamicStruct>());
-        emit userAdded(info);
-    });
+    dispatcher.registerHandler(SignalNum::USER_ADDED,
+                               [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
+                                   if (checkSelf(self, SignalNum::USER_ADDED)) return;
+                                   UserInfo info;
+                                   info.fromDynamicStruct(params[MSG_PARAM_USER_INFO].extract<Poco::DynamicStruct>());
+                                   emit self->userAdded(info);
+                               });
 
-    dispatcher.registerHandler(SignalNum::USER_UPDATED, [this](const Poco::DynamicStruct &params) {
-        UserInfo info;
-        info.fromDynamicStruct(params[MSG_PARAM_USER_INFO].extract<Poco::DynamicStruct>());
-        emit userUpdated(info);
-    });
+    dispatcher.registerHandler(SignalNum::USER_UPDATED,
+                               [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
+                                   if (checkSelf(self, SignalNum::USER_UPDATED)) return;
+                                   UserInfo info;
+                                   info.fromDynamicStruct(params[MSG_PARAM_USER_INFO].extract<Poco::DynamicStruct>());
+                                   emit self->userUpdated(info);
+                               });
 
-    dispatcher.registerHandler(SignalNum::USER_REMOVED, [this](const Poco::DynamicStruct &params) {
-        UserDbId userDbId = 0;
-        CommonUtility::readValueFromStruct(params, MSG_PARAM_USER_DB_ID, userDbId);
-        emit userRemoved(userDbId);
-    });
+    dispatcher.registerHandler(SignalNum::USER_REMOVED,
+                               [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
+                                   if (checkSelf(self, SignalNum::USER_REMOVED)) return;
+                                   UserDbId userDbId = 0;
+                                   CommonUtility::readValueFromStruct(params, MSG_PARAM_USER_DB_ID, userDbId);
+                                   emit self->userRemoved(userDbId);
+                               });
 }
 
 // -- Account ------------------------------------------------------------------
 
 void ServerCommService::registerAccountHandlers(SignalDispatcher &dispatcher) {
-    dispatcher.registerHandler(SignalNum::ACCOUNT_ADDED, [this](const Poco::DynamicStruct &params) {
-        AccountInfo info;
-        info.fromDynamicStruct(params[MSG_PARAM_ACCOUNT_INFO].extract<Poco::DynamicStruct>());
-        emit accountAdded(info);
-    });
+    dispatcher.registerHandler(SignalNum::ACCOUNT_ADDED,
+                               [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
+                                   if (checkSelf(self, SignalNum::ACCOUNT_ADDED)) return;
+                                   AccountInfo info;
+                                   info.fromDynamicStruct(params[MSG_PARAM_ACCOUNT_INFO].extract<Poco::DynamicStruct>());
+                                   emit self->accountAdded(info);
+                               });
 
-    dispatcher.registerHandler(SignalNum::ACCOUNT_UPDATED, [this](const Poco::DynamicStruct &params) {
-        AccountInfo info;
-        info.fromDynamicStruct(params[MSG_PARAM_ACCOUNT_INFO].extract<Poco::DynamicStruct>());
-        emit accountUpdated(info);
-    });
+    dispatcher.registerHandler(SignalNum::ACCOUNT_UPDATED,
+                               [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
+                                   if (checkSelf(self, SignalNum::ACCOUNT_UPDATED)) return;
+                                   AccountInfo info;
+                                   info.fromDynamicStruct(params[MSG_PARAM_ACCOUNT_INFO].extract<Poco::DynamicStruct>());
+                                   emit self->accountUpdated(info);
+                               });
 
-    dispatcher.registerHandler(SignalNum::ACCOUNT_REMOVED, [this](const Poco::DynamicStruct &params) {
-        AccountDbId accountDbId = 0;
-        CommonUtility::readValueFromStruct(params, MSG_PARAM_ACCOUNT_DB_ID, accountDbId);
-        emit accountRemoved(accountDbId);
-    });
+    dispatcher.registerHandler(SignalNum::ACCOUNT_REMOVED,
+                               [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
+                                   if (checkSelf(self, SignalNum::ACCOUNT_REMOVED)) return;
+                                   AccountDbId accountDbId = 0;
+                                   CommonUtility::readValueFromStruct(params, MSG_PARAM_ACCOUNT_DB_ID, accountDbId);
+                                   emit self->accountRemoved(accountDbId);
+                               });
 }
 
 // -- Drive ---------------------------------------------------------------------
 
 void ServerCommService::registerDriveHandlers(SignalDispatcher &dispatcher) {
-    dispatcher.registerHandler(SignalNum::DRIVE_ADDED, [this](const Poco::DynamicStruct &params) {
-        DriveInfo info;
-        info.fromDynamicStruct(params[MSG_PARAM_DRIVE_INFO].extract<Poco::DynamicStruct>());
-        emit driveAdded(info);
-    });
+    dispatcher.registerHandler(SignalNum::DRIVE_ADDED,
+                               [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
+                                   if (checkSelf(self, SignalNum::DRIVE_ADDED)) return;
+                                   DriveInfo info;
+                                   info.fromDynamicStruct(params[MSG_PARAM_DRIVE_INFO].extract<Poco::DynamicStruct>());
+                                   emit self->driveAdded(info);
+                               });
 
-    dispatcher.registerHandler(SignalNum::DRIVE_UPDATED, [this](const Poco::DynamicStruct &params) {
-        DriveInfo info;
-        info.fromDynamicStruct(params[MSG_PARAM_DRIVE_INFO].extract<Poco::DynamicStruct>());
-        emit driveUpdated(info);
-    });
+    dispatcher.registerHandler(SignalNum::DRIVE_UPDATED,
+                               [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
+                                   if (checkSelf(self, SignalNum::DRIVE_UPDATED)) return;
+                                   DriveInfo info;
+                                   info.fromDynamicStruct(params[MSG_PARAM_DRIVE_INFO].extract<Poco::DynamicStruct>());
+                                   emit self->driveUpdated(info);
+                               });
 
-    dispatcher.registerHandler(SignalNum::DRIVE_REMOVED, [this](const Poco::DynamicStruct &params) {
-        DriveDbId driveDbId = 0;
-        CommonUtility::readValueFromStruct(params, MSG_PARAM_DRIVE_DB_ID, driveDbId);
-        emit driveRemoved(driveDbId);
-    });
+    dispatcher.registerHandler(SignalNum::DRIVE_REMOVED,
+                               [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
+                                   if (checkSelf(self, SignalNum::DRIVE_REMOVED)) return;
+                                   DriveDbId driveDbId = 0;
+                                   CommonUtility::readValueFromStruct(params, MSG_PARAM_DRIVE_DB_ID, driveDbId);
+                                   emit self->driveRemoved(driveDbId);
+                               });
 }
 
 // -- Sync ----------------------------------------------------------------------
 
 void ServerCommService::registerSyncHandlers(SignalDispatcher &dispatcher) {
-    dispatcher.registerHandler(SignalNum::SYNC_ADDED, [this](const Poco::DynamicStruct &params) {
-        SyncInfo info;
-        info.fromDynamicStruct(params[MSG_PARAM_SYNC_INFO].extract<Poco::DynamicStruct>());
-        emit syncAdded(info);
-    });
+    dispatcher.registerHandler(SignalNum::SYNC_ADDED,
+                               [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
+                                   if (checkSelf(self, SignalNum::SYNC_ADDED)) return;
+                                   SyncInfo info;
+                                   info.fromDynamicStruct(params[MSG_PARAM_SYNC_INFO].extract<Poco::DynamicStruct>());
+                                   emit self->syncAdded(info);
+                               });
 
-    dispatcher.registerHandler(SignalNum::SYNC_UPDATED, [this](const Poco::DynamicStruct &params) {
-        SyncInfo info;
-        info.fromDynamicStruct(params[MSG_PARAM_SYNC_INFO].extract<Poco::DynamicStruct>());
-        emit syncUpdated(info);
-    });
+    dispatcher.registerHandler(SignalNum::SYNC_UPDATED,
+                               [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
+                                   if (checkSelf(self, SignalNum::SYNC_UPDATED)) return;
+                                   SyncInfo info;
+                                   info.fromDynamicStruct(params[MSG_PARAM_SYNC_INFO].extract<Poco::DynamicStruct>());
+                                   emit self->syncUpdated(info);
+                               });
 
-    dispatcher.registerHandler(SignalNum::SYNC_REMOVED, [this](const Poco::DynamicStruct &params) {
-        SyncDbId syncDbId = 0;
-        CommonUtility::readValueFromStruct(params, MSG_PARAM_SYNC_DB_ID, syncDbId);
-        emit syncRemoved(syncDbId);
-    });
+    dispatcher.registerHandler(SignalNum::SYNC_REMOVED,
+                               [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
+                                   if (checkSelf(self, SignalNum::SYNC_REMOVED)) return;
+                                   SyncDbId syncDbId = 0;
+                                   CommonUtility::readValueFromStruct(params, MSG_PARAM_SYNC_DB_ID, syncDbId);
+                                   emit self->syncRemoved(syncDbId);
+                               });
 
-    dispatcher.registerHandler(SignalNum::SYNC_PROGRESSINFO, [this](const Poco::DynamicStruct &params) {
-        SyncDbId syncDbId = 0;
-        auto status = SyncStatus::Undefined;
-        auto step = SyncStep::Idle;
-        CommonUtility::readValueFromStruct(params, MSG_PARAM_SYNC_DB_ID, syncDbId);
-        CommonUtility::readValueFromStruct(params, MSG_PARAM_SYNC_STATUS, status);
-        CommonUtility::readValueFromStruct(params, MSG_PARAM_SYNC_STEP, step);
+    dispatcher.registerHandler(
+            SignalNum::SYNC_PROGRESSINFO, [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
+                if (checkSelf(self, SignalNum::SYNC_PROGRESSINFO)) return;
+                SyncDbId syncDbId = 0;
+                auto status = SyncStatus::Undefined;
+                auto step = SyncStep::Idle;
+                CommonUtility::readValueFromStruct(params, MSG_PARAM_SYNC_DB_ID, syncDbId);
+                CommonUtility::readValueFromStruct(params, MSG_PARAM_SYNC_STATUS, status);
+                CommonUtility::readValueFromStruct(params, MSG_PARAM_SYNC_STEP, step);
 
-        const Poco::DynamicStruct progressStruct = params[MSG_PARAM_SYNC_PROGRESS].extract<Poco::DynamicStruct>();
-        int64_t currentFile = 0;
-        int64_t totalFiles = 0;
-        int64_t completedSize = 0;
-        int64_t totalSize = 0;
-        int64_t estimatedRemainingTime = 0;
-        CommonUtility::readValueFromStruct(progressStruct, MSG_PARAM_CURRENT_FILE, currentFile);
-        CommonUtility::readValueFromStruct(progressStruct, MSG_PARAM_TOTAL_FILES, totalFiles);
-        CommonUtility::readValueFromStruct(progressStruct, MSG_PARAM_COMPLETED_SIZE, completedSize);
-        CommonUtility::readValueFromStruct(progressStruct, MSG_PARAM_TOTAL_SIZE, totalSize);
-        CommonUtility::readValueFromStruct(progressStruct, MSG_PARAM_ESTIMATED_REMAINING_TIME, estimatedRemainingTime);
+                const Poco::DynamicStruct progressStruct = params[MSG_PARAM_SYNC_PROGRESS].extract<Poco::DynamicStruct>();
+                int64_t currentFile = 0;
+                int64_t totalFiles = 0;
+                int64_t completedSize = 0;
+                int64_t totalSize = 0;
+                int64_t estimatedRemainingTime = 0;
+                CommonUtility::readValueFromStruct(progressStruct, MSG_PARAM_CURRENT_FILE, currentFile);
+                CommonUtility::readValueFromStruct(progressStruct, MSG_PARAM_TOTAL_FILES, totalFiles);
+                CommonUtility::readValueFromStruct(progressStruct, MSG_PARAM_COMPLETED_SIZE, completedSize);
+                CommonUtility::readValueFromStruct(progressStruct, MSG_PARAM_TOTAL_SIZE, totalSize);
+                CommonUtility::readValueFromStruct(progressStruct, MSG_PARAM_ESTIMATED_REMAINING_TIME, estimatedRemainingTime);
 
-        emit syncProgressInfo(syncDbId, status, step, currentFile, totalFiles, completedSize, totalSize, estimatedRemainingTime);
-    });
+                emit self->syncProgressInfo(syncDbId, status, step, currentFile, totalFiles, completedSize, totalSize,
+                                            estimatedRemainingTime);
+            });
 
-    dispatcher.registerHandler(SignalNum::SYNC_COMPLETEDITEM, [this](const Poco::DynamicStruct &params) {
-        SyncDbId syncDbId = 0;
-        CommonUtility::readValueFromStruct(params, MSG_PARAM_SYNC_DB_ID, syncDbId);
-        SyncFileItemInfo info;
-        info.fromDynamicStruct(params[MSG_PARAM_ITEM_INFO].extract<Poco::DynamicStruct>());
-        emit itemCompleted(syncDbId, info);
-    });
+    dispatcher.registerHandler(SignalNum::SYNC_COMPLETEDITEM,
+                               [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
+                                   if (checkSelf(self, SignalNum::SYNC_COMPLETEDITEM)) return;
+                                   SyncDbId syncDbId = 0;
+                                   CommonUtility::readValueFromStruct(params, MSG_PARAM_SYNC_DB_ID, syncDbId);
+                                   SyncFileItemInfo info;
+                                   info.fromDynamicStruct(params[MSG_PARAM_ITEM_INFO].extract<Poco::DynamicStruct>());
+                                   emit self->itemCompleted(syncDbId, info);
+                               });
 }
 
 // -- Error ---------------------------------------------------------------------
 
 void ServerCommService::registerErrorHandlers(SignalDispatcher &dispatcher) {
-    dispatcher.registerHandler(SignalNum::UTILITY_ERROR_ADDED, [this](const Poco::DynamicStruct &params) {
-        ErrorInfo info;
-        info.fromDynamicStruct(params[MSG_PARAM_ERROR_INFO].extract<Poco::DynamicStruct>());
-        emit errorAdded(info);
-    });
+    dispatcher.registerHandler(SignalNum::UTILITY_ERROR_ADDED,
+                               [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
+                                   if (checkSelf(self, SignalNum::UTILITY_ERROR_ADDED)) return;
+                                   ErrorInfo info;
+                                   info.fromDynamicStruct(params[MSG_PARAM_ERROR_INFO].extract<Poco::DynamicStruct>());
+                                   emit self->errorAdded(info);
+                               });
 
-    dispatcher.registerHandler(SignalNum::UTILITY_ERROR_REMOVED, [this](const Poco::DynamicStruct &params) {
-        ErrorDbId errorDbId = 0;
-        CommonUtility::readValueFromStruct(params, MSG_PARAM_ERROR_DB_ID, errorDbId);
-        emit errorRemoved(errorDbId);
-    });
+    dispatcher.registerHandler(SignalNum::UTILITY_ERROR_REMOVED,
+                               [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
+                                   if (checkSelf(self, SignalNum::UTILITY_ERROR_REMOVED)) return;
+                                   ErrorDbId errorDbId = 0;
+                                   CommonUtility::readValueFromStruct(params, MSG_PARAM_ERROR_DB_ID, errorDbId);
+                                   emit self->errorRemoved(errorDbId);
+                               });
 }
 
 // -- Updater -------------------------------------------------------------------
 
 void ServerCommService::registerUpdaterHandlers(SignalDispatcher &dispatcher) {
-    dispatcher.registerHandler(SignalNum::UPDATER_STATE_CHANGED, [this](const Poco::DynamicStruct &params) {
-        UpdateState state = UpdateState::Unknown;
-        CommonUtility::readValueFromStruct(params, MSG_PARAM_UPDATE_STATE, state);
-        emit updateStateChanged(state);
-    });
+    dispatcher.registerHandler(SignalNum::UPDATER_STATE_CHANGED,
+                               [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
+                                   if (checkSelf(self, SignalNum::UPDATER_STATE_CHANGED)) return;
+                                   UpdateState state = UpdateState::Unknown;
+                                   CommonUtility::readValueFromStruct(params, MSG_PARAM_UPDATE_STATE, state);
+                                   emit self->updateStateChanged(state);
+                               });
 
-    dispatcher.registerHandler(SignalNum::UPDATER_SHOW_DIALOG, [this](const Poco::DynamicStruct &params) {
-        VersionInfo info;
-        info.fromDynamicStruct(params[MSG_PARAM_VERSION_INFO].extract<Poco::DynamicStruct>());
-        emit showUpdateDialog(info);
-    });
+    dispatcher.registerHandler(SignalNum::UPDATER_SHOW_DIALOG,
+                               [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
+                                   if (checkSelf(self, SignalNum::UPDATER_SHOW_DIALOG)) return;
+                                   VersionInfo info;
+                                   info.fromDynamicStruct(params[MSG_PARAM_VERSION_INFO].extract<Poco::DynamicStruct>());
+                                   emit self->showUpdateDialog(info);
+                               });
 }
 
 // -- Utility -------------------------------------------------------------------
 
 void ServerCommService::registerUtilityHandlers(SignalDispatcher &dispatcher) {
-    dispatcher.registerHandler(SignalNum::UTILITY_SHOW_NOTIFICATION, [this](const Poco::DynamicStruct &params) {
-        CommString title;
-        CommString message;
-        CommonUtility::readValueFromStruct(params, MSG_PARAM_TITLE, title);
-        CommonUtility::readValueFromStruct(params, MSG_PARAM_MESSAGE, message);
-        emit showNotification(CommonUtility::commString2QStr(title), CommonUtility::commString2QStr(message));
+    dispatcher.registerHandler(
+            SignalNum::UTILITY_SHOW_NOTIFICATION, [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
+                if (checkSelf(self, SignalNum::UTILITY_SHOW_NOTIFICATION)) return;
+                CommString title;
+                CommString message;
+                CommonUtility::readValueFromStruct(params, MSG_PARAM_TITLE, title);
+                CommonUtility::readValueFromStruct(params, MSG_PARAM_MESSAGE, message);
+                emit self->showNotification(CommonUtility::commString2QStr(title), CommonUtility::commString2QStr(message));
+            });
+
+    dispatcher.registerHandler(SignalNum::UTILITY_SHOW_SETTINGS,
+                               [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &) {
+                                   if (checkSelf(self, SignalNum::UTILITY_SHOW_SETTINGS)) return;
+                                   emit self->showSettings();
+                               });
+
+    dispatcher.registerHandler(SignalNum::UTILITY_SHOW_SYNTHESIS,
+                               [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &) {
+                                   if (checkSelf(self, SignalNum::UTILITY_SHOW_SYNTHESIS)) return;
+                                   emit self->showSynthesis();
+                               });
+
+    dispatcher.registerHandler(SignalNum::UTILITY_LOG_UPLOAD_STATUS_UPDATED,
+                               [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
+                                   if (checkSelf(self, SignalNum::UTILITY_LOG_UPLOAD_STATUS_UPDATED)) return;
+                                   LogUploadState state = LogUploadState::None;
+                                   int32_t percentage = 0;
+                                   CommonUtility::readValueFromStruct(params, MSG_PARAM_LOG_UPLOAD_STATE, state);
+                                   CommonUtility::readValueFromStruct(params, MSG_PARAM_PERCENTAGE, percentage);
+                                   emit self->logUploadStatusUpdated(state, percentage);
+                               });
+
+    dispatcher.registerHandler(SignalNum::UTILITY_QUIT, [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &) {
+        if (checkSelf(self, SignalNum::UTILITY_QUIT)) return;
+        emit self->quit();
     });
-
-    dispatcher.registerHandler(SignalNum::UTILITY_SHOW_SETTINGS, [this](const Poco::DynamicStruct &) { emit showSettings(); });
-
-    dispatcher.registerHandler(SignalNum::UTILITY_SHOW_SYNTHESIS, [this](const Poco::DynamicStruct &) { emit showSynthesis(); });
-
-    dispatcher.registerHandler(SignalNum::UTILITY_LOG_UPLOAD_STATUS_UPDATED, [this](const Poco::DynamicStruct &params) {
-        LogUploadState state = LogUploadState::None;
-        int32_t percentage = 0;
-        CommonUtility::readValueFromStruct(params, MSG_PARAM_LOG_UPLOAD_STATE, state);
-        CommonUtility::readValueFromStruct(params, MSG_PARAM_PERCENTAGE, percentage);
-        emit logUploadStatusUpdated(state, percentage);
-    });
-
-    dispatcher.registerHandler(SignalNum::UTILITY_QUIT, [this](const Poco::DynamicStruct &) { emit quit(); });
 }
 
 } // namespace KDC

--- a/src/gui4/linux/app/services/servercommservice.cpp
+++ b/src/gui4/linux/app/services/servercommservice.cpp
@@ -95,4 +95,27 @@ void ServerCommService::registerUserHandlers(SignalDispatcher &dispatcher) {
     });
 }
 
+// -- Account ------------------------------------------------------------------
+
+void ServerCommService::registerAccountHandlers(SignalDispatcher &dispatcher) {
+    dispatcher.registerHandler(SignalNum::ACCOUNT_ADDED, [this](const Poco::DynamicStruct &params) {
+        AccountInfo info;
+        info.fromDynamicStruct(params[kAccountInfo].extract<Poco::DynamicStruct>());
+        emit accountAdded(info);
+    });
+
+    dispatcher.registerHandler(SignalNum::ACCOUNT_UPDATED, [this](const Poco::DynamicStruct &params) {
+        AccountInfo info;
+        info.fromDynamicStruct(params[kAccountInfo].extract<Poco::DynamicStruct>());
+        emit accountUpdated(info);
+    });
+
+    dispatcher.registerHandler(SignalNum::ACCOUNT_REMOVED, [this](const Poco::DynamicStruct &params) {
+        AccountDbId accountDbId = 0;
+        CommonUtility::readValueFromStruct(params, kAccountDbId, accountDbId);
+        emit accountRemoved(accountDbId);
+    });
+}
+
+
 } // namespace KDC

--- a/src/gui4/linux/app/services/servercommservice.cpp
+++ b/src/gui4/linux/app/services/servercommservice.cpp
@@ -28,7 +28,7 @@ Q_LOGGING_CATEGORY(lcServerCommService, "gui.v4.servercommservice", QtInfoMsg)
 
 namespace {
 
-bool checkSelf(const QPointer<KDC::ServerCommService> &self, SignalNum num) {
+bool isSelfInvalid(const QPointer<KDC::ServerCommService> &self, SignalNum num) {
     if (!self) {
         qCWarning(lcServerCommService) << "Signal" << toString(num).c_str()
                                        << "received after ServerCommService destruction - ignoring";
@@ -57,7 +57,7 @@ ServerCommService::ServerCommService(SignalDispatcher &dispatcher, QObject *pare
 void ServerCommService::registerUserHandlers(SignalDispatcher &dispatcher) {
     dispatcher.registerHandler(SignalNum::USER_ADDED,
                                [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
-                                   if (checkSelf(self, SignalNum::USER_ADDED)) return;
+                                   if (isSelfInvalid(self, SignalNum::USER_ADDED)) return;
                                    UserInfo info;
                                    info.fromDynamicStruct(params[MSG_PARAM_USER_INFO].extract<Poco::DynamicStruct>());
                                    emit self->userAdded(info);
@@ -65,7 +65,7 @@ void ServerCommService::registerUserHandlers(SignalDispatcher &dispatcher) {
 
     dispatcher.registerHandler(SignalNum::USER_UPDATED,
                                [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
-                                   if (checkSelf(self, SignalNum::USER_UPDATED)) return;
+                                   if (isSelfInvalid(self, SignalNum::USER_UPDATED)) return;
                                    UserInfo info;
                                    info.fromDynamicStruct(params[MSG_PARAM_USER_INFO].extract<Poco::DynamicStruct>());
                                    emit self->userUpdated(info);
@@ -73,7 +73,7 @@ void ServerCommService::registerUserHandlers(SignalDispatcher &dispatcher) {
 
     dispatcher.registerHandler(SignalNum::USER_REMOVED,
                                [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
-                                   if (checkSelf(self, SignalNum::USER_REMOVED)) return;
+                                   if (isSelfInvalid(self, SignalNum::USER_REMOVED)) return;
                                    UserDbId userDbId = 0;
                                    CommonUtility::readValueFromStruct(params, MSG_PARAM_USER_DB_ID, userDbId);
                                    emit self->userRemoved(userDbId);
@@ -85,7 +85,7 @@ void ServerCommService::registerUserHandlers(SignalDispatcher &dispatcher) {
 void ServerCommService::registerAccountHandlers(SignalDispatcher &dispatcher) {
     dispatcher.registerHandler(SignalNum::ACCOUNT_ADDED,
                                [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
-                                   if (checkSelf(self, SignalNum::ACCOUNT_ADDED)) return;
+                                   if (isSelfInvalid(self, SignalNum::ACCOUNT_ADDED)) return;
                                    AccountInfo info;
                                    info.fromDynamicStruct(params[MSG_PARAM_ACCOUNT_INFO].extract<Poco::DynamicStruct>());
                                    emit self->accountAdded(info);
@@ -93,7 +93,7 @@ void ServerCommService::registerAccountHandlers(SignalDispatcher &dispatcher) {
 
     dispatcher.registerHandler(SignalNum::ACCOUNT_UPDATED,
                                [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
-                                   if (checkSelf(self, SignalNum::ACCOUNT_UPDATED)) return;
+                                   if (isSelfInvalid(self, SignalNum::ACCOUNT_UPDATED)) return;
                                    AccountInfo info;
                                    info.fromDynamicStruct(params[MSG_PARAM_ACCOUNT_INFO].extract<Poco::DynamicStruct>());
                                    emit self->accountUpdated(info);
@@ -101,7 +101,7 @@ void ServerCommService::registerAccountHandlers(SignalDispatcher &dispatcher) {
 
     dispatcher.registerHandler(SignalNum::ACCOUNT_REMOVED,
                                [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
-                                   if (checkSelf(self, SignalNum::ACCOUNT_REMOVED)) return;
+                                   if (isSelfInvalid(self, SignalNum::ACCOUNT_REMOVED)) return;
                                    AccountDbId accountDbId = 0;
                                    CommonUtility::readValueFromStruct(params, MSG_PARAM_ACCOUNT_DB_ID, accountDbId);
                                    emit self->accountRemoved(accountDbId);
@@ -113,7 +113,7 @@ void ServerCommService::registerAccountHandlers(SignalDispatcher &dispatcher) {
 void ServerCommService::registerDriveHandlers(SignalDispatcher &dispatcher) {
     dispatcher.registerHandler(SignalNum::DRIVE_ADDED,
                                [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
-                                   if (checkSelf(self, SignalNum::DRIVE_ADDED)) return;
+                                   if (isSelfInvalid(self, SignalNum::DRIVE_ADDED)) return;
                                    DriveInfo info;
                                    info.fromDynamicStruct(params[MSG_PARAM_DRIVE_INFO].extract<Poco::DynamicStruct>());
                                    emit self->driveAdded(info);
@@ -121,7 +121,7 @@ void ServerCommService::registerDriveHandlers(SignalDispatcher &dispatcher) {
 
     dispatcher.registerHandler(SignalNum::DRIVE_UPDATED,
                                [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
-                                   if (checkSelf(self, SignalNum::DRIVE_UPDATED)) return;
+                                   if (isSelfInvalid(self, SignalNum::DRIVE_UPDATED)) return;
                                    DriveInfo info;
                                    info.fromDynamicStruct(params[MSG_PARAM_DRIVE_INFO].extract<Poco::DynamicStruct>());
                                    emit self->driveUpdated(info);
@@ -129,7 +129,7 @@ void ServerCommService::registerDriveHandlers(SignalDispatcher &dispatcher) {
 
     dispatcher.registerHandler(SignalNum::DRIVE_REMOVED,
                                [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
-                                   if (checkSelf(self, SignalNum::DRIVE_REMOVED)) return;
+                                   if (isSelfInvalid(self, SignalNum::DRIVE_REMOVED)) return;
                                    DriveDbId driveDbId = 0;
                                    CommonUtility::readValueFromStruct(params, MSG_PARAM_DRIVE_DB_ID, driveDbId);
                                    emit self->driveRemoved(driveDbId);
@@ -141,7 +141,7 @@ void ServerCommService::registerDriveHandlers(SignalDispatcher &dispatcher) {
 void ServerCommService::registerSyncHandlers(SignalDispatcher &dispatcher) {
     dispatcher.registerHandler(SignalNum::SYNC_ADDED,
                                [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
-                                   if (checkSelf(self, SignalNum::SYNC_ADDED)) return;
+                                   if (isSelfInvalid(self, SignalNum::SYNC_ADDED)) return;
                                    SyncInfo info;
                                    info.fromDynamicStruct(params[MSG_PARAM_SYNC_INFO].extract<Poco::DynamicStruct>());
                                    emit self->syncAdded(info);
@@ -149,7 +149,7 @@ void ServerCommService::registerSyncHandlers(SignalDispatcher &dispatcher) {
 
     dispatcher.registerHandler(SignalNum::SYNC_UPDATED,
                                [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
-                                   if (checkSelf(self, SignalNum::SYNC_UPDATED)) return;
+                                   if (isSelfInvalid(self, SignalNum::SYNC_UPDATED)) return;
                                    SyncInfo info;
                                    info.fromDynamicStruct(params[MSG_PARAM_SYNC_INFO].extract<Poco::DynamicStruct>());
                                    emit self->syncUpdated(info);
@@ -157,7 +157,7 @@ void ServerCommService::registerSyncHandlers(SignalDispatcher &dispatcher) {
 
     dispatcher.registerHandler(SignalNum::SYNC_REMOVED,
                                [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
-                                   if (checkSelf(self, SignalNum::SYNC_REMOVED)) return;
+                                   if (isSelfInvalid(self, SignalNum::SYNC_REMOVED)) return;
                                    SyncDbId syncDbId = 0;
                                    CommonUtility::readValueFromStruct(params, MSG_PARAM_SYNC_DB_ID, syncDbId);
                                    emit self->syncRemoved(syncDbId);
@@ -165,7 +165,7 @@ void ServerCommService::registerSyncHandlers(SignalDispatcher &dispatcher) {
 
     dispatcher.registerHandler(
             SignalNum::SYNC_PROGRESSINFO, [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
-                if (checkSelf(self, SignalNum::SYNC_PROGRESSINFO)) return;
+                if (isSelfInvalid(self, SignalNum::SYNC_PROGRESSINFO)) return;
                 SyncDbId syncDbId = 0;
                 auto status = SyncStatus::Undefined;
                 auto step = SyncStep::Idle;
@@ -191,7 +191,7 @@ void ServerCommService::registerSyncHandlers(SignalDispatcher &dispatcher) {
 
     dispatcher.registerHandler(SignalNum::SYNC_COMPLETEDITEM,
                                [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
-                                   if (checkSelf(self, SignalNum::SYNC_COMPLETEDITEM)) return;
+                                   if (isSelfInvalid(self, SignalNum::SYNC_COMPLETEDITEM)) return;
                                    SyncDbId syncDbId = 0;
                                    CommonUtility::readValueFromStruct(params, MSG_PARAM_SYNC_DB_ID, syncDbId);
                                    SyncFileItemInfo info;
@@ -205,7 +205,7 @@ void ServerCommService::registerSyncHandlers(SignalDispatcher &dispatcher) {
 void ServerCommService::registerErrorHandlers(SignalDispatcher &dispatcher) {
     dispatcher.registerHandler(SignalNum::UTILITY_ERROR_ADDED,
                                [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
-                                   if (checkSelf(self, SignalNum::UTILITY_ERROR_ADDED)) return;
+                                   if (isSelfInvalid(self, SignalNum::UTILITY_ERROR_ADDED)) return;
                                    ErrorInfo info;
                                    info.fromDynamicStruct(params[MSG_PARAM_ERROR_INFO].extract<Poco::DynamicStruct>());
                                    emit self->errorAdded(info);
@@ -213,7 +213,7 @@ void ServerCommService::registerErrorHandlers(SignalDispatcher &dispatcher) {
 
     dispatcher.registerHandler(SignalNum::UTILITY_ERROR_REMOVED,
                                [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
-                                   if (checkSelf(self, SignalNum::UTILITY_ERROR_REMOVED)) return;
+                                   if (isSelfInvalid(self, SignalNum::UTILITY_ERROR_REMOVED)) return;
                                    ErrorDbId errorDbId = 0;
                                    CommonUtility::readValueFromStruct(params, MSG_PARAM_ERROR_DB_ID, errorDbId);
                                    emit self->errorRemoved(errorDbId);
@@ -225,7 +225,7 @@ void ServerCommService::registerErrorHandlers(SignalDispatcher &dispatcher) {
 void ServerCommService::registerUpdaterHandlers(SignalDispatcher &dispatcher) {
     dispatcher.registerHandler(SignalNum::UPDATER_STATE_CHANGED,
                                [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
-                                   if (checkSelf(self, SignalNum::UPDATER_STATE_CHANGED)) return;
+                                   if (isSelfInvalid(self, SignalNum::UPDATER_STATE_CHANGED)) return;
                                    UpdateState state = UpdateState::Unknown;
                                    CommonUtility::readValueFromStruct(params, MSG_PARAM_UPDATE_STATE, state);
                                    emit self->updateStateChanged(state);
@@ -233,7 +233,7 @@ void ServerCommService::registerUpdaterHandlers(SignalDispatcher &dispatcher) {
 
     dispatcher.registerHandler(SignalNum::UPDATER_SHOW_DIALOG,
                                [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
-                                   if (checkSelf(self, SignalNum::UPDATER_SHOW_DIALOG)) return;
+                                   if (isSelfInvalid(self, SignalNum::UPDATER_SHOW_DIALOG)) return;
                                    VersionInfo info;
                                    info.fromDynamicStruct(params[MSG_PARAM_VERSION_INFO].extract<Poco::DynamicStruct>());
                                    emit self->showUpdateDialog(info);
@@ -245,7 +245,7 @@ void ServerCommService::registerUpdaterHandlers(SignalDispatcher &dispatcher) {
 void ServerCommService::registerUtilityHandlers(SignalDispatcher &dispatcher) {
     dispatcher.registerHandler(
             SignalNum::UTILITY_SHOW_NOTIFICATION, [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
-                if (checkSelf(self, SignalNum::UTILITY_SHOW_NOTIFICATION)) return;
+                if (isSelfInvalid(self, SignalNum::UTILITY_SHOW_NOTIFICATION)) return;
                 CommString title;
                 CommString message;
                 CommonUtility::readValueFromStruct(params, MSG_PARAM_TITLE, title);
@@ -255,19 +255,19 @@ void ServerCommService::registerUtilityHandlers(SignalDispatcher &dispatcher) {
 
     dispatcher.registerHandler(SignalNum::UTILITY_SHOW_SETTINGS,
                                [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &) {
-                                   if (checkSelf(self, SignalNum::UTILITY_SHOW_SETTINGS)) return;
+                                   if (isSelfInvalid(self, SignalNum::UTILITY_SHOW_SETTINGS)) return;
                                    emit self->showSettings();
                                });
 
     dispatcher.registerHandler(SignalNum::UTILITY_SHOW_SYNTHESIS,
                                [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &) {
-                                   if (checkSelf(self, SignalNum::UTILITY_SHOW_SYNTHESIS)) return;
+                                   if (isSelfInvalid(self, SignalNum::UTILITY_SHOW_SYNTHESIS)) return;
                                    emit self->showSynthesis();
                                });
 
     dispatcher.registerHandler(SignalNum::UTILITY_LOG_UPLOAD_STATUS_UPDATED,
                                [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
-                                   if (checkSelf(self, SignalNum::UTILITY_LOG_UPLOAD_STATUS_UPDATED)) return;
+                                   if (isSelfInvalid(self, SignalNum::UTILITY_LOG_UPLOAD_STATUS_UPDATED)) return;
                                    LogUploadState state = LogUploadState::None;
                                    int32_t percentage = 0;
                                    CommonUtility::readValueFromStruct(params, MSG_PARAM_LOG_UPLOAD_STATE, state);
@@ -276,7 +276,7 @@ void ServerCommService::registerUtilityHandlers(SignalDispatcher &dispatcher) {
                                });
 
     dispatcher.registerHandler(SignalNum::UTILITY_QUIT, [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &) {
-        if (checkSelf(self, SignalNum::UTILITY_QUIT)) return;
+        if (isSelfInvalid(self, SignalNum::UTILITY_QUIT)) return;
         emit self->quit();
     });
 }

--- a/src/gui4/linux/app/services/servercommservice.cpp
+++ b/src/gui4/linux/app/services/servercommservice.cpp
@@ -208,5 +208,20 @@ void ServerCommService::registerErrorHandlers(SignalDispatcher &dispatcher) {
     });
 }
 
+// -- Updater -------------------------------------------------------------------
+
+void ServerCommService::registerUpdaterHandlers(SignalDispatcher &dispatcher) {
+    dispatcher.registerHandler(SignalNum::UPDATER_STATE_CHANGED, [this](const Poco::DynamicStruct &params) {
+        UpdateState state = UpdateState::Unknown;
+        CommonUtility::readValueFromStruct(params, kUpdateState, state);
+        emit updateStateChanged(state);
+    });
+
+    dispatcher.registerHandler(SignalNum::UPDATER_SHOW_DIALOG, [this](const Poco::DynamicStruct &params) {
+        VersionInfo info;
+        info.fromDynamicStruct(params[kVersionInfo].extract<Poco::DynamicStruct>());
+        emit showUpdateDialog(info);
+    });
+}
 
 } // namespace KDC

--- a/src/gui4/linux/app/services/servercommservice.cpp
+++ b/src/gui4/linux/app/services/servercommservice.cpp
@@ -117,5 +117,27 @@ void ServerCommService::registerAccountHandlers(SignalDispatcher &dispatcher) {
     });
 }
 
+// -- Drive ---------------------------------------------------------------------
+
+void ServerCommService::registerDriveHandlers(SignalDispatcher &dispatcher) {
+    dispatcher.registerHandler(SignalNum::DRIVE_ADDED, [this](const Poco::DynamicStruct &params) {
+        DriveInfo info;
+        info.fromDynamicStruct(params[kDriveInfo].extract<Poco::DynamicStruct>());
+        emit driveAdded(info);
+    });
+
+    dispatcher.registerHandler(SignalNum::DRIVE_UPDATED, [this](const Poco::DynamicStruct &params) {
+        DriveInfo info;
+        info.fromDynamicStruct(params[kDriveInfo].extract<Poco::DynamicStruct>());
+        emit driveUpdated(info);
+    });
+
+    dispatcher.registerHandler(SignalNum::DRIVE_REMOVED, [this](const Poco::DynamicStruct &params) {
+        DriveDbId driveDbId = 0;
+        CommonUtility::readValueFromStruct(params, kDriveDbId, driveDbId);
+        emit driveRemoved(driveDbId);
+    });
+}
+
 
 } // namespace KDC

--- a/src/gui4/linux/app/services/servercommservice.cpp
+++ b/src/gui4/linux/app/services/servercommservice.cpp
@@ -22,22 +22,8 @@
 #include "libcommon/utility/utility.h"
 
 #include <QLoggingCategory>
-#include <QPointer>
 
 Q_LOGGING_CATEGORY(lcServerCommService, "gui.v4.servercommservice", QtInfoMsg)
-
-namespace {
-
-bool isSelfInvalid(const QPointer<KDC::ServerCommService> &self, SignalNum num) {
-    if (!self) {
-        qCWarning(lcServerCommService) << "Signal" << toString(num).c_str()
-                                       << "received after ServerCommService destruction - ignoring";
-        return true;
-    }
-    return false;
-}
-
-} // namespace
 
 namespace KDC {
 
@@ -55,230 +41,183 @@ ServerCommService::ServerCommService(SignalDispatcher &dispatcher, QObject *pare
 // -- User ---------------------------------------------------------------------
 
 void ServerCommService::registerUserHandlers(SignalDispatcher &dispatcher) {
-    dispatcher.registerHandler(SignalNum::USER_ADDED,
-                               [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
-                                   if (isSelfInvalid(self, SignalNum::USER_ADDED)) return;
-                                   UserInfo info;
-                                   info.fromDynamicStruct(params[MSG_PARAM_USER_INFO].extract<Poco::DynamicStruct>());
-                                   emit self->userAdded(info);
-                               });
+    dispatcher.registerHandler(SignalNum::USER_ADDED, [this](const Poco::DynamicStruct &params) {
+        UserInfo info;
+        info.fromDynamicStruct(params[MSG_PARAM_USER_INFO].extract<Poco::DynamicStruct>());
+        emit userAdded(info);
+    });
 
-    dispatcher.registerHandler(SignalNum::USER_UPDATED,
-                               [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
-                                   if (isSelfInvalid(self, SignalNum::USER_UPDATED)) return;
-                                   UserInfo info;
-                                   info.fromDynamicStruct(params[MSG_PARAM_USER_INFO].extract<Poco::DynamicStruct>());
-                                   emit self->userUpdated(info);
-                               });
+    dispatcher.registerHandler(SignalNum::USER_UPDATED, [this](const Poco::DynamicStruct &params) {
+        UserInfo info;
+        info.fromDynamicStruct(params[MSG_PARAM_USER_INFO].extract<Poco::DynamicStruct>());
+        emit userUpdated(info);
+    });
 
-    dispatcher.registerHandler(SignalNum::USER_REMOVED,
-                               [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
-                                   if (isSelfInvalid(self, SignalNum::USER_REMOVED)) return;
-                                   UserDbId userDbId = 0;
-                                   CommonUtility::readValueFromStruct(params, MSG_PARAM_USER_DB_ID, userDbId);
-                                   emit self->userRemoved(userDbId);
-                               });
+    dispatcher.registerHandler(SignalNum::USER_REMOVED, [this](const Poco::DynamicStruct &params) {
+        UserDbId userDbId = 0;
+        CommonUtility::readValueFromStruct(params, MSG_PARAM_USER_DB_ID, userDbId);
+        emit userRemoved(userDbId);
+    });
 }
 
 // -- Account ------------------------------------------------------------------
 
 void ServerCommService::registerAccountHandlers(SignalDispatcher &dispatcher) {
-    dispatcher.registerHandler(SignalNum::ACCOUNT_ADDED,
-                               [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
-                                   if (isSelfInvalid(self, SignalNum::ACCOUNT_ADDED)) return;
-                                   AccountInfo info;
-                                   info.fromDynamicStruct(params[MSG_PARAM_ACCOUNT_INFO].extract<Poco::DynamicStruct>());
-                                   emit self->accountAdded(info);
-                               });
+    dispatcher.registerHandler(SignalNum::ACCOUNT_ADDED, [this](const Poco::DynamicStruct &params) {
+        AccountInfo info;
+        info.fromDynamicStruct(params[MSG_PARAM_ACCOUNT_INFO].extract<Poco::DynamicStruct>());
+        emit accountAdded(info);
+    });
 
-    dispatcher.registerHandler(SignalNum::ACCOUNT_UPDATED,
-                               [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
-                                   if (isSelfInvalid(self, SignalNum::ACCOUNT_UPDATED)) return;
-                                   AccountInfo info;
-                                   info.fromDynamicStruct(params[MSG_PARAM_ACCOUNT_INFO].extract<Poco::DynamicStruct>());
-                                   emit self->accountUpdated(info);
-                               });
+    dispatcher.registerHandler(SignalNum::ACCOUNT_UPDATED, [this](const Poco::DynamicStruct &params) {
+        AccountInfo info;
+        info.fromDynamicStruct(params[MSG_PARAM_ACCOUNT_INFO].extract<Poco::DynamicStruct>());
+        emit accountUpdated(info);
+    });
 
-    dispatcher.registerHandler(SignalNum::ACCOUNT_REMOVED,
-                               [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
-                                   if (isSelfInvalid(self, SignalNum::ACCOUNT_REMOVED)) return;
-                                   AccountDbId accountDbId = 0;
-                                   CommonUtility::readValueFromStruct(params, MSG_PARAM_ACCOUNT_DB_ID, accountDbId);
-                                   emit self->accountRemoved(accountDbId);
-                               });
+    dispatcher.registerHandler(SignalNum::ACCOUNT_REMOVED, [this](const Poco::DynamicStruct &params) {
+        AccountDbId accountDbId = 0;
+        CommonUtility::readValueFromStruct(params, MSG_PARAM_ACCOUNT_DB_ID, accountDbId);
+        emit accountRemoved(accountDbId);
+    });
 }
 
 // -- Drive ---------------------------------------------------------------------
 
 void ServerCommService::registerDriveHandlers(SignalDispatcher &dispatcher) {
-    dispatcher.registerHandler(SignalNum::DRIVE_ADDED,
-                               [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
-                                   if (isSelfInvalid(self, SignalNum::DRIVE_ADDED)) return;
-                                   DriveInfo info;
-                                   info.fromDynamicStruct(params[MSG_PARAM_DRIVE_INFO].extract<Poco::DynamicStruct>());
-                                   emit self->driveAdded(info);
-                               });
+    dispatcher.registerHandler(SignalNum::DRIVE_ADDED, [this](const Poco::DynamicStruct &params) {
+        DriveInfo info;
+        info.fromDynamicStruct(params[MSG_PARAM_DRIVE_INFO].extract<Poco::DynamicStruct>());
+        emit driveAdded(info);
+    });
 
-    dispatcher.registerHandler(SignalNum::DRIVE_UPDATED,
-                               [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
-                                   if (isSelfInvalid(self, SignalNum::DRIVE_UPDATED)) return;
-                                   DriveInfo info;
-                                   info.fromDynamicStruct(params[MSG_PARAM_DRIVE_INFO].extract<Poco::DynamicStruct>());
-                                   emit self->driveUpdated(info);
-                               });
+    dispatcher.registerHandler(SignalNum::DRIVE_UPDATED, [this](const Poco::DynamicStruct &params) {
+        DriveInfo info;
+        info.fromDynamicStruct(params[MSG_PARAM_DRIVE_INFO].extract<Poco::DynamicStruct>());
+        emit driveUpdated(info);
+    });
 
-    dispatcher.registerHandler(SignalNum::DRIVE_REMOVED,
-                               [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
-                                   if (isSelfInvalid(self, SignalNum::DRIVE_REMOVED)) return;
-                                   DriveDbId driveDbId = 0;
-                                   CommonUtility::readValueFromStruct(params, MSG_PARAM_DRIVE_DB_ID, driveDbId);
-                                   emit self->driveRemoved(driveDbId);
-                               });
+    dispatcher.registerHandler(SignalNum::DRIVE_REMOVED, [this](const Poco::DynamicStruct &params) {
+        DriveDbId driveDbId = 0;
+        CommonUtility::readValueFromStruct(params, MSG_PARAM_DRIVE_DB_ID, driveDbId);
+        emit driveRemoved(driveDbId);
+    });
 }
 
 // -- Sync ----------------------------------------------------------------------
 
 void ServerCommService::registerSyncHandlers(SignalDispatcher &dispatcher) {
-    dispatcher.registerHandler(SignalNum::SYNC_ADDED,
-                               [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
-                                   if (isSelfInvalid(self, SignalNum::SYNC_ADDED)) return;
-                                   SyncInfo info;
-                                   info.fromDynamicStruct(params[MSG_PARAM_SYNC_INFO].extract<Poco::DynamicStruct>());
-                                   emit self->syncAdded(info);
-                               });
+    dispatcher.registerHandler(SignalNum::SYNC_ADDED, [this](const Poco::DynamicStruct &params) {
+        SyncInfo info;
+        info.fromDynamicStruct(params[MSG_PARAM_SYNC_INFO].extract<Poco::DynamicStruct>());
+        emit syncAdded(info);
+    });
 
-    dispatcher.registerHandler(SignalNum::SYNC_UPDATED,
-                               [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
-                                   if (isSelfInvalid(self, SignalNum::SYNC_UPDATED)) return;
-                                   SyncInfo info;
-                                   info.fromDynamicStruct(params[MSG_PARAM_SYNC_INFO].extract<Poco::DynamicStruct>());
-                                   emit self->syncUpdated(info);
-                               });
+    dispatcher.registerHandler(SignalNum::SYNC_UPDATED, [this](const Poco::DynamicStruct &params) {
+        SyncInfo info;
+        info.fromDynamicStruct(params[MSG_PARAM_SYNC_INFO].extract<Poco::DynamicStruct>());
+        emit syncUpdated(info);
+    });
 
-    dispatcher.registerHandler(SignalNum::SYNC_REMOVED,
-                               [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
-                                   if (isSelfInvalid(self, SignalNum::SYNC_REMOVED)) return;
-                                   SyncDbId syncDbId = 0;
-                                   CommonUtility::readValueFromStruct(params, MSG_PARAM_SYNC_DB_ID, syncDbId);
-                                   emit self->syncRemoved(syncDbId);
-                               });
+    dispatcher.registerHandler(SignalNum::SYNC_REMOVED, [this](const Poco::DynamicStruct &params) {
+        SyncDbId syncDbId = 0;
+        CommonUtility::readValueFromStruct(params, MSG_PARAM_SYNC_DB_ID, syncDbId);
+        emit syncRemoved(syncDbId);
+    });
 
-    dispatcher.registerHandler(
-            SignalNum::SYNC_PROGRESSINFO, [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
-                if (isSelfInvalid(self, SignalNum::SYNC_PROGRESSINFO)) return;
-                SyncDbId syncDbId = 0;
-                auto status = SyncStatus::Undefined;
-                auto step = SyncStep::Idle;
-                CommonUtility::readValueFromStruct(params, MSG_PARAM_SYNC_DB_ID, syncDbId);
-                CommonUtility::readValueFromStruct(params, MSG_PARAM_SYNC_STATUS, status);
-                CommonUtility::readValueFromStruct(params, MSG_PARAM_SYNC_STEP, step);
+    dispatcher.registerHandler(SignalNum::SYNC_PROGRESSINFO, [this](const Poco::DynamicStruct &params) {
+        SyncDbId syncDbId = 0;
+        auto status = SyncStatus::Undefined;
+        auto step = SyncStep::Idle;
+        CommonUtility::readValueFromStruct(params, MSG_PARAM_SYNC_DB_ID, syncDbId);
+        CommonUtility::readValueFromStruct(params, MSG_PARAM_SYNC_STATUS, status);
+        CommonUtility::readValueFromStruct(params, MSG_PARAM_SYNC_STEP, step);
 
-                const Poco::DynamicStruct progressStruct = params[MSG_PARAM_SYNC_PROGRESS].extract<Poco::DynamicStruct>();
-                int64_t currentFile = 0;
-                int64_t totalFiles = 0;
-                int64_t completedSize = 0;
-                int64_t totalSize = 0;
-                int64_t estimatedRemainingTime = 0;
-                CommonUtility::readValueFromStruct(progressStruct, MSG_PARAM_CURRENT_FILE, currentFile);
-                CommonUtility::readValueFromStruct(progressStruct, MSG_PARAM_TOTAL_FILES, totalFiles);
-                CommonUtility::readValueFromStruct(progressStruct, MSG_PARAM_COMPLETED_SIZE, completedSize);
-                CommonUtility::readValueFromStruct(progressStruct, MSG_PARAM_TOTAL_SIZE, totalSize);
-                CommonUtility::readValueFromStruct(progressStruct, MSG_PARAM_ESTIMATED_REMAINING_TIME, estimatedRemainingTime);
+        const Poco::DynamicStruct progressStruct = params[MSG_PARAM_SYNC_PROGRESS].extract<Poco::DynamicStruct>();
+        int64_t currentFile = 0;
+        int64_t totalFiles = 0;
+        int64_t completedSize = 0;
+        int64_t totalSize = 0;
+        int64_t estimatedRemainingTime = 0;
+        CommonUtility::readValueFromStruct(progressStruct, MSG_PARAM_CURRENT_FILE, currentFile);
+        CommonUtility::readValueFromStruct(progressStruct, MSG_PARAM_TOTAL_FILES, totalFiles);
+        CommonUtility::readValueFromStruct(progressStruct, MSG_PARAM_COMPLETED_SIZE, completedSize);
+        CommonUtility::readValueFromStruct(progressStruct, MSG_PARAM_TOTAL_SIZE, totalSize);
+        CommonUtility::readValueFromStruct(progressStruct, MSG_PARAM_ESTIMATED_REMAINING_TIME, estimatedRemainingTime);
 
-                emit self->syncProgressInfo(syncDbId, status, step, currentFile, totalFiles, completedSize, totalSize,
-                                            estimatedRemainingTime);
-            });
+        emit syncProgressInfo(syncDbId, status, step, currentFile, totalFiles, completedSize, totalSize,
+                              estimatedRemainingTime);
+    });
 
-    dispatcher.registerHandler(SignalNum::SYNC_COMPLETEDITEM,
-                               [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
-                                   if (isSelfInvalid(self, SignalNum::SYNC_COMPLETEDITEM)) return;
-                                   SyncDbId syncDbId = 0;
-                                   CommonUtility::readValueFromStruct(params, MSG_PARAM_SYNC_DB_ID, syncDbId);
-                                   SyncFileItemInfo info;
-                                   info.fromDynamicStruct(params[MSG_PARAM_ITEM_INFO].extract<Poco::DynamicStruct>());
-                                   emit self->itemCompleted(syncDbId, info);
-                               });
+    dispatcher.registerHandler(SignalNum::SYNC_COMPLETEDITEM, [this](const Poco::DynamicStruct &params) {
+        SyncDbId syncDbId = 0;
+        CommonUtility::readValueFromStruct(params, MSG_PARAM_SYNC_DB_ID, syncDbId);
+        SyncFileItemInfo info;
+        info.fromDynamicStruct(params[MSG_PARAM_ITEM_INFO].extract<Poco::DynamicStruct>());
+        emit itemCompleted(syncDbId, info);
+    });
 }
 
 // -- Error ---------------------------------------------------------------------
 
 void ServerCommService::registerErrorHandlers(SignalDispatcher &dispatcher) {
-    dispatcher.registerHandler(SignalNum::UTILITY_ERROR_ADDED,
-                               [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
-                                   if (isSelfInvalid(self, SignalNum::UTILITY_ERROR_ADDED)) return;
-                                   ErrorInfo info;
-                                   info.fromDynamicStruct(params[MSG_PARAM_ERROR_INFO].extract<Poco::DynamicStruct>());
-                                   emit self->errorAdded(info);
-                               });
+    dispatcher.registerHandler(SignalNum::UTILITY_ERROR_ADDED, [this](const Poco::DynamicStruct &params) {
+        ErrorInfo info;
+        info.fromDynamicStruct(params[MSG_PARAM_ERROR_INFO].extract<Poco::DynamicStruct>());
+        emit errorAdded(info);
+    });
 
-    dispatcher.registerHandler(SignalNum::UTILITY_ERROR_REMOVED,
-                               [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
-                                   if (isSelfInvalid(self, SignalNum::UTILITY_ERROR_REMOVED)) return;
-                                   ErrorDbId errorDbId = 0;
-                                   CommonUtility::readValueFromStruct(params, MSG_PARAM_ERROR_DB_ID, errorDbId);
-                                   emit self->errorRemoved(errorDbId);
-                               });
+    dispatcher.registerHandler(SignalNum::UTILITY_ERROR_REMOVED, [this](const Poco::DynamicStruct &params) {
+        ErrorDbId errorDbId = 0;
+        CommonUtility::readValueFromStruct(params, MSG_PARAM_ERROR_DB_ID, errorDbId);
+        emit errorRemoved(errorDbId);
+    });
 }
 
 // -- Updater -------------------------------------------------------------------
 
 void ServerCommService::registerUpdaterHandlers(SignalDispatcher &dispatcher) {
-    dispatcher.registerHandler(SignalNum::UPDATER_STATE_CHANGED,
-                               [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
-                                   if (isSelfInvalid(self, SignalNum::UPDATER_STATE_CHANGED)) return;
-                                   UpdateState state = UpdateState::Unknown;
-                                   CommonUtility::readValueFromStruct(params, MSG_PARAM_UPDATE_STATE, state);
-                                   emit self->updateStateChanged(state);
-                               });
+    dispatcher.registerHandler(SignalNum::UPDATER_STATE_CHANGED, [this](const Poco::DynamicStruct &params) {
+        UpdateState state = UpdateState::Unknown;
+        CommonUtility::readValueFromStruct(params, MSG_PARAM_UPDATE_STATE, state);
+        emit updateStateChanged(state);
+    });
 
-    dispatcher.registerHandler(SignalNum::UPDATER_SHOW_DIALOG,
-                               [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
-                                   if (isSelfInvalid(self, SignalNum::UPDATER_SHOW_DIALOG)) return;
-                                   VersionInfo info;
-                                   info.fromDynamicStruct(params[MSG_PARAM_VERSION_INFO].extract<Poco::DynamicStruct>());
-                                   emit self->showUpdateDialog(info);
-                               });
+    dispatcher.registerHandler(SignalNum::UPDATER_SHOW_DIALOG, [this](const Poco::DynamicStruct &params) {
+        VersionInfo info;
+        info.fromDynamicStruct(params[MSG_PARAM_VERSION_INFO].extract<Poco::DynamicStruct>());
+        emit showUpdateDialog(info);
+    });
 }
 
 // -- Utility -------------------------------------------------------------------
 
 void ServerCommService::registerUtilityHandlers(SignalDispatcher &dispatcher) {
-    dispatcher.registerHandler(
-            SignalNum::UTILITY_SHOW_NOTIFICATION, [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
-                if (isSelfInvalid(self, SignalNum::UTILITY_SHOW_NOTIFICATION)) return;
-                CommString title;
-                CommString message;
-                CommonUtility::readValueFromStruct(params, MSG_PARAM_TITLE, title);
-                CommonUtility::readValueFromStruct(params, MSG_PARAM_MESSAGE, message);
-                emit self->showNotification(CommonUtility::commString2QStr(title), CommonUtility::commString2QStr(message));
-            });
-
-    dispatcher.registerHandler(SignalNum::UTILITY_SHOW_SETTINGS,
-                               [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &) {
-                                   if (isSelfInvalid(self, SignalNum::UTILITY_SHOW_SETTINGS)) return;
-                                   emit self->showSettings();
-                               });
-
-    dispatcher.registerHandler(SignalNum::UTILITY_SHOW_SYNTHESIS,
-                               [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &) {
-                                   if (isSelfInvalid(self, SignalNum::UTILITY_SHOW_SYNTHESIS)) return;
-                                   emit self->showSynthesis();
-                               });
-
-    dispatcher.registerHandler(SignalNum::UTILITY_LOG_UPLOAD_STATUS_UPDATED,
-                               [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &params) {
-                                   if (isSelfInvalid(self, SignalNum::UTILITY_LOG_UPLOAD_STATUS_UPDATED)) return;
-                                   LogUploadState state = LogUploadState::None;
-                                   int32_t percentage = 0;
-                                   CommonUtility::readValueFromStruct(params, MSG_PARAM_LOG_UPLOAD_STATE, state);
-                                   CommonUtility::readValueFromStruct(params, MSG_PARAM_PERCENTAGE, percentage);
-                                   emit self->logUploadStatusUpdated(state, percentage);
-                               });
-
-    dispatcher.registerHandler(SignalNum::UTILITY_QUIT, [self = QPointer<ServerCommService>(this)](const Poco::DynamicStruct &) {
-        if (isSelfInvalid(self, SignalNum::UTILITY_QUIT)) return;
-        emit self->quit();
+    dispatcher.registerHandler(SignalNum::UTILITY_SHOW_NOTIFICATION, [this](const Poco::DynamicStruct &params) {
+        CommString title;
+        CommString message;
+        CommonUtility::readValueFromStruct(params, MSG_PARAM_TITLE, title);
+        CommonUtility::readValueFromStruct(params, MSG_PARAM_MESSAGE, message);
+        emit showNotification(CommonUtility::commString2QStr(title), CommonUtility::commString2QStr(message));
     });
+
+    dispatcher.registerHandler(SignalNum::UTILITY_SHOW_SETTINGS, [this](const Poco::DynamicStruct &) {
+        emit showSettings();
+    });
+
+    dispatcher.registerHandler(SignalNum::UTILITY_SHOW_SYNTHESIS, [this](const Poco::DynamicStruct &) {
+        emit showSynthesis();
+    });
+
+    dispatcher.registerHandler(SignalNum::UTILITY_LOG_UPLOAD_STATUS_UPDATED, [this](const Poco::DynamicStruct &params) {
+        LogUploadState state = LogUploadState::None;
+        int32_t percentage = 0;
+        CommonUtility::readValueFromStruct(params, MSG_PARAM_LOG_UPLOAD_STATE, state);
+        CommonUtility::readValueFromStruct(params, MSG_PARAM_PERCENTAGE, percentage);
+        emit logUploadStatusUpdated(state, percentage);
+    });
+
+    dispatcher.registerHandler(SignalNum::UTILITY_QUIT, [this](const Poco::DynamicStruct &) { emit quit(); });
 }
 
 } // namespace KDC

--- a/src/gui4/linux/app/services/servercommservice.cpp
+++ b/src/gui4/linux/app/services/servercommservice.cpp
@@ -18,6 +18,7 @@
 
 #include "servercommservice.h"
 
+#include "libcommon/comm.h"
 #include "libcommon/utility/utility.h"
 
 #include <QLoggingCategory>
@@ -26,41 +27,6 @@ Q_LOGGING_CATEGORY(lcServerCommService, "gui.v4.servercommservice", QtInfoMsg)
 
 namespace KDC {
 
-// Param keys ─ mirrors the server-side signal job static constants.
-namespace {
-// User
-constexpr auto kUserInfo = "userInfo";
-constexpr auto kUserDbId = "userDbId";
-// Account
-constexpr auto kAccountInfo = "accountInfo";
-constexpr auto kAccountDbId = "accountDbId";
-// Drive
-constexpr auto kDriveInfo = "driveInfo";
-constexpr auto kDriveDbId = "driveDbId";
-// Sync
-constexpr auto kSyncInfo = "syncInfo";
-constexpr auto kSyncDbId = "syncDbId";
-constexpr auto kSyncStatus = "syncStatus";
-constexpr auto kSyncStep = "syncStep";
-constexpr auto kSyncProgress = "SyncProgress";
-constexpr auto kCurrentFile = "currentFile";
-constexpr auto kTotalFiles = "totalFiles";
-constexpr auto kCompletedSize = "completedSize";
-constexpr auto kTotalSize = "totalSize";
-constexpr auto kEstimatedRemainingTime = "estimatedRemainingTime";
-constexpr auto kItemInfo = "itemInfo";
-// Error
-constexpr auto kErrorInfo = "errorInfo";
-constexpr auto kErrorDbId = "errorDbId";
-// Updater
-constexpr auto kUpdateState = "updateState";
-constexpr auto kVersionInfo = "versionInfo";
-// Utility
-constexpr auto kTitle = "title";
-constexpr auto kMessage = "message";
-constexpr auto kLogUploadState = "state";
-constexpr auto kPercentage = "percentage";
-} // namespace
 
 ServerCommService::ServerCommService(SignalDispatcher &dispatcher, QObject *parent) :
     QObject(parent) {
@@ -78,19 +44,19 @@ ServerCommService::ServerCommService(SignalDispatcher &dispatcher, QObject *pare
 void ServerCommService::registerUserHandlers(SignalDispatcher &dispatcher) {
     dispatcher.registerHandler(SignalNum::USER_ADDED, [this](const Poco::DynamicStruct &params) {
         UserInfo info;
-        info.fromDynamicStruct(params[kUserInfo].extract<Poco::DynamicStruct>());
+        info.fromDynamicStruct(params[MSG_PARAM_USER_INFO].extract<Poco::DynamicStruct>());
         emit userAdded(info);
     });
 
     dispatcher.registerHandler(SignalNum::USER_UPDATED, [this](const Poco::DynamicStruct &params) {
         UserInfo info;
-        info.fromDynamicStruct(params[kUserInfo].extract<Poco::DynamicStruct>());
+        info.fromDynamicStruct(params[MSG_PARAM_USER_INFO].extract<Poco::DynamicStruct>());
         emit userUpdated(info);
     });
 
     dispatcher.registerHandler(SignalNum::USER_REMOVED, [this](const Poco::DynamicStruct &params) {
         UserDbId userDbId = 0;
-        CommonUtility::readValueFromStruct(params, kUserDbId, userDbId);
+        CommonUtility::readValueFromStruct(params, MSG_PARAM_USER_DB_ID, userDbId);
         emit userRemoved(userDbId);
     });
 }
@@ -100,19 +66,19 @@ void ServerCommService::registerUserHandlers(SignalDispatcher &dispatcher) {
 void ServerCommService::registerAccountHandlers(SignalDispatcher &dispatcher) {
     dispatcher.registerHandler(SignalNum::ACCOUNT_ADDED, [this](const Poco::DynamicStruct &params) {
         AccountInfo info;
-        info.fromDynamicStruct(params[kAccountInfo].extract<Poco::DynamicStruct>());
+        info.fromDynamicStruct(params[MSG_PARAM_ACCOUNT_INFO].extract<Poco::DynamicStruct>());
         emit accountAdded(info);
     });
 
     dispatcher.registerHandler(SignalNum::ACCOUNT_UPDATED, [this](const Poco::DynamicStruct &params) {
         AccountInfo info;
-        info.fromDynamicStruct(params[kAccountInfo].extract<Poco::DynamicStruct>());
+        info.fromDynamicStruct(params[MSG_PARAM_ACCOUNT_INFO].extract<Poco::DynamicStruct>());
         emit accountUpdated(info);
     });
 
     dispatcher.registerHandler(SignalNum::ACCOUNT_REMOVED, [this](const Poco::DynamicStruct &params) {
         AccountDbId accountDbId = 0;
-        CommonUtility::readValueFromStruct(params, kAccountDbId, accountDbId);
+        CommonUtility::readValueFromStruct(params, MSG_PARAM_ACCOUNT_DB_ID, accountDbId);
         emit accountRemoved(accountDbId);
     });
 }
@@ -122,19 +88,19 @@ void ServerCommService::registerAccountHandlers(SignalDispatcher &dispatcher) {
 void ServerCommService::registerDriveHandlers(SignalDispatcher &dispatcher) {
     dispatcher.registerHandler(SignalNum::DRIVE_ADDED, [this](const Poco::DynamicStruct &params) {
         DriveInfo info;
-        info.fromDynamicStruct(params[kDriveInfo].extract<Poco::DynamicStruct>());
+        info.fromDynamicStruct(params[MSG_PARAM_DRIVE_INFO].extract<Poco::DynamicStruct>());
         emit driveAdded(info);
     });
 
     dispatcher.registerHandler(SignalNum::DRIVE_UPDATED, [this](const Poco::DynamicStruct &params) {
         DriveInfo info;
-        info.fromDynamicStruct(params[kDriveInfo].extract<Poco::DynamicStruct>());
+        info.fromDynamicStruct(params[MSG_PARAM_DRIVE_INFO].extract<Poco::DynamicStruct>());
         emit driveUpdated(info);
     });
 
     dispatcher.registerHandler(SignalNum::DRIVE_REMOVED, [this](const Poco::DynamicStruct &params) {
         DriveDbId driveDbId = 0;
-        CommonUtility::readValueFromStruct(params, kDriveDbId, driveDbId);
+        CommonUtility::readValueFromStruct(params, MSG_PARAM_DRIVE_DB_ID, driveDbId);
         emit driveRemoved(driveDbId);
     });
 }
@@ -144,19 +110,19 @@ void ServerCommService::registerDriveHandlers(SignalDispatcher &dispatcher) {
 void ServerCommService::registerSyncHandlers(SignalDispatcher &dispatcher) {
     dispatcher.registerHandler(SignalNum::SYNC_ADDED, [this](const Poco::DynamicStruct &params) {
         SyncInfo info;
-        info.fromDynamicStruct(params[kSyncInfo].extract<Poco::DynamicStruct>());
+        info.fromDynamicStruct(params[MSG_PARAM_SYNC_INFO].extract<Poco::DynamicStruct>());
         emit syncAdded(info);
     });
 
     dispatcher.registerHandler(SignalNum::SYNC_UPDATED, [this](const Poco::DynamicStruct &params) {
         SyncInfo info;
-        info.fromDynamicStruct(params[kSyncInfo].extract<Poco::DynamicStruct>());
+        info.fromDynamicStruct(params[MSG_PARAM_SYNC_INFO].extract<Poco::DynamicStruct>());
         emit syncUpdated(info);
     });
 
     dispatcher.registerHandler(SignalNum::SYNC_REMOVED, [this](const Poco::DynamicStruct &params) {
         SyncDbId syncDbId = 0;
-        CommonUtility::readValueFromStruct(params, kSyncDbId, syncDbId);
+        CommonUtility::readValueFromStruct(params, MSG_PARAM_SYNC_DB_ID, syncDbId);
         emit syncRemoved(syncDbId);
     });
 
@@ -164,30 +130,30 @@ void ServerCommService::registerSyncHandlers(SignalDispatcher &dispatcher) {
         SyncDbId syncDbId = 0;
         auto status = SyncStatus::Undefined;
         auto step = SyncStep::Idle;
-        CommonUtility::readValueFromStruct(params, kSyncDbId, syncDbId);
-        CommonUtility::readValueFromStruct(params, kSyncStatus, status);
-        CommonUtility::readValueFromStruct(params, kSyncStep, step);
+        CommonUtility::readValueFromStruct(params, MSG_PARAM_SYNC_DB_ID, syncDbId);
+        CommonUtility::readValueFromStruct(params, MSG_PARAM_SYNC_STATUS, status);
+        CommonUtility::readValueFromStruct(params, MSG_PARAM_SYNC_STEP, step);
 
-        const Poco::DynamicStruct progressStruct = params[kSyncProgress].extract<Poco::DynamicStruct>();
+        const Poco::DynamicStruct progressStruct = params[MSG_PARAM_SYNC_PROGRESS].extract<Poco::DynamicStruct>();
         int64_t currentFile = 0;
         int64_t totalFiles = 0;
         int64_t completedSize = 0;
         int64_t totalSize = 0;
         int64_t estimatedRemainingTime = 0;
-        CommonUtility::readValueFromStruct(progressStruct, kCurrentFile, currentFile);
-        CommonUtility::readValueFromStruct(progressStruct, kTotalFiles, totalFiles);
-        CommonUtility::readValueFromStruct(progressStruct, kCompletedSize, completedSize);
-        CommonUtility::readValueFromStruct(progressStruct, kTotalSize, totalSize);
-        CommonUtility::readValueFromStruct(progressStruct, kEstimatedRemainingTime, estimatedRemainingTime);
+        CommonUtility::readValueFromStruct(progressStruct, MSG_PARAM_CURRENT_FILE, currentFile);
+        CommonUtility::readValueFromStruct(progressStruct, MSG_PARAM_TOTAL_FILES, totalFiles);
+        CommonUtility::readValueFromStruct(progressStruct, MSG_PARAM_COMPLETED_SIZE, completedSize);
+        CommonUtility::readValueFromStruct(progressStruct, MSG_PARAM_TOTAL_SIZE, totalSize);
+        CommonUtility::readValueFromStruct(progressStruct, MSG_PARAM_ESTIMATED_REMAINING_TIME, estimatedRemainingTime);
 
         emit syncProgressInfo(syncDbId, status, step, currentFile, totalFiles, completedSize, totalSize, estimatedRemainingTime);
     });
 
     dispatcher.registerHandler(SignalNum::SYNC_COMPLETEDITEM, [this](const Poco::DynamicStruct &params) {
         SyncDbId syncDbId = 0;
-        CommonUtility::readValueFromStruct(params, kSyncDbId, syncDbId);
+        CommonUtility::readValueFromStruct(params, MSG_PARAM_SYNC_DB_ID, syncDbId);
         SyncFileItemInfo info;
-        info.fromDynamicStruct(params[kItemInfo].extract<Poco::DynamicStruct>());
+        info.fromDynamicStruct(params[MSG_PARAM_ITEM_INFO].extract<Poco::DynamicStruct>());
         emit itemCompleted(syncDbId, info);
     });
 }
@@ -197,13 +163,13 @@ void ServerCommService::registerSyncHandlers(SignalDispatcher &dispatcher) {
 void ServerCommService::registerErrorHandlers(SignalDispatcher &dispatcher) {
     dispatcher.registerHandler(SignalNum::UTILITY_ERROR_ADDED, [this](const Poco::DynamicStruct &params) {
         ErrorInfo info;
-        info.fromDynamicStruct(params[kErrorInfo].extract<Poco::DynamicStruct>());
+        info.fromDynamicStruct(params[MSG_PARAM_ERROR_INFO].extract<Poco::DynamicStruct>());
         emit errorAdded(info);
     });
 
     dispatcher.registerHandler(SignalNum::UTILITY_ERROR_REMOVED, [this](const Poco::DynamicStruct &params) {
         ErrorDbId errorDbId = 0;
-        CommonUtility::readValueFromStruct(params, kErrorDbId, errorDbId);
+        CommonUtility::readValueFromStruct(params, MSG_PARAM_ERROR_DB_ID, errorDbId);
         emit errorRemoved(errorDbId);
     });
 }
@@ -213,13 +179,13 @@ void ServerCommService::registerErrorHandlers(SignalDispatcher &dispatcher) {
 void ServerCommService::registerUpdaterHandlers(SignalDispatcher &dispatcher) {
     dispatcher.registerHandler(SignalNum::UPDATER_STATE_CHANGED, [this](const Poco::DynamicStruct &params) {
         UpdateState state = UpdateState::Unknown;
-        CommonUtility::readValueFromStruct(params, kUpdateState, state);
+        CommonUtility::readValueFromStruct(params, MSG_PARAM_UPDATE_STATE, state);
         emit updateStateChanged(state);
     });
 
     dispatcher.registerHandler(SignalNum::UPDATER_SHOW_DIALOG, [this](const Poco::DynamicStruct &params) {
         VersionInfo info;
-        info.fromDynamicStruct(params[kVersionInfo].extract<Poco::DynamicStruct>());
+        info.fromDynamicStruct(params[MSG_PARAM_VERSION_INFO].extract<Poco::DynamicStruct>());
         emit showUpdateDialog(info);
     });
 }
@@ -230,8 +196,8 @@ void ServerCommService::registerUtilityHandlers(SignalDispatcher &dispatcher) {
     dispatcher.registerHandler(SignalNum::UTILITY_SHOW_NOTIFICATION, [this](const Poco::DynamicStruct &params) {
         CommString title;
         CommString message;
-        CommonUtility::readValueFromStruct(params, kTitle, title);
-        CommonUtility::readValueFromStruct(params, kMessage, message);
+        CommonUtility::readValueFromStruct(params, MSG_PARAM_TITLE, title);
+        CommonUtility::readValueFromStruct(params, MSG_PARAM_MESSAGE, message);
         emit showNotification(CommonUtility::commString2QStr(title), CommonUtility::commString2QStr(message));
     });
 
@@ -242,8 +208,8 @@ void ServerCommService::registerUtilityHandlers(SignalDispatcher &dispatcher) {
     dispatcher.registerHandler(SignalNum::UTILITY_LOG_UPLOAD_STATUS_UPDATED, [this](const Poco::DynamicStruct &params) {
         LogUploadState state = LogUploadState::None;
         int32_t percentage = 0;
-        CommonUtility::readValueFromStruct(params, kLogUploadState, state);
-        CommonUtility::readValueFromStruct(params, kPercentage, percentage);
+        CommonUtility::readValueFromStruct(params, MSG_PARAM_LOG_UPLOAD_STATE, state);
+        CommonUtility::readValueFromStruct(params, MSG_PARAM_PERCENTAGE, percentage);
         emit logUploadStatusUpdated(state, percentage);
     });
 

--- a/src/gui4/linux/app/services/servercommservice.cpp
+++ b/src/gui4/linux/app/services/servercommservice.cpp
@@ -192,5 +192,21 @@ void ServerCommService::registerSyncHandlers(SignalDispatcher &dispatcher) {
     });
 }
 
+// -- Error ---------------------------------------------------------------------
+
+void ServerCommService::registerErrorHandlers(SignalDispatcher &dispatcher) {
+    dispatcher.registerHandler(SignalNum::UTILITY_ERROR_ADDED, [this](const Poco::DynamicStruct &params) {
+        ErrorInfo info;
+        info.fromDynamicStruct(params[kErrorInfo].extract<Poco::DynamicStruct>());
+        emit errorAdded(info);
+    });
+
+    dispatcher.registerHandler(SignalNum::UTILITY_ERROR_REMOVED, [this](const Poco::DynamicStruct &params) {
+        ErrorDbId errorDbId = 0;
+        CommonUtility::readValueFromStruct(params, kErrorDbId, errorDbId);
+        emit errorRemoved(errorDbId);
+    });
+}
+
 
 } // namespace KDC

--- a/src/gui4/linux/app/services/servercommservice.cpp
+++ b/src/gui4/linux/app/services/servercommservice.cpp
@@ -224,4 +224,30 @@ void ServerCommService::registerUpdaterHandlers(SignalDispatcher &dispatcher) {
     });
 }
 
+// -- Utility -------------------------------------------------------------------
+
+void ServerCommService::registerUtilityHandlers(SignalDispatcher &dispatcher) {
+    dispatcher.registerHandler(SignalNum::UTILITY_SHOW_NOTIFICATION, [this](const Poco::DynamicStruct &params) {
+        CommString title;
+        CommString message;
+        CommonUtility::readValueFromStruct(params, kTitle, title);
+        CommonUtility::readValueFromStruct(params, kMessage, message);
+        emit showNotification(CommonUtility::commString2QStr(title), CommonUtility::commString2QStr(message));
+    });
+
+    dispatcher.registerHandler(SignalNum::UTILITY_SHOW_SETTINGS, [this](const Poco::DynamicStruct &) { emit showSettings(); });
+
+    dispatcher.registerHandler(SignalNum::UTILITY_SHOW_SYNTHESIS, [this](const Poco::DynamicStruct &) { emit showSynthesis(); });
+
+    dispatcher.registerHandler(SignalNum::UTILITY_LOG_UPLOAD_STATUS_UPDATED, [this](const Poco::DynamicStruct &params) {
+        LogUploadState state = LogUploadState::None;
+        int32_t percentage = 0;
+        CommonUtility::readValueFromStruct(params, kLogUploadState, state);
+        CommonUtility::readValueFromStruct(params, kPercentage, percentage);
+        emit logUploadStatusUpdated(state, percentage);
+    });
+
+    dispatcher.registerHandler(SignalNum::UTILITY_QUIT, [this](const Poco::DynamicStruct &) { emit quit(); });
+}
+
 } // namespace KDC

--- a/src/gui4/linux/app/services/servercommservice.h
+++ b/src/gui4/linux/app/services/servercommservice.h
@@ -81,7 +81,7 @@ class ServerCommService : public QObject {
         void showNotification(const QString &title, const QString &message);
         void showSettings();
         void showSynthesis();
-        void logUploadStatusUpdated(LogUploadState state, int percentage);
+        void logUploadStatusUpdated(LogUploadState state, int32_t percentage);
         void quit();
 
     private:

--- a/src/gui4/linux/app/services/servercommservice.h
+++ b/src/gui4/linux/app/services/servercommservice.h
@@ -1,0 +1,97 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "communicationlayer/signaldispatcher.h"
+#include "libcommon/utility/cstypes.h"
+#include "libcommon/utility/types.h"
+#include "libcommon/info/accountinfo.h"
+#include "libcommon/info/driveinfo.h"
+#include "libcommon/info/errorinfo.h"
+#include "libcommon/info/syncfileiteminfo.h"
+#include "libcommon/info/syncinfo.h"
+#include "libcommon/info/userinfo.h"
+
+#include <QObject>
+
+namespace KDC {
+
+/**
+ * Registers handlers on the SignalDispatcher for every server-initiated signal
+ * and re-emits them as typed Qt signals for consumption by app models and QML.
+ *
+ * Signals that are still sent via the legacy QDataStream channel (OldCommServer)
+ * are not handled here and are listed in the implementation file for reference.
+ */
+class ServerCommService : public QObject {
+        Q_OBJECT
+
+    public:
+        explicit ServerCommService(SignalDispatcher &dispatcher, QObject *parent = nullptr);
+
+    signals:
+        // --- User ---
+        void userAdded(const UserInfo &info);
+        void userUpdated(const UserInfo &info);
+        void userRemoved(UserDbId userDbId);
+
+        // --- Account ---
+        void accountAdded(const AccountInfo &info);
+        void accountUpdated(const AccountInfo &info);
+        void accountRemoved(AccountDbId accountDbId);
+
+        // --- Drive ---
+        void driveAdded(const DriveInfo &info);
+        void driveUpdated(const DriveInfo &info);
+        void driveRemoved(DriveDbId driveDbId);
+
+        // --- Sync ---
+        void syncAdded(const SyncInfo &info);
+        void syncUpdated(const SyncInfo &info);
+        void syncRemoved(SyncDbId syncDbId);
+        void syncProgressInfo(SyncDbId syncDbId, SyncStatus status, SyncStep step, int64_t currentFile, int64_t totalFiles,
+                              int64_t completedSize, int64_t totalSize, int64_t estimatedRemainingTime);
+        void itemCompleted(SyncDbId syncDbId, const SyncFileItemInfo &info);
+
+        // --- Error ---
+        void errorAdded(const ErrorInfo &info);
+        void errorRemoved(ErrorDbId errorDbId);
+
+        // --- Updater ---
+        void updateStateChanged(UpdateState state);
+        void showUpdateDialog(const VersionInfo &info);
+
+        // --- Utility ---
+        void showNotification(const QString &title, const QString &message);
+        void showSettings();
+        void showSynthesis();
+        void logUploadStatusUpdated(LogUploadState state, int percentage);
+        void quit();
+
+    private:
+        void registerUserHandlers(SignalDispatcher &dispatcher);
+        void registerAccountHandlers(SignalDispatcher &dispatcher);
+        void registerDriveHandlers(SignalDispatcher &dispatcher);
+        void registerSyncHandlers(SignalDispatcher &dispatcher);
+        void registerErrorHandlers(SignalDispatcher &dispatcher);
+        void registerUpdaterHandlers(SignalDispatcher &dispatcher);
+        void registerUtilityHandlers(SignalDispatcher &dispatcher);
+};
+
+} // namespace KDC

--- a/src/gui4/linux/app/services/servercommservice.h
+++ b/src/gui4/linux/app/services/servercommservice.h
@@ -35,9 +35,6 @@ namespace KDC {
 /**
  * Registers handlers on the SignalDispatcher for every server-initiated signal
  * and re-emits them as typed Qt signals for consumption by app models and QML.
- *
- * Signals that are still sent via the legacy QDataStream channel (OldCommServer)
- * are not handled here and are listed in the implementation file for reference.
  */
 class ServerCommService : public QObject {
         Q_OBJECT

--- a/src/gui4/linux/appclientlinux.cpp
+++ b/src/gui4/linux/appclientlinux.cpp
@@ -43,6 +43,7 @@ AppClientLinux::AppClientLinux(int &argc, char **argv) :
     (void) connect(&_ipcClient, &IpcClient::connected, this, &AppClientLinux::ipcConnected);
     (void) connect(&_ipcClient, &IpcClient::disconnected, this, &AppClientLinux::ipcDisconnected);
     (void) connect(&_ipcClient, &IpcClient::serverSignalReceived, &_signalDispatcher, &SignalDispatcher::dispatch);
+    (void) connect(&_serverCommService, &ServerCommService::quit, this, &QCoreApplication::quit);
 
 
 #ifdef QT_DEBUG

--- a/src/gui4/linux/appclientlinux.cpp
+++ b/src/gui4/linux/appclientlinux.cpp
@@ -43,7 +43,6 @@ AppClientLinux::AppClientLinux(int &argc, char **argv) :
     (void) connect(&_ipcClient, &IpcClient::connected, this, &AppClientLinux::ipcConnected);
     (void) connect(&_ipcClient, &IpcClient::disconnected, this, &AppClientLinux::ipcDisconnected);
     (void) connect(&_ipcClient, &IpcClient::serverSignalReceived, &_signalDispatcher, &SignalDispatcher::dispatch);
-    (void) connect(&_serverCommService, &ServerCommService::quit, this, &QCoreApplication::quit);
 
 
 #ifdef QT_DEBUG

--- a/src/gui4/linux/appclientlinux.h
+++ b/src/gui4/linux/appclientlinux.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include "app/services/servercommservice.h"
 #include "communicationlayer/ipcclient.h"
 #include "communicationlayer/signaldispatcher.h"
 
@@ -45,6 +46,7 @@ class AppClientLinux : public QGuiApplication {
          * Call registerHandler() on the returned dispatcher before the IPC connection is established.
          */
         SignalDispatcher &signalDispatcher() { return _signalDispatcher; }
+        ServerCommService &serverCommService() { return _serverCommService; }
 
     signals:
         /** Emitted once the first IPC connection to the server has been successfully established. */
@@ -57,6 +59,7 @@ class AppClientLinux : public QGuiApplication {
 
         IpcClient _ipcClient{this};
         SignalDispatcher _signalDispatcher{this};
+        ServerCommService _serverCommService{_signalDispatcher, this};
 };
 
 } // namespace KDC

--- a/src/gui4/linux/communicationlayer/ipcclient.h
+++ b/src/gui4/linux/communicationlayer/ipcclient.h
@@ -65,7 +65,6 @@ class IpcClient : public QObject {
         void onErrorOccurred(QAbstractSocket::SocketError socketError);
         void onReadyRead();
 
-
     private:
         void handleResponseMessage(const Poco::DynamicStruct &ipcMessage, int32_t id);
         void handleServerSignal(const Poco::DynamicStruct &ipcMessage, int32_t id);

--- a/src/libcommon/comm.h
+++ b/src/libcommon/comm.h
@@ -39,6 +39,40 @@ inline constexpr char MSG_SIGNAL_ID[] = "id";
 inline constexpr char MSG_SIGNAL_NUM[] = "num";
 inline constexpr char MSG_SIGNAL_PARAMS[] = "params";
 
+// Signal / request–response payload parameter keys.
+// Shared between server-side jobs (src/server/comm/guijobs/) and GUI clients.
+inline constexpr char MSG_PARAM_USER_INFO[] = "userInfo";
+inline constexpr char MSG_PARAM_USER_DB_ID[] = "userDbId";
+inline constexpr char MSG_PARAM_USER_INFO_LIST[] = "userInfoList";
+inline constexpr char MSG_PARAM_USER_DB_ID_LIST[] = "userDbIdList";
+inline constexpr char MSG_PARAM_ACCOUNT_INFO[] = "accountInfo";
+inline constexpr char MSG_PARAM_ACCOUNT_DB_ID[] = "accountDbId";
+inline constexpr char MSG_PARAM_ACCOUNT_INFO_LIST[] = "accountInfoList";
+inline constexpr char MSG_PARAM_DRIVE_INFO[] = "driveInfo";
+inline constexpr char MSG_PARAM_DRIVE_DB_ID[] = "driveDbId";
+inline constexpr char MSG_PARAM_DRIVE_INFO_LIST[] = "driveInfoList";
+inline constexpr char MSG_PARAM_SYNC_INFO[] = "syncInfo";
+inline constexpr char MSG_PARAM_SYNC_DB_ID[] = "syncDbId";
+inline constexpr char MSG_PARAM_SYNC_INFO_LIST[] = "syncInfoList";
+inline constexpr char MSG_PARAM_SYNC_STATUS[] = "syncStatus";
+inline constexpr char MSG_PARAM_SYNC_STEP[] = "syncStep";
+inline constexpr char MSG_PARAM_SYNC_PROGRESS[] = "SyncProgress";
+inline constexpr char MSG_PARAM_CURRENT_FILE[] = "currentFile";
+inline constexpr char MSG_PARAM_TOTAL_FILES[] = "totalFiles";
+inline constexpr char MSG_PARAM_COMPLETED_SIZE[] = "completedSize";
+inline constexpr char MSG_PARAM_TOTAL_SIZE[] = "totalSize";
+inline constexpr char MSG_PARAM_ESTIMATED_REMAINING_TIME[] = "estimatedRemainingTime";
+inline constexpr char MSG_PARAM_ITEM_INFO[] = "itemInfo";
+inline constexpr char MSG_PARAM_ERROR_INFO[] = "errorInfo";
+inline constexpr char MSG_PARAM_ERROR_DB_ID[] = "errorDbId";
+inline constexpr char MSG_PARAM_ERROR_INFO_LIST[] = "errorInfoList";
+inline constexpr char MSG_PARAM_UPDATE_STATE[] = "updateState";
+inline constexpr char MSG_PARAM_VERSION_INFO[] = "versionInfo";
+inline constexpr char MSG_PARAM_TITLE[] = "title";
+inline constexpr char MSG_PARAM_MESSAGE[] = "message";
+inline constexpr char MSG_PARAM_LOG_UPLOAD_STATE[] = "state";
+inline constexpr char MSG_PARAM_PERCENTAGE[] = "percentage";
+
 inline constexpr char EXECUTE_ERROR_MSG[] = "C/S function call timeout or error!";
 
 /**

--- a/src/server/comm/guijobs/abstractsyncaddjob.cpp
+++ b/src/server/comm/guijobs/abstractsyncaddjob.cpp
@@ -66,7 +66,7 @@ ExitInfo AbstractSyncAddJob::deserializeInputParms() {
 }
 
 ExitInfo AbstractSyncAddJob::serializeOutputParms() {
-    writeParamValue(outParamsSyncInfo, _syncInfo, info2DynamicVar<SyncInfo>);
+    writeParamValue(MSG_PARAM_SYNC_INFO, _syncInfo, info2DynamicVar<SyncInfo>);
 
     return ExitCode::Ok;
 }

--- a/src/server/comm/guijobs/abstractsyncaddjob.cpp
+++ b/src/server/comm/guijobs/abstractsyncaddjob.cpp
@@ -28,15 +28,22 @@
 #include "libcommon/comm.h"
 #include "libcommonserver/log/log.h"
 
-// Input parameters keys
+// deserializeInputParms() reads: {
+//   "localFolderPath":    CommString,
+//   "serverFolderPath":   CommString,
+//   "serverFolderNodeId": NodeId,
+//   "liteSync":           bool,
+//   "blackList":          NodeId[]
+// }
 static const auto inParamsLocalFolderPath = "localFolderPath";
 static const auto inParamsServerFolderPath = "serverFolderPath";
 static const auto inParamsServerFolderNodeId = "serverFolderNodeId";
 static const auto inParamsLiteSync = "liteSync";
 static const auto inParamsBlackList = "blackList";
 
-// Output parameters keys
-static const auto outParamsSyncInfo = "syncInfo";
+// serializeOutputParms() writes: {
+//   MSG_PARAM_SYNC_INFO ("syncInfo"):  SyncInfo
+// }
 
 namespace KDC {
 

--- a/src/server/comm/guijobs/signalaccountaddedjob.cpp
+++ b/src/server/comm/guijobs/signalaccountaddedjob.cpp
@@ -21,9 +21,6 @@
 #include "libcommon/comm.h"
 
 // Signal: SignalNum::ACCOUNT_ADDED
-// serializeOutputParms() writes: {
-//   MSG_PARAM_ACCOUNT_INFO ("accountInfo"): AccountInfo
-// }
 
 namespace KDC {
 

--- a/src/server/comm/guijobs/signalaccountaddedjob.cpp
+++ b/src/server/comm/guijobs/signalaccountaddedjob.cpp
@@ -31,7 +31,7 @@ SignalAccountAddedJob::SignalAccountAddedJob(const AccountInfo &accountInfo) :
 }
 
 ExitInfo SignalAccountAddedJob::serializeOutputParms() {
-    writeParamValue(outParamsAccountInfo, _accountInfo, info2DynamicVar<AccountInfo>);
+    writeParamValue(MSG_PARAM_ACCOUNT_INFO, _accountInfo, info2DynamicVar<AccountInfo>);
     return ExitCode::Ok;
 }
 

--- a/src/server/comm/guijobs/signalaccountaddedjob.cpp
+++ b/src/server/comm/guijobs/signalaccountaddedjob.cpp
@@ -20,8 +20,10 @@
 #include "libcommon/utility/utility.h"
 #include "libcommon/comm.h"
 
-// Output parameters keys
-static const auto outParamsAccountInfo = "accountInfo";
+// Signal: SignalNum::ACCOUNT_ADDED
+// serializeOutputParms() writes: {
+//   MSG_PARAM_ACCOUNT_INFO ("accountInfo"): AccountInfo
+// }
 
 namespace KDC {
 

--- a/src/server/comm/guijobs/signalaccountremovedjob.cpp
+++ b/src/server/comm/guijobs/signalaccountremovedjob.cpp
@@ -22,9 +22,6 @@
 
 
 // Signal: SignalNum::ACCOUNT_REMOVED
-// serializeOutputParms() writes: {
-//   MSG_PARAM_ACCOUNT_DB_ID ("accountDbId"): AccountDbId
-// }
 
 namespace KDC {
 

--- a/src/server/comm/guijobs/signalaccountremovedjob.cpp
+++ b/src/server/comm/guijobs/signalaccountremovedjob.cpp
@@ -31,7 +31,7 @@ SignalAccountRemovedJob::SignalAccountRemovedJob(int accountDbId) :
 }
 
 ExitInfo SignalAccountRemovedJob::serializeOutputParms() {
-    writeParamValue(outParamsAccountDbId, _accountDbId);
+    writeParamValue(MSG_PARAM_ACCOUNT_DB_ID, _accountDbId);
     return ExitCode::Ok;
 }
 

--- a/src/server/comm/guijobs/signalaccountremovedjob.cpp
+++ b/src/server/comm/guijobs/signalaccountremovedjob.cpp
@@ -20,8 +20,11 @@
 #include "libcommon/utility/utility.h"
 #include "libcommon/comm.h"
 
-// Output parameters keys
-static const auto outParamsAccountDbId = "accountDbId";
+
+// Signal: SignalNum::ACCOUNT_REMOVED
+// serializeOutputParms() writes: {
+//   MSG_PARAM_ACCOUNT_DB_ID ("accountDbId"): AccountDbId
+// }
 
 namespace KDC {
 

--- a/src/server/comm/guijobs/signalaccountupdatedjob.cpp
+++ b/src/server/comm/guijobs/signalaccountupdatedjob.cpp
@@ -22,9 +22,6 @@
 
 
 // Signal: SignalNum::ACCOUNT_UPDATED
-// serializeOutputParms() writes: {
-//   MSG_PARAM_ACCOUNT_INFO ("accountInfo"): AccountInfo
-// }
 
 namespace KDC {
 

--- a/src/server/comm/guijobs/signalaccountupdatedjob.cpp
+++ b/src/server/comm/guijobs/signalaccountupdatedjob.cpp
@@ -31,7 +31,7 @@ SignalAccountUpdatedJob::SignalAccountUpdatedJob(const AccountInfo &accountInfo)
 }
 
 ExitInfo SignalAccountUpdatedJob::serializeOutputParms() {
-    writeParamValue(outParamsAccountInfo, _accountInfo, info2DynamicVar<AccountInfo>);
+    writeParamValue(MSG_PARAM_ACCOUNT_INFO, _accountInfo, info2DynamicVar<AccountInfo>);
     return ExitCode::Ok;
 }
 

--- a/src/server/comm/guijobs/signalaccountupdatedjob.cpp
+++ b/src/server/comm/guijobs/signalaccountupdatedjob.cpp
@@ -20,8 +20,11 @@
 #include "libcommon/utility/utility.h"
 #include "libcommon/comm.h"
 
-// Output parameters keys
-static const auto outParamsAccountInfo = "accountInfo";
+
+// Signal: SignalNum::ACCOUNT_UPDATED
+// serializeOutputParms() writes: {
+//   MSG_PARAM_ACCOUNT_INFO ("accountInfo"): AccountInfo
+// }
 
 namespace KDC {
 

--- a/src/server/comm/guijobs/signaldriveaddedjob.cpp
+++ b/src/server/comm/guijobs/signaldriveaddedjob.cpp
@@ -22,9 +22,6 @@
 
 
 // Signal: SignalNum::DRIVE_ADDED
-// serializeOutputParms() writes: {
-//   MSG_PARAM_DRIVE_INFO ("driveInfo"): DriveInfo
-// }
 
 namespace KDC {
 

--- a/src/server/comm/guijobs/signaldriveaddedjob.cpp
+++ b/src/server/comm/guijobs/signaldriveaddedjob.cpp
@@ -20,8 +20,11 @@
 #include "libcommon/utility/utility.h"
 #include "libcommon/comm.h"
 
-// Output parameters keys
-static const auto outParamsDriveInfo = "driveInfo";
+
+// Signal: SignalNum::DRIVE_ADDED
+// serializeOutputParms() writes: {
+//   MSG_PARAM_DRIVE_INFO ("driveInfo"): DriveInfo
+// }
 
 namespace KDC {
 

--- a/src/server/comm/guijobs/signaldriveaddedjob.cpp
+++ b/src/server/comm/guijobs/signaldriveaddedjob.cpp
@@ -31,7 +31,7 @@ SignalDriveAddedJob::SignalDriveAddedJob(const DriveInfo &driveInfo) :
 }
 
 ExitInfo SignalDriveAddedJob::serializeOutputParms() {
-    writeParamValue(outParamsDriveInfo, _driveInfo, info2DynamicVar<DriveInfo>);
+    writeParamValue(MSG_PARAM_DRIVE_INFO, _driveInfo, info2DynamicVar<DriveInfo>);
     return ExitCode::Ok;
 }
 

--- a/src/server/comm/guijobs/signaldriveremovedjob.cpp
+++ b/src/server/comm/guijobs/signaldriveremovedjob.cpp
@@ -20,8 +20,11 @@
 #include "libcommon/utility/utility.h"
 #include "libcommon/comm.h"
 
-// Output parameters keys
-static const auto outParamsDriveDbId = "driveDbId";
+
+// Signal: SignalNum::DRIVE_REMOVED
+// serializeOutputParms() writes: {
+//   MSG_PARAM_DRIVE_DB_ID ("driveDbId"): DriveDbId
+// }
 
 namespace KDC {
 

--- a/src/server/comm/guijobs/signaldriveremovedjob.cpp
+++ b/src/server/comm/guijobs/signaldriveremovedjob.cpp
@@ -22,9 +22,6 @@
 
 
 // Signal: SignalNum::DRIVE_REMOVED
-// serializeOutputParms() writes: {
-//   MSG_PARAM_DRIVE_DB_ID ("driveDbId"): DriveDbId
-// }
 
 namespace KDC {
 

--- a/src/server/comm/guijobs/signaldriveremovedjob.cpp
+++ b/src/server/comm/guijobs/signaldriveremovedjob.cpp
@@ -31,7 +31,7 @@ SignalDriveRemovedJob::SignalDriveRemovedJob(int driveDbId) :
 }
 
 ExitInfo SignalDriveRemovedJob::serializeOutputParms() {
-    writeParamValue(outParamsDriveDbId, _driveDbId);
+    writeParamValue(MSG_PARAM_DRIVE_DB_ID, _driveDbId);
     return ExitCode::Ok;
 }
 

--- a/src/server/comm/guijobs/signaldriveupdatedjob.cpp
+++ b/src/server/comm/guijobs/signaldriveupdatedjob.cpp
@@ -31,7 +31,7 @@ SignalDriveUpdatedJob::SignalDriveUpdatedJob(DriveInfo driveInfo) :
 }
 
 ExitInfo SignalDriveUpdatedJob::serializeOutputParms() {
-    writeParamValue(outParamsDriveInfo, _driveInfo, info2DynamicVar<DriveInfo>);
+    writeParamValue(MSG_PARAM_DRIVE_INFO, _driveInfo, info2DynamicVar<DriveInfo>);
 
     return ExitCode::Ok;
 }

--- a/src/server/comm/guijobs/signaldriveupdatedjob.cpp
+++ b/src/server/comm/guijobs/signaldriveupdatedjob.cpp
@@ -22,9 +22,6 @@
 
 
 // Signal: SignalNum::DRIVE_UPDATED
-// serializeOutputParms() writes: {
-//   MSG_PARAM_DRIVE_INFO ("driveInfo"): DriveInfo
-// }
 
 namespace KDC {
 

--- a/src/server/comm/guijobs/signaldriveupdatedjob.cpp
+++ b/src/server/comm/guijobs/signaldriveupdatedjob.cpp
@@ -20,8 +20,11 @@
 #include "libcommon/utility/utility.h"
 #include "libcommon/comm.h"
 
-// Output parameters keys
-static const auto outParamsDriveInfo = "driveInfo";
+
+// Signal: SignalNum::DRIVE_UPDATED
+// serializeOutputParms() writes: {
+//   MSG_PARAM_DRIVE_INFO ("driveInfo"): DriveInfo
+// }
 
 namespace KDC {
 

--- a/src/server/comm/guijobs/signalerroraddedjob.cpp
+++ b/src/server/comm/guijobs/signalerroraddedjob.cpp
@@ -20,8 +20,11 @@
 #include "libcommon/utility/utility.h"
 #include "libcommon/comm.h"
 
-// Output parameters keys
-static const auto outParamsErrorInfo = "errorInfo";
+
+// Signal: SignalNum::UTILITY_ERROR_ADDED
+// serializeOutputParms() writes: {
+//   MSG_PARAM_ERROR_INFO ("errorInfo"): ErrorInfo
+// }
 
 namespace KDC {
 

--- a/src/server/comm/guijobs/signalerroraddedjob.cpp
+++ b/src/server/comm/guijobs/signalerroraddedjob.cpp
@@ -22,9 +22,6 @@
 
 
 // Signal: SignalNum::UTILITY_ERROR_ADDED
-// serializeOutputParms() writes: {
-//   MSG_PARAM_ERROR_INFO ("errorInfo"): ErrorInfo
-// }
 
 namespace KDC {
 

--- a/src/server/comm/guijobs/signalerroraddedjob.cpp
+++ b/src/server/comm/guijobs/signalerroraddedjob.cpp
@@ -31,7 +31,7 @@ SignalErrorAddedJob::SignalErrorAddedJob(const ErrorInfo &errorInfo) :
 }
 
 ExitInfo SignalErrorAddedJob::serializeOutputParms() {
-    writeParamValue(outParamsErrorInfo, _errorInfo, info2DynamicVar<ErrorInfo>);
+    writeParamValue(MSG_PARAM_ERROR_INFO, _errorInfo, info2DynamicVar<ErrorInfo>);
     return ExitCode::Ok;
 }
 

--- a/src/server/comm/guijobs/signalerrorremovedjob.cpp
+++ b/src/server/comm/guijobs/signalerrorremovedjob.cpp
@@ -30,7 +30,7 @@ SignalErrorRemovedJob::SignalErrorRemovedJob(const int &errorDbId) :
 }
 
 ExitInfo SignalErrorRemovedJob::serializeOutputParms() {
-    writeParamValue(outParamsErrorDbId, _errorDbId);
+    writeParamValue(MSG_PARAM_ERROR_DB_ID, _errorDbId);
     return ExitCode::Ok;
 }
 

--- a/src/server/comm/guijobs/signalerrorremovedjob.cpp
+++ b/src/server/comm/guijobs/signalerrorremovedjob.cpp
@@ -19,8 +19,11 @@
 #include "signalerrorremovedjob.h"
 #include "libcommon/comm.h"
 
-// Output parameters keys
-static const auto outParamsErrorDbId = "errorDbId";
+
+// Signal: SignalNum::UTILITY_ERROR_REMOVED
+// serializeOutputParms() writes: {
+//   MSG_PARAM_ERROR_DB_ID ("errorDbId"): ErrorDbId
+// }
 
 namespace KDC {
 

--- a/src/server/comm/guijobs/signalerrorremovedjob.cpp
+++ b/src/server/comm/guijobs/signalerrorremovedjob.cpp
@@ -21,9 +21,6 @@
 
 
 // Signal: SignalNum::UTILITY_ERROR_REMOVED
-// serializeOutputParms() writes: {
-//   MSG_PARAM_ERROR_DB_ID ("errorDbId"): ErrorDbId
-// }
 
 namespace KDC {
 

--- a/src/server/comm/guijobs/signalsyncaddedjob.cpp
+++ b/src/server/comm/guijobs/signalsyncaddedjob.cpp
@@ -22,9 +22,6 @@
 
 
 // Signal: SignalNum::SYNC_ADDED
-// serializeOutputParms() writes: {
-//   MSG_PARAM_SYNC_INFO ("syncInfo"): SyncInfo
-// }
 
 namespace KDC {
 

--- a/src/server/comm/guijobs/signalsyncaddedjob.cpp
+++ b/src/server/comm/guijobs/signalsyncaddedjob.cpp
@@ -20,8 +20,11 @@
 #include "libcommon/utility/utility.h"
 #include "libcommon/comm.h"
 
-// Output parameters keys
-static const auto outParamsSyncInfo = "syncInfo";
+
+// Signal: SignalNum::SYNC_ADDED
+// serializeOutputParms() writes: {
+//   MSG_PARAM_SYNC_INFO ("syncInfo"): SyncInfo
+// }
 
 namespace KDC {
 

--- a/src/server/comm/guijobs/signalsyncaddedjob.cpp
+++ b/src/server/comm/guijobs/signalsyncaddedjob.cpp
@@ -31,7 +31,7 @@ SignalSyncAddedJob::SignalSyncAddedJob(const SyncInfo &syncInfo) :
 }
 
 ExitInfo SignalSyncAddedJob::serializeOutputParms() {
-    writeParamValue(outParamsSyncInfo, _syncInfo, info2DynamicVar<SyncInfo>);
+    writeParamValue(MSG_PARAM_SYNC_INFO, _syncInfo, info2DynamicVar<SyncInfo>);
     return ExitCode::Ok;
 }
 

--- a/src/server/comm/guijobs/signalsynccompleteditemjob.cpp
+++ b/src/server/comm/guijobs/signalsynccompleteditemjob.cpp
@@ -22,10 +22,6 @@
 
 
 // Signal: SignalNum::SYNC_COMPLETEDITEM
-// serializeOutputParms() writes: {
-//   MSG_PARAM_SYNC_DB_ID ("syncDbId"): SyncDbId,
-//   MSG_PARAM_ITEM_INFO ("itemInfo"):  SyncFileItemInfo
-// }
 
 namespace KDC {
 

--- a/src/server/comm/guijobs/signalsynccompleteditemjob.cpp
+++ b/src/server/comm/guijobs/signalsynccompleteditemjob.cpp
@@ -20,9 +20,12 @@
 #include "libcommon/utility/utility.h"
 #include "libcommon/comm.h"
 
-// Output parameters keys
-static const auto outParamsSyncDbId = "syncDbId";
-static const auto outParamsItemInfo = "itemInfo";
+
+// Signal: SignalNum::SYNC_COMPLETEDITEM
+// serializeOutputParms() writes: {
+//   MSG_PARAM_SYNC_DB_ID ("syncDbId"): SyncDbId,
+//   MSG_PARAM_ITEM_INFO ("itemInfo"):  SyncFileItemInfo
+// }
 
 namespace KDC {
 

--- a/src/server/comm/guijobs/signalsynccompleteditemjob.cpp
+++ b/src/server/comm/guijobs/signalsynccompleteditemjob.cpp
@@ -33,8 +33,8 @@ SignalSyncCompletedItemJob::SignalSyncCompletedItemJob(int syncDbId, const SyncF
 }
 
 ExitInfo SignalSyncCompletedItemJob::serializeOutputParms() {
-    writeParamValue(outParamsSyncDbId, _syncDbId);
-    writeParamValue(outParamsItemInfo, _itemInfo, info2DynamicVar<SyncFileItemInfo>);
+    writeParamValue(MSG_PARAM_SYNC_DB_ID, _syncDbId);
+    writeParamValue(MSG_PARAM_ITEM_INFO, _itemInfo, info2DynamicVar<SyncFileItemInfo>);
     return ExitCode::Ok;
 }
 

--- a/src/server/comm/guijobs/signalsyncprogressinfojob.cpp
+++ b/src/server/comm/guijobs/signalsyncprogressinfojob.cpp
@@ -22,18 +22,6 @@
 
 
 // Signal: SignalNum::SYNC_PROGRESSINFO
-// serializeOutputParms() writes: {
-//   MSG_PARAM_SYNC_DB_ID ("syncDbId"):       SyncDbId,
-//   MSG_PARAM_SYNC_STATUS ("syncStatus"):    SyncStatus,
-//   MSG_PARAM_SYNC_STEP ("syncStep"):        SyncStep,
-//   MSG_PARAM_SYNC_PROGRESS ("SyncProgress"): {
-//     MSG_PARAM_CURRENT_FILE ("currentFile"):                        int64_t,
-//     MSG_PARAM_TOTAL_FILES ("totalFiles"):                          int64_t,
-//     MSG_PARAM_COMPLETED_SIZE ("completedSize"):                    int64_t,
-//     MSG_PARAM_TOTAL_SIZE ("totalSize"):                            int64_t,
-//     MSG_PARAM_ESTIMATED_REMAINING_TIME ("estimatedRemainingTime"): int64_t
-//   }
-// }
 
 namespace KDC {
 

--- a/src/server/comm/guijobs/signalsyncprogressinfojob.cpp
+++ b/src/server/comm/guijobs/signalsyncprogressinfojob.cpp
@@ -20,11 +20,20 @@
 #include "libcommon/utility/utility.h"
 #include "libcommon/comm.h"
 
-// Output parameters keys
-static const auto outParamsSyncDbId = "syncDbId";
-static const auto outParamsSyncstatus = "syncStatus";
-static const auto outParamsSyncStep = "syncStep";
-static const auto outParamsSyncProgress = "SyncProgress";
+
+// Signal: SignalNum::SYNC_PROGRESSINFO
+// serializeOutputParms() writes: {
+//   MSG_PARAM_SYNC_DB_ID ("syncDbId"):       SyncDbId,
+//   MSG_PARAM_SYNC_STATUS ("syncStatus"):    SyncStatus,
+//   MSG_PARAM_SYNC_STEP ("syncStep"):        SyncStep,
+//   MSG_PARAM_SYNC_PROGRESS ("SyncProgress"): {
+//     MSG_PARAM_CURRENT_FILE ("currentFile"):                        int64_t,
+//     MSG_PARAM_TOTAL_FILES ("totalFiles"):                          int64_t,
+//     MSG_PARAM_COMPLETED_SIZE ("completedSize"):                    int64_t,
+//     MSG_PARAM_TOTAL_SIZE ("totalSize"):                            int64_t,
+//     MSG_PARAM_ESTIMATED_REMAINING_TIME ("estimatedRemainingTime"): int64_t
+//   }
+// }
 
 namespace KDC {
 

--- a/src/server/comm/guijobs/signalsyncprogressinfojob.cpp
+++ b/src/server/comm/guijobs/signalsyncprogressinfojob.cpp
@@ -38,10 +38,10 @@ SignalSyncProgressInfoJob::SignalSyncProgressInfoJob(int syncDbId, SyncStatus sy
 }
 
 ExitInfo SignalSyncProgressInfoJob::serializeOutputParms() {
-    writeParamValue(outParamsSyncDbId, _syncDbId);
-    writeParamValue(outParamsSyncstatus, _syncStatus);
-    writeParamValue(outParamsSyncStep, _syncStep);
-    writeParamValue(outParamsSyncProgress, _syncProgress, info2DynamicVar<SyncProgress>);
+    writeParamValue(MSG_PARAM_SYNC_DB_ID, _syncDbId);
+    writeParamValue(MSG_PARAM_SYNC_STATUS, _syncStatus);
+    writeParamValue(MSG_PARAM_SYNC_STEP, _syncStep);
+    writeParamValue(MSG_PARAM_SYNC_PROGRESS, _syncProgress, info2DynamicVar<SyncProgress>);
     return ExitCode::Ok;
 }
 

--- a/src/server/comm/guijobs/signalsyncremovedjob.cpp
+++ b/src/server/comm/guijobs/signalsyncremovedjob.cpp
@@ -22,9 +22,6 @@
 
 
 // Signal: SignalNum::SYNC_REMOVED
-// serializeOutputParms() writes: {
-//   MSG_PARAM_SYNC_DB_ID ("syncDbId"): SyncDbId
-// }
 
 namespace KDC {
 

--- a/src/server/comm/guijobs/signalsyncremovedjob.cpp
+++ b/src/server/comm/guijobs/signalsyncremovedjob.cpp
@@ -20,8 +20,11 @@
 #include "libcommon/utility/utility.h"
 #include "libcommon/comm.h"
 
-// Output parameters keys
-static const auto outParamsSyncDbId = "syncDbId";
+
+// Signal: SignalNum::SYNC_REMOVED
+// serializeOutputParms() writes: {
+//   MSG_PARAM_SYNC_DB_ID ("syncDbId"): SyncDbId
+// }
 
 namespace KDC {
 

--- a/src/server/comm/guijobs/signalsyncremovedjob.cpp
+++ b/src/server/comm/guijobs/signalsyncremovedjob.cpp
@@ -31,7 +31,7 @@ SignalSyncRemovedJob::SignalSyncRemovedJob(int syncDbId) :
 }
 
 ExitInfo SignalSyncRemovedJob::serializeOutputParms() {
-    writeParamValue(outParamsSyncDbId, _syncDbId);
+    writeParamValue(MSG_PARAM_SYNC_DB_ID, _syncDbId);
     return ExitCode::Ok;
 }
 

--- a/src/server/comm/guijobs/signalsyncupdatedjob.cpp
+++ b/src/server/comm/guijobs/signalsyncupdatedjob.cpp
@@ -20,8 +20,11 @@
 #include "libcommon/utility/utility.h"
 #include "libcommon/comm.h"
 
-// Output parameters keys
-static const auto outParamsSyncInfo = "syncInfo";
+
+// Signal: SignalNum::SYNC_UPDATED
+// serializeOutputParms() writes: {
+//   MSG_PARAM_SYNC_INFO ("syncInfo"): SyncInfo
+// }
 
 namespace KDC {
 

--- a/src/server/comm/guijobs/signalsyncupdatedjob.cpp
+++ b/src/server/comm/guijobs/signalsyncupdatedjob.cpp
@@ -31,7 +31,7 @@ SignalSyncUpdatedJob::SignalSyncUpdatedJob(const SyncInfo &syncInfo) :
 }
 
 ExitInfo SignalSyncUpdatedJob::serializeOutputParms() {
-    writeParamValue(outParamsSyncInfo, _syncInfo, info2DynamicVar<SyncInfo>);
+    writeParamValue(MSG_PARAM_SYNC_INFO, _syncInfo, info2DynamicVar<SyncInfo>);
 
     return ExitCode::Ok;
 }

--- a/src/server/comm/guijobs/signalsyncupdatedjob.cpp
+++ b/src/server/comm/guijobs/signalsyncupdatedjob.cpp
@@ -22,9 +22,6 @@
 
 
 // Signal: SignalNum::SYNC_UPDATED
-// serializeOutputParms() writes: {
-//   MSG_PARAM_SYNC_INFO ("syncInfo"): SyncInfo
-// }
 
 namespace KDC {
 

--- a/src/server/comm/guijobs/signalupdatershowdialogjob.cpp
+++ b/src/server/comm/guijobs/signalupdatershowdialogjob.cpp
@@ -22,9 +22,6 @@
 
 
 // Signal: SignalNum::UPDATER_SHOW_DIALOG
-// serializeOutputParms() writes: {
-//   MSG_PARAM_VERSION_INFO ("versionInfo"): VersionInfo
-// }
 
 namespace KDC {
 

--- a/src/server/comm/guijobs/signalupdatershowdialogjob.cpp
+++ b/src/server/comm/guijobs/signalupdatershowdialogjob.cpp
@@ -31,7 +31,7 @@ SignalUpdaterShowDialogJob::SignalUpdaterShowDialogJob(const VersionInfo &versio
 }
 
 ExitInfo SignalUpdaterShowDialogJob::serializeOutputParms() {
-    writeParamValue(outParamsVersionInfo, _versionInfo, info2DynamicVar<VersionInfo>);
+    writeParamValue(MSG_PARAM_VERSION_INFO, _versionInfo, info2DynamicVar<VersionInfo>);
     return ExitCode::Ok;
 }
 

--- a/src/server/comm/guijobs/signalupdatershowdialogjob.cpp
+++ b/src/server/comm/guijobs/signalupdatershowdialogjob.cpp
@@ -20,8 +20,11 @@
 #include "libcommon/utility/utility.h"
 #include "libcommon/comm.h"
 
-// Output parameters keys
-static const auto outParamsVersionInfo = "versionInfo";
+
+// Signal: SignalNum::UPDATER_SHOW_DIALOG
+// serializeOutputParms() writes: {
+//   MSG_PARAM_VERSION_INFO ("versionInfo"): VersionInfo
+// }
 
 namespace KDC {
 

--- a/src/server/comm/guijobs/signalupdaterstatechangedjob.cpp
+++ b/src/server/comm/guijobs/signalupdaterstatechangedjob.cpp
@@ -31,7 +31,7 @@ SignalUpdaterStateChangedJob::SignalUpdaterStateChangedJob(const UpdateState upd
 }
 
 ExitInfo SignalUpdaterStateChangedJob::serializeOutputParms() {
-    writeParamValue(outParamsUpdateState, _updateState);
+    writeParamValue(MSG_PARAM_UPDATE_STATE, _updateState);
 
     return ExitCode::Ok;
 }

--- a/src/server/comm/guijobs/signalupdaterstatechangedjob.cpp
+++ b/src/server/comm/guijobs/signalupdaterstatechangedjob.cpp
@@ -20,8 +20,11 @@
 #include "libcommon/utility/utility.h"
 #include "libcommon/comm.h"
 
-// Output parameters keys
-static const auto outParamsUpdateState = "updateState";
+
+// Signal: SignalNum::UPDATER_STATE_CHANGED
+// serializeOutputParms() writes: {
+//   MSG_PARAM_UPDATE_STATE ("updateState"): UpdateState
+// }
 
 namespace KDC {
 

--- a/src/server/comm/guijobs/signalupdaterstatechangedjob.cpp
+++ b/src/server/comm/guijobs/signalupdaterstatechangedjob.cpp
@@ -22,9 +22,6 @@
 
 
 // Signal: SignalNum::UPDATER_STATE_CHANGED
-// serializeOutputParms() writes: {
-//   MSG_PARAM_UPDATE_STATE ("updateState"): UpdateState
-// }
 
 namespace KDC {
 

--- a/src/server/comm/guijobs/signaluseraddedjob.cpp
+++ b/src/server/comm/guijobs/signaluseraddedjob.cpp
@@ -20,8 +20,11 @@
 #include "libcommon/utility/utility.h"
 #include "libcommon/comm.h"
 
-// Output parameters keys
-static const auto outParamsUserInfo = "userInfo";
+
+// Signal: SignalNum::USER_ADDED
+// serializeOutputParms() writes: {
+//   MSG_PARAM_USER_INFO ("userInfo"): UserInfo
+// }
 
 namespace KDC {
 

--- a/src/server/comm/guijobs/signaluseraddedjob.cpp
+++ b/src/server/comm/guijobs/signaluseraddedjob.cpp
@@ -22,9 +22,6 @@
 
 
 // Signal: SignalNum::USER_ADDED
-// serializeOutputParms() writes: {
-//   MSG_PARAM_USER_INFO ("userInfo"): UserInfo
-// }
 
 namespace KDC {
 

--- a/src/server/comm/guijobs/signaluseraddedjob.cpp
+++ b/src/server/comm/guijobs/signaluseraddedjob.cpp
@@ -31,7 +31,7 @@ SignalUserAddedJob::SignalUserAddedJob(const UserInfo &userInfo) :
 }
 
 ExitInfo SignalUserAddedJob::serializeOutputParms() {
-    writeParamValue(outParamsUserInfo, _userInfo, info2DynamicVar<UserInfo>);
+    writeParamValue(MSG_PARAM_USER_INFO, _userInfo, info2DynamicVar<UserInfo>);
     return ExitCode::Ok;
 }
 

--- a/src/server/comm/guijobs/signaluserremovedjob.cpp
+++ b/src/server/comm/guijobs/signaluserremovedjob.cpp
@@ -31,7 +31,7 @@ SignalUserRemovedJob::SignalUserRemovedJob(int userDbId) :
 }
 
 ExitInfo SignalUserRemovedJob::serializeOutputParms() {
-    writeParamValue(outParamsUserDbId, _userDbId);
+    writeParamValue(MSG_PARAM_USER_DB_ID, _userDbId);
     return ExitCode::Ok;
 }
 

--- a/src/server/comm/guijobs/signaluserremovedjob.cpp
+++ b/src/server/comm/guijobs/signaluserremovedjob.cpp
@@ -20,8 +20,11 @@
 #include "libcommon/utility/utility.h"
 #include "libcommon/comm.h"
 
-// Output parameters keys
-static const auto outParamsUserDbId = "userDbId";
+
+// Signal: SignalNum::USER_REMOVED
+// serializeOutputParms() writes: {
+//   MSG_PARAM_USER_DB_ID ("userDbId"): UserDbId
+// }
 
 namespace KDC {
 

--- a/src/server/comm/guijobs/signaluserremovedjob.cpp
+++ b/src/server/comm/guijobs/signaluserremovedjob.cpp
@@ -22,9 +22,6 @@
 
 
 // Signal: SignalNum::USER_REMOVED
-// serializeOutputParms() writes: {
-//   MSG_PARAM_USER_DB_ID ("userDbId"): UserDbId
-// }
 
 namespace KDC {
 

--- a/src/server/comm/guijobs/signaluserupdatedjob.cpp
+++ b/src/server/comm/guijobs/signaluserupdatedjob.cpp
@@ -31,7 +31,7 @@ SignalUserUpdatedJob::SignalUserUpdatedJob(const UserInfo &userInfo) :
 }
 
 ExitInfo SignalUserUpdatedJob::serializeOutputParms() {
-    writeParamValue(outParamsUserInfo, _userInfo, info2DynamicVar<UserInfo>);
+    writeParamValue(MSG_PARAM_USER_INFO, _userInfo, info2DynamicVar<UserInfo>);
 
     return ExitCode::Ok;
 }

--- a/src/server/comm/guijobs/signaluserupdatedjob.cpp
+++ b/src/server/comm/guijobs/signaluserupdatedjob.cpp
@@ -20,8 +20,11 @@
 #include "libcommon/utility/utility.h"
 #include "libcommon/comm.h"
 
-// Output parameters keys
-static const auto outParamsUserInfo = "userInfo";
+
+// Signal: SignalNum::USER_UPDATED
+// serializeOutputParms() writes: {
+//   MSG_PARAM_USER_INFO ("userInfo"): UserInfo
+// }
 
 namespace KDC {
 

--- a/src/server/comm/guijobs/signaluserupdatedjob.cpp
+++ b/src/server/comm/guijobs/signaluserupdatedjob.cpp
@@ -22,9 +22,6 @@
 
 
 // Signal: SignalNum::USER_UPDATED
-// serializeOutputParms() writes: {
-//   MSG_PARAM_USER_INFO ("userInfo"): UserInfo
-// }
 
 namespace KDC {
 

--- a/src/server/comm/guijobs/signalutilityloguploadstatejob.cpp
+++ b/src/server/comm/guijobs/signalutilityloguploadstatejob.cpp
@@ -20,9 +20,12 @@
 
 #include "libcommon/comm.h"
 
-// Output parameters keys
-static const auto outParamsLogUploadState = "state";
-static const auto outParamsPercentage = "percentage";
+
+// Signal: SignalNum::UTILITY_LOG_UPLOAD_STATUS_UPDATED
+// serializeOutputParms() writes: {
+//   MSG_PARAM_LOG_UPLOAD_STATE ("state"):  LogUploadState,
+//   MSG_PARAM_PERCENTAGE ("percentage"):   int32_t
+// }
 
 namespace KDC {
 

--- a/src/server/comm/guijobs/signalutilityloguploadstatejob.cpp
+++ b/src/server/comm/guijobs/signalutilityloguploadstatejob.cpp
@@ -22,10 +22,6 @@
 
 
 // Signal: SignalNum::UTILITY_LOG_UPLOAD_STATUS_UPDATED
-// serializeOutputParms() writes: {
-//   MSG_PARAM_LOG_UPLOAD_STATE ("state"):  LogUploadState,
-//   MSG_PARAM_PERCENTAGE ("percentage"):   int32_t
-// }
 
 namespace KDC {
 

--- a/src/server/comm/guijobs/signalutilityloguploadstatejob.cpp
+++ b/src/server/comm/guijobs/signalutilityloguploadstatejob.cpp
@@ -33,8 +33,8 @@ SignalUtilityLogUploadStateJob::SignalUtilityLogUploadStateJob(const LogUploadSt
 }
 
 ExitInfo SignalUtilityLogUploadStateJob::serializeOutputParms() {
-    writeParamValue(outParamsLogUploadState, _state);
-    writeParamValue(outParamsPercentage, _percentage);
+    writeParamValue(MSG_PARAM_LOG_UPLOAD_STATE, _state);
+    writeParamValue(MSG_PARAM_PERCENTAGE, _percentage);
 
     return ExitCode::Ok;
 }

--- a/src/server/comm/guijobs/signalutilityshownotificationjob.cpp
+++ b/src/server/comm/guijobs/signalutilityshownotificationjob.cpp
@@ -22,10 +22,6 @@
 
 
 // Signal: SignalNum::UTILITY_SHOW_NOTIFICATION
-// serializeOutputParms() writes: {
-//   MSG_PARAM_TITLE ("title"):     CommString,
-//   MSG_PARAM_MESSAGE ("message"): CommString
-// }
 
 namespace KDC {
 

--- a/src/server/comm/guijobs/signalutilityshownotificationjob.cpp
+++ b/src/server/comm/guijobs/signalutilityshownotificationjob.cpp
@@ -33,8 +33,8 @@ SignalUtilityShowNotificationJob::SignalUtilityShowNotificationJob(CommString ti
 }
 
 ExitInfo SignalUtilityShowNotificationJob::serializeOutputParms() {
-    writeParamValue(outParamsTitle, _title);
-    writeParamValue(outParamsMessage, _message);
+    writeParamValue(MSG_PARAM_TITLE, _title);
+    writeParamValue(MSG_PARAM_MESSAGE, _message);
 
     return ExitCode::Ok;
 }

--- a/src/server/comm/guijobs/signalutilityshownotificationjob.cpp
+++ b/src/server/comm/guijobs/signalutilityshownotificationjob.cpp
@@ -20,9 +20,12 @@
 
 #include "libcommon/comm.h"
 
-// Output parameters keys
-static const auto outParamsTitle = "title";
-static const auto outParamsMessage = "message";
+
+// Signal: SignalNum::UTILITY_SHOW_NOTIFICATION
+// serializeOutputParms() writes: {
+//   MSG_PARAM_TITLE ("title"):     CommString,
+//   MSG_PARAM_MESSAGE ("message"): CommString
+// }
 
 namespace KDC {
 


### PR DESCRIPTION
## Summary
Introduces `ServerCommService`, a new Qt service class that registers
handlers on `SignalDispatcher` for all server-initiated IPC signals and
re-emits them as typed Qt signals for consumption by app models and QML.
As a prerequisite, all signal job files in `src/server/comm/guijobs/`
are migrated to use shared `MSG_PARAM_*` string constants defined in
`comm.h`, replacing the previous file-local `static const auto` keys.

## Changes
- Add `ServerCommService` (`app/services/servercommservice.cpp/.h`):
  registers handlers for user, account, drive, sync, error, updater, and
  utility signals, and exposes them as typed Qt signals
- Declare 24 `MSG_PARAM_*` inline constexpr string constants in
  `src/libcommon/comm.h` to serve as the single source of truth for IPC
  payload parameter keys
- Replace file-local parameter key variables with `MSG_PARAM_*` constants
  across all 20+ signal job `.cpp` files in `src/server/comm/guijobs/`
- Instantiate `ServerCommService` as a member of `AppClientLinux` and
  wire its `quit` signal to `QCoreApplication::quit`
- Register `servercommservice.cpp/.h` in `CMakeLists.txt`

## Technical Details
The migration of server-side job files to `MSG_PARAM_*` constants is a
prerequisite: the GUI handler and the server serializer must agree on the
same key strings, and having them defined in one place (`comm.h`) removes
the previous implicit contract maintained by duplicated string literals.