### PR TITLE
feat(linux-v4): add SyncService facade for sync operations

### DIFF
--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -30,6 +30,8 @@ set(GUI_SOURCE_FILES # C++ files for the GUI application
         app/services/userservice.h
         app/services/driveservice.cpp
         app/services/driveservice.h
+        app/services/syncservice.cpp
+        app/services/syncservice.h
 )
 
 set(GUI_QML_SINGLETON_FILES # QML singletons (tokens, theme, etc.)

--- a/src/gui4/linux/app/services/syncservice.cpp
+++ b/src/gui4/linux/app/services/syncservice.cpp
@@ -64,7 +64,7 @@ void SyncService::loadSyncs() {
 
     _commService.requestSyncInfoList([this](const ExitInfo &exitInfo, const std::vector<SyncInfo> &list) {
         endAction(actionLoadSyncs);
-        if (exitInfo.code() != ExitCode::Ok) {
+        if (!exitInfo) {
             notifyRequestFailure(exitInfo, RequestNum::SYNC_INFOLIST);
             return;
         }
@@ -88,7 +88,7 @@ void SyncService::addSync(const qint64 userDbId, const qint64 accountId, const q
 
     _commService.requestSyncAdd(request, [this](const ExitInfo &exitInfo, const SyncInfo &syncInfo) {
         endAction(actionAddSync);
-        if (exitInfo.code() != ExitCode::Ok) {
+        if (!exitInfo) {
             notifyRequestFailure(exitInfo, RequestNum::SYNC_ADD);
             return;
         }
@@ -102,7 +102,7 @@ void SyncService::startSync(const qint64 syncDbId) {
 
     _commService.requestSyncStart(static_cast<SyncDbId>(syncDbId), [this, syncDbId](const ExitInfo &exitInfo) {
         endAction(actionStartSync, syncDbId);
-        if (exitInfo.code() != ExitCode::Ok) {
+        if (!exitInfo) {
             notifyRequestFailure(exitInfo, RequestNum::SYNC_START);
         }
     });
@@ -113,7 +113,7 @@ void SyncService::stopSync(const qint64 syncDbId) {
 
     _commService.requestSyncStop(static_cast<SyncDbId>(syncDbId), [this, syncDbId](const ExitInfo &exitInfo) {
         endAction(actionStopSync, syncDbId);
-        if (exitInfo.code() != ExitCode::Ok) {
+        if (!exitInfo) {
             notifyRequestFailure(exitInfo, RequestNum::SYNC_STOP);
         }
     });
@@ -125,7 +125,7 @@ void SyncService::deleteSync(const qint64 syncDbId) {
     // Cache consistency is signal-driven: we wait for syncRemoved/syncUpdated pushes.
     _commService.requestSyncDelete(static_cast<SyncDbId>(syncDbId), [this, syncDbId](const ExitInfo &exitInfo) {
         endAction(actionDeleteSync, syncDbId);
-        if (exitInfo.code() != ExitCode::Ok) {
+        if (!exitInfo) {
             notifyRequestFailure(exitInfo, RequestNum::SYNC_DELETE);
         }
     });
@@ -137,7 +137,7 @@ void SyncService::querySyncStatus(const qint64 syncDbId) {
     _commService.requestSyncStatus(static_cast<SyncDbId>(syncDbId),
                                    [this, syncDbId](const ExitInfo &exitInfo, const SyncStatus status) {
                                        endAction(actionQuerySyncStatus, syncDbId);
-                                       if (exitInfo.code() != ExitCode::Ok) {
+                                       if (!exitInfo) {
                                            notifyRequestFailure(exitInfo, RequestNum::SYNC_STATUS);
                                            return;
                                        }
@@ -149,16 +149,16 @@ void SyncService::querySyncStatus(const qint64 syncDbId) {
 void SyncService::findGoodPathForNewSync(const QString &basePath) {
     beginAction(actionFindGoodPathForNewSync);
 
-    _commService.requestFindGoodPathForNewSync(
-            QStr2Path(basePath), [this](const ExitInfo &exitInfo, const GoodPathResult &result) {
-                endAction(actionFindGoodPathForNewSync);
-                if (exitInfo.code() != ExitCode::Ok) {
-                    notifyRequestFailure(exitInfo, RequestNum::UTILITY_FINDGOODPATHFORNEWSYNC);
-                    return;
-                }
+    _commService.requestFindGoodPathForNewSync(QStr2Path(basePath),
+                                               [this](const ExitInfo &exitInfo, const GoodPathResult &result) {
+                                                   endAction(actionFindGoodPathForNewSync);
+                                                   if (!exitInfo) {
+                                                       notifyRequestFailure(exitInfo, RequestNum::UTILITY_FINDGOODPATHFORNEWSYNC);
+                                                       return;
+                                                   }
 
-                emit suggestedPathReceived(Path2QStr(result.goodPath), result.errorMessage);
-            });
+                                                   emit suggestedPathReceived(Path2QStr(result.goodPath), result.errorMessage);
+                                               });
 }
 
 void SyncService::isPathValidForNewSync(const QString &path, const int32_t syncConfiguration) {
@@ -173,7 +173,7 @@ void SyncService::isPathValidForNewSync(const QString &path, const int32_t syncC
     _commService.requestIsPathValidForNewSync(QStr2Path(path), static_cast<SyncConfiguration>(syncConfiguration),
                                               [this](const ExitInfo &exitInfo, const bool isValid) {
                                                   endAction(actionIsPathValidForNewSync);
-                                                  if (exitInfo.code() != ExitCode::Ok) {
+                                                  if (!exitInfo) {
                                                       notifyRequestFailure(exitInfo, RequestNum::UTILITY_ISPATHVALIDFORNEWSYNC);
                                                       emit pathValidationReceived(false);
                                                       return;
@@ -228,8 +228,7 @@ bool SyncService::isActionPending(const QString &actionKey, const qint64 scopeId
 }
 
 bool SyncService::isValidSyncConfigurationValue(const int32_t syncConfiguration) const {
-    return syncConfiguration >= toInt(SyncConfiguration::Classic) &&
-           syncConfiguration < toInt(SyncConfiguration::EnumEnd);
+    return syncConfiguration >= toInt(SyncConfiguration::Classic) && syncConfiguration < toInt(SyncConfiguration::EnumEnd);
 }
 
 void SyncService::setLoading(const bool loading) {

--- a/src/gui4/linux/app/services/syncservice.cpp
+++ b/src/gui4/linux/app/services/syncservice.cpp
@@ -142,6 +142,7 @@ void SyncService::deleteSync(const qint64 syncDbId) {
 }
 
 void SyncService::querySyncStatus(const qint64 syncDbId) {
+    beginRequest();
     setLastError(QString());
 
     const QPointer<SyncService> self(this);
@@ -151,6 +152,7 @@ void SyncService::querySyncStatus(const qint64 syncDbId) {
                                            return;
                                        }
 
+                                       self->endRequest();
                                        if (exitInfo.code() != ExitCode::Ok) {
                                            self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
                                            return;

--- a/src/gui4/linux/app/services/syncservice.cpp
+++ b/src/gui4/linux/app/services/syncservice.cpp
@@ -28,7 +28,7 @@ namespace KDC {
 
 Q_LOGGING_CATEGORY(lcSyncService, "gui.v4.syncservice", QtInfoMsg)
 
-SyncService::SyncService(CommService &commService, AppCache &appCache, QObject *parent) :
+SyncService::SyncService(CommService &commService, AppCache &appCache, QObject *const parent) :
     QObject(parent),
     _commService(commService),
     _appCache(appCache) {

--- a/src/gui4/linux/app/services/syncservice.cpp
+++ b/src/gui4/linux/app/services/syncservice.cpp
@@ -22,7 +22,6 @@
 #include "libcommon/utility/types.h"
 
 #include <QLoggingCategory>
-#include <QPointer>
 
 namespace KDC {
 
@@ -43,19 +42,14 @@ void SyncService::loadSyncs() {
     beginRequest();
     setLastError(QString());
 
-    const QPointer<SyncService> self(this);
-    _commService.requestSyncInfoList([self](const ExitInfo &exitInfo, const std::vector<SyncInfo> &list) {
-        if (!self) {
-            return;
-        }
-
-        self->endRequest();
+    _commService.requestSyncInfoList([this](const ExitInfo &exitInfo, const std::vector<SyncInfo> &list) {
+        endRequest();
         if (exitInfo.code() != ExitCode::Ok) {
-            self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+            setLastError(ServiceUtils::formatExitInfo(exitInfo));
             return;
         }
 
-        self->_appCache.replaceSyncs(list);
+        _appCache.replaceSyncs(list);
     });
 }
 
@@ -73,19 +67,14 @@ void SyncService::addSync(const qint64 userDbId, const qint64 accountId, const q
     request.serverFolderNodeId = QStr2Str(serverFolderNodeId);
     request.liteSync = liteSync;
 
-    const QPointer<SyncService> self(this);
-    _commService.requestSyncAdd(request, [self](const ExitInfo &exitInfo, const SyncInfo &syncInfo) {
-        if (!self) {
-            return;
-        }
-
-        self->endRequest();
+    _commService.requestSyncAdd(request, [this](const ExitInfo &exitInfo, const SyncInfo &syncInfo) {
+        endRequest();
         if (exitInfo.code() != ExitCode::Ok) {
-            self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+            setLastError(ServiceUtils::formatExitInfo(exitInfo));
             return;
         }
 
-        emit self->syncAddCompleted(static_cast<qint64>(syncInfo.dbId()));
+        emit syncAddCompleted(static_cast<qint64>(syncInfo.dbId()));
     });
 }
 
@@ -93,15 +82,10 @@ void SyncService::startSync(const qint64 syncDbId) {
     beginRequest();
     setLastError(QString());
 
-    const QPointer<SyncService> self(this);
-    _commService.requestSyncStart(static_cast<SyncDbId>(syncDbId), [self](const ExitInfo &exitInfo) {
-        if (!self) {
-            return;
-        }
-
-        self->endRequest();
+    _commService.requestSyncStart(static_cast<SyncDbId>(syncDbId), [this](const ExitInfo &exitInfo) {
+        endRequest();
         if (exitInfo.code() != ExitCode::Ok) {
-            self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+            setLastError(ServiceUtils::formatExitInfo(exitInfo));
         }
     });
 }
@@ -110,15 +94,10 @@ void SyncService::stopSync(const qint64 syncDbId) {
     beginRequest();
     setLastError(QString());
 
-    const QPointer<SyncService> self(this);
-    _commService.requestSyncStop(static_cast<SyncDbId>(syncDbId), [self](const ExitInfo &exitInfo) {
-        if (!self) {
-            return;
-        }
-
-        self->endRequest();
+    _commService.requestSyncStop(static_cast<SyncDbId>(syncDbId), [this](const ExitInfo &exitInfo) {
+        endRequest();
         if (exitInfo.code() != ExitCode::Ok) {
-            self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+            setLastError(ServiceUtils::formatExitInfo(exitInfo));
         }
     });
 }
@@ -127,16 +106,11 @@ void SyncService::deleteSync(const qint64 syncDbId) {
     beginRequest();
     setLastError(QString());
 
-    const QPointer<SyncService> self(this);
     // Cache consistency is signal-driven: we wait for syncRemoved/syncUpdated pushes.
-    _commService.requestSyncDelete(static_cast<SyncDbId>(syncDbId), [self](const ExitInfo &exitInfo) {
-        if (!self) {
-            return;
-        }
-
-        self->endRequest();
+    _commService.requestSyncDelete(static_cast<SyncDbId>(syncDbId), [this](const ExitInfo &exitInfo) {
+        endRequest();
         if (exitInfo.code() != ExitCode::Ok) {
-            self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+            setLastError(ServiceUtils::formatExitInfo(exitInfo));
         }
     });
 }
@@ -145,20 +119,15 @@ void SyncService::querySyncStatus(const qint64 syncDbId) {
     beginRequest();
     setLastError(QString());
 
-    const QPointer<SyncService> self(this);
     _commService.requestSyncStatus(static_cast<SyncDbId>(syncDbId),
-                                   [self, syncDbId](const ExitInfo &exitInfo, const SyncStatus status) {
-                                       if (!self) {
-                                           return;
-                                       }
-
-                                       self->endRequest();
+                                   [this, syncDbId](const ExitInfo &exitInfo, const SyncStatus status) {
+                                       endRequest();
                                        if (exitInfo.code() != ExitCode::Ok) {
-                                           self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+                                           setLastError(ServiceUtils::formatExitInfo(exitInfo));
                                            return;
                                        }
 
-                                       emit self->syncStatusReceived(syncDbId, toInt(status));
+                                       emit syncStatusReceived(syncDbId, toInt(status));
                                    });
 }
 
@@ -166,20 +135,15 @@ void SyncService::findGoodPathForNewSync(const QString &basePath) {
     beginRequest();
     setLastError(QString());
 
-    const QPointer<SyncService> self(this);
     _commService.requestFindGoodPathForNewSync(
-            QStr2Path(basePath), [self](const ExitInfo &exitInfo, const GoodPathResult &result) {
-                if (!self) {
-                    return;
-                }
-
-                self->endRequest();
+            QStr2Path(basePath), [this](const ExitInfo &exitInfo, const GoodPathResult &result) {
+                endRequest();
                 if (exitInfo.code() != ExitCode::Ok) {
-                    self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+                    setLastError(ServiceUtils::formatExitInfo(exitInfo));
                     return;
                 }
 
-                emit self->suggestedPathReceived(Path2QStr(result.goodPath), result.errorMessage);
+                emit suggestedPathReceived(Path2QStr(result.goodPath), result.errorMessage);
             });
 }
 
@@ -193,21 +157,16 @@ void SyncService::isPathValidForNewSync(const QString &path, const int32_t syncC
 
     beginRequest();
 
-    const QPointer<SyncService> self(this);
     _commService.requestIsPathValidForNewSync(QStr2Path(path), static_cast<SyncConfiguration>(syncConfiguration),
-                                              [self](const ExitInfo &exitInfo, const bool isValid) {
-                                                  if (!self) {
-                                                      return;
-                                                  }
-
-                                                  self->endRequest();
+                                              [this](const ExitInfo &exitInfo, const bool isValid) {
+                                                  endRequest();
                                                   if (exitInfo.code() != ExitCode::Ok) {
-                                                      self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
-                                                      emit self->pathValidationReceived(false);
+                                                      setLastError(ServiceUtils::formatExitInfo(exitInfo));
+                                                      emit pathValidationReceived(false);
                                                       return;
                                                   }
 
-                                                  emit self->pathValidationReceived(isValid);
+                                                  emit pathValidationReceived(isValid);
                                               });
 }
 

--- a/src/gui4/linux/app/services/syncservice.cpp
+++ b/src/gui4/linux/app/services/syncservice.cpp
@@ -17,35 +17,55 @@
  */
 
 #include "syncservice.h"
-#include "serviceutils.h"
 
 #include "libcommon/utility/types.h"
 
 #include <QLoggingCategory>
 
+namespace {
+constexpr char serviceKeySync[] = "sync";
+constexpr char actionLoadSyncs[] = "loadSyncs";
+constexpr char actionAddSync[] = "addSync";
+constexpr char actionStartSync[] = "startSync";
+constexpr char actionStopSync[] = "stopSync";
+constexpr char actionDeleteSync[] = "deleteSync";
+constexpr char actionQuerySyncStatus[] = "querySyncStatus";
+constexpr char actionFindGoodPathForNewSync[] = "findGoodPathForNewSync";
+constexpr char actionIsPathValidForNewSync[] = "isPathValidForNewSync";
+} // namespace
+
 namespace KDC {
 
 Q_LOGGING_CATEGORY(lcSyncService, "gui.v4.syncservice", QtInfoMsg)
 
-SyncService::SyncService(CommService &commService, AppCache &appCache, QObject *const parent) :
+SyncService::SyncService(CommService &commService, AppCache &appCache, ServiceActionTracker &serviceActionTracker,
+                         ServiceEventBus &serviceEventBus, QObject *const parent) :
     QObject(parent),
     _commService(commService),
-    _appCache(appCache) {
+    _appCache(appCache),
+    _serviceActionTracker(serviceActionTracker),
+    _serviceEventBus(serviceEventBus) {
     (void) connect(&_commService, &CommService::syncAdded, &_appCache, &AppCache::upsertSync);
     (void) connect(&_commService, &CommService::syncUpdated, &_appCache, &AppCache::upsertSync);
     (void) connect(&_commService, &CommService::syncRemoved, &_appCache, &AppCache::removeSync);
     (void) connect(&_commService, &CommService::errorAdded, &_appCache, &AppCache::upsertError);
     (void) connect(&_commService, &CommService::errorRemoved, &_appCache, &AppCache::removeError);
+    (void) connect(&_serviceActionTracker, &ServiceActionTracker::servicePendingChanged, this,
+                   [this](const QString &serviceKey, const bool pending) {
+                       if (serviceKey == serviceKeySync) {
+                           setLoading(pending);
+                       }
+                   });
+    setLoading(_serviceActionTracker.isServicePending(serviceKeySync));
 }
 
 void SyncService::loadSyncs() {
-    beginRequest();
-    setLastError(QString());
+    beginAction(actionLoadSyncs);
 
     _commService.requestSyncInfoList([this](const ExitInfo &exitInfo, const std::vector<SyncInfo> &list) {
-        endRequest();
+        endAction(actionLoadSyncs);
         if (exitInfo.code() != ExitCode::Ok) {
-            setLastError(ServiceUtils::formatExitInfo(exitInfo));
+            notifyRequestFailure(exitInfo, RequestNum::SYNC_INFOLIST);
             return;
         }
 
@@ -55,8 +75,7 @@ void SyncService::loadSyncs() {
 
 void SyncService::addSync(const qint64 userDbId, const qint64 accountId, const qint64 driveId, const QString &localFolderPath,
                           const QString &serverFolderPath, const QString &serverFolderNodeId, const bool liteSync) {
-    beginRequest();
-    setLastError(QString());
+    beginAction(actionAddSync);
 
     SyncAddRequest request;
     request.userDbId = static_cast<UserDbId>(userDbId);
@@ -68,9 +87,9 @@ void SyncService::addSync(const qint64 userDbId, const qint64 accountId, const q
     request.liteSync = liteSync;
 
     _commService.requestSyncAdd(request, [this](const ExitInfo &exitInfo, const SyncInfo &syncInfo) {
-        endRequest();
+        endAction(actionAddSync);
         if (exitInfo.code() != ExitCode::Ok) {
-            setLastError(ServiceUtils::formatExitInfo(exitInfo));
+            notifyRequestFailure(exitInfo, RequestNum::SYNC_ADD);
             return;
         }
 
@@ -79,51 +98,47 @@ void SyncService::addSync(const qint64 userDbId, const qint64 accountId, const q
 }
 
 void SyncService::startSync(const qint64 syncDbId) {
-    beginRequest();
-    setLastError(QString());
+    beginAction(actionStartSync, syncDbId);
 
-    _commService.requestSyncStart(static_cast<SyncDbId>(syncDbId), [this](const ExitInfo &exitInfo) {
-        endRequest();
+    _commService.requestSyncStart(static_cast<SyncDbId>(syncDbId), [this, syncDbId](const ExitInfo &exitInfo) {
+        endAction(actionStartSync, syncDbId);
         if (exitInfo.code() != ExitCode::Ok) {
-            setLastError(ServiceUtils::formatExitInfo(exitInfo));
+            notifyRequestFailure(exitInfo, RequestNum::SYNC_START);
         }
     });
 }
 
 void SyncService::stopSync(const qint64 syncDbId) {
-    beginRequest();
-    setLastError(QString());
+    beginAction(actionStopSync, syncDbId);
 
-    _commService.requestSyncStop(static_cast<SyncDbId>(syncDbId), [this](const ExitInfo &exitInfo) {
-        endRequest();
+    _commService.requestSyncStop(static_cast<SyncDbId>(syncDbId), [this, syncDbId](const ExitInfo &exitInfo) {
+        endAction(actionStopSync, syncDbId);
         if (exitInfo.code() != ExitCode::Ok) {
-            setLastError(ServiceUtils::formatExitInfo(exitInfo));
+            notifyRequestFailure(exitInfo, RequestNum::SYNC_STOP);
         }
     });
 }
 
 void SyncService::deleteSync(const qint64 syncDbId) {
-    beginRequest();
-    setLastError(QString());
+    beginAction(actionDeleteSync, syncDbId);
 
     // Cache consistency is signal-driven: we wait for syncRemoved/syncUpdated pushes.
-    _commService.requestSyncDelete(static_cast<SyncDbId>(syncDbId), [this](const ExitInfo &exitInfo) {
-        endRequest();
+    _commService.requestSyncDelete(static_cast<SyncDbId>(syncDbId), [this, syncDbId](const ExitInfo &exitInfo) {
+        endAction(actionDeleteSync, syncDbId);
         if (exitInfo.code() != ExitCode::Ok) {
-            setLastError(ServiceUtils::formatExitInfo(exitInfo));
+            notifyRequestFailure(exitInfo, RequestNum::SYNC_DELETE);
         }
     });
 }
 
 void SyncService::querySyncStatus(const qint64 syncDbId) {
-    beginRequest();
-    setLastError(QString());
+    beginAction(actionQuerySyncStatus, syncDbId);
 
     _commService.requestSyncStatus(static_cast<SyncDbId>(syncDbId),
                                    [this, syncDbId](const ExitInfo &exitInfo, const SyncStatus status) {
-                                       endRequest();
+                                       endAction(actionQuerySyncStatus, syncDbId);
                                        if (exitInfo.code() != ExitCode::Ok) {
-                                           setLastError(ServiceUtils::formatExitInfo(exitInfo));
+                                           notifyRequestFailure(exitInfo, RequestNum::SYNC_STATUS);
                                            return;
                                        }
 
@@ -132,14 +147,13 @@ void SyncService::querySyncStatus(const qint64 syncDbId) {
 }
 
 void SyncService::findGoodPathForNewSync(const QString &basePath) {
-    beginRequest();
-    setLastError(QString());
+    beginAction(actionFindGoodPathForNewSync);
 
     _commService.requestFindGoodPathForNewSync(
             QStr2Path(basePath), [this](const ExitInfo &exitInfo, const GoodPathResult &result) {
-                endRequest();
+                endAction(actionFindGoodPathForNewSync);
                 if (exitInfo.code() != ExitCode::Ok) {
-                    setLastError(ServiceUtils::formatExitInfo(exitInfo));
+                    notifyRequestFailure(exitInfo, RequestNum::UTILITY_FINDGOODPATHFORNEWSYNC);
                     return;
                 }
 
@@ -148,20 +162,19 @@ void SyncService::findGoodPathForNewSync(const QString &basePath) {
 }
 
 void SyncService::isPathValidForNewSync(const QString &path, const int32_t syncConfiguration) {
-    setLastError(QString());
     if (!isValidSyncConfigurationValue(syncConfiguration)) {
-        setLastError(QStringLiteral("Invalid sync configuration value: %1").arg(syncConfiguration));
+        qCWarning(lcSyncService) << "isPathValidForNewSync: invalid sync configuration value:" << syncConfiguration;
         emit pathValidationReceived(false);
         return;
     }
 
-    beginRequest();
+    beginAction(actionIsPathValidForNewSync);
 
     _commService.requestIsPathValidForNewSync(QStr2Path(path), static_cast<SyncConfiguration>(syncConfiguration),
                                               [this](const ExitInfo &exitInfo, const bool isValid) {
-                                                  endRequest();
+                                                  endAction(actionIsPathValidForNewSync);
                                                   if (exitInfo.code() != ExitCode::Ok) {
-                                                      setLastError(ServiceUtils::formatExitInfo(exitInfo));
+                                                      notifyRequestFailure(exitInfo, RequestNum::UTILITY_ISPATHVALIDFORNEWSYNC);
                                                       emit pathValidationReceived(false);
                                                       return;
                                                   }
@@ -170,23 +183,48 @@ void SyncService::isPathValidForNewSync(const QString &path, const int32_t syncC
                                               });
 }
 
-void SyncService::beginRequest() {
-    ++_pendingRequestCount;
-    setLoading(true);
+bool SyncService::isLoadSyncsPending() const {
+    return isActionPending(actionLoadSyncs);
 }
 
-void SyncService::endRequest() {
-    if (_pendingRequestCount <= 0) {
-        qCWarning(lcSyncService) << "endRequest called with non-positive pending count:" << _pendingRequestCount;
-        _pendingRequestCount = 0;
-        setLoading(false);
-        return;
-    }
+bool SyncService::isAddSyncPending() const {
+    return isActionPending(actionAddSync);
+}
 
-    --_pendingRequestCount;
-    if (_pendingRequestCount == 0) {
-        setLoading(false);
-    }
+bool SyncService::isStartSyncPending(const qint64 syncDbId) const {
+    return isActionPending(actionStartSync, syncDbId);
+}
+
+bool SyncService::isStopSyncPending(const qint64 syncDbId) const {
+    return isActionPending(actionStopSync, syncDbId);
+}
+
+bool SyncService::isDeleteSyncPending(const qint64 syncDbId) const {
+    return isActionPending(actionDeleteSync, syncDbId);
+}
+
+bool SyncService::isQuerySyncStatusPending(const qint64 syncDbId) const {
+    return isActionPending(actionQuerySyncStatus, syncDbId);
+}
+
+bool SyncService::isFindGoodPathForNewSyncPending() const {
+    return isActionPending(actionFindGoodPathForNewSync);
+}
+
+bool SyncService::isPathValidForNewSyncPending() const {
+    return isActionPending(actionIsPathValidForNewSync);
+}
+
+void SyncService::beginAction(const QString &actionKey, const qint64 scopeId) {
+    _serviceActionTracker.beginAction(serviceKeySync, actionKey, scopeId);
+}
+
+void SyncService::endAction(const QString &actionKey, const qint64 scopeId) {
+    _serviceActionTracker.endAction(serviceKeySync, actionKey, scopeId);
+}
+
+bool SyncService::isActionPending(const QString &actionKey, const qint64 scopeId) const {
+    return _serviceActionTracker.isActionPending(serviceKeySync, actionKey, scopeId);
 }
 
 bool SyncService::isValidSyncConfigurationValue(const int32_t syncConfiguration) const {
@@ -202,12 +240,9 @@ void SyncService::setLoading(const bool loading) {
     emit loadingChanged();
 }
 
-void SyncService::setLastError(const QString &error) {
-    if (_lastError == error) {
-        return;
-    }
-    _lastError = error;
-    emit lastErrorChanged();
+void SyncService::notifyRequestFailure(const ExitInfo &exitInfo, const RequestNum requestNum) {
+    qCWarning(lcSyncService) << "Sync service request failed | code:" << exitInfo.code() << "/ cause:" << exitInfo.cause();
+    _serviceEventBus.notifyGenericError(exitInfo, requestNum);
 }
 
 } // namespace KDC

--- a/src/gui4/linux/app/services/syncservice.cpp
+++ b/src/gui4/linux/app/services/syncservice.cpp
@@ -1,0 +1,252 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "syncservice.h"
+#include "serviceutils.h"
+
+#include "libcommon/utility/types.h"
+
+#include <QLoggingCategory>
+#include <QPointer>
+
+namespace KDC {
+
+Q_LOGGING_CATEGORY(lcSyncService, "gui.v4.syncservice", QtInfoMsg)
+
+SyncService::SyncService(CommService &commService, AppCache &appCache, QObject *parent) :
+    QObject(parent),
+    _commService(commService),
+    _appCache(appCache) {
+    (void) connect(&_commService, &CommService::syncAdded, &_appCache, &AppCache::upsertSync);
+    (void) connect(&_commService, &CommService::syncUpdated, &_appCache, &AppCache::upsertSync);
+    (void) connect(&_commService, &CommService::syncRemoved, &_appCache, &AppCache::removeSync);
+    (void) connect(&_commService, &CommService::errorAdded, &_appCache, &AppCache::upsertError);
+    (void) connect(&_commService, &CommService::errorRemoved, &_appCache, &AppCache::removeError);
+}
+
+void SyncService::loadSyncs() {
+    beginRequest();
+    setLastError(QString());
+
+    const QPointer<SyncService> self(this);
+    _commService.requestSyncInfoList([self](const ExitInfo &exitInfo, const std::vector<SyncInfo> &list) {
+        if (!self) {
+            return;
+        }
+
+        self->endRequest();
+        if (exitInfo.code() != ExitCode::Ok) {
+            self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+            return;
+        }
+
+        self->_appCache.replaceSyncs(list);
+    });
+}
+
+void SyncService::addSync(const qint64 userDbId, const qint64 accountId, const qint64 driveId, const QString &localFolderPath,
+                          const QString &serverFolderPath, const QString &serverFolderNodeId, const bool liteSync) {
+    beginRequest();
+    setLastError(QString());
+
+    SyncAddRequest request;
+    request.userDbId = static_cast<UserDbId>(userDbId);
+    request.accountId = static_cast<AccountId>(accountId);
+    request.driveId = static_cast<DriveId>(driveId);
+    request.localFolderPath = QStr2Path(localFolderPath);
+    request.serverFolderPath = QStr2Path(serverFolderPath);
+    request.serverFolderNodeId = QStr2Str(serverFolderNodeId);
+    request.liteSync = liteSync;
+
+    const QPointer<SyncService> self(this);
+    _commService.requestSyncAdd(request, [self](const ExitInfo &exitInfo, const SyncInfo &syncInfo) {
+        if (!self) {
+            return;
+        }
+
+        self->endRequest();
+        if (exitInfo.code() != ExitCode::Ok) {
+            self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+            return;
+        }
+
+        emit self->syncAddCompleted(static_cast<qint64>(syncInfo.dbId()));
+    });
+}
+
+void SyncService::startSync(const qint64 syncDbId) {
+    beginRequest();
+    setLastError(QString());
+
+    const QPointer<SyncService> self(this);
+    _commService.requestSyncStart(static_cast<SyncDbId>(syncDbId), [self](const ExitInfo &exitInfo) {
+        if (!self) {
+            return;
+        }
+
+        self->endRequest();
+        if (exitInfo.code() != ExitCode::Ok) {
+            self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+        }
+    });
+}
+
+void SyncService::stopSync(const qint64 syncDbId) {
+    beginRequest();
+    setLastError(QString());
+
+    const QPointer<SyncService> self(this);
+    _commService.requestSyncStop(static_cast<SyncDbId>(syncDbId), [self](const ExitInfo &exitInfo) {
+        if (!self) {
+            return;
+        }
+
+        self->endRequest();
+        if (exitInfo.code() != ExitCode::Ok) {
+            self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+        }
+    });
+}
+
+void SyncService::deleteSync(const qint64 syncDbId) {
+    beginRequest();
+    setLastError(QString());
+
+    const QPointer<SyncService> self(this);
+    // Cache consistency is signal-driven: we wait for syncRemoved/syncUpdated pushes.
+    _commService.requestSyncDelete(static_cast<SyncDbId>(syncDbId), [self](const ExitInfo &exitInfo) {
+        if (!self) {
+            return;
+        }
+
+        self->endRequest();
+        if (exitInfo.code() != ExitCode::Ok) {
+            self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+        }
+    });
+}
+
+void SyncService::querySyncStatus(const qint64 syncDbId) {
+    setLastError(QString());
+
+    const QPointer<SyncService> self(this);
+    _commService.requestSyncStatus(static_cast<SyncDbId>(syncDbId),
+                                   [self, syncDbId](const ExitInfo &exitInfo, const SyncStatus status) {
+                                       if (!self) {
+                                           return;
+                                       }
+
+                                       if (exitInfo.code() != ExitCode::Ok) {
+                                           self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+                                           return;
+                                       }
+
+                                       emit self->syncStatusReceived(syncDbId, toInt(status));
+                                   });
+}
+
+void SyncService::findGoodPathForNewSync(const QString &basePath) {
+    beginRequest();
+    setLastError(QString());
+
+    const QPointer<SyncService> self(this);
+    _commService.requestFindGoodPathForNewSync(
+            QStr2Path(basePath), [self](const ExitInfo &exitInfo, const GoodPathResult &result) {
+                if (!self) {
+                    return;
+                }
+
+                self->endRequest();
+                if (exitInfo.code() != ExitCode::Ok) {
+                    self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+                    return;
+                }
+
+                emit self->suggestedPathReceived(Path2QStr(result.goodPath), result.errorMessage);
+            });
+}
+
+void SyncService::isPathValidForNewSync(const QString &path, const int32_t syncConfiguration) {
+    setLastError(QString());
+    if (!isValidSyncConfigurationValue(syncConfiguration)) {
+        setLastError(QStringLiteral("Invalid sync configuration value: %1").arg(syncConfiguration));
+        emit pathValidationReceived(false);
+        return;
+    }
+
+    beginRequest();
+
+    const QPointer<SyncService> self(this);
+    _commService.requestIsPathValidForNewSync(QStr2Path(path), static_cast<SyncConfiguration>(syncConfiguration),
+                                              [self](const ExitInfo &exitInfo, const bool isValid) {
+                                                  if (!self) {
+                                                      return;
+                                                  }
+
+                                                  self->endRequest();
+                                                  if (exitInfo.code() != ExitCode::Ok) {
+                                                      self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+                                                      emit self->pathValidationReceived(false);
+                                                      return;
+                                                  }
+
+                                                  emit self->pathValidationReceived(isValid);
+                                              });
+}
+
+void SyncService::beginRequest() {
+    ++_pendingRequestCount;
+    setLoading(true);
+}
+
+void SyncService::endRequest() {
+    if (_pendingRequestCount <= 0) {
+        qCWarning(lcSyncService) << "endRequest called with non-positive pending count:" << _pendingRequestCount;
+        _pendingRequestCount = 0;
+        setLoading(false);
+        return;
+    }
+
+    --_pendingRequestCount;
+    if (_pendingRequestCount == 0) {
+        setLoading(false);
+    }
+}
+
+bool SyncService::isValidSyncConfigurationValue(const int32_t syncConfiguration) const {
+    return syncConfiguration >= toInt(SyncConfiguration::Classic) &&
+           syncConfiguration < toInt(SyncConfiguration::EnumEnd);
+}
+
+void SyncService::setLoading(const bool loading) {
+    if (_loading == loading) {
+        return;
+    }
+    _loading = loading;
+    emit loadingChanged();
+}
+
+void SyncService::setLastError(const QString &error) {
+    if (_lastError == error) {
+        return;
+    }
+    _lastError = error;
+    emit lastErrorChanged();
+}
+
+} // namespace KDC

--- a/src/gui4/linux/app/services/syncservice.h
+++ b/src/gui4/linux/app/services/syncservice.h
@@ -1,0 +1,78 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "app/cache/appcache.h"
+#include "app/services/commservice.h"
+
+#include <QObject>
+#include <QString>
+
+#include <cstdint>
+
+namespace KDC {
+
+/**
+ * High-level sync-oriented facade exposed to QML.
+ */
+class SyncService : public QObject {
+        Q_OBJECT
+        Q_PROPERTY(bool loading READ loading NOTIFY loadingChanged)
+        Q_PROPERTY(QString lastError READ lastError NOTIFY lastErrorChanged)
+
+    public:
+        explicit SyncService(CommService &commService, AppCache &appCache, QObject *parent = nullptr);
+
+        bool loading() const { return _loading; }
+        const QString &lastError() const { return _lastError; }
+
+        Q_INVOKABLE void loadSyncs();
+        Q_INVOKABLE void addSync(qint64 userDbId, qint64 accountId, qint64 driveId, const QString &localFolderPath,
+                                 const QString &serverFolderPath, const QString &serverFolderNodeId, bool liteSync);
+        Q_INVOKABLE void startSync(qint64 syncDbId);
+        Q_INVOKABLE void stopSync(qint64 syncDbId);
+        Q_INVOKABLE void deleteSync(qint64 syncDbId);
+        Q_INVOKABLE void querySyncStatus(qint64 syncDbId);
+        Q_INVOKABLE void findGoodPathForNewSync(const QString &basePath);
+        Q_INVOKABLE void isPathValidForNewSync(const QString &path, int32_t syncConfiguration);
+
+    signals:
+        void loadingChanged();
+        void lastErrorChanged();
+        void syncStatusReceived(qint64 syncDbId, int32_t status);
+        // The second argument can carry a non-blocking warning message from the backend.
+        void suggestedPathReceived(const QString &goodPath, const QString &warningMessage);
+        void pathValidationReceived(bool isValid);
+        void syncAddCompleted(qint64 syncDbId);
+
+    private:
+        void beginRequest();
+        void endRequest();
+        void setLoading(bool loading);
+        void setLastError(const QString &error);
+        bool isValidSyncConfigurationValue(int32_t syncConfiguration) const;
+
+        CommService &_commService;
+        AppCache &_appCache;
+        int32_t _pendingRequestCount{0};
+        bool _loading{false};
+        QString _lastError;
+};
+
+} // namespace KDC

--- a/src/gui4/linux/app/services/syncservice.h
+++ b/src/gui4/linux/app/services/syncservice.h
@@ -20,6 +20,8 @@
 
 #include "app/cache/appcache.h"
 #include "app/services/commservice.h"
+#include "app/services/serviceactiontracker.h"
+#include "app/services/serviceeventbus.h"
 
 #include <QObject>
 #include <QString>
@@ -30,17 +32,22 @@ namespace KDC {
 
 /**
  * High-level sync-oriented facade exposed to QML.
+ *
+ * Role:
+ * - orchestrates sync requests through CommService;
+ * - updates AppCache snapshots and incremental entities;
+ * - reports transient cross-service failures through ServiceEventBus;
+ * - registers per-action pending state in ServiceActionTracker.
  */
 class SyncService : public QObject {
         Q_OBJECT
         Q_PROPERTY(bool loading READ loading NOTIFY loadingChanged)
-        Q_PROPERTY(QString lastError READ lastError NOTIFY lastErrorChanged)
 
     public:
-        explicit SyncService(CommService &commService, AppCache &appCache, QObject *parent = nullptr);
+        explicit SyncService(CommService &commService, AppCache &appCache, ServiceActionTracker &serviceActionTracker,
+                             ServiceEventBus &serviceEventBus, QObject *parent = nullptr);
 
-        bool loading() const { return _loading; }
-        const QString &lastError() const { return _lastError; }
+        [[nodiscard]] bool loading() const { return _loading; }
 
         Q_INVOKABLE void loadSyncs();
         Q_INVOKABLE void addSync(qint64 userDbId, qint64 accountId, qint64 driveId, const QString &localFolderPath,
@@ -51,10 +58,17 @@ class SyncService : public QObject {
         Q_INVOKABLE void querySyncStatus(qint64 syncDbId);
         Q_INVOKABLE void findGoodPathForNewSync(const QString &basePath);
         Q_INVOKABLE void isPathValidForNewSync(const QString &path, int32_t syncConfiguration);
+        Q_INVOKABLE [[nodiscard]] bool isLoadSyncsPending() const;
+        Q_INVOKABLE [[nodiscard]] bool isAddSyncPending() const;
+        Q_INVOKABLE [[nodiscard]] bool isStartSyncPending(qint64 syncDbId) const;
+        Q_INVOKABLE [[nodiscard]] bool isStopSyncPending(qint64 syncDbId) const;
+        Q_INVOKABLE [[nodiscard]] bool isDeleteSyncPending(qint64 syncDbId) const;
+        Q_INVOKABLE [[nodiscard]] bool isQuerySyncStatusPending(qint64 syncDbId) const;
+        Q_INVOKABLE [[nodiscard]] bool isFindGoodPathForNewSyncPending() const;
+        Q_INVOKABLE [[nodiscard]] bool isPathValidForNewSyncPending() const;
 
     signals:
         void loadingChanged();
-        void lastErrorChanged();
         void syncStatusReceived(qint64 syncDbId, int32_t status);
         // The second argument can carry a non-blocking warning message from the backend.
         void suggestedPathReceived(const QString &goodPath, const QString &warningMessage);
@@ -62,17 +76,18 @@ class SyncService : public QObject {
         void syncAddCompleted(qint64 syncDbId);
 
     private:
-        void beginRequest();
-        void endRequest();
+        void beginAction(const QString &actionKey, qint64 scopeId = 0);
+        void endAction(const QString &actionKey, qint64 scopeId = 0);
         void setLoading(bool loading);
-        void setLastError(const QString &error);
-        bool isValidSyncConfigurationValue(int32_t syncConfiguration) const;
+        [[nodiscard]] bool isActionPending(const QString &actionKey, qint64 scopeId = 0) const;
+        void notifyRequestFailure(const ExitInfo &exitInfo, RequestNum requestNum);
+        [[nodiscard]] bool isValidSyncConfigurationValue(int32_t syncConfiguration) const;
 
         CommService &_commService;
         AppCache &_appCache;
-        int32_t _pendingRequestCount{0};
+        ServiceActionTracker &_serviceActionTracker;
+        ServiceEventBus &_serviceEventBus;
         bool _loading{false};
-        QString _lastError;
 };
 
 } // namespace KDC


### PR DESCRIPTION
## Summary
This PR introduces the sync-oriented service facade for Linux v4 and completes the service foundation stack. It exposes core sync operations and path validation flows to QML while keeping state and feedback handling centralized.

## Changes
- add `SyncService` with QML-facing methods: `loadSyncs`, `addSync`, `startSync`, `stopSync`, `deleteSync`, `querySyncStatus`, `findGoodPathForNewSync`, `isPathValidForNewSync`
- add sync-related signals including status updates, suggested path feedback, and sync creation completion
- add sync configuration value validation and request lifecycle management (`loading`, `lastError`, pending counter)
- register `syncservice` sources in `src/gui4/linux/CMakeLists.txt`

## Technical Details
`SyncService` wraps asynchronous `CommService` callbacks and normalizes sync-specific responses for QML consumers. Suggested path notifications now expose both a path and backend warning message for non-blocking UX feedback.

## Testing
- built `kdrive_qml` on branch `linux-v4/c1-04-sync-service`

## Depends On
- Depends on #1775