### PR TITLE
fix(i18n): localize ToggleSwitch states and update resources

### DIFF
--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/AdvancedSyncSetupContentDialog/DialogPages/SyncSetupPage.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/AdvancedSyncSetupContentDialog/DialogPages/SyncSetupPage.xaml
@@ -247,6 +247,8 @@
                 </Grid>
 
                 <ToggleSwitch Grid.Row="1"
+                              OnContent="{x:Bind kDrive:Localizer.Instance.GetString('labelActivated')}"
+                              OffContent="{x:Bind kDrive:Localizer.Instance.GetString('labelDeactivated')}"
                               IsEnabled="{x:Bind AdvancedSyncSetupContentDialogVM.NewSync.SupportsLiteSync , Mode=OneWay}"
                               IsOn="{x:Bind AdvancedSyncSetupContentDialogVM.NewSync.SyncType, Converter={StaticResource SyncTypeToBoolConverter}, Mode=TwoWay}" />
 

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/SyncSetupPage.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/SyncSetupPage.xaml
@@ -302,6 +302,8 @@
                     </Grid>
 
                     <ToggleSwitch Grid.Row="1"
+                                  OnContent="{x:Bind kDrive:Localizer.Instance.GetString('labelActivated')}"
+                                  OffContent="{x:Bind kDrive:Localizer.Instance.GetString('labelDeactivated')}"
                                   IsEnabled="{x:Bind DriveSetupContentDialogVM.CurrentSync.SupportsLiteSync , Mode=OneWay}"
                                   IsOn="{x:Bind DriveSetupContentDialogVM.CurrentSync.SyncType, Converter={StaticResource SyncTypeToBoolConverter}, Mode=TwoWay}" />
 

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/UpdateExpander.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/UpdateExpander.xaml
@@ -49,7 +49,9 @@
                                Height="32"
                                Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
             </toolKit:SettingsCard.HeaderIcon>
-            <ToggleSwitch IsOn="{x:Bind ViewModel.Settings.UpdateManager.AutoUpdateEnabled, Mode=OneWay}"
+            <ToggleSwitch OnContent="{x:Bind kDrive:Localizer.Instance.GetString('labelActivated')}"
+                          OffContent="{x:Bind kDrive:Localizer.Instance.GetString('labelDeactivated')}"
+                          IsOn="{x:Bind ViewModel.Settings.UpdateManager.AutoUpdateEnabled, Mode=OneWay}"
                           Tapped="AutoUpdateToggleSwitch_Tapped"
                           IsEnabled="False" />
         </toolKit:SettingsCard>

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/SettingsPage.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/SettingsPage.xaml
@@ -107,6 +107,8 @@
                                               Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
                         </toolKit:SettingsCard.HeaderIcon>
                         <ToggleSwitch IsOn="{x:Bind ViewModel.Settings.AutoStart, Mode=OneWay}"
+                                      OnContent="{x:Bind kDrive:Localizer.Instance.GetString('labelActivated'), Mode=OneWay}"
+                                      OffContent="{x:Bind kDrive:Localizer.Instance.GetString('labelDeactivated'), Mode=OneWay}"
                                       Toggled="AutoStartToggleSwitch_Toggled" />
                     </toolKit:SettingsCard>
                     <!-- General - Notifications -->
@@ -158,6 +160,8 @@
                                               Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
                         </toolKit:SettingsCard.HeaderIcon>
                         <ToggleSwitch x:Name="MoveToTrashToggleSwitch"
+                                      OnContent="{x:Bind kDrive:Localizer.Instance.GetString('labelActivated'), Mode=OneWay}"
+                                      OffContent="{x:Bind kDrive:Localizer.Instance.GetString('labelDeactivated'), Mode=OneWay}"
                                       IsOn="{x:Bind ViewModel.Settings.MoveToTrash, Mode=OneWay}"
                                       Toggled="MoveToTrashToggleSwitch_Toggled" />
                         <toolKit:SettingsCard.Description>
