### PR TITLE
feat(linux-v4): add AppCache and service facade foundation

### DIFF
--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -14,6 +14,7 @@ set(GUI_SOURCE_FILES # C++ files for the GUI application
         main.cpp
         appclientlinux.cpp
         appclientlinux.h
+        app/cache/appcache.cpp
         app/cache/appcache.h
         communicationlayer/ipcclient.cpp
         communicationlayer/ipcclient.h

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -24,6 +24,8 @@ set(GUI_SOURCE_FILES # C++ files for the GUI application
         app/services/commservice.h
         app/services/serviceutils.cpp
         app/services/serviceutils.h
+        app/services/userservice.cpp
+        app/services/userservice.h
 )
 
 set(GUI_QML_SINGLETON_FILES # QML singletons (tokens, theme, etc.)

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -22,6 +22,8 @@ set(GUI_SOURCE_FILES # C++ files for the GUI application
         communicationlayer/signaldispatcher.h
         app/services/commservice.cpp
         app/services/commservice.h
+        app/services/serviceutils.cpp
+        app/services/serviceutils.h
 )
 
 set(GUI_QML_SINGLETON_FILES # QML singletons (tokens, theme, etc.)

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -28,6 +28,8 @@ set(GUI_SOURCE_FILES # C++ files for the GUI application
         app/services/userservice.h
         app/services/driveservice.cpp
         app/services/driveservice.h
+        app/services/syncservice.cpp
+        app/services/syncservice.h
 )
 
 set(GUI_QML_SINGLETON_FILES # QML singletons (tokens, theme, etc.)

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -14,6 +14,7 @@ set(GUI_SOURCE_FILES # C++ files for the GUI application
         main.cpp
         appclientlinux.cpp
         appclientlinux.h
+        app/cache/appcache.h
         communicationlayer/ipcclient.cpp
         communicationlayer/ipcclient.h
         communicationlayer/signaldispatcher.cpp

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -26,6 +26,8 @@ set(GUI_SOURCE_FILES # C++ files for the GUI application
         app/services/serviceutils.h
         app/services/userservice.cpp
         app/services/userservice.h
+        app/services/driveservice.cpp
+        app/services/driveservice.h
 )
 
 set(GUI_QML_SINGLETON_FILES # QML singletons (tokens, theme, etc.)

--- a/src/gui4/linux/app/cache/appcache.cpp
+++ b/src/gui4/linux/app/cache/appcache.cpp
@@ -93,6 +93,12 @@ void AppCache::setSelectedSyncDbId(const qint64 syncDbId) {
 
 void AppCache::clearAll() {
     // Connection state is intentionally preserved: cache content and transport connectivity are orthogonal.
+    const bool usersListChanged = !_users.empty();
+    const bool accountsListChanged = !_accounts.empty();
+    const bool drivesListChanged = !_drives.empty();
+    const bool availableDrivesListChanged = !_availableDrives.empty();
+    const bool syncsListChanged = !_syncs.empty();
+    const bool errorsListChanged = !_errors.empty();
     const bool userSelectionChanged = _selectedUserDbId != 0;
     const bool driveSelectionChanged = _selectedDriveDbId != 0;
     const bool syncSelectionChanged = _selectedSyncDbId != 0;
@@ -107,12 +113,24 @@ void AppCache::clearAll() {
     _selectedDriveDbId = 0;
     _selectedSyncDbId = 0;
 
-    emit usersChanged();
-    emit accountsChanged();
-    emit drivesChanged();
-    emit availableDrivesChanged();
-    emit syncsChanged();
-    emit errorsChanged();
+    if (usersListChanged) {
+        emit usersChanged();
+    }
+    if (accountsListChanged) {
+        emit accountsChanged();
+    }
+    if (drivesListChanged) {
+        emit drivesChanged();
+    }
+    if (availableDrivesListChanged) {
+        emit availableDrivesChanged();
+    }
+    if (syncsListChanged) {
+        emit syncsChanged();
+    }
+    if (errorsListChanged) {
+        emit errorsChanged();
+    }
     if (userSelectionChanged) {
         emit selectedUserDbIdChanged();
     }
@@ -163,11 +181,14 @@ void AppCache::removeUser(const UserDbId userDbId) {
     if (!removeById(_users, userDbId, [](const UserInfo &user) { return user.dbId(); })) {
         return;
     }
-    if (_selectedUserDbId == userDbId) {
+    const bool selectionChanged = _selectedUserDbId == userDbId;
+    if (selectionChanged) {
         _selectedUserDbId = 0;
-        emit selectedUserDbIdChanged();
     }
     emit usersChanged();
+    if (selectionChanged) {
+        emit selectedUserDbIdChanged();
+    }
 }
 
 void AppCache::upsertAccount(const AccountInfo &info) {
@@ -191,11 +212,14 @@ void AppCache::removeDrive(const DriveDbId driveDbId) {
     if (!removeById(_drives, driveDbId, [](const DriveInfo &drive) { return drive.dbId(); })) {
         return;
     }
-    if (_selectedDriveDbId == driveDbId) {
+    const bool selectionChanged = _selectedDriveDbId == driveDbId;
+    if (selectionChanged) {
         _selectedDriveDbId = 0;
-        emit selectedDriveDbIdChanged();
     }
     emit drivesChanged();
+    if (selectionChanged) {
+        emit selectedDriveDbIdChanged();
+    }
 }
 
 void AppCache::upsertSync(const SyncInfo &info) {
@@ -207,11 +231,14 @@ void AppCache::removeSync(const SyncDbId syncDbId) {
     if (!removeById(_syncs, syncDbId, [](const SyncInfo &sync) { return sync.dbId(); })) {
         return;
     }
-    if (_selectedSyncDbId == syncDbId) {
+    const bool selectionChanged = _selectedSyncDbId == syncDbId;
+    if (selectionChanged) {
         _selectedSyncDbId = 0;
-        emit selectedSyncDbIdChanged();
     }
     emit syncsChanged();
+    if (selectionChanged) {
+        emit selectedSyncDbIdChanged();
+    }
 }
 
 void AppCache::upsertError(const ErrorInfo &info) {

--- a/src/gui4/linux/app/cache/appcache.cpp
+++ b/src/gui4/linux/app/cache/appcache.cpp
@@ -1,0 +1,229 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "appcache.h"
+
+#include <algorithm>
+
+namespace {
+template<typename T, typename IdType, typename Getter>
+void upsertById(std::vector<T> &list, const T &value, IdType id, Getter getter) {
+    const auto it = std::find_if(list.begin(), list.end(), [id, getter](const T &existing) { return getter(existing) == id; });
+    if (it == list.end()) {
+        list.push_back(value);
+        return;
+    }
+    *it = value;
+}
+
+template<typename T, typename IdType, typename Getter>
+bool removeById(std::vector<T> &list, IdType id, Getter getter) {
+    const auto initialSize = list.size();
+    std::erase_if(list, [id, getter](const T &value) { return getter(value) == id; });
+    return list.size() != initialSize;
+}
+} // namespace
+
+namespace KDC {
+
+AppCache::AppCache(QObject *parent) :
+    QObject(parent) {}
+
+qint64 AppCache::selectedUserDbId() const {
+    return static_cast<qint64>(_selectedUserDbId);
+}
+
+qint64 AppCache::selectedDriveDbId() const {
+    return static_cast<qint64>(_selectedDriveDbId);
+}
+
+qint64 AppCache::selectedSyncDbId() const {
+    return static_cast<qint64>(_selectedSyncDbId);
+}
+
+void AppCache::setConnected(const bool connected) {
+    if (_connected == connected) {
+        return;
+    }
+    _connected = connected;
+    emit connectedChanged();
+}
+
+void AppCache::setSelectedUserDbId(const qint64 userDbId) {
+    const auto typedUserDbId = static_cast<UserDbId>(userDbId);
+    if (_selectedUserDbId == typedUserDbId) {
+        return;
+    }
+    _selectedUserDbId = typedUserDbId;
+    emit selectedUserDbIdChanged();
+}
+
+void AppCache::setSelectedDriveDbId(const qint64 driveDbId) {
+    const auto typedDriveDbId = static_cast<DriveDbId>(driveDbId);
+    if (_selectedDriveDbId == typedDriveDbId) {
+        return;
+    }
+    _selectedDriveDbId = typedDriveDbId;
+    emit selectedDriveDbIdChanged();
+}
+
+void AppCache::setSelectedSyncDbId(const qint64 syncDbId) {
+    const auto typedSyncDbId = static_cast<SyncDbId>(syncDbId);
+    if (_selectedSyncDbId == typedSyncDbId) {
+        return;
+    }
+    _selectedSyncDbId = typedSyncDbId;
+    emit selectedSyncDbIdChanged();
+}
+
+void AppCache::clearAll() {
+    // Connection state is intentionally preserved: cache content and transport connectivity are orthogonal.
+    const bool userSelectionChanged = _selectedUserDbId != 0;
+    const bool driveSelectionChanged = _selectedDriveDbId != 0;
+    const bool syncSelectionChanged = _selectedSyncDbId != 0;
+
+    _users.clear();
+    _accounts.clear();
+    _drives.clear();
+    _availableDrives.clear();
+    _syncs.clear();
+    _errors.clear();
+    _selectedUserDbId = 0;
+    _selectedDriveDbId = 0;
+    _selectedSyncDbId = 0;
+
+    emit usersChanged();
+    emit accountsChanged();
+    emit drivesChanged();
+    emit availableDrivesChanged();
+    emit syncsChanged();
+    emit errorsChanged();
+    if (userSelectionChanged) {
+        emit selectedUserDbIdChanged();
+    }
+    if (driveSelectionChanged) {
+        emit selectedDriveDbIdChanged();
+    }
+    if (syncSelectionChanged) {
+        emit selectedSyncDbIdChanged();
+    }
+}
+
+void AppCache::replaceUsers(const std::vector<UserInfo> &users) {
+    _users = users;
+    emit usersChanged();
+}
+
+void AppCache::replaceAccounts(const std::vector<AccountInfo> &accounts) {
+    _accounts = accounts;
+    emit accountsChanged();
+}
+
+void AppCache::replaceDrives(const std::vector<DriveInfo> &drives) {
+    _drives = drives;
+    emit drivesChanged();
+}
+
+void AppCache::replaceAvailableDrives(const std::vector<DriveAvailableInfo> &availableDrives) {
+    _availableDrives = availableDrives;
+    emit availableDrivesChanged();
+}
+
+void AppCache::replaceSyncs(const std::vector<SyncInfo> &syncs) {
+    _syncs = syncs;
+    emit syncsChanged();
+}
+
+void AppCache::replaceErrors(const std::vector<ErrorInfo> &errors) {
+    _errors = errors;
+    emit errorsChanged();
+}
+
+void AppCache::upsertUser(const UserInfo &info) {
+    upsertById(_users, info, info.dbId(), [](const UserInfo &user) { return user.dbId(); });
+    emit usersChanged();
+}
+
+void AppCache::removeUser(const UserDbId userDbId) {
+    if (!removeById(_users, userDbId, [](const UserInfo &user) { return user.dbId(); })) {
+        return;
+    }
+    if (_selectedUserDbId == userDbId) {
+        _selectedUserDbId = 0;
+        emit selectedUserDbIdChanged();
+    }
+    emit usersChanged();
+}
+
+void AppCache::upsertAccount(const AccountInfo &info) {
+    upsertById(_accounts, info, info.dbId(), [](const AccountInfo &account) { return account.dbId(); });
+    emit accountsChanged();
+}
+
+void AppCache::removeAccount(const AccountDbId accountDbId) {
+    if (!removeById(_accounts, accountDbId, [](const AccountInfo &account) { return account.dbId(); })) {
+        return;
+    }
+    emit accountsChanged();
+}
+
+void AppCache::upsertDrive(const DriveInfo &info) {
+    upsertById(_drives, info, info.dbId(), [](const DriveInfo &drive) { return drive.dbId(); });
+    emit drivesChanged();
+}
+
+void AppCache::removeDrive(const DriveDbId driveDbId) {
+    if (!removeById(_drives, driveDbId, [](const DriveInfo &drive) { return drive.dbId(); })) {
+        return;
+    }
+    if (_selectedDriveDbId == driveDbId) {
+        _selectedDriveDbId = 0;
+        emit selectedDriveDbIdChanged();
+    }
+    emit drivesChanged();
+}
+
+void AppCache::upsertSync(const SyncInfo &info) {
+    upsertById(_syncs, info, info.dbId(), [](const SyncInfo &sync) { return sync.dbId(); });
+    emit syncsChanged();
+}
+
+void AppCache::removeSync(const SyncDbId syncDbId) {
+    if (!removeById(_syncs, syncDbId, [](const SyncInfo &sync) { return sync.dbId(); })) {
+        return;
+    }
+    if (_selectedSyncDbId == syncDbId) {
+        _selectedSyncDbId = 0;
+        emit selectedSyncDbIdChanged();
+    }
+    emit syncsChanged();
+}
+
+void AppCache::upsertError(const ErrorInfo &info) {
+    upsertById(_errors, info, info.dbId(), [](const ErrorInfo &error) { return error.dbId(); });
+    emit errorsChanged();
+}
+
+void AppCache::removeError(const ErrorDbId errorDbId) {
+    if (!removeById(_errors, errorDbId, [](const ErrorInfo &error) { return error.dbId(); })) {
+        return;
+    }
+    emit errorsChanged();
+}
+
+} // namespace KDC

--- a/src/gui4/linux/app/cache/appcache.cpp
+++ b/src/gui4/linux/app/cache/appcache.cpp
@@ -21,6 +21,16 @@
 #include <algorithm>
 
 namespace {
+/**
+ * Inserts @p value into @p list if no element matches @p id, or replaces the matching element.
+ * @tparam T       Element type stored in the list.
+ * @tparam IdType  Type of the identifier used for lookup.
+ * @tparam Getter  Callable of signature `IdType(const T &)` that extracts the id from an element.
+ * @param list     The vector to update.
+ * @param value    The new element to insert or use as replacement.
+ * @param id       The identifier to look up.
+ * @param getter   Callable that returns the id of a given element.
+ */
 template<typename T, typename IdType, typename Getter>
 void upsertById(std::vector<T> &list, const T &value, IdType id, Getter getter) {
     const auto it = std::find_if(list.begin(), list.end(), [id, getter](const T &existing) { return getter(existing) == id; });
@@ -31,6 +41,16 @@ void upsertById(std::vector<T> &list, const T &value, IdType id, Getter getter) 
     *it = value;
 }
 
+/**
+ * Removes from @p list all elements whose id matches @p id.
+ * @tparam T       Element type stored in the list.
+ * @tparam IdType  Type of the identifier used for lookup.
+ * @tparam Getter  Callable of signature `IdType(const T &)` that extracts the id from an element.
+ * @param list     The vector to update.
+ * @param id       The identifier of the element to remove.
+ * @param getter   Callable that returns the id of a given element.
+ * @return         `true` if at least one element was removed, `false` otherwise.
+ */
 template<typename T, typename IdType, typename Getter>
 bool removeById(std::vector<T> &list, IdType id, Getter getter) {
     const auto initialSize = list.size();

--- a/src/gui4/linux/app/cache/appcache.cpp
+++ b/src/gui4/linux/app/cache/appcache.cpp
@@ -113,33 +113,15 @@ void AppCache::clearAll() {
     _selectedDriveDbId = 0;
     _selectedSyncDbId = 0;
 
-    if (usersListChanged) {
-        emit usersChanged();
-    }
-    if (accountsListChanged) {
-        emit accountsChanged();
-    }
-    if (drivesListChanged) {
-        emit drivesChanged();
-    }
-    if (availableDrivesListChanged) {
-        emit availableDrivesChanged();
-    }
-    if (syncsListChanged) {
-        emit syncsChanged();
-    }
-    if (errorsListChanged) {
-        emit errorsChanged();
-    }
-    if (userSelectionChanged) {
-        emit selectedUserDbIdChanged();
-    }
-    if (driveSelectionChanged) {
-        emit selectedDriveDbIdChanged();
-    }
-    if (syncSelectionChanged) {
-        emit selectedSyncDbIdChanged();
-    }
+    if (usersListChanged) emit usersChanged();
+    if (accountsListChanged) emit accountsChanged();
+    if (drivesListChanged) emit drivesChanged();
+    if (availableDrivesListChanged) emit availableDrivesChanged();
+    if (syncsListChanged) emit syncsChanged();
+    if (errorsListChanged) emit errorsChanged();
+    if (userSelectionChanged) emit selectedUserDbIdChanged();
+    if (driveSelectionChanged) emit selectedDriveDbIdChanged();
+    if (syncSelectionChanged) emit selectedSyncDbIdChanged();
 }
 
 void AppCache::replaceUsers(const std::vector<UserInfo> &users) {

--- a/src/gui4/linux/app/cache/appcache.h
+++ b/src/gui4/linux/app/cache/appcache.h
@@ -42,9 +42,9 @@ namespace KDC {
 class AppCache : public QObject {
         Q_OBJECT
         Q_PROPERTY(bool connected READ connected WRITE setConnected NOTIFY connectedChanged)
-        Q_PROPERTY(qint64 selectedUserDbId READ selectedUserDbId WRITE setSelectedUserDbId NOTIFY selectedUserDbIdChanged)
-        Q_PROPERTY(qint64 selectedDriveDbId READ selectedDriveDbId WRITE setSelectedDriveDbId NOTIFY selectedDriveDbIdChanged)
-        Q_PROPERTY(qint64 selectedSyncDbId READ selectedSyncDbId WRITE setSelectedSyncDbId NOTIFY selectedSyncDbIdChanged)
+        Q_PROPERTY(qint64 selectedUserDbId READ selectedUserDbId NOTIFY selectedUserDbIdChanged)
+        Q_PROPERTY(qint64 selectedDriveDbId READ selectedDriveDbId NOTIFY selectedDriveDbIdChanged)
+        Q_PROPERTY(qint64 selectedSyncDbId READ selectedSyncDbId NOTIFY selectedSyncDbIdChanged)
 
     public:
         explicit AppCache(QObject *parent = nullptr);

--- a/src/gui4/linux/app/cache/appcache.h
+++ b/src/gui4/linux/app/cache/appcache.h
@@ -1,0 +1,123 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "libcommon/utility/types.h"
+#include "libcommon/info/accountinfo.h"
+#include "libcommon/info/driveavailableinfo.h"
+#include "libcommon/info/driveinfo.h"
+#include "libcommon/info/errorinfo.h"
+#include "libcommon/info/syncinfo.h"
+#include "libcommon/info/userinfo.h"
+
+#include <QObject>
+
+#include <vector>
+
+namespace KDC {
+
+/**
+ * Central observable cache for Linux v4 UI-facing state.
+ *
+ * The cache stores typed snapshots and incremental updates coming from C++ services.
+ * QML-facing services and list models should read from this cache instead of parsing
+ * transport payloads directly.
+ */
+class AppCache : public QObject {
+        Q_OBJECT
+        Q_PROPERTY(bool connected READ connected WRITE setConnected NOTIFY connectedChanged)
+        Q_PROPERTY(qint64 selectedUserDbId READ selectedUserDbId WRITE setSelectedUserDbId NOTIFY selectedUserDbIdChanged)
+        Q_PROPERTY(qint64 selectedDriveDbId READ selectedDriveDbId WRITE setSelectedDriveDbId NOTIFY selectedDriveDbIdChanged)
+        Q_PROPERTY(qint64 selectedSyncDbId READ selectedSyncDbId WRITE setSelectedSyncDbId NOTIFY selectedSyncDbIdChanged)
+
+    public:
+        explicit AppCache(QObject *parent = nullptr);
+
+        bool connected() const { return _connected; }
+        qint64 selectedUserDbId() const;
+        qint64 selectedDriveDbId() const;
+        qint64 selectedSyncDbId() const;
+
+        const std::vector<UserInfo> &users() const { return _users; }
+        const std::vector<AccountInfo> &accounts() const { return _accounts; }
+        const std::vector<DriveInfo> &drives() const { return _drives; }
+        // Available drives for the currently selected user context.
+        const std::vector<DriveAvailableInfo> &availableDrives() const { return _availableDrives; }
+        const std::vector<SyncInfo> &syncs() const { return _syncs; }
+        const std::vector<ErrorInfo> &errors() const { return _errors; }
+
+        void setConnected(bool connected);
+        void setSelectedUserDbId(qint64 userDbId);
+        void setSelectedDriveDbId(qint64 driveDbId);
+        void setSelectedSyncDbId(qint64 syncDbId);
+
+        void clearAll();
+
+        void replaceUsers(const std::vector<UserInfo> &users);
+        void replaceAccounts(const std::vector<AccountInfo> &accounts);
+        void replaceDrives(const std::vector<DriveInfo> &drives);
+        // Replaces the current selected-user available drives snapshot.
+        void replaceAvailableDrives(const std::vector<DriveAvailableInfo> &availableDrives);
+        void replaceSyncs(const std::vector<SyncInfo> &syncs);
+        void replaceErrors(const std::vector<ErrorInfo> &errors);
+
+    public slots:
+        void upsertUser(const UserInfo &info);
+        void removeUser(UserDbId userDbId);
+
+        void upsertAccount(const AccountInfo &info);
+        void removeAccount(AccountDbId accountDbId);
+
+        void upsertDrive(const DriveInfo &info);
+        void removeDrive(DriveDbId driveDbId);
+
+        void upsertSync(const SyncInfo &info);
+        void removeSync(SyncDbId syncDbId);
+
+        void upsertError(const ErrorInfo &info);
+        void removeError(ErrorDbId errorDbId);
+
+    signals:
+        void connectedChanged();
+        void selectedUserDbIdChanged();
+        void selectedDriveDbIdChanged();
+        void selectedSyncDbIdChanged();
+
+        void usersChanged();
+        void accountsChanged();
+        void drivesChanged();
+        void availableDrivesChanged();
+        void syncsChanged();
+        void errorsChanged();
+
+    private:
+        bool _connected{false};
+        UserDbId _selectedUserDbId{0};
+        DriveDbId _selectedDriveDbId{0};
+        SyncDbId _selectedSyncDbId{0};
+
+        std::vector<UserInfo> _users;
+        std::vector<AccountInfo> _accounts;
+        std::vector<DriveInfo> _drives;
+        std::vector<DriveAvailableInfo> _availableDrives;
+        std::vector<SyncInfo> _syncs;
+        std::vector<ErrorInfo> _errors;
+};
+
+} // namespace KDC

--- a/src/gui4/linux/app/services/driveservice.cpp
+++ b/src/gui4/linux/app/services/driveservice.cpp
@@ -1,0 +1,129 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "driveservice.h"
+#include "serviceutils.h"
+
+#include <QPointer>
+
+namespace KDC {
+
+DriveService::DriveService(CommService &commService, AppCache &appCache, QObject *parent) :
+    QObject(parent),
+    _commService(commService),
+    _appCache(appCache) {
+    (void) connect(&_commService, &CommService::driveAdded, &_appCache, &AppCache::upsertDrive);
+    (void) connect(&_commService, &CommService::driveUpdated, &_appCache, &AppCache::upsertDrive);
+    (void) connect(&_commService, &CommService::driveRemoved, &_appCache, &AppCache::removeDrive);
+    (void) connect(&_appCache, &AppCache::selectedDriveDbIdChanged, this, &DriveService::activeDriveDbIdChanged);
+}
+
+void DriveService::loadDrives() {
+    beginRequest();
+    setLastError(QString());
+
+    const QPointer<DriveService> self(this);
+    _commService.requestDriveInfoList([self](const ExitInfo &exitInfo, const std::vector<DriveInfo> &list) {
+        if (!self) {
+            return;
+        }
+
+        self->endRequest();
+        if (exitInfo.code() != ExitCode::Ok) {
+            self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+            return;
+        }
+
+        self->_appCache.replaceDrives(list);
+    });
+}
+
+void DriveService::deleteDrive(const qint64 driveDbId) {
+    beginRequest();
+    setLastError(QString());
+
+    const QPointer<DriveService> self(this);
+    // Cache consistency is signal-driven: we wait for driveRemoved/driveUpdated pushes.
+    _commService.requestDriveDelete(static_cast<DriveDbId>(driveDbId), [self](const ExitInfo &exitInfo) {
+        if (!self) {
+            return;
+        }
+
+        self->endRequest();
+        if (exitInfo.code() != ExitCode::Ok) {
+            self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+        }
+    });
+}
+
+void DriveService::setActiveDrive(const qint64 driveDbId) {
+    _appCache.setSelectedDriveDbId(driveDbId);
+}
+
+void DriveService::updateDrive(const DriveInfo &driveInfo) {
+    beginRequest();
+    setLastError(QString());
+
+    const QPointer<DriveService> self(this);
+    _commService.requestDriveUpdate(driveInfo, [self](const ExitInfo &exitInfo) {
+        if (!self) {
+            return;
+        }
+
+        self->endRequest();
+        if (exitInfo.code() != ExitCode::Ok) {
+            self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+        }
+    });
+}
+
+void DriveService::beginRequest() {
+    ++_pendingRequestCount;
+    setLoading(true);
+}
+
+void DriveService::endRequest() {
+    if (_pendingRequestCount <= 0) {
+        _pendingRequestCount = 0;
+        setLoading(false);
+        return;
+    }
+
+    --_pendingRequestCount;
+    if (_pendingRequestCount == 0) {
+        setLoading(false);
+    }
+}
+
+void DriveService::setLoading(const bool loading) {
+    if (_loading == loading) {
+        return;
+    }
+    _loading = loading;
+    emit loadingChanged();
+}
+
+void DriveService::setLastError(const QString &error) {
+    if (_lastError == error) {
+        return;
+    }
+    _lastError = error;
+    emit lastErrorChanged();
+}
+
+} // namespace KDC

--- a/src/gui4/linux/app/services/driveservice.cpp
+++ b/src/gui4/linux/app/services/driveservice.cpp
@@ -19,6 +19,7 @@
 #include "driveservice.h"
 #include "serviceutils.h"
 
+#include <QDebug>
 #include <QPointer>
 
 namespace KDC {
@@ -99,6 +100,7 @@ void DriveService::beginRequest() {
 
 void DriveService::endRequest() {
     if (_pendingRequestCount <= 0) {
+        qWarning() << "DriveService::endRequest called with non-positive pending count:" << _pendingRequestCount;
         _pendingRequestCount = 0;
         setLoading(false);
         return;

--- a/src/gui4/linux/app/services/driveservice.cpp
+++ b/src/gui4/linux/app/services/driveservice.cpp
@@ -19,10 +19,12 @@
 #include "driveservice.h"
 #include "serviceutils.h"
 
-#include <QDebug>
+#include <QLoggingCategory>
 #include <QPointer>
 
 namespace KDC {
+
+Q_LOGGING_CATEGORY(lcDriveService, "gui.v4.driveservice", QtInfoMsg)
 
 DriveService::DriveService(CommService &commService, AppCache &appCache, QObject *parent) :
     QObject(parent),
@@ -100,7 +102,7 @@ void DriveService::beginRequest() {
 
 void DriveService::endRequest() {
     if (_pendingRequestCount <= 0) {
-        qWarning() << "DriveService::endRequest called with non-positive pending count:" << _pendingRequestCount;
+        qCWarning(lcDriveService) << "endRequest called with non-positive pending count:" << _pendingRequestCount;
         _pendingRequestCount = 0;
         setLoading(false);
         return;

--- a/src/gui4/linux/app/services/driveservice.h
+++ b/src/gui4/linux/app/services/driveservice.h
@@ -1,0 +1,74 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "app/cache/appcache.h"
+#include "app/services/commservice.h"
+
+#include <QObject>
+#include <QString>
+
+#include <cstdint>
+
+namespace KDC {
+
+/**
+ * High-level drive-oriented facade.
+ *
+ * QML should use the Q_INVOKABLE methods. updateDrive() remains C++-facing until
+ * a stable QML edit contract for DriveInfo is introduced.
+ */
+class DriveService : public QObject {
+        Q_OBJECT
+        Q_PROPERTY(bool loading READ loading NOTIFY loadingChanged)
+        Q_PROPERTY(QString lastError READ lastError NOTIFY lastErrorChanged)
+        Q_PROPERTY(qint64 activeDriveDbId READ activeDriveDbId NOTIFY activeDriveDbIdChanged)
+
+    public:
+        explicit DriveService(CommService &commService, AppCache &appCache, QObject *parent = nullptr);
+
+        bool loading() const { return _loading; }
+        const QString &lastError() const { return _lastError; }
+        qint64 activeDriveDbId() const { return _appCache.selectedDriveDbId(); }
+
+        Q_INVOKABLE void loadDrives();
+        Q_INVOKABLE void deleteDrive(qint64 driveDbId);
+        Q_INVOKABLE void setActiveDrive(qint64 driveDbId);
+
+        void updateDrive(const DriveInfo &driveInfo);
+
+    signals:
+        void loadingChanged();
+        void lastErrorChanged();
+        void activeDriveDbIdChanged();
+
+    private:
+        void beginRequest();
+        void endRequest();
+        void setLoading(bool loading);
+        void setLastError(const QString &error);
+
+        CommService &_commService;
+        AppCache &_appCache;
+        int32_t _pendingRequestCount{0};
+        bool _loading{false};
+        QString _lastError;
+};
+
+} // namespace KDC

--- a/src/gui4/linux/app/services/serviceutils.cpp
+++ b/src/gui4/linux/app/services/serviceutils.cpp
@@ -17,15 +17,16 @@
  */
 
 #include "serviceutils.h"
-
-#include <cstdint>
+#include "libcommon/utility/types.h"
 
 namespace KDC::ServiceUtils {
 
 QString formatExitInfo(const ExitInfo &exitInfo) {
-    return QStringLiteral("IPC request failed (code=%1, cause=%2)")
-            .arg(static_cast<int32_t>(exitInfo.code()))
-            .arg(static_cast<int32_t>(exitInfo.cause()));
+    return QStringLiteral("IPC request failed (code=%1[%2], cause=%3[%4])")
+            .arg(QString::fromStdString(toString(exitInfo.code())))
+            .arg(toInt(exitInfo.code()))
+            .arg(QString::fromStdString(toString(exitInfo.cause())))
+            .arg(toInt(exitInfo.cause()));
 }
 
 } // namespace KDC::ServiceUtils

--- a/src/gui4/linux/app/services/serviceutils.cpp
+++ b/src/gui4/linux/app/services/serviceutils.cpp
@@ -1,0 +1,31 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "serviceutils.h"
+
+#include <cstdint>
+
+namespace KDC::ServiceUtils {
+
+QString formatExitInfo(const ExitInfo &exitInfo) {
+    return QStringLiteral("IPC request failed (code=%1, cause=%2)")
+            .arg(static_cast<int32_t>(exitInfo.code()))
+            .arg(static_cast<int32_t>(exitInfo.cause()));
+}
+
+} // namespace KDC::ServiceUtils

--- a/src/gui4/linux/app/services/serviceutils.h
+++ b/src/gui4/linux/app/services/serviceutils.h
@@ -1,0 +1,29 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "libcommon/utility/types.h"
+
+#include <QString>
+
+namespace KDC::ServiceUtils {
+
+QString formatExitInfo(const ExitInfo &exitInfo);
+
+} // namespace KDC::ServiceUtils

--- a/src/gui4/linux/app/services/syncservice.cpp
+++ b/src/gui4/linux/app/services/syncservice.cpp
@@ -21,10 +21,12 @@
 
 #include "libcommon/utility/types.h"
 
-#include <QDebug>
+#include <QLoggingCategory>
 #include <QPointer>
 
 namespace KDC {
+
+Q_LOGGING_CATEGORY(lcSyncService, "gui.v4.syncservice", QtInfoMsg)
 
 SyncService::SyncService(CommService &commService, AppCache &appCache, QObject *parent) :
     QObject(parent),
@@ -214,7 +216,7 @@ void SyncService::beginRequest() {
 
 void SyncService::endRequest() {
     if (_pendingRequestCount <= 0) {
-        qWarning() << "SyncService::endRequest called with non-positive pending count:" << _pendingRequestCount;
+        qCWarning(lcSyncService) << "endRequest called with non-positive pending count:" << _pendingRequestCount;
         _pendingRequestCount = 0;
         setLoading(false);
         return;

--- a/src/gui4/linux/app/services/syncservice.cpp
+++ b/src/gui4/linux/app/services/syncservice.cpp
@@ -1,0 +1,249 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "syncservice.h"
+#include "serviceutils.h"
+
+#include "libcommon/utility/types.h"
+
+#include <QPointer>
+
+namespace KDC {
+
+SyncService::SyncService(CommService &commService, AppCache &appCache, QObject *parent) :
+    QObject(parent),
+    _commService(commService),
+    _appCache(appCache) {
+    (void) connect(&_commService, &CommService::syncAdded, &_appCache, &AppCache::upsertSync);
+    (void) connect(&_commService, &CommService::syncUpdated, &_appCache, &AppCache::upsertSync);
+    (void) connect(&_commService, &CommService::syncRemoved, &_appCache, &AppCache::removeSync);
+    (void) connect(&_commService, &CommService::errorAdded, &_appCache, &AppCache::upsertError);
+    (void) connect(&_commService, &CommService::errorRemoved, &_appCache, &AppCache::removeError);
+}
+
+void SyncService::loadSyncs() {
+    beginRequest();
+    setLastError(QString());
+
+    const QPointer<SyncService> self(this);
+    _commService.requestSyncInfoList([self](const ExitInfo &exitInfo, const std::vector<SyncInfo> &list) {
+        if (!self) {
+            return;
+        }
+
+        self->endRequest();
+        if (exitInfo.code() != ExitCode::Ok) {
+            self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+            return;
+        }
+
+        self->_appCache.replaceSyncs(list);
+    });
+}
+
+void SyncService::addSync(const qint64 userDbId, const qint64 accountId, const qint64 driveId, const QString &localFolderPath,
+                          const QString &serverFolderPath, const QString &serverFolderNodeId, const bool liteSync) {
+    beginRequest();
+    setLastError(QString());
+
+    SyncAddRequest request;
+    request.userDbId = static_cast<UserDbId>(userDbId);
+    request.accountId = static_cast<AccountId>(accountId);
+    request.driveId = static_cast<DriveId>(driveId);
+    request.localFolderPath = QStr2Path(localFolderPath);
+    request.serverFolderPath = QStr2Path(serverFolderPath);
+    request.serverFolderNodeId = QStr2Str(serverFolderNodeId);
+    request.liteSync = liteSync;
+
+    const QPointer<SyncService> self(this);
+    _commService.requestSyncAdd(request, [self](const ExitInfo &exitInfo, const SyncInfo &syncInfo) {
+        if (!self) {
+            return;
+        }
+
+        self->endRequest();
+        if (exitInfo.code() != ExitCode::Ok) {
+            self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+            return;
+        }
+
+        self->_appCache.upsertSync(syncInfo);
+        emit self->syncAddCompleted(static_cast<qint64>(syncInfo.dbId()));
+    });
+}
+
+void SyncService::startSync(const qint64 syncDbId) {
+    beginRequest();
+    setLastError(QString());
+
+    const QPointer<SyncService> self(this);
+    _commService.requestSyncStart(static_cast<SyncDbId>(syncDbId), [self](const ExitInfo &exitInfo) {
+        if (!self) {
+            return;
+        }
+
+        self->endRequest();
+        if (exitInfo.code() != ExitCode::Ok) {
+            self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+        }
+    });
+}
+
+void SyncService::stopSync(const qint64 syncDbId) {
+    beginRequest();
+    setLastError(QString());
+
+    const QPointer<SyncService> self(this);
+    _commService.requestSyncStop(static_cast<SyncDbId>(syncDbId), [self](const ExitInfo &exitInfo) {
+        if (!self) {
+            return;
+        }
+
+        self->endRequest();
+        if (exitInfo.code() != ExitCode::Ok) {
+            self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+        }
+    });
+}
+
+void SyncService::deleteSync(const qint64 syncDbId) {
+    beginRequest();
+    setLastError(QString());
+
+    const QPointer<SyncService> self(this);
+    // Cache consistency is signal-driven: we wait for syncRemoved/syncUpdated pushes.
+    _commService.requestSyncDelete(static_cast<SyncDbId>(syncDbId), [self](const ExitInfo &exitInfo) {
+        if (!self) {
+            return;
+        }
+
+        self->endRequest();
+        if (exitInfo.code() != ExitCode::Ok) {
+            self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+        }
+    });
+}
+
+void SyncService::querySyncStatus(const qint64 syncDbId) {
+    beginRequest();
+    setLastError(QString());
+
+    const QPointer<SyncService> self(this);
+    _commService.requestSyncStatus(static_cast<SyncDbId>(syncDbId),
+                                   [self, syncDbId](const ExitInfo &exitInfo, const SyncStatus status) {
+                                       if (!self) {
+                                           return;
+                                       }
+
+                                       self->endRequest();
+                                       if (exitInfo.code() != ExitCode::Ok) {
+                                           self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+                                           return;
+                                       }
+
+                                       emit self->syncStatusReceived(syncDbId, static_cast<int32_t>(status));
+                                   });
+}
+
+void SyncService::findGoodPathForNewSync(const QString &basePath) {
+    beginRequest();
+    setLastError(QString());
+
+    const QPointer<SyncService> self(this);
+    _commService.requestFindGoodPathForNewSync(
+            QStr2Path(basePath), [self](const ExitInfo &exitInfo, const GoodPathResult &result) {
+                if (!self) {
+                    return;
+                }
+
+                self->endRequest();
+                if (exitInfo.code() != ExitCode::Ok) {
+                    self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+                    return;
+                }
+
+                emit self->suggestedPathReceived(Path2QStr(result.goodPath), result.errorMessage);
+            });
+}
+
+void SyncService::isPathValidForNewSync(const QString &path, const int32_t syncConfiguration) {
+    setLastError(QString());
+    if (!isValidSyncConfigurationValue(syncConfiguration)) {
+        setLastError(QStringLiteral("Invalid sync configuration value: %1").arg(syncConfiguration));
+        return;
+    }
+
+    beginRequest();
+
+    const QPointer<SyncService> self(this);
+    _commService.requestIsPathValidForNewSync(QStr2Path(path), static_cast<SyncConfiguration>(syncConfiguration),
+                                              [self](const ExitInfo &exitInfo, const bool isValid) {
+                                                  if (!self) {
+                                                      return;
+                                                  }
+
+                                                  self->endRequest();
+                                                  if (exitInfo.code() != ExitCode::Ok) {
+                                                      self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+                                                      return;
+                                                  }
+
+                                                  emit self->pathValidationReceived(isValid);
+                                              });
+}
+
+void SyncService::beginRequest() {
+    ++_pendingRequestCount;
+    setLoading(true);
+}
+
+void SyncService::endRequest() {
+    if (_pendingRequestCount <= 0) {
+        _pendingRequestCount = 0;
+        setLoading(false);
+        return;
+    }
+
+    --_pendingRequestCount;
+    if (_pendingRequestCount == 0) {
+        setLoading(false);
+    }
+}
+
+bool SyncService::isValidSyncConfigurationValue(const int32_t syncConfiguration) const {
+    return syncConfiguration >= static_cast<int32_t>(SyncConfiguration::Classic) &&
+           syncConfiguration < static_cast<int32_t>(SyncConfiguration::EnumEnd);
+}
+
+void SyncService::setLoading(const bool loading) {
+    if (_loading == loading) {
+        return;
+    }
+    _loading = loading;
+    emit loadingChanged();
+}
+
+void SyncService::setLastError(const QString &error) {
+    if (_lastError == error) {
+        return;
+    }
+    _lastError = error;
+    emit lastErrorChanged();
+}
+
+} // namespace KDC

--- a/src/gui4/linux/app/services/syncservice.cpp
+++ b/src/gui4/linux/app/services/syncservice.cpp
@@ -21,6 +21,7 @@
 
 #include "libcommon/utility/types.h"
 
+#include <QDebug>
 #include <QPointer>
 
 namespace KDC {
@@ -82,7 +83,6 @@ void SyncService::addSync(const qint64 userDbId, const qint64 accountId, const q
             return;
         }
 
-        self->_appCache.upsertSync(syncInfo);
         emit self->syncAddCompleted(static_cast<qint64>(syncInfo.dbId()));
     });
 }
@@ -140,7 +140,6 @@ void SyncService::deleteSync(const qint64 syncDbId) {
 }
 
 void SyncService::querySyncStatus(const qint64 syncDbId) {
-    beginRequest();
     setLastError(QString());
 
     const QPointer<SyncService> self(this);
@@ -150,7 +149,6 @@ void SyncService::querySyncStatus(const qint64 syncDbId) {
                                            return;
                                        }
 
-                                       self->endRequest();
                                        if (exitInfo.code() != ExitCode::Ok) {
                                            self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
                                            return;
@@ -185,6 +183,7 @@ void SyncService::isPathValidForNewSync(const QString &path, const int32_t syncC
     setLastError(QString());
     if (!isValidSyncConfigurationValue(syncConfiguration)) {
         setLastError(QStringLiteral("Invalid sync configuration value: %1").arg(syncConfiguration));
+        emit pathValidationReceived(false);
         return;
     }
 
@@ -200,6 +199,7 @@ void SyncService::isPathValidForNewSync(const QString &path, const int32_t syncC
                                                   self->endRequest();
                                                   if (exitInfo.code() != ExitCode::Ok) {
                                                       self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+                                                      emit self->pathValidationReceived(false);
                                                       return;
                                                   }
 
@@ -214,6 +214,7 @@ void SyncService::beginRequest() {
 
 void SyncService::endRequest() {
     if (_pendingRequestCount <= 0) {
+        qWarning() << "SyncService::endRequest called with non-positive pending count:" << _pendingRequestCount;
         _pendingRequestCount = 0;
         setLoading(false);
         return;

--- a/src/gui4/linux/app/services/syncservice.cpp
+++ b/src/gui4/linux/app/services/syncservice.cpp
@@ -156,7 +156,7 @@ void SyncService::querySyncStatus(const qint64 syncDbId) {
                                            return;
                                        }
 
-                                       emit self->syncStatusReceived(syncDbId, static_cast<int32_t>(status));
+                                       emit self->syncStatusReceived(syncDbId, toInt(status));
                                    });
 }
 
@@ -229,8 +229,8 @@ void SyncService::endRequest() {
 }
 
 bool SyncService::isValidSyncConfigurationValue(const int32_t syncConfiguration) const {
-    return syncConfiguration >= static_cast<int32_t>(SyncConfiguration::Classic) &&
-           syncConfiguration < static_cast<int32_t>(SyncConfiguration::EnumEnd);
+    return syncConfiguration >= toInt(SyncConfiguration::Classic) &&
+           syncConfiguration < toInt(SyncConfiguration::EnumEnd);
 }
 
 void SyncService::setLoading(const bool loading) {

--- a/src/gui4/linux/app/services/syncservice.h
+++ b/src/gui4/linux/app/services/syncservice.h
@@ -56,7 +56,8 @@ class SyncService : public QObject {
         void loadingChanged();
         void lastErrorChanged();
         void syncStatusReceived(qint64 syncDbId, int32_t status);
-        void suggestedPathReceived(const QString &goodPath, const QString &errorMessage);
+        // The second argument can carry a non-blocking warning message from the backend.
+        void suggestedPathReceived(const QString &goodPath, const QString &warningMessage);
         void pathValidationReceived(bool isValid);
         void syncAddCompleted(qint64 syncDbId);
 

--- a/src/gui4/linux/app/services/syncservice.h
+++ b/src/gui4/linux/app/services/syncservice.h
@@ -1,0 +1,77 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "app/cache/appcache.h"
+#include "app/services/commservice.h"
+
+#include <QObject>
+#include <QString>
+
+#include <cstdint>
+
+namespace KDC {
+
+/**
+ * High-level sync-oriented facade exposed to QML.
+ */
+class SyncService : public QObject {
+        Q_OBJECT
+        Q_PROPERTY(bool loading READ loading NOTIFY loadingChanged)
+        Q_PROPERTY(QString lastError READ lastError NOTIFY lastErrorChanged)
+
+    public:
+        explicit SyncService(CommService &commService, AppCache &appCache, QObject *parent = nullptr);
+
+        bool loading() const { return _loading; }
+        const QString &lastError() const { return _lastError; }
+
+        Q_INVOKABLE void loadSyncs();
+        Q_INVOKABLE void addSync(qint64 userDbId, qint64 accountId, qint64 driveId, const QString &localFolderPath,
+                                 const QString &serverFolderPath, const QString &serverFolderNodeId, bool liteSync);
+        Q_INVOKABLE void startSync(qint64 syncDbId);
+        Q_INVOKABLE void stopSync(qint64 syncDbId);
+        Q_INVOKABLE void deleteSync(qint64 syncDbId);
+        Q_INVOKABLE void querySyncStatus(qint64 syncDbId);
+        Q_INVOKABLE void findGoodPathForNewSync(const QString &basePath);
+        Q_INVOKABLE void isPathValidForNewSync(const QString &path, int32_t syncConfiguration);
+
+    signals:
+        void loadingChanged();
+        void lastErrorChanged();
+        void syncStatusReceived(qint64 syncDbId, int32_t status);
+        void suggestedPathReceived(const QString &goodPath, const QString &errorMessage);
+        void pathValidationReceived(bool isValid);
+        void syncAddCompleted(qint64 syncDbId);
+
+    private:
+        void beginRequest();
+        void endRequest();
+        void setLoading(bool loading);
+        void setLastError(const QString &error);
+        bool isValidSyncConfigurationValue(int32_t syncConfiguration) const;
+
+        CommService &_commService;
+        AppCache &_appCache;
+        int32_t _pendingRequestCount{0};
+        bool _loading{false};
+        QString _lastError;
+};
+
+} // namespace KDC

--- a/src/gui4/linux/app/services/userservice.cpp
+++ b/src/gui4/linux/app/services/userservice.cpp
@@ -19,6 +19,7 @@
 #include "userservice.h"
 #include "serviceutils.h"
 
+#include <QDebug>
 #include <QPointer>
 
 namespace KDC {
@@ -102,9 +103,13 @@ void UserService::requestLoginToken(const QString &code, const QString &codeVeri
         }
 
         self->endRequest();
+        if (!result.error.isEmpty() || !result.errorDescription.isEmpty()) {
+            emit self->loginTokenFailed(result.error, result.errorDescription);
+            return;
+        }
+
         if (exitInfo.code() != ExitCode::Ok) {
             self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
-            emit self->loginTokenFailed(result.error, result.errorDescription);
             return;
         }
 
@@ -119,6 +124,7 @@ void UserService::beginRequest() {
 
 void UserService::endRequest() {
     if (_pendingRequestCount <= 0) {
+        qWarning() << "UserService::endRequest called with non-positive pending count:" << _pendingRequestCount;
         _pendingRequestCount = 0;
         setLoading(false);
         return;

--- a/src/gui4/linux/app/services/userservice.cpp
+++ b/src/gui4/linux/app/services/userservice.cpp
@@ -19,10 +19,12 @@
 #include "userservice.h"
 #include "serviceutils.h"
 
-#include <QDebug>
+#include <QLoggingCategory>
 #include <QPointer>
 
 namespace KDC {
+
+Q_LOGGING_CATEGORY(lcUserService, "gui.v4.userservice", QtInfoMsg)
 
 UserService::UserService(CommService &commService, AppCache &appCache, QObject *parent) :
     QObject(parent),
@@ -124,7 +126,7 @@ void UserService::beginRequest() {
 
 void UserService::endRequest() {
     if (_pendingRequestCount <= 0) {
-        qWarning() << "UserService::endRequest called with non-positive pending count:" << _pendingRequestCount;
+        qCWarning(lcUserService) << "endRequest called with non-positive pending count:" << _pendingRequestCount;
         _pendingRequestCount = 0;
         setLoading(false);
         return;

--- a/src/gui4/linux/app/services/userservice.cpp
+++ b/src/gui4/linux/app/services/userservice.cpp
@@ -1,0 +1,149 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "userservice.h"
+#include "serviceutils.h"
+
+#include <QPointer>
+
+namespace KDC {
+
+UserService::UserService(CommService &commService, AppCache &appCache, QObject *parent) :
+    QObject(parent),
+    _commService(commService),
+    _appCache(appCache) {
+    (void) connect(&_commService, &CommService::userAdded, &_appCache, &AppCache::upsertUser);
+    (void) connect(&_commService, &CommService::userUpdated, &_appCache, &AppCache::upsertUser);
+    (void) connect(&_commService, &CommService::userRemoved, &_appCache, &AppCache::removeUser);
+}
+
+void UserService::loadUsers() {
+    beginRequest();
+    setLastError(QString());
+
+    const QPointer<UserService> self(this);
+    _commService.requestUserInfoList([self](const ExitInfo &exitInfo, const std::vector<UserInfo> &list) {
+        if (!self) {
+            return;
+        }
+
+        self->endRequest();
+        if (exitInfo.code() != ExitCode::Ok) {
+            self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+            return;
+        }
+
+        self->_appCache.replaceUsers(list);
+    });
+}
+
+void UserService::loadAvailableDrives(const qint64 userDbId) {
+    beginRequest();
+    setLastError(QString());
+
+    const QPointer<UserService> self(this);
+    _commService.requestUserAvailableDrives(static_cast<UserDbId>(userDbId),
+                                            [self](const ExitInfo &exitInfo, const std::vector<DriveAvailableInfo> &list) {
+                                                if (!self) {
+                                                    return;
+                                                }
+
+                                                self->endRequest();
+                                                if (exitInfo.code() != ExitCode::Ok) {
+                                                    self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+                                                    return;
+                                                }
+
+                                                self->_appCache.replaceAvailableDrives(list);
+                                            });
+}
+
+void UserService::deleteUser(const qint64 userDbId) {
+    beginRequest();
+    setLastError(QString());
+
+    const QPointer<UserService> self(this);
+    // Cache consistency is signal-driven: we wait for userRemoved/userUpdated pushes.
+    _commService.requestDeleteUser(static_cast<UserDbId>(userDbId), [self](const ExitInfo &exitInfo) {
+        if (!self) {
+            return;
+        }
+
+        self->endRequest();
+        if (exitInfo.code() != ExitCode::Ok) {
+            self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+        }
+    });
+}
+
+void UserService::requestLoginToken(const QString &code, const QString &codeVerifier) {
+    beginRequest();
+    setLastError(QString());
+
+    const QPointer<UserService> self(this);
+    _commService.requestLoginToken(code, codeVerifier, [self](const ExitInfo &exitInfo, const LoginTokenResult &result) {
+        if (!self) {
+            return;
+        }
+
+        self->endRequest();
+        if (exitInfo.code() != ExitCode::Ok) {
+            self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+            emit self->loginTokenFailed(result.error, result.errorDescription);
+            return;
+        }
+
+        emit self->loginTokenSucceeded(static_cast<qint64>(result.userDbId));
+    });
+}
+
+void UserService::beginRequest() {
+    ++_pendingRequestCount;
+    setLoading(true);
+}
+
+void UserService::endRequest() {
+    if (_pendingRequestCount <= 0) {
+        _pendingRequestCount = 0;
+        setLoading(false);
+        return;
+    }
+
+    --_pendingRequestCount;
+    if (_pendingRequestCount == 0) {
+        setLoading(false);
+    }
+}
+
+void UserService::setLoading(const bool loading) {
+    if (_loading == loading) {
+        return;
+    }
+    _loading = loading;
+    emit loadingChanged();
+}
+
+void UserService::setLastError(const QString &error) {
+    if (_lastError == error) {
+        return;
+    }
+    _lastError = error;
+    emit lastErrorChanged();
+}
+
+} // namespace KDC

--- a/src/gui4/linux/app/services/userservice.h
+++ b/src/gui4/linux/app/services/userservice.h
@@ -1,0 +1,71 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "app/cache/appcache.h"
+#include "app/services/commservice.h"
+
+#include <QObject>
+#include <QString>
+
+#include <cstdint>
+
+namespace KDC {
+
+/**
+ * High-level user-oriented facade exposed to QML.
+ *
+ * This service orchestrates user requests over CommService and updates AppCache.
+ */
+class UserService : public QObject {
+        Q_OBJECT
+        Q_PROPERTY(bool loading READ loading NOTIFY loadingChanged)
+        Q_PROPERTY(QString lastError READ lastError NOTIFY lastErrorChanged)
+
+    public:
+        explicit UserService(CommService &commService, AppCache &appCache, QObject *parent = nullptr);
+
+        bool loading() const { return _loading; }
+        const QString &lastError() const { return _lastError; }
+
+        Q_INVOKABLE void loadUsers();
+        Q_INVOKABLE void loadAvailableDrives(qint64 userDbId);
+        Q_INVOKABLE void deleteUser(qint64 userDbId);
+        Q_INVOKABLE void requestLoginToken(const QString &code, const QString &codeVerifier);
+
+    signals:
+        void loadingChanged();
+        void lastErrorChanged();
+        void loginTokenSucceeded(qint64 userDbId);
+        void loginTokenFailed(const QString &error, const QString &errorDescription);
+
+    private:
+        void beginRequest();
+        void endRequest();
+        void setLoading(bool loading);
+        void setLastError(const QString &error);
+
+        CommService &_commService;
+        AppCache &_appCache;
+        int32_t _pendingRequestCount{0};
+        bool _loading{false};
+        QString _lastError;
+};
+
+} // namespace KDC


### PR DESCRIPTION
## Summary
This PR introduces the C1 foundation layer for Linux v4 by adding an observable AppCache and QML-facing service facades on top of CommService. It centralizes state updates and request lifecycle handling so upcoming router and model work can consume a stable C++ API.

## Changes
- Added `AppCache` (`appcache.h/.cpp`) as the central UI state store for connection state, selected entities, and typed collections (`users`, `drives`, `syncs`, `errors`, and related snapshots).
- Implemented cache mutation APIs (`replace*`, `upsert*`, `remove*`, `clearAll`) with Qt signals for reactive UI updates.
- Added `ServiceUtils::formatExitInfo` to standardize IPC failure formatting across services.
- Added `UserService`, `DriveService`, and `SyncService` with `loading` and `lastError` properties and QML invokables for key user, drive, and sync operations.
- Wired CommService push signals to AppCache so cache consistency is driven by server events.
- Integrated all new C1 sources into `src/gui4/linux/CMakeLists.txt`.
- Refined C1 behavior with follow-up fixes: read-only cache selection properties from QML, improved signal ordering in removals, better login token error separation, request underflow warnings, and sync-side validation/loading adjustments.

## Technical Details
The services use a pending-request counter (`beginRequest` and `endRequest`) to keep `loading` consistent when multiple requests overlap. Cache updates are signal-driven from CommService pushes for mutation flows, reducing divergence between local optimistic state and backend state. In AppCache removal paths, collection change signals are emitted before selection-reset signals to preserve list/selection coherence for QML bindings.