### PR TITLE
ci(windows): deactivate BullseyeCoverage before release build

### DIFF
--- a/.github/actions/build_windows/action.yml
+++ b/.github/actions/build_windows/action.yml
@@ -65,6 +65,7 @@ runs:
     - name: Deactivate BullseyeCoverage
       run: |
         & "cov01.exe" "-0" # coverage off
+      shell: powershell
 
     - name: Build kDrive desktop
       id: build

--- a/.github/actions/build_windows/action.yml
+++ b/.github/actions/build_windows/action.yml
@@ -22,268 +22,272 @@ inputs:
     description: 'If true, build the Windows app with the new client'
     required: false
     default: 'false'
-    
+
 outputs:
   kDrive_version:
     description: 'The version of the kDrive app built'
     value: ${{ steps.set_version.outputs.kDrive_version }}
 
 runs:
-    using: "composite"
-    steps:
-      
-      - name: Load system Path into Github environment
-        run : echo Path=%Path%>> %GITHUB_ENV%
-        shell: cmd
+  using: "composite"
+  steps:
 
-      - name: Restore extension packages
-        run : nuget restore extensions/windows/cfapi/kDriveExt.sln
-        shell: powershell
+    - name: Load system Path into Github environment
+      run: echo Path=%Path%>> %GITHUB_ENV%
+      shell: cmd
 
-      - name: Import Windows certificate
-        env:
-          WINDOWS_VIRTUAL_CERT:  ${{ inputs.virtual_cert }}
-          WINDOWS_PHYSICAL_CERT: ${{ inputs.physical_cert }}
-        run: |
-          if("${{ inputs.release_build }}" -eq "true") {
-            New-Item -ItemType directory -Path certificate
-            Set-Content -Path certificate/tempCert.txt -Value $env:WINDOWS_PHYSICAL_CERT
-            certutil -decode certificate/tempCert.txt certificate/certificate.cert
-            Remove-Item -path certificate -include tempCert.txt
-            Import-Certificate -Filepath certificate/certificate.cert -CertStoreLocation Cert:\LocalMachine\My
-            Write-Host "Physical certificate imported successfully."
-            } else {
-            New-Item -ItemType directory -Path certificate
-            Set-Content -Path certificate/tempCert.txt -Value $env:WINDOWS_VIRTUAL_CERT
-            certutil -decode certificate/tempCert.txt certificate/certificate.pfx
-            Remove-Item -path certificate -include tempCert.txt
-            Import-PfxCertificate -FilePath certificate/certificate.pfx -CertStoreLocation Cert:\LocalMachine\My -Password (ConvertTo-SecureString -String "${{ inputs.virtual_cert_pass }}" -Force -AsPlainText)
-            Write-Host "Virtual certificate imported successfully."
-            }
-        shell: powershell
+    - name: Restore extension packages
+      run: nuget restore extensions/windows/cfapi/kDriveExt.sln
+      shell: powershell
 