@@ -407,6 +411,8 @@
                             <toolKit:SettingsCard Header="{x:Bind kDrive:Localizer.Instance.GetString('proxyNeedAuth'), Mode=OneWay}"
                                                   IsEnabled="{x:Bind ViewModel.Settings.ProxyConfig.ManualConfigrationRequired, Mode=OneWay}">
                                 <ToggleSwitch x:Name="ProxyNeedsAuthToggleSwitch"
+                                              OnContent="{x:Bind kDrive:Localizer.Instance.GetString('labelActivated'), Mode=OneWay}"
+                                              OffContent="{x:Bind kDrive:Localizer.Instance.GetString('labelDeactivated'), Mode=OneWay}"
                                               IsOn="{x:Bind ViewModel.Settings.ProxyConfig.NeedsAuth, Mode=OneWay}"
                                               Toggled="ProxyConfig_Changed" />
                             </toolKit:SettingsCard>
@@ -460,6 +466,8 @@
                                                   Description="{x:Bind kDrive:Localizer.Instance.GetString('enableDebugLogDescription'), Mode=OneWay}"
                                                   Background="{ThemeResource LayerFillColorDefault}">
                                 <ToggleSwitch x:Name="EnableDebugLogsToggleSwitch"
+                                              OnContent="{x:Bind kDrive:Localizer.Instance.GetString('labelActivated'), Mode=OneWay}"
+                                              OffContent="{x:Bind kDrive:Localizer.Instance.GetString('labelDeactivated'), Mode=OneWay}"
                                               IsOn="{x:Bind ViewModel.Settings.LogEnabled, Mode=OneWay}"
                                               Toggled="EnableDebugLogsToggleSwitch_Toggled" />
                             </toolKit:SettingsCard>
@@ -468,6 +476,8 @@
                                                   Background="{ThemeResource LayerFillColorDefault}"
                                                   Visibility="{x:Bind EnableDebugLogsToggleSwitch.IsOn, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}">
                                 <ToggleSwitch Toggled="PurgeOldLogsToggleSwitch_Toggled"
+                                              OnContent="{x:Bind kDrive:Localizer.Instance.GetString('labelActivated'), Mode=OneWay}"
+                                              OffContent="{x:Bind kDrive:Localizer.Instance.GetString('labelDeactivated'), Mode=OneWay}"
                                               IsOn="{x:Bind ViewModel.Settings.PurgeOldLogs, Mode=OneWay}" />
                             </toolKit:SettingsCard>
                             <toolKit:SettingsCard Header="{x:Bind kDrive:Localizer.Instance.GetString('extendedLogSetting'), Mode=OneWay}"
@@ -478,6 +488,8 @@
                                     <ToolTip Content="{x:Bind kDrive:Localizer.Instance.GetString('extendedLogWarning'), Mode=OneWay}" />
                                 </ToolTipService.ToolTip>
                                 <ToggleSwitch x:Name="ExtendedLogToggleSwitch"
+                                              OnContent="{x:Bind kDrive:Localizer.Instance.GetString('labelActivated'), Mode=OneWay}"
+                                              OffContent="{x:Bind kDrive:Localizer.Instance.GetString('labelDeactivated'), Mode=OneWay}"
                                               Toggled="ExtendedLogToggleSwitch_Toggled"
                                               IsOn="{x:Bind ViewModel.Settings.ExtendedLogEnbaled, Mode=OneWay}" />
                             </toolKit:SettingsCard>

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/TemplateExclusionPage.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/TemplateExclusionPage.xaml
@@ -163,6 +163,8 @@
                                                           Click="TemplateCheckBox_Click" />
 
                                                 <ToggleSwitch Grid.Column="2"
