### PR TITLE
feat(CacheDirectory): Implement CacheDirectory class for managed download caching

### DIFF
--- a/src/libcommonserver/CMakeLists.txt
+++ b/src/libcommonserver/CMakeLists.txt
@@ -43,6 +43,7 @@ set(libcommonserver_SRCS
     io/filestat.h
     io/iohelper.h io/iohelper.cpp
     io/permissionsholder.h io/permissionsholder.cpp
+    io/cachedirectory.h io/cachedirectory.cpp
     # Log
     log/log.h log/log.cpp
     log/customrollingfileappender.h log/customrollingfileappender.cpp

--- a/src/libcommonserver/io/cachedirectory.cpp
+++ b/src/libcommonserver/io/cachedirectory.cpp
@@ -71,8 +71,13 @@ ExitInfo CacheDirectory::initDirectory() noexcept {
 }
 
 void CacheDirectory::cleanUp() const {
+    if (_cacheDirectoryPath.empty()) return;
+
     auto ioError = IoError::Unknown;
     IoHelper::DirectoryIterator dirIt(_cacheDirectoryPath, false, ioError);
+    if (ioError != IoError::Success) {
+        return;
+    }
     bool endOfDir = false;
     DirectoryEntry entry;
     while (dirIt.next(entry, endOfDir, ioError) && !endOfDir) {

--- a/src/libcommonserver/io/cachedirectory.cpp
+++ b/src/libcommonserver/io/cachedirectory.cpp
@@ -18,15 +18,19 @@
 
 #include "cachedirectory.h"
 
+#include "config.h" // APPLICATION
+
 namespace KDC {
 
 CacheDirectory::CacheDirectory(const SyncPath &localSyncPath) {
-    static const auto cacheDirName = std::format(".{}-cache", APPLICATION_NAME);
-    _cacheDirectoryPath = localSyncPath / cacheDirName;
-    initDirectory();
+    initDirectory(localSyncPath);
 }
 
-const SyncPath &CacheDirectory::directoryPath() noexcept {
+CacheDirectory::~CacheDirectory() {
+    if (_deleteFolderUponDestruction) deleteDirectory();
+}
+
+const SyncPath &CacheDirectory::path() noexcept {
     const std::scoped_lock lock(_mutex);
 
     bool exists = false;
@@ -36,22 +40,10 @@ const SyncPath &CacheDirectory::directoryPath() noexcept {
                                         CommonUtility::ws2s(Utility::formatIoError(_cacheDirectoryPath, ioError)));
     }
 
-    if (_cacheDirectoryPath.empty() || !exists) {
+    if (!exists) {
         resetDirectoryPath();
     }
     return _cacheDirectoryPath;
-}
-
-void CacheDirectory::initDirectory() noexcept {
-    if (auto ioError = IoError::Success;
-        !IoHelper::createDirectory(_cacheDirectoryPath, false, ioError) && ioError != IoError::DirectoryExists) {
-        sentry::Handler::captureMessage(sentry::Level::Error, "Failed to create kDrive-cache",
-                                        CommonUtility::ws2s(Utility::formatIoError(_cacheDirectoryPath, ioError)));
-        _cacheDirectoryPath.clear(); // Clear the path if the directory could not be created.
-        return;
-    }
-
-    return;
 }
 
 void CacheDirectory::deleteDirectory() const noexcept {
@@ -60,9 +52,23 @@ void CacheDirectory::deleteDirectory() const noexcept {
     (void) IoHelper::deleteItem(_cacheDirectoryPath, ioError);
 }
 
+void CacheDirectory::initDirectory(const SyncPath &localSyncPath) noexcept {
+    static const auto cacheDirName = std::format(".{}-cache", APPLICATION_NAME);
+    _cacheDirectoryPath = localSyncPath / cacheDirName;
+
+    if (auto ioError = IoError::Success;
+        !IoHelper::createDirectory(_cacheDirectoryPath, false, ioError) && ioError != IoError::DirectoryExists) {
+        sentry::Handler::captureMessage(sentry::Level::Error, "Failed to create kDrive-cache",
+                                        CommonUtility::ws2s(Utility::formatIoError(_cacheDirectoryPath, ioError)));
+        return;
+    }
+
+    return;
+}
+
 void CacheDirectory::resetDirectoryPath() noexcept {
     deleteDirectory();
-    initDirectory();
+    initDirectory(_cacheDirectoryPath.parent_path());
 }
 
 } // namespace KDC

--- a/src/libcommonserver/io/cachedirectory.cpp
+++ b/src/libcommonserver/io/cachedirectory.cpp
@@ -39,7 +39,7 @@ ExitInfo CacheDirectory::path(SyncPath &cacheDirectory) noexcept {
                                         CommonUtility::ws2s(Utility::formatIoError(_cacheDirectoryPath, ioError)));
     }
     if (!exists) {
-        return initDirectory();
+        if (const auto exitInfo = initDirectory(); !exitInfo) return exitInfo;
     }
 
     cacheDirectory = _cacheDirectoryPath;

--- a/src/libcommonserver/io/cachedirectory.cpp
+++ b/src/libcommonserver/io/cachedirectory.cpp
@@ -22,15 +22,14 @@
 
 namespace KDC {
 
-CacheDirectory::CacheDirectory(const SyncPath &localSyncPath) {
-    initDirectory(localSyncPath);
-}
+CacheDirectory::CacheDirectory(const SyncPath &localSyncPath) :
+    _syncDirectoryPath(localSyncPath) {}
 
 CacheDirectory::~CacheDirectory() {
-    deleteDirectory();
+    cleanUp();
 }
 
-const SyncPath &CacheDirectory::path() noexcept {
+ExitInfo CacheDirectory::path(SyncPath &cacheDirectory) noexcept {
     const std::scoped_lock lock(_mutex);
 
     bool exists = false;
@@ -39,40 +38,37 @@ const SyncPath &CacheDirectory::path() noexcept {
         sentry::Handler::captureMessage(sentry::Level::Error, "Failed to check if kDrive-cache exist",
                                         CommonUtility::ws2s(Utility::formatIoError(_cacheDirectoryPath, ioError)));
     }
-
     if (!exists) {
-        resetDirectoryPath();
+        return initDirectory();
     }
 
-    return _cacheDirectoryPath;
+    cacheDirectory = _cacheDirectoryPath;
+    return ExitCode::Ok;
 }
 
-void CacheDirectory::initDirectory(const SyncPath &localSyncPath) noexcept {
+ExitInfo CacheDirectory::initDirectory() noexcept {
+    if (_syncDirectoryPath.empty()) {
+        return {ExitCode::LogicError, ExitCause::InvalidArgument};
+    }
+
     const auto cacheDirName = Poco::format(".%s-cache", std::string(APPLICATION_NAME));
-    _cacheDirectoryPath = localSyncPath / cacheDirName;
+    _cacheDirectoryPath = _syncDirectoryPath / cacheDirName;
 
     if (auto ioError = IoError::Success;
         !IoHelper::createDirectory(_cacheDirectoryPath, false, ioError) && ioError != IoError::DirectoryExists) {
         sentry::Handler::captureMessage(sentry::Level::Error, "Failed to create kDrive-cache",
                                         CommonUtility::ws2s(Utility::formatIoError(_cacheDirectoryPath, ioError)));
-        return;
+        return {ExitCode::SystemError, ExitCause::TmpDirAccessError};
     }
 
     // Hide cache directory
     IoHelper::setFileHidden(_cacheDirectoryPath, true);
 
-    return;
+    return ExitCode::Ok;
 }
 
-void CacheDirectory::deleteDirectory() const noexcept {
-    // It is the best effort, we cannot log/sentry anything here as the logger/sentry may have been destroyed already.
-    auto ioError = IoError::Success;
-    (void) IoHelper::deleteItem(_cacheDirectoryPath, ioError);
-}
-
-void CacheDirectory::resetDirectoryPath() noexcept {
-    deleteDirectory();
-    initDirectory(_cacheDirectoryPath.parent_path());
+void CacheDirectory::cleanUp() {
+    // TODO
 }
 
 } // namespace KDC

--- a/src/libcommonserver/io/cachedirectory.cpp
+++ b/src/libcommonserver/io/cachedirectory.cpp
@@ -20,6 +20,8 @@
 
 #include "config.h" // APPLICATION
 
+#include <format>
+
 namespace KDC {
 
 CacheDirectory::CacheDirectory(const SyncPath &localSyncPath) {

--- a/src/libcommonserver/io/cachedirectory.cpp
+++ b/src/libcommonserver/io/cachedirectory.cpp
@@ -20,8 +20,6 @@
 
 #include "config.h" // APPLICATION
 
-#include <regex>
-
 namespace KDC {
 
 CacheDirectory::CacheDirectory(const SyncPath &localSyncPath) :
@@ -29,6 +27,15 @@ CacheDirectory::CacheDirectory(const SyncPath &localSyncPath) :
 
 CacheDirectory::~CacheDirectory() {
     cleanUp();
+}
+
+std::string CacheDirectory::createTmpFileName() {
+    return std::string(tmpFilePrefix) + CommonUtility::generateRandomStringAlphaNum(tmpFileRandomPartLength);
+}
+
+bool CacheDirectory::isTmpFileName(std::string_view fileName) noexcept {
+    const auto expectedSize = tmpFilePrefix.size() + static_cast<size_t>(tmpFileRandomPartLength);
+    return fileName.size() == expectedSize && fileName.starts_with(tmpFilePrefix);
 }
 
 ExitInfo CacheDirectory::path(SyncPath &cacheDirectory) noexcept {
@@ -81,7 +88,7 @@ void CacheDirectory::cleanUp() const {
     bool endOfDir = false;
     DirectoryEntry entry;
     while (dirIt.next(entry, endOfDir, ioError) && !endOfDir) {
-        if (std::regex_match(SyncName2Str(entry.path().filename().native()), std::regex(R"(kdrive_.{10})"))) {
+        if (isTmpFileName(SyncName2Str(entry.path().filename().native()))) {
             (void) IoHelper::deleteItem(entry.path());
         }
     }

--- a/src/libcommonserver/io/cachedirectory.cpp
+++ b/src/libcommonserver/io/cachedirectory.cpp
@@ -45,6 +45,10 @@ const SyncPath &CacheDirectory::path() noexcept {
     if (!exists) {
         resetDirectoryPath();
     }
+
+    // Hide cache directory
+    IoHelper::setFileHidden(_cacheDirectoryPath, true);
+
     return _cacheDirectoryPath;
 }
 

--- a/src/libcommonserver/io/cachedirectory.cpp
+++ b/src/libcommonserver/io/cachedirectory.cpp
@@ -20,6 +20,8 @@
 
 #include "config.h" // APPLICATION
 
+#include <regex>
+
 namespace KDC {
 
 CacheDirectory::CacheDirectory(const SyncPath &localSyncPath) :
@@ -67,8 +69,16 @@ ExitInfo CacheDirectory::initDirectory() noexcept {
     return ExitCode::Ok;
 }
 
-void CacheDirectory::cleanUp() {
-    // TODO
+void CacheDirectory::cleanUp() const {
+    auto ioError = IoError::Unknown;
+    IoHelper::DirectoryIterator dirIt(_cacheDirectoryPath, false, ioError);
+    bool endOfDir = false;
+    DirectoryEntry entry;
+    while (dirIt.next(entry, endOfDir, ioError) && !endOfDir) {
+        if (std::regex_match(SyncName2Str(entry.path().filename().native()), std::regex(R"(kdrive_.{10})"))) {
+            (void) IoHelper::deleteItem(entry.path());
+        }
+    }
 }
 
 } // namespace KDC

--- a/src/libcommonserver/io/cachedirectory.cpp
+++ b/src/libcommonserver/io/cachedirectory.cpp
@@ -33,7 +33,7 @@ std::string CacheDirectory::createTmpFileName() {
     return std::string(tmpFilePrefix) + CommonUtility::generateRandomStringAlphaNum(tmpFileRandomPartLength);
 }
 
-bool CacheDirectory::isTmpFileName(std::string_view fileName) noexcept {
+bool CacheDirectory::isTmpFileName(const std::string_view fileName) noexcept {
     const auto expectedSize = tmpFilePrefix.size() + static_cast<size_t>(tmpFileRandomPartLength);
     return fileName.size() == expectedSize && fileName.starts_with(tmpFilePrefix);
 }

--- a/src/libcommonserver/io/cachedirectory.cpp
+++ b/src/libcommonserver/io/cachedirectory.cpp
@@ -39,6 +39,7 @@ ExitInfo CacheDirectory::path(SyncPath &cacheDirectory) noexcept {
         !IoHelper::checkIfPathExists(_cacheDirectoryPath, exists, ioError, IoHelper::PathCheckOption::Insensitive)) {
         sentry::Handler::captureMessage(sentry::Level::Error, "Failed to check if kDrive-cache exist",
                                         CommonUtility::ws2s(Utility::formatIoError(_cacheDirectoryPath, ioError)));
+        return {ExitCode::SystemError, ExitCause::TmpDirAccessError};
     }
     if (!exists) {
         if (const auto exitInfo = initDirectory(); !exitInfo) return exitInfo;

--- a/src/libcommonserver/io/cachedirectory.cpp
+++ b/src/libcommonserver/io/cachedirectory.cpp
@@ -27,7 +27,7 @@ CacheDirectory::CacheDirectory(const SyncPath &localSyncPath) {
 }
 
 CacheDirectory::~CacheDirectory() {
-    if (_deleteFolderUponDestruction) deleteDirectory();
+    deleteDirectory();
 }
 
 const SyncPath &CacheDirectory::path() noexcept {
@@ -46,14 +46,8 @@ const SyncPath &CacheDirectory::path() noexcept {
     return _cacheDirectoryPath;
 }
 
-void CacheDirectory::deleteDirectory() const noexcept {
-    // It is the best effort, we cannot log/sentry anything here as the logger/sentry may have been destroyed already.
-    auto ioError = IoError::Success;
-    (void) IoHelper::deleteItem(_cacheDirectoryPath, ioError);
-}
-
 void CacheDirectory::initDirectory(const SyncPath &localSyncPath) noexcept {
-    static const auto cacheDirName = std::format(".{}-cache", APPLICATION_NAME);
+    const auto cacheDirName = std::format(".{}-cache", APPLICATION_NAME);
     _cacheDirectoryPath = localSyncPath / cacheDirName;
 
     if (auto ioError = IoError::Success;
@@ -64,6 +58,12 @@ void CacheDirectory::initDirectory(const SyncPath &localSyncPath) noexcept {
     }
 
     return;
+}
+
+void CacheDirectory::deleteDirectory() const noexcept {
+    // It is the best effort, we cannot log/sentry anything here as the logger/sentry may have been destroyed already.
+    auto ioError = IoError::Success;
+    (void) IoHelper::deleteItem(_cacheDirectoryPath, ioError);
 }
 
 void CacheDirectory::resetDirectoryPath() noexcept {

--- a/src/libcommonserver/io/cachedirectory.cpp
+++ b/src/libcommonserver/io/cachedirectory.cpp
@@ -44,9 +44,6 @@ const SyncPath &CacheDirectory::path() noexcept {
         resetDirectoryPath();
     }
 
-    // Hide cache directory
-    IoHelper::setFileHidden(_cacheDirectoryPath, true);
-
     return _cacheDirectoryPath;
 }
 
@@ -60,6 +57,9 @@ void CacheDirectory::initDirectory(const SyncPath &localSyncPath) noexcept {
                                         CommonUtility::ws2s(Utility::formatIoError(_cacheDirectoryPath, ioError)));
         return;
     }
+
+    // Hide cache directory
+    IoHelper::setFileHidden(_cacheDirectoryPath, true);
 
     return;
 }

--- a/src/libcommonserver/io/cachedirectory.cpp
+++ b/src/libcommonserver/io/cachedirectory.cpp
@@ -20,8 +20,6 @@
 
 #include "config.h" // APPLICATION
 
-#include <format>
-
 namespace KDC {
 
 CacheDirectory::CacheDirectory(const SyncPath &localSyncPath) {
@@ -53,7 +51,7 @@ const SyncPath &CacheDirectory::path() noexcept {
 }
 
 void CacheDirectory::initDirectory(const SyncPath &localSyncPath) noexcept {
-    const auto cacheDirName = std::format(".{}-cache", APPLICATION_NAME);
+    const auto cacheDirName = Poco::format(".%s-cache", std::string(APPLICATION_NAME));
     _cacheDirectoryPath = localSyncPath / cacheDirName;
 
     if (auto ioError = IoError::Success;

--- a/src/libcommonserver/io/cachedirectory.h
+++ b/src/libcommonserver/io/cachedirectory.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include "libcommon/utility/types.h"
+
 namespace KDC {
 
 class CacheDirectory {
@@ -25,19 +27,15 @@ class CacheDirectory {
         ~CacheDirectory();
 
         const SyncPath &path() noexcept;
-        void deleteDirectory() const noexcept;
 
-        void setDeleteFolderUponDestruction(const bool deleteFolderUponDestruction) {
-            _deleteFolderUponDestruction = deleteFolderUponDestruction;
-        }
 
     private:
         void initDirectory(const SyncPath &localSyncPath) noexcept;
+        void deleteDirectory() const noexcept;
         void resetDirectoryPath() noexcept;
 
-        mutable std::mutex _mutex;
+        mutable std::recursive_mutex _mutex;
         SyncPath _cacheDirectoryPath;
-        bool _deleteFolderUponDestruction{false};
 };
 
 } // namespace KDC

--- a/src/libcommonserver/io/cachedirectory.h
+++ b/src/libcommonserver/io/cachedirectory.h
@@ -1,8 +1,7 @@
 /*
  * Infomaniak kDrive - Desktop
  * Copyright (C) 2023-2026 Infomaniak Network SA
- *
- * This program is free software: you can redistribute it and/or modify
+ ** This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
@@ -23,17 +22,22 @@ namespace KDC {
 class CacheDirectory {
     public:
         explicit CacheDirectory(const SyncPath &localSyncPath);
-        ~CacheDirectory() { deleteDirectory(); }
+        ~CacheDirectory();
 
-        const SyncPath &directoryPath() noexcept;
+        const SyncPath &path() noexcept;
+        void deleteDirectory() const noexcept;
+
+        void setDeleteFolderUponDestruction(const bool deleteFolderUponDestruction) {
+            _deleteFolderUponDestruction = deleteFolderUponDestruction;
+        }
 
     private:
-        void initDirectory() noexcept;
-        void deleteDirectory() const noexcept;
+        void initDirectory(const SyncPath &localSyncPath) noexcept;
         void resetDirectoryPath() noexcept;
 
         mutable std::mutex _mutex;
         SyncPath _cacheDirectoryPath;
+        bool _deleteFolderUponDestruction{false};
 };
 
 } // namespace KDC

--- a/src/libcommonserver/io/cachedirectory.h
+++ b/src/libcommonserver/io/cachedirectory.h
@@ -21,6 +21,7 @@
 #include "libcommon/utility/types.h"
 
 #include <mutex>
+#include <string_view>
 
 namespace KDC {
 
@@ -31,7 +32,14 @@ class CacheDirectory {
 
         ExitInfo path(SyncPath &cacheDirectory) noexcept;
 
+        // Shared naming contract used by creators and cleanup logic.
+        static std::string createTmpFileName();
+        static bool isTmpFileName(std::string_view fileName) noexcept;
+
     private:
+        static constexpr std::string_view tmpFilePrefix = "kdrive_";
+        static constexpr int tmpFileRandomPartLength = 10;
+
         ExitInfo initDirectory() noexcept;
         void cleanUp() const;
 

--- a/src/libcommonserver/io/cachedirectory.h
+++ b/src/libcommonserver/io/cachedirectory.h
@@ -1,7 +1,8 @@
 /*
  * Infomaniak kDrive - Desktop
  * Copyright (C) 2023-2026 Infomaniak Network SA
- ** This program is free software: you can redistribute it and/or modify
+ *
+ * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
@@ -18,6 +19,8 @@
 #pragma once
 
 #include "libcommon/utility/types.h"
+
+#include <mutex>
 
 namespace KDC {
 

--- a/src/libcommonserver/io/cachedirectory.h
+++ b/src/libcommonserver/io/cachedirectory.h
@@ -33,7 +33,7 @@ class CacheDirectory {
 
     private:
         ExitInfo initDirectory() noexcept;
-        void cleanUp();
+        void cleanUp() const;
 
         const SyncPath _syncDirectoryPath;
 

--- a/src/libcommonserver/io/cachedirectory.h
+++ b/src/libcommonserver/io/cachedirectory.h
@@ -38,7 +38,7 @@ class CacheDirectory {
 
     private:
         static constexpr std::string_view tmpFilePrefix = "kdrive_";
-        static constexpr int tmpFileRandomPartLength = 10;
+        static constexpr uint32_t tmpFileRandomPartLength = 10;
 
         ExitInfo initDirectory() noexcept;
         void cleanUp() const;

--- a/src/libcommonserver/io/cachedirectory.h
+++ b/src/libcommonserver/io/cachedirectory.h
@@ -29,12 +29,13 @@ class CacheDirectory {
         explicit CacheDirectory(const SyncPath &localSyncPath);
         ~CacheDirectory();
 
-        const SyncPath &path() noexcept;
+        ExitInfo path(SyncPath &cacheDirectory) noexcept;
 
     private:
-        void initDirectory(const SyncPath &localSyncPath) noexcept;
-        void deleteDirectory() const noexcept;
-        void resetDirectoryPath() noexcept;
+        ExitInfo initDirectory() noexcept;
+        void cleanUp();
+
+        const SyncPath _syncDirectoryPath;
 
         mutable std::mutex _mutex;
         SyncPath _cacheDirectoryPath;

--- a/src/libcommonserver/io/cachedirectory.h
+++ b/src/libcommonserver/io/cachedirectory.h
@@ -31,13 +31,12 @@ class CacheDirectory {
 
         const SyncPath &path() noexcept;
 
-
     private:
         void initDirectory(const SyncPath &localSyncPath) noexcept;
         void deleteDirectory() const noexcept;
         void resetDirectoryPath() noexcept;
 
-        mutable std::recursive_mutex _mutex;
+        mutable std::mutex _mutex;
         SyncPath _cacheDirectoryPath;
 };
 

--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 #include "log/sentry/handler.h"
 #include "filestat.h"
 #include "iohelper.h"
@@ -645,120 +646,6 @@ bool IoHelper::appTempDirectoryPath(SyncPath &directoryPath, IoError &ioError) n
     (void) std::filesystem::create_directory(directoryPath, ec);
     ioError = stdError2ioError(ec);
     return ioError == IoError::Success;
-}
-
-namespace details {
-
-class CacheDirectoryHandler {
-    public:
-        static CacheDirectoryHandler &instance() noexcept {
-            static CacheDirectoryHandler instance;
-            return instance;
-        }
-        const SyncPath &directoryPath() noexcept {
-            std::scoped_lock lock(_mutex);
-
-            bool exists = false;
-            auto ioError = IoError::Unknown;
-            if (!IoHelper::checkIfPathExists(_directoryPath, exists, ioError, IoHelper::PathCheckOption::Insensitive)) {
-                sentry::Handler::captureMessage(sentry::Level::Error, "Failed to check if kDrive-cache exist",
-                                                CommonUtility::ws2s(Utility::formatIoError(_directoryPath, ioError)));
-            }
-
-            if (_directoryPath.empty() || !exists) {
-                resetDirectoryPathInternal();
-            }
-            return _directoryPath;
-        }
-        void setDirectoryPath(const SyncPath &newPath) {
-            deleteDirectoryPath();
-            _directoryPath = newPath;
-            createDirectoryPath();
-        }
-        void resetDirectoryPath() noexcept {
-            std::lock_guard<std::mutex> lock(_mutex);
-            resetDirectoryPathInternal();
-        }
-        ~CacheDirectoryHandler() { deleteDirectoryPath(); }
-
-    private:
-        mutable std::mutex _mutex;
-        SyncPath _directoryPath;
-
-        void resetDirectoryPathInternal() noexcept {
-            deleteDirectoryPath();
-            initDirectoryPath();
-            if (!_directoryPath.empty()) createDirectoryPath();
-        }
-
-        CacheDirectoryHandler() {
-            if (_directoryPath.empty()) initDirectoryPath();
-            if (!_directoryPath.empty()) createDirectoryPath();
-        }
-
-        void initDirectoryPath() noexcept {
-            static const SyncName cacheDirName =
-                    SyncName("." + Str2SyncName(APPLICATION_NAME)) + SyncName(Str2SyncName("-cache"));
-            // if (initDirectoryPathFromEnv("KDRIVE_CACHE_PATH", cacheDirName)) return;
-
-            // #if defined(KD_LINUX)
-            //             if (initDirectoryPathFromEnv("XDG_CACHE_HOME", cacheDirName)) return;
-            //             if (initDirectoryPathFromEnv("HOME", cacheDirName, ".cache")) return;
-            // #endif
-            // IoError ioError = IoError::Success;
-            // if (!IoHelper::deviceTempDirectoryPath(_directoryPath, ioError)) {
-            //     return;
-            // }
-            _directoryPath /= cacheDirName;
-            return;
-        }
-
-        bool initDirectoryPathFromEnv(const std::string &envVar, const SyncName &cacheDirName,
-                                      const SyncPath &subDir = "") noexcept {
-            bool isSet = false;
-            if (const auto value = CommonUtility::envVarValue(envVar, isSet); isSet && !value.empty()) {
-                if (subDir.empty()) {
-                    _directoryPath = SyncPath(value) / cacheDirName;
-                } else {
-                    _directoryPath = SyncPath(value) / subDir / cacheDirName;
-                }
-                return true;
-            }
-            return false;
-        };
-
-        void createDirectoryPath() noexcept {
-            if (!_directoryPath.empty()) {
-                IoError ioError = IoError::Success;
-                if (!IoHelper::createDirectory(_directoryPath, true, ioError) && ioError != IoError::DirectoryExists) {
-                    sentry::Handler::captureMessage(sentry::Level::Error, "Failed to create kDrive-cache",
-                                                    CommonUtility::ws2s(Utility::formatIoError(_directoryPath, ioError)));
-                    _directoryPath.clear(); // Clear the path if the directory could not be created.
-                    return;
-                }
-            }
-        }
-
-        void deleteDirectoryPath() noexcept {
-            // It is a best effort, we cannot log/sentry anything here as the logger/sentry may have been destroyed already.
-            IoError ioError = IoError::Success;
-            (void) IoHelper::deleteItem(_directoryPath, ioError);
-        }
-};
-
-} // namespace details
-
-void IoHelper::setCacheDirectoryPath(const SyncPath &newPath) {
-    if (!newPath.empty()) {
-        details::CacheDirectoryHandler::instance().setDirectoryPath(newPath);
-    } else {
-        details::CacheDirectoryHandler::instance().resetDirectoryPath();
-    }
-}
-
-bool IoHelper::cacheDirectoryPath(SyncPath &directoryPath) noexcept {
-    directoryPath = details::CacheDirectoryHandler::instance().directoryPath();
-    return !directoryPath.empty();
 }
 
 bool IoHelper::logDirectoryPath(SyncPath &directoryPath, IoError &ioError) noexcept {

--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -697,17 +697,18 @@ class CacheDirectoryHandler {
         }
 
         void initDirectoryPath() noexcept {
-            static const SyncName cacheDirName = SyncName(Str2SyncName(APPLICATION_NAME)) + SyncName(Str2SyncName("-cache"));
-            if (initDirectoryPathFromEnv("KDRIVE_CACHE_PATH", cacheDirName)) return;
+            static const SyncName cacheDirName =
+                    SyncName("." + Str2SyncName(APPLICATION_NAME)) + SyncName(Str2SyncName("-cache"));
+            // if (initDirectoryPathFromEnv("KDRIVE_CACHE_PATH", cacheDirName)) return;
 
-#if defined(KD_LINUX)
-            if (initDirectoryPathFromEnv("XDG_CACHE_HOME", cacheDirName)) return;
-            if (initDirectoryPathFromEnv("HOME", cacheDirName, ".cache")) return;
-#endif
-            IoError ioError = IoError::Success;
-            if (!IoHelper::deviceTempDirectoryPath(_directoryPath, ioError)) {
-                return;
-            }
+            // #if defined(KD_LINUX)
+            //             if (initDirectoryPathFromEnv("XDG_CACHE_HOME", cacheDirName)) return;
+            //             if (initDirectoryPathFromEnv("HOME", cacheDirName, ".cache")) return;
+            // #endif
+            // IoError ioError = IoError::Success;
+            // if (!IoHelper::deviceTempDirectoryPath(_directoryPath, ioError)) {
+            //     return;
+            // }
             _directoryPath /= cacheDirName;
             return;
         }

--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -636,18 +636,6 @@ bool IoHelper::deviceTempDirectoryPath(SyncPath &directoryPath, IoError &ioError
     return ioError == IoError::Success;
 }
 
-bool IoHelper::appTempDirectoryPath(SyncPath &directoryPath, IoError &ioError) noexcept {
-    SyncPath tmpDirPath;
-    if (const auto res = !deviceTempDirectoryPath(tmpDirPath, ioError)) return res;
-
-    static const SyncName kDriveTmpDirName = Str("kDrive-tmp");
-    directoryPath = tmpDirPath / kDriveTmpDirName;
-    std::error_code ec;
-    (void) std::filesystem::create_directory(directoryPath, ec);
-    ioError = stdError2ioError(ec);
-    return ioError == IoError::Success;
-}
-
 bool IoHelper::logDirectoryPath(SyncPath &directoryPath, IoError &ioError) noexcept {
     if (Log::instance()) {
         SyncPath filePath = Log::instance()->getLogFilePath();

--- a/src/libcommonserver/io/iohelper.h
+++ b/src/libcommonserver/io/iohelper.h
@@ -185,7 +185,6 @@ struct IoHelper {
 
         static bool isPathOnMountedDisk(const SyncPath &path, bool &isMounted, IoError &ioError) noexcept;
 
-#if defined(KD_MACOS) || defined(KD_WINDOWS)
         //! Hides or reveals the item indicated by path.
         /*!
          \param path is a file system path to a directory entry (we also call it an item).
@@ -193,7 +192,6 @@ struct IoHelper {
          terminal when using a sheer `ls` command).
          */
         static void setFileHidden(const SyncPath &path, bool hidden) noexcept;
-#endif
 
         //! Checks if the item indicated by the specified path exists.
         /*!

--- a/src/libcommonserver/io/iohelper.h
+++ b/src/libcommonserver/io/iohelper.h
@@ -117,14 +117,6 @@ struct IoHelper {
          */
         static bool deviceTempDirectoryPath(SyncPath &directoryPath, IoError &ioError) noexcept;
 
-        //! Returns the location of the kDrive temporary subdirectory.
-        /*!
-         \param directoryPath is the path to the kDrive temporary directory. Empty if there is an error.
-         \param ioError holds the error returned when an underlying OS API call fails.
-         \return true if no unexpected error occurred, false otherwise.
-         */
-        static bool appTempDirectoryPath(SyncPath &directoryPath, IoError &ioError) noexcept;
-
         //! Returns the log directory path of the application.
         /*!
          \param directoryPath is set with the path of to the log directory of the application. Empty if there is an error.

--- a/src/libcommonserver/io/iohelper.h
+++ b/src/libcommonserver/io/iohelper.h
@@ -125,15 +125,6 @@ struct IoHelper {
          */
         static bool appTempDirectoryPath(SyncPath &directoryPath, IoError &ioError) noexcept;
 
-
-        //! Returns the directory location suitable for temporary files.
-        /*! This directory is deleted at the end of the application run.
-          ! The location of this folder can be enforced with the env variable: KDRIVE_CACHE_PATH
-         \param directoryPath is a path to a directory suitable for temporary files. Empty if there is an error.
-         \return true if no unexpected error occurred, false otherwise.
-         */
-        static bool cacheDirectoryPath(SyncPath &directoryPath) noexcept;
-
         //! Returns the log directory path of the application.
         /*!
          \param directoryPath is set with the path of to the log directory of the application. Empty if there is an error.
@@ -597,7 +588,6 @@ struct IoHelper {
                                                   IoError &ioError) noexcept;
         static bool _getFileStatFn(const SyncPath &path, FileStat *filestat, IoError &ioError) noexcept;
         static bool _unsuportedFSLogged;
-        static void setCacheDirectoryPath(const SyncPath &newPath);
 
     private:
         static log4cplus::Logger _logger;

--- a/src/libcommonserver/io/iohelper_linux.cpp
+++ b/src/libcommonserver/io/iohelper_linux.cpp
@@ -192,7 +192,7 @@ bool IoHelper::isPathOnMountedDisk(const SyncPath &path, bool &isMounted, IoErro
     return true;
 }
 
-void IoHelper::setFileHidden(const SyncPath &, bool) noexcept {
+void IoHelper::setFileHidden(const SyncPath &, const bool) noexcept {
     // Items whose names begin with a period are hidden on Linux.
 }
 

--- a/src/libcommonserver/io/iohelper_linux.cpp
+++ b/src/libcommonserver/io/iohelper_linux.cpp
@@ -191,4 +191,9 @@ bool IoHelper::isPathOnMountedDisk(const SyncPath &path, bool &isMounted, IoErro
     isMounted = true;
     return true;
 }
+
+void IoHelper::setFileHidden(const SyncPath &, bool) noexcept {
+    // Items whose names begin with a period are hidden on Linux.
+}
+
 } // namespace KDC

--- a/src/libcommonserver/utility/utility.cpp
+++ b/src/libcommonserver/utility/utility.cpp
@@ -194,13 +194,13 @@ bool Utility::checkIfEqualUpToCaseAndEncoding(const SyncPath &a, const SyncPath 
 
     SyncPath normalizedA;
     if (!Utility::normalizedSyncPath(a, normalizedA)) {
-        LOGW_WARN(_logger, L"Error in Utility::normalizedSyncPath: " << Utility::formatSyncPath(a));
+        LOGW_WARN(logger(), L"Error in Utility::normalizedSyncPath: " << Utility::formatSyncPath(a));
         return false;
     }
 
     SyncPath normalizedB;
     if (!Utility::normalizedSyncPath(b, normalizedB)) {
-        LOGW_WARN(_logger, L"Error in Utility::normalizedSyncPath: " << Utility::formatSyncPath(b));
+        LOGW_WARN(logger(), L"Error in Utility::normalizedSyncPath: " << Utility::formatSyncPath(b));
         return false;
     }
 
@@ -580,15 +580,19 @@ bool Utility::isError500(const Poco::Net::HTTPResponse::HTTPStatus httpErrorCode
 }
 
 static constexpr uint64_t maxNbCreationTmpFolderRetries = 3;
-IoError Utility::tryCreateTmpDir(const std::shared_ptr<CacheDirectory> cacheDirectory,
-                                 const SyncName &name /*= Str("testDir")*/) {
+ExitInfo Utility::tryCreateTmpDir(const std::shared_ptr<CacheDirectory> cacheDirectory,
+                                  const SyncName &name /*= Str("testDir")*/) {
 #if defined(KD_MACOS)
     if (!cacheDirectory) {
-        LOG_WARN(_logger, "Cache directory not provided!");
-        return IoError::InvalidArgument;
+        LOG_WARN(logger(), "Cache directory not provided!");
+        return {ExitCode::SystemError, ExitCause::InvalidArgument};
     }
 
-    SyncPath tmpPath = cacheDirectory->path() / name;
+    SyncPath cacheDirectoryPath;
+    if (const auto exitInfo = cacheDirectory->path(cacheDirectoryPath); !exitInfo) {
+        return exitInfo;
+    }
+    SyncPath tmpPath = cacheDirectoryPath / name;
     std::error_code ec;
     uint64_t retries = 0;
     bool directoryCreated = false;
@@ -596,78 +600,88 @@ IoError Utility::tryCreateTmpDir(const std::shared_ptr<CacheDirectory> cacheDire
         directoryCreated = std::filesystem::create_directory(tmpPath, ec);
         if (!directoryCreated || ec.value()) {
             if (ec.value() == static_cast<int>(std::errc::illegal_byte_sequence)) {
-                return IoError::InvalidFileName;
+                return {ExitCode::SystemError, ExitCause::InvalidName};
             }
             retries++;
             // Retry with a random suffix added to item name
-            tmpPath = cacheDirectory->path() / (name + CommonUtility::generateRandomStringAlphaNum());
+            tmpPath = cacheDirectoryPath / (name + CommonUtility::generateRandomStringAlphaNum());
         }
     } while ((!directoryCreated || ec.value()) && retries < maxNbCreationTmpFolderRetries);
 
-    if (ec.value()) return IoHelper::stdError2ioError(ec);
+    if (ec.value()) {
+        LOGW_WARN(logger(), L"Failed to create directory " << Utility::formatStdError(tmpPath, ec));
+        return {ExitCode::SystemError,
+                IoHelper::stdError2ioError(ec) == IoError::AccessDenied ? ExitCause::TmpDirAccessError : ExitCause::Unknown};
+    }
 
     auto ioError = IoError::Unknown;
     (void) IoHelper::deleteItem(tmpPath, ioError);
-    return ioError;
 #else
     (void) name;
-    return IoError::Success;
 #endif
+    return ExitCode::Ok;
 }
 
-IoError Utility::tryCreateTmpFile(const std::shared_ptr<CacheDirectory> cacheDirectory,
-                                  const SyncName &name /*= Str("testFile")*/) {
+ExitInfo checkTmpDirectoryRights(const SyncPath &path) {
+    bool read = false;
+    bool write = false;
+    bool exec = false;
+    if (auto ioError = IoError::Unknown; !IoHelper::getRights(path, read, write, exec, ioError)) {
+        return {ExitCode::SystemError, !read || !write ? ExitCause::TmpDirAccessError : ExitCause::Unknown};
+    }
+    return ExitCode::Ok;
+}
+
+ExitInfo Utility::tryCreateTmpFile(const std::shared_ptr<CacheDirectory> cacheDirectory,
+                                   const SyncName &name /*= Str("testFile")*/) {
     if (!cacheDirectory) {
-        LOG_WARN(_logger, "Cache directory not provided!");
-        return IoError::InvalidArgument;
+        LOG_WARN(logger(), "Cache directory not provided!");
+        return {ExitCode::SystemError, ExitCause::InvalidArgument};
     }
 
-    SyncPath tmpPath = cacheDirectory->path() / name;
+    SyncPath cacheDirectoryPath;
+    if (const auto exitInfo = cacheDirectory->path(cacheDirectoryPath); !exitInfo) {
+        return exitInfo;
+    }
+    SyncPath tmpPath = cacheDirectoryPath / name;
     uint64_t retries = 0;
     bool ok = false;
     do {
         bool exists = false;
-        auto ioError = IoError::Unknown;
         // Check if item already exist (it should not exist at this point)
-        if (!IoHelper::checkIfPathExists(tmpPath, exists, ioError, IoHelper::PathCheckOption::Insensitive)) {
-            LOGW_WARN(_logger, L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(tmpPath, ioError));
-            return ioError;
+        if (auto ioError = IoError::Unknown;
+            !IoHelper::checkIfPathExists(tmpPath, exists, ioError, IoHelper::PathCheckOption::Insensitive)) {
+            LOGW_WARN(logger(), L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(tmpPath, ioError));
+            return {ExitCode::SystemError, ioError == IoError::AccessDenied ? ExitCause::TmpDirAccessError : ExitCause::Unknown};
         }
         if (exists) {
             retries++;
             // Retry with a random suffix added to item name
-            tmpPath = cacheDirectory->path() / (name + Str2SyncName(CommonUtility::generateRandomStringAlphaNum()));
+            tmpPath = cacheDirectoryPath / (name + Str2SyncName(CommonUtility::generateRandomStringAlphaNum()));
             continue;
         }
 
-        std::ofstream output = std::ofstream(tmpPath.native().c_str(), std::ios::binary);
+        auto output = std::ofstream(tmpPath.native().c_str(), std::ios::binary);
         if (!output) {
-            bool read = false;
-            bool write = false;
-            bool exec = false;
-            if (!IoHelper::getRights(cacheDirectory->path(), read, write, exec, ioError)) {
-                return ioError;
-            }
-            if (!read || !write) {
-                return IoError::AccessDenied;
-            }
+            if (const auto exitInfo = checkTmpDirectoryRights(cacheDirectoryPath); !exitInfo) return exitInfo;
 
             retries++;
             // Retry with a random suffix added to item name
-            tmpPath = cacheDirectory->path() / (name + Str2SyncName(CommonUtility::generateRandomStringAlphaNum()));
+            tmpPath = cacheDirectoryPath / (name + Str2SyncName(CommonUtility::generateRandomStringAlphaNum()));
             continue;
         }
         output.close();
 
         // Check again if item already exist (it should exist at this point)
-        if (!IoHelper::checkIfPathExists(tmpPath, exists, ioError, IoHelper::PathCheckOption::Insensitive)) {
-            LOGW_WARN(_logger, L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(tmpPath, ioError));
-            return ioError;
+        if (auto ioError = IoError::Unknown;
+            !IoHelper::checkIfPathExists(tmpPath, exists, ioError, IoHelper::PathCheckOption::Insensitive)) {
+            LOGW_WARN(logger(), L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(tmpPath, ioError));
+            return {ExitCode::SystemError, ioError == IoError::AccessDenied ? ExitCause::TmpDirAccessError : ExitCause::Unknown};
         }
         if (!exists) {
             retries++;
             // Retry with a random suffix added to item name
-            tmpPath = cacheDirectory->path() / (name + Str2SyncName(CommonUtility::generateRandomStringAlphaNum()));
+            tmpPath = cacheDirectoryPath / (name + Str2SyncName(CommonUtility::generateRandomStringAlphaNum()));
             continue;
         }
         ok = true;
@@ -675,7 +689,7 @@ IoError Utility::tryCreateTmpFile(const std::shared_ptr<CacheDirectory> cacheDir
 
     auto ioError = IoError::Unknown;
     (void) IoHelper::deleteItem(tmpPath, ioError);
-    return ioError;
+    return ExitCode::Ok;
 }
 
 void Utility::msleep(const int64_t msec) {

--- a/src/libcommonserver/utility/utility.cpp
+++ b/src/libcommonserver/utility/utility.cpp
@@ -627,7 +627,10 @@ ExitInfo checkTmpDirectoryRights(const SyncPath &path) {
     bool write = false;
     bool exec = false;
     if (auto ioError = IoError::Unknown; !IoHelper::getRights(path, read, write, exec, ioError)) {
-        return {ExitCode::SystemError, !read || !write ? ExitCause::TmpDirAccessError : ExitCause::Unknown};
+        return {ExitCode::SystemError};
+    }
+    if (!read || !write) {
+        return {ExitCode::SystemError, ExitCause::TmpDirAccessError};
     }
     return ExitCode::Ok;
 }
@@ -648,19 +651,6 @@ ExitInfo Utility::tryCreateTmpFile(const std::shared_ptr<CacheDirectory> cacheDi
     bool ok = false;
     do {
         bool exists = false;
-        // Check if item already exist (it should not exist at this point)
-        if (auto ioError = IoError::Unknown;
-            !IoHelper::checkIfPathExists(tmpPath, exists, ioError, IoHelper::PathCheckOption::Insensitive)) {
-            LOGW_WARN(logger(), L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(tmpPath, ioError));
-            return {ExitCode::SystemError, ioError == IoError::AccessDenied ? ExitCause::TmpDirAccessError : ExitCause::Unknown};
-        }
-        if (exists) {
-            retries++;
-            // Retry with a random suffix added to item name
-            tmpPath = cacheDirectoryPath / (name + Str2SyncName(CommonUtility::generateRandomStringAlphaNum()));
-            continue;
-        }
-
         auto output = std::ofstream(tmpPath.native().c_str(), std::ios::binary);
         if (!output) {
             if (const auto exitInfo = checkTmpDirectoryRights(cacheDirectoryPath); !exitInfo) return exitInfo;
@@ -672,7 +662,7 @@ ExitInfo Utility::tryCreateTmpFile(const std::shared_ptr<CacheDirectory> cacheDi
         }
         output.close();
 
-        // Check again if item already exist (it should exist at this point)
+        // Check if item already exist (it should exist at this point)
         if (auto ioError = IoError::Unknown;
             !IoHelper::checkIfPathExists(tmpPath, exists, ioError, IoHelper::PathCheckOption::Insensitive)) {
             LOGW_WARN(logger(), L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(tmpPath, ioError));

--- a/src/libcommonserver/utility/utility.cpp
+++ b/src/libcommonserver/utility/utility.cpp
@@ -585,7 +585,7 @@ IoError Utility::tryCreateTmpDir(const std::shared_ptr<CacheDirectory> cacheDire
 #if defined(KD_MACOS)
     if (!cacheDirectory) {
         LOG_WARN(_logger, "Cache directory not provided!");
-        return IoError::NoSuchFileOrDirectory;
+        return IoError::InvalidArgument;
     }
 
     SyncPath tmpPath = cacheDirectory->path() / name;
@@ -619,7 +619,7 @@ IoError Utility::tryCreateTmpFile(const std::shared_ptr<CacheDirectory> cacheDir
                                   const SyncName &name /*= Str("testFile")*/) {
     if (!cacheDirectory) {
         LOG_WARN(_logger, "Cache directory not provided!");
-        return IoError::NoSuchFileOrDirectory;
+        return IoError::InvalidArgument;
     }
 
     SyncPath tmpPath = cacheDirectory->path() / name;

--- a/src/libcommonserver/utility/utility.cpp
+++ b/src/libcommonserver/utility/utility.cpp
@@ -580,14 +580,15 @@ bool Utility::isError500(const Poco::Net::HTTPResponse::HTTPStatus httpErrorCode
 }
 
 static constexpr uint64_t maxNbCreationTmpFolderRetries = 3;
-IoError Utility::tryCreateTmpDir(const SyncName &name /*= Str("testDir")*/) {
+IoError Utility::tryCreateTmpDir(const std::shared_ptr<CacheDirectory> cacheDirectory,
+                                 const SyncName &name /*= Str("testDir")*/) {
 #if defined(KD_MACOS)
-    SyncPath tmpDirPath;
-    if (auto ioError = IoError::Unknown; !IoHelper::appTempDirectoryPath(tmpDirPath, ioError)) {
-        return ioError;
+    if (!cacheDirectory) {
+        LOG_WARN(_logger, "Cache directory not provided!");
+        return IoError::NoSuchFileOrDirectory;
     }
 
-    SyncPath tmpPath = tmpDirPath / name;
+    SyncPath tmpPath = cacheDirectory->path() / name;
     std::error_code ec;
     uint64_t retries = 0;
     bool directoryCreated = false;
@@ -599,7 +600,7 @@ IoError Utility::tryCreateTmpDir(const SyncName &name /*= Str("testDir")*/) {
             }
             retries++;
             // Retry with a random suffix added to item name
-            tmpPath = tmpDirPath / (name + CommonUtility::generateRandomStringAlphaNum());
+            tmpPath = cacheDirectory->path() / (name + CommonUtility::generateRandomStringAlphaNum());
         }
     } while ((!directoryCreated || ec.value()) && retries < maxNbCreationTmpFolderRetries);
 
@@ -614,13 +615,14 @@ IoError Utility::tryCreateTmpDir(const SyncName &name /*= Str("testDir")*/) {
 #endif
 }
 
-IoError Utility::tryCreateTmpFile(const SyncName &name /*= Str("testFile")*/) {
-    SyncPath tmpDirPath;
-    if (auto ioError = IoError::Unknown; !IoHelper::appTempDirectoryPath(tmpDirPath, ioError)) {
-        return ioError;
+IoError Utility::tryCreateTmpFile(const std::shared_ptr<CacheDirectory> cacheDirectory,
+                                  const SyncName &name /*= Str("testFile")*/) {
+    if (!cacheDirectory) {
+        LOG_WARN(_logger, "Cache directory not provided!");
+        return IoError::NoSuchFileOrDirectory;
     }
 
-    SyncPath tmpPath = tmpDirPath / name;
+    SyncPath tmpPath = cacheDirectory->path() / name;
     uint64_t retries = 0;
     bool ok = false;
     do {
@@ -634,7 +636,7 @@ IoError Utility::tryCreateTmpFile(const SyncName &name /*= Str("testFile")*/) {
         if (exists) {
             retries++;
             // Retry with a random suffix added to item name
-            tmpPath = tmpDirPath / (name + Str2SyncName(CommonUtility::generateRandomStringAlphaNum()));
+            tmpPath = cacheDirectory->path() / (name + Str2SyncName(CommonUtility::generateRandomStringAlphaNum()));
             continue;
         }
 
@@ -643,7 +645,7 @@ IoError Utility::tryCreateTmpFile(const SyncName &name /*= Str("testFile")*/) {
             bool read = false;
             bool write = false;
             bool exec = false;
-            if (!IoHelper::getRights(tmpDirPath, read, write, exec, ioError)) {
+            if (!IoHelper::getRights(cacheDirectory->path(), read, write, exec, ioError)) {
                 return ioError;
             }
             if (!read || !write) {
@@ -652,7 +654,7 @@ IoError Utility::tryCreateTmpFile(const SyncName &name /*= Str("testFile")*/) {
 
             retries++;
             // Retry with a random suffix added to item name
-            tmpPath = tmpDirPath / (name + Str2SyncName(CommonUtility::generateRandomStringAlphaNum()));
+            tmpPath = cacheDirectory->path() / (name + Str2SyncName(CommonUtility::generateRandomStringAlphaNum()));
             continue;
         }
         output.close();
@@ -665,7 +667,7 @@ IoError Utility::tryCreateTmpFile(const SyncName &name /*= Str("testFile")*/) {
         if (!exists) {
             retries++;
             // Retry with a random suffix added to item name
-            tmpPath = tmpDirPath / (name + Str2SyncName(CommonUtility::generateRandomStringAlphaNum()));
+            tmpPath = cacheDirectory->path() / (name + Str2SyncName(CommonUtility::generateRandomStringAlphaNum()));
             continue;
         }
         ok = true;

--- a/src/libcommonserver/utility/utility.cpp
+++ b/src/libcommonserver/utility/utility.cpp
@@ -622,6 +622,7 @@ ExitInfo Utility::tryCreateTmpDir(const std::shared_ptr<CacheDirectory> cacheDir
     return ExitCode::Ok;
 }
 
+namespace {
 ExitInfo checkTmpDirectoryRights(const SyncPath &path) {
     bool read = false;
     bool write = false;
@@ -634,6 +635,7 @@ ExitInfo checkTmpDirectoryRights(const SyncPath &path) {
     }
     return ExitCode::Ok;
 }
+} // namespace
 
 ExitInfo Utility::tryCreateTmpFile(const std::shared_ptr<CacheDirectory> cacheDirectory,
                                    const SyncName &name /*= Str("testFile")*/) {
@@ -679,7 +681,7 @@ ExitInfo Utility::tryCreateTmpFile(const std::shared_ptr<CacheDirectory> cacheDi
 
     auto ioError = IoError::Unknown;
     (void) IoHelper::deleteItem(tmpPath, ioError);
-    return ExitCode::Ok;
+    return ok ? ExitCode::Ok : ExitCode::SystemError;
 }
 
 void Utility::msleep(const int64_t msec) {

--- a/src/libcommonserver/utility/utility.h
+++ b/src/libcommonserver/utility/utility.h
@@ -189,15 +189,15 @@ struct COMMONSERVER_EXPORT Utility {
         /**
          * @brief Check if a directory can be created in the temp directory.
          * @param name the name of the directory to create.
-         * @return IoError
+         * @return ExitInfo
          */
-        static IoError tryCreateTmpDir(std::shared_ptr<CacheDirectory> cacheDirectory, const SyncName &name = Str("testDir"));
+        static ExitInfo tryCreateTmpDir(std::shared_ptr<CacheDirectory> cacheDirectory, const SyncName &name = Str("testDir"));
         /**
          * @brief Check if a file can be created in the temp directory.
          * @param name the name of the file to create.
-         * @return IoError
+         * @return ExitInfo
          */
-        static IoError tryCreateTmpFile(std::shared_ptr<CacheDirectory> cacheDirectory, const SyncName &name = Str("testFile"));
+        static ExitInfo tryCreateTmpFile(std::shared_ptr<CacheDirectory> cacheDirectory, const SyncName &name = Str("testFile"));
 
         static void msleep(int64_t msec);
 

--- a/src/libcommonserver/utility/utility.h
+++ b/src/libcommonserver/utility/utility.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include "io/cachedirectory.h"
 #include "libcommonserver/commonserverlib.h"
 #include "libcommonserver/db/dbdefs.h"
 #include "libcommonserver/log/log.h"
@@ -190,13 +191,13 @@ struct COMMONSERVER_EXPORT Utility {
          * @param name the name of the directory to create.
          * @return IoError
          */
-        static IoError tryCreateTmpDir(const SyncName &name = Str("testDir"));
+        static IoError tryCreateTmpDir(std::shared_ptr<CacheDirectory> cacheDirectory, const SyncName &name = Str("testDir"));
         /**
          * @brief Check if a file can be created in the temp directory.
          * @param name the name of the file to create.
          * @return IoError
          */
-        static IoError tryCreateTmpFile(const SyncName &name = Str("testFile"));
+        static IoError tryCreateTmpFile(std::shared_ptr<CacheDirectory> cacheDirectory, const SyncName &name = Str("testFile"));
 
         static void msleep(int64_t msec);
 

--- a/src/libsyncengine/CMakeLists.txt
+++ b/src/libsyncengine/CMakeLists.txt
@@ -142,6 +142,7 @@ set(syncengine_SRCS
     syncpal/excludelistpropagator.h syncpal/excludelistpropagator.cpp
     syncpal/tmpblacklistmanager.h syncpal/tmpblacklistmanager.cpp
     syncpal/conflictingfilescorrector.h syncpal/conflictingfilescorrector.cpp
+    syncpal/cachedirectory.h syncpal/cachedirectory.cpp
     # Progress Dispatcher
     progress/estimates.h
     progress/progressitem.h

--- a/src/libsyncengine/CMakeLists.txt
+++ b/src/libsyncengine/CMakeLists.txt
@@ -142,7 +142,6 @@ set(syncengine_SRCS
     syncpal/excludelistpropagator.h syncpal/excludelistpropagator.cpp
     syncpal/tmpblacklistmanager.h syncpal/tmpblacklistmanager.cpp
     syncpal/conflictingfilescorrector.h syncpal/conflictingfilescorrector.cpp
-    syncpal/cachedirectory.h syncpal/cachedirectory.cpp
     # Progress Dispatcher
     progress/estimates.h
     progress/progressitem.h

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
@@ -585,7 +585,7 @@ ExitInfo DownloadJob::createTmpFile(std::optional<std::reference_wrapper<std::is
 
     std::ofstream output;
     do {
-        const std::string tmpFileName = "kdrive_" + CommonUtility::generateRandomStringAlphaNum();
+        const std::string tmpFileName = CacheDirectory::createTmpFileName();
         _tmpPath = cacheDirectoryPath / tmpFileName;
 
         output.open(_tmpPath.native().c_str(), std::ofstream::out | std::ofstream::binary);

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
@@ -29,8 +29,6 @@
 #include <unistd.h>
 #endif
 
-#include "../../../../libcommonserver/io/cachedirectory.h"
-
 #include "utility/timerutility.h"
 
 #include <fstream>
@@ -47,9 +45,10 @@ namespace KDC {
 #define READ_RETRIES 10
 #define READ_RETRIES_NETWORK_LOST 100
 
-DownloadJob::DownloadJob(const std::shared_ptr<Vfs> vfs, const SyncPath &localSyncFolder, const DriveDbId driveDbId,
-                         const NodeId &remoteFileId, const SyncPath &localpath, const int64_t expectedSize,
-                         const SyncTime creationTime, const SyncTime modificationTime, const bool isCreate) :
+DownloadJob::DownloadJob(const std::shared_ptr<Vfs> vfs, const std::shared_ptr<CacheDirectory> cacheDirectory,
+                         const DriveDbId driveDbId, const NodeId &remoteFileId, const SyncPath &localpath,
+                         const int64_t expectedSize, const SyncTime creationTime /*= 0*/, const SyncTime modificationTime /*= 0*/,
+                         const bool isCreate /*= false*/) :
     AbstractTokenNetworkJob(ApiType::Drive, 0, 0, driveDbId, 0, false),
     _remoteFileId(remoteFileId),
     _localpath(localpath),
@@ -58,24 +57,15 @@ DownloadJob::DownloadJob(const std::shared_ptr<Vfs> vfs, const SyncPath &localSy
     _modificationTimeIn(modificationTime),
     _isCreate(isCreate),
     _vfs(vfs),
-    _localSyncFolder(localSyncFolder) {
+    _cacheDirectory(cacheDirectory) {
     _httpMethod = Poco::Net::HTTPRequest::HTTP_GET;
     _customTimeout = 60;
     _trials = TRIALS;
-}
 
-DownloadJob::DownloadJob(const std::shared_ptr<Vfs> vfs, const SyncPath &localSyncFolder, const DriveDbId driveDbId,
-                         const NodeId &remoteFileId, const SyncPath &localpath, const int64_t expectedSize) :
-    AbstractTokenNetworkJob(ApiType::Drive, 0, 0, driveDbId, 0, false),
-    _remoteFileId(remoteFileId),
-    _localpath(localpath),
-    _expectedSize(expectedSize),
-    _ignoreDateTime(true),
-    _vfs(vfs),
-    _localSyncFolder(localSyncFolder) {
-    _httpMethod = Poco::Net::HTTPRequest::HTTP_GET;
-    _customTimeout = 60;
-    _trials = TRIALS;
+    if (!_cacheDirectory) {
+        // If no cache directory have been provided, fallback to creating a temporary cache directory into parent folder.
+        _cacheDirectory = std::make_shared<CacheDirectory>(localpath.parent_path());
+    }
 }
 
 DownloadJob::~DownloadJob() {
@@ -573,11 +563,10 @@ ExitInfo DownloadJob::createTmpFile(std::optional<std::reference_wrapper<std::is
     fetchFinished = false;
     fetchError = false;
 
-    CacheDirectory cacheDirectory(_localSyncFolder);
     std::ofstream output;
     do {
         const std::string tmpFileName = "kdrive_" + CommonUtility::generateRandomStringAlphaNum();
-        _tmpPath = cacheDirectory.path() / tmpFileName;
+        _tmpPath = _cacheDirectory->path() / tmpFileName;
 
         output.open(_tmpPath.native().c_str(), std::ofstream::out | std::ofstream::binary);
         if (!output.is_open()) {

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
@@ -578,14 +578,14 @@ ExitInfo DownloadJob::createTmpFile(std::optional<std::reference_wrapper<std::is
     fetchFinished = false;
     fetchError = false;
 
+    SyncPath cacheDirectoryPath;
+    if (const auto exitInfo = _cacheDirectory->path(cacheDirectoryPath); !exitInfo) {
+        return exitInfo;
+    }
+
     std::ofstream output;
     do {
         const std::string tmpFileName = "kdrive_" + CommonUtility::generateRandomStringAlphaNum();
-
-        SyncPath cacheDirectoryPath;
-        if (const auto exitInfo = _cacheDirectory->path(cacheDirectoryPath); !exitInfo) {
-            return exitInfo;
-        }
         _tmpPath = cacheDirectoryPath / tmpFileName;
 
         output.open(_tmpPath.native().c_str(), std::ofstream::out | std::ofstream::binary);

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
@@ -581,7 +581,12 @@ ExitInfo DownloadJob::createTmpFile(std::optional<std::reference_wrapper<std::is
     std::ofstream output;
     do {
         const std::string tmpFileName = "kdrive_" + CommonUtility::generateRandomStringAlphaNum();
-        _tmpPath = _cacheDirectory->path() / tmpFileName;
+
+        SyncPath cacheDirectoryPath;
+        if (const auto exitInfo = _cacheDirectory->path(cacheDirectoryPath); !exitInfo) {
+            return exitInfo;
+        }
+        _tmpPath = cacheDirectoryPath / tmpFileName;
 
         output.open(_tmpPath.native().c_str(), std::ofstream::out | std::ofstream::binary);
         if (!output.is_open()) {

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
@@ -29,6 +29,8 @@
 #include <unistd.h>
 #endif
 
+#include "../../../../libcommonserver/io/cachedirectory.h"
+
 #include "utility/timerutility.h"
 
 #include <fstream>
@@ -45,9 +47,9 @@ namespace KDC {
 #define READ_RETRIES 10
 #define READ_RETRIES_NETWORK_LOST 100
 
-DownloadJob::DownloadJob(const std::shared_ptr<Vfs> vfs, const DriveDbId driveDbId, const NodeId &remoteFileId,
-                         const SyncPath &localpath, const int64_t expectedSize, const SyncTime creationTime,
-                         const SyncTime modificationTime, const bool isCreate) :
+DownloadJob::DownloadJob(const std::shared_ptr<Vfs> vfs, const SyncPath &localSyncFolder, const DriveDbId driveDbId,
+                         const NodeId &remoteFileId, const SyncPath &localpath, const int64_t expectedSize,
+                         const SyncTime creationTime, const SyncTime modificationTime, const bool isCreate) :
     AbstractTokenNetworkJob(ApiType::Drive, 0, 0, driveDbId, 0, false),
     _remoteFileId(remoteFileId),
     _localpath(localpath),
@@ -55,20 +57,22 @@ DownloadJob::DownloadJob(const std::shared_ptr<Vfs> vfs, const DriveDbId driveDb
     _creationTimeIn(creationTime),
     _modificationTimeIn(modificationTime),
     _isCreate(isCreate),
-    _vfs(vfs) {
+    _vfs(vfs),
+    _localSyncFolder(localSyncFolder) {
     _httpMethod = Poco::Net::HTTPRequest::HTTP_GET;
     _customTimeout = 60;
     _trials = TRIALS;
 }
 
-DownloadJob::DownloadJob(const std::shared_ptr<Vfs> vfs, const DriveDbId driveDbId, const NodeId &remoteFileId,
-                         const SyncPath &localpath, int64_t expectedSize) :
+DownloadJob::DownloadJob(const std::shared_ptr<Vfs> vfs, const SyncPath &localSyncFolder, const DriveDbId driveDbId,
+                         const NodeId &remoteFileId, const SyncPath &localpath, const int64_t expectedSize) :
     AbstractTokenNetworkJob(ApiType::Drive, 0, 0, driveDbId, 0, false),
     _remoteFileId(remoteFileId),
     _localpath(localpath),
     _expectedSize(expectedSize),
     _ignoreDateTime(true),
-    _vfs(vfs) {
+    _vfs(vfs),
+    _localSyncFolder(localSyncFolder) {
     _httpMethod = Poco::Net::HTTPRequest::HTTP_GET;
     _customTimeout = 60;
     _trials = TRIALS;
@@ -569,16 +573,11 @@ ExitInfo DownloadJob::createTmpFile(std::optional<std::reference_wrapper<std::is
     fetchFinished = false;
     fetchError = false;
 
-    SyncPath cacheDirectoryPath;
-    if (!IoHelper::cacheDirectoryPath(cacheDirectoryPath)) {
-        LOGW_WARN(_logger, L"Failed to get cache directory");
-        return {ExitCode::SystemError, ExitCause::TmpDirAccessError};
-    }
-
+    CacheDirectory cacheDirectory(_localSyncFolder);
     std::ofstream output;
     do {
         const std::string tmpFileName = "kdrive_" + CommonUtility::generateRandomStringAlphaNum();
-        _tmpPath = cacheDirectoryPath / tmpFileName;
+        _tmpPath = cacheDirectory.path() / tmpFileName;
 
         output.open(_tmpPath.native().c_str(), std::ofstream::out | std::ofstream::binary);
         if (!output.is_open()) {

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
@@ -144,7 +144,7 @@ ExitInfo DownloadJob::runJob() noexcept {
     if (!_fileDownloadInfo.isCreate && _vfs) {
         // Get hydration status
         VfsStatus vfsStatus;
-        _vfs->status(_fileDownloadInfo.localpath, vfsStatus);
+        (void) _vfs->status(_fileDownloadInfo.localpath, vfsStatus);
         _isHydrated = vfsStatus.isHydrated;
 
         // Update size on file system
@@ -465,7 +465,7 @@ ExitInfo DownloadJob::moveTmpFile() {
 
             // Move file
             IoError ioError = IoError::Success;
-            IoHelper::moveItem(_tmpPath, _fileDownloadInfo.localpath, ioError);
+            (void) IoHelper::moveItem(_tmpPath, _fileDownloadInfo.localpath, ioError);
             crossDeviceLinkError = ioError == IoError::CrossDeviceLink; // Unable to move between 2 distinct file systems
             if (ioError != IoError::Success && !crossDeviceLinkError) {
                 LOGW_WARN(_logger, L"Failed to move downloaded file " << Utility::formatSyncPath(_tmpPath) << L" to "

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
@@ -45,26 +45,19 @@ namespace KDC {
 #define READ_RETRIES 10
 #define READ_RETRIES_NETWORK_LOST 100
 
-DownloadJob::DownloadJob(const std::shared_ptr<Vfs> vfs, const std::shared_ptr<CacheDirectory> cacheDirectory,
-                         const DriveDbId driveDbId, const NodeId &remoteFileId, const SyncPath &localpath,
-                         const int64_t expectedSize, const SyncTime creationTime /*= 0*/, const SyncTime modificationTime /*= 0*/,
-                         const bool isCreate /*= false*/) :
-    AbstractTokenNetworkJob(ApiType::Drive, 0, 0, driveDbId, 0, false),
-    _remoteFileId(remoteFileId),
-    _localpath(localpath),
-    _expectedSize(expectedSize),
-    _creationTimeIn(creationTime),
-    _modificationTimeIn(modificationTime),
-    _isCreate(isCreate),
+DownloadJob::DownloadJob(const std::shared_ptr<Vfs> vfs, std::shared_ptr<CacheDirectory> cacheDirectory,
+                         const FileDownloadInfo &fileDownloadInfo) :
+    AbstractTokenNetworkJob(ApiType::Drive, 0, 0, fileDownloadInfo.driveDbId, 0, false),
     _vfs(vfs),
-    _cacheDirectory(cacheDirectory) {
+    _cacheDirectory(cacheDirectory),
+    _fileDownloadInfo(fileDownloadInfo) {
     _httpMethod = Poco::Net::HTTPRequest::HTTP_GET;
     _customTimeout = 60;
     _trials = TRIALS;
 
     if (!_cacheDirectory) {
         // If no cache directory have been provided, fallback to creating a temporary cache directory into parent folder.
-        _cacheDirectory = std::make_shared<CacheDirectory>(localpath.parent_path());
+        _cacheDirectory = std::make_shared<CacheDirectory>(_fileDownloadInfo.localpath.parent_path());
     }
 }
 
@@ -72,35 +65,41 @@ DownloadJob::~DownloadJob() {
     // Remove tmp file
     // For a remote CREATE operation, the tmp file should no longer exist, but if an error occurred in handleResponse, it must
     // be deleted.
-    if (!removeTmpFile() && !_isCreate) {
+    if (!removeTmpFile() && !_fileDownloadInfo.isCreate) {
         LOGW_WARN(_logger, L"Failed to remove tmp file: " << Utility::formatSyncPath(_tmpPath));
     }
 
     if (!_vfs) return;
 
     // If the download job intent is to create a new local file, then there is no downloaded file after cancellation.
-    if (_responseHandlingCanceled && _isCreate) return;
+    if (_responseHandlingCanceled && _fileDownloadInfo.isCreate) return;
 
     if (_responseHandlingCanceled) {
-        if (const ExitInfo exitInfo = _vfs->setPinState(_localpath, PinState::OnlineOnly); !exitInfo) {
-            LOGW_WARN(_logger, L"Error in vfsSetPinState: " << Utility::formatSyncPath(_localpath) << L": " << exitInfo);
+        if (const ExitInfo exitInfo = _vfs->setPinState(_fileDownloadInfo.localpath, PinState::OnlineOnly); !exitInfo) {
+            LOGW_WARN(_logger,
+                      L"Error in vfsSetPinState: " << Utility::formatSyncPath(_fileDownloadInfo.localpath) << L": " << exitInfo);
         }
 
-        if (const ExitInfo exitInfo = _vfs->forceStatus(_localpath, VfsStatus()); !exitInfo) {
-            LOGW_WARN(_logger, L"Error in vfsForceStatus: " << Utility::formatSyncPath(_localpath) << L": " << exitInfo);
+        if (const ExitInfo exitInfo = _vfs->forceStatus(_fileDownloadInfo.localpath, VfsStatus()); !exitInfo) {
+            LOGW_WARN(_logger,
+                      L"Error in vfsForceStatus: " << Utility::formatSyncPath(_fileDownloadInfo.localpath) << L": " << exitInfo);
         }
 
-        _vfs->cancelHydrate(_localpath);
+        _vfs->cancelHydrate(_fileDownloadInfo.localpath);
     } else {
-        if (const ExitInfo res = _vfs->setPinState(
-                    _localpath, exitInfo().code() == ExitCode::Ok ? PinState::AlwaysLocal : PinState::OnlineOnly);
+        if (const ExitInfo res =
+                    _vfs->setPinState(_fileDownloadInfo.localpath,
+                                      exitInfo().code() == ExitCode::Ok ? PinState::AlwaysLocal : PinState::OnlineOnly);
             !res) {
-            LOGW_WARN(_logger, L"Error in vfsSetPinState: " << Utility::formatSyncPath(_localpath) << L": " << res);
+            LOGW_WARN(_logger,
+                      L"Error in vfsSetPinState: " << Utility::formatSyncPath(_fileDownloadInfo.localpath) << L": " << res);
         }
 
-        if (const ExitInfo res = _vfs->forceStatus(_localpath, VfsStatus({.isHydrated = exitInfo().code() == ExitCode::Ok}));
+        if (const ExitInfo res =
+                    _vfs->forceStatus(_fileDownloadInfo.localpath, VfsStatus({.isHydrated = exitInfo().code() == ExitCode::Ok}));
             !res) {
-            LOGW_WARN(_logger, L"Error in vfsForceStatus: " << Utility::formatSyncPath(_localpath) << L": " << res);
+            LOGW_WARN(_logger,
+                      L"Error in vfsForceStatus: " << Utility::formatSyncPath(_fileDownloadInfo.localpath) << L": " << res);
         }
     }
 }
@@ -108,12 +107,17 @@ DownloadJob::~DownloadJob() {
 std::string DownloadJob::getSpecificUrl() {
     std::string str = AbstractTokenNetworkJob::getSpecificUrl();
     str += "/files/";
-    str += _remoteFileId;
+    str += _fileDownloadInfo.remoteFileId;
     str += "/download";
     return str;
 }
 
 ExitInfo DownloadJob::canRun() {
+    if (_fileDownloadInfo.remoteFileId.empty() || _fileDownloadInfo.localpath.empty()) {
+        LOG_WARN(_logger, "Missing mandatory inputs! ");
+        return ExitCode::LogicError;
+    }
+
     if (bypassCheck()) {
         return ExitCode::Ok;
     }
@@ -121,13 +125,14 @@ ExitInfo DownloadJob::canRun() {
     // Check that we can create the item here
     bool exists = false;
     IoError ioError = IoError::Success;
-    if (!IoHelper::checkIfPathExists(_localpath, exists, ioError, IoHelper::PathCheckOption::Insensitive)) {
-        LOGW_WARN(_logger, L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(_localpath, ioError));
+    if (!IoHelper::checkIfPathExists(_fileDownloadInfo.localpath, exists, ioError, IoHelper::PathCheckOption::Insensitive)) {
+        LOGW_WARN(_logger,
+                  L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(_fileDownloadInfo.localpath, ioError));
         return {ExitCode::SystemError, ExitCause::FileAccessError};
     }
 
-    if (_isCreate && exists) {
-        LOGW_DEBUG(_logger, L"Item with " << Utility::formatSyncPath(_localpath)
+    if (_fileDownloadInfo.isCreate && exists) {
+        LOGW_DEBUG(_logger, L"Item with " << Utility::formatSyncPath(_fileDownloadInfo.localpath)
                                           << L" already exists. Aborting current sync and restarting.");
         return {ExitCode::DataError, ExitCause::FileExists};
     }
@@ -136,36 +141,40 @@ ExitInfo DownloadJob::canRun() {
 }
 
 ExitInfo DownloadJob::runJob() noexcept {
-    if (!_isCreate && _vfs) {
+    if (!_fileDownloadInfo.isCreate && _vfs) {
         // Get hydration status
         VfsStatus vfsStatus;
-        _vfs->status(_localpath, vfsStatus);
+        _vfs->status(_fileDownloadInfo.localpath, vfsStatus);
         _isHydrated = vfsStatus.isHydrated;
 
         // Update size on file system
         FileStat filestat;
         IoError ioError = IoError::Success;
-        if (!IoHelper::getFileStat(_localpath, &filestat, ioError, IoHelper::PathCheckOption::Insensitive)) {
-            LOGW_WARN(_logger, L"Error in IoHelper::getFileStat: " << Utility::formatIoError(_localpath, ioError));
+        if (!IoHelper::getFileStat(_fileDownloadInfo.localpath, &filestat, ioError, IoHelper::PathCheckOption::Insensitive)) {
+            LOGW_WARN(_logger,
+                      L"Error in IoHelper::getFileStat: " << Utility::formatIoError(_fileDownloadInfo.localpath, ioError));
             return ExitCode::SystemError;
         }
         if (ioError == IoError::NoSuchFileOrDirectory) {
-            LOGW_WARN(_logger, L"Item does not exist anymore: " << Utility::formatSyncPath(_localpath));
+            LOGW_WARN(_logger, L"Item does not exist anymore: " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
             return {ExitCode::SystemError, ExitCause::NotFound};
         } else if (ioError == IoError::AccessDenied) {
-            LOGW_WARN(_logger, L"Item misses search permission: " << Utility::formatSyncPath(_localpath));
+            LOGW_WARN(_logger, L"Item misses search permission: " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
             return {ExitCode::SystemError, ExitCause::FileAccessError};
         }
 
-        if (const ExitInfo exitInfo = _vfs->updateMetadata(_localpath, filestat.creationTime, filestat.modificationTime,
-                                                           _expectedSize, std::to_string(filestat.inode));
+        if (const ExitInfo exitInfo =
+                    _vfs->updateMetadata(_fileDownloadInfo.localpath, filestat.creationTime, filestat.modificationTime,
+                                         _fileDownloadInfo.expectedSize, std::to_string(filestat.inode));
             !exitInfo) {
-            LOGW_WARN(_logger, L"Update metadata failed " << exitInfo << L" " << Utility::formatSyncPath(_localpath));
+            LOGW_WARN(_logger,
+                      L"Update metadata failed " << exitInfo << L" " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
             return exitInfo;
         }
 
-        if (const ExitInfo exitInfo = _vfs->forceStatus(_localpath, VfsStatus({.isSyncing = true})); !exitInfo) {
-            LOGW_WARN(_logger, L"Error in vfsForceStatus: " << Utility::formatSyncPath(_localpath) << L": " << exitInfo);
+        if (const ExitInfo exitInfo = _vfs->forceStatus(_fileDownloadInfo.localpath, VfsStatus({.isSyncing = true})); !exitInfo) {
+            LOGW_WARN(_logger,
+                      L"Error in vfsForceStatus: " << Utility::formatSyncPath(_fileDownloadInfo.localpath) << L": " << exitInfo);
             return exitInfo;
         }
     }
@@ -218,16 +227,17 @@ ExitInfo DownloadJob::handleResponse(std::istream &is) {
         if (!_responseHandlingCanceled) {
             if (_vfs && !_isHydrated && !fetchFinished) { // updateFetchStatus is used only for hydration.
                 // Update fetch status
-                if (ExitInfo exitInfo =
-                            _vfs->updateFetchStatus(_tmpPath, _localpath, getProgress(), fetchCanceled, fetchFinished);
+                if (ExitInfo exitInfo = _vfs->updateFetchStatus(_tmpPath, _fileDownloadInfo.localpath, getProgress(),
+                                                                fetchCanceled, fetchFinished);
                     !exitInfo) {
-                    LOGW_WARN(_logger,
-                              L"Error in vfsUpdateFetchStatus: " << Utility::formatSyncPath(_localpath) << L" : " << exitInfo);
+                    LOGW_WARN(_logger, L"Error in vfsUpdateFetchStatus: " << Utility::formatSyncPath(_fileDownloadInfo.localpath)
+                                                                          << L" : " << exitInfo);
                     fetchError = true;
                 } else if (fetchCanceled) {
-                    LOGW_WARN(_logger, L"Update fetch status canceled: " << Utility::formatSyncPath(_localpath));
+                    LOGW_WARN(_logger, L"Update fetch status canceled: " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
                 } else if (!fetchFinished) {
-                    LOGW_WARN(_logger, L"Update fetch status not terminated: " << Utility::formatSyncPath(_localpath));
+                    LOGW_WARN(_logger,
+                              L"Update fetch status not terminated: " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
                 }
 
                 _responseHandlingCanceled = fetchCanceled || fetchError || (!fetchFinished);
@@ -254,7 +264,7 @@ ExitInfo DownloadJob::handleResponse(std::istream &is) {
                                httpResponse().getContentLength() == Poco::Net::HTTPMessage::UNKNOWN_CONTENT_LENGTH
                                        ? BUF_SIZE
                                        : (httpResponse().getContentLength() - getProgress());
-                       !hasEnoughPlace(_tmpPath, _localpath, neededPlace, _logger)) {
+                       !hasEnoughPlace(_tmpPath, _fileDownloadInfo.localpath, neededPlace, _logger)) {
                 return {ExitCode::SystemError, ExitCause::NotEnoughDiskSpace};
             } else {
                 return {ExitCode::SystemError, ExitCause::FileAccessError};
@@ -262,14 +272,15 @@ ExitInfo DownloadJob::handleResponse(std::istream &is) {
         }
     }
     if (!_ignoreDateTime) {
-        if (const IoError ioError = IoHelper::setFileDates(_localpath, _creationTimeIn, _modificationTimeIn, isLink);
+        if (const IoError ioError = IoHelper::setFileDates(_fileDownloadInfo.localpath, _fileDownloadInfo.creationTime,
+                                                           _fileDownloadInfo.modificationTime, isLink);
             ioError == IoError::Unknown) {
-            LOGW_WARN(_logger, L"Error in IoHelper::setFileDates: " << Utility::formatSyncPath(_localpath));
+            LOGW_WARN(_logger, L"Error in IoHelper::setFileDates: " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
             // Do nothing (remote file will be updated during the next sync)
             sentry::Handler::captureMessage(sentry::Level::Warning, "DownloadJob::handleResponse", "Unable to set file dates");
         } else if (ioError == IoError::NoSuchFileOrDirectory || ioError == IoError::AccessDenied) {
             LOGW_INFO(_logger, L"Item does not exist anymore or access is denied. Restarting sync: "
-                                       << Utility::formatSyncPath(_localpath));
+                                       << Utility::formatSyncPath(_fileDownloadInfo.localpath));
             return {ExitCode::DataError, ExitCause::InvalidSnapshot};
         }
     }
@@ -277,16 +288,16 @@ ExitInfo DownloadJob::handleResponse(std::istream &is) {
     // Retrieve inode
     FileStat filestat;
     IoError ioError = IoError::Success;
-    if (!IoHelper::getFileStat(_localpath, &filestat, ioError, IoHelper::PathCheckOption::Insensitive)) {
-        LOGW_WARN(_logger, L"Error in IoHelper::getFileStat: " << Utility::formatIoError(_localpath, ioError));
+    if (!IoHelper::getFileStat(_fileDownloadInfo.localpath, &filestat, ioError, IoHelper::PathCheckOption::Insensitive)) {
+        LOGW_WARN(_logger, L"Error in IoHelper::getFileStat: " << Utility::formatIoError(_fileDownloadInfo.localpath, ioError));
         return ExitCode::SystemError;
     }
 
     if (ioError == IoError::NoSuchFileOrDirectory) {
-        LOGW_WARN(_logger, L"Item does not exist anymore: " << Utility::formatSyncPath(_localpath));
+        LOGW_WARN(_logger, L"Item does not exist anymore: " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
         return {ExitCode::DataError, ExitCause::InvalidSnapshot};
     } else if (ioError == IoError::AccessDenied) {
-        LOGW_WARN(_logger, L"Item misses search permission: " << Utility::formatSyncPath(_localpath));
+        LOGW_WARN(_logger, L"Item misses search permission: " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
         return {ExitCode::SystemError, ExitCause::FileAccessError};
     }
 
@@ -295,21 +306,21 @@ ExitInfo DownloadJob::handleResponse(std::istream &is) {
     _modificationTimeOut = filestat.modificationTime;
     _sizeOut = filestat.size;
 #if defined(KD_MACOS) || defined(KD_WINDOWS)
-    if (_creationTimeIn != _creationTimeOut || _modificationTimeIn != _modificationTimeOut) {
+    if (_fileDownloadInfo.creationTime != _creationTimeOut || _fileDownloadInfo.modificationTime != _modificationTimeOut) {
         // In the following cases, it is not an issue:
         // - Windows: if creation/modification date = 0, it is set to current date
         // - macOS: if creation date > modification date, creation date is set to modification date
         LOGW_INFO(_logger, L"Impossible to set creation and/or modification time(s) on local file."
-                                   << L" Desired values: " << _creationTimeIn << L"/" << _modificationTimeIn << L" Set values: "
-                                   << _creationTimeOut << L"/" << _modificationTimeOut << L" for "
-                                   << Utility::formatSyncPath(_localpath));
+                                   << L" Desired values: " << _fileDownloadInfo.creationTime << L"/"
+                                   << _fileDownloadInfo.modificationTime << L" Set values: " << _creationTimeOut << L"/"
+                                   << _modificationTimeOut << L" for " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
     }
 #else
     // On Linux, the creation date cannot be set
-    if (_modificationTimeIn != _modificationTimeOut) {
+    if (_fileDownloadInfo.modificationTime != _modificationTimeOut) {
         LOGW_INFO(_logger, L"Impossible to set modification time on local file."
-                                   << L" Desired value: " << _modificationTimeIn << L" Set value: " << _modificationTimeOut
-                                   << L" for " << Utility::formatSyncPath(_localpath));
+                                   << L" Desired value: " << _fileDownloadInfo.modificationTime << L" Set value: "
+                                   << _modificationTimeOut << L" for " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
     }
 #endif
 
@@ -318,61 +329,61 @@ ExitInfo DownloadJob::handleResponse(std::istream &is) {
 
 ExitInfo DownloadJob::createLink(const std::string &mimeType, const std::string &data) {
     // Delete in case it already exists (EDIT operation)
-    (void) IoHelper::deleteItem(_localpath);
+    (void) IoHelper::deleteItem(_fileDownloadInfo.localpath);
 
     if (mimeType == mimeTypeSymlink || mimeType == mimeTypeSymlinkFolder) {
         // Create symlink
         const auto targetPath = Str2Path(data);
-        if (targetPath == _localpath) {
-            LOGW_DEBUG(_logger, L"Cannot create symlink on itself: " << Utility::formatSyncPath(_localpath));
+        if (targetPath == _fileDownloadInfo.localpath) {
+            LOGW_DEBUG(_logger, L"Cannot create symlink on itself: " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
             return {};
         }
 
         LOGW_DEBUG(_logger, L"Create symlink with target " << Utility::formatSyncPath(targetPath) << L", "
-                                                           << Utility::formatSyncPath(_localpath));
+                                                           << Utility::formatSyncPath(_fileDownloadInfo.localpath));
 
         bool isFolder = mimeType == mimeTypeSymlinkFolder;
         IoError ioError = IoError::Success;
-        if (!IoHelper::createSymlink(targetPath, _localpath, isFolder, ioError)) {
+        if (!IoHelper::createSymlink(targetPath, _fileDownloadInfo.localpath, isFolder, ioError)) {
             LOGW_WARN(_logger, L"Failed to create symlink: " << Utility::formatIoError(targetPath, ioError));
             return {};
         }
     } else if (mimeType == mimeTypeHardlink) {
         // Unreachable code
         const auto targetPath = Str2Path(data);
-        if (targetPath == _localpath) {
-            LOGW_DEBUG(_logger, L"Cannot create hardlink on itself: " << Utility::formatSyncPath(_localpath));
+        if (targetPath == _fileDownloadInfo.localpath) {
+            LOGW_DEBUG(_logger, L"Cannot create hardlink on itself: " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
             return {};
         }
 
         LOGW_DEBUG(_logger, L"Create hardlink: target " << Utility::formatSyncPath(targetPath) << L", "
-                                                        << Utility::formatSyncPath(_localpath));
+                                                        << Utility::formatSyncPath(_fileDownloadInfo.localpath));
 
         std::error_code ec;
-        std::filesystem::create_hard_link(targetPath, _localpath, ec);
+        std::filesystem::create_hard_link(targetPath, _fileDownloadInfo.localpath, ec);
         if (ec) {
             LOGW_WARN(_logger, L"Failed to create hardlink: target " << Utility::formatSyncPath(targetPath) << L", "
-                                                                     << Utility::formatSyncPath(_localpath) << L", "
-                                                                     << Utility::formatStdError(ec));
+                                                                     << Utility::formatSyncPath(_fileDownloadInfo.localpath)
+                                                                     << L", " << Utility::formatStdError(ec));
             return {};
         }
     } else if (mimeType == mimeTypeJunction) {
 #if defined(KD_WINDOWS)
-        LOGW_DEBUG(_logger, L"Create junction: " << Utility::formatSyncPath(_localpath));
+        LOGW_DEBUG(_logger, L"Create junction: " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
 
         IoError ioError = IoError::Success;
-        if (!IoHelper::createJunction(data, _localpath, ioError)) {
-            LOGW_WARN(_logger, L"Failed to create junction: " << Utility::formatIoError(_localpath, ioError));
+        if (!IoHelper::createJunction(data, _fileDownloadInfo.localpath, ioError)) {
+            LOGW_WARN(_logger, L"Failed to create junction: " << Utility::formatIoError(_fileDownloadInfo.localpath, ioError));
             return {};
         }
 #endif
     } else if (mimeType == mimeTypeFinderAlias) {
 #if defined(KD_MACOS)
-        LOGW_DEBUG(_logger, L"Create alias: " << Utility::formatSyncPath(_localpath));
+        LOGW_DEBUG(_logger, L"Create alias: " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
 
         IoError ioError = IoError::Success;
-        if (!IoHelper::createAlias(data, _localpath, ioError)) {
-            LOGW_WARN(_logger, L"Failed to create alias: " << Utility::formatIoError(_localpath, ioError));
+        if (!IoHelper::createAlias(data, _fileDownloadInfo.localpath, ioError)) {
+            LOGW_WARN(_logger, L"Failed to create alias: " << Utility::formatIoError(_fileDownloadInfo.localpath, ioError));
 
             if (ioError == IoError::Unknown) {
                 // Could be an alias imported into the drive by drag&drop in the webapp
@@ -392,8 +403,9 @@ ExitInfo DownloadJob::createLink(const std::string &mimeType, const std::string 
                         return {};
                     }
 
-                    if (!IoHelper::createAlias(data2, _localpath, ioError)) {
-                        LOGW_WARN(_logger, L"Failed to create alias: " << Utility::formatIoError(_localpath, ioError));
+                    if (!IoHelper::createAlias(data2, _fileDownloadInfo.localpath, ioError)) {
+                        LOGW_WARN(_logger,
+                                  L"Failed to create alias: " << Utility::formatIoError(_fileDownloadInfo.localpath, ioError));
                         return {};
                     }
 
@@ -447,35 +459,35 @@ ExitInfo DownloadJob::moveTmpFile() {
         bool sharingViolationError = false;
 #endif
         static const bool forceCopy = CommonUtility::envVarValue("KDRIVE_PRESERVE_PERMISSIONS_ON_CREATE") == "1";
-        if (_isCreate && !forceCopy) {
+        if (_fileDownloadInfo.isCreate && !forceCopy) {
             // Make sure we are allowed to propagate the change
-            PermissionsHolder _(_localpath.parent_path(), _logger);
+            PermissionsHolder _(_fileDownloadInfo.localpath.parent_path(), _logger);
 
             // Move file
             IoError ioError = IoError::Success;
-            IoHelper::moveItem(_tmpPath, _localpath, ioError);
+            IoHelper::moveItem(_tmpPath, _fileDownloadInfo.localpath, ioError);
             crossDeviceLinkError = ioError == IoError::CrossDeviceLink; // Unable to move between 2 distinct file systems
             if (ioError != IoError::Success && !crossDeviceLinkError) {
                 LOGW_WARN(_logger, L"Failed to move downloaded file " << Utility::formatSyncPath(_tmpPath) << L" to "
-                                                                      << Utility::formatSyncPath(_localpath) << L", err='"
-                                                                      << Utility::formatIoError(ioError) << L"'");
+                                                                      << Utility::formatSyncPath(_fileDownloadInfo.localpath)
+                                                                      << L", err='" << Utility::formatIoError(ioError) << L"'");
                 error = true;
                 accessDeniedError = ioError == IoError::AccessDenied;
                 // NB: On Windows, ec.value() == ERROR_SHARING_VIOLATION is translated as IoError::AccessDenied
             }
         }
 
-        if (!_isCreate || crossDeviceLinkError || forceCopy) {
+        if (!_fileDownloadInfo.isCreate || crossDeviceLinkError || forceCopy) {
             // Make sure we are allowed to propagate the change
-            PermissionsHolder _(_localpath.parent_path(), _logger);
+            PermissionsHolder _(_fileDownloadInfo.localpath.parent_path(), _logger);
 
             // Copy file content (i.e. when the target exists, do not change its node id).
             std::error_code ec;
-            std::filesystem::copy(_tmpPath, _localpath, std::filesystem::copy_options::overwrite_existing, ec);
+            std::filesystem::copy(_tmpPath, _fileDownloadInfo.localpath, std::filesystem::copy_options::overwrite_existing, ec);
             if (ec) {
                 LOGW_WARN(_logger, L"Failed to copy downloaded file " << Utility::formatSyncPath(_tmpPath) << L" to "
-                                                                      << Utility::formatSyncPath(_localpath) << L", err='"
-                                                                      << Utility::formatStdError(ec) << L"'");
+                                                                      << Utility::formatSyncPath(_fileDownloadInfo.localpath)
+                                                                      << L", err='" << Utility::formatStdError(ec) << L"'");
                 error = true;
                 accessDeniedError = IoHelper::stdError2ioError(ec.value()) == IoError::AccessDenied;
 #if defined(KD_WINDOWS)
@@ -491,7 +503,8 @@ ExitInfo DownloadJob::moveTmpFile() {
                     // Retry
                     retry = true;
                     Utility::msleep(10);
-                    LOGW_DEBUG(_logger, L"Retrying to copy downloaded file: " << Utility::formatSyncPath(_localpath));
+                    LOGW_DEBUG(_logger,
+                               L"Retrying to copy downloaded file: " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
                     counter--;
                     continue;
                 } else {
@@ -505,19 +518,21 @@ ExitInfo DownloadJob::moveTmpFile() {
             } else {
                 bool exists = false;
                 IoError ioError = IoError::Success;
-                if (!IoHelper::checkIfPathExists(_localpath.parent_path(), exists, ioError,
+                if (!IoHelper::checkIfPathExists(_fileDownloadInfo.localpath.parent_path(), exists, ioError,
                                                  IoHelper::PathCheckOption::Insensitive)) {
                     LOGW_WARN(_logger, L"Error in IoHelper::checkIfPathExists: "
-                                               << Utility::formatIoError(_localpath.parent_path(), ioError));
+                                               << Utility::formatIoError(_fileDownloadInfo.localpath.parent_path(), ioError));
                     return ExitCode::SystemError;
                 }
                 if (ioError == IoError::AccessDenied) {
-                    LOGW_WARN(_logger, L"Access denied to item " << Utility::formatSyncPath(_localpath.parent_path()));
+                    LOGW_WARN(_logger,
+                              L"Access denied to item " << Utility::formatSyncPath(_fileDownloadInfo.localpath.parent_path()));
                     return {ExitCode::SystemError, ExitCause::FileAccessError};
                 }
 
                 if (!exists) {
-                    LOGW_INFO(_logger, L"Parent of item does not exist anymore " << Utility::formatSyncPath(_localpath));
+                    LOGW_INFO(_logger,
+                              L"Parent of item does not exist anymore " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
                     disableRetry();
                 }
 
@@ -587,7 +602,7 @@ ExitInfo DownloadJob::createTmpFile(std::optional<std::reference_wrapper<std::is
         setProgress(0);
 
         if (expectedSize != Poco::Net::HTTPMessage::UNKNOWN_CONTENT_LENGTH) {
-            if (!hasEnoughPlace(_tmpPath, _localpath, expectedSize, _logger)) {
+            if (!hasEnoughPlace(_tmpPath, _fileDownloadInfo.localpath, expectedSize, _logger)) {
                 writeError = true;
             }
             if (expectedSize < 0) {
@@ -681,12 +696,15 @@ ExitInfo DownloadJob::createTmpFile(std::optional<std::reference_wrapper<std::is
                 if (_vfs && !_isHydrated) { // updateFetchStatus is used only for hydration.
                     if (timer.elapsed<std::chrono::milliseconds>().count() > NOTIFICATION_DELAY || done) {
                         // Update fetch status
-                        if (!_vfs->updateFetchStatus(_tmpPath, _localpath, getProgress(), fetchCanceled, fetchFinished)) {
-                            LOGW_WARN(_logger, L"Error in vfsUpdateFetchStatus: " << Utility::formatSyncPath(_localpath));
+                        if (!_vfs->updateFetchStatus(_tmpPath, _fileDownloadInfo.localpath, getProgress(), fetchCanceled,
+                                                     fetchFinished)) {
+                            LOGW_WARN(_logger,
+                                      L"Error in vfsUpdateFetchStatus: " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
                             fetchError = true;
                             break;
                         } else if (fetchCanceled) {
-                            LOGW_WARN(_logger, L"Update fetch status canceled: " << Utility::formatSyncPath(_localpath));
+                            LOGW_WARN(_logger,
+                                      L"Update fetch status canceled: " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
                             break;
                         }
                         timer.restart();

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.h
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.h
@@ -25,10 +25,11 @@ namespace KDC {
 
 class DownloadJob : public AbstractTokenNetworkJob {
     public:
-        DownloadJob(const std::shared_ptr<Vfs> vfs, DriveDbId driveDbId, const NodeId &remoteFileId, const SyncPath &localpath,
-                    int64_t expectedSize, SyncTime creationTime, SyncTime modificationTime, bool isCreate);
-        DownloadJob(const std::shared_ptr<Vfs> vfs, DriveDbId driveDbId, const NodeId &remoteFileId, const SyncPath &localpath,
-                    int64_t expectedSize);
+        DownloadJob(const std::shared_ptr<Vfs> vfs, const SyncPath &localSyncFolder, DriveDbId driveDbId,
+                    const NodeId &remoteFileId, const SyncPath &localpath, int64_t expectedSize, SyncTime creationTime,
+                    SyncTime modificationTime, bool isCreate);
+        DownloadJob(const std::shared_ptr<Vfs> vfs, const SyncPath &localSyncFolder, DriveDbId driveDbId,
+                    const NodeId &remoteFileId, const SyncPath &localpath, int64_t expectedSize);
         ~DownloadJob() override;
 
         inline const NodeId &remoteNodeId() const { return _remoteFileId; }
@@ -92,6 +93,7 @@ class DownloadJob : public AbstractTokenNetworkJob {
 
         const std::shared_ptr<Vfs> _vfs;
         bool _isHydrated{true};
+        const SyncPath _localSyncFolder;
 
         friend class TestNetworkJobs;
 };

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.h
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.h
@@ -19,17 +19,17 @@
 #pragma once
 
 #include "jobs/network/abstracttokennetworkjob.h"
+
 #include "libcommonserver/vfs/vfs.h"
+#include "libcommonserver/io/cachedirectory.h"
 
 namespace KDC {
 
 class DownloadJob : public AbstractTokenNetworkJob {
     public:
-        DownloadJob(const std::shared_ptr<Vfs> vfs, const SyncPath &localSyncFolder, DriveDbId driveDbId,
-                    const NodeId &remoteFileId, const SyncPath &localpath, int64_t expectedSize, SyncTime creationTime,
-                    SyncTime modificationTime, bool isCreate);
-        DownloadJob(const std::shared_ptr<Vfs> vfs, const SyncPath &localSyncFolder, DriveDbId driveDbId,
-                    const NodeId &remoteFileId, const SyncPath &localpath, int64_t expectedSize);
+        DownloadJob(const std::shared_ptr<Vfs> vfs, std::shared_ptr<CacheDirectory> cacheDirectory, DriveDbId driveDbId,
+                    const NodeId &remoteFileId, const SyncPath &localpath, int64_t expectedSize, SyncTime creationTime = 0,
+                    SyncTime modificationTime = 0, bool isCreate = false);
         ~DownloadJob() override;
 
         inline const NodeId &remoteNodeId() const { return _remoteFileId; }
@@ -93,7 +93,7 @@ class DownloadJob : public AbstractTokenNetworkJob {
 
         const std::shared_ptr<Vfs> _vfs;
         bool _isHydrated{true};
-        const SyncPath _localSyncFolder;
+        std::shared_ptr<CacheDirectory> _cacheDirectory;
 
         friend class TestNetworkJobs;
 };

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.h
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.h
@@ -27,20 +27,28 @@ namespace KDC {
 
 class DownloadJob : public AbstractTokenNetworkJob {
     public:
-        DownloadJob(const std::shared_ptr<Vfs> vfs, std::shared_ptr<CacheDirectory> cacheDirectory, DriveDbId driveDbId,
-                    const NodeId &remoteFileId, const SyncPath &localpath, int64_t expectedSize, SyncTime creationTime = 0,
-                    SyncTime modificationTime = 0, bool isCreate = false);
+        struct FileDownloadInfo {
+                const DriveDbId driveDbId = 0;
+                const NodeId remoteFileId;
+                const SyncPath localpath;
+                const int64_t expectedSize = Poco::Net::HTTPMessage::UNKNOWN_CONTENT_LENGTH;
+                const SyncTime creationTime = 0;
+                SyncTime modificationTime = 0;
+                bool isCreate = false;
+        };
+        DownloadJob(const std::shared_ptr<Vfs> vfs, std::shared_ptr<CacheDirectory> cacheDirectory,
+                    const FileDownloadInfo &fileDownloadInfo);
         ~DownloadJob() override;
 
-        inline const NodeId &remoteNodeId() const { return _remoteFileId; }
-        inline const SyncPath &localPath() const { return _localpath; }
+        inline const NodeId &remoteNodeId() const { return _fileDownloadInfo.remoteFileId; }
+        inline const SyncPath &localPath() const { return _fileDownloadInfo.localpath; }
 
         inline const NodeId &localNodeId() const { return _localNodeId; }
         inline SyncTime creationTime() const { return _creationTimeOut; }
         inline SyncTime modificationTime() const { return _modificationTimeOut; }
         [[nodiscard]] inline int64_t size() const { return _sizeOut; }
 
-        [[nodiscard]] int64_t expectedSize() const { return _expectedSize; }
+        [[nodiscard]] int64_t expectedSize() const { return _fileDownloadInfo.expectedSize; }
 
     private:
         std::string getSpecificUrl() override;
@@ -74,14 +82,11 @@ class DownloadJob : public AbstractTokenNetworkJob {
         static bool hasEnoughPlace(const SyncPath &tmpDirPath, const SyncPath &destDirPath, int64_t neededPlace,
                                    log4cplus::Logger logger);
 
-        NodeId _remoteFileId;
-        SyncPath _localpath;
-        SyncPath _tmpPath;
-        const int64_t _expectedSize = Poco::Net::HTTPMessage::UNKNOWN_CONTENT_LENGTH;
-        const SyncTime _creationTimeIn = 0;
-        const SyncTime _modificationTimeIn = 0;
+        const std::shared_ptr<Vfs> _vfs;
+        std::shared_ptr<CacheDirectory> _cacheDirectory;
+        FileDownloadInfo _fileDownloadInfo;
 
-        bool _isCreate = false;
+        SyncPath _tmpPath;
         bool _ignoreDateTime = false;
         bool _responseHandlingCanceled = false;
 
@@ -91,9 +96,7 @@ class DownloadJob : public AbstractTokenNetworkJob {
         SyncTime _modificationTimeOut = 0;
         int64_t _sizeOut = -1; // Do not use 0 here as it is a valid size.
 
-        const std::shared_ptr<Vfs> _vfs;
         bool _isHydrated{true};
-        std::shared_ptr<CacheDirectory> _cacheDirectory;
 
         friend class TestNetworkJobs;
 };

--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -395,8 +395,8 @@ ExitInfo ExecutorWorker::handleCreateOp(SyncOpPtr syncOp, std::shared_ptr<SyncJo
                     if (const ExitInfo exitInfoCheckAlreadyExcluded =
                                 checkAlreadyExcluded(absoluteLocalFilePath, createDirJob->parentDirId());
                         !exitInfoCheckAlreadyExcluded) {
-                        LOG_SYNCPAL_WARN(_logger, "Error in ExecutorWorker::checkAlreadyExcluded"
-                                                          << " " << exitInfoCheckAlreadyExcluded);
+                        LOG_SYNCPAL_WARN(_logger,
+                                         "Error in ExecutorWorker::checkAlreadyExcluded" << " " << exitInfoCheckAlreadyExcluded);
                         return exitInfoCheckAlreadyExcluded;
                     }
 
@@ -579,7 +579,7 @@ ExitInfo ExecutorWorker::generateCreateJob(SyncOpPtr syncOp, std::shared_ptr<Syn
                     return ExitCode::Ok;
                 } else {
                     try {
-                        job = std::make_shared<DownloadJob>(_syncPal->vfs(), _syncPal->driveDbId(),
+                        job = std::make_shared<DownloadJob>(_syncPal->vfs(), _syncPal->localPath(), _syncPal->driveDbId(),
                                                             syncOp->affectedNode()->id().value_or(""), absoluteLocalFilePath,
                                                             syncOp->affectedNode()->size(),
                                                             syncOp->affectedNode()->createdAt().value_or(0),
@@ -825,9 +825,9 @@ ExitInfo ExecutorWorker::generateEditJob(SyncOpPtr syncOp, std::shared_ptr<SyncJ
         SyncPath absoluteLocalFilePath = _syncPal->localPath() / relativeLocalFilePath;
 
         try {
-            job = std::make_shared<DownloadJob>(_syncPal->vfs(), _syncPal->driveDbId(), syncOp->affectedNode()->id().value_or(""),
-                                                absoluteLocalFilePath, syncOp->affectedNode()->size(),
-                                                syncOp->affectedNode()->createdAt().value_or(0),
+            job = std::make_shared<DownloadJob>(_syncPal->vfs(), _syncPal->localPath(), _syncPal->driveDbId(),
+                                                syncOp->affectedNode()->id().value_or(""), absoluteLocalFilePath,
+                                                syncOp->affectedNode()->size(), syncOp->affectedNode()->createdAt().value_or(0),
                                                 syncOp->affectedNode()->modificationTime().value_or(0), false);
         } catch (std::exception const &e) {
             LOGW_SYNCPAL_WARN(_logger, L"Error in DownloadJob::DownloadJob for driveDbId=" << _syncPal->driveDbId() << L" : "

--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -579,7 +579,7 @@ ExitInfo ExecutorWorker::generateCreateJob(SyncOpPtr syncOp, std::shared_ptr<Syn
                     return ExitCode::Ok;
                 } else {
                     try {
-                        job = std::make_shared<DownloadJob>(_syncPal->vfs(), _syncPal->localPath(), _syncPal->driveDbId(),
+                        job = std::make_shared<DownloadJob>(_syncPal->vfs(), _syncPal->cacheDirectory(), _syncPal->driveDbId(),
                                                             syncOp->affectedNode()->id().value_or(""), absoluteLocalFilePath,
                                                             syncOp->affectedNode()->size(),
                                                             syncOp->affectedNode()->createdAt().value_or(0),
@@ -825,7 +825,7 @@ ExitInfo ExecutorWorker::generateEditJob(SyncOpPtr syncOp, std::shared_ptr<SyncJ
         SyncPath absoluteLocalFilePath = _syncPal->localPath() / relativeLocalFilePath;
 
         try {
-            job = std::make_shared<DownloadJob>(_syncPal->vfs(), _syncPal->localPath(), _syncPal->driveDbId(),
+            job = std::make_shared<DownloadJob>(_syncPal->vfs(), _syncPal->cacheDirectory(), _syncPal->driveDbId(),
                                                 syncOp->affectedNode()->id().value_or(""), absoluteLocalFilePath,
                                                 syncOp->affectedNode()->size(), syncOp->affectedNode()->createdAt().value_or(0),
                                                 syncOp->affectedNode()->modificationTime().value_or(0), false);

--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -579,11 +579,12 @@ ExitInfo ExecutorWorker::generateCreateJob(SyncOpPtr syncOp, std::shared_ptr<Syn
                     return ExitCode::Ok;
                 } else {
                     try {
-                        job = std::make_shared<DownloadJob>(_syncPal->vfs(), _syncPal->cacheDirectory(), _syncPal->driveDbId(),
-                                                            syncOp->affectedNode()->id().value_or(""), absoluteLocalFilePath,
-                                                            syncOp->affectedNode()->size(),
-                                                            syncOp->affectedNode()->createdAt().value_or(0),
-                                                            syncOp->affectedNode()->modificationTime().value_or(0), true);
+                        job = std::make_shared<DownloadJob>(
+                                _syncPal->vfs(), _syncPal->cacheDirectory(),
+                                DownloadJob::FileDownloadInfo{_syncPal->driveDbId(), syncOp->affectedNode()->id().value_or(""),
+                                                              absoluteLocalFilePath, syncOp->affectedNode()->size(),
+                                                              syncOp->affectedNode()->createdAt().value_or(0),
+                                                              syncOp->affectedNode()->modificationTime().value_or(0), true});
                     } catch (std::exception const &e) {
                         LOGW_SYNCPAL_WARN(_logger, L"Error in DownloadJob::DownloadJob for driveDbId="
                                                            << _syncPal->driveDbId() << L" : " << CommonUtility::s2ws(e.what()));
@@ -825,10 +826,12 @@ ExitInfo ExecutorWorker::generateEditJob(SyncOpPtr syncOp, std::shared_ptr<SyncJ
         SyncPath absoluteLocalFilePath = _syncPal->localPath() / relativeLocalFilePath;
 
         try {
-            job = std::make_shared<DownloadJob>(_syncPal->vfs(), _syncPal->cacheDirectory(), _syncPal->driveDbId(),
-                                                syncOp->affectedNode()->id().value_or(""), absoluteLocalFilePath,
-                                                syncOp->affectedNode()->size(), syncOp->affectedNode()->createdAt().value_or(0),
-                                                syncOp->affectedNode()->modificationTime().value_or(0), false);
+            job = std::make_shared<DownloadJob>(
+                    _syncPal->vfs(), _syncPal->cacheDirectory(),
+                    DownloadJob::FileDownloadInfo{_syncPal->driveDbId(), syncOp->affectedNode()->id().value_or(""),
+                                                  absoluteLocalFilePath, syncOp->affectedNode()->size(),
+                                                  syncOp->affectedNode()->createdAt().value_or(0),
+                                                  syncOp->affectedNode()->modificationTime().value_or(0), false});
         } catch (std::exception const &e) {
             LOGW_SYNCPAL_WARN(_logger, L"Error in DownloadJob::DownloadJob for driveDbId=" << _syncPal->driveDbId() << L" : "
                                                                                            << CommonUtility::s2ws(e.what()));

--- a/src/libsyncengine/syncpal/cachedirectory.cpp
+++ b/src/libsyncengine/syncpal/cachedirectory.cpp
@@ -1,0 +1,68 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "cachedirectory.h"
+
+namespace KDC {
+
+CacheDirectory::CacheDirectory(const SyncPath &localSyncPath) {
+    static const auto cacheDirName = std::format(".{}-cache", APPLICATION_NAME);
+    _cacheDirectoryPath = localSyncPath / cacheDirName;
+    initDirectory();
+}
+
+const SyncPath &CacheDirectory::directoryPath() noexcept {
+    const std::scoped_lock lock(_mutex);
+
+    bool exists = false;
+    if (auto ioError = IoError::Unknown;
+        !IoHelper::checkIfPathExists(_cacheDirectoryPath, exists, ioError, IoHelper::PathCheckOption::Insensitive)) {
+        sentry::Handler::captureMessage(sentry::Level::Error, "Failed to check if kDrive-cache exist",
+                                        CommonUtility::ws2s(Utility::formatIoError(_cacheDirectoryPath, ioError)));
+    }
+
+    if (_cacheDirectoryPath.empty() || !exists) {
+        resetDirectoryPath();
+    }
+    return _cacheDirectoryPath;
+}
+
+void CacheDirectory::initDirectory() noexcept {
+    if (auto ioError = IoError::Success;
+        !IoHelper::createDirectory(_cacheDirectoryPath, false, ioError) && ioError != IoError::DirectoryExists) {
+        sentry::Handler::captureMessage(sentry::Level::Error, "Failed to create kDrive-cache",
+                                        CommonUtility::ws2s(Utility::formatIoError(_cacheDirectoryPath, ioError)));
+        _cacheDirectoryPath.clear(); // Clear the path if the directory could not be created.
+        return;
+    }
+
+    return;
+}
+
+void CacheDirectory::deleteDirectory() const noexcept {
+    // It is the best effort, we cannot log/sentry anything here as the logger/sentry may have been destroyed already.
+    auto ioError = IoError::Success;
+    (void) IoHelper::deleteItem(_cacheDirectoryPath, ioError);
+}
+
+void CacheDirectory::resetDirectoryPath() noexcept {
+    deleteDirectory();
+    initDirectory();
+}
+
+} // namespace KDC

--- a/src/libsyncengine/syncpal/cachedirectory.h
+++ b/src/libsyncengine/syncpal/cachedirectory.h
@@ -1,0 +1,39 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace KDC {
+
+class CacheDirectory {
+    public:
+        explicit CacheDirectory(const SyncPath &localSyncPath);
+        ~CacheDirectory() { deleteDirectory(); }
+
+        const SyncPath &directoryPath() noexcept;
+
+    private:
+        void initDirectory() noexcept;
+        void deleteDirectory() const noexcept;
+        void resetDirectoryPath() noexcept;
+
+        mutable std::mutex _mutex;
+        SyncPath _cacheDirectoryPath;
+};
+
+} // namespace KDC

--- a/src/libsyncengine/syncpal/syncpal.cpp
+++ b/src/libsyncengine/syncpal/syncpal.cpp
@@ -722,7 +722,9 @@ ExitCode SyncPal::addDlDirectJob(const SyncPath &relativePath, const SyncPath &a
     // Hydration job
     std::shared_ptr<DownloadJob> job = nullptr;
     try {
-        job = std::make_shared<DownloadJob>(vfs(), _cacheDirectory, driveDbId(), remoteNodeId, absoluteLocalPath, expectedSize);
+        job = std::make_shared<DownloadJob>(
+                vfs(), _cacheDirectory,
+                DownloadJob::FileDownloadInfo{driveDbId(), remoteNodeId, absoluteLocalPath, expectedSize});
         if (!job) {
             LOG_SYNCPAL_WARN(_logger, "Memory allocation error");
             return ExitCode::SystemError;

--- a/src/libsyncengine/syncpal/syncpal.cpp
+++ b/src/libsyncengine/syncpal/syncpal.cpp
@@ -720,7 +720,7 @@ ExitCode SyncPal::addDlDirectJob(const SyncPath &relativePath, const SyncPath &a
     // Hydration job
     std::shared_ptr<DownloadJob> job = nullptr;
     try {
-        job = std::make_shared<DownloadJob>(vfs(), driveDbId(), remoteNodeId, absoluteLocalPath, expectedSize);
+        job = std::make_shared<DownloadJob>(vfs(), localPath(), driveDbId(), remoteNodeId, absoluteLocalPath, expectedSize);
         if (!job) {
             LOG_SYNCPAL_WARN(_logger, "Memory allocation error");
             return ExitCode::SystemError;

--- a/src/libsyncengine/syncpal/syncpal.cpp
+++ b/src/libsyncengine/syncpal/syncpal.cpp
@@ -108,6 +108,8 @@ SyncPal::SyncPal(std::shared_ptr<Vfs> vfs, const int syncDbId_, const std::strin
     _syncInfo.targetPath = sync.targetPath();
     _syncInfo.targetPath.make_preferred();
 
+    _cacheDirectory = std::make_shared<CacheDirectory>(_syncInfo.localPath);
+
     // Get drive
     Drive drive;
     if (!ParmsDb::instance()->selectDrive(driveDbId(), drive, found)) {
@@ -720,7 +722,7 @@ ExitCode SyncPal::addDlDirectJob(const SyncPath &relativePath, const SyncPath &a
     // Hydration job
     std::shared_ptr<DownloadJob> job = nullptr;
     try {
-        job = std::make_shared<DownloadJob>(vfs(), localPath(), driveDbId(), remoteNodeId, absoluteLocalPath, expectedSize);
+        job = std::make_shared<DownloadJob>(vfs(), _cacheDirectory, driveDbId(), remoteNodeId, absoluteLocalPath, expectedSize);
         if (!job) {
             LOG_SYNCPAL_WARN(_logger, "Memory allocation error");
             return ExitCode::SystemError;

--- a/src/libsyncengine/syncpal/syncpal.h
+++ b/src/libsyncengine/syncpal/syncpal.h
@@ -341,6 +341,8 @@ class SYNCENGINE_EXPORT SyncPal : public std::enable_shared_from_this<SyncPal> {
             (void) _localOperationSet->removeOp(localNodeId, operationType);
         }
 
+        [[nodiscard]] std::shared_ptr<CacheDirectory> cacheDirectory() const { return _cacheDirectory; }
+
     protected:
         virtual void createWorkers(const std::chrono::seconds &startDelay = std::chrono::seconds(0));
 
@@ -425,6 +427,8 @@ class SYNCENGINE_EXPORT SyncPal : public std::enable_shared_from_this<SyncPal> {
         void setUpConflictingFilesCorrector(const std::vector<Error> &keepLocalErrorList,
                                             const std::vector<Error> &keepRemoteErrorList);
         log4cplus::Logger _logger;
+
+        std::shared_ptr<CacheDirectory> _cacheDirectory;
 
         // TODO : Refactor to not use friend classes (should be reserved for test purpose).
         friend class SyncPalWorker;

--- a/src/libsyncengine/syncpal/syncpal.h
+++ b/src/libsyncengine/syncpal/syncpal.h
@@ -20,6 +20,7 @@
 
 #include "syncenginelib.h"
 #include "db/syncdb.h"
+#include "io/cachedirectory.h"
 #include "progress/progressinfo.h"
 #include "syncpal/conflictingfilescorrector.h"
 #include "update_detection/file_system_observer/snapshot/livesnapshot.h"

--- a/src/libsyncengine/update_detection/file_system_observer/remotefilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/remotefilesystemobserverworker.cpp
@@ -798,15 +798,15 @@ ExitInfo RemoteFileSystemObserverWorker::checkRightsAndUpdateItem(const NodeId &
 }
 
 ExitInfo RemoteFileSystemObserverWorker::checkForUnsupportedCharacters(const SyncName &name, const NodeId &nodeId,
-                                                                       NodeType type) {
+                                                                       const NodeType type) {
     ExitInfo exitInfo = ExitCode::Ok;
 #if defined(KD_MACOS)
     // Check that the name doesn't contain a character not yet supported by the filesystem (ex: U+1FA77 on pre macOS 13.4)
     auto ioError = IoError::Unknown;
     if (type == NodeType::File) {
-        ioError = Utility::tryCreateTmpFile(name);
+        ioError = Utility::tryCreateTmpFile(_syncPal->cacheDirectory(), name);
     } else if (type == NodeType::Directory) {
-        ioError = Utility::tryCreateTmpDir(name);
+        ioError = Utility::tryCreateTmpDir(_syncPal->cacheDirectory(), name);
     }
 
     if (ioError == IoError::AccessDenied) {

--- a/src/libsyncengine/update_detection/file_system_observer/remotefilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/remotefilesystemobserverworker.cpp
@@ -802,18 +802,16 @@ ExitInfo RemoteFileSystemObserverWorker::checkForUnsupportedCharacters(const Syn
     ExitInfo exitInfo = ExitCode::Ok;
 #if defined(KD_MACOS)
     // Check that the name doesn't contain a character not yet supported by the filesystem (ex: U+1FA77 on pre macOS 13.4)
-    auto ioError = IoError::Unknown;
     if (type == NodeType::File) {
-        ioError = Utility::tryCreateTmpFile(_syncPal->cacheDirectory(), name);
+        exitInfo = Utility::tryCreateTmpFile(_syncPal->cacheDirectory(), name);
     } else if (type == NodeType::Directory) {
-        ioError = Utility::tryCreateTmpDir(_syncPal->cacheDirectory(), name);
+        exitInfo = Utility::tryCreateTmpDir(_syncPal->cacheDirectory(), name);
     }
 
-    if (ioError == IoError::AccessDenied) {
+    if (exitInfo.cause() == ExitCause::TmpDirAccessError) {
         LOGW_SYNCPAL_ERROR(_logger, L"Can't access tmp directory.");
-        exitInfo = {ExitCode::SystemError, ExitCause::TmpDirAccessError};
         _syncPal->addError(Error(ERR_ID, exitInfo.code(), exitInfo.cause()));
-    } else if (ioError != IoError::Success) {
+    } else if (!exitInfo) {
         LOGW_SYNCPAL_DEBUG(_logger, L"The file/directory name contains a character not yet supported by the filesystem "
                                             << SyncName2WStr(name) << L". Item is ignored.");
         _syncPal->addError(

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -476,14 +476,9 @@ void AppServer::init() {
     if (ParmsDb::instance()->versionUpdated()) Utility::restartLoginItemAgent();
 #endif
 
-    // Check if temp directory is accessible.
-    if (Utility::tryCreateTmpFile() == IoError::Success) {
-        // Start syncs
-        LOG_DEBUG(_logger, "Start syncs");
-        QTimer::singleShot(0, [=, this]() { startSyncsAndRetryOnError(); });
-    } else {
-        addError(Error(ERR_ID, ExitCode::SystemError, ExitCause::TmpDirAccessError));
-    }
+    // Start syncs
+    LOG_DEBUG(_logger, "Start syncs");
+    QTimer::singleShot(0, [=, this]() { startSyncsAndRetryOnError(); });
 
     // Init JobManager(s)
     if (!GuiJobManagerSingleton::instance()) {
@@ -583,13 +578,6 @@ void AppServer::cleanup() {
     // Close ParmsDb
     ParmsDb::instance()->close();
     LOG_DEBUG(_logger, "ParmsDb closed");
-
-    // Clean up tmp directory
-    SyncPath tmpDirPath;
-    auto dummyIoError = IoError::Unknown;
-    if (IoHelper::appTempDirectoryPath(tmpDirPath, dummyIoError)) {
-        (void) IoHelper::deleteItem(tmpDirPath, dummyIoError);
-    }
 }
 
 void AppServer::reset() {
@@ -616,8 +604,8 @@ void AppServer::stopSyncTask(const SyncDbId syncDbId) {
 
     {
         const std::scoped_lock lock(vfsMapMutex);
-        LOG_IF_FAIL(!vfsMap[syncDbId] ||
-                    vfsMap[syncDbId].use_count() <= 1) // `use_count` can be zero when the local drive has been removed.
+        // LOG_IF_FAIL(!vfsMap[syncDbId] ||
+        //             vfsMap[syncDbId].use_count() <= 1) // `use_count` can be zero when the local drive has been removed.
         (void) vfsMap.erase(syncDbId);
     }
 }

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -3382,14 +3382,6 @@ void AppServer::logUsefulInformation() {
     LOG_INFO(_logger, "locale: " << QLocale::system().name().toStdString());
     LOG_INFO(_logger, "# of logical CPU core: " << std::thread::hardware_concurrency());
 
-    // Log cache path
-    SyncPath cachePath;
-    if (!IoHelper::cacheDirectoryPath(cachePath)) {
-        LOGW_WARN(_logger, L"Error getting cache directory");
-    }
-    LOGW_INFO(_logger, L"cache " << Utility::formatSyncPath(cachePath));
-    LOGW_INFO(_logger, L"free space for cache: " << Utility::getFreeDiskSpace(cachePath) << L" bytes");
-
     // Log app ID
     LOG_INFO(Log::instance()->getLogger(), "App ID: " << appUID());
 

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -604,8 +604,8 @@ void AppServer::stopSyncTask(const SyncDbId syncDbId) {
 
     {
         const std::scoped_lock lock(vfsMapMutex);
-        // LOG_IF_FAIL(!vfsMap[syncDbId] ||
-        //             vfsMap[syncDbId].use_count() <= 1) // `use_count` can be zero when the local drive has been removed.
+        LOG_IF_FAIL(!vfsMap[syncDbId] ||
+                    vfsMap[syncDbId].use_count() <= 1) // `use_count` can be zero when the local drive has been removed.
         (void) vfsMap.erase(syncDbId);
     }
 }

--- a/sync-exclude-linux.lst
+++ b/sync-exclude-linux.lst
@@ -9,7 +9,7 @@
 *_conflict_*_*_*
 *_blacklisted_*_*_*
 kDrive Rescue Folder
-kDrive-cache
+.kDrive-cache
 *~
 ~$*
 *.~*

--- a/sync-exclude-osx.lst
+++ b/sync-exclude-osx.lst
@@ -9,7 +9,7 @@
 *_conflict_*_*_*
 *_blacklisted_*_*_*
 kDrive Rescue Folder
-kDrive-cache
+.kDrive-cache
 *~
 ~$*
 *.~*

--- a/sync-exclude-win.lst
+++ b/sync-exclude-win.lst
@@ -9,7 +9,7 @@
 *_conflict_*_*_*
 *_blacklisted_*_*_*
 kDrive Rescue Folder
-kDrive-cache
+.kDrive-cache
 *~
 ~$*
 *.~*

--- a/test/libcommon/CMakeLists.txt
+++ b/test/libcommon/CMakeLists.txt
@@ -30,6 +30,7 @@ set(testcommon_SRCS
         io/testio.h io/testio.cpp io/testgetitemtype.cpp io/testgetfilesize.cpp io/testcheckifpathexists.cpp io/testgetnodeid.cpp io/testgetfilestat.cpp io/testgetrights.cpp io/testisfileaccessible.cpp io/testfilechanged.cpp
         io/testcheckifisdirectory.cpp io/testcreatesymlink.cpp io/testcheckifdehydrated.cpp io/testcheckdirectoryiterator.cpp io/testrights.cpp io/testopenfile.cpp io/testgetdirectorysize.cpp
         io/testmoveitemtotrash.cpp io/testispathonmounteddisk.cpp
+        io/testcachedirectory.h io/testcachedirectory.cpp
 )
 
 if(APPLE)

--- a/test/libcommon/io/testcachedirectory.cpp
+++ b/test/libcommon/io/testcachedirectory.cpp
@@ -23,8 +23,6 @@
 #include "test_utility/localtemporarydirectory.h"
 #include "test_utility/testhelpers.h"
 
-#include <regex>
-
 namespace KDC {
 
 void TestCacheDirectory::testCacheDir() {
@@ -74,7 +72,7 @@ void TestCacheDirectory::testCleanUpCacheDir() {
     DirectoryEntry entry;
     auto count = 0;
     while (dirIt.next(entry, endOfDir, ioError) && !endOfDir) {
-        if (std::regex_match(SyncName2Str(entry.path().filename().native()), std::regex(R"(kdrive_.{10})"))) {
+        if (CacheDirectory::isTmpFileName(SyncName2Str(entry.path().filename().native()))) {
             CPPUNIT_ASSERT(false);
         }
         count++;

--- a/test/libcommon/io/testcachedirectory.cpp
+++ b/test/libcommon/io/testcachedirectory.cpp
@@ -1,0 +1,85 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "testcachedirectory.h"
+
+#include "io/cachedirectory.h"
+#include "io/iohelper.h"
+#include "test_utility/localtemporarydirectory.h"
+#include "test_utility/testhelpers.h"
+
+#include <regex>
+
+namespace KDC {
+
+void TestCacheDirectory::testCacheDir() {
+    // Create cache directory
+    const LocalTemporaryDirectory tmpDir;
+    const auto cacheDirectory = std::make_shared<CacheDirectory>(tmpDir.path());
+
+    SyncPath cacheDirectoryPath;
+    CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, cacheDirectory->path(cacheDirectoryPath).code());
+    CPPUNIT_ASSERT(!cacheDirectoryPath.empty());
+
+    // Delete the tmp directory and make sure it is re-created
+    auto ioError = IoError::Unknown;
+    CPPUNIT_ASSERT(IoHelper::deleteItem(cacheDirectoryPath, ioError));
+
+    bool exists = false;
+    CPPUNIT_ASSERT(IoHelper::checkIfPathExists(cacheDirectoryPath, exists, ioError, IoHelper::PathCheckOption::Insensitive));
+    CPPUNIT_ASSERT(!exists);
+
+    CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, cacheDirectory->path(cacheDirectoryPath).code());
+    CPPUNIT_ASSERT(!cacheDirectoryPath.empty());
+
+    CPPUNIT_ASSERT(IoHelper::checkIfPathExists(cacheDirectoryPath, exists, ioError, IoHelper::PathCheckOption::Insensitive));
+    CPPUNIT_ASSERT(exists);
+}
+
+void TestCacheDirectory::testCleanUpCacheDir() {
+    const LocalTemporaryDirectory tmpDir;
+    SyncPath cacheDirectoryPath;
+    {
+        CacheDirectory cacheDirectory(tmpDir.path());
+        CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, cacheDirectory.path(cacheDirectoryPath).code());
+        CPPUNIT_ASSERT(!cacheDirectoryPath.empty());
+
+        // Generate test files
+        testhelpers::generateTestFile(cacheDirectoryPath / Str("kdrive_1234567890"));
+        testhelpers::generateTestFile(cacheDirectoryPath / Str("kdrive_0987654321"));
+        testhelpers::generateTestFile(cacheDirectoryPath / Str("kdrive_123456789"));
+        testhelpers::generateTestFile(cacheDirectoryPath / Str("drive_1234567890"));
+        testhelpers::generateTestFile(cacheDirectoryPath / Str("myFile.txt"));
+    }
+
+    // Check the file been correctly cleaned
+    auto ioError = IoError::Unknown;
+    IoHelper::DirectoryIterator dirIt(cacheDirectoryPath, false, ioError);
+    bool endOfDir = false;
+    DirectoryEntry entry;
+    auto count = 0;
+    while (dirIt.next(entry, endOfDir, ioError) && !endOfDir) {
+        if (std::regex_match(SyncName2Str(entry.path().filename().native()), std::regex(R"(kdrive_.{10})"))) {
+            CPPUNIT_ASSERT(false);
+        }
+        count++;
+    }
+    CPPUNIT_ASSERT_EQUAL(3, count);
+}
+
+} // namespace KDC

--- a/test/libcommon/io/testcachedirectory.h
+++ b/test/libcommon/io/testcachedirectory.h
@@ -1,0 +1,40 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "testincludes.h"
+
+namespace KDC {
+
+class TestCacheDirectory final : public CppUnit::TestFixture, public TestBase {
+        CPPUNIT_TEST_SUITE(TestCacheDirectory);
+        CPPUNIT_TEST(testCacheDir);
+        CPPUNIT_TEST(testCleanUpCacheDir);
+        CPPUNIT_TEST_SUITE_END();
+
+    public:
+        void setUp() override { TestBase::start(); }
+        void tearDown() override { TestBase::stop(); }
+
+    private:
+        void testCacheDir();
+        void testCleanUpCacheDir();
+};
+
+} // namespace KDC

--- a/test/libcommon/io/testio.cpp
+++ b/test/libcommon/io/testio.cpp
@@ -104,12 +104,6 @@ void TestIo::testTempDirectoryPath() {
     }
 }
 
-void TestIo::testCacheDirectoryPath() {
-    SyncPath cachePath;
-    CPPUNIT_ASSERT(_testObj->cacheDirectoryPath(cachePath));
-    CPPUNIT_ASSERT(!cachePath.empty());
-}
-
 void TestIo::testLogDirectoryPath() {
     {
         SyncPath logDirPath;

--- a/test/libcommon/io/testio.cpp
+++ b/test/libcommon/io/testio.cpp
@@ -62,10 +62,6 @@ void TestIo::testTempDirectoryPath() {
         CPPUNIT_ASSERT(IoHelper::deviceTempDirectoryPath(tmpPath, ioError));
         CPPUNIT_ASSERT(!tmpPath.empty());
         CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
-
-        CPPUNIT_ASSERT(IoHelper::appTempDirectoryPath(tmpPath, ioError));
-        CPPUNIT_ASSERT(!tmpPath.empty());
-        CPPUNIT_ASSERT_EQUAL_MESSAGE(toString(ioError) + "!=" + toString(IoError::Success), IoError::Success, ioError);
     }
 
     {

--- a/test/libcommon/io/testio.h
+++ b/test/libcommon/io/testio.h
@@ -37,7 +37,6 @@ class TestIo : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST(testGetItemType);
         CPPUNIT_TEST(testGetFileSize);
         CPPUNIT_TEST(testTempDirectoryPath);
-        CPPUNIT_TEST(testCacheDirectoryPath);
         CPPUNIT_TEST(testLogDirectoryPath);
         CPPUNIT_TEST(testCheckIfPathExists);
         CPPUNIT_TEST(testCheckIfIsDirectory);
@@ -87,7 +86,6 @@ class TestIo : public CppUnit::TestFixture, public TestBase {
         void testGetItemType(void);
         void testGetFileSize(void);
         void testTempDirectoryPath(void);
-        void testCacheDirectoryPath(void);
         void testLogDirectoryPath(void);
         void testGetNodeId(void);
         void testCheckDirectoryIterator(void);

--- a/test/libcommon/test.cpp
+++ b/test/libcommon/test.cpp
@@ -26,6 +26,7 @@
 #include "utility/testjsonparserutility.h"
 #include "log/testlog.h"
 #include "io/testio.h"
+#include "io/testcachedirectory.h"
 
 namespace KDC {
 CPPUNIT_TEST_SUITE_REGISTRATION(TestApiToken);
@@ -36,6 +37,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION(TestUrlHelper);
 CPPUNIT_TEST_SUITE_REGISTRATION(TestJsonParserUtility);
 CPPUNIT_TEST_SUITE_REGISTRATION(TestLog);
 CPPUNIT_TEST_SUITE_REGISTRATION(TestIo);
+CPPUNIT_TEST_SUITE_REGISTRATION(TestCacheDirectory);
 } // namespace KDC
 
 int main(int, char **) {

--- a/test/libcommonserver/utility/testutility.cpp
+++ b/test/libcommonserver/utility/testutility.cpp
@@ -485,16 +485,16 @@ void TestUtility::testUserName() {
 }
 
 void TestUtility::testTryCreateTmpDir() {
-    SyncPath tmpDirPath;
-    IoError ioError = IoError::Unknown;
-    (void) IoHelper::appTempDirectoryPath(tmpDirPath, ioError);
+    const LocalTemporaryDirectory tmpDir;
+    const auto cacheDirectory = std::make_shared<CacheDirectory>(tmpDir.path());
 
-    CPPUNIT_ASSERT_EQUAL(IoError::Success, Utility::tryCreateTmpDir());
-    CPPUNIT_ASSERT_EQUAL(IoError::Success, Utility::tryCreateTmpDir(Str("test name")));
+    CPPUNIT_ASSERT_EQUAL(IoError::Success, Utility::tryCreateTmpDir(cacheDirectory));
+    CPPUNIT_ASSERT_EQUAL(IoError::Success, Utility::tryCreateTmpDir(cacheDirectory, Str("test name")));
 
     // Make sure the item are correctly removed from the tmp dir
     IoHelper::DirectoryIterator dir;
-    CPPUNIT_ASSERT(IoHelper::getDirectoryIterator(tmpDirPath, true, ioError, dir));
+    auto ioError = IoError::Unknown;
+    CPPUNIT_ASSERT(IoHelper::getDirectoryIterator(cacheDirectory->path(), true, ioError, dir));
 
     DirectoryEntry entry;
     bool endOfDirectory = false;
@@ -506,49 +506,38 @@ void TestUtility::testTryCreateTmpDir() {
 
     // Try to create a tmp dir but a directory already exist with the same name
     SyncName testDirName = Str("testDir");
-    CPPUNIT_ASSERT(IoHelper::createDirectory(tmpDirPath / testDirName, false, ioError));
-    CPPUNIT_ASSERT_EQUAL(IoError::Success, Utility::tryCreateTmpDir(testDirName));
+    CPPUNIT_ASSERT(IoHelper::createDirectory(cacheDirectory->path() / testDirName, false, ioError));
+    CPPUNIT_ASSERT_EQUAL(IoError::Success, Utility::tryCreateTmpDir(cacheDirectory, testDirName));
 
     // Delete the tmp directory and make sure it is re-created
-    CPPUNIT_ASSERT(IoHelper::deleteItem(tmpDirPath, ioError));
-    CPPUNIT_ASSERT_EQUAL(IoError::Success, Utility::tryCreateTmpDir());
+    CPPUNIT_ASSERT(IoHelper::deleteItem(cacheDirectory->path(), ioError));
+    CPPUNIT_ASSERT_EQUAL(IoError::Success, Utility::tryCreateTmpDir(cacheDirectory));
 
 #if defined(KD_MACOS)
     {
-        // Saves the current value of "KDRIVE_TMP_PATH".
-        const std::string previousPathString = CommonUtility::envVarValue("KDRIVE_TMP_PATH");
-
-        // Change the tmp directory used by the app.
-        const LocalTemporaryDirectory temporaryDirectory;
-        const auto newTmpPath = SyncPath(temporaryDirectory.path());
-        (void) CommonUtility::setenv("KDRIVE_TMP_PATH", Path2Str(newTmpPath).c_str(), 1);
-
         // Remove access rights.
-        auto ioError = IoError::Unknown;
-        CPPUNIT_ASSERT(IoHelper::setRights(newTmpPath, false, false, false, ioError));
-        CPPUNIT_ASSERT_EQUAL(IoError::AccessDenied, Utility::tryCreateTmpDir());
+        ioError = IoError::Unknown;
+        CPPUNIT_ASSERT(IoHelper::setRights(cacheDirectory->path(), false, false, false, ioError));
+        CPPUNIT_ASSERT_EQUAL(IoError::AccessDenied, Utility::tryCreateTmpDir(cacheDirectory));
 
         // Add back access rights.
-        CPPUNIT_ASSERT(IoHelper::setRights(newTmpPath, true, true, true, ioError));
-        CPPUNIT_ASSERT_EQUAL(IoError::Success, Utility::tryCreateTmpDir());
-
-        // Restores previous value for "KDRIVE_TMP_PATH".
-        (void) CommonUtility::setenv("KDRIVE_TMP_PATH", previousPathString.c_str(), 1);
+        CPPUNIT_ASSERT(IoHelper::setRights(cacheDirectory->path(), true, true, true, ioError));
+        CPPUNIT_ASSERT_EQUAL(IoError::Success, Utility::tryCreateTmpDir(cacheDirectory));
     }
 #endif
 }
 
 void TestUtility::testTryCreateTmpFile() {
-    SyncPath tmpDirPath;
-    IoError ioError = IoError::Unknown;
-    (void) IoHelper::appTempDirectoryPath(tmpDirPath, ioError);
+    const LocalTemporaryDirectory tmpDir;
+    const auto cacheDirectory = std::make_shared<CacheDirectory>(tmpDir.path());
 
-    CPPUNIT_ASSERT_EQUAL(IoError::Success, Utility::tryCreateTmpFile());
-    CPPUNIT_ASSERT_EQUAL(IoError::Success, Utility::tryCreateTmpFile(Str("test name")));
+    CPPUNIT_ASSERT_EQUAL(IoError::Success, Utility::tryCreateTmpFile(cacheDirectory));
+    CPPUNIT_ASSERT_EQUAL(IoError::Success, Utility::tryCreateTmpFile(cacheDirectory, Str("test name")));
 
     // Make sure the item are correctly removed from the tmp dir
     IoHelper::DirectoryIterator dir;
-    CPPUNIT_ASSERT(IoHelper::getDirectoryIterator(tmpDirPath, true, ioError, dir));
+    auto ioError = IoError::Unknown;
+    CPPUNIT_ASSERT(IoHelper::getDirectoryIterator(cacheDirectory->path(), true, ioError, dir));
 
     DirectoryEntry entry;
     bool endOfDirectory = false;
@@ -559,33 +548,22 @@ void TestUtility::testTryCreateTmpFile() {
     CPPUNIT_ASSERT_EQUAL(0, counter);
 
     // Try to create a tmp file but a file already exist with the same name but different capitalization.
-    testhelpers::generateTestFile(tmpDirPath / Str("TestFile"));
-    CPPUNIT_ASSERT_EQUAL(IoError::Success, Utility::tryCreateTmpFile(Str("testFile")));
+    testhelpers::generateTestFile(cacheDirectory->path() / Str("TestFile"));
+    CPPUNIT_ASSERT_EQUAL(IoError::Success, Utility::tryCreateTmpFile(cacheDirectory, Str("testFile")));
 
     // Delete the tmp directory and make sure it is re-created
-    CPPUNIT_ASSERT(IoHelper::deleteItem(tmpDirPath, ioError));
-    CPPUNIT_ASSERT_EQUAL(IoError::Success, Utility::tryCreateTmpFile());
+    CPPUNIT_ASSERT(IoHelper::deleteItem(cacheDirectory->path(), ioError));
+    CPPUNIT_ASSERT_EQUAL(IoError::Success, Utility::tryCreateTmpFile(cacheDirectory));
 
     {
-        // Saves the current value of "KDRIVE_TMP_PATH".
-        const std::string previousPathString = CommonUtility::envVarValue("KDRIVE_TMP_PATH");
-
-        // Change the tmp directory used by the app.
-        const LocalTemporaryDirectory temporaryDirectory;
-        const auto newTmpPath = SyncPath(temporaryDirectory.path());
-        (void) CommonUtility::setenv("KDRIVE_TMP_PATH", Path2Str(newTmpPath).c_str(), 1);
-
         // Remove access rights.
-        auto ioError = IoError::Unknown;
-        CPPUNIT_ASSERT(IoHelper::setRights(newTmpPath, false, false, false, ioError));
-        CPPUNIT_ASSERT_EQUAL(IoError::AccessDenied, Utility::tryCreateTmpFile());
+        ioError = IoError::Unknown;
+        CPPUNIT_ASSERT(IoHelper::setRights(cacheDirectory->path(), false, false, false, ioError));
+        CPPUNIT_ASSERT_EQUAL(IoError::AccessDenied, Utility::tryCreateTmpFile(cacheDirectory));
 
         // Add back access rights.
-        CPPUNIT_ASSERT(IoHelper::setRights(newTmpPath, true, true, true, ioError));
-        CPPUNIT_ASSERT_EQUAL(IoError::Success, Utility::tryCreateTmpFile());
-
-        // Restores previous value for "KDRIVE_TMP_PATH".
-        (void) CommonUtility::setenv("KDRIVE_TMP_PATH", previousPathString.c_str(), 1);
+        CPPUNIT_ASSERT(IoHelper::setRights(cacheDirectory->path(), true, true, true, ioError));
+        CPPUNIT_ASSERT_EQUAL(IoError::Success, Utility::tryCreateTmpFile(cacheDirectory));
     }
 }
 

--- a/test/libcommonserver/utility/testutility.cpp
+++ b/test/libcommonserver/utility/testutility.cpp
@@ -488,13 +488,16 @@ void TestUtility::testTryCreateTmpDir() {
     const LocalTemporaryDirectory tmpDir;
     const auto cacheDirectory = std::make_shared<CacheDirectory>(tmpDir.path());
 
-    CPPUNIT_ASSERT_EQUAL(IoError::Success, Utility::tryCreateTmpDir(cacheDirectory));
-    CPPUNIT_ASSERT_EQUAL(IoError::Success, Utility::tryCreateTmpDir(cacheDirectory, Str("test name")));
+    CPPUNIT_ASSERT(Utility::tryCreateTmpDir(cacheDirectory));
+    CPPUNIT_ASSERT(Utility::tryCreateTmpDir(cacheDirectory, Str("test name")));
 
     // Make sure the item are correctly removed from the tmp dir
     IoHelper::DirectoryIterator dir;
     auto ioError = IoError::Unknown;
-    CPPUNIT_ASSERT(IoHelper::getDirectoryIterator(cacheDirectory->path(), true, ioError, dir));
+    SyncPath cacheDirectoryPath;
+    CPPUNIT_ASSERT(cacheDirectory->path(cacheDirectoryPath));
+
+    CPPUNIT_ASSERT(IoHelper::getDirectoryIterator(cacheDirectoryPath, true, ioError, dir));
 
     DirectoryEntry entry;
     bool endOfDirectory = false;
@@ -505,24 +508,25 @@ void TestUtility::testTryCreateTmpDir() {
     CPPUNIT_ASSERT_EQUAL(0, counter);
 
     // Try to create a tmp dir but a directory already exist with the same name
-    SyncName testDirName = Str("testDir");
-    CPPUNIT_ASSERT(IoHelper::createDirectory(cacheDirectory->path() / testDirName, false, ioError));
-    CPPUNIT_ASSERT_EQUAL(IoError::Success, Utility::tryCreateTmpDir(cacheDirectory, testDirName));
+    const SyncName testDirName = Str("testDir");
+    CPPUNIT_ASSERT(IoHelper::createDirectory(cacheDirectoryPath / testDirName, false, ioError));
+    CPPUNIT_ASSERT(Utility::tryCreateTmpDir(cacheDirectory, testDirName));
 
     // Delete the tmp directory and make sure it is re-created
-    CPPUNIT_ASSERT(IoHelper::deleteItem(cacheDirectory->path(), ioError));
-    CPPUNIT_ASSERT_EQUAL(IoError::Success, Utility::tryCreateTmpDir(cacheDirectory));
+    CPPUNIT_ASSERT(IoHelper::deleteItem(cacheDirectoryPath, ioError));
+    CPPUNIT_ASSERT(Utility::tryCreateTmpDir(cacheDirectory));
 
 #if defined(KD_MACOS)
     {
         // Remove access rights.
         ioError = IoError::Unknown;
-        CPPUNIT_ASSERT(IoHelper::setRights(cacheDirectory->path(), false, false, false, ioError));
-        CPPUNIT_ASSERT_EQUAL(IoError::AccessDenied, Utility::tryCreateTmpDir(cacheDirectory));
+        CPPUNIT_ASSERT(IoHelper::setRights(cacheDirectoryPath, false, false, false, ioError));
+        CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::SystemError, ExitCause::TmpDirAccessError),
+                             Utility::tryCreateTmpDir(cacheDirectory));
 
         // Add back access rights.
-        CPPUNIT_ASSERT(IoHelper::setRights(cacheDirectory->path(), true, true, true, ioError));
-        CPPUNIT_ASSERT_EQUAL(IoError::Success, Utility::tryCreateTmpDir(cacheDirectory));
+        CPPUNIT_ASSERT(IoHelper::setRights(cacheDirectoryPath, true, true, true, ioError));
+        CPPUNIT_ASSERT(Utility::tryCreateTmpDir(cacheDirectory));
     }
 #endif
 }
@@ -531,13 +535,15 @@ void TestUtility::testTryCreateTmpFile() {
     const LocalTemporaryDirectory tmpDir;
     const auto cacheDirectory = std::make_shared<CacheDirectory>(tmpDir.path());
 
-    CPPUNIT_ASSERT_EQUAL(IoError::Success, Utility::tryCreateTmpFile(cacheDirectory));
-    CPPUNIT_ASSERT_EQUAL(IoError::Success, Utility::tryCreateTmpFile(cacheDirectory, Str("test name")));
+    CPPUNIT_ASSERT(Utility::tryCreateTmpFile(cacheDirectory));
+    CPPUNIT_ASSERT(Utility::tryCreateTmpFile(cacheDirectory, Str("test name")));
 
     // Make sure the item are correctly removed from the tmp dir
     IoHelper::DirectoryIterator dir;
     auto ioError = IoError::Unknown;
-    CPPUNIT_ASSERT(IoHelper::getDirectoryIterator(cacheDirectory->path(), true, ioError, dir));
+    SyncPath cacheDirectoryPath;
+    CPPUNIT_ASSERT(cacheDirectory->path(cacheDirectoryPath));
+    CPPUNIT_ASSERT(IoHelper::getDirectoryIterator(cacheDirectoryPath, true, ioError, dir));
 
     DirectoryEntry entry;
     bool endOfDirectory = false;
@@ -548,22 +554,23 @@ void TestUtility::testTryCreateTmpFile() {
     CPPUNIT_ASSERT_EQUAL(0, counter);
 
     // Try to create a tmp file but a file already exist with the same name but different capitalization.
-    testhelpers::generateTestFile(cacheDirectory->path() / Str("TestFile"));
-    CPPUNIT_ASSERT_EQUAL(IoError::Success, Utility::tryCreateTmpFile(cacheDirectory, Str("testFile")));
+    testhelpers::generateTestFile(cacheDirectoryPath / Str("TestFile"));
+    CPPUNIT_ASSERT(Utility::tryCreateTmpFile(cacheDirectory, Str("testFile")));
 
     // Delete the tmp directory and make sure it is re-created
-    CPPUNIT_ASSERT(IoHelper::deleteItem(cacheDirectory->path(), ioError));
-    CPPUNIT_ASSERT_EQUAL(IoError::Success, Utility::tryCreateTmpFile(cacheDirectory));
+    CPPUNIT_ASSERT(IoHelper::deleteItem(cacheDirectoryPath, ioError));
+    CPPUNIT_ASSERT(Utility::tryCreateTmpFile(cacheDirectory));
 
     {
         // Remove access rights.
         ioError = IoError::Unknown;
-        CPPUNIT_ASSERT(IoHelper::setRights(cacheDirectory->path(), false, false, false, ioError));
-        CPPUNIT_ASSERT_EQUAL(IoError::AccessDenied, Utility::tryCreateTmpFile(cacheDirectory));
+        CPPUNIT_ASSERT(IoHelper::setRights(cacheDirectoryPath, false, false, false, ioError));
+        CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::SystemError, ExitCause::TmpDirAccessError),
+                             Utility::tryCreateTmpFile(cacheDirectory));
 
         // Add back access rights.
-        CPPUNIT_ASSERT(IoHelper::setRights(cacheDirectory->path(), true, true, true, ioError));
-        CPPUNIT_ASSERT_EQUAL(IoError::Success, Utility::tryCreateTmpFile(cacheDirectory));
+        CPPUNIT_ASSERT(IoHelper::setRights(cacheDirectoryPath, true, true, true, ioError));
+        CPPUNIT_ASSERT(Utility::tryCreateTmpFile(cacheDirectory));
     }
 }
 

--- a/test/libcommonserver/utility/testutility.cpp
+++ b/test/libcommonserver/utility/testutility.cpp
@@ -512,10 +512,6 @@ void TestUtility::testTryCreateTmpDir() {
     CPPUNIT_ASSERT(IoHelper::createDirectory(cacheDirectoryPath / testDirName, false, ioError));
     CPPUNIT_ASSERT(Utility::tryCreateTmpDir(cacheDirectory, testDirName));
 
-    // Delete the tmp directory and make sure it is re-created
-    CPPUNIT_ASSERT(IoHelper::deleteItem(cacheDirectoryPath, ioError));
-    CPPUNIT_ASSERT(Utility::tryCreateTmpDir(cacheDirectory));
-
 #if defined(KD_MACOS)
     {
         // Remove access rights.
@@ -556,10 +552,6 @@ void TestUtility::testTryCreateTmpFile() {
     // Try to create a tmp file but a file already exist with the same name but different capitalization.
     testhelpers::generateTestFile(cacheDirectoryPath / Str("TestFile"));
     CPPUNIT_ASSERT(Utility::tryCreateTmpFile(cacheDirectory, Str("testFile")));
-
-    // Delete the tmp directory and make sure it is re-created
-    CPPUNIT_ASSERT(IoHelper::deleteItem(cacheDirectoryPath, ioError));
-    CPPUNIT_ASSERT(Utility::tryCreateTmpFile(cacheDirectory));
 
     {
         // Remove access rights.

--- a/test/libsyncengine/benchmark/benchmarkparalleljobs.cpp
+++ b/test/libsyncengine/benchmark/benchmarkparalleljobs.cpp
@@ -120,7 +120,7 @@ void BenchmarkParallelJobs::benchmarkParallelJobs() {
             dataExtractor.addRow(std::to_string(nbThreads));
             for (uint16_t i = 0; i < nbRepetition; i++) {
                 runJobs(static_cast<uint16_t>(nbThreads), dataExtractor,
-                        generateDownloadJobs(remoteDirId, localTmpDir.path(), static_cast<uint64_t>(size * 1000 * 1000)));
+                        generateDownloadJobs(remoteDirId, localTmpDir.path(), static_cast<int64_t>(size * 1000 * 1000)));
             }
         }
         dataExtractor.print();
@@ -144,7 +144,7 @@ void BenchmarkParallelJobs::benchmarkParallelJobs() {
                 const LocalTemporaryDirectory localTmpDirDownload(filename);
                 const NodeId remoteDirId = size == 1 ? "3477086" : "3477931";
                 downloadJobs = generateDownloadJobs(remoteDirId, localTmpDirDownload.path(),
-                                                    static_cast<uint64_t>(size * 1000 * 1000), nbFiles / 2);
+                                                    static_cast<int64_t>(size * 1000 * 1000), nbFiles / 2);
                 // Mix jobs in list
                 std::list<std::shared_ptr<SyncJob>> jobs;
                 auto it1 = uploadJobs.begin();
@@ -222,7 +222,7 @@ std::list<std::shared_ptr<SyncJob>> BenchmarkParallelJobs::generateUploadSession
 
 std::list<std::shared_ptr<SyncJob>> BenchmarkParallelJobs::generateDownloadJobs(const NodeId &remoteDirId,
                                                                                 const SyncPath &localTestFolderPath,
-                                                                                const uint64_t expectedSize,
+                                                                                const int64_t expectedSize,
                                                                                 const uint16_t nbMaxJob /*= 0*/) const {
     std::list<NodeId> remoteFileIds;
     (void) retrieveRemoteFileIds(remoteDirId, remoteFileIds);
@@ -230,8 +230,8 @@ std::list<std::shared_ptr<SyncJob>> BenchmarkParallelJobs::generateDownloadJobs(
     uint64_t counter = 0;
     std::list<std::shared_ptr<SyncJob>> jobs;
     for (const auto &remoteFileId: remoteFileIds) {
-        const auto job =
-                std::make_shared<DownloadJob>(nullptr, nullptr, driveDbId, remoteFileId, localTestFolderPath, expectedSize);
+        const auto job = std::make_shared<DownloadJob>(
+                nullptr, nullptr, DownloadJob::FileDownloadInfo{driveDbId, remoteFileId, localTestFolderPath, expectedSize});
         (void) jobs.push_back(job);
         counter++;
         if (nbMaxJob && counter >= nbMaxJob) {

--- a/test/libsyncengine/benchmark/benchmarkparalleljobs.cpp
+++ b/test/libsyncengine/benchmark/benchmarkparalleljobs.cpp
@@ -227,13 +227,11 @@ std::list<std::shared_ptr<SyncJob>> BenchmarkParallelJobs::generateDownloadJobs(
     std::list<NodeId> remoteFileIds;
     (void) retrieveRemoteFileIds(remoteDirId, remoteFileIds);
 
-    LocalTemporaryDirectory tempDir;
-
     uint64_t counter = 0;
     std::list<std::shared_ptr<SyncJob>> jobs;
     for (const auto &remoteFileId: remoteFileIds) {
-        const auto job = std::make_shared<DownloadJob>(nullptr, tempDir.path(), driveDbId, remoteFileId, localTestFolderPath,
-                                                       expectedSize);
+        const auto job =
+                std::make_shared<DownloadJob>(nullptr, nullptr, driveDbId, remoteFileId, localTestFolderPath, expectedSize);
         (void) jobs.push_back(job);
         counter++;
         if (nbMaxJob && counter >= nbMaxJob) {

--- a/test/libsyncengine/benchmark/benchmarkparalleljobs.cpp
+++ b/test/libsyncengine/benchmark/benchmarkparalleljobs.cpp
@@ -227,10 +227,13 @@ std::list<std::shared_ptr<SyncJob>> BenchmarkParallelJobs::generateDownloadJobs(
     std::list<NodeId> remoteFileIds;
     (void) retrieveRemoteFileIds(remoteDirId, remoteFileIds);
 
+    LocalTemporaryDirectory tempDir;
+
     uint64_t counter = 0;
     std::list<std::shared_ptr<SyncJob>> jobs;
     for (const auto &remoteFileId: remoteFileIds) {
-        const auto job = std::make_shared<DownloadJob>(nullptr, driveDbId, remoteFileId, localTestFolderPath, expectedSize);
+        const auto job = std::make_shared<DownloadJob>(nullptr, tempDir.path(), driveDbId, remoteFileId, localTestFolderPath,
+                                                       expectedSize);
         (void) jobs.push_back(job);
         counter++;
         if (nbMaxJob && counter >= nbMaxJob) {

--- a/test/libsyncengine/benchmark/benchmarkparalleljobs.h
+++ b/test/libsyncengine/benchmark/benchmarkparalleljobs.h
@@ -47,7 +47,7 @@ class BenchmarkParallelJobs : public CppUnit::TestFixture, public TestBase {
                                                                       const SyncPath &localTestFolderPath,
                                                                       const uint16_t nbParallelChunkJobs) const;
         std::list<std::shared_ptr<SyncJob>> generateDownloadJobs(const NodeId &remoteDirId, const SyncPath &localTestFolderPath,
-                                                                 const uint64_t expectedSize, const uint16_t nbMaxJob = 0) const;
+                                                                 const int64_t expectedSize, const uint16_t nbMaxJob = 0) const;
         void runJobs(const uint16_t nbThread, DataExtractor &dataExtractor,
                      const std::list<std::shared_ptr<SyncJob>> &jobs) const;
 

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -103,7 +103,7 @@ void TestNetworkJobs::setUp() {
     (void) KeyChainManager::instance(true);
     (void) KeyChainManager::instance()->writeToken(keychainKey, _apiToken.reconstructJsonString());
     // Create parmsDb
-    (void) ParmsDb::instance(_localParmsDbTempDir.path() / MockDb::makeDbMockFileName(), KDRIVE_VERSION_STRING, true, true);
+    (void) ParmsDb::instance(_localTempDir.path() / MockDb::makeDbMockFileName(), KDRIVE_VERSION_STRING, true, true);
     ParametersCache::instance()->parameters().setExtendedLog(true);
 
     // Insert user, account & drive
@@ -290,8 +290,8 @@ void TestNetworkJobs::testDownload() {
         int64_t sizeOut = 0;
         // Download (CREATE propagation)
         {
-            DownloadJob job(nullptr, _driveDbId, testFileRemoteId, localDestFilePath, 0, creationTimeIn.count(),
-                            modificationTimeIn.count(), false);
+            DownloadJob job(nullptr, _localTempDir.path(), _driveDbId, testFileRemoteId, localDestFilePath, 0,
+                            creationTimeIn.count(), modificationTimeIn.count(), false);
             const ExitCode exitCode = job.runSynchronously();
             sizeOut = job.size();
             CPPUNIT_ASSERT(exitCode == ExitCode::Ok);
@@ -330,8 +330,8 @@ void TestNetworkJobs::testDownload() {
         // Download again (EDIT propagation)
         {
             modificationTimeIn += std::chrono::minutes(1);
-            DownloadJob job(nullptr, _driveDbId, testFileRemoteId, localDestFilePath, 0, creationTimeIn.count(),
-                            modificationTimeIn.count(), false);
+            DownloadJob job(nullptr, _localTempDir.path(), _driveDbId, testFileRemoteId, localDestFilePath, 0,
+                            creationTimeIn.count(), modificationTimeIn.count(), false);
             const ExitCode exitCode = job.runSynchronously();
             sizeOut = job.size();
             CPPUNIT_ASSERT(exitCode == ExitCode::Ok);
@@ -378,7 +378,7 @@ void TestNetworkJobs::testDownload() {
             vfs->setMockForceStatus([]([[maybe_unused]] const SyncPath & /*path*/,
                                        [[maybe_unused]] const VfsStatus & /*vfsStatus*/) -> ExitInfo { return ExitCode::Ok; });
 
-            DownloadJob job(vfs, _driveDbId, testFileRemoteId, localDestFilePath, 0, creationTimeIn.count(),
+            DownloadJob job(vfs, _localTempDir.path(), _driveDbId, testFileRemoteId, localDestFilePath, 0, creationTimeIn.count(),
                             modificationTimeIn.count(), false);
             const ExitCode exitCode = job.runSynchronously();
             CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, exitCode);
@@ -444,7 +444,7 @@ void TestNetworkJobs::testDownload() {
         IoHelperTestUtilities::setTempDirectoryPathFunction(MockTempDirectoryPath);
         // CREATE
         {
-            DownloadJob job(nullptr, _driveDbId, testFileRemoteId, localDestFilePath, 0, 0, 0, true);
+            DownloadJob job(nullptr, _localTempDir.path(), _driveDbId, testFileRemoteId, localDestFilePath, 0, 0, 0, true);
             const ExitCode exitCode = job.runSynchronously();
             CPPUNIT_ASSERT_GREATER(int64_t{-1}, job.size());
             CPPUNIT_ASSERT(exitCode == ExitCode::Ok);
@@ -465,7 +465,7 @@ void TestNetworkJobs::testDownload() {
 
         // EDIT
         {
-            DownloadJob job(nullptr, _driveDbId, testFileRemoteId, localDestFilePath, 0, 0, 0, false);
+            DownloadJob job(nullptr, _localTempDir.path(), _driveDbId, testFileRemoteId, localDestFilePath, 0, 0, 0, false);
             const ExitCode exitCode = job.runSynchronously();
             CPPUNIT_ASSERT_GREATER(int64_t{-1}, job.size());
             CPPUNIT_ASSERT(exitCode == ExitCode::Ok);
@@ -511,36 +511,38 @@ void TestNetworkJobs::testDownload() {
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
         CPPUNIT_ASSERT_MESSAGE("Small partition not found", exist);
 
-        // Not Enough disk space (tmp dir)
-        {
-            // Trying to download a file with size 9Mo in a 8Mo disk should fail with SystemError,
-            // NotEnoughDiskSpace.
-            const SyncPath localDestFilePath = temporaryDirectory.path() / "9Mo.txt";
-            DownloadJob downloadJob(nullptr, _driveDbId, remoteTmpDir.id(), localDestFilePath, 0, 0, 0, false);
-
-            IoHelperTestUtilities::setCacheDirectoryPath(smallPartitionPath);
-
-            downloadJob.runSynchronously();
-            CPPUNIT_ASSERT_EQUAL(int64_t{-1}, downloadJob.size());
-            IoHelperTestUtilities::resetFunctions();
-            CPPUNIT_ASSERT_EQUAL_MESSAGE(std::string("Space available at " + smallPartitionPath.string() + " -> " +
-                                                     std::to_string(Utility::getFreeDiskSpace(smallPartitionPath))),
-                                         ExitInfo(ExitCode::SystemError, ExitCause::NotEnoughDiskSpace), downloadJob.exitInfo());
-        }
-
-        // Not Enough disk space (destination dir)
-        {
-            // Trying to download a file with size 9Mo in a 8Mo disk should fail with SystemError,
-            // NotEnoughDiskSpace.
-            const SyncPath localDestFilePath = smallPartitionPath / "9Mo.txt";
-            DownloadJob downloadJob(nullptr, _driveDbId, remoteTmpDir.id(), localDestFilePath, 0, 0, 0, false);
-
-            downloadJob.runSynchronously();
-            CPPUNIT_ASSERT_EQUAL(int64_t{-1}, downloadJob.size());
-            CPPUNIT_ASSERT_EQUAL_MESSAGE(std::string("Space available at " + smallPartitionPath.string() + " -> " +
-                                                     std::to_string(Utility::getFreeDiskSpace(smallPartitionPath))),
-                                         ExitInfo(ExitCode::SystemError, ExitCause::NotEnoughDiskSpace), downloadJob.exitInfo());
-        }
+        // // Not Enough disk space (tmp dir)
+        // {
+        //     // Trying to download a file with size 9Mo in a 8Mo disk should fail with SystemError,
+        //     // NotEnoughDiskSpace.
+        //     const SyncPath localDestFilePath = temporaryDirectory.path() / "9Mo.txt";
+        //     DownloadJob downloadJob(nullptr, _driveDbId, remoteTmpDir.id(), localDestFilePath, 0, 0, 0, false);
+        //
+        //     IoHelperTestUtilities::setCacheDirectoryPath(smallPartitionPath);
+        //
+        //     downloadJob.runSynchronously();
+        //     CPPUNIT_ASSERT_EQUAL(int64_t{-1}, downloadJob.size());
+        //     IoHelperTestUtilities::resetFunctions();
+        //     CPPUNIT_ASSERT_EQUAL_MESSAGE(std::string("Space available at " + smallPartitionPath.string() + " -> " +
+        //                                              std::to_string(Utility::getFreeDiskSpace(smallPartitionPath))),
+        //                                  ExitInfo(ExitCode::SystemError, ExitCause::NotEnoughDiskSpace),
+        //                                  downloadJob.exitInfo());
+        // }
+        //
+        // // Not Enough disk space (destination dir)
+        // {
+        //     // Trying to download a file with size 9Mo in a 8Mo disk should fail with SystemError,
+        //     // NotEnoughDiskSpace.
+        //     const SyncPath localDestFilePath = smallPartitionPath / "9Mo.txt";
+        //     DownloadJob downloadJob(nullptr, _driveDbId, remoteTmpDir.id(), localDestFilePath, 0, 0, 0, false);
+        //
+        //     downloadJob.runSynchronously();
+        //     CPPUNIT_ASSERT_EQUAL(int64_t{-1}, downloadJob.size());
+        //     CPPUNIT_ASSERT_EQUAL_MESSAGE(std::string("Space available at " + smallPartitionPath.string() + " -> " +
+        //                                              std::to_string(Utility::getFreeDiskSpace(smallPartitionPath))),
+        //                                  ExitInfo(ExitCode::SystemError, ExitCause::NotEnoughDiskSpace),
+        //                                  downloadJob.exitInfo());
+        // }
     }
 
     // Empty file
@@ -559,7 +561,7 @@ void TestNetworkJobs::testDownload() {
         const SyncPath localDestFilePath = temporaryDirectorySync.path() / "empty_file.txt";
         // Download an empty file
         {
-            DownloadJob job(nullptr, _driveDbId, remote0bytesFileId, localDestFilePath, 0, 0, 0, false);
+            DownloadJob job(nullptr, _localTempDir.path(), _driveDbId, remote0bytesFileId, localDestFilePath, 0, 0, 0, false);
             (void) job.runSynchronously();
             CPPUNIT_ASSERT_EQUAL(int64_t{0}, job.size());
             CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, job.exitInfo().code());
@@ -580,8 +582,8 @@ void TestNetworkJobs::testDownload() {
 
         // Download a file symlink
         {
-            DownloadJob job(nullptr, _driveDbId, testFileSymlinkRemoteId, localDestFilePath, 0, creationTimeIn.count(),
-                            modificationTimeIn.count(), false);
+            DownloadJob job(nullptr, _localTempDir.path(), _driveDbId, testFileSymlinkRemoteId, localDestFilePath, 0,
+                            creationTimeIn.count(), modificationTimeIn.count(), false);
             const ExitCode exitCode = job.runSynchronously();
             CPPUNIT_ASSERT_GREATER(int64_t{-1}, job.size());
             CPPUNIT_ASSERT(exitCode == ExitCode::Ok);
@@ -621,8 +623,8 @@ void TestNetworkJobs::testDownload() {
 
         // Download a folder symlink
         {
-            DownloadJob job(nullptr, _driveDbId, testFolderSymlinkRemoteId, localDestFilePath, 0, creationTimeIn.count(),
-                            modificationTimeIn.count(), false);
+            DownloadJob job(nullptr, _localTempDir.path(), _driveDbId, testFolderSymlinkRemoteId, localDestFilePath, 0,
+                            creationTimeIn.count(), modificationTimeIn.count(), false);
             const ExitCode exitCode = job.runSynchronously();
             CPPUNIT_ASSERT_GREATER(int64_t{-1}, job.size());
             CPPUNIT_ASSERT(exitCode == ExitCode::Ok);
@@ -662,8 +664,8 @@ void TestNetworkJobs::testDownload() {
 
         // Download a valid alias
         {
-            DownloadJob job(nullptr, _driveDbId, testAliasGoodRemoteId, localDestFilePath, 0, creationTimeIn.count(),
-                            modificationTimeIn.count(), false);
+            DownloadJob job(nullptr, _localTempDir.path(), _driveDbId, testAliasGoodRemoteId, localDestFilePath, 0,
+                            creationTimeIn.count(), modificationTimeIn.count(), false);
             const ExitCode exitCode = job.runSynchronously();
             CPPUNIT_ASSERT_GREATER(int64_t{-1}, job.size());
             CPPUNIT_ASSERT(exitCode == ExitCode::Ok);
@@ -693,7 +695,7 @@ void TestNetworkJobs::testDownload() {
 
         // Download an invalid alias (not imported by the desktop app)
         {
-            DownloadJob job(nullptr, _driveDbId, testAliasDnDRemoteId, localDestFilePath, 0, 0, 0, false);
+            DownloadJob job(nullptr, _localTempDir.path(), _driveDbId, testAliasDnDRemoteId, localDestFilePath, 0, 0, 0, false);
             const ExitCode exitCode = job.runSynchronously();
             CPPUNIT_ASSERT(exitCode == ExitCode::Ok);
         }
@@ -712,7 +714,8 @@ void TestNetworkJobs::testDownload() {
 
         // Download an invalid alias (corrupted)
         {
-            DownloadJob job(nullptr, _driveDbId, testAliasCorruptedRemoteId, localDestFilePath, 0, 0, 0, false);
+            DownloadJob job(nullptr, _localTempDir.path(), _driveDbId, testAliasCorruptedRemoteId, localDestFilePath, 0, 0, 0,
+                            false);
             const ExitCode exitCode = job.runSynchronously();
             CPPUNIT_ASSERT(exitCode == ExitCode::SystemError);
         }
@@ -771,8 +774,8 @@ void TestNetworkJobs::testDownloadAborted() {
                 return ExitCode::Ok;
             });
 
-    std::shared_ptr<DownloadJob> job =
-            std::make_shared<DownloadJob>(vfs, _driveDbId, testBigFileRemoteId, localDestFilePath, 0, 0, 0, false);
+    std::shared_ptr<DownloadJob> job = std::make_shared<DownloadJob>(vfs, _localTempDir.path(), _driveDbId, testBigFileRemoteId,
+                                                                     localDestFilePath, 0, 0, 0, false);
     SyncJobManagerSingleton::instance()->queueAsyncJob(job);
 
     int counter = 0;

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -293,8 +293,9 @@ void TestNetworkJobs::testDownload() {
         int64_t sizeOut = 0;
         // Download (CREATE propagation)
         {
-            DownloadJob job(nullptr, _cacheDirectory, _driveDbId, testFileRemoteId, localDestFilePath, 0, creationTimeIn.count(),
-                            modificationTimeIn.count(), false);
+            DownloadJob job(nullptr, _cacheDirectory,
+                            DownloadJob::FileDownloadInfo{_driveDbId, testFileRemoteId, localDestFilePath, 0,
+                                                          creationTimeIn.count(), modificationTimeIn.count(), false});
             const ExitCode exitCode = job.runSynchronously();
             sizeOut = job.size();
             CPPUNIT_ASSERT(exitCode == ExitCode::Ok);
@@ -333,8 +334,9 @@ void TestNetworkJobs::testDownload() {
         // Download again (EDIT propagation)
         {
             modificationTimeIn += std::chrono::minutes(1);
-            DownloadJob job(nullptr, _cacheDirectory, _driveDbId, testFileRemoteId, localDestFilePath, 0, creationTimeIn.count(),
-                            modificationTimeIn.count(), false);
+            DownloadJob job(nullptr, _cacheDirectory,
+                            DownloadJob::FileDownloadInfo{_driveDbId, testFileRemoteId, localDestFilePath, 0,
+                                                          creationTimeIn.count(), modificationTimeIn.count(), false});
             const ExitCode exitCode = job.runSynchronously();
             sizeOut = job.size();
             CPPUNIT_ASSERT(exitCode == ExitCode::Ok);
@@ -381,8 +383,9 @@ void TestNetworkJobs::testDownload() {
             vfs->setMockForceStatus([]([[maybe_unused]] const SyncPath & /*path*/,
                                        [[maybe_unused]] const VfsStatus & /*vfsStatus*/) -> ExitInfo { return ExitCode::Ok; });
 
-            DownloadJob job(vfs, _cacheDirectory, _driveDbId, testFileRemoteId, localDestFilePath, 0, creationTimeIn.count(),
-                            modificationTimeIn.count(), false);
+            DownloadJob job(vfs, _cacheDirectory,
+                            DownloadJob::FileDownloadInfo{_driveDbId, testFileRemoteId, localDestFilePath, 0,
+                                                          creationTimeIn.count(), modificationTimeIn.count(), false});
             const ExitCode exitCode = job.runSynchronously();
             CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, exitCode);
             CPPUNIT_ASSERT_EQUAL(true, job._isHydrated);
@@ -429,8 +432,9 @@ void TestNetworkJobs::testDownload() {
             (void) IoHelper::deleteItem(_cacheDirectory->path());
 
             modificationTimeIn += std::chrono::minutes(1);
-            DownloadJob job(nullptr, _cacheDirectory, _driveDbId, testFileRemoteId, localDestFilePath, 0, creationTimeIn.count(),
-                            modificationTimeIn.count(), false);
+            DownloadJob job(nullptr, _cacheDirectory,
+                            DownloadJob::FileDownloadInfo{_driveDbId, testFileRemoteId, localDestFilePath, 0,
+                                                          creationTimeIn.count(), modificationTimeIn.count(), false});
             CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, job.runSynchronously().code());
         }
     }
@@ -457,7 +461,8 @@ void TestNetworkJobs::testDownload() {
         IoHelperTestUtilities::setTempDirectoryPathFunction(MockTempDirectoryPath);
         // CREATE
         {
-            DownloadJob job(nullptr, _cacheDirectory, _driveDbId, testFileRemoteId, localDestFilePath, 0, 0, 0, true);
+            DownloadJob job(nullptr, _cacheDirectory,
+                            DownloadJob::FileDownloadInfo{_driveDbId, testFileRemoteId, localDestFilePath, 0, 0, 0, true});
             const ExitCode exitCode = job.runSynchronously();
             CPPUNIT_ASSERT_GREATER(int64_t{-1}, job.size());
             CPPUNIT_ASSERT(exitCode == ExitCode::Ok);
@@ -478,7 +483,8 @@ void TestNetworkJobs::testDownload() {
 
         // EDIT
         {
-            DownloadJob job(nullptr, _cacheDirectory, _driveDbId, testFileRemoteId, localDestFilePath, 0, 0, 0, false);
+            DownloadJob job(nullptr, _cacheDirectory,
+                            DownloadJob::FileDownloadInfo{_driveDbId, testFileRemoteId, localDestFilePath, 0, 0, 0, false});
             const ExitCode exitCode = job.runSynchronously();
             CPPUNIT_ASSERT_GREATER(int64_t{-1}, job.size());
             CPPUNIT_ASSERT(exitCode == ExitCode::Ok);
@@ -531,7 +537,9 @@ void TestNetworkJobs::testDownload() {
             // Trying to download a file with size 9Mo in a 8Mo disk should fail with SystemError,
             // NotEnoughDiskSpace.
             const SyncPath localDestFilePath = smallPartitionPath / "9Mo.txt";
-            DownloadJob downloadJob(nullptr, cacheDirectory, _driveDbId, remoteTmpDir.id(), localDestFilePath, 0, 0, 0, false);
+            DownloadJob downloadJob(
+                    nullptr, cacheDirectory,
+                    DownloadJob::FileDownloadInfo{_driveDbId, remoteTmpDir.id(), localDestFilePath, 0, 0, 0, false});
 
             (void) downloadJob.runSynchronously();
             CPPUNIT_ASSERT_EQUAL(int64_t{-1}, downloadJob.size());
@@ -557,7 +565,8 @@ void TestNetworkJobs::testDownload() {
         const SyncPath localDestFilePath = temporaryDirectorySync.path() / "empty_file.txt";
         // Download an empty file
         {
-            DownloadJob job(nullptr, _cacheDirectory, _driveDbId, remote0bytesFileId, localDestFilePath, 0, 0, 0, false);
+            DownloadJob job(nullptr, _cacheDirectory,
+                            DownloadJob::FileDownloadInfo{_driveDbId, remote0bytesFileId, localDestFilePath, 0, 0, 0, false});
             (void) job.runSynchronously();
             CPPUNIT_ASSERT_EQUAL(int64_t{0}, job.size());
             CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, job.exitInfo().code());
@@ -578,8 +587,9 @@ void TestNetworkJobs::testDownload() {
 
         // Download a file symlink
         {
-            DownloadJob job(nullptr, _cacheDirectory, _driveDbId, testFileSymlinkRemoteId, localDestFilePath, 0,
-                            creationTimeIn.count(), modificationTimeIn.count(), false);
+            DownloadJob job(nullptr, _cacheDirectory,
+                            DownloadJob::FileDownloadInfo{_driveDbId, testFileSymlinkRemoteId, localDestFilePath, 0,
+                                                          creationTimeIn.count(), modificationTimeIn.count(), false});
             const ExitCode exitCode = job.runSynchronously();
             CPPUNIT_ASSERT_GREATER(int64_t{-1}, job.size());
             CPPUNIT_ASSERT(exitCode == ExitCode::Ok);
@@ -619,8 +629,9 @@ void TestNetworkJobs::testDownload() {
 
         // Download a folder symlink
         {
-            DownloadJob job(nullptr, _cacheDirectory, _driveDbId, testFolderSymlinkRemoteId, localDestFilePath, 0,
-                            creationTimeIn.count(), modificationTimeIn.count(), false);
+            DownloadJob job(nullptr, _cacheDirectory,
+                            DownloadJob::FileDownloadInfo{_driveDbId, testFolderSymlinkRemoteId, localDestFilePath, 0,
+                                                          creationTimeIn.count(), modificationTimeIn.count(), false});
             const ExitCode exitCode = job.runSynchronously();
             CPPUNIT_ASSERT_GREATER(int64_t{-1}, job.size());
             CPPUNIT_ASSERT(exitCode == ExitCode::Ok);
@@ -660,8 +671,9 @@ void TestNetworkJobs::testDownload() {
 
         // Download a valid alias
         {
-            DownloadJob job(nullptr, _cacheDirectory, _driveDbId, testAliasGoodRemoteId, localDestFilePath, 0,
-                            creationTimeIn.count(), modificationTimeIn.count(), false);
+            DownloadJob job(nullptr, _cacheDirectory,
+                            DownloadJob::FileDownloadInfo{_driveDbId, testAliasGoodRemoteId, localDestFilePath, 0,
+                                                          creationTimeIn.count(), modificationTimeIn.count(), false});
             const ExitCode exitCode = job.runSynchronously();
             CPPUNIT_ASSERT_GREATER(int64_t{-1}, job.size());
             CPPUNIT_ASSERT(exitCode == ExitCode::Ok);
@@ -691,7 +703,8 @@ void TestNetworkJobs::testDownload() {
 
         // Download an invalid alias (not imported by the desktop app)
         {
-            DownloadJob job(nullptr, _cacheDirectory, _driveDbId, testAliasDnDRemoteId, localDestFilePath, 0, 0, 0, false);
+            DownloadJob job(nullptr, _cacheDirectory,
+                            DownloadJob::FileDownloadInfo{_driveDbId, testAliasDnDRemoteId, localDestFilePath, 0, 0, 0, false});
             const ExitCode exitCode = job.runSynchronously();
             CPPUNIT_ASSERT(exitCode == ExitCode::Ok);
         }
@@ -710,7 +723,9 @@ void TestNetworkJobs::testDownload() {
 
         // Download an invalid alias (corrupted)
         {
-            DownloadJob job(nullptr, _cacheDirectory, _driveDbId, testAliasCorruptedRemoteId, localDestFilePath, 0, 0, 0, false);
+            DownloadJob job(
+                    nullptr, _cacheDirectory,
+                    DownloadJob::FileDownloadInfo{_driveDbId, testAliasCorruptedRemoteId, localDestFilePath, 0, 0, 0, false});
             const ExitCode exitCode = job.runSynchronously();
             CPPUNIT_ASSERT(exitCode == ExitCode::SystemError);
         }
@@ -769,8 +784,9 @@ void TestNetworkJobs::testDownloadAborted() {
                 return ExitCode::Ok;
             });
 
-    std::shared_ptr<DownloadJob> job = std::make_shared<DownloadJob>(vfs, _cacheDirectory, _driveDbId, testBigFileRemoteId,
-                                                                     localDestFilePath, 0, 0, 0, false);
+    std::shared_ptr<DownloadJob> job = std::make_shared<DownloadJob>(
+            vfs, _cacheDirectory,
+            DownloadJob::FileDownloadInfo{_driveDbId, testBigFileRemoteId, localDestFilePath, 0, 0, 0, false});
     SyncJobManagerSingleton::instance()->queueAsyncJob(job);
 
     int counter = 0;

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -429,7 +429,9 @@ void TestNetworkJobs::testDownload() {
 
         // Download again (EDIT propagation) but cache directory has been deleted
         {
-            (void) IoHelper::deleteItem(_cacheDirectory->path());
+            SyncPath cacheDirectoryPath;
+            CPPUNIT_ASSERT(_cacheDirectory->path(cacheDirectoryPath));
+            (void) IoHelper::deleteItem(cacheDirectoryPath);
 
             modificationTimeIn += std::chrono::minutes(1);
             DownloadJob job(nullptr, _cacheDirectory,

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -423,6 +423,16 @@ void TestNetworkJobs::testDownload() {
             CPPUNIT_ASSERT(value == litesync_attrs::statusOffline);
         }
 #endif
+
+        // Download again (EDIT propagation) but cache directory has been deleted
+        {
+            (void) IoHelper::deleteItem(_cacheDirectory->path());
+
+            modificationTimeIn += std::chrono::minutes(1);
+            DownloadJob job(nullptr, _cacheDirectory, _driveDbId, testFileRemoteId, localDestFilePath, 0, creationTimeIn.count(),
+                            modificationTimeIn.count(), false);
+            CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, job.runSynchronously().code());
+        }
     }
 
     // Cross Device Link

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -129,6 +129,9 @@ void TestNetworkJobs::setUp() {
     if (ParmsDb::instance()->selectParameters(parameters, found) && found) {
         Proxy::instance(parameters.proxyConfig());
     }
+
+    // Setup cache directory
+    _cacheDirectory = std::make_shared<CacheDirectory>(_localTempDir.path());
 }
 
 void TestNetworkJobs::tearDown() {
@@ -290,8 +293,8 @@ void TestNetworkJobs::testDownload() {
         int64_t sizeOut = 0;
         // Download (CREATE propagation)
         {
-            DownloadJob job(nullptr, _localTempDir.path(), _driveDbId, testFileRemoteId, localDestFilePath, 0,
-                            creationTimeIn.count(), modificationTimeIn.count(), false);
+            DownloadJob job(nullptr, _cacheDirectory, _driveDbId, testFileRemoteId, localDestFilePath, 0, creationTimeIn.count(),
+                            modificationTimeIn.count(), false);
             const ExitCode exitCode = job.runSynchronously();
             sizeOut = job.size();
             CPPUNIT_ASSERT(exitCode == ExitCode::Ok);
@@ -330,8 +333,8 @@ void TestNetworkJobs::testDownload() {
         // Download again (EDIT propagation)
         {
             modificationTimeIn += std::chrono::minutes(1);
-            DownloadJob job(nullptr, _localTempDir.path(), _driveDbId, testFileRemoteId, localDestFilePath, 0,
-                            creationTimeIn.count(), modificationTimeIn.count(), false);
+            DownloadJob job(nullptr, _cacheDirectory, _driveDbId, testFileRemoteId, localDestFilePath, 0, creationTimeIn.count(),
+                            modificationTimeIn.count(), false);
             const ExitCode exitCode = job.runSynchronously();
             sizeOut = job.size();
             CPPUNIT_ASSERT(exitCode == ExitCode::Ok);
@@ -378,7 +381,7 @@ void TestNetworkJobs::testDownload() {
             vfs->setMockForceStatus([]([[maybe_unused]] const SyncPath & /*path*/,
                                        [[maybe_unused]] const VfsStatus & /*vfsStatus*/) -> ExitInfo { return ExitCode::Ok; });
 
-            DownloadJob job(vfs, _localTempDir.path(), _driveDbId, testFileRemoteId, localDestFilePath, 0, creationTimeIn.count(),
+            DownloadJob job(vfs, _cacheDirectory, _driveDbId, testFileRemoteId, localDestFilePath, 0, creationTimeIn.count(),
                             modificationTimeIn.count(), false);
             const ExitCode exitCode = job.runSynchronously();
             CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, exitCode);
@@ -444,7 +447,7 @@ void TestNetworkJobs::testDownload() {
         IoHelperTestUtilities::setTempDirectoryPathFunction(MockTempDirectoryPath);
         // CREATE
         {
-            DownloadJob job(nullptr, _localTempDir.path(), _driveDbId, testFileRemoteId, localDestFilePath, 0, 0, 0, true);
+            DownloadJob job(nullptr, _cacheDirectory, _driveDbId, testFileRemoteId, localDestFilePath, 0, 0, 0, true);
             const ExitCode exitCode = job.runSynchronously();
             CPPUNIT_ASSERT_GREATER(int64_t{-1}, job.size());
             CPPUNIT_ASSERT(exitCode == ExitCode::Ok);
@@ -465,7 +468,7 @@ void TestNetworkJobs::testDownload() {
 
         // EDIT
         {
-            DownloadJob job(nullptr, _localTempDir.path(), _driveDbId, testFileRemoteId, localDestFilePath, 0, 0, 0, false);
+            DownloadJob job(nullptr, _cacheDirectory, _driveDbId, testFileRemoteId, localDestFilePath, 0, 0, 0, false);
             const ExitCode exitCode = job.runSynchronously();
             CPPUNIT_ASSERT_GREATER(int64_t{-1}, job.size());
             CPPUNIT_ASSERT(exitCode == ExitCode::Ok);
@@ -510,6 +513,8 @@ void TestNetworkJobs::testDownload() {
                                                                               IoHelper::PathCheckOption::Insensitive));
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
         CPPUNIT_ASSERT_MESSAGE("Small partition not found", exist);
+
+        // TODO : put it back!!!
 
         // // Not Enough disk space (tmp dir)
         // {
@@ -561,7 +566,7 @@ void TestNetworkJobs::testDownload() {
         const SyncPath localDestFilePath = temporaryDirectorySync.path() / "empty_file.txt";
         // Download an empty file
         {
-            DownloadJob job(nullptr, _localTempDir.path(), _driveDbId, remote0bytesFileId, localDestFilePath, 0, 0, 0, false);
+            DownloadJob job(nullptr, _cacheDirectory, _driveDbId, remote0bytesFileId, localDestFilePath, 0, 0, 0, false);
             (void) job.runSynchronously();
             CPPUNIT_ASSERT_EQUAL(int64_t{0}, job.size());
             CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, job.exitInfo().code());
@@ -582,7 +587,7 @@ void TestNetworkJobs::testDownload() {
 
         // Download a file symlink
         {
-            DownloadJob job(nullptr, _localTempDir.path(), _driveDbId, testFileSymlinkRemoteId, localDestFilePath, 0,
+            DownloadJob job(nullptr, _cacheDirectory, _driveDbId, testFileSymlinkRemoteId, localDestFilePath, 0,
                             creationTimeIn.count(), modificationTimeIn.count(), false);
             const ExitCode exitCode = job.runSynchronously();
             CPPUNIT_ASSERT_GREATER(int64_t{-1}, job.size());
@@ -623,7 +628,7 @@ void TestNetworkJobs::testDownload() {
 
         // Download a folder symlink
         {
-            DownloadJob job(nullptr, _localTempDir.path(), _driveDbId, testFolderSymlinkRemoteId, localDestFilePath, 0,
+            DownloadJob job(nullptr, _cacheDirectory, _driveDbId, testFolderSymlinkRemoteId, localDestFilePath, 0,
                             creationTimeIn.count(), modificationTimeIn.count(), false);
             const ExitCode exitCode = job.runSynchronously();
             CPPUNIT_ASSERT_GREATER(int64_t{-1}, job.size());
@@ -664,7 +669,7 @@ void TestNetworkJobs::testDownload() {
 
         // Download a valid alias
         {
-            DownloadJob job(nullptr, _localTempDir.path(), _driveDbId, testAliasGoodRemoteId, localDestFilePath, 0,
+            DownloadJob job(nullptr, _cacheDirectory, _driveDbId, testAliasGoodRemoteId, localDestFilePath, 0,
                             creationTimeIn.count(), modificationTimeIn.count(), false);
             const ExitCode exitCode = job.runSynchronously();
             CPPUNIT_ASSERT_GREATER(int64_t{-1}, job.size());
@@ -695,7 +700,7 @@ void TestNetworkJobs::testDownload() {
 
         // Download an invalid alias (not imported by the desktop app)
         {
-            DownloadJob job(nullptr, _localTempDir.path(), _driveDbId, testAliasDnDRemoteId, localDestFilePath, 0, 0, 0, false);
+            DownloadJob job(nullptr, _cacheDirectory, _driveDbId, testAliasDnDRemoteId, localDestFilePath, 0, 0, 0, false);
             const ExitCode exitCode = job.runSynchronously();
             CPPUNIT_ASSERT(exitCode == ExitCode::Ok);
         }
@@ -714,8 +719,7 @@ void TestNetworkJobs::testDownload() {
 
         // Download an invalid alias (corrupted)
         {
-            DownloadJob job(nullptr, _localTempDir.path(), _driveDbId, testAliasCorruptedRemoteId, localDestFilePath, 0, 0, 0,
-                            false);
+            DownloadJob job(nullptr, _cacheDirectory, _driveDbId, testAliasCorruptedRemoteId, localDestFilePath, 0, 0, 0, false);
             const ExitCode exitCode = job.runSynchronously();
             CPPUNIT_ASSERT(exitCode == ExitCode::SystemError);
         }
@@ -774,7 +778,7 @@ void TestNetworkJobs::testDownloadAborted() {
                 return ExitCode::Ok;
             });
 
-    std::shared_ptr<DownloadJob> job = std::make_shared<DownloadJob>(vfs, _localTempDir.path(), _driveDbId, testBigFileRemoteId,
+    std::shared_ptr<DownloadJob> job = std::make_shared<DownloadJob>(vfs, _cacheDirectory, _driveDbId, testBigFileRemoteId,
                                                                      localDestFilePath, 0, 0, 0, false);
     SyncJobManagerSingleton::instance()->queueAsyncJob(job);
 

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -514,40 +514,21 @@ void TestNetworkJobs::testDownload() {
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
         CPPUNIT_ASSERT_MESSAGE("Small partition not found", exist);
 
-        // TODO : put it back!!!
+        const auto cacheDirectory = std::make_shared<CacheDirectory>(smallPartitionPath);
 
-        // // Not Enough disk space (tmp dir)
-        // {
-        //     // Trying to download a file with size 9Mo in a 8Mo disk should fail with SystemError,
-        //     // NotEnoughDiskSpace.
-        //     const SyncPath localDestFilePath = temporaryDirectory.path() / "9Mo.txt";
-        //     DownloadJob downloadJob(nullptr, _driveDbId, remoteTmpDir.id(), localDestFilePath, 0, 0, 0, false);
-        //
-        //     IoHelperTestUtilities::setCacheDirectoryPath(smallPartitionPath);
-        //
-        //     downloadJob.runSynchronously();
-        //     CPPUNIT_ASSERT_EQUAL(int64_t{-1}, downloadJob.size());
-        //     IoHelperTestUtilities::resetFunctions();
-        //     CPPUNIT_ASSERT_EQUAL_MESSAGE(std::string("Space available at " + smallPartitionPath.string() + " -> " +
-        //                                              std::to_string(Utility::getFreeDiskSpace(smallPartitionPath))),
-        //                                  ExitInfo(ExitCode::SystemError, ExitCause::NotEnoughDiskSpace),
-        //                                  downloadJob.exitInfo());
-        // }
-        //
-        // // Not Enough disk space (destination dir)
-        // {
-        //     // Trying to download a file with size 9Mo in a 8Mo disk should fail with SystemError,
-        //     // NotEnoughDiskSpace.
-        //     const SyncPath localDestFilePath = smallPartitionPath / "9Mo.txt";
-        //     DownloadJob downloadJob(nullptr, _driveDbId, remoteTmpDir.id(), localDestFilePath, 0, 0, 0, false);
-        //
-        //     downloadJob.runSynchronously();
-        //     CPPUNIT_ASSERT_EQUAL(int64_t{-1}, downloadJob.size());
-        //     CPPUNIT_ASSERT_EQUAL_MESSAGE(std::string("Space available at " + smallPartitionPath.string() + " -> " +
-        //                                              std::to_string(Utility::getFreeDiskSpace(smallPartitionPath))),
-        //                                  ExitInfo(ExitCode::SystemError, ExitCause::NotEnoughDiskSpace),
-        //                                  downloadJob.exitInfo());
-        // }
+        // Not Enough disk space (destination dir)
+        {
+            // Trying to download a file with size 9Mo in a 8Mo disk should fail with SystemError,
+            // NotEnoughDiskSpace.
+            const SyncPath localDestFilePath = smallPartitionPath / "9Mo.txt";
+            DownloadJob downloadJob(nullptr, cacheDirectory, _driveDbId, remoteTmpDir.id(), localDestFilePath, 0, 0, 0, false);
+
+            (void) downloadJob.runSynchronously();
+            CPPUNIT_ASSERT_EQUAL(int64_t{-1}, downloadJob.size());
+            CPPUNIT_ASSERT_EQUAL_MESSAGE(std::string("Space available at " + smallPartitionPath.string() + " -> " +
+                                                     std::to_string(Utility::getFreeDiskSpace(smallPartitionPath))),
+                                         ExitInfo(ExitCode::SystemError, ExitCause::NotEnoughDiskSpace), downloadJob.exitInfo());
+        }
     }
 
     // Empty file

--- a/test/libsyncengine/jobs/network/testnetworkjobs.h
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.h
@@ -128,6 +128,6 @@ class TestNetworkJobs : public CppUnit::TestFixture, public TestBase {
 
         static uint64_t _nbParallelThreads;
 
-        LocalTemporaryDirectory _localParmsDbTempDir{"testNetworkJobs"};
+        LocalTemporaryDirectory _localTempDir{"testNetworkJobs"};
 };
 } // namespace KDC

--- a/test/libsyncengine/jobs/network/testnetworkjobs.h
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.h
@@ -19,11 +19,14 @@
 #pragma once
 
 #include "testincludes.h"
+
+#include "io/cachedirectory.h"
 #include "keychainmanager/apitoken.h"
 #include "test_utility/localtemporarydirectory.h"
 
 #include "utility/types.h"
 #include "libcommonserver/io/iohelper.h"
+
 using namespace CppUnit;
 
 namespace KDC {
@@ -129,5 +132,6 @@ class TestNetworkJobs : public CppUnit::TestFixture, public TestBase {
         static uint64_t _nbParallelThreads;
 
         LocalTemporaryDirectory _localTempDir{"testNetworkJobs"};
+        std::shared_ptr<CacheDirectory> _cacheDirectory;
 };
 } // namespace KDC

--- a/test/libsyncengine/jobs/testsyncjobmanagersingleton.cpp
+++ b/test/libsyncengine/jobs/testsyncjobmanagersingleton.cpp
@@ -385,9 +385,10 @@ void TestSyncJobManagerSingleton::testCanRunjob() {
         uint64_t counter = 0;
         const NodeId testBigFileRemoteId = "97601"; // test_ci/big_file_dir/big_text_file.txt
         for (auto i = 0; i < 20; i++) {
-            const auto job = std::make_shared<DownloadJob>(nullptr, cacheDirectory, driveDbId, testBigFileRemoteId,
-                                                           localTmpDir.path(), 110 * 1024 * 1024, testhelpers::defaultFileSize,
-                                                           testhelpers::defaultFileSize, false);
+            const auto job = std::make_shared<DownloadJob>(
+                    nullptr, cacheDirectory,
+                    DownloadJob::FileDownloadInfo{driveDbId, testBigFileRemoteId, localTmpDir.path(), 110 * 1024 * 1024,
+                                                  testhelpers::defaultFileSize, testhelpers::defaultFileSize, false});
             if (!SyncJobManagerSingleton::instance()->canRunJob(job)) {
                 noMoreRun = true;
                 break;

--- a/test/libsyncengine/jobs/testsyncjobmanagersingleton.cpp
+++ b/test/libsyncengine/jobs/testsyncjobmanagersingleton.cpp
@@ -379,12 +379,13 @@ void TestSyncJobManagerSingleton::testCanRunjob() {
         const RemoteTemporaryDirectory remoteTmpDir(driveDbId, _testVariables.remoteDirId, "testCanRunjob");
 
         const LocalTemporaryDirectory localTmpDir("testCanRunjob");
+        const auto cacheDirectory = std::make_shared<CacheDirectory>(localTmpDir.path());
 
         bool noMoreRun = false;
         uint64_t counter = 0;
         const NodeId testBigFileRemoteId = "97601"; // test_ci/big_file_dir/big_text_file.txt
         for (auto i = 0; i < 20; i++) {
-            const auto job = std::make_shared<DownloadJob>(nullptr, _localTempDir.path(), driveDbId, testBigFileRemoteId,
+            const auto job = std::make_shared<DownloadJob>(nullptr, cacheDirectory, driveDbId, testBigFileRemoteId,
                                                            localTmpDir.path(), 110 * 1024 * 1024, testhelpers::defaultFileSize,
                                                            testhelpers::defaultFileSize, false);
             if (!SyncJobManagerSingleton::instance()->canRunJob(job)) {

--- a/test/libsyncengine/jobs/testsyncjobmanagersingleton.cpp
+++ b/test/libsyncengine/jobs/testsyncjobmanagersingleton.cpp
@@ -384,9 +384,9 @@ void TestSyncJobManagerSingleton::testCanRunjob() {
         uint64_t counter = 0;
         const NodeId testBigFileRemoteId = "97601"; // test_ci/big_file_dir/big_text_file.txt
         for (auto i = 0; i < 20; i++) {
-            const auto job =
-                    std::make_shared<DownloadJob>(nullptr, driveDbId, testBigFileRemoteId, localTmpDir.path(), 110 * 1024 * 1024,
-                                                  testhelpers::defaultFileSize, testhelpers::defaultFileSize, false);
+            const auto job = std::make_shared<DownloadJob>(nullptr, _localTempDir.path(), driveDbId, testBigFileRemoteId,
+                                                           localTmpDir.path(), 110 * 1024 * 1024, testhelpers::defaultFileSize,
+                                                           testhelpers::defaultFileSize, false);
             if (!SyncJobManagerSingleton::instance()->canRunJob(job)) {
                 noMoreRun = true;
                 break;

--- a/test/libsyncengine/requests/testexclusiontemplatecache.cpp
+++ b/test/libsyncengine/requests/testexclusiontemplatecache.cpp
@@ -17,6 +17,8 @@
  */
 
 #include "testexclusiontemplatecache.h"
+
+#include "io/cachedirectory.h"
 #include "libparms/db/parmsdb.h"
 #include "requests/parameterscache.h"
 #include "mocks/libcommonserver/db/mockdb.h"
@@ -129,12 +131,12 @@ void TestExclusionTemplateCache::testIsExcluded() {
 #endif
 }
 void TestExclusionTemplateCache::testCacheFolderIsExcluded() {
-    SyncPath cachePath;
-    CPPUNIT_ASSERT(IoHelper::cacheDirectoryPath(cachePath));
-    CPPUNIT_ASSERT(!cachePath.empty());
+    LocalTemporaryDirectory tmpLocalFolder("testCacheFolderIsExcluded");
+    CacheDirectory cacheDirectory(tmpLocalFolder.path());
+    CPPUNIT_ASSERT(!cacheDirectory.path().empty());
     bool isWarning = false;
-    CPPUNIT_ASSERT_MESSAGE(cachePath.filename().string() + " is not excluded",
-                           ExclusionTemplateCache::instance()->isExcluded(cachePath.filename(), isWarning));
+    CPPUNIT_ASSERT_MESSAGE(cacheDirectory.path().filename().string() + " is not excluded",
+                           ExclusionTemplateCache::instance()->isExcluded(cacheDirectory.path().filename(), isWarning));
     CPPUNIT_ASSERT(!isWarning);
 }
 

--- a/test/libsyncengine/requests/testexclusiontemplatecache.cpp
+++ b/test/libsyncengine/requests/testexclusiontemplatecache.cpp
@@ -133,10 +133,12 @@ void TestExclusionTemplateCache::testIsExcluded() {
 void TestExclusionTemplateCache::testCacheFolderIsExcluded() {
     LocalTemporaryDirectory tmpLocalFolder("testCacheFolderIsExcluded");
     CacheDirectory cacheDirectory(tmpLocalFolder.path());
-    CPPUNIT_ASSERT(!cacheDirectory.path().empty());
+    SyncPath cacheDirectoryPath;
+    CPPUNIT_ASSERT(cacheDirectory.path(cacheDirectoryPath));
+    CPPUNIT_ASSERT(!cacheDirectoryPath.empty());
     bool isWarning = false;
-    CPPUNIT_ASSERT_MESSAGE(cacheDirectory.path().filename().string() + " is not excluded",
-                           ExclusionTemplateCache::instance()->isExcluded(cacheDirectory.path().filename(), isWarning));
+    CPPUNIT_ASSERT_MESSAGE(cacheDirectoryPath.filename().string() + " is not excluded",
+                           ExclusionTemplateCache::instance()->isExcluded(cacheDirectoryPath.filename(), isWarning));
     CPPUNIT_ASSERT(!isWarning);
 }
 

--- a/test/libsyncengine/requests/testexclusiontemplatecache.cpp
+++ b/test/libsyncengine/requests/testexclusiontemplatecache.cpp
@@ -131,7 +131,7 @@ void TestExclusionTemplateCache::testIsExcluded() {
 #endif
 }
 void TestExclusionTemplateCache::testCacheFolderIsExcluded() {
-    LocalTemporaryDirectory tmpLocalFolder("testCacheFolderIsExcluded");
+    const LocalTemporaryDirectory tmpLocalFolder("testCacheFolderIsExcluded");
     CacheDirectory cacheDirectory(tmpLocalFolder.path());
     SyncPath cacheDirectoryPath;
     CPPUNIT_ASSERT(cacheDirectory.path(cacheDirectoryPath));

--- a/test/libsyncengine/update_detection/file_system_observer/testremotefilesystemobserverworker.cpp
+++ b/test/libsyncengine/update_detection/file_system_observer/testremotefilesystemobserverworker.cpp
@@ -88,7 +88,7 @@ void TestRemoteFileSystemObserverWorker::setUp() {
     Drive drive(_driveDbId, driveId, account.dbId(), std::string(), 0, std::string());
     (void) ParmsDb::instance()->insertDrive(drive);
 
-    Sync sync(1, drive.dbId(), "/", "", "/");
+    Sync sync(1, drive.dbId(), testhelpers::localTestDirPath(), "", "/");
     (void) ParmsDb::instance()->insertSync(sync);
 
     _syncPal = std::make_shared<SyncPalTest>(sync.dbId(), KDRIVE_VERSION_STRING);

--- a/test/server/updater/testwindowsupdater.cpp
+++ b/test/server/updater/testwindowsupdater.cpp
@@ -141,7 +141,7 @@ void TestWindowsUpdater::testIsSignatureValid() {
         const testhelpers::TestVariables testVariables;
         static const NodeId signedFileId = "5304421";
         const auto signedFilePath = tmpDir.path() / "testfile.exe";
-        DownloadJob job(nullptr, cacheDirectory, _driveDbId, signedFileId, signedFilePath, 0);
+        DownloadJob job(nullptr, cacheDirectory, DownloadJob::FileDownloadInfo{_driveDbId, signedFileId, signedFilePath, 0});
         (void) job.runSynchronously();
         CPPUNIT_ASSERT(DigitalSignatureChecker_win(SyncPath(signedFilePath)).isSignatureValid());
     }

--- a/test/server/updater/testwindowsupdater.cpp
+++ b/test/server/updater/testwindowsupdater.cpp
@@ -137,10 +137,11 @@ void TestWindowsUpdater::testIsSignatureValid() {
     CPPUNIT_ASSERT(!DigitalSignatureChecker_win(SyncPath(testPath)).isSignatureValid());
     // Path to an existing signed file.
     {
+        const auto cacheDirectory = std::make_shared<CacheDirectory>(tmpDir.path());
         const testhelpers::TestVariables testVariables;
         static const NodeId signedFileId = "5304421";
         const auto signedFilePath = tmpDir.path() / "testfile.exe";
-        DownloadJob job(nullptr, _driveDbId, signedFileId, signedFilePath, 0);
+        DownloadJob job(nullptr, cacheDirectory, _driveDbId, signedFileId, signedFilePath, 0);
         (void) job.runSynchronously();
         CPPUNIT_ASSERT(DigitalSignatureChecker_win(SyncPath(signedFilePath)).isSignatureValid());
     }

--- a/test/test_utility/iohelpertestutilities.cpp
+++ b/test/test_utility/iohelpertestutilities.cpp
@@ -40,10 +40,6 @@ void IoHelperTestUtilities::setTempDirectoryPathFunction(std::function<SyncPath(
     _tempDirectoryPath = f;
 }
 
-void IoHelperTestUtilities::setCacheDirectoryPath(const SyncPath &newPath) {
-    IoHelper::setCacheDirectoryPath(newPath);
-}
-
 #if defined(KD_MACOS)
 void IoHelperTestUtilities::setReadAliasFunction(
         std::function<bool(const SyncPath &path, SyncPath &targetPath, IoError &ioError)> f) {
@@ -53,7 +49,8 @@ void IoHelperTestUtilities::setReadAliasFunction(
 
 void IoHelperTestUtilities::resetFunctions() {
     // Reset to default std::filesytem implementation.
-    setRename(static_cast<void (*)(const SyncPath &srcPath, const SyncPath &destPath, std::error_code &ec)>(&std::filesystem::rename));
+    setRename(static_cast<void (*)(const SyncPath &srcPath, const SyncPath &destPath, std::error_code &ec)>(
+            &std::filesystem::rename));
     setIsDirectoryFunction(static_cast<bool (*)(const SyncPath &path, std::error_code &ec)>(&std::filesystem::is_directory));
     setIsSymlinkFunction(static_cast<bool (*)(const SyncPath &path, std::error_code &ec)>(&std::filesystem::is_symlink));
     setReadSymlinkFunction(static_cast<SyncPath (*)(const SyncPath &path, std::error_code &ec)>(&std::filesystem::read_symlink));
@@ -67,6 +64,5 @@ void IoHelperTestUtilities::resetFunctions() {
         return readAlias(path, data, targetPath, ioError);
     });
 #endif
-    IoHelper::setCacheDirectoryPath("");
 }
 } // namespace KDC

--- a/test/test_utility/iohelpertestutilities.h
+++ b/test/test_utility/iohelpertestutilities.h
@@ -27,7 +27,6 @@ struct IoHelperTestUtilities : public IoHelper {
         static void setReadSymlinkFunction(std::function<SyncPath(const SyncPath &path, std::error_code &ec)> f);
         static void setFileSizeFunction(std::function<std::uintmax_t(const SyncPath &path, std::error_code &ec)> f);
         static void setTempDirectoryPathFunction(std::function<SyncPath(std::error_code &ec)> f);
-        static void setCacheDirectoryPath(const SyncPath &newPath);
 
 #if defined(KD_MACOS)
         static void setReadAliasFunction(std::function<bool(const SyncPath &path, SyncPath &targetPath, IoError &ioError)> f);


### PR DESCRIPTION
Depends on #1753

## Summary

This PR introduces a new `CacheDirectory` class to encapsulate and manage the cache directory used during file downloads, replacing the previous static approach in `IoHelper`.

## Changes

- **feat(CacheDirectory):** Create new `CacheDirectory` class in `libcommonserver/io/`
  - RAII pattern: directory created in constructor, cleaned up files in cache directory upon destruction (the directory itself remains)
  - Thread-safe access with `std::recursive_mutex`
  - Auto-recovery if cache directory is deleted during operation
  
- **feat(DownloadJob):** Integrate `CacheDirectory` into download workflow
  - Updated constructor to accept `std::shared_ptr<CacheDirectory>`
  - Fallback to creating cache in parent folder if not provided
  
- **feat(SyncPal):** Manage cache directory at SyncPal level
  - Single cache directory instance per sync
  - Accessible via `cacheDirectory()` getter
  
- **test:** Update all download-related tests to use new pattern
  - Add unit test for cache directory recovery scenario
  - Re-activate disk space test on low space partition

## Technical Details

The cache directory is now:
- Named `.kDrive-cache` (hidden directory) inside the sync folder
- Automatically recreated if deleted mid-operation
- Properly excluded from sync via `sync-exclude-*.lst` files

## Testing

- All existing download tests updated
- New test case for cache directory deletion recovery
- Disk space verification tests re-enabled

## Checklist

- [x] Code compiles on all platforms
- [x] Unit tests updated and passing
- [x] No hardcoded credentials or paths
- [x] Cache directory properly excluded from sync