### PR TITLE
feat: add env variable to force extended log

### DIFF
--- a/src/gui/debuggingdialog.cpp
+++ b/src/gui/debuggingdialog.cpp
@@ -591,10 +591,10 @@ void DebuggingDialog::setNeedToSave(bool value) {
 }
 
 void DebuggingDialog::updateExtendedLogCheckBoxState() {
-    if (CommonUtility::envVarValue("KDRIVE_ACTIVATE_EXTENDED_LOG") == "1") {
+    if (CommonUtility::envVarValue("KDRIVE_FORCE_EXTENDED_LOG") == "1") {
         _extendedLogCheckBox->setDisabled(true);
         _extendedLogCheckBox->setToolTip(
-                tr("The extended full log is activated through the KDRIVE_ACTIVATE_EXTENDED_LOG environment variable. Set it to "
+                tr("The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to "
                    "0 to disable it."));
     }
 }

--- a/src/gui/debuggingdialog.cpp
+++ b/src/gui/debuggingdialog.cpp
@@ -182,6 +182,7 @@ void DebuggingDialog::initUI() {
     _extendedLogCheckBox->setContentsMargins(boxHMargin, 0, boxHMargin, 0);
     _extendedLogCheckBox->setText(tr("Extended Full Log"));
     _extendedLogCheckBox->setToolTip(extendedLogCheckBoxToolTip);
+    updateExtendedLogCheckBoxState();
     debugLevelSelectionHBox->addWidget(_extendedLogCheckBox);
 
     // Debug info main box | Debug Level Main Box | Debug level select box | Helper
@@ -581,11 +582,21 @@ void DebuggingDialog::updateUI() {
         _extendedLogCheckBox->show();
         _extendedLogHelpButton->show();
     }
+    updateExtendedLogCheckBoxState();
 }
 
 void DebuggingDialog::setNeedToSave(bool value) {
     _needToSave = value;
     _saveButton->setEnabled(value);
+}
+
+void DebuggingDialog::updateExtendedLogCheckBoxState() {
+    if (CommonUtility::envVarValue("KDRIVE_ACTIVATE_EXTENDED_LOG") == "1") {
+        _extendedLogCheckBox->setDisabled(true);
+        _extendedLogCheckBox->setToolTip(
+                tr("The extended full log is activated through the KDRIVE_ACTIVATE_EXTENDED_LOG environment variable. Set it to "
+                   "0 to disable it."));
+    }
 }
 
 QString DebuggingDialog::convertAppStateTimeToLocalHumanReadable(const QString &time) const {

--- a/src/gui/debuggingdialog.h
+++ b/src/gui/debuggingdialog.h
@@ -76,6 +76,8 @@ class DebuggingDialog : public CustomDialog {
         void updateUI();
         void setNeedToSave(bool value);
 
+        void updateExtendedLogCheckBoxState();
+
         // helpers
         QString convertAppStateTimeToLocalHumanReadable(const QString &time) const;
     private slots:

--- a/src/libsyncengine/jobs/abstractjob.h
+++ b/src/libsyncengine/jobs/abstractjob.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include "libcommon/utility/utility.h"
 #include "utility/types.h"
 
 #include <Poco/Runnable.h>
@@ -52,7 +53,7 @@ class AbstractJob : public Poco::Runnable {
 
         UniqueId jobId() const { return _jobId; }
 
-        bool isExtendedLog() const { return _isExtendedLog; }
+        bool isExtendedLog() const { return _isExtendedLog || CommonUtility::envVarValue("KDRIVE_ACTIVATE_EXTENDED_LOG") == "1"; }
         bool isRunning() const { return _isRunning; }
 
         virtual void abort();

--- a/src/libsyncengine/jobs/abstractjob.h
+++ b/src/libsyncengine/jobs/abstractjob.h
@@ -53,7 +53,7 @@ class AbstractJob : public Poco::Runnable {
 
         UniqueId jobId() const { return _jobId; }
 
-        bool isExtendedLog() const { return _isExtendedLog || CommonUtility::envVarValue("KDRIVE_ACTIVATE_EXTENDED_LOG") == "1"; }
+        bool isExtendedLog() const { return _isExtendedLog; }
         bool isRunning() const { return _isRunning; }
 
         virtual void abort();

--- a/src/libsyncengine/jobs/abstractjob.h
+++ b/src/libsyncengine/jobs/abstractjob.h
@@ -18,7 +18,6 @@
 
 #pragma once
 
-#include "libcommon/utility/utility.h"
 #include "utility/types.h"
 
 #include <Poco/Runnable.h>

--- a/src/libsyncengine/requests/parameterscache.cpp
+++ b/src/libsyncengine/requests/parameterscache.cpp
@@ -35,7 +35,7 @@ std::shared_ptr<ParametersCache> ParametersCache::instance(const bool isTest /*=
         } catch (std::exception const &) {
             return nullptr;
         }
-        _forceExtendedLog = CommonUtility::envVarValue("KDRIVE_ACTIVATE_EXTENDED_LOG") == "1";
+        _forceExtendedLog = CommonUtility::envVarValue("KDRIVE_FORCE_EXTENDED_LOG") == "1";
     }
 
     return _instance;

--- a/src/libsyncengine/requests/parameterscache.cpp
+++ b/src/libsyncengine/requests/parameterscache.cpp
@@ -26,6 +26,7 @@
 namespace KDC {
 
 std::shared_ptr<ParametersCache> ParametersCache::_instance = nullptr;
+bool ParametersCache::_forceExtendedLog = false;
 
 std::shared_ptr<ParametersCache> ParametersCache::instance(const bool isTest /*= false*/) {
     if (_instance == nullptr) {
@@ -34,6 +35,7 @@ std::shared_ptr<ParametersCache> ParametersCache::instance(const bool isTest /*=
         } catch (std::exception const &) {
             return nullptr;
         }
+        _forceExtendedLog = CommonUtility::envVarValue("KDRIVE_ACTIVATE_EXTENDED_LOG") == "1";
     }
 
     return _instance;
@@ -45,13 +47,8 @@ void ParametersCache::reset() {
     }
 }
 
-bool ParametersCache::forceExtendedLogEnabled() noexcept {
-    static const bool forceExtendedLog = CommonUtility::envVarValue("KDRIVE_ACTIVATE_EXTENDED_LOG") == "1";
-    return forceExtendedLog;
-}
-
 bool ParametersCache::isExtendedLogEnabled() noexcept {
-    if (forceExtendedLogEnabled()) {
+    if (_forceExtendedLog) {
         return true;
     }
     // If _instance is not initialized, use extended log by default

--- a/src/libsyncengine/requests/parameterscache.cpp
+++ b/src/libsyncengine/requests/parameterscache.cpp
@@ -26,8 +26,6 @@
 namespace KDC {
 
 std::shared_ptr<ParametersCache> ParametersCache::_instance = nullptr;
-bool ParametersCache::_forceExtendedLog = false;
-bool ParametersCache::_forceExtendedLogInitialized = false;
 
 std::shared_ptr<ParametersCache> ParametersCache::instance(const bool isTest /*= false*/) {
     if (_instance == nullptr) {
@@ -45,16 +43,11 @@ void ParametersCache::reset() {
     if (_instance) {
         _instance = nullptr;
     }
-    _forceExtendedLogInitialized = false;
-    _forceExtendedLog = false;
 }
 
 bool ParametersCache::forceExtendedLogEnabled() noexcept {
-    if (!_forceExtendedLogInitialized) {
-        _forceExtendedLog = CommonUtility::envVarValue("KDRIVE_ACTIVATE_EXTENDED_LOG") == "1";
-        _forceExtendedLogInitialized = true;
-    }
-    return _forceExtendedLog;
+    static const bool forceExtendedLog = CommonUtility::envVarValue("KDRIVE_ACTIVATE_EXTENDED_LOG") == "1";
+    return forceExtendedLog;
 }
 
 bool ParametersCache::isExtendedLogEnabled() noexcept {

--- a/src/libsyncengine/requests/parameterscache.cpp
+++ b/src/libsyncengine/requests/parameterscache.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "parameterscache.h"
+#include "libcommon/utility/utility.h"
 #include "libparms/db/parmsdb.h"
 #include "libcommonserver/log/log.h"
 
@@ -25,6 +26,8 @@
 namespace KDC {
 
 std::shared_ptr<ParametersCache> ParametersCache::_instance = nullptr;
+bool ParametersCache::_forceExtendedLog = false;
+bool ParametersCache::_forceExtendedLogInitialized = false;
 
 std::shared_ptr<ParametersCache> ParametersCache::instance(const bool isTest /*= false*/) {
     if (_instance == nullptr) {
@@ -42,6 +45,24 @@ void ParametersCache::reset() {
     if (_instance) {
         _instance = nullptr;
     }
+    _forceExtendedLogInitialized = false;
+    _forceExtendedLog = false;
+}
+
+bool ParametersCache::forceExtendedLogEnabled() noexcept {
+    if (!_forceExtendedLogInitialized) {
+        _forceExtendedLog = CommonUtility::envVarValue("KDRIVE_ACTIVATE_EXTENDED_LOG") == "1";
+        _forceExtendedLogInitialized = true;
+    }
+    return _forceExtendedLog;
+}
+
+bool ParametersCache::isExtendedLogEnabled() noexcept {
+    if (forceExtendedLogEnabled()) {
+        return true;
+    }
+    // If _instance is not initialized, use extended log by default
+    return instance() ? instance()->_parameters.extendedLog() : true;
 }
 
 ParametersCache::ParametersCache(bool isTest /*= false*/) {

--- a/src/libsyncengine/requests/parameterscache.h
+++ b/src/libsyncengine/requests/parameterscache.h
@@ -46,8 +46,7 @@ class SYNCENGINE_EXPORT ParametersCache {
     private:
         static std::shared_ptr<ParametersCache> _instance;
         Parameters _parameters;
-
-        static bool forceExtendedLogEnabled() noexcept;
+        static bool _forceExtendedLog;
 
         ParametersCache(bool isTest = false);
 };

--- a/src/libsyncengine/requests/parameterscache.h
+++ b/src/libsyncengine/requests/parameterscache.h
@@ -45,9 +45,8 @@ class SYNCENGINE_EXPORT ParametersCache {
 
     private:
         static std::shared_ptr<ParametersCache> _instance;
-        static bool _forceExtendedLog;
-        static bool _forceExtendedLogInitialized;
         Parameters _parameters;
+
         static bool forceExtendedLogEnabled() noexcept;
 
         ParametersCache(bool isTest = false);

--- a/src/libsyncengine/requests/parameterscache.h
+++ b/src/libsyncengine/requests/parameterscache.h
@@ -21,7 +21,6 @@
 #include "syncenginelib.h"
 #include "libparms/db/parameters.h"
 #include "libcommon/utility/types.h"
-#include "libcommon/utility/utility.h"
 
 #include <memory>
 
@@ -33,12 +32,7 @@ class SYNCENGINE_EXPORT ParametersCache {
 
         static void reset();
 
-        // If _instance is not initialized, use extended log by default
-        static bool isExtendedLogEnabled() noexcept {
-            static bool forceExtendedLog = CommonUtility::envVarValue("KDRIVE_ACTIVATE_EXTENDED_LOG") == "1";
-            if (forceExtendedLog) return true;
-            return instance() ? instance()->_parameters.extendedLog() : true;
-        }
+        static bool isExtendedLogEnabled() noexcept;
 
         ParametersCache(ParametersCache const &) = delete;
         void operator=(ParametersCache const &) = delete;
@@ -51,7 +45,10 @@ class SYNCENGINE_EXPORT ParametersCache {
 
     private:
         static std::shared_ptr<ParametersCache> _instance;
+        static bool _forceExtendedLog;
+        static bool _forceExtendedLogInitialized;
         Parameters _parameters;
+        static bool forceExtendedLogEnabled() noexcept;
 
         ParametersCache(bool isTest = false);
 };

--- a/src/libsyncengine/requests/parameterscache.h
+++ b/src/libsyncengine/requests/parameterscache.h
@@ -35,7 +35,8 @@ class SYNCENGINE_EXPORT ParametersCache {
 
         // If _instance is not initialized, use extended log by default
         static bool isExtendedLogEnabled() noexcept {
-            if (CommonUtility::envVarValue("KDRIVE_ACTIVATE_EXTENDED_LOG") == "1") return true;
+            static bool forceExtendedLog = CommonUtility::envVarValue("KDRIVE_ACTIVATE_EXTENDED_LOG") == "1";
+            if (forceExtendedLog) return true;
             return instance() ? instance()->_parameters.extendedLog() : true;
         }
 

--- a/src/libsyncengine/requests/parameterscache.h
+++ b/src/libsyncengine/requests/parameterscache.h
@@ -21,6 +21,7 @@
 #include "syncenginelib.h"
 #include "libparms/db/parameters.h"
 #include "libcommon/utility/types.h"
+#include "libcommon/utility/utility.h"
 
 #include <memory>
 
@@ -33,7 +34,10 @@ class SYNCENGINE_EXPORT ParametersCache {
         static void reset();
 
         // If _instance is not initialized, use extended log by default
-        static bool isExtendedLogEnabled() noexcept { return instance() ? instance()->_parameters.extendedLog() : true; }
+        static bool isExtendedLogEnabled() noexcept {
+            if (CommonUtility::envVarValue("KDRIVE_ACTIVATE_EXTENDED_LOG") == "1") return true;
+            return instance() ? instance()->_parameters.extendedLog() : true;
+        }
 
         ParametersCache(ParametersCache const &) = delete;
         void operator=(ParametersCache const &) = delete;

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -3411,7 +3411,12 @@ void AppServer::logUsefulInformation() {
 
     // Log level
     LOG_INFO(Log::instance()->getLogger(), "Log level: " << ParametersCache::instance()->parameters().logLevel());
-    LOG_INFO(Log::instance()->getLogger(), "Extended log activated: " << ParametersCache::instance()->parameters().extendedLog());
+    if (CommonUtility::envVarValue("KDRIVE_ACTIVATE_EXTENDED_LOG") == "1") {
+        LOG_INFO(Log::instance()->getLogger(), "Extended log forced by environment variable KDRIVE_ACTIVATE_EXTENDED_LOG");
+    } else {
+        LOG_INFO(Log::instance()->getLogger(),
+                 "Extended log activated: " << ParametersCache::instance()->parameters().extendedLog());
+    }
 
     LOG_INFO(_logger, "********************");
 }

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -3411,8 +3411,8 @@ void AppServer::logUsefulInformation() {
 
     // Log level
     LOG_INFO(Log::instance()->getLogger(), "Log level: " << ParametersCache::instance()->parameters().logLevel());
-    if (CommonUtility::envVarValue("KDRIVE_ACTIVATE_EXTENDED_LOG") == "1") {
-        LOG_INFO(Log::instance()->getLogger(), "Extended log forced by environment variable KDRIVE_ACTIVATE_EXTENDED_LOG");
+    if (CommonUtility::envVarValue("KDRIVE_FORCE_EXTENDED_LOG") == "1") {
+        LOG_INFO(Log::instance()->getLogger(), "Extended log forced by environment variable KDRIVE_FORCE_EXTENDED_LOG");
     } else {
         LOG_INFO(Log::instance()->getLogger(),
                  "Extended log activated: " << ParametersCache::instance()->parameters().extendedLog());

--- a/test/libsyncengine/CMakeLists.txt
+++ b/test/libsyncengine/CMakeLists.txt
@@ -29,6 +29,7 @@ set(testsyncengine_SRCS
         # Database
         db/testsyncdb.h db/testsyncdb.cpp
         # Jobs
+        jobs/testabstractjob.h jobs/testabstractjob.cpp
         jobs/testsyncjobmanagersingleton.h jobs/testsyncjobmanagersingleton.cpp
         ## Network jobs
         jobs/network/testsnapshotitemhandler.h jobs/network/testsnapshotitemhandler.cpp

--- a/test/libsyncengine/jobs/testabstractjob.cpp
+++ b/test/libsyncengine/jobs/testabstractjob.cpp
@@ -1,0 +1,69 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "testabstractjob.h"
+
+#include "jobs/abstractjob.h"
+#include "libcommon/utility/utility.h"
+#include "requests/parameterscache.h"
+
+#include <cstdlib>
+
+namespace KDC {
+
+namespace {
+
+class TestJob final : public AbstractJob {
+    public:
+        ExitInfo runJob() override { return ExitCode::Ok; }
+};
+
+} // namespace
+
+void TestAbstractJob::setUp() {
+    TestBase::start();
+    _previousExtendedLogEnvVarValue = CommonUtility::envVarValue("KDRIVE_ACTIVATE_EXTENDED_LOG", _isExtendedLogEnvVarSet);
+}
+
+void TestAbstractJob::tearDown() {
+    if (_isExtendedLogEnvVarSet) {
+        (void) CommonUtility::setenv("KDRIVE_ACTIVATE_EXTENDED_LOG", _previousExtendedLogEnvVarValue.c_str(), 1);
+    } else {
+#if defined(KD_WINDOWS)
+        _putenv_s("KDRIVE_ACTIVATE_EXTENDED_LOG", "");
+#else
+        (void) unsetenv("KDRIVE_ACTIVATE_EXTENDED_LOG");
+#endif
+    }
+    ParametersCache::reset();
+    TestBase::stop();
+}
+
+void TestAbstractJob::testIsExtendedLogEnabledByEnvironmentVariable() {
+    (void) CommonUtility::setenv("KDRIVE_ACTIVATE_EXTENDED_LOG", "1", 1);
+    ParametersCache::reset();
+
+    auto parametersCache = ParametersCache::instance(true);
+    CPPUNIT_ASSERT(parametersCache != nullptr);
+    parametersCache->parameters().setExtendedLog(false);
+
+    TestJob job;
+    CPPUNIT_ASSERT(job.isExtendedLog());
+}
+
+} // namespace KDC

--- a/test/libsyncengine/jobs/testabstractjob.cpp
+++ b/test/libsyncengine/jobs/testabstractjob.cpp
@@ -37,17 +37,17 @@ class TestJob final : public AbstractJob {
 
 void TestAbstractJob::setUp() {
     TestBase::start();
-    _previousExtendedLogEnvVarValue = CommonUtility::envVarValue("KDRIVE_ACTIVATE_EXTENDED_LOG", _isExtendedLogEnvVarSet);
+    _previousExtendedLogEnvVarValue = CommonUtility::envVarValue("KDRIVE_FORCE_EXTENDED_LOG", _isExtendedLogEnvVarSet);
 }
 
 void TestAbstractJob::tearDown() {
     if (_isExtendedLogEnvVarSet) {
-        (void) CommonUtility::setenv("KDRIVE_ACTIVATE_EXTENDED_LOG", _previousExtendedLogEnvVarValue.c_str(), 1);
+        (void) CommonUtility::setenv("KDRIVE_FORCE_EXTENDED_LOG", _previousExtendedLogEnvVarValue.c_str(), 1);
     } else {
 #if defined(KD_WINDOWS)
-        _putenv_s("KDRIVE_ACTIVATE_EXTENDED_LOG", "");
+        _putenv_s("KDRIVE_FORCE_EXTENDED_LOG", "");
 #else
-        (void) unsetenv("KDRIVE_ACTIVATE_EXTENDED_LOG");
+        (void) unsetenv("KDRIVE_FORCE_EXTENDED_LOG");
 #endif
     }
     ParametersCache::reset();
@@ -55,7 +55,7 @@ void TestAbstractJob::tearDown() {
 }
 
 void TestAbstractJob::testIsExtendedLogEnabledByEnvironmentVariable() {
-    (void) CommonUtility::setenv("KDRIVE_ACTIVATE_EXTENDED_LOG", "1", 1);
+    (void) CommonUtility::setenv("KDRIVE_FORCE_EXTENDED_LOG", "1", 1);
     ParametersCache::reset();
 
     auto parametersCache = ParametersCache::instance(true);

--- a/test/libsyncengine/jobs/testabstractjob.h
+++ b/test/libsyncengine/jobs/testabstractjob.h
@@ -30,6 +30,7 @@ class TestAbstractJob : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST(testIsExtendedLogEnabledByEnvironmentVariable);
         CPPUNIT_TEST_SUITE_END();
 
+    public:
         void setUp() override;
         void tearDown() override;
 

--- a/test/libsyncengine/jobs/testabstractjob.h
+++ b/test/libsyncengine/jobs/testabstractjob.h
@@ -1,0 +1,44 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "testincludes.h"
+
+#include <string>
+
+namespace KDC {
+
+class TestAbstractJob : public CppUnit::TestFixture, public TestBase {
+    public:
+        CPPUNIT_TEST_SUITE(TestAbstractJob);
+        CPPUNIT_TEST(testIsExtendedLogEnabledByEnvironmentVariable);
+        CPPUNIT_TEST_SUITE_END();
+
+        void setUp() override;
+        void tearDown() override;
+
+    protected:
+        void testIsExtendedLogEnabledByEnvironmentVariable();
+
+    private:
+        bool _isExtendedLogEnvVarSet = false;
+        std::string _previousExtendedLogEnvVarValue;
+};
+
+} // namespace KDC

--- a/test/libsyncengine/test.cpp
+++ b/test/libsyncengine/test.cpp
@@ -43,6 +43,7 @@
 #include "jobs/network/kDrive_API/testloguploadjob.h"
 #include "jobs/network/testsnapshotitemhandler.h"
 #include "jobs/local/testlocaljobs.h"
+#include "jobs/testabstractjob.h"
 #include "jobs/testsyncjobmanagersingleton.h"
 #include "propagation/executor/testfilerescuer.h"
 #include "requests/testexclusiontemplatecache.h"
@@ -67,6 +68,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION(TestSyncDb);
 CPPUNIT_TEST_SUITE_REGISTRATION(TestSyncNodeCache);
 
 CPPUNIT_TEST_SUITE_REGISTRATION(TestLocalJobs);
+CPPUNIT_TEST_SUITE_REGISTRATION(TestAbstractJob);
 CPPUNIT_TEST_SUITE_REGISTRATION(TestSyncJobManagerSingleton);
 CPPUNIT_TEST_SUITE_REGISTRATION(TestSnapshot);
 CPPUNIT_TEST_SUITE_REGISTRATION(TestFsOperation);


### PR DESCRIPTION
## Summary
This PR adds support for an environment variable `KDRIVE_ACTIVATE_EXTENDED_LOG` that allows forcing extended log mode at runtime without recompiling.
## Changes
- `src/libsyncengine/jobs/abstractjob.h`: Updated `isExtendedLog()` to also return `true` when the `KDRIVE_ACTIVATE_EXTENDED_LOG` environment variable is set to `"1"`.
## Motivation
This makes it easier to enable verbose/extended logging in production or CI environments without code changes, by simply setting an environment variable.