+                                                              OnContent="{x:Bind kDrive:Localizer.Instance.GetString('labelActivated')}"
+                                                              OffContent="{x:Bind kDrive:Localizer.Instance.GetString('labelDeactivated')}"
                                                               IsOn="{x:Bind Warning, Mode=OneWay}"
                                                               Toggled="WarningToggleSwitch_Toggled"
                                                               HorizontalAlignment="Right">

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/de-DE/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/de-DE/Resources.resw
@@ -6,7 +6,7 @@
   Locale: de, German
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Mon, 13 Apr 2026 15:02:06 +0200 
+  Exported at: Thu, 16 Apr 2026 16:32:33 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -920,6 +920,9 @@ Es wird in Ihrem Browser geöffnet.</value>
   <data name="labelAccessRightsModified" xml:space="preserve"> 
     <value>Zugriffsrechte geändert</value> 
   </data> 
+  <data name="labelActivated" xml:space="preserve"> 
+    <value>Aktiviert</value> 
+  </data> 
   <data name="labelAgo" xml:space="preserve"> 
     <value>Vor %@</value> 
     <comment>Suffix for relative timestamps in activity lists; %@ is the time period (e.g., 5 minutes).</comment> 
@@ -982,6 +985,9 @@ Nützlich, wenn Sie wissen, dass die wichtige Arbeit online auf kDrive ist.</val
   </data> 
   <data name="labelDate" xml:space="preserve"> 
     <value>Datum</value> 
+  </data> 
+  <data name="labelDeactivated" xml:space="preserve"> 
+    <value>Deaktiviert</value> 
   </data> 
   <data name="labelFAQ" xml:space="preserve"> 
     <value>FAQ</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/en-US/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/en-US/Resources.resw
@@ -6,7 +6,7 @@
   Locale: en, English
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Mon, 13 Apr 2026 15:02:06 +0200 
+  Exported at: Thu, 16 Apr 2026 16:32:33 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -920,6 +920,9 @@ It will open in your browser.</value>
   <data name="labelAccessRightsModified" xml:space="preserve"> 
     <value>Access rights modified</value> 
   </data> 
+  <data name="labelActivated" xml:space="preserve"> 
+    <value>Enabled</value> 
+  </data> 
   <data name="labelAgo" xml:space="preserve"> 
     <value>%@ ago</value> 
     <comment>Suffix for relative timestamps in activity lists; %@ is the time period (e.g., 5 minutes).</comment> 
@@ -982,6 +985,9 @@ Useful if you know the important work is online on kDrive.</value>
   </data> 
   <data name="labelDate" xml:space="preserve"> 
     <value>Date</value> 
+  </data> 
+  <data name="labelDeactivated" xml:space="preserve"> 
+    <value>Disabled</value> 
   </data> 
   <data name="labelFAQ" xml:space="preserve"> 
     <value>FAQ</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/es-ES/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/es-ES/Resources.resw
@@ -6,7 +6,7 @@
   Locale: es, Spanish
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Mon, 13 Apr 2026 15:02:06 +0200 
+  Exported at: Thu, 16 Apr 2026 16:32:33 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -920,6 +920,9 @@ Se abrirá en su navegador.</value>
   <data name="labelAccessRightsModified" xml:space="preserve"> 
     <value>Derechos de acceso modificados</value> 
   </data> 
+  <data name="labelActivated" xml:space="preserve"> 
+    <value>Activado</value> 
+  </data> 
   <data name="labelAgo" xml:space="preserve"> 
     <value>hace %@</value> 
     <comment>Suffix for relative timestamps in activity lists; %@ is the time period (e.g., 5 minutes).</comment> 
@@ -982,6 +985,9 @@ Tenga cuidado, esto puede sobrescribir el trabajo de sus colaboradores.</value>
   </data> 
   <data name="labelDate" xml:space="preserve"> 
     <value>Fecha</value> 
+  </data> 
+  <data name="labelDeactivated" xml:space="preserve"> 
+    <value>Desactivado</value> 
   </data> 
   <data name="labelFAQ" xml:space="preserve"> 
     <value>FAQ</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/fr-FR/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/fr-FR/Resources.resw
