### PR TITLE
fix(socket): use 127.0.0.1 instead of localhost for TCP and at auto retry

### DIFF
--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/SocketServerCommProtocol.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/SocketServerCommProtocol.cs
@@ -43,6 +43,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
         private int _inBufferJsonBalance = 0;
         private readonly ConcurrentDictionary<long, TaskCompletionSource<CommData>> _pendingRequests = [];
         private bool _stopRequested = false;
+        private const string _host = "127.0.0.1";
         private long NextId
         {
             get
@@ -92,10 +93,10 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                     {
                         int port = int.Parse(File.ReadAllText(commPortFilePath).Trim());
 
-                        Logger.Log(Logger.Level.Info, $"Attempting to connect to localhost:{port}");
+                        Logger.Log(Logger.Level.Info, $"Attempting to connect to {_host}:{port}");
                         _client?.Dispose();
                         _client = new TcpClient();
-                        await _client.ConnectAsync("127.0.0.1", port).ConfigureAwait(false);
+                        await _client.ConnectAsync(_host, port).ConfigureAwait(false);
                         Logger.Log(Logger.Level.Info, "Connected to server.");
                     }
                     catch (SocketException ex)

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/SocketServerCommProtocol.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/SocketServerCommProtocol.cs
@@ -95,7 +95,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                         Logger.Log(Logger.Level.Info, $"Attempting to connect to localhost:{port}");
                         _client?.Dispose();
                         _client = new TcpClient();
-                        await _client.ConnectAsync("localhost", port).ConfigureAwait(false);
+                        await _client.ConnectAsync("127.0.0.1", port).ConfigureAwait(false);
                         Logger.Log(Logger.Level.Info, "Connected to server.");
                     }
                     catch (SocketException ex)

--- a/src/server/comm/socketcommserver.cpp
+++ b/src/server/comm/socketcommserver.cpp
@@ -19,6 +19,9 @@
 #include "socketcommserver.h"
 
 #include "libcommon/utility/utility.h"
