### PR TITLE
feat(checksum): checksum verifications of newly downloaded installer

### DIFF
--- a/src/libcommon/utility/types.h
+++ b/src/libcommon/utility/types.h
@@ -605,7 +605,7 @@ struct VersionInfo {
         std::string tag; // Version number. Example: 3.6.4
         uint64_t buildVersion{0}; // Build number. Should be > 0.
         std::string downloadUrl; // URL to download the version
-        std::string checksum; // Optional. Checksum of the file, used to verify the integrity of the downloaded installer.
+        std::string checksum; // Verify if the downloaded file is correct, and not corrupted. Uses a SHA-256
         std::string minOsVersion; // Optional. Minimum supported version of the OS. Examples: 26.3.1, 22.04, 10.0.26200, ...
         std::string minAppVersion; // Optional. Minimum supported version of the application. Example: 3.6.4
 

--- a/src/server/updater/abstractupdater.h
+++ b/src/server/updater/abstractupdater.h
@@ -79,6 +79,7 @@ class AbstractUpdater {
         bool _appShouldBeBlocked{false};
 
         friend class TestAbstractUpdater;
+        friend class TestWindowsUpdater;
         friend class MockUpdater;
 };
 

--- a/src/server/updater/windowsupdater.cpp
+++ b/src/server/updater/windowsupdater.cpp
@@ -187,7 +187,9 @@ bool WindowsUpdater::verifyFileChecksum(const SyncPath &filepath) {
         if (ioError == IoError::Success) {
             LOGW_INFO(Log::instance()->getLogger(), L"corrupted file at " << Utility::formatSyncPath(filepath) << L" deleted");
         } else {
-            LOGW_WARN(Log::instance()->getLogger(), L"couldn't reach corrupted file at " << Utility::formatSyncPath(filepath));
+            LOGW_WARN(Log::instance()->getLogger(), L"couldn't reach corrupted file at " << Utility::formatSyncPath(filepath)
+                                                                                         << L" : IOError state "
+                                                                                         << static_cast<int>(ioError));
         }
 
         // Send to Sentry

--- a/src/server/updater/windowsupdater.cpp
+++ b/src/server/updater/windowsupdater.cpp
@@ -191,8 +191,7 @@ bool WindowsUpdater::verifyFileChecksum(const SyncPath &filepath) {
         }
 
         // Send to Sentry
-        KDC::sentry::Handler::captureMessage(KDC::sentry::Level::Error,
-                                             "Updater::verifyChecksum::" + reason,
+        KDC::sentry::Handler::captureMessage(KDC::sentry::Level::Error, "Updater::verifyChecksum::" + reason,
                                              "Checksum verification failed: " + reason);
         return false;
     };
@@ -239,10 +238,10 @@ std::string WindowsUpdater::computeFileChecksum(const SyncPath &filepath) {
 
     std::array<char, 8192> buffer{};
     while (file.read(buffer.data(), buffer.size())) {
-        SHA256_Update(&sha256, buffer.data(), static_cast<std::size_t>(file.gcount()));
+        (void) SHA256_Update(&sha256, buffer.data(), static_cast<std::size_t>(file.gcount()));
     }
     // Process remaining bytes
-    SHA256_Update(&sha256, buffer.data(), static_cast<std::size_t>(file.gcount()));
+    (void) SHA256_Update(&sha256, buffer.data(), static_cast<std::size_t>(file.gcount()));
 
     std::array<std::uint8_t, SHA256_DIGEST_LENGTH> hash{};
     if (SHA256_Final(hash.data(), &sha256) != 1) {

--- a/src/server/updater/windowsupdater.cpp
+++ b/src/server/updater/windowsupdater.cpp
@@ -67,17 +67,11 @@ void WindowsUpdater::startInstaller() {
     }
     if (std::error_code ec; !std::filesystem::exists(filepath, ec)) {
         LOGW_WARN(Log::instance()->getLogger(), L"Installer file not found. " << Utility::formatStdError(filepath, ec));
-        if (_autoUpdate) {
-            LOG_ERROR(Log::instance()->getLogger(), "Already tried to re-download the installer before.");
-            setState(UpdateState::UpdateError);
-            return;
-        }
-        _autoUpdate = true;
-        downloadUpdate();
+        retryDownload(filepath);
         return;
     }
     if (!verifyFileChecksum(filepath)) {
-        setState(UpdateState::UpdateError); // Or create UpdateState::ChecksumError
+        retryDownload(filepath);
         return;
     }
 
@@ -271,6 +265,16 @@ bool WindowsUpdater::verifyDigitalSignature(const SyncPath &filepath) {
         return false;
     }
     return true;
+}
+
+void WindowsUpdater::retryDownload(const SyncPath &filepath) {
+    if (_autoUpdate) {
+        LOG_ERROR(Log::instance()->getLogger(), "Already tried to re-download the installer before.");
+        setState(UpdateState::UpdateError);
+        return;
+    }
+    _autoUpdate = true;
+    downloadUpdate();
 }
 
 } // namespace KDC

--- a/src/server/updater/windowsupdater.cpp
+++ b/src/server/updater/windowsupdater.cpp
@@ -199,7 +199,7 @@ std::streamsize WindowsUpdater::getExpectedInstallerSize(const std::string &down
 }
 
 bool WindowsUpdater::verifyFileChecksum(const SyncPath &filepath) {
-    const std::string &expectedChecksum = CommonUtility::toLower(versionInfo().checksum);
+    const std::string &expectedChecksum = CommonUtility::trim(CommonUtility::toLower(versionInfo().checksum));
 
     auto cleanupAndFail = [&](const std::string &reason) {
         auto ioError = IoError::Success;
@@ -227,7 +227,7 @@ bool WindowsUpdater::verifyFileChecksum(const SyncPath &filepath) {
     }
 
     // Compute actual checksum
-    const std::string actualChecksum = CommonUtility::toLower(computeFileChecksum(filepath));
+    const std::string actualChecksum = CommonUtility::trim(CommonUtility::toLower(computeFileChecksum(filepath)));
     if (actualChecksum.empty()) {
         LOGW_ERROR(Log::instance()->getLogger(), L"Failed to compute file checksum.");
         return cleanupAndFail("computeFailed");

--- a/src/server/updater/windowsupdater.cpp
+++ b/src/server/updater/windowsupdater.cpp
@@ -76,6 +76,16 @@ void WindowsUpdater::startInstaller() {
         downloadUpdate();
         return;
     }
+    if (!verifyFileChecksum(filepath)) {
+        setState(UpdateState::UpdateError); // Or create UpdateState::ChecksumError
+        return;
+    }
+
+    if (!verifyDigitalSignature(filepath)) {
+        setState(UpdateState::UpdateError);
+        return;
+    }
+
     _autoUpdate = false;
 
     LOGW_INFO(Log::instance()->getLogger(), L"Starting updater " << Utility::formatSyncPath(filepath));
@@ -138,11 +148,6 @@ void WindowsUpdater::downloadFinished(const UniqueId jobId) {
         return;
     }
 
-    if (!verifyDigitalSignature(filepath)) {
-        setState(UpdateState::UpdateError);
-        return;
-    }
-
     LOGW_INFO(Log::instance()->getLogger(),
               L"Installer downloaded at: " << Utility::formatSyncPath(filepath) << L". Update is ready to be installed.");
     setState(UpdateState::Ready);
@@ -171,6 +176,63 @@ std::streamsize WindowsUpdater::getExpectedInstallerSize(const std::string &down
     DirectDownloadJob job(downloadUrl);
     (void) job.runSynchronously();
     return job.httpResponse().getContentLength();
+}
+
+bool WindowsUpdater::verifyFileChecksum(const SyncPath &filepath) {
+    // const auto &expectedChecksum = versionInfo(_currentChannel).checksum;
+    const std::string &expectedChecksum = "083a301369cd711e9803f7d90d342a3778f9cb864ab22992b49fccddc3b9256c"; // capybara test
+
+    if (expectedChecksum.empty()) {
+        LOGW_WARN(Log::instance()->getLogger(), L"Checksum not available from API. Skipping verification.");
+        return true;    // to not be blocking as long as not implemented on kStore
+    }
+
+    std::string actualChecksum = computeFileChecksum(filepath);
+
+    if (actualChecksum.empty()) {
+        LOGW_WARN(Log::instance()->getLogger(), L"Failed to compute file checksum.");
+        return false; // block the installation
+    }
+    if (actualChecksum != expectedChecksum) {
+        LOGW_ERROR(Log::instance()->getLogger(), L"Checksum mismatch! Expected: " << CommonUtility::s2ws(expectedChecksum)
+                                                                                  << L", Got: "
+                                                                                  << CommonUtility::s2ws(actualChecksum));
+        return false;
+    }
+
+    LOGW_INFO(Log::instance()->getLogger(), L"Checksum verification passed.");
+    return true;
+}
+
+std::string WindowsUpdater::computeFileChecksum(const SyncPath &filepath) {
+    std::ifstream file(filepath, std::ios::binary);
+    if (!file) {
+        LOGW_WARN(Log::instance()->getLogger(), L"missing filepath for Checksum compute");
+        return "";
+    }
+
+    SHA256_CTX sha256;  // Using SHA256 instead of the project-standard XXH3 for security.
+                        // XXH3 is a non-cryptographic hash; an attacker could craft a malicious
+                        // file with the same XXH3 hash (collision attack).
+    SHA256_Init(&sha256);
+
+    char buffer[8192];
+    while (file.read(buffer, sizeof(buffer))) {
+        SHA256_Update(&sha256, buffer, file.gcount());
+    }
+    // Process remaining bytes
+    SHA256_Update(&sha256, buffer, file.gcount());
+
+    unsigned char hash[SHA256_DIGEST_LENGTH];
+    SHA256_Final(hash, &sha256);
+
+    // Convert to hex string
+    std::stringstream ss;
+    for (int i = 0; i < SHA256_DIGEST_LENGTH; i++) {
+        ss << std::hex << std::setw(2) << std::setfill('0') << (int) hash[i];
+    }
+
+    return ss.str();
 }
 
 bool WindowsUpdater::verifyDigitalSignature(const SyncPath &filepath) {

--- a/src/server/updater/windowsupdater.cpp
+++ b/src/server/updater/windowsupdater.cpp
@@ -64,7 +64,7 @@ void WindowsUpdater::onUpdateFound() {
         }
 
         if (!verifyDigitalSignature(filepath)) {
-            setState(UpdateState::UpdateError);
+            retryDownload(filepath);
             return;
         }
 
@@ -92,7 +92,7 @@ void WindowsUpdater::startInstaller() {
     }
 
     if (!verifyDigitalSignature(filepath)) {
-        setState(UpdateState::UpdateError);
+        retryDownload(filepath);
         return;
     }
 
@@ -164,7 +164,7 @@ void WindowsUpdater::downloadFinished(const UniqueId jobId) {
     }
 
     if (!verifyDigitalSignature(filepath)) {
-        setState(UpdateState::UpdateError);
+        retryDownload(filepath);
         return;
     }
 

--- a/src/server/updater/windowsupdater.cpp
+++ b/src/server/updater/windowsupdater.cpp
@@ -252,7 +252,7 @@ std::string WindowsUpdater::computeFileChecksum(const SyncPath &filepath) {
     std::string result;
     result.reserve(SHA256_DIGEST_LENGTH * 2);
     for (const auto &byte: hash) {
-        result += std::format("{:02x}", static_cast<int>(byte));
+        result += std::format("{:02x}", static_cast<int32_t>(byte));
     }
 
     return result;

--- a/src/server/updater/windowsupdater.cpp
+++ b/src/server/updater/windowsupdater.cpp
@@ -277,11 +277,14 @@ bool WindowsUpdater::verifyDigitalSignature(const SyncPath &filepath) {
 
 void WindowsUpdater::retryDownload(const SyncPath &filepath) {
     if (_autoUpdate) {
-        LOG_ERROR(Log::instance()->getLogger(), "Already tried to re-download the installer before.");
+        LOGW_ERROR(Log::instance()->getLogger(),
+                  L"Already tried to re-download the installer at " + Utility::formatSyncPath(filepath) + L" before.");
         setState(UpdateState::UpdateError);
         _autoUpdate = false;
         return;
     }
+    LOGW_WARN(Log::instance()->getLogger(),
+              L"Retrying download of installer after failure of checksum or signature verification.");
     _autoUpdate = true;
     downloadUpdate();
 }

--- a/src/server/updater/windowsupdater.cpp
+++ b/src/server/updater/windowsupdater.cpp
@@ -199,7 +199,7 @@ std::streamsize WindowsUpdater::getExpectedInstallerSize(const std::string &down
 }
 
 bool WindowsUpdater::verifyFileChecksum(const SyncPath &filepath) {
-    const std::string &expectedChecksum = CommonUtility::trim(CommonUtility::toLower(versionInfo().checksum));
+    const std::string expectedChecksum = CommonUtility::trim(CommonUtility::toLower(versionInfo().checksum));
 
     auto cleanupAndFail = [&](const std::string &reason) {
         auto ioError = IoError::Success;

--- a/src/server/updater/windowsupdater.cpp
+++ b/src/server/updater/windowsupdater.cpp
@@ -213,8 +213,10 @@ bool WindowsUpdater::verifyFileChecksum(const SyncPath &filepath) {
         }
 
         // Send to Sentry
-        KDC::sentry::Handler::captureMessage(KDC::sentry::Level::Error, "Updater::verifyChecksum::" + reason,
+        KDC::sentry::Handler::captureMessage(KDC::sentry::Level::Error, "Updater::verifyChecksum",
                                              "Checksum verification failed: " + reason);
+
+        LOGW_ERROR(Log::instance()->getLogger(), L"Checksum verification failed: " << CommonUtility::s2ws(reason));
         return false;
     };
 

--- a/src/server/updater/windowsupdater.cpp
+++ b/src/server/updater/windowsupdater.cpp
@@ -281,6 +281,7 @@ void WindowsUpdater::retryDownload(const SyncPath &filepath) {
     if (_autoUpdate) {
         LOG_ERROR(Log::instance()->getLogger(), "Already tried to re-download the installer before.");
         setState(UpdateState::UpdateError);
+        _autoUpdate = false;
         return;
     }
     _autoUpdate = true;

--- a/src/server/updater/windowsupdater.cpp
+++ b/src/server/updater/windowsupdater.cpp
@@ -229,28 +229,34 @@ std::string WindowsUpdater::computeFileChecksum(const SyncPath &filepath) {
         return "";
     }
 
-    SHA256_CTX sha256;  // Using SHA256 instead of the project-standard XXH3 for security.
-                        // XXH3 is a non-cryptographic hash; an attacker could craft a malicious
-                        // file with the same XXH3 hash (collision attack).
-    SHA256_Init(&sha256);
+    SHA256_CTX sha256{}; // Using SHA256 instead of the project-standard XXH3 for security.
+                         // XXH3 is a non-cryptographic hash; an attacker could craft a malicious
+                         // file with the same XXH3 hash (collision attack).
+    if (SHA256_Init(&sha256) != 1) { // Check return value
+        LOGW_WARN(Log::instance()->getLogger(), L"SHA256_Init failed");
+        return "";
+    }
 
-    char buffer[8192];
-    while (file.read(buffer, sizeof(buffer))) {
-        SHA256_Update(&sha256, buffer, file.gcount());
+    std::array<char, 8192> buffer{};
+    while (file.read(buffer.data(), buffer.size())) {
+        SHA256_Update(&sha256, buffer.data(), static_cast<std::size_t>(file.gcount()));
     }
     // Process remaining bytes
-    SHA256_Update(&sha256, buffer, file.gcount());
+    SHA256_Update(&sha256, buffer.data(), static_cast<std::size_t>(file.gcount()));
 
-    unsigned char hash[SHA256_DIGEST_LENGTH];
-    SHA256_Final(hash, &sha256);
-
-    // Convert to hex string
-    std::stringstream ss;
-    for (int i = 0; i < SHA256_DIGEST_LENGTH; i++) {
-        ss << std::hex << std::setw(2) << std::setfill('0') << (int) hash[i];
+    std::array<std::uint8_t, SHA256_DIGEST_LENGTH> hash{};
+    if (SHA256_Final(hash.data(), &sha256) != 1) {
+        LOGW_WARN(Log::instance()->getLogger(), L"SHA256_Final failed");
+        return "";
     }
 
-    return ss.str();
+    std::string result;
+    result.reserve(SHA256_DIGEST_LENGTH * 2);
+    for (const auto &byte: hash) {
+        result += std::format("{:02x}", static_cast<int>(byte));
+    }
+
+    return result;
 }
 
 bool WindowsUpdater::verifyDigitalSignature(const SyncPath &filepath) {

--- a/src/server/updater/windowsupdater.cpp
+++ b/src/server/updater/windowsupdater.cpp
@@ -202,7 +202,7 @@ bool WindowsUpdater::verifyFileChecksum(const SyncPath &filepath) {
         return false;
     };
 
-    // Skip if API doesn't provide checksum (development)
+    // Skip if API doesn't provide checksum
     if (expectedChecksum.empty()) {
         LOGW_WARN(Log::instance()->getLogger(), L"Checksum not available from API. Skipping verification.");
         return true;

--- a/src/server/updater/windowsupdater.cpp
+++ b/src/server/updater/windowsupdater.cpp
@@ -57,6 +57,11 @@ void WindowsUpdater::onUpdateFound() {
         LOGW_INFO(Log::instance()->getLogger(), L"Installer already downloaded at " << Utility::formatSyncPath(filepath)
                                                                                     << L". Update is ready to be installed.");
 
+        if (!verifyFileChecksum(filepath)) {
+            retryDownload(filepath);
+            return;
+        }
+
         if (!verifyDigitalSignature(filepath)) {
             setState(UpdateState::UpdateError);
             return;
@@ -149,6 +154,16 @@ void WindowsUpdater::downloadFinished(const UniqueId jobId) {
     if (std::error_code ec; !std::filesystem::exists(filepath, ec)) {
         LOGW_WARN(Log::instance()->getLogger(), L"Installer file not found. " << Utility::formatStdError(filepath, ec));
         downloadUpdate();
+        return;
+    }
+
+    if (!verifyFileChecksum(filepath)) {
+        retryDownload(filepath);
+        return;
+    }
+
+    if (!verifyDigitalSignature(filepath)) {
+        setState(UpdateState::UpdateError);
         return;
     }
 

--- a/src/server/updater/windowsupdater.cpp
+++ b/src/server/updater/windowsupdater.cpp
@@ -199,7 +199,7 @@ std::streamsize WindowsUpdater::getExpectedInstallerSize(const std::string &down
 }
 
 bool WindowsUpdater::verifyFileChecksum(const SyncPath &filepath) {
-    const std::string &expectedChecksum = CommonUtility::toLower(versionInfo(_currentChannel).checksum);
+    const std::string &expectedChecksum = CommonUtility::toLower(versionInfo().checksum);
 
     auto cleanupAndFail = [&](const std::string &reason) {
         auto ioError = IoError::Success;

--- a/src/server/updater/windowsupdater.cpp
+++ b/src/server/updater/windowsupdater.cpp
@@ -179,25 +179,43 @@ std::streamsize WindowsUpdater::getExpectedInstallerSize(const std::string &down
 }
 
 bool WindowsUpdater::verifyFileChecksum(const SyncPath &filepath) {
-    // const auto &expectedChecksum = versionInfo(_currentChannel).checksum;
-    const std::string &expectedChecksum = "083a301369cd711e9803f7d90d342a3778f9cb864ab22992b49fccddc3b9256c"; // capybara test
+    const std::string &expectedChecksum = versionInfo(_currentChannel).checksum;
 
+    auto cleanupAndFail = [&](const std::string &reason) {
+        auto ioError = IoError::Success;
+        (void) IoHelper::deleteItem(filepath, ioError);
+        if (ioError == IoError::Success) {
+            LOGW_INFO(Log::instance()->getLogger(), L"corrupted file at " << Utility::formatSyncPath(filepath) << L" deleted");
+        } else {
+            LOGW_WARN(Log::instance()->getLogger(), L"couldn't reach corrupted file at " << Utility::formatSyncPath(filepath));
+        }
+
+        // Send to Sentry
+        KDC::sentry::Handler::captureMessage(KDC::sentry::Level::Error,
+                                             "Updater::verifyChecksum::" + reason,
+                                             "Checksum verification failed: " + reason);
+        return false;
+    };
+
+    // Skip if API doesn't provide checksum (development)
     if (expectedChecksum.empty()) {
         LOGW_WARN(Log::instance()->getLogger(), L"Checksum not available from API. Skipping verification.");
-        return true;    // to not be blocking as long as not implemented on kStore
+        return true;
     }
 
+    // Compute actual checksum
     std::string actualChecksum = computeFileChecksum(filepath);
-
     if (actualChecksum.empty()) {
-        LOGW_WARN(Log::instance()->getLogger(), L"Failed to compute file checksum.");
-        return false; // block the installation
+        LOGW_ERROR(Log::instance()->getLogger(), L"Failed to compute file checksum.");
+        return cleanupAndFail("computeFailed");
     }
+
+    // Verify match
     if (actualChecksum != expectedChecksum) {
         LOGW_ERROR(Log::instance()->getLogger(), L"Checksum mismatch! Expected: " << CommonUtility::s2ws(expectedChecksum)
                                                                                   << L", Got: "
                                                                                   << CommonUtility::s2ws(actualChecksum));
-        return false;
+        return cleanupAndFail("mismatch");
     }
 
     LOGW_INFO(Log::instance()->getLogger(), L"Checksum verification passed.");

--- a/src/server/updater/windowsupdater.cpp
+++ b/src/server/updater/windowsupdater.cpp
@@ -25,7 +25,8 @@
 #include <format>
 #include <fstream>
 
-#include <openssl/sha.h>
+#include <Poco/SHA2Engine.h>
+#include <Poco/DigestStream.h>
 
 #include "windowsupdater.h"
 #include "log/log.h"
@@ -244,39 +245,19 @@ bool WindowsUpdater::verifyFileChecksum(const SyncPath &filepath) {
 
 std::string WindowsUpdater::computeFileChecksum(const SyncPath &filepath) {
     std::ifstream file(filepath, std::ios::binary);
-    if (!file) {
-        LOGW_WARN(Log::instance()->getLogger(), L"missing filepath for Checksum compute");
-        return "";
-    }
+    if (!file) return "";
 
-    SHA256_CTX sha256{}; // Using SHA256 instead of the project-standard XXH3 for security.
-                         // XXH3 is a non-cryptographic hash; an attacker could craft a malicious
-                         // file with the same XXH3 hash (collision attack).
-    if (SHA256_Init(&sha256) != 1) { // Check return value
-        LOGW_WARN(Log::instance()->getLogger(), L"SHA256_Init failed");
-        return "";
-    }
+    Poco::SHA2Engine sha256(Poco::SHA2Engine::ALGORITHM::SHA_256);
+    // Using SHA256 instead of the project-standard XXH3 for security.
+    // XXH3 is a non-cryptographic hash; an attacker could craft a malicious
+    // file with the same XXH3 hash (collision attack).
 
     std::array<char, 8192> buffer{};
-    while (file.read(buffer.data(), buffer.size())) {
-        (void) SHA256_Update(&sha256, buffer.data(), static_cast<std::size_t>(file.gcount()));
-    }
-    // Process remaining bytes
-    (void) SHA256_Update(&sha256, buffer.data(), static_cast<std::size_t>(file.gcount()));
-
-    std::array<std::uint8_t, SHA256_DIGEST_LENGTH> hash{};
-    if (SHA256_Final(hash.data(), &sha256) != 1) {
-        LOGW_WARN(Log::instance()->getLogger(), L"SHA256_Final failed");
-        return "";
+    while (file.read(buffer.data(), buffer.size()) || file.gcount() > 0) {
+        sha256.update(buffer.data(), static_cast<std::size_t>(file.gcount()));
     }
 
-    std::string result;
-    result.reserve(SHA256_DIGEST_LENGTH * 2);
-    for (const auto &byte: hash) {
-        result += std::format("{:02x}", static_cast<int32_t>(byte));
-    }
-
-    return result;
+    return Poco::DigestEngine::digestToHex(sha256.digest());
 }
 
 bool WindowsUpdater::verifyDigitalSignature(const SyncPath &filepath) {

--- a/src/server/updater/windowsupdater.cpp
+++ b/src/server/updater/windowsupdater.cpp
@@ -17,6 +17,16 @@
  */
 
 #include <QProcess>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <format>
+#include <fstream>
+
+#include <openssl/sha.h>
+
 #include "windowsupdater.h"
 #include "log/log.h"
 #include "jobs/network/directdownloadjob.h"
@@ -173,7 +183,7 @@ std::streamsize WindowsUpdater::getExpectedInstallerSize(const std::string &down
 }
 
 bool WindowsUpdater::verifyFileChecksum(const SyncPath &filepath) {
-    const std::string &expectedChecksum = versionInfo(_currentChannel).checksum;
+    const std::string &expectedChecksum = CommonUtility::toLower(versionInfo(_currentChannel).checksum);
 
     auto cleanupAndFail = [&](const std::string &reason) {
         auto ioError = IoError::Success;
@@ -199,13 +209,13 @@ bool WindowsUpdater::verifyFileChecksum(const SyncPath &filepath) {
     }
 
     // Compute actual checksum
-    std::string actualChecksum = computeFileChecksum(filepath);
+    const std::string actualChecksum = CommonUtility::toLower(computeFileChecksum(filepath));
     if (actualChecksum.empty()) {
         LOGW_ERROR(Log::instance()->getLogger(), L"Failed to compute file checksum.");
         return cleanupAndFail("computeFailed");
     }
 
-    // Verify match
+    // verify checksum
     if (actualChecksum != expectedChecksum) {
         LOGW_ERROR(Log::instance()->getLogger(), L"Checksum mismatch! Expected: " << CommonUtility::s2ws(expectedChecksum)
                                                                                   << L", Got: "

--- a/src/server/updater/windowsupdater.h
+++ b/src/server/updater/windowsupdater.h
@@ -72,6 +72,12 @@ class WindowsUpdater : public AbstractUpdater {
          */
         virtual bool verifyDigitalSignature(const SyncPath &filepath);
 
+        /**
+         * @brief Attempt to re-download the installer. Fails if already attempted.
+         * @param filepath Path to the installer file.
+         */
+        void retryDownload(const SyncPath &filepath);
+
         bool _autoUpdate{false};
 
         friend class TestWindowsUpdater;

--- a/src/server/updater/windowsupdater.h
+++ b/src/server/updater/windowsupdater.h
@@ -56,7 +56,7 @@ class WindowsUpdater : public AbstractUpdater {
          * @param filepath Path to the downloaded installer.
          * @return true if the checksum is valid.
          */
-        virtual bool verifyFileChecksum(const SyncPath &filepath);
+        bool verifyFileChecksum(const SyncPath &filepath);
 
         /**
          * Compute the checksum of the downloaded installer.
@@ -73,6 +73,8 @@ class WindowsUpdater : public AbstractUpdater {
         virtual bool verifyDigitalSignature(const SyncPath &filepath);
 
         bool _autoUpdate{false};
+
+        friend class TestWindowsUpdater;
 };
 
 } // namespace KDC

--- a/src/server/updater/windowsupdater.h
+++ b/src/server/updater/windowsupdater.h
@@ -52,6 +52,20 @@ class WindowsUpdater : public AbstractUpdater {
         virtual std::streamsize getExpectedInstallerSize(const std::string &downloadUrl);
 
         /**
+         * Check the checksum of the downloaded installer. Delete the file if the checksum is not valid.
+         * @param filepath Path to the downloaded installer.
+         * @return true if the checksum is valid.
+         */
+        virtual bool verifyFileChecksum(const SyncPath &filepath);
+
+        /**
+         * Compute the checksum of the downloaded installer.
+         * @param filepath Path to the downloaded installer.
+         * @return the result checksum
+         */
+        std::string computeFileChecksum(const SyncPath &filepath);
+
+        /**
          * Check the digital signature of the downloaded installer. Delete the file if the signature is not valid.
          * @param filepath Path to the downloaded installer.
          * @return true if the signature is valid.

--- a/test/server/updater/mockversionretriever.h
+++ b/test/server/updater/mockversionretriever.h
@@ -30,13 +30,9 @@ class MockVersionRetriever : public VersionRetriever {
         void setUpdateShouldBeAvailable(const bool val) { _updateShouldBeAvailable = val; }
         void setBigMinAppVersion(const bool val) { _bigMinAppVersion = val; }
         void setBigMinOsVersion(const bool bigMinOsVersion) { _bigMinOsVersion = bigMinOsVersion; }
-        void setAllVersionInfo(const AllVersionsInfo &versionInfo) { _versionsInfo = versionInfo; }
+        void setVersionInfo(const VersionInfo &versionInfo) { _versionsInfo = versionInfo; }
         void setVersionReceived(const bool isVersionReceived) { _isVersionReceived = isVersionReceived; }
-        void setChecksumForAllChannels(const std::string &checksum) {
-            for (auto &[channel, info]: _versionsInfo) {
-                info.checksum = checksum;
-            }
-        }
+        void setChecksum(const std::string &checksum) { _versionsInfo.checksum = checksum; }
 
     private:
         ExitCode generateGetAppVersionJob(const DistributionChannel channel, std::shared_ptr<AbstractNetworkJob> &job) override {

--- a/test/server/updater/mockversionretriever.h
+++ b/test/server/updater/mockversionretriever.h
@@ -30,6 +30,13 @@ class MockVersionRetriever : public VersionRetriever {
         void setUpdateShouldBeAvailable(const bool val) { _updateShouldBeAvailable = val; }
         void setBigMinAppVersion(const bool val) { _bigMinAppVersion = val; }
         void setBigMinOsVersion(const bool bigMinOsVersion) { _bigMinOsVersion = bigMinOsVersion; }
+        void setAllVersionInfo(const AllVersionsInfo &versionInfo) { _versionsInfo = versionInfo; }
+        void setVersionReceived(const bool isVersionReceived) { _isVersionReceived = isVersionReceived; }
+        void setChecksumForAllChannels(const std::string &checksum) {
+            for (auto &[channel, info]: _versionsInfo) {
+                info.checksum = checksum;
+            }
+        }
 
     private:
         ExitCode generateGetAppVersionJob(const DistributionChannel channel, std::shared_ptr<AbstractNetworkJob> &job) override {

--- a/test/server/updater/testabstractupdater.cpp
+++ b/test/server/updater/testabstractupdater.cpp
@@ -44,6 +44,16 @@ void unskipVersion() {
 }
 } // namespace
 
+void TestAbstractUpdater::generateValidVersionInfo(VersionInfo &versionInfo) {
+    versionInfo.channel = DistributionChannel::Prod;
+    versionInfo.tag = "3.8.2";
+    versionInfo.buildVersion = 3;
+    versionInfo.downloadUrl = "https://downloads/kDrive-3.8.2.3.exe";
+    versionInfo.checksum = "";
+    versionInfo.minOsVersion = "";
+    versionInfo.minAppVersion = "";
+}
+
 void TestAbstractUpdater::setUp() {
     TestBase::start();
     // Init parmsDb

--- a/test/server/updater/testabstractupdater.h
+++ b/test/server/updater/testabstractupdater.h
@@ -34,6 +34,8 @@ class TestAbstractUpdater final : public CppUnit::TestFixture, public TestBase {
         void setUp() override;
         void tearDown() override;
 
+        static void generateValidAllVersionsInfo(AllVersionsInfo &versionsInfo);
+
     protected:
         void testSkipUnskipVersion();
         void testIsVersionSkipped();

--- a/test/server/updater/testabstractupdater.h
+++ b/test/server/updater/testabstractupdater.h
@@ -34,7 +34,7 @@ class TestAbstractUpdater final : public CppUnit::TestFixture, public TestBase {
         void setUp() override;
         void tearDown() override;
 
-        static void generateValidAllVersionsInfo(AllVersionsInfo &versionsInfo);
+        static void generateValidVersionInfo(VersionInfo &versionInfo);
 
     protected:
         void testSkipUnskipVersion();

--- a/test/server/updater/testwindowsupdater.cpp
+++ b/test/server/updater/testwindowsupdater.cpp
@@ -161,14 +161,14 @@ void TestWindowsUpdater::testIsChecksumValid() {
     };
 
     static const std::string noChecksumValue("");
-    static const std::string fakeChecksumValue("083a301369cd711e9803f7d90d342a3778f9cb864ab22992b49fccddc3b9256c");
-    static const std::string trueChecksumValue("3d735840895bcb958f359009b06cbe9b840ae9e2df22651f431bfec4ac7b696f");
+    static const std::string invalidChecksumValue("083a301369cd711e9803f7d90d342a3778f9cb864ab22992b49fccddc3b9256c");
+    static const std::string validChecksumValue("3d735840895bcb958f359009b06cbe9b840ae9e2df22651f431bfec4ac7b696f");
 
     const std::vector<TestCase> testCases = {
             {noChecksumValue, "picture-1.jpg", true}, // kstore is missing checksum
-            {fakeChecksumValue, "picture-1111.jpg", false}, // can't calculate checksum (file doesn't exist)
-            {fakeChecksumValue, "picture-1.jpg", false}, // checksum is invalid
-            {trueChecksumValue, "picture-1.jpg", true}, // checksum is valid
+            {invalidChecksumValue, "picture-1111.jpg", false}, // can't calculate checksum (file doesn't exist)
+            {invalidChecksumValue, "picture-1.jpg", false}, // checksum is invalid
+            {validChecksumValue, "picture-1.jpg", true}, // checksum is valid
     };
 
     for (const auto &testCase: testCases) {

--- a/test/server/updater/testwindowsupdater.cpp
+++ b/test/server/updater/testwindowsupdater.cpp
@@ -148,4 +148,9 @@ void TestWindowsUpdater::testIsSignatureValid() {
     }
 }
 
+void TestWindowsUpdater::testIsChecksumValid() {
+    // file have wrong checksum
+    CPPUNIT_ASSERT(false);
+}
+
 } // namespace KDC

--- a/test/server/updater/testwindowsupdater.cpp
+++ b/test/server/updater/testwindowsupdater.cpp
@@ -177,21 +177,20 @@ void TestWindowsUpdater::testIsChecksumValid() {
 
         // Only copy file if it's expected to exist
         if (testCase.fileName == "picture-1.jpg") {
-            IoHelper::copyFileOrDirectory(testhelpers::localTestDirPath() / "test_pictures/picture-1.jpg", tmpDir.path(),
-                                          ioError);
+            (void) IoHelper::copyFileOrDirectory(testhelpers::localTestDirPath() / "test_pictures/picture-1.jpg", tmpDir.path(),
+                                                 ioError);
         }
 
         WindowsUpdater updater;
-        AbstractUpdater &up = static_cast<AbstractUpdater &>(updater);
 
         AllVersionsInfo versionInfo;
         TestAbstractUpdater::generateValidAllVersionsInfo(versionInfo);
-        std::shared_ptr<MockUpdateChecker> testUpdateChecker = std::make_shared<MockUpdateChecker>();
+        auto testUpdateChecker = std::make_shared<MockUpdateChecker>();
 
         testUpdateChecker->setAllVersionInfo(versionInfo);
         testUpdateChecker->setVersionReceived(true);
         testUpdateChecker->setChecksumForAllChannels(testCase.checksumValue);
-        up._updateChecker = testUpdateChecker;
+        updater._updateChecker = testUpdateChecker;
 
         CPPUNIT_ASSERT_EQUAL(testCase.expectedValid, updater.verifyFileChecksum(tmpDir.path() / testCase.fileName));
     }

--- a/test/server/updater/testwindowsupdater.cpp
+++ b/test/server/updater/testwindowsupdater.cpp
@@ -179,6 +179,7 @@ void TestWindowsUpdater::testIsChecksumValid() {
         if (testCase.fileName == "picture-1.jpg") {
             (void) IoHelper::copyFileOrDirectory(testhelpers::localTestDirPath() / "test_pictures/picture-1.jpg", tmpDir.path(),
                                                  ioError);
+            CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
         }
 
         WindowsUpdater updater;

--- a/test/server/updater/testwindowsupdater.cpp
+++ b/test/server/updater/testwindowsupdater.cpp
@@ -28,6 +28,8 @@
 #include "test_utility/testhelpers.h"
 #include "updater/windowsupdater.h"
 #include "utility/digitalsignaturechecker_win.h"
+#include "mockupdatechecker.h"
+#include "jobs/syncjobmanager.h"
 
 namespace KDC {
 
@@ -71,6 +73,8 @@ void TestWindowsUpdater::tearDown() {
     ParmsDb::instance()->close();
     ParmsDb::reset();
     ParametersCache::reset();
+    SyncJobManagerSingleton::instance()->stop();
+    SyncJobManagerSingleton::clear();
     TestBase::stop();
 }
 
@@ -149,8 +153,50 @@ void TestWindowsUpdater::testIsSignatureValid() {
 }
 
 void TestWindowsUpdater::testIsChecksumValid() {
-    // file have wrong checksum
-    CPPUNIT_ASSERT(false);
+    // App version is NOT blocked
+    static const std::string noChecksumValue("");
+    static const std::string fakeChecksumValue("ddd");
+    static const std::string trueChecksumValue("3d735840895bcb958f359009b06cbe9b840ae9e2df22651f431bfec4ac7b696f");
+    LocalTemporaryDirectory tmpDir;
+    auto path = tmpDir.path();
+    IoError ioError = IoError::Success;
+    IoHelper::copyFileOrDirectory(testhelpers::localTestDirPath() / "test_pictures/picture-1.jpg", tmpDir.path(), ioError);
+    {
+        WindowsUpdater updater;
+        std::shared_ptr<MockUpdateChecker> testUpdateChecker = std::make_shared<MockUpdateChecker>();
+        AbstractUpdater &up = static_cast<AbstractUpdater&>(updater);
+        testUpdateChecker.get()->setVersionReceived(true);
+        testUpdateChecker.get()->setChecksumForAllChannels(noChecksumValue);
+        up._updateChecker = testUpdateChecker;
+        UniqueId jobId = 0;
+        (void) testUpdateChecker.get()->checkUpdateAvailability(&jobId);
+        while (!SyncJobManagerSingleton::instance()->isJobFinished(jobId)) Utility::msleep(10);
+        CPPUNIT_ASSERT(updater.verifyFileChecksum(tmpDir.path() / "picture-1.jpg"));
+    }
+    {
+        WindowsUpdater updater;
+        std::shared_ptr<MockUpdateChecker> testUpdateChecker = std::make_shared<MockUpdateChecker>();
+        AbstractUpdater &up = static_cast<AbstractUpdater &>(updater);
+        testUpdateChecker.get()->setVersionReceived(true);
+        testUpdateChecker.get()->setChecksumForAllChannels(fakeChecksumValue);
+        up._updateChecker = testUpdateChecker;
+        UniqueId jobId = 0;
+        (void) testUpdateChecker.get()->checkUpdateAvailability(&jobId);
+        while (!SyncJobManagerSingleton::instance()->isJobFinished(jobId)) Utility::msleep(10);
+        CPPUNIT_ASSERT(updater.verifyFileChecksum(tmpDir.path() / "picture-1.jpg"));
+    }
+    {
+        WindowsUpdater updater;
+        std::shared_ptr<MockUpdateChecker> testUpdateChecker = std::make_shared<MockUpdateChecker>();
+        AbstractUpdater &up = static_cast<AbstractUpdater &>(updater);
+        testUpdateChecker.get()->setVersionReceived(true);
+        testUpdateChecker.get()->setChecksumForAllChannels(trueChecksumValue);
+        up._updateChecker = testUpdateChecker;
+        UniqueId jobId = 0;
+        (void) testUpdateChecker.get()->checkUpdateAvailability(&jobId);
+        while (!SyncJobManagerSingleton::instance()->isJobFinished(jobId)) Utility::msleep(10);
+        CPPUNIT_ASSERT(updater.verifyFileChecksum(tmpDir.path() / "picture-1.jpg"));
+    }
 }
 
 } // namespace KDC

--- a/test/server/updater/testwindowsupdater.cpp
+++ b/test/server/updater/testwindowsupdater.cpp
@@ -154,14 +154,32 @@ void TestWindowsUpdater::testIsSignatureValid() {
 }
 
 void TestWindowsUpdater::testIsChecksumValid() {
+    struct TestCase {
+            std::string checksumValue;
+            std::string fileName;
+            bool expectedValid;
+    };
+
     static const std::string noChecksumValue("");
-    static const std::string fakeChecksumValue("083a301369cd711e9803f7d90d342a3778f9cb864ab22992b49fccddc3b9256c"); // capybara
+    static const std::string fakeChecksumValue("083a301369cd711e9803f7d90d342a3778f9cb864ab22992b49fccddc3b9256c");
     static const std::string trueChecksumValue("3d735840895bcb958f359009b06cbe9b840ae9e2df22651f431bfec4ac7b696f");
-    {
+
+    const std::vector<TestCase> testCases = {
+            {noChecksumValue, "picture-1.jpg", true}, // kstore is missing checksum
+            {fakeChecksumValue, "picture-1111.jpg", false}, // can't calculate checksum (file doesn't exist)
+            {fakeChecksumValue, "picture-1.jpg", false}, // checksum is invalid
+            {trueChecksumValue, "picture-1.jpg", true}, // checksum is valid
+    };
+
+    for (const auto &testCase: testCases) {
         LocalTemporaryDirectory tmpDir;
-        auto path = tmpDir.path();
         IoError ioError = IoError::Success;
-        IoHelper::copyFileOrDirectory(testhelpers::localTestDirPath() / "test_pictures/picture-1.jpg", tmpDir.path(), ioError);
+
+        // Only copy file if it's expected to exist
+        if (testCase.fileName == "picture-1.jpg") {
+            IoHelper::copyFileOrDirectory(testhelpers::localTestDirPath() / "test_pictures/picture-1.jpg", tmpDir.path(),
+                                          ioError);
+        }
 
         WindowsUpdater updater;
         AbstractUpdater &up = static_cast<AbstractUpdater &>(updater);
@@ -170,68 +188,12 @@ void TestWindowsUpdater::testIsChecksumValid() {
         TestAbstractUpdater::generateValidAllVersionsInfo(versionInfo);
         std::shared_ptr<MockUpdateChecker> testUpdateChecker = std::make_shared<MockUpdateChecker>();
 
-        testUpdateChecker.get()->setAllVersionInfo(versionInfo);
-        testUpdateChecker.get()->setVersionReceived(true);
-        testUpdateChecker.get()->setChecksumForAllChannels(noChecksumValue);
+        testUpdateChecker->setAllVersionInfo(versionInfo);
+        testUpdateChecker->setVersionReceived(true);
+        testUpdateChecker->setChecksumForAllChannels(testCase.checksumValue);
         up._updateChecker = testUpdateChecker;
-        CPPUNIT_ASSERT(updater.verifyFileChecksum(tmpDir.path() / "picture-1.jpg")); // kstore is missing checksum
-    }
-    {
-        LocalTemporaryDirectory tmpDir;
-        auto path = tmpDir.path();
-        IoError ioError = IoError::Success;
-        IoHelper::copyFileOrDirectory(testhelpers::localTestDirPath() / "test_pictures/picture-1.jpg", tmpDir.path(), ioError);
 
-        WindowsUpdater updater;
-        AbstractUpdater &up = static_cast<AbstractUpdater &>(updater);
-
-        AllVersionsInfo versionInfo;
-        TestAbstractUpdater::generateValidAllVersionsInfo(versionInfo);
-        std::shared_ptr<MockUpdateChecker> testUpdateChecker = std::make_shared<MockUpdateChecker>();
-
-        testUpdateChecker.get()->setAllVersionInfo(versionInfo);
-        testUpdateChecker.get()->setVersionReceived(true);
-        testUpdateChecker.get()->setChecksumForAllChannels(fakeChecksumValue);
-        up._updateChecker = testUpdateChecker;
-        CPPUNIT_ASSERT(!updater.verifyFileChecksum(tmpDir.path() / "picture-1111.jpg")); // can't calculate checksum
-    }
-    {
-        LocalTemporaryDirectory tmpDir;
-        auto path = tmpDir.path();
-        IoError ioError = IoError::Success;
-        IoHelper::copyFileOrDirectory(testhelpers::localTestDirPath() / "test_pictures/picture-1.jpg", tmpDir.path(), ioError);
-
-        WindowsUpdater updater;
-        AbstractUpdater &up = static_cast<AbstractUpdater &>(updater);
-
-        AllVersionsInfo versionInfo;
-        TestAbstractUpdater::generateValidAllVersionsInfo(versionInfo);
-        std::shared_ptr<MockUpdateChecker> testUpdateChecker = std::make_shared<MockUpdateChecker>();
-
-        testUpdateChecker.get()->setAllVersionInfo(versionInfo);
-        testUpdateChecker.get()->setVersionReceived(true);
-        testUpdateChecker.get()->setChecksumForAllChannels(fakeChecksumValue);
-        up._updateChecker = testUpdateChecker;
-        CPPUNIT_ASSERT(!updater.verifyFileChecksum(tmpDir.path() / "picture-1.jpg")); // checksum is invalid
-    }
-    {
-        LocalTemporaryDirectory tmpDir;
-        auto path = tmpDir.path();
-        IoError ioError = IoError::Success;
-        IoHelper::copyFileOrDirectory(testhelpers::localTestDirPath() / "test_pictures/picture-1.jpg", tmpDir.path(), ioError);
-
-        WindowsUpdater updater;
-        AbstractUpdater &up = static_cast<AbstractUpdater &>(updater);
-
-        AllVersionsInfo versionInfo;
-        TestAbstractUpdater::generateValidAllVersionsInfo(versionInfo);
-        std::shared_ptr<MockUpdateChecker> testUpdateChecker = std::make_shared<MockUpdateChecker>();
-
-        testUpdateChecker.get()->setAllVersionInfo(versionInfo);
-        testUpdateChecker.get()->setVersionReceived(true);
-        testUpdateChecker.get()->setChecksumForAllChannels(trueChecksumValue);
-        up._updateChecker = testUpdateChecker;
-        CPPUNIT_ASSERT(updater.verifyFileChecksum(tmpDir.path() / "picture-1.jpg")); // checksum is valid
+        CPPUNIT_ASSERT_EQUAL(testCase.expectedValid, updater.verifyFileChecksum(tmpDir.path() / testCase.fileName));
     }
 }
 

--- a/test/server/updater/testwindowsupdater.cpp
+++ b/test/server/updater/testwindowsupdater.cpp
@@ -29,7 +29,7 @@
 #include "test_utility/testhelpers.h"
 #include "updater/windowsupdater.h"
 #include "utility/digitalsignaturechecker_win.h"
-#include "mockupdatechecker.h"
+#include "mockversionretriever.h"
 #include "jobs/syncjobmanager.h"
 
 namespace KDC {
@@ -184,14 +184,13 @@ void TestWindowsUpdater::testIsChecksumValid() {
 
         WindowsUpdater updater;
 
-        AllVersionsInfo versionInfo;
-        TestAbstractUpdater::generateValidAllVersionsInfo(versionInfo);
-        auto testUpdateChecker = std::make_shared<MockUpdateChecker>();
-
-        testUpdateChecker->setAllVersionInfo(versionInfo);
-        testUpdateChecker->setVersionReceived(true);
-        testUpdateChecker->setChecksumForAllChannels(testCase.checksumValue);
-        updater._updateChecker = testUpdateChecker;
+        VersionInfo versionInfo;
+        TestAbstractUpdater::generateValidVersionInfo(versionInfo);
+        auto mockVersionRetriever = std::make_shared<MockVersionRetriever>();
+        mockVersionRetriever->setVersionInfo(versionInfo);
+        mockVersionRetriever->setVersionReceived(true);
+        mockVersionRetriever->setChecksum(testCase.checksumValue);
+        updater._versionRetriever = mockVersionRetriever;
 
         CPPUNIT_ASSERT_EQUAL(testCase.expectedValid, updater.verifyFileChecksum(tmpDir.path() / testCase.fileName));
     }

--- a/test/server/updater/testwindowsupdater.cpp
+++ b/test/server/updater/testwindowsupdater.cpp
@@ -18,6 +18,7 @@
 
 #include "testwindowsupdater.h"
 
+#include "testabstractupdater.h"
 #include "db/parmsdb.h"
 #include "requests/parameterscache.h"
 #include "io/iohelper.h"
@@ -153,49 +154,84 @@ void TestWindowsUpdater::testIsSignatureValid() {
 }
 
 void TestWindowsUpdater::testIsChecksumValid() {
-    // App version is NOT blocked
     static const std::string noChecksumValue("");
-    static const std::string fakeChecksumValue("ddd");
+    static const std::string fakeChecksumValue("083a301369cd711e9803f7d90d342a3778f9cb864ab22992b49fccddc3b9256c"); // capybara
     static const std::string trueChecksumValue("3d735840895bcb958f359009b06cbe9b840ae9e2df22651f431bfec4ac7b696f");
-    LocalTemporaryDirectory tmpDir;
-    auto path = tmpDir.path();
-    IoError ioError = IoError::Success;
-    IoHelper::copyFileOrDirectory(testhelpers::localTestDirPath() / "test_pictures/picture-1.jpg", tmpDir.path(), ioError);
     {
+        LocalTemporaryDirectory tmpDir;
+        auto path = tmpDir.path();
+        IoError ioError = IoError::Success;
+        IoHelper::copyFileOrDirectory(testhelpers::localTestDirPath() / "test_pictures/picture-1.jpg", tmpDir.path(), ioError);
+
         WindowsUpdater updater;
+        AbstractUpdater &up = static_cast<AbstractUpdater &>(updater);
+
+        AllVersionsInfo versionInfo;
+        TestAbstractUpdater::generateValidAllVersionsInfo(versionInfo);
         std::shared_ptr<MockUpdateChecker> testUpdateChecker = std::make_shared<MockUpdateChecker>();
-        AbstractUpdater &up = static_cast<AbstractUpdater&>(updater);
+
+        testUpdateChecker.get()->setAllVersionInfo(versionInfo);
         testUpdateChecker.get()->setVersionReceived(true);
         testUpdateChecker.get()->setChecksumForAllChannels(noChecksumValue);
         up._updateChecker = testUpdateChecker;
-        UniqueId jobId = 0;
-        (void) testUpdateChecker.get()->checkUpdateAvailability(&jobId);
-        while (!SyncJobManagerSingleton::instance()->isJobFinished(jobId)) Utility::msleep(10);
-        CPPUNIT_ASSERT(updater.verifyFileChecksum(tmpDir.path() / "picture-1.jpg"));
+        CPPUNIT_ASSERT(updater.verifyFileChecksum(tmpDir.path() / "picture-1.jpg")); // kstore is missing checksum
     }
     {
+        LocalTemporaryDirectory tmpDir;
+        auto path = tmpDir.path();
+        IoError ioError = IoError::Success;
+        IoHelper::copyFileOrDirectory(testhelpers::localTestDirPath() / "test_pictures/picture-1.jpg", tmpDir.path(), ioError);
+
         WindowsUpdater updater;
-        std::shared_ptr<MockUpdateChecker> testUpdateChecker = std::make_shared<MockUpdateChecker>();
         AbstractUpdater &up = static_cast<AbstractUpdater &>(updater);
+
+        AllVersionsInfo versionInfo;
+        TestAbstractUpdater::generateValidAllVersionsInfo(versionInfo);
+        std::shared_ptr<MockUpdateChecker> testUpdateChecker = std::make_shared<MockUpdateChecker>();
+
+        testUpdateChecker.get()->setAllVersionInfo(versionInfo);
         testUpdateChecker.get()->setVersionReceived(true);
         testUpdateChecker.get()->setChecksumForAllChannels(fakeChecksumValue);
         up._updateChecker = testUpdateChecker;
-        UniqueId jobId = 0;
-        (void) testUpdateChecker.get()->checkUpdateAvailability(&jobId);
-        while (!SyncJobManagerSingleton::instance()->isJobFinished(jobId)) Utility::msleep(10);
-        CPPUNIT_ASSERT(updater.verifyFileChecksum(tmpDir.path() / "picture-1.jpg"));
+        CPPUNIT_ASSERT(!updater.verifyFileChecksum(tmpDir.path() / "picture-1111.jpg")); // can't calculate checksum
     }
     {
+        LocalTemporaryDirectory tmpDir;
+        auto path = tmpDir.path();
+        IoError ioError = IoError::Success;
+        IoHelper::copyFileOrDirectory(testhelpers::localTestDirPath() / "test_pictures/picture-1.jpg", tmpDir.path(), ioError);
+
         WindowsUpdater updater;
-        std::shared_ptr<MockUpdateChecker> testUpdateChecker = std::make_shared<MockUpdateChecker>();
         AbstractUpdater &up = static_cast<AbstractUpdater &>(updater);
+
+        AllVersionsInfo versionInfo;
+        TestAbstractUpdater::generateValidAllVersionsInfo(versionInfo);
+        std::shared_ptr<MockUpdateChecker> testUpdateChecker = std::make_shared<MockUpdateChecker>();
+
+        testUpdateChecker.get()->setAllVersionInfo(versionInfo);
+        testUpdateChecker.get()->setVersionReceived(true);
+        testUpdateChecker.get()->setChecksumForAllChannels(fakeChecksumValue);
+        up._updateChecker = testUpdateChecker;
+        CPPUNIT_ASSERT(!updater.verifyFileChecksum(tmpDir.path() / "picture-1.jpg")); // checksum is invalid
+    }
+    {
+        LocalTemporaryDirectory tmpDir;
+        auto path = tmpDir.path();
+        IoError ioError = IoError::Success;
+        IoHelper::copyFileOrDirectory(testhelpers::localTestDirPath() / "test_pictures/picture-1.jpg", tmpDir.path(), ioError);
+
+        WindowsUpdater updater;
+        AbstractUpdater &up = static_cast<AbstractUpdater &>(updater);
+
+        AllVersionsInfo versionInfo;
+        TestAbstractUpdater::generateValidAllVersionsInfo(versionInfo);
+        std::shared_ptr<MockUpdateChecker> testUpdateChecker = std::make_shared<MockUpdateChecker>();
+
+        testUpdateChecker.get()->setAllVersionInfo(versionInfo);
         testUpdateChecker.get()->setVersionReceived(true);
         testUpdateChecker.get()->setChecksumForAllChannels(trueChecksumValue);
         up._updateChecker = testUpdateChecker;
-        UniqueId jobId = 0;
-        (void) testUpdateChecker.get()->checkUpdateAvailability(&jobId);
-        while (!SyncJobManagerSingleton::instance()->isJobFinished(jobId)) Utility::msleep(10);
-        CPPUNIT_ASSERT(updater.verifyFileChecksum(tmpDir.path() / "picture-1.jpg"));
+        CPPUNIT_ASSERT(updater.verifyFileChecksum(tmpDir.path() / "picture-1.jpg")); // checksum is valid
     }
 }
 

--- a/test/server/updater/testwindowsupdater.h
+++ b/test/server/updater/testwindowsupdater.h
@@ -26,6 +26,7 @@ class TestWindowsUpdater final : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST_SUITE(TestWindowsUpdater);
         CPPUNIT_TEST(testOnUpdateFound);
         CPPUNIT_TEST(testIsSignatureValid);
+        CPPUNIT_TEST(testIsChecksumValid);
         CPPUNIT_TEST_SUITE_END();
 
     public:
@@ -35,6 +36,7 @@ class TestWindowsUpdater final : public CppUnit::TestFixture, public TestBase {
     private:
         void testOnUpdateFound();
         void testIsSignatureValid();
+        void testIsChecksumValid();
 
         int _driveDbId{0};
 };


### PR DESCRIPTION
depends on #1749
# checksum verification
- implemented a checksum of the installer to verify the integrity of the file
- moved the signature verification of the installer into correct place
- sentry logs if installer is corrupted