### PR TITLE
feat(drive): add PackInfo to drive metadata and IPC payloads

### DIFF
--- a/src/libcommon/CMakeLists.txt
+++ b/src/libcommon/CMakeLists.txt
@@ -44,6 +44,7 @@ set(libcommon_SRCS
     info/exclusionappinfo.h info/exclusionappinfo.cpp
     info/proxyconfiginfo.h info/proxyconfiginfo.cpp
     info/searchinfo.h info/searchinfo.cpp
+    info/packinfo.h info/packinfo.cpp
     log/sentry/handler.h log/sentry/handler.cpp
     log/sentry/abstractptrace.h 
     log/sentry/abstractcounterscopedptrace.h

--- a/src/libcommon/info/driveinfo.cpp
+++ b/src/libcommon/info/driveinfo.cpp
@@ -31,7 +31,7 @@ static const auto driveInfoMaintenance = "maintenance";
 static const auto driveInfoLocked = "locked";
 static const auto driveInfoUsedSize = "usedSize";
 static const auto driveInfoAccessDenied = "accessDenied";
-static const auto driveInfoPackIsFree = "isFree";
+static const auto driveInfoPackInfo = "packInfo";
 
 namespace KDC {
 
@@ -48,7 +48,7 @@ void DriveInfo::toDynamicStruct(Poco::DynamicStruct &dstruct) const {
     CommonUtility::writeValueToStruct(dstruct, driveInfoLocked, _locked);
     CommonUtility::writeValueToStruct(dstruct, driveInfoUsedSize, _usedSize);
     CommonUtility::writeValueToStruct(dstruct, driveInfoAccessDenied, _accessDenied);
-    CommonUtility::writeValueToStruct(dstruct, driveInfoPackIsFree, _packIsFree);
+    CommonUtility::writeValueToStruct(dstruct, driveInfoPackInfo, _packInfo, info2DynamicVar<PackInfo>);
 }
 
 void DriveInfo::fromDynamicStruct(const Poco::DynamicStruct &dstruct) {
@@ -72,7 +72,7 @@ void DriveInfo::fromDynamicStruct(const Poco::DynamicStruct &dstruct) {
     CommonUtility::readValueFromStruct(dstruct, driveInfoLocked, _locked);
     CommonUtility::readValueFromStruct(dstruct, driveInfoUsedSize, _usedSize);
     CommonUtility::readValueFromStruct(dstruct, driveInfoAccessDenied, _accessDenied);
-    CommonUtility::readValueFromStruct(dstruct, driveInfoPackIsFree, _packIsFree);
+    CommonUtility::readValueFromStruct(dstruct, driveInfoPackInfo, _packInfo, dynamicVar2Struct<PackInfo>);
 }
 
 void operator>>(QDataStream &in, DriveInfo &info) {
@@ -86,10 +86,8 @@ void operator>>(QDataStream &in, DriveInfo &info) {
     bool maintenance{false};
     bool locked{false};
     bool accessDenied{false};
-    bool packIsFree{false};
 
-    in >> dbId >> id >> accountDbId >> name >> color >> notifications >> admin >> maintenance >> locked >> accessDenied >>
-            packIsFree;
+    in >> dbId >> id >> accountDbId >> name >> color >> notifications >> admin >> maintenance >> locked >> accessDenied;
 
     info.setDbId(static_cast<DriveDbId>(dbId));
     info.setId(static_cast<DriveId>(id));
@@ -101,13 +99,12 @@ void operator>>(QDataStream &in, DriveInfo &info) {
     info.setMaintenance(maintenance);
     info.setLocked(locked);
     info.setAccessDenied(accessDenied);
-    info.setPackIsFree(packIsFree);
 }
 
 QDataStream &operator<<(QDataStream &out, const DriveInfo &info) {
     out << static_cast<qint64>(info.dbId()) << static_cast<qint64>(info.id()) << static_cast<qint64>(info.accountDbId())
         << info.name() << info.color() << info.notifications() << info.admin() << info.maintenance() << info.locked()
-        << info.accessDenied() << info.packIsFree();
+        << info.accessDenied();
     return out;
 }
 

--- a/src/libcommon/info/driveinfo.h
+++ b/src/libcommon/info/driveinfo.h
@@ -59,7 +59,7 @@ class DriveInfo {
         void setAccessDenied(const bool accessDenied) { _accessDenied = accessDenied; }
 
         [[nodiscard]] const PackInfo &packInfo() const { return _packInfo; }
-        void setPackInfo(const PackInfo packInfo) { _packInfo = packInfo; }
+        void setPackInfo(const PackInfo &packInfo) { _packInfo = packInfo; }
 
         void toDynamicStruct(Poco::DynamicStruct &dstruct) const;
         void fromDynamicStruct(const Poco::DynamicStruct &dstruct);

--- a/src/libcommon/info/driveinfo.h
+++ b/src/libcommon/info/driveinfo.h
@@ -58,8 +58,8 @@ class DriveInfo {
         bool accessDenied() const { return _accessDenied; }
         void setAccessDenied(const bool accessDenied) { _accessDenied = accessDenied; }
 
-        [[nodiscard]] bool packIsFree() const { return _packIsFree; }
-        void setPackIsFree(const bool pack_is_free) { _packIsFree = pack_is_free; }
+        [[nodiscard]] const PackInfo &packInfo() const { return _packInfo; }
+        void setPackInfo(const PackInfo packInfo) { _packInfo = packInfo; }
 
         void toDynamicStruct(Poco::DynamicStruct &dstruct) const;
         void fromDynamicStruct(const Poco::DynamicStruct &dstruct);
@@ -88,7 +88,7 @@ class DriveInfo {
         int64_t _usedSize{0};
         bool _accessDenied{false};
 
-        bool _packIsFree{false};
+        PackInfo _packInfo;
 };
 
 void operator>>(QDataStream &in, DriveInfo &info);

--- a/src/libcommon/info/driveinfo.h
+++ b/src/libcommon/info/driveinfo.h
@@ -69,7 +69,7 @@ class DriveInfo {
                    lhs.name() == rhs.name() && lhs.size() == rhs.size() && lhs.color() == rhs.color() &&
                    lhs.notifications() == rhs.notifications() && lhs.admin() == rhs.admin() &&
                    lhs.maintenance() == rhs.maintenance() && lhs.locked() == rhs.locked() && lhs.usedSize() == rhs.usedSize() &&
-                   lhs.accessDenied() == rhs.accessDenied();
+                   lhs.accessDenied() == rhs.accessDenied() && lhs.packInfo() == rhs.packInfo();
         }
 
     private:

--- a/src/libcommon/info/packinfo.cpp
+++ b/src/libcommon/info/packinfo.cpp
@@ -1,0 +1,54 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "packinfo.h"
+
+#include "libcommon/utility/utility.h"
+
+namespace KDC {
+
+static const auto packId = "id";
+static const auto packName = "name";
+static const auto packDisplayName = "displayName";
+static const auto packIsFree = "isFree";
+
+PackInfo::PackInfo(const uint64_t id, const std::string &name, const std::string &displayName, const bool isFree) :
+    _id(id),
+    _name(name),
+    _displayName(displayName),
+    _isFree(isFree) {}
+
+void PackInfo::toDynamicStruct(Poco::DynamicStruct &dstruct) const {
+    CommonUtility::writeValueToStruct(dstruct, packId, _id);
+    CommonUtility::writeValueToStruct(dstruct, packName, CommonUtility::str2CommString(_name));
+    CommonUtility::writeValueToStruct(dstruct, packDisplayName, CommonUtility::str2CommString(_displayName));
+    CommonUtility::writeValueToStruct(dstruct, packIsFree, _isFree);
+}
+
+void PackInfo::fromDynamicStruct(const Poco::DynamicStruct &dstruct) {
+    CommonUtility::readValueFromStruct(dstruct, packId, _id);
+    CommString name;
+    CommonUtility::readValueFromStruct(dstruct, packName, name);
+    _name = CommonUtility::commString2Str(name);
+    CommString displayName;
+    CommonUtility::readValueFromStruct(dstruct, packDisplayName, displayName);
+    _displayName = CommonUtility::commString2Str(displayName);
+    CommonUtility::readValueFromStruct(dstruct, packIsFree, _isFree);
+}
+
+} // namespace KDC

--- a/src/libcommon/info/packinfo.h
+++ b/src/libcommon/info/packinfo.h
@@ -32,9 +32,9 @@ class PackInfo {
         [[nodiscard]] uint64_t id() const { return _id; }
         void setId(const uint64_t id) { _id = id; }
         [[nodiscard]] const std::string &name() const { return _name; }
-        void setName(const std::string &name) { _name = name; }
+        void setName(const std::string_view name) { _name = name; }
         [[nodiscard]] const std::string &displayName() const { return _displayName; }
-        void setDisplayName(const std::string &displayName) { _displayName = displayName; }
+        void setDisplayName(const std::string_view displayName) { _displayName = displayName; }
         [[nodiscard]] bool isFree() const { return _isFree; }
         void setIsFree(const bool isFree) { _isFree = isFree; }
 

--- a/src/libcommon/info/packinfo.h
+++ b/src/libcommon/info/packinfo.h
@@ -1,0 +1,57 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QDataStream>
+
+#include <Poco/Dynamic/Struct.h>
+
+namespace KDC {
+
+class PackInfo {
+    public:
+        PackInfo() = default;
+        PackInfo(const uint64_t id, const std::string &name, const std::string &displayName, const bool isFree);
+
+        [[nodiscard]] uint64_t id() const { return _id; }
+        void setId(const uint64_t id) { _id = id; }
+        [[nodiscard]] const std::string &name() const { return _name; }
+        void setName(const std::string &name) { _name = name; }
+        [[nodiscard]] const std::string &displayName() const { return _displayName; }
+        void setDisplayName(const std::string &displayName) { _displayName = displayName; }
+        [[nodiscard]] bool isFree() const { return _isFree; }
+        void setIsFree(const bool isFree) { _isFree = isFree; }
+
+        void toDynamicStruct(Poco::DynamicStruct &dstruct) const;
+        void fromDynamicStruct(const Poco::DynamicStruct &dstruct);
+
+        friend bool operator==(const PackInfo &lhs, const PackInfo &rhs) {
+            return lhs.id() == rhs.id() && lhs.name() == rhs.name() && lhs.displayName() == rhs.displayName() &&
+                   lhs.isFree() == rhs.isFree();
+        }
+
+    private:
+        uint64_t _id{0};
+        std::string _name;
+        std::string _displayName;
+        bool _isFree{false}; // False by default in order not to offer to upgrade when this value is not yet up to date.
+};
+
+
+} // namespace KDC

--- a/src/libparms/db/drive.h
+++ b/src/libparms/db/drive.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include "info/packinfo.h"
+#include "libcommon/info/packinfo.h"
 #include "libparms/parmslib.h"
 #include "utility/types.h"
 

--- a/src/libparms/db/drive.h
+++ b/src/libparms/db/drive.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include "info/packinfo.h"
 #include "libparms/parmslib.h"
 #include "utility/types.h"
 
@@ -36,13 +37,6 @@ class PARMS_EXPORT Drive {
                 bool _asleep{false};
                 bool _wakingUp{false};
                 int64_t _maintenanceFrom{0};
-        };
-
-        struct PackInfo {
-                uint64_t id{0};
-                std::string name;
-                std::string displayName;
-                bool isFree{false}; // False by default in order not to offer to upgrade when this value is not yet up to date.
         };
 
         Drive();

--- a/src/libsyncengine/jobs/network/kDrive_API/getinfodrivejob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/getinfodrivejob.cpp
@@ -96,10 +96,17 @@ ExitInfo GetInfoDriveJob::handleJsonResponse(const std::string &replyBody) {
     }
 
     if (Poco::JSON::Object::Ptr packObj = dataObj->getObject(packKey); packObj) { // Not mandatory
-        (void) JsonParserUtility::extractValue(packObj, idKey, _packInfo.id, false);
-        (void) JsonParserUtility::extractValue(packObj, nameKey, _packInfo.name, false);
-        (void) JsonParserUtility::extractValue(packObj, packDisplayNameKey, _packInfo.displayName, false);
-        (void) JsonParserUtility::extractValue(packObj, packIsFreeKey, _packInfo.isFree, false);
+        uint64_t packId = 0;
+        (void) JsonParserUtility::extractValue(packObj, idKey, packId, false);
+        _packInfo.setId(packId);
+        std::string name;
+        (void) JsonParserUtility::extractValue(packObj, nameKey, name, false);
+        _packInfo.setName(name);
+        (void) JsonParserUtility::extractValue(packObj, packDisplayNameKey, name, false);
+        _packInfo.setDisplayName(name);
+        bool isFree = false;
+        (void) JsonParserUtility::extractValue(packObj, packIsFreeKey, isFree, false);
+        _packInfo.setIsFree(isFree);
     }
 
     return ExitCode::Ok;

--- a/src/libsyncengine/jobs/network/kDrive_API/getinfodrivejob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/getinfodrivejob.cpp
@@ -99,11 +99,12 @@ ExitInfo GetInfoDriveJob::handleJsonResponse(const std::string &replyBody) {
         uint64_t packId = 0;
         (void) JsonParserUtility::extractValue(packObj, idKey, packId, false);
         _packInfo.setId(packId);
-        std::string name;
-        (void) JsonParserUtility::extractValue(packObj, nameKey, name, false);
-        _packInfo.setName(name);
-        (void) JsonParserUtility::extractValue(packObj, packDisplayNameKey, name, false);
-        _packInfo.setDisplayName(name);
+        std::string packName;
+        (void) JsonParserUtility::extractValue(packObj, nameKey, packName, false);
+        _packInfo.setName(packName);
+        std::string packDisplayName;
+        (void) JsonParserUtility::extractValue(packObj, packDisplayNameKey, packDisplayName, false);
+        _packInfo.setDisplayName(packDisplayName);
         bool isFree = false;
         (void) JsonParserUtility::extractValue(packObj, packIsFreeKey, isFree, false);
         _packInfo.setIsFree(isFree);

--- a/src/libsyncengine/jobs/network/kDrive_API/getinfodrivejob.h
+++ b/src/libsyncengine/jobs/network/kDrive_API/getinfodrivejob.h
@@ -38,7 +38,7 @@ class GetInfoDriveJob : public AbstractTokenNetworkJob {
         [[nodiscard]] int64_t maintenanceFrom() const { return _maintenanceFrom; }
         [[nodiscard]] bool isLocked() const { return _isLocked; }
         [[nodiscard]] int64_t usedSize() const { return _usedSize; }
-        [[nodiscard]] const Drive::PackInfo &packInfo() const { return _packInfo; }
+        [[nodiscard]] const PackInfo &packInfo() const { return _packInfo; }
 
     protected:
         ExitInfo handleError(const std::string &replyBody, const Poco::URI &uri) override;
@@ -57,7 +57,7 @@ class GetInfoDriveJob : public AbstractTokenNetworkJob {
         int64_t _maintenanceFrom{0};
         bool _isLocked{false};
         int64_t _usedSize{0};
-        Drive::PackInfo _packInfo;
+        PackInfo _packInfo;
 };
 
 } // namespace KDC

--- a/src/server/requests/serverrequests.cpp
+++ b/src/server/requests/serverrequests.cpp
@@ -1925,10 +1925,7 @@ ExitInfo ServerRequests::loadDriveInfo(Drive &drive, const AccountId previousAcc
         quotaUpdated = true;
     }
 
-    drive.setPackInfo({.id = job->packInfo().id,
-                       .name = job->packInfo().name,
-                       .displayName = job->packInfo().displayName,
-                       .isFree = job->packInfo().isFree});
+    drive.setPackInfo(job->packInfo());
 
     return ExitCode::Ok;
 }

--- a/src/server/requests/serverrequests.cpp
+++ b/src/server/requests/serverrequests.cpp
@@ -2235,6 +2235,7 @@ void ServerRequests::driveToDriveInfo(const Drive &drive, DriveInfo &driveInfo) 
     driveInfo.setLocked(drive.locked());
     driveInfo.setUsedSize(drive.usedSize());
     driveInfo.setAccessDenied(drive.accessDenied());
+    driveInfo.setPackInfo(drive.packInfo());
 }
 
 void ServerRequests::syncToSyncInfo(const Sync &sync, SyncInfo &syncInfo) {

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -1046,8 +1046,8 @@ void TestNetworkJobs::testGetInfoDrive() {
     CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, exitCode);
 
     CPPUNIT_ASSERT_EQUAL(std::string("kDrive Desktop Team"), job.name());
-    CPPUNIT_ASSERT_EQUAL(std::string("pro"), job.packInfo().name);
-    CPPUNIT_ASSERT(!job.packInfo().isFree);
+    CPPUNIT_ASSERT_EQUAL(std::string("pro"), job.packInfo().name());
+    CPPUNIT_ASSERT(!job.packInfo().isFree());
 }
 
 void TestNetworkJobs::testThumbnail() {
@@ -1566,7 +1566,7 @@ void TestNetworkJobs::testGetInfoUserTrialsOn401Error() {
         public:
             explicit GetInfoUserJobMock(const UserDbId userDbId, const ApiToken &apiToken) :
                 GetInfoUserJob(userDbId),
-                _apiToken(apiToken){};
+                _apiToken(apiToken) {};
 
             [[nodiscard]] Poco::Net::HTTPResponse httpResponse() const override {
                 return Poco::Net::HTTPResponse(Poco::Net::HTTPResponse::HTTP_UNAUTHORIZED);

--- a/test/server/comm/guicommchannel/testguicommchannel.cpp
+++ b/test/server/comm/guicommchannel/testguicommchannel.cpp
@@ -325,8 +325,8 @@ void TestGuiCommChannel::testUserInfoListJob() {
         QImage avatar;
         (void) avatar.loadFromData(avatarQBA);
 
-        const UserInfo ui1(1, 1001, "aaaaa","a1a1a1", "aaaaa@xxx.com", avatar, true);
-        const UserInfo ui2(2, 1002, "bbbbb","b1b1b1", "bbbbb@xxx.com", avatar, false);
+        const UserInfo ui1(1, 1001, "aaaaa", "a1a1a1", "aaaaa@xxx.com", avatar, true);
+        const UserInfo ui2(2, 1002, "bbbbb", "b1b1b1", "bbbbb@xxx.com", avatar, false);
 
         userInfoListJob->_userInfoList = {ui1, ui2};
     };
@@ -530,7 +530,7 @@ std::vector<DriveInfo> createDriveInfoList() {
     di1.setAccessDenied(false);
     di1.setSize(1000000000);
     di1.setUsedSize(50000000);
-    di1.setPackIsFree(true);
+    di1.setPackInfo(PackInfo(1, "pack_free", "PackFree", true));
 
     DriveInfo di2;
     di2.setDbId(2);
@@ -545,7 +545,7 @@ std::vector<DriveInfo> createDriveInfoList() {
     di2.setAccessDenied(true);
     di2.setSize(2000000000);
     di2.setUsedSize(60000000);
-    di2.setPackIsFree(false);
+    di2.setPackInfo(PackInfo(2, "pack_pro", "PackPro", false));
 
     return {di1, di2};
 }
@@ -564,7 +564,12 @@ Poco::JSON::Array createDriveInfoObjList() {
     (void) driveInfoObj1.set("notifications", true);
     (void) driveInfoObj1.set("size", 1000000000);
     (void) driveInfoObj1.set("usedSize", 50000000);
-    (void) driveInfoObj1.set("isFree", true);
+    Poco::JSON::Object packInfoObj1;
+    (void) packInfoObj1.set("id", 1);
+    (void) packInfoObj1.set("name", toBase64(Str("pack_free")));
+    (void) packInfoObj1.set("displayName", toBase64(Str("PackFree")));
+    (void) packInfoObj1.set("isFree", true);
+    (void) driveInfoObj1.set("packInfo", packInfoObj1);
 
     Poco::JSON::Object driveInfoObj2;
     (void) driveInfoObj2.set("accessDenied", true);
@@ -579,7 +584,12 @@ Poco::JSON::Array createDriveInfoObjList() {
     (void) driveInfoObj2.set("notifications", false);
     (void) driveInfoObj2.set("size", 2000000000);
     (void) driveInfoObj2.set("usedSize", 60000000);
-    (void) driveInfoObj2.set("isFree", false);
+    Poco::JSON::Object packInfoObj2;
+    (void) packInfoObj2.set("id", 2);
+    (void) packInfoObj2.set("name", toBase64(Str("pack_pro")));
+    (void) packInfoObj2.set("displayName", toBase64(Str("PackPro")));
+    (void) packInfoObj2.set("isFree", false);
+    (void) driveInfoObj2.set("packInfo", packInfoObj2);
 
     Poco::JSON::Array driveInfoObjList;
 


### PR DESCRIPTION
## What this PR does
- Introduces a dedicated PackInfo model in libcommon and wires it into build sources.
- Replaces the previous packIsFree boolean-only handling in DriveInfo with a full packInfo object (id, name, displayName, isFree).
- Propagates the new type through drive loading (GetInfoDriveJob, ServerRequests, Drive DB model).
- Fixes DriveInfo JSON serialization to write packInfo as a dynamic struct, avoiding runtime Bad cast on Poco::Dynamic::structToString.

## Tests
- Updates network and GUI communication tests to assert the new packInfo payload structure and accessors.

## Commit split
1. feat(drive): add PackInfo model to drive metadata flow
2. test(drive): update pack info expectations in jobs and GUI comm

## Notes
- Full local execution of kDrive_test_server could not be completed in this environment because of runtime init assertions unrelated to this diff (Sentry/ParmsDb init). The failing path in testDriveInfoListJob is directly addressed by the serialization fix.