### PR TITLE
docs(agents): add Linux v4 AGENTS guide and align root AGENTS norms

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,18 +1,25 @@
 # kDrive Desktop — Root AGENTS.md
 
 ## Project Snapshot
-C++20 desktop sync client for Infomaniak kDrive. Single-product monolith built with CMake + Conan 2. The repository contains a background **server** daemon (`src/server/`), a legacy **Qt Widgets GUI** (`src/gui/`), and v4 frontends under `src/gui4/`. All sync logic lives in `src/libsyncengine/`. Targets macOS, Windows, and Linux.
+
+C++20 desktop sync client for Infomaniak kDrive. Single-product monolith built with CMake + Conan 2. The repository
+contains a background **server** daemon (`src/server/`), a legacy **Qt Widgets GUI** (`src/gui/`), and v4 frontends
+under `src/gui4/`. All sync logic lives in `src/libsyncengine/`. Targets macOS, Windows, and Linux.
 
 All code is in the `KDC` namespace.
 
 ## How to Use These Files
+
 At the start of every session:
+
 1. **Read this file** — universal conventions, security rules, and the component index below.
-2. **Read the sub-AGENTS.md for each component you'll touch** — e.g. editing `src/libsyncengine/` → read [`src/libsyncengine/AGENTS.md`](src/libsyncengine/AGENTS.md) before writing any code.
+2. **Read the sub-AGENTS.md for each component you'll touch** — e.g. editing `src/libsyncengine/` → read [
+   `src/libsyncengine/AGENTS.md`](src/libsyncengine/AGENTS.md) before writing any code.
 
 Nearest file wins: the sub-AGENTS.md closest to the file you're editing takes precedence over this root file.
 
 ## Setup & Build
+
 ```bash
 # Install Conan 2 dependencies (run from repo root)
 conan install . --build=missing -s build_type=Debug
@@ -29,58 +36,78 @@ clang-format -i <file>
 ```
 
 ## Universal Conventions
+
 - **Language:** C++20. `#pragma once` for header guards. All code in `KDC` namespace.
 - **Style:** Google-based clang-format, 4-space indent, 130-char line limit. Enforced by `.githooks/pre-commit`.
 - **Includes:** Relative to `src/` root — e.g., `#include "libcommon/utility/types.h"`.
 - **Platform files:** Use suffixes `_mac.mm` / `_win.cpp` / `_linux.cpp` for platform-specific code.
 - **Logging:** `LOG_INFO`, `LOG_DEBUG`, `LOG_WARN`, `LOG_ERROR` from log4cplus. Never `std::cout`.
-- **Commits:** Conventional commits format (`feat(scope):`, `fix(scope):`, `refactor(scope):`), validated by `.githooks/commit-msg`.
+- **Commits:** Conventional commits format (`feat(scope):`, `fix(scope):`, `refactor(scope):`), validated by
+  `.githooks/commit-msg`.
 - **Branch naming:** No enforced convention currently.
 
 ## Security & Secrets
+
 - Never commit API tokens, passwords, or credentials. Use env vars (`KDRIVE_TEST_CI_API_TOKEN`, etc.).
 - Keychain access is managed by `libcommonserver/keychainmanager/`.
 - Sentry DSN and signing secrets are injected by CI only.
 
 ## AGENTS.md Maintenance
-> **Important:** When making significant changes to a directory that contains an AGENTS.md file (new patterns, new architecture, new commands), update that AGENTS.md to reflect the changes. Keep documentation in sync with code.
+
+> **Important:** When making significant changes to a directory that contains an AGENTS.md file (new patterns, new
+> architecture, new commands), update that AGENTS.md to reflect the changes. Keep documentation in sync with code.
 
 ## User Preferences & Auto-Correction
-> **New Norms:** If the user corrects you (e.g., "Don't use X, use Y"), add that rule to the "Local norms" section immediately so you don't make the same mistake again.
+
+> **New Norms:** If the user corrects you (e.g., "Don't use X, use Y"), add that rule to the "Local norms" section
+> immediately so you don't make the same mistake again.
 
 ### Local Norms
