### PR TITLE
fix(sync): improve error handling in delete and exist jobs

### DIFF
--- a/src/libsyncengine/jobs/local/synclocaldeletejob.cpp
+++ b/src/libsyncengine/jobs/local/synclocaldeletejob.cpp
@@ -147,7 +147,11 @@ ExitInfo SyncLocalDeleteJob::canRun() {
 
     // Check if the item we want to delete locally has a remote counterpart.
     ItemsExistJob existsJob(_syncPal->syncInfo().driveDbId, {_remoteNodeId});
-    existsJob.runSynchronously();
+    if (ExitInfo exitInfo = existsJob.runSynchronously(); !exitInfo) {
+        LOG_WARN(_logger, "Error in ItemsExistJob: " << exitInfo);
+        return exitInfo;
+    }
+
     if (!existsJob.exists(_remoteNodeId, ioError) && ioError == IoError::NoSuchFileOrDirectory)
         return ExitCode::Ok; // Safe deletion.
 

--- a/src/libsyncengine/jobs/network/kDrive_API/itemsexistjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/itemsexistjob.cpp
@@ -86,11 +86,13 @@ ExitInfo ItemsExistJob::handleResponse(std::istream &is) {
         NodeId nodeId;
         if (!JsonParserUtility::extractValue(obj, idKey, nodeId)) {
             LOG_WARN(_logger, "Missing object:" << idKey);
+            _nodeExistenceMap.erase(nodeId);
             continue;
         }
         bool exists = false;
         if (!JsonParserUtility::extractValue(obj, resultKey, exists)) {
             LOG_WARN(_logger, "Missing object:" << resultKey);
+            _nodeExistenceMap.erase(nodeId);
             continue;
         }
         if (!_nodeExistenceMap.contains(nodeId)) {

--- a/src/libsyncengine/jobs/network/kDrive_API/itemsexistjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/itemsexistjob.cpp
@@ -86,14 +86,12 @@ ExitInfo ItemsExistJob::handleResponse(std::istream &is) {
         NodeId nodeId;
         if (!JsonParserUtility::extractValue(obj, idKey, nodeId)) {
             LOG_WARN(_logger, "Missing object:" << idKey);
-            _nodeExistenceMap.erase(nodeId);
-            continue;
+            return {ExitCode::BackError, ExitCause::MissingReplyData};
         }
         bool exists = false;
         if (!JsonParserUtility::extractValue(obj, resultKey, exists)) {
             LOG_WARN(_logger, "Missing object:" << resultKey);
-            _nodeExistenceMap.erase(nodeId);
-            continue;
+            return {ExitCode::BackError, ExitCause::MissingReplyData};
         }
         if (!_nodeExistenceMap.contains(nodeId)) {
             LOG_WARN(_logger, "ID " << nodeId << " is not watched.");


### PR DESCRIPTION
Add early exit and logging on ItemsExistJob failure in canRun. Remove invalid nodes from _nodeExistenceMap on malformed JSON response.