### PR TITLE
fix(get-item-type): Fixes the returned `IoError` value in `IoHelper::getItemType` after calling `_readAlias`

### DIFF
--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -415,11 +415,9 @@ bool IoHelper::getItemType(const SyncPath &path, ItemType &itemType) noexcept {
 
     if (isAlias) {
         // !!! isAlias is true for a symlink and for a Finder alias !!!
-        IoError aliasReadError = IoError::Success;
-        if (!_readAlias(path, itemType.targetPath, aliasReadError)) {
+        if (!_readAlias(path, itemType.targetPath, itemType.ioError)) {
             LOGW_WARN(logger(),
                       L"Failed to read an item first identified as an alias: " << Utility::formatIoError(path, itemType.ioError));
-            itemType.ioError = aliasReadError;
 
             return false;
         }

--- a/src/libcommonserver/io/iohelper_mac.mm
+++ b/src/libcommonserver/io/iohelper_mac.mm
@@ -151,6 +151,7 @@ bool IoHelper::readAlias(const SyncPath &aliasPath, std::string &data, SyncPath 
                 const auto errorDescriptionStdString = std::string([(__bridge NSString *) errorDescription UTF8String]);
                 LOG_WARN(logger(), "Native CF Error description: " << errorDescriptionStdString);
                 CFRelease(error);
+                CFRelease(errorDescription);
 
                 return false;
             }

--- a/src/libcommonserver/io/iohelper_mac.mm
+++ b/src/libcommonserver/io/iohelper_mac.mm
@@ -140,11 +140,18 @@ bool IoHelper::readAlias(const SyncPath &aliasPath, std::string &data, SyncPath 
     if (bookmarkRef == nil) {
         if (error) {
             ioError = nsError2ioError((__bridge NSError *) error);
-            CFRelease(error);
             if (ioError != IoError::Unknown) {
+                CFRelease(error);
+
                 return true;
             } else {
                 LOGW_WARN(logger(), L"Error in CFURLCreateBookmarkDataFromFile: " << Utility::formatIoError(aliasPath, ioError));
+
+                CFStringRef errorDescription = CFErrorCopyDescription(error);
+                const auto errorDescriptionStdString = std::string([(__bridge NSString *) errorDescription UTF8String]);
+                LOG_WARN(logger(), "Native CF Error description: " << errorDescriptionStdString);
+                CFRelease(error);
+
                 return false;
             }
         }

--- a/src/libcommonserver/io/iohelper_mac.mm
+++ b/src/libcommonserver/io/iohelper_mac.mm
@@ -146,12 +146,12 @@ bool IoHelper::readAlias(const SyncPath &aliasPath, std::string &data, SyncPath 
                 return true;
             } else {
                 LOGW_WARN(logger(), L"Error in CFURLCreateBookmarkDataFromFile: " << Utility::formatIoError(aliasPath, ioError));
-
-                CFStringRef errorDescription = CFErrorCopyDescription(error);
-                const auto errorDescriptionStdString = std::string([(__bridge NSString *) errorDescription UTF8String]);
-                LOG_WARN(logger(), "Native CF Error description: " << errorDescriptionStdString);
+                if (CFStringRef errorDescription = CFErrorCopyDescription(error); errorDescription) {
+                    const auto errorDescriptionStdString = std::string([(__bridge NSString *) errorDescription UTF8String]);
+                    LOGW_WARN(logger(), L"Native CF Error description: " << CommonUtility::s2ws(errorDescriptionStdString));
+                    CFRelease(errorDescription);
+                }
                 CFRelease(error);
-                CFRelease(errorDescription);
 
                 return false;
             }
@@ -160,8 +160,8 @@ bool IoHelper::readAlias(const SyncPath &aliasPath, std::string &data, SyncPath 
         return false;
     }
 
-    const uint32_t size = (uint32_t) CFDataGetLength(bookmarkRef);
-    unsigned char *buffer = new unsigned char[size];
+    const auto size = (uint32_t) CFDataGetLength(bookmarkRef);
+    auto *buffer = new unsigned char[size];
     CFDataGetBytes(bookmarkRef, CFRangeMake(0, size), (UInt8 *) buffer);
     data = std::string(reinterpret_cast<char const *>(buffer), size);
     delete[] buffer;

--- a/test/libcommon/CMakeLists.txt
+++ b/test/libcommon/CMakeLists.txt
@@ -33,7 +33,7 @@ set(testcommon_SRCS
 )
 
 if(APPLE)
-    list(APPEND testcommon_SRCS ../test_utility/testhelpers_mac.cpp io/testcreatealias.cpp io/testgetxattrvalue.cpp io/testsetxattrvalue.cpp io/testremovexattr.cpp)
+    list(APPEND testcommon_SRCS ../test_utility/testhelpers_mac.cpp io/testcreatealias.cpp io/testreadalias.cpp io/testgetxattrvalue.cpp io/testsetxattrvalue.cpp io/testremovexattr.cpp)
 elseif (WIN32)
     list(APPEND testcommon_SRCS ../test_utility/testhelpers_win.cpp io/testcreatejunction.cpp io/testgetxattrvalue.cpp io/testsetxattrvalue.cpp io/testgetlongpathname.cpp)
 else ()

--- a/test/libcommon/io/testcreatealias.cpp
+++ b/test/libcommon/io/testcreatealias.cpp
@@ -1,6 +1,6 @@
 /*
  * Infomaniak kDrive - Desktop
- * Copyright (C) 2023-2026 Infomaniak Network SA
+ * Copyright (C) 2023-2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/test/libcommon/io/testcreatealias.cpp
+++ b/test/libcommon/io/testcreatealias.cpp
@@ -1,6 +1,6 @@
 /*
  * Infomaniak kDrive - Desktop
- * Copyright (C) 2023-2025 Infomaniak Network SA
+ * Copyright (C) 2023-2026 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/test/libcommon/io/testio.h
+++ b/test/libcommon/io/testio.h
@@ -59,6 +59,7 @@ class TestIo : public CppUnit::TestFixture, public TestBase {
 #if defined(KD_MACOS)
         CPPUNIT_TEST(testRemoveXAttr);
         CPPUNIT_TEST(testCreateAlias);
+        CPPUNIT_TEST(testReadAlias);
 #endif
 #if defined(KD_WINDOWS)
         CPPUNIT_TEST(testCreateJunction);
@@ -106,6 +107,7 @@ class TestIo : public CppUnit::TestFixture, public TestBase {
 #if defined(KD_MACOS)
         void testRemoveXAttr(void);
         void testCreateAlias(void);
+        void testReadAlias();
 #elif defined(KD_WINDOWS)
         void testCreateJunction();
         void testGetLongPathName();

--- a/test/libcommon/io/testreadalias.cpp
+++ b/test/libcommon/io/testreadalias.cpp
@@ -1,0 +1,153 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "testio.h"
+
+#include <filesystem>
+
+using namespace CppUnit;
+
+namespace KDC {
+
+
+void TestIo::testReadAlias() {
+    // A MacOSX Finder alias on a regular file.
+    {
+        const LocalTemporaryDirectory temporaryDirectory;
+        const SyncPath targetPath = _localTestDirPath / "test_pictures/picture-1.jpg";
+        const SyncPath path = temporaryDirectory.path() / "regular_file_alias";
+        IoError createAliasError = IoError::Unknown;
+        CPPUNIT_ASSERT_MESSAGE(toString(createAliasError), IoHelper::createAliasFromPath(targetPath, path, createAliasError));
+
+
+        IoError readAliasError = IoError::Unknown;
+        std::string data;
+        SyncPath actualTargetPath;
+        CPPUNIT_ASSERT_MESSAGE(toString(readAliasError), IoHelper::readAlias(path, data, actualTargetPath, readAliasError));
+        CPPUNIT_ASSERT_EQUAL(IoError::Success, readAliasError);
+        CPPUNIT_ASSERT_EQUAL(targetPath, actualTargetPath);
+        CPPUNIT_ASSERT(!data.empty());
+    }
+
+    // A MacOSX Finder alias on a regular directory.
+    {
+        const LocalTemporaryDirectory temporaryDirectory;
+        const SyncPath targetPath = _localTestDirPath / "test_pictures";
+        const SyncPath path = temporaryDirectory.path() / "regular_dir_alias";
+
+        IoError createAliasError = IoError::Unknown;
+        CPPUNIT_ASSERT_MESSAGE(toString(createAliasError), IoHelper::createAliasFromPath(targetPath, path, createAliasError));
+        CPPUNIT_ASSERT_EQUAL(IoError::Success, createAliasError);
+
+        IoError readAliasError = IoError::Unknown;
+        std::string data;
+        SyncPath actualTargetPath;
+        CPPUNIT_ASSERT_MESSAGE(toString(readAliasError), IoHelper::readAlias(path, data, actualTargetPath, readAliasError));
+        CPPUNIT_ASSERT_EQUAL(IoError::Success, readAliasError);
+        CPPUNIT_ASSERT_EQUAL(targetPath, actualTargetPath);
+        CPPUNIT_ASSERT(!data.empty());
+    }
+
+    // The alias file does not exist: success with empty data, empty target path and IoError::NoSuchFileOrDirectory output error.
+    {
+        const LocalTemporaryDirectory temporaryDirectory;
+        const SyncPath targetPath = _localTestDirPath / "non-existing.jpg"; // This file does not exist.
+        const SyncPath path = temporaryDirectory.path() / "non_existing_dir_alias"; // This file does not exist.
+
+        IoError readAliasError = IoError::Unknown;
+        std::string data;
+        SyncPath actualTargetPath;
+        CPPUNIT_ASSERT_MESSAGE(toString(readAliasError), IoHelper::readAlias(path, data, actualTargetPath, readAliasError));
+        CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, readAliasError);
+        CPPUNIT_ASSERT_EQUAL(SyncPath{}, actualTargetPath);
+        CPPUNIT_ASSERT_EQUAL(std::string{}, data);
+    }
+
+
+    // The alias path is the target path (of an existing file): success
+    {
+        const LocalTemporaryDirectory temporaryDirectory;
+        const SyncPath path = temporaryDirectory.path() / "file.txt";
+        { std::ofstream ofs(path); }
+        const SyncPath targetPath = path;
+
+        IoError createAliasError = IoError::Unknown;
+        CPPUNIT_ASSERT_MESSAGE(toString(createAliasError), IoHelper::createAliasFromPath(targetPath, path, createAliasError));
+        CPPUNIT_ASSERT_EQUAL(IoError::Success, createAliasError);
+
+        IoError readAliasError = IoError::Unknown;
+        std::string data;
+        SyncPath actualTargetPath;
+        CPPUNIT_ASSERT_MESSAGE(toString(readAliasError), IoHelper::readAlias(path, data, actualTargetPath, readAliasError));
+        CPPUNIT_ASSERT_EQUAL(IoError::Success, readAliasError);
+        CPPUNIT_ASSERT_EQUAL(targetPath, actualTargetPath);
+        CPPUNIT_ASSERT(!data.empty());
+    }
+
+    // The alias file name is very long: failure
+    {
+        const std::string veryLongfileName(1000,
+                                           'a'); // Exceeds the max allowed name length on every file system of interest.
+        const SyncPath path = _localTestDirPath / veryLongfileName; // This file doesn't exist.
+        const SyncPath targetPath = _localTestDirPath / "test_pictures/picture-1.jpg";
+
+        IoError readAliasError = IoError::Unknown;
+        std::string data;
+        SyncPath actualTargetPath;
+        CPPUNIT_ASSERT_MESSAGE(toString(readAliasError), IoHelper::readAlias(path, data, actualTargetPath, readAliasError));
+        CPPUNIT_ASSERT_EQUAL(IoError::InvalidFileName, readAliasError);
+        CPPUNIT_ASSERT_EQUAL(SyncPath{}, actualTargetPath);
+        CPPUNIT_ASSERT(data.empty());
+    }
+
+    // The alias file path is very long: failure
+    {
+        const std::string pathSegment(50, 'a');
+        const SyncPath path = makeVeryLonPath(_localTestDirPath);
+        const SyncPath targetPath = _localTestDirPath / "test_pictures/picture-1.jpg";
+
+        IoError readAliasError = IoError::Unknown;
+        std::string data;
+        SyncPath actualTargetPath;
+        CPPUNIT_ASSERT_MESSAGE(toString(readAliasError), IoHelper::readAlias(path, data, actualTargetPath, readAliasError));
+        CPPUNIT_ASSERT_EQUAL(IoError::InvalidFileName, readAliasError);
+        CPPUNIT_ASSERT_EQUAL(SyncPath{}, actualTargetPath);
+        CPPUNIT_ASSERT(data.empty());
+    }
+
+    // The alias file name contains emojis: success
+    {
+        const LocalTemporaryDirectory temporaryDirectory;
+        const SyncPath path = temporaryDirectory.path() / makeFileNameWithEmojis();
+        const SyncPath targetPath = _localTestDirPath / "test_pictures/picture-1.jpg";
+
+        IoError aliasError = IoError::Unknown;
+        CPPUNIT_ASSERT_MESSAGE(toString(aliasError), IoHelper::createAliasFromPath(targetPath, path, aliasError));
+
+        IoError readAliasError = IoError::Unknown;
+        std::string data;
+        SyncPath actualTargetPath;
+        CPPUNIT_ASSERT_MESSAGE(toString(readAliasError), IoHelper::readAlias(path, data, actualTargetPath, readAliasError));
+        CPPUNIT_ASSERT_EQUAL(IoError::Success, readAliasError);
+        CPPUNIT_ASSERT_EQUAL(targetPath, actualTargetPath);
+        CPPUNIT_ASSERT(!data.empty());
+    }
+}
+
+
+} // namespace KDC

--- a/test/libcommon/io/testreadalias.cpp
+++ b/test/libcommon/io/testreadalias.cpp
@@ -1,6 +1,6 @@
 /*
  * Infomaniak kDrive - Desktop
- * Copyright (C) 2023-2025 Infomaniak Network SA
+ * Copyright (C) 2023-2026 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
These changes 
- fixe the returned `IoError` value in `IoHelper::getItemType` after calling `_readAlias`,
- let the `IoHelper::readAlias` method display in addition the actual `CFError` description when `CFURLCreateBookmarkDataFromFile` fails for a reason that we haven't identified yet.