+#include "utility/utility.h"
+
+constexpr char host[] = "127.0.0.1";
 
 namespace KDC {
 
@@ -139,7 +142,7 @@ void SocketCommChannel::callbackHandler() {
 
 uint64_t SocketCommChannel::bytesAvailable() const {
     try {
-        return static_cast<uint64_t>((std::max)(0, _socket.available()));
+        return static_cast<uint64_t>((std::max) (0, _socket.available()));
     } catch (Poco::Exception &ex) {
         LOG_ERROR(Log::instance()->getLogger(), "Exception in StreamSocket::available: " << ex.displayText());
         return static_cast<uint64_t>(0);
@@ -175,7 +178,7 @@ void SocketCommServer::close() {
         if (!_serverSocket.isNull()) {
             Poco::Net::StreamSocket socket;
             try {
-                socket.connect(Poco::Net::SocketAddress("localhost", getPort())); // Connect to unblock accept
+                socket.connect(Poco::Net::SocketAddress(host, getPort())); // Connect to unblock accept
             } catch (Poco::Exception &ex) {
                 LOG_ERROR(Log::instance()->getLogger(), "Exception in StreamSocket::connect: " << ex.displayText());
             }
@@ -234,12 +237,21 @@ void saveCommPort(unsigned short port) {
 }
 
 void SocketCommServer::execute() {
-    try {
-        _serverSocket.bind(Poco::Net::SocketAddress("localhost", "0"), true, true);
-    } catch (Poco::Exception &ex) {
-        LOG_ERROR(Log::instance()->getLogger(), "Exception in ServerSocket::bind: " << ex.displayText());
-        return;
-    }
+    int retries = 0;
+    do {
+        try {
+            _serverSocket.bind(Poco::Net::SocketAddress(host, "0"), true, true);
+        } catch (Poco::Exception &ex) {
+            LOG_ERROR(Log::instance()->getLogger(), "Exception in ServerSocket::bind: " << ex.displayText());
+            Utility::msleep(500);
+            ++retries;
+            if (retries == 10) {
+                sentry::Handler::captureMessage(
+                        sentry::Level::Error, "SocketCommServer bind error",
+                        "Failed to bind server socket after 10 retries: " + std::string(ex.displayText()));
+            }
+        }
+    } while (_serverSocket.address().port() == 0); // Loop until a port is successfully assigned
 
     LOG_DEBUG(Log::instance()->getLogger(), name() << " listening on port " << getPort());
     saveCommPort(getPort());

--- a/src/server/comm/socketcommserver.cpp
+++ b/src/server/comm/socketcommserver.cpp
@@ -168,6 +168,10 @@ SocketCommServer::~SocketCommServer() {
     }
 }
 
+std::string SocketCommServer::getHost() {
+    return host;
+}
+
 void SocketCommServer::close() {
     if (_stopAsked) {
         LOG_DEBUG(Log::instance()->getLogger(), name() << " is already stoping");

--- a/src/server/comm/socketcommserver.cpp
+++ b/src/server/comm/socketcommserver.cpp
@@ -19,11 +19,11 @@
 #include "socketcommserver.h"
 
 #include "libcommon/utility/utility.h"
-#include "utility/utility.h"
-
-constexpr char host[] = "127.0.0.1";
+#include "libcommonserver/utility/utility.h"
 
 namespace KDC {
+
+constexpr char host[] = "127.0.0.1";
 
 SocketCommChannel::SocketCommChannel(const Poco::Net::StreamSocket &socket) :
     AbstractCommChannel(),

--- a/src/server/comm/socketcommserver.cpp
+++ b/src/server/comm/socketcommserver.cpp
@@ -242,9 +242,11 @@ void saveCommPort(unsigned short port) {
 
 void SocketCommServer::execute() {
     int retries = 0;
+    bool bindSuccess = false;
     do {
         try {
             _serverSocket.bind(Poco::Net::SocketAddress(host, "0"), true, true);
+            bindSuccess = true;
         } catch (Poco::Exception &ex) {
             LOG_ERROR(Log::instance()->getLogger(), "Exception in ServerSocket::bind: " << ex.displayText());
             Utility::msleep(500);
@@ -255,7 +257,7 @@ void SocketCommServer::execute() {
                         "Failed to bind server socket after 10 retries: " + std::string(ex.displayText()));
             }
         }
-    } while (_serverSocket.address().port() == 0); // Loop until a port is successfully assigned
+    } while (!bindSuccess); // Loop until bind is successful
 
     LOG_DEBUG(Log::instance()->getLogger(), name() << " listening on port " << getPort());
     saveCommPort(getPort());

--- a/src/server/comm/socketcommserver.h
+++ b/src/server/comm/socketcommserver.h
@@ -56,6 +56,7 @@ class SocketCommServer : public AbstractCommServer {
         SocketCommServer(const std::string &name);
         ~SocketCommServer();
         Poco::UInt16 getPort() const { return _serverSocket.address().port(); }
+        static std::string getHost();
         void close() final;
         bool listen() override;
         std::shared_ptr<AbstractCommChannel> nextPendingConnection() override;

--- a/test/server/comm/testsocketcomm.cpp
+++ b/test/server/comm/testsocketcomm.cpp
@@ -50,7 +50,7 @@ void TestSocketComm::testServerListen() {
 
     // Create a client socket and connect to the server
     Poco::Net::StreamSocket clientSocket;
-    clientSocket.connect(Poco::Net::SocketAddress("localhost", _socketCommServerTest->getPort()));
+    clientSocket.connect(Poco::Net::SocketAddress("127.0.0.1", _socketCommServerTest->getPort()));
     auto clientSideChannel = std::make_shared<SocketCommChannelTest>(clientSocket);
 
     // Wait for the server to accept the connection

--- a/test/server/comm/testsocketcomm.cpp
+++ b/test/server/comm/testsocketcomm.cpp
@@ -50,7 +50,7 @@ void TestSocketComm::testServerListen() {
 
     // Create a client socket and connect to the server
     Poco::Net::StreamSocket clientSocket;
-    clientSocket.connect(Poco::Net::SocketAddress("127.0.0.1", _socketCommServerTest->getPort()));
+    clientSocket.connect(Poco::Net::SocketAddress(SocketCommServer::getHost(), _socketCommServerTest->getPort()));
     auto clientSideChannel = std::make_shared<SocketCommChannelTest>(clientSocket);
 
     // Wait for the server to accept the connection
@@ -95,7 +95,7 @@ void TestSocketComm::testServerCallbacks() {
 
     // Create a client socket and connect to the server
     Poco::Net::StreamSocket clientSocket;
-    clientSocket.connect(Poco::Net::SocketAddress("localhost", _socketCommServerTest->getPort()));
+    clientSocket.connect(Poco::Net::SocketAddress(SocketCommServer::getHost(), _socketCommServerTest->getPort()));
     auto clientSideChannel = std::make_shared<SocketCommChannelTest>(clientSocket);
 
     // Wait for the server to accept the connection
@@ -130,7 +130,7 @@ void TestSocketComm::testChannelReadyReadCallback() {
 
     // Create a client socket and connect to the server
     Poco::Net::StreamSocket clientSocket;
-    clientSocket.connect(Poco::Net::SocketAddress("localhost", _socketCommServerTest->getPort()));
+    clientSocket.connect(Poco::Net::SocketAddress(SocketCommServer::getHost(), _socketCommServerTest->getPort()));
     auto clientSideChannel = std::make_shared<SocketCommChannelTest>(clientSocket);
 
     // Wait for the server to accept the connection
@@ -170,7 +170,7 @@ void TestSocketComm::testChannelReadAndWriteData() {
 
     // Create a client socket and connect to the server
     Poco::Net::StreamSocket clientSocket;
-    clientSocket.connect(Poco::Net::SocketAddress("localhost", _socketCommServerTest->getPort()));
+    clientSocket.connect(Poco::Net::SocketAddress(SocketCommServer::getHost(), _socketCommServerTest->getPort()));
     auto clientSideChannel = std::make_shared<SocketCommChannelTest>(clientSocket);
 
     // Wait for the server to accept the connection


### PR DESCRIPTION
Replaced "localhost" with "127.0.0.1" in both C# and C++ socket connection logic to avoid DNS resolution issues and ensure consistent use of the IPv4 loopback address. This affects both client and server code paths.