-- In versioned documentation such as `AGENTS.md`, use repo-relative paths, not hardcoded absolute filesystem paths.
-- For Linux builds/validation, use `infomaniak-build-tools/linux/build-release-via-podman.sh` rather than direct `cmake --build`.
+
 <!-- Add project-specific user corrections here -->
+
+- In versioned documentation such as `AGENTS.md`, use repo-relative paths, not hardcoded absolute filesystem paths.
+- For Linux builds/validation, use `infomaniak-build-tools/linux/build-release-via-podman.sh` rather than direct
+  `cmake --build`.
+- In AGENTS documentation, do not add links to `.md` files that are not versioned in git.
 - Prefer documentation for private implementation methods in the `.cpp` file rather than the header.
-- Do not introduce raw `int` in new code when a named fixed-width type fits the use case (e.g. `uint8_t`, `int32_t`, ...).
+- Do not introduce raw `int` in new code when a named fixed-width type fits the use case (e.g. `uint8_t`,
+  `int32_t`, ...).
+- Do not run `clang-format` on `CMakeLists.txt` files (it can break formatting/structure unexpectedly in this project).
 
 ## JIT Index
 
 ### Source Libraries
+
 - Common types/utilities: `src/libcommon/` → [see AGENTS.md](src/libcommon/AGENTS.md)
 - Server utilities + platform I/O: `src/libcommonserver/` → [see AGENTS.md](src/libcommonserver/AGENTS.md)
 - Parameters database: `src/libparms/` → [see AGENTS.md](src/libparms/AGENTS.md)
 - Sync engine (core): `src/libsyncengine/` → [see AGENTS.md](src/libsyncengine/AGENTS.md)
 - GUI (Qt Widgets, legacy): `src/gui/` → [see AGENTS.md](src/gui/AGENTS.md)
-- GUI (Linux Qt/QML redesign for v4): `src/gui4/linux/` → [see AGENTS.md](src/gui4/linux/AGENTS.md)
+- GUI (Linux Qt/QML redesign for v4): `src/gui4/linux/` → [see AGENTS.md](src/gui4/linux/AGENTS.md) (authoritative for
+  Linux v4)
 - GUI (macOS Swift redesign for v4): `src/gui4/macOS/` → [see AGENTS.md](src/gui4/macOS/AGENTS.md)
 - GUI (Windows WinUI3 redesign for v4): `src/gui4/windows/` → [see AGENTS.md](src/gui4/windows/AGENTS.md)
 - Background server process: `src/server/` → [see AGENTS.md](src/server/AGENTS.md)
 
 ### Tests
+
 - Test infrastructure overview: `test/` → [see AGENTS.md](test/AGENTS.md)
 - Sync engine tests: `test/libsyncengine/` → [see AGENTS.md](test/libsyncengine/AGENTS.md)
 
 ### Infrastructure
+
 - Shell extensions (macOS/Windows): `extensions/` → [see AGENTS.md](extensions/AGENTS.md)
-- Conan dependencies & recipes: `infomaniak-build-tools/conan/` → [see AGENTS.md](infomaniak-build-tools/conan/AGENTS.md)
+- Conan dependencies & recipes:
+  `infomaniak-build-tools/conan/` → [see AGENTS.md](infomaniak-build-tools/conan/AGENTS.md)
 
 ### Legal & Licensing
+
 - Third-party licenses and attributions: [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md)
 - Project license: [`LICENSE`](LICENSE) (GPL v3)
 
 ### Quick Find Commands
+
 ```bash
 # Find a class definition
 rg -n "class ClassName" src/
@@ -99,6 +126,7 @@ rg -rn "TestClassName" test/
 ```
 
 ## Definition of Done
+
 - Code compiles on all 3 platforms (CI validates).
 - `clang-format` reports no diff on touched files.
 - New logic has a corresponding test in `test/`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,8 @@ clang-format -i <file>
 - Do not introduce raw `int` in new code when a named fixed-width type fits the use case (e.g. `uint8_t`,
   `int32_t`, ...).
 - Do not run `clang-format` on `CMakeLists.txt` files (it can break formatting/structure unexpectedly in this project).
