### PR TITLE
fix(abstract-token-network-job): Removes faulty retrieval of possibly non-existing drive DB ID

### DIFF
--- a/src/libsyncengine/jobs/network/abstracttokennetworkjob.cpp
+++ b/src/libsyncengine/jobs/network/abstracttokennetworkjob.cpp
@@ -410,34 +410,6 @@ Account AbstractTokenNetworkJob::getAccount(const Drive &drive) const {
     return account;
 }
 
-void AbstractTokenNetworkJob::loadUserInfoFromDriveDbId() {
-    assert(_driveDbId > 0 && "Invalid drive DB ID.");
-
-    {
-        const std::scoped_lock lock(_cacheMutex);
-
-        if (const auto it = _driveToApiKeyMap.find(_driveDbId); it != _driveToApiKeyMap.end()) {
-            _userDbId = it->second.userDbId;
-            _driveId = it->second.driveId;
-
-            return;
-        }
-    }
-
-    // Get drive
-    const Drive &drive = getDrive(_driveDbId);
-    _driveId = drive.driveId();
-
-    // Get account
-    const Account &account = getAccount(drive);
-    _userDbId = account.userDbId();
-
-    loadUserInfoFromUserDbId();
-
-    const std::scoped_lock lock(_cacheMutex);
-    _driveToApiKeyMap[_driveDbId] = {_userDbId, _driveId};
-}
-
 ApiToken AbstractTokenNetworkJob::retrieveApiTokenFromUserCache() {
     assert(_userDbId > 0 && "Invalid user DB ID.");
 
@@ -507,7 +479,6 @@ ApiToken AbstractTokenNetworkJob::loadApiToken() {
         case ApiType::NotifyDrive: {
             if (_driveDbId) loadUserInfoFromDriveDbId();
             apiToken = retrieveApiTokenFromUserCache();
-            if (!_driveDbId) setDriveDbIdFromDriveId();
             break;
         }
         case ApiType::Profile:

--- a/src/libsyncengine/jobs/network/abstracttokennetworkjob.cpp
+++ b/src/libsyncengine/jobs/network/abstracttokennetworkjob.cpp
@@ -410,6 +410,34 @@ Account AbstractTokenNetworkJob::getAccount(const Drive &drive) const {
     return account;
 }
 
+void AbstractTokenNetworkJob::loadUserInfoFromDriveDbId() {
+    assert(_driveDbId > 0 && "Invalid drive DB ID.");
+
+    {
+        const std::scoped_lock lock(_cacheMutex);
+
+        if (const auto it = _driveToApiKeyMap.find(_driveDbId); it != _driveToApiKeyMap.end()) {
+            _userDbId = it->second.userDbId;
+            _driveId = it->second.driveId;
+
+            return;
+        }
+    }
+
+    // Get drive
+    const Drive &drive = getDrive(_driveDbId);
+    _driveId = drive.driveId();
+
+    // Get account
+    const Account &account = getAccount(drive);
+    _userDbId = account.userDbId();
+
+    loadUserInfoFromUserDbId();
+
+    const std::scoped_lock lock(_cacheMutex);
+    _driveToApiKeyMap[_driveDbId] = {_userDbId, _driveId};
+}
+
 ApiToken AbstractTokenNetworkJob::retrieveApiTokenFromUserCache() {
     assert(_userDbId > 0 && "Invalid user DB ID.");
 
@@ -423,32 +451,6 @@ ApiToken AbstractTokenNetworkJob::retrieveApiTokenFromUserCache() {
         _userId = it->second.userId;
         return it->second.login->apiToken();
     }
-}
-
-void AbstractTokenNetworkJob::setDriveDbIdFromDriveId() {
-    assert(_driveId > 0 && "Invalid drive ID.");
-
-    Drive drive;
-    bool found = false;
-    if (!ParmsDb::instance()->selectDriveByDriveId(_driveId, drive, found)) {
-        assert(false);
-        constexpr auto err{"Error in ParmsDb::selectDriveById"};
-        LOG_WARN(_logger, err);
-        throw DbError(err);
-    }
-
-    if (!found) {
-        assert(false);
-        const std::string err = "Drive not found for driveId=" + std::to_string(_driveId);
-        LOG_WARN(_logger, err);
-        throw DataError(err);
-    }
-
-    _driveDbId = drive.dbId();
-
-    const std::scoped_lock lock(_cacheMutex);
-
-    _driveToApiKeyMap[_driveDbId] = {_userDbId, _driveId};
 }
 
 ApiToken AbstractTokenNetworkJob::loadApiToken() {

--- a/src/libsyncengine/jobs/network/abstracttokennetworkjob.h
+++ b/src/libsyncengine/jobs/network/abstracttokennetworkjob.h
@@ -117,7 +117,6 @@ class AbstractTokenNetworkJob : public AbstractNetworkJob {
         ApiToken retrieveApiTokenFromUserCache();
         Account getAccount(const Drive &drive) const;
         Drive getDrive(DriveDbId driveDbId) const;
-        void setDriveDbIdFromDriveId();
 
         /// @throw InvalidArgumentError
         void checkParametersValidity();


### PR DESCRIPTION
When creating a drive in non-_LiteSync_ mode, the request that lists the content of the remote drive that will be synchronized cannot retrieve the DB identifier of the drive as it is not recorded yet. This causes the creation process to fail in _Release_ mode and and assertion failure in _Debug_ mode.

The proposed changes removes the faulty method that vainly attempts to retrieve `driveDbId` from the knowledge of `driveId`.