-      - name: Build kDrive desktop
-        id: build
-        run: |
-          call "C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Auxiliary/Build/vcvars64.bat"
-          IF "${{ inputs.release_build }}"=="true" (
-            powershell "certutil -scinfo -Silent"
-
-            IF "${{ inputs.build_new_client }}"=="true" (
-              powershell "./infomaniak-build-tools/windows/build-drive.ps1" -ci -ext -msi -clean remake -upload -tokenPass ${{ inputs.physical_cert_pass }} -newGui $true
-            ) ELSE (
-              powershell "./infomaniak-build-tools/windows/build-drive.ps1" -ci -ext -msi -clean remake -upload -tokenPass ${{ inputs.physical_cert_pass }}
-            )
-
-          ) ELSE (
-            powershell -File "./infomaniak-build-tools/windows/build-drive.ps1" -ci -unitTests
-          )
-        shell: cmd
-
-      - name: Fetch dependencies
-        run: |
-          mkdir dependencies
-          # kDrive_vfs_win lib is not cached and therefore is uploaded as a separate artifact
-          Get-ChildItem -Path ${{ github.workspace }}/build-windows/install/bin/ -Filter "*.dll" |
-              Where-Object {
-                      $_.Name -ne "kDrive_vfs_win.dll" -and
-                      $_.Name -ne "KDContextMenu.dll" -and
-                      $_.Name -ne "KDOverlays.dll" -and
-                      $_.Name -ne "Vfs.dll"
-              } |
-              Copy-Item -Destination ./dependencies/
-          Copy-Item "${{ github.workspace }}/build-windows/install/bin/crashpad_handler.exe" ./dependencies/ -ErrorAction SilentlyContinue
-          cp "C:\Program Files (x86)\cppunit\lib\cppunit_dll.dll" ./dependencies/
-        shell: powershell
-        if: steps.build.outcome == 'success'
-
-      - name: Fetch Conan dependencies (Windows)
-        if: steps.build.outcome == 'success'
-        shell: powershell
-        run: |
-          $conanRunBat = Get-ChildItem -Path "${{ github.workspace }}" -Recurse -Filter "conanrun.ps1" | Select-Object -First 1
-          if ($conanRunBat) {
-            Write-Host "Sourcing $($conanRunBat.FullName)"
-            & $conanRunBat.FullName *> $null
+    - name: Import Windows certificate
+      env:
+        WINDOWS_VIRTUAL_CERT: ${{ inputs.virtual_cert }}
+        WINDOWS_PHYSICAL_CERT: ${{ inputs.physical_cert }}
+      run: |
+        if("${{ inputs.release_build }}" -eq "true") {
+          New-Item -ItemType directory -Path certificate
+          Set-Content -Path certificate/tempCert.txt -Value $env:WINDOWS_PHYSICAL_CERT
+          certutil -decode certificate/tempCert.txt certificate/certificate.cert
+          Remove-Item -path certificate -include tempCert.txt
+          Import-Certificate -Filepath certificate/certificate.cert -CertStoreLocation Cert:\LocalMachine\My
+          Write-Host "Physical certificate imported successfully."
           } else {
-            Write-Host "No conanrun.ps1 found, skipping Conan dependencies fetch."
-            exit 0
+          New-Item -ItemType directory -Path certificate
+          Set-Content -Path certificate/tempCert.txt -Value $env:WINDOWS_VIRTUAL_CERT
+          certutil -decode certificate/tempCert.txt certificate/certificate.pfx
+          Remove-Item -path certificate -include tempCert.txt
+          Import-PfxCertificate -FilePath certificate/certificate.pfx -CertStoreLocation Cert:\LocalMachine\My -Password (ConvertTo-SecureString -String "${{ inputs.virtual_cert_pass }}" -Force -AsPlainText)
+          Write-Host "Virtual certificate imported successfully."
           }
-          
-          New-Item -ItemType Directory -Path "./dependencies/platforms" -Force *> $null
-          $patterns = @(
-              "xxhash*.dll",
-              "log4cplus*.dll",
-              "libssl*.dll",
-              "libcrypto*.dll",
-              "crashpad_handler.exe",
-              "Qt6Widgets.dll",
-              "Qt6Gui.dll",
-              "Qt6Network.dll",
-              "Qt6Sql.dll",
-              "Qt6Core.dll",
-              "Qt6DBus.dll",
-              "Qt6Svg.dll",
-              "qoffscreen.dll",
-              "PocoCrypto.dll",
-              "PocoFoundation.dll",
-              "PocoJSON.dll",
-              "PocoNet.dll",
-              "PocoNetSSL.dll",
-              "PocoUtil.dll",
-              "PocoXML.dll"
-          )
+      shell: powershell
 
-          $paths = $env:PATH -split ';' | Where-Object { $_ -like '*\.conan2\p*' }
-          foreach ($dir in $paths) {
-            if (Test-Path $dir) {
-              foreach ($pattern in $patterns) {
-                if ($pattern -eq "qoffscreen.dll") {
-                  $searchDir = Split-Path -Parent $dir
-                  $destination = "./dependencies/platforms/"
-                } else {
-                  $searchDir = $dir
-                  $destination = "./dependencies/"
-                }
-                Get-ChildItem -Path $searchDir -Recurse -Filter $pattern -ErrorAction SilentlyContinue | ForEach-Object {
-                  Copy-Item -Path $_.FullName -Destination $destination -Force
-                  Write-Host "`tConan dependency found -> $($_.FullName)"
-                }
+    - name: Deactivate BullseyeCoverage
+      run: |
+        & "cov01.exe" "-0" # coverage off
+
+    - name: Build kDrive desktop
+      id: build
+      run: |
+        call "C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Auxiliary/Build/vcvars64.bat"
+        IF "${{ inputs.release_build }}"=="true" (
+          powershell "certutil -scinfo -Silent"
+        
+          IF "${{ inputs.build_new_client }}"=="true" (
+            powershell "./infomaniak-build-tools/windows/build-drive.ps1" -ci -ext -msi -clean remake -upload -tokenPass ${{ inputs.physical_cert_pass }} -newGui $true
+          ) ELSE (
+            powershell "./infomaniak-build-tools/windows/build-drive.ps1" -ci -ext -msi -clean remake -upload -tokenPass ${{ inputs.physical_cert_pass }}
+          )
+        
+        ) ELSE (
+          powershell -File "./infomaniak-build-tools/windows/build-drive.ps1" -ci -unitTests
+        )
+      shell: cmd
+
+    - name: Fetch dependencies
+      run: |
+        mkdir dependencies
+        # kDrive_vfs_win lib is not cached and therefore is uploaded as a separate artifact
+        Get-ChildItem -Path ${{ github.workspace }}/build-windows/install/bin/ -Filter "*.dll" |
+            Where-Object {
+                    $_.Name -ne "kDrive_vfs_win.dll" -and
+                    $_.Name -ne "KDContextMenu.dll" -and
+                    $_.Name -ne "KDOverlays.dll" -and
+                    $_.Name -ne "Vfs.dll"
+            } |
+            Copy-Item -Destination ./dependencies/
+        Copy-Item "${{ github.workspace }}/build-windows/install/bin/crashpad_handler.exe" ./dependencies/ -ErrorAction SilentlyContinue
+        cp "C:\Program Files (x86)\cppunit\lib\cppunit_dll.dll" ./dependencies/
+      shell: powershell
+      if: steps.build.outcome == 'success'
+
+    - name: Fetch Conan dependencies (Windows)
+      if: steps.build.outcome == 'success'
+      shell: powershell
+      run: |
+        $conanRunBat = Get-ChildItem -Path "${{ github.workspace }}" -Recurse -Filter "conanrun.ps1" | Select-Object -First 1
+        if ($conanRunBat) {
+          Write-Host "Sourcing $($conanRunBat.FullName)"
+          & $conanRunBat.FullName *> $null
+        } else {
+          Write-Host "No conanrun.ps1 found, skipping Conan dependencies fetch."
+          exit 0
+        }
+        
+        New-Item -ItemType Directory -Path "./dependencies/platforms" -Force *> $null
+        $patterns = @(
+            "xxhash*.dll",
+            "log4cplus*.dll",
+            "libssl*.dll",
+            "libcrypto*.dll",
+            "crashpad_handler.exe",
+            "Qt6Widgets.dll",
+            "Qt6Gui.dll",
+            "Qt6Network.dll",
+            "Qt6Sql.dll",
+            "Qt6Core.dll",
+            "Qt6DBus.dll",
+            "Qt6Svg.dll",
+            "qoffscreen.dll",
+            "PocoCrypto.dll",
+            "PocoFoundation.dll",
+            "PocoJSON.dll",
+            "PocoNet.dll",
+            "PocoNetSSL.dll",
+            "PocoUtil.dll",
+            "PocoXML.dll"
+        )
+        
+        $paths = $env:PATH -split ';' | Where-Object { $_ -like '*\.conan2\p*' }
+        foreach ($dir in $paths) {
+          if (Test-Path $dir) {
+            foreach ($pattern in $patterns) {
+              if ($pattern -eq "qoffscreen.dll") {
+                $searchDir = Split-Path -Parent $dir
+                $destination = "./dependencies/platforms/"
+              } else {
+                $searchDir = $dir
+                $destination = "./dependencies/"
+              }
+              Get-ChildItem -Path $searchDir -Recurse -Filter $pattern -ErrorAction SilentlyContinue | ForEach-Object {
+                Copy-Item -Path $_.FullName -Destination $destination -Force
+                Write-Host "`tConan dependency found -> $($_.FullName)"
               }
             }
           }
+        }
 
-      - name:  Fetch kDrive dependencies (lst and vfs lib)
-        run: |
-          mkdir uncached_dependencies
-          $uncached = @(
-              "sync-exclude.lst",
-              "kDrive_vfs_win.dll",
-              "KDContextMenu.dll",
-              "KDOverlays.dll",
-              "Vfs.dll"
-          )
-          $uncached | ForEach-Object {
-              Copy-Item "${{ github.workspace }}/build-windows/install/bin/$_" ./uncached_dependencies/
-          }
-        shell: powershell
-        if: steps.build.outcome == 'success'
+    - name: Fetch kDrive dependencies (lst and vfs lib)
+      run: |
+        mkdir uncached_dependencies
+        $uncached = @(
+            "sync-exclude.lst",
+            "kDrive_vfs_win.dll",
+            "KDContextMenu.dll",
+            "KDOverlays.dll",
+            "Vfs.dll"
+        )
+        $uncached | ForEach-Object {
+            Copy-Item "${{ github.workspace }}/build-windows/install/bin/$_" ./uncached_dependencies/
+        }
+      shell: powershell
+      if: steps.build.outcome == 'success'
 
-      - name: Upload build common files
-        uses: actions/upload-artifact@v4
-        with:
-          name: windows-build-common-files
-          path: |
-              ./dependencies/*
-          retention-days: 1
-          compression-level: 0
-        if: steps.build.outcome == 'success'
+    - name: Upload build common files
+      uses: actions/upload-artifact@v4
+      with:
+        name: windows-build-common-files
+        path: |
+          ./dependencies/*
+        retention-days: 1
+        compression-level: 0
+      if: steps.build.outcome == 'success'
 
-      - name: Upload uncached build common files
-        uses: actions/upload-artifact@v4
-        with:
-          name: windows-build-common-files-uncached
-          path: |
-              ./uncached_dependencies/*
-          retention-days: 1
-          compression-level: 0
-        if: steps.build.outcome == 'success'
+    - name: Upload uncached build common files
+      uses: actions/upload-artifact@v4
+      with:
+        name: windows-build-common-files-uncached
+        path: |
+          ./uncached_dependencies/*
+        retention-days: 1
+        compression-level: 0
+      if: steps.build.outcome == 'success'
 
-      - name: Upload build test common executable
-        uses: actions/upload-artifact@v4
-        with:
-          name: win-kDrive_test_common
-          path: ${{ github.workspace }}/build-windows/build/bin/kDrive_test_common.exe
-          retention-days: 1
-          compression-level: 0
-        if: ${{ steps.build.outcome == 'success' && inputs.release_build == 'false' }}
+    - name: Upload build test common executable
+      uses: actions/upload-artifact@v4
+      with:
+        name: win-kDrive_test_common
+        path: ${{ github.workspace }}/build-windows/build/bin/kDrive_test_common.exe
+        retention-days: 1
+        compression-level: 0
+      if: ${{ steps.build.outcome == 'success' && inputs.release_build == 'false' }}
 
-      - name: Upload build test common server executable
-        uses: actions/upload-artifact@v4
-        with:
-          name: win-kDrive_test_common_server
-          path: ${{ github.workspace }}/build-windows/build/bin/kDrive_test_common_server.exe
-          retention-days: 1
-          compression-level: 0
-        if: ${{ steps.build.outcome == 'success' && inputs.release_build == 'false' }}
+    - name: Upload build test common server executable
+      uses: actions/upload-artifact@v4
+      with:
+        name: win-kDrive_test_common_server
+        path: ${{ github.workspace }}/build-windows/build/bin/kDrive_test_common_server.exe
+        retention-days: 1
+        compression-level: 0
+      if: ${{ steps.build.outcome == 'success' && inputs.release_build == 'false' }}
 
-      - name: Upload build test server executable
-        uses: actions/upload-artifact@v4
-        with:
-          name: win-kDrive_test_server
-          path: ${{ github.workspace }}/build-windows/build/bin/kDrive_test_server.exe
-          retention-days: 1
-          compression-level: 0
-        if: ${{ steps.build.outcome == 'success' && inputs.release_build == 'false' }}
+    - name: Upload build test server executable
+      uses: actions/upload-artifact@v4
+      with:
+        name: win-kDrive_test_server
+        path: ${{ github.workspace }}/build-windows/build/bin/kDrive_test_server.exe
+        retention-days: 1
+        compression-level: 0
+      if: ${{ steps.build.outcome == 'success' && inputs.release_build == 'false' }}
 
-      - name: Upload build test syncengine executable
-        uses: actions/upload-artifact@v4
-        with:
-          name: win-kDrive_test_syncengine
-          path: ${{ github.workspace }}/build-windows/build/bin/kDrive_test_syncengine.exe
-          retention-days: 1
-          compression-level: 0
-        if: ${{ steps.build.outcome == 'success' && inputs.release_build == 'false' }}
+    - name: Upload build test syncengine executable
+      uses: actions/upload-artifact@v4
+      with:
+        name: win-kDrive_test_syncengine
+        path: ${{ github.workspace }}/build-windows/build/bin/kDrive_test_syncengine.exe
+        retention-days: 1
+        compression-level: 0
+      if: ${{ steps.build.outcome == 'success' && inputs.release_build == 'false' }}
 
-      - name: Upload build test parms executable
-        uses: actions/upload-artifact@v4
-        with:
-          name: win-kDrive_test_parms
-          path: ${{ github.workspace }}/build-windows/build/bin/kDrive_test_parms.exe
-          retention-days: 1
-          compression-level: 0
-        if: ${{ steps.build.outcome == 'success' && inputs.release_build == 'false' }}
+    - name: Upload build test parms executable
+      uses: actions/upload-artifact@v4
+      with:
+        name: win-kDrive_test_parms
+        path: ${{ github.workspace }}/build-windows/build/bin/kDrive_test_parms.exe
+        retention-days: 1
+        compression-level: 0
+      if: ${{ steps.build.outcome == 'success' && inputs.release_build == 'false' }}
 
-      - name: Download sentry-cli for Windows
-        run: |
-          Invoke-WebRequest -Uri https://github.com/getsentry/sentry-cli/releases/download/2.46.0/sentry-cli-Windows-x86_64.exe -OutFile sentry-cli.exe
-        shell: powershell
-        if: ${{ steps.build.outcome == 'success' && inputs.release_build == 'true' }}
+    - name: Download sentry-cli for Windows
+      run: |
+        Invoke-WebRequest -Uri https://github.com/getsentry/sentry-cli/releases/download/2.46.0/sentry-cli-Windows-x86_64.exe -OutFile sentry-cli.exe
+      shell: powershell
+      if: ${{ steps.build.outcome == 'success' && inputs.release_build == 'true' }}
 
-      - name : Create sentry server artifacts
-        run: |
-          .\sentry-cli debug-files bundle-sources ${{ github.workspace }}/build-windows/build/bin/kDrive.pdb
-          mkdir ${{ github.workspace }}/build-windows/sentry-server-artifacts
-          Move-Item -Path ${{ github.workspace }}/build-windows/build/bin/kDrive.src.zip -Destination ${{ github.workspace }}/build-windows/sentry-server-artifacts/kDrive.src.zip
-          Move-Item -Path ${{ github.workspace }}/build-windows/build/bin/kDrive.pdb -Destination ${{ github.workspace }}/build-windows/sentry-server-artifacts/kDrive.pdb
-        shell: powershell
-        if: ${{ steps.build.outcome == 'success' && inputs.release_build == 'true' }}
+    - name: Create sentry server artifacts
+      run: |
+        .\sentry-cli debug-files bundle-sources ${{ github.workspace }}/build-windows/build/bin/kDrive.pdb
+        mkdir ${{ github.workspace }}/build-windows/sentry-server-artifacts
+        Move-Item -Path ${{ github.workspace }}/build-windows/build/bin/kDrive.src.zip -Destination ${{ github.workspace }}/build-windows/sentry-server-artifacts/kDrive.src.zip
+        Move-Item -Path ${{ github.workspace }}/build-windows/build/bin/kDrive.pdb -Destination ${{ github.workspace }}/build-windows/sentry-server-artifacts/kDrive.pdb
+      shell: powershell
+      if: ${{ steps.build.outcome == 'success' && inputs.release_build == 'true' }}
 
-      - name : Create sentry client artifacts
-        run: |
-          .\sentry-cli debug-files bundle-sources ${{ github.workspace }}/build-windows/build/bin/kDrive_client.pdb
-          mkdir ${{ github.workspace }}/build-windows/sentry-client-artifacts
-          Move-Item -Path ${{ github.workspace }}/build-windows/build/bin/kDrive_client.src.zip -Destination ${{ github.workspace }}/build-windows/sentry-client-artifacts/kDrive_client.src.zip
-          Move-Item -Path ${{ github.workspace }}/build-windows/build/bin/kDrive_client.pdb -Destination ${{ github.workspace }}/build-windows/sentry-client-artifacts/kDrive_client.pdb
-        shell: powershell
-        if: ${{ steps.build.outcome == 'success' && inputs.release_build == 'true' }}
+    - name: Create sentry client artifacts
+      run: |
+        .\sentry-cli debug-files bundle-sources ${{ github.workspace }}/build-windows/build/bin/kDrive_client.pdb
+        mkdir ${{ github.workspace }}/build-windows/sentry-client-artifacts
+        Move-Item -Path ${{ github.workspace }}/build-windows/build/bin/kDrive_client.src.zip -Destination ${{ github.workspace }}/build-windows/sentry-client-artifacts/kDrive_client.src.zip
+        Move-Item -Path ${{ github.workspace }}/build-windows/build/bin/kDrive_client.pdb -Destination ${{ github.workspace }}/build-windows/sentry-client-artifacts/kDrive_client.pdb
+      shell: powershell
+      if: ${{ steps.build.outcome == 'success' && inputs.release_build == 'true' }}
 
-      - name: Upload sentry server artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: win-release-artifacts-server-debug
-          path: ${{ github.workspace }}/build-windows/sentry-server-artifacts
-          retention-days: 1
-          compression-level: 0
-        if: ${{ steps.build.outcome == 'success' && inputs.release_build == 'true' }}
+    - name: Upload sentry server artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: win-release-artifacts-server-debug
+        path: ${{ github.workspace }}/build-windows/sentry-server-artifacts
+        retention-days: 1
+        compression-level: 0
+      if: ${{ steps.build.outcome == 'success' && inputs.release_build == 'true' }}
 
-      - name: Upload sentry client artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: win-release-artifacts-client-debug
-          path: ${{ github.workspace }}/build-windows/sentry-client-artifacts
-          retention-days: 1
-          compression-level: 0
-        if: ${{ steps.build.outcome == 'success' && inputs.release_build == 'true' }}
+    - name: Upload sentry client artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: win-release-artifacts-client-debug
+        path: ${{ github.workspace }}/build-windows/sentry-client-artifacts
+        retention-days: 1
+        compression-level: 0
+      if: ${{ steps.build.outcome == 'success' && inputs.release_build == 'true' }}
 
-      - name: Upload app installer
-        uses: actions/upload-artifact@v4
-        with:
-          name: win-release-artifacts-installer
-          path: ${{ github.workspace }}\build-windows\kDrive-* # kDrive-x.x.x.yyyymmdd.exe
-          retention-days: 1
-        if: ${{ steps.build.outcome == 'success' && inputs.release_build == 'true' }}
+    - name: Upload app installer
+      uses: actions/upload-artifact@v4
+      with:
+        name: win-release-artifacts-installer
+        path: ${{ github.workspace }}\build-windows\kDrive-* # kDrive-x.x.x.yyyymmdd.exe
+        retention-days: 1
+      if: ${{ steps.build.outcome == 'success' && inputs.release_build == 'true' }}
 
-      - name: Clean-up generated code
-        run : powershell ./infomaniak-build-tools/windows/build-drive.ps1 -clean all
-        shell: powershell
+    - name: Clean-up generated code
+      run: powershell ./infomaniak-build-tools/windows/build-drive.ps1 -clean all
+      shell: powershell

--- a/version.json
+++ b/version.json
@@ -1,8 +1,8 @@
 {
   "Version": {
-    "major": 9,
-    "minor": 0,
-    "patch": 0,
+    "major": 3,
+    "minor": 8,
+    "patch": 4,
     "build": 1,
     "year": 2026
   }

--- a/version.json
+++ b/version.json
@@ -1,8 +1,8 @@
 {
   "Version": {
-    "major": 3,
-    "minor": 8,
-    "patch": 4,
+    "major": 9,
+    "minor": 0,
+    "patch": 0,
     "build": 1,
     "year": 2026
   }


### PR DESCRIPTION
## Summary

Add a step to deactivate `BullseyeCoverage` (`cov01.exe -0`) before running the Windows release build, preventing code coverage instrumentation from interfering with the release output.

## Changes

- `.github/actions/build_windows/action.yml`: Add *Deactivate BullseyeCoverage* step before the build step
- `version.json`: Version bump