### PR TITLE
fix: Fix memory leaks in DownloadJob and abort handler

### DIFF
--- a/src/libsyncengine/jobs/abstractjob.cpp
+++ b/src/libsyncengine/jobs/abstractjob.cpp
@@ -74,7 +74,7 @@ bool AbstractJob::isAborted() const {
 void AbstractJob::callback(const UniqueId id) {
     try {
         const std::scoped_lock lock(_additionalCallbackMutex);
-        if (_mainCallback && _additionalCallback && !_aborted) {
+        if (_mainCallback && _additionalCallback) {
             _additionalCallback(id); // Call the "additional" callback first since the main callback might delete the last
                                      // reference on the job
         }

--- a/src/libsyncengine/syncpal/syncpal.cpp
+++ b/src/libsyncengine/syncpal/syncpal.cpp
@@ -735,11 +735,13 @@ ExitCode SyncPal::addDlDirectJob(const SyncPath &relativePath, const SyncPath &a
     std::function<void(UniqueId)> callback = std::bind_front(&SyncPal::directDownloadCallback, this);
     job->setAdditionalCallback(callback);
 
-    const auto progressPercentCallback = [job, this](UniqueId,
+    const auto progressPercentCallback = [jobWeak = std::weak_ptr<DownloadJob>(job), this](UniqueId,
                                                      int progress // %
                                          ) {
-        if (!setProgress(job->affectedFilePath(), progress)) {
-            LOGW_SYNCPAL_WARN(_logger, L"Error in SyncPal::setProgress: " << Utility::formatSyncPath(job->affectedFilePath()));
+        if (auto job = jobWeak.lock()) {
+            if (!setProgress(job->affectedFilePath(), progress)) {
+                LOGW_SYNCPAL_WARN(_logger, L"Error in SyncPal::setProgress: " << Utility::formatSyncPath(job->affectedFilePath()));
+            }
         }
     };
 

--- a/src/libsyncengine/syncpal/syncpal.cpp
+++ b/src/libsyncengine/syncpal/syncpal.cpp
@@ -735,12 +735,11 @@ ExitCode SyncPal::addDlDirectJob(const SyncPath &relativePath, const SyncPath &a
     std::function<void(UniqueId)> callback = std::bind_front(&SyncPal::directDownloadCallback, this);
     job->setAdditionalCallback(callback);
 
-    const auto progressPercentCallback = [jobWeak = std::weak_ptr<DownloadJob>(job), this](UniqueId,
-                                                     int progress // %
-                                         ) {
+    const auto progressPercentCallback = [jobWeak = std::weak_ptr<DownloadJob>(job), this](UniqueId, int progress) {
         if (auto job = jobWeak.lock()) {
             if (!setProgress(job->affectedFilePath(), progress)) {
-                LOGW_SYNCPAL_WARN(_logger, L"Error in SyncPal::setProgress: " << Utility::formatSyncPath(job->affectedFilePath()));
+                LOGW_SYNCPAL_WARN(_logger,
+                                  L"Error in SyncPal::setProgress: " << Utility::formatSyncPath(job->affectedFilePath()));
             }
         }
     };


### PR DESCRIPTION
## Summary
This PR fixes two memory leak issues in the job system:

### 1. Circular Reference in DownloadJob (src/libsyncengine/syncpal/syncpal.cpp)
Fixed a circular reference in `SyncPal::addDlDirectJob()` where the `progressPercentCallback` lambda was capturing the job's `shared_ptr` by copy. This prevented the job from being destroyed even after completion because the callback member held a reference to the job instance.

**Solution:** Use `std::weak_ptr` instead of `std::shared_ptr` in the lambda capture to break the circular dependency.

### 2. Missing Callback Invocation for Aborted Jobs (src/libsyncengine/jobs/abstractjob.cpp)
Fixed an issue where aborted jobs never invoked the `_additionalCallback` (which removes jobs from tracking maps), causing orphaned entries in `_directDownloadJobsMap` and preventing proper cleanup.

**Solution:** Always call the additional callback regardless of the `_aborted` flag, ensuring registered cleanup functions execute.

## Changes
- `src/libsyncengine/jobs/abstractjob.cpp`: Remove `_aborted` check from additional callback invocation
- `src/libsyncengine/syncpal/syncpal.cpp`: Use weak_ptr in progress callback to break circular reference
