### PR TITLE
fix(sync): restore missing sync add and drive search response fields

### DIFF
--- a/src/server/comm/guijobs/abstractsyncaddjob.cpp
+++ b/src/server/comm/guijobs/abstractsyncaddjob.cpp
@@ -110,6 +110,7 @@ ExitInfo AbstractSyncAddJob::process(SyncInfo &syncInfo) {
     Utility::restartFinderExtension();
 #endif
 
+    _syncInfo = syncInfo;
     return ExitCode::Ok;
 }
 

--- a/src/server/comm/guijobs/abstractsyncaddjob.cpp
+++ b/src/server/comm/guijobs/abstractsyncaddjob.cpp
@@ -1,6 +1,6 @@
 /*
  * Infomaniak kDrive - Desktop
- * Copyright (C) 2023-2025 Infomaniak Network SA
+ * Copyright (C) 2023-2026 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/server/comm/guijobs/abstractsyncaddjob.cpp
+++ b/src/server/comm/guijobs/abstractsyncaddjob.cpp
@@ -71,7 +71,7 @@ ExitInfo AbstractSyncAddJob::serializeOutputParms() {
     return ExitCode::Ok;
 }
 
-ExitInfo AbstractSyncAddJob::process(SyncInfo &syncInfo) {
+ExitInfo AbstractSyncAddJob::process(const SyncInfo &syncInfo) {
     // Check if sync is valid
     Sync sync;
     ServerRequests::syncInfoToSync(syncInfo, sync);

--- a/src/server/comm/guijobs/abstractsyncaddjob.h
+++ b/src/server/comm/guijobs/abstractsyncaddjob.h
@@ -33,7 +33,7 @@ class AbstractSyncAddJob : public AbstractGuiJob {
         ExitInfo serializeOutputParms() override;
         ExitInfo process() override { return ExitCode::Ok; }
 
-        ExitInfo process(SyncInfo &syncInfo);
+        ExitInfo process(const SyncInfo &syncInfo);
 
         auto localFolderPath() const { return _localFolderPath; }
         auto serverFolderPath() const { return _serverFolderPath; }

--- a/src/server/comm/guijobs/abstractsyncaddjob.h
+++ b/src/server/comm/guijobs/abstractsyncaddjob.h
@@ -1,6 +1,6 @@
 /*
  * Infomaniak kDrive - Desktop
- * Copyright (C) 2023-2025 Infomaniak Network SA
+ * Copyright (C) 2023-2026 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/server/comm/guijobs/drivesearchjob.cpp
+++ b/src/server/comm/guijobs/drivesearchjob.cpp
@@ -1,6 +1,6 @@
 /*
  * Infomaniak kDrive - Desktop
- * Copyright (C) 2023-2025 Infomaniak Network SA
+ * Copyright (C) 2023-2026 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -85,6 +85,7 @@ ExitInfo DriveSearchJob::process() {
     // Send search request (synchronously for now)
     SearchJob searchJob(sync.driveDbId(), _syncDbId, CommonUtility::commString2Str(_searchString));
     (void) searchJob.runSynchronously();
+    _hasMore = searchJob.hasMore();
     for (const auto &searchInfo: searchJob.searchResults()) {
         _searchInfoList.push_back(searchInfo);
     }


### PR DESCRIPTION
## Summary
This PR fixes two server-side response contract issues in GUI jobs.

First, `AbstractSyncAddJob` now assigns the created `SyncInfo` to the member
that is actually serialized back to the client. Without that assignment, the
JSON response for sync creation could return an empty or stale `syncInfo`
payload even when the sync creation itself succeeded.

Second, `DriveSearchJob` now propagates the `hasMore` flag returned by
`SearchJob`. Until now, the JSON job always serialized `false`, which made the
search pagination state incorrect for Linux v4 and any other client consuming
the JSON contract.

## Changes
- assign `_syncInfo = syncInfo` at the end of
  `src/server/comm/guijobs/abstractsyncaddjob.cpp`
- assign `_hasMore = searchJob.hasMore()` in
  `src/server/comm/guijobs/drivesearchjob.cpp`
- update the copyright year in the two touched files

## Why
- `SYNC_ADD` / `SYNC_ADD2` responses are expected to return a valid `syncInfo`
  object to the caller
- `DRIVE_SEARCH` responses are expected to expose whether additional pages are
  available
- both bugs were in the server job layer: the underlying work completed, but
  part of the response state was never copied into the serialized output