@@ -6,7 +6,7 @@
   Locale: fr, French
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Mon, 13 Apr 2026 15:02:06 +0200 
+  Exported at: Thu, 16 Apr 2026 16:32:33 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -920,6 +920,9 @@ Il s’ouvrira dans votre navigateur.</value>
   <data name="labelAccessRightsModified" xml:space="preserve"> 
     <value>Droits d’accès modifiés</value> 
   </data> 
+  <data name="labelActivated" xml:space="preserve"> 
+    <value>Activé</value> 
+  </data> 
   <data name="labelAgo" xml:space="preserve"> 
     <value>il y a %@</value> 
     <comment>Suffix for relative timestamps in activity lists; %@ is the time period (e.g., 5 minutes).</comment> 
@@ -982,6 +985,9 @@ Utile si vous savez que le travail important est en ligne sur kDrive.</value>
   </data> 
   <data name="labelDate" xml:space="preserve"> 
     <value>Date</value> 
+  </data> 
+  <data name="labelDeactivated" xml:space="preserve"> 
+    <value>Desactivé</value> 
   </data> 
   <data name="labelFAQ" xml:space="preserve"> 
     <value>FAQ</value> 
@@ -1507,7 +1513,7 @@ Connexion internet requise pour y accéder.</value>
     <value>Règles de synchronisation</value> 
   </data> 
   <data name="syncShortStatusError" xml:space="preserve"> 
-    <value>Une erreur s'est produite</value> 
+    <value>Une erreur s’est produite</value> 
   </data> 
   <data name="syncShortStatusIdle" xml:space="preserve"> 
     <value>La dernière synchronisation a réussi</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/it-IT/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/it-IT/Resources.resw
@@ -6,7 +6,7 @@
   Locale: it, Italian
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Mon, 13 Apr 2026 15:02:06 +0200 
+  Exported at: Thu, 16 Apr 2026 16:32:33 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -920,6 +920,9 @@ Si aprirà nel tuo browser.</value>
   <data name="labelAccessRightsModified" xml:space="preserve"> 
     <value>Diritti di accesso modificati</value> 
   </data> 
+  <data name="labelActivated" xml:space="preserve"> 
+    <value>Attivato</value> 
+  </data> 
   <data name="labelAgo" xml:space="preserve"> 
     <value>%@ fa</value> 
     <comment>Suffix for relative timestamps in activity lists; %@ is the time period (e.g., 5 minutes).</comment> 
@@ -982,6 +985,9 @@ Attenzione, questa operazione potrebbe sovrascrivere il lavoro dei tuoi collabor
   </data> 
   <data name="labelDate" xml:space="preserve"> 
     <value>Data</value> 
+  </data> 
+  <data name="labelDeactivated" xml:space="preserve"> 
+    <value>Disattivato</value> 
   </data> 
   <data name="labelFAQ" xml:space="preserve"> 
     <value>FAQ</value> 
@@ -1510,7 +1516,7 @@ Questi dati consentono al nostro team di correggere e ottimizzare rapidamente l�
     <value>Si è verificato un errore</value> 
   </data> 
   <data name="syncShortStatusIdle" xml:space="preserve"> 
-    <value>L'ultima sincronizzazione è avvenuta con successo</value> 
+    <value>L’ultima sincronizzazione è avvenuta con successo</value> 
   </data> 
   <data name="syncShortStatusPaused" xml:space="preserve"> 
     <value>La sincronizzazione è in pausa</value> 


### PR DESCRIPTION
Add translations for ToggleSwitch "Activated"/"Deactivated" states in all supported languages via labelActivated/labelDeactivated in Resources.resw. Update XAML pages to use these localized labels for OnContent/OffContent, improving multilingual UI consistency. Fix French typographic apostrophe in syncShortStatusError and syncShortStatusIdle. Update resource export dates.