+- For any branch named `linux-v4/*`: create it from `linux-v4/main`, and compute diffs against `linux-v4/main` by
+  default. `linux-v4/main` is the feature-integration branch regularly rebased on `develop`.
 
 ## JIT Index
 

--- a/src/gui4/linux/AGENTS.md
+++ b/src/gui4/linux/AGENTS.md
@@ -19,6 +19,8 @@
 - Prefer documenting private implementation helpers in `.cpp` rather than headers.
 - Do not introduce raw `int` in new code when a fixed-width type fits (`uint8_t`, `int32_t`, ...).
 - Do not run `clang-format` on `CMakeLists.txt` in this repository.
+- For any branch named `linux-v4/*`: create it from `linux-v4/main`, and compute diffs against `linux-v4/main` by
+  default. `linux-v4/main` is the Linux v4 integration branch regularly rebased on `develop`.
 
 ## Scope
 

--- a/src/gui4/linux/AGENTS.md
+++ b/src/gui4/linux/AGENTS.md
@@ -1,0 +1,122 @@
+# gui4/linux — Linux v4 Qt/QML Frontend
+
+## Maintenance Cadence
+
+- This area changes frequently and often receives large feature additions.
+- Update this file very regularly; it must stay aligned with the current architecture and workflows.
+- Any significant change under `src/gui4/linux/` (new layer, new pattern, new build/run command) must include an
+  `AGENTS.md` update in the same PR.
+
+## User Preferences & Auto-Correction
+
+> New norm: if the user corrects a working rule, add it here immediately to avoid repeating the same mistake.
+
+### Local Norms (Linux v4)
+
+- In versioned documentation, use repo-relative paths (no hardcoded absolute paths).
+- Do not add links to `.md` files that are not versioned in git.
+- For Linux validation, prefer `infomaniak-build-tools/linux/build-release-via-podman.sh`.
+- Prefer documenting private implementation helpers in `.cpp` rather than headers.
+- Do not introduce raw `int` in new code when a fixed-width type fits (`uint8_t`, `int32_t`, ...).
+- Do not run `clang-format` on `CMakeLists.txt` in this repository.
+
+## Scope
+
+- Linux-only v4 frontend based on Qt 6.8 (QML + C++).
+- This package handles UI bootstrap and server communication only.
+- Sync business logic stays in `src/libsyncengine/` and server-side jobs.
+
+## Current Structure
+
+- `main.cpp`: process entry point + single-instance lock file.
+- `appclientlinux.*`: top-level app wiring (logging, IPC lifecycle, dispatcher/service ownership).
+- `communicationlayer/ipcclient.*`: raw TCP JSON transport, request/reply correlation, reconnect-before-first-connect
+  logic.
+- `communicationlayer/signaldispatcher.*`: server-push signal fanout to registered handlers.
+- `app/services/commservice.*`: typed request/signal facade above `IpcClient`.
+- `ui/`: QML shell and design tokens.
+
+## Build And Validation
+
+```bash
+# From repo root: configure a Linux debug tree (example used in CLion workflow)
+cmake --preset conan-debug -S . -B build-linux/build/build/Debug
+
+# Preferred Linux validation build
+infomaniak-build-tools/linux/build-release-via-podman.sh
+
+# Optional fast local iteration build (not the canonical validation path)
+cmake --build build-linux/build/build/Debug --target kdrive_qml -- -j 12
+```
+
+## Architecture Rules
+
+- Keep layers strict:
+    - `communicationlayer/*` = transport/protocol mechanics only.
+    - `app/services/*` = typed backend facade for upper layers.
+    - `ui/*` = presentation and bindings; no protocol code.
+- QML must never call `IpcClient` directly.
+- New backend calls must be added in `CommService`, not in UI files.
+- Server-push events must be registered in `CommService::register*Handlers` and re-emitted as typed Qt signals.
+- When object lifetime is uncertain in async callbacks, guard with `QPointer<T>`.
+
+## IPC And Error Handling
+
+- Transport is loopback TCP + JSON envelope shared with `libcommon/comm.h` / `libcommon/commjson.h`.
+- `IpcClient` treats post-connection socket failure as fatal (disconnect/error after first successful connection exits
+  process).
+- Request methods should parse `Poco::DynamicStruct` into typed DTOs before exposing data upward.
+- Use shared `msgParam*` keys and enums from `libcommon`; avoid ad-hoc string keys.
+
+## Coding Conventions (Linux v4)
+
+- Use `QLoggingCategory` + `qCDebug/qCInfo/qCWarning/qCCritical`; no `std::cout`.
+- Do not introduce raw `int` when fixed-width types are appropriate (`int32_t`, `uint8_t`, ...).
+- Prefer documenting private implementation helpers in `.cpp` rather than headers.
+- Do not run `clang-format` on `CMakeLists.txt` in this repository.
+
+## Change Playbooks
+
+### Add a new request in `CommService`
+
+1. Verify `RequestNum` and `msgParam*` exist in `libcommon`.
+2. Add callback typedef if needed.
+3. Add method declaration in `commservice.h`.
+4. Implement method in `commservice.cpp` using `_ipcClient.sendRequest(...)`.
+5. Convert IPC payload to typed result object before invoking callback.
+
+### Add a new server-push signal
+
+1. Verify `SignalNum` and payload keys in `libcommon`.
+2. Register handler in the appropriate `register*Handlers` method.
+3. Parse payload safely into typed fields/DTOs.
+4. Emit a typed Qt signal from `CommService`.
+
+## Quick Find
+
+```bash
+# Linux v4 files
+find src/gui4/linux -type f | sort
+
+# IPC request methods and callsites
+rg -n "request[A-Z].*\\(" src/gui4/linux/app/services/commservice.* -g "*.h" -g "*.cpp"
+
+# Signal registrations
+rg -n "registerHandler\\(" src/gui4/linux/app/services/commservice.cpp
+
+# Shared request/signal enums and JSON keys
+rg -n "enum class (RequestNum|SignalNum)|msgParam" src/libcommon/comm.h src/libcommon/commjson.h
+
+# Logging categories in Linux v4 frontend
+rg -n "Q_LOGGING_CATEGORY|qC(Debug|Info|Warning|Critical)" src/gui4/linux -g "*.cpp" -g "*.h"
+```
+
+## Pre-PR Checks
+
+```bash
+# Build the Linux v4 frontend target locally
+cmake --build build-linux/build/build/Debug --target kdrive_qml -- -j 12
+
+# Run the canonical Linux validation build
+infomaniak-build-tools/linux/build-release-via-podman.sh
+```


### PR DESCRIPTION
## Summary
This PR updates AGENTS documentation for Linux v4 work:
- adds a dedicated `src/gui4/linux/AGENTS.md` from scratch,
- updates root `AGENTS.md` local norms and index clarity,
- keeps guidance aligned with current Linux v4 branch workflow and documentation constraints.

## Changes
- Added new file: `src/gui4/linux/AGENTS.md`.
- Added Linux v4 maintenance cadence guidance (frequent updates required).
- Added Linux v4 local norms, including:
  - repo-relative paths in versioned docs,
  - no links to non-versioned `.md`,
  - Linux validation via `infomaniak-build-tools/linux/build-release-via-podman.sh`,
  - fixed-width integer preference,
  - no `clang-format` on `CMakeLists.txt`,
  - branch rule for `linux-v4/*` (create/diff from `linux-v4/main`).
- Updated root `AGENTS.md`:
  - local norms enriched with the same documentation/build/branch constraints,
  - Linux v4 AGENTS index entry clarified as authoritative,
  - formatting/wrapping cleanup for readability.

## Technical Details
- Scope is documentation-only (`AGENTS.md` files).
- No runtime behavior change, no build logic change, no production code change.

## Rationale
- Linux v4 is evolving quickly; nearest-wins AGENTS guidance must stay explicit and current.
- The `linux-v4/main` base rule avoids branch drift and inconsistent diff bases.
- Explicit documentation constraints reduce recurring review noise.
