### PR TITLE
feat(settings): centralize HelpDesk URL in app constants

### DIFF
--- a/src/gui4/windows/kDrive client/kDrive client/AppConstants.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/AppConstants.cs
@@ -62,8 +62,8 @@ namespace Infomaniak.kDrive
     {
         public Uri HomeUri { get; }
         public Uri TarrifsUri { get; }
+        public Uri HelpUri { get; }
     }
-
 
     internal sealed class CustomAppConstants : IAppConstants
     {
@@ -146,6 +146,7 @@ namespace Infomaniak.kDrive
     {
         public Uri HomeUri { get; } = new Uri("https://www.infomaniak.com/fr/ksuite");
         public Uri TarrifsUri { get; } = new Uri("https://www.infomaniak.com/gtl/myksuite#prices");
+        public Uri HelpUri { get; } = new Uri("https://www.infomaniak.com/gtl/support");
     }
 
     internal sealed class ProductionAppConstants : IAppConstants

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/DefaultError.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/DefaultError.xaml.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
+using Windows.System;
 
 namespace Infomaniak.kDrive.CustomControls.Errors
 {
@@ -75,7 +76,7 @@ namespace Infomaniak.kDrive.CustomControls.Errors
             Control? control = sender as Control;
             if (control is not null)
                 control.IsEnabled = false;
-            if (!await kDrive.Localizer.Instance.TryLaunchUriAsync("helpURL"))
+            if (!await Launcher.LaunchUriAsync(App.Constants.kSuite.HelpUri))
             {
                 Logger.Log(Logger.Level.Error, "Failed to launch HelpDesk URI.");
                 Utility.ShowUnexpectedErrorTeachingTip();

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/SettingsPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/SettingsPage.xaml.cs
@@ -28,7 +28,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Windows.System;
 
 namespace Infomaniak.kDrive.Pages.Settings
 {
@@ -515,7 +514,7 @@ namespace Infomaniak.kDrive.Pages.Settings
             if (control is not null)
                 control.IsEnabled = false;
 
-            if (!await Launcher.LaunchUriAsync(App.Constants.kSuite.HelpUri))
+            if (!await Windows.System.Launcher.LaunchUriAsync(App.Constants.kSuite.HelpUri))
             {
                 Logger.Log(Logger.Level.Error, "Failed to launch HelpDesk URI.");
                 Utility.ShowUnexpectedErrorTeachingTip();

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/SettingsPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/SettingsPage.xaml.cs
@@ -28,6 +28,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Windows.System;
 
 namespace Infomaniak.kDrive.Pages.Settings
 {
@@ -513,7 +514,8 @@ namespace Infomaniak.kDrive.Pages.Settings
             Control? control = sender as Control;
             if (control is not null)
                 control.IsEnabled = false;
-            if (!await kDrive.Localizer.Instance.TryLaunchUriAsync("helpURL"))
+
+            if (!await Launcher.LaunchUriAsync(App.Constants.kSuite.HelpUri))
             {
                 Logger.Log(Logger.Level.Error, "Failed to launch HelpDesk URI.");
                 Utility.ShowUnexpectedErrorTeachingTip();


### PR DESCRIPTION
Add HelpUri to IkSuiteConstants and use it for HelpDesk actions Switch HelpDesk button logic to use Launcher with centralized URL Import Windows.System where needed for Launcher usage