### PR TITLE
feat(linux-gui): introduce cache-first architecture with CachePipeline

### DIFF
--- a/src/gui4/linux/AGENTS.md
+++ b/src/gui4/linux/AGENTS.md
@@ -31,7 +31,8 @@
 ## Current Structure
 
 - `main.cpp`: process entry point + single-instance lock file.
-- `appclientlinux.*`: top-level app wiring (logging, IPC lifecycle, dispatcher/service ownership).
+- `appclientlinux.*`: top-level app wiring (logging, IPC lifecycle, dispatcher/service ownership,
+  QML engine bootstrap, and context-property injection for cache/services).
 - `communicationlayer/ipcclient.*`: raw TCP JSON transport, request/reply correlation, reconnect-before-first-connect
   logic.
 - `communicationlayer/signaldispatcher.*`: server-push signal fanout to registered handlers.
@@ -39,6 +40,8 @@
 - `app/cache/appcache.*`: central observable cache (`AppCache` QObject) — typed snapshots and incremental
   `upsert*`/`remove*` slots for users, accounts, drives, available drives, syncs, and errors; QML models and
   services read from it instead of parsing transport payloads directly.
+- `app/cache/cachepipeline.*`: single wiring point from `CommService` server-push signals to `AppCache`
+  incremental updates (`signal -> cache` pipeline).
 - `ui/`: QML shell and design tokens.
 
 ## Build And Validation
@@ -63,6 +66,10 @@ cmake --build build-linux/build/build/Debug --target kdrive_qml -- -j 12
 - QML must never call `IpcClient` directly.
 - New backend calls must be added in `CommService`, not in UI files.
 - Server-push events must be registered in `CommService::register*Handlers` and re-emitted as typed Qt signals.
+- Connections from `CommService` signals to `AppCache` slots must live in `CachePipeline` only
+  (no duplicated service-level wiring).
+- App bootstrap should inject C++ facades (`appCache`, `userService`, `driveService`, `syncService`) at the
+  QML engine boundary (`QQmlApplicationEngine::rootContext()`).
 - When object lifetime is uncertain in async callbacks, guard with `QPointer<T>`.
 
 ## IPC And Error Handling

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -16,6 +16,8 @@ set(GUI_SOURCE_FILES # C++ files for the GUI application
         appclientlinux.h
         app/cache/appcache.cpp
         app/cache/appcache.h
+        app/cache/cachepipeline.cpp
+        app/cache/cachepipeline.h
         communicationlayer/ipcclient.cpp
         communicationlayer/ipcclient.h
         communicationlayer/signaldispatcher.cpp

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -28,6 +28,8 @@ set(GUI_SOURCE_FILES # C++ files for the GUI application
         app/services/userservice.h
         app/services/driveservice.cpp
         app/services/driveservice.h
+        app/services/syncservice.cpp
+        app/services/syncservice.h
 )
 
 set(GUI_QML_SINGLETON_FILES # QML singletons (tokens, theme, etc.)

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -26,6 +26,8 @@ set(GUI_SOURCE_FILES # C++ files for the GUI application
         app/services/serviceutils.h
         app/services/userservice.cpp
         app/services/userservice.h
+        app/services/driveservice.cpp
+        app/services/driveservice.h
 )
 
 set(GUI_QML_SINGLETON_FILES # QML singletons (tokens, theme, etc.)

--- a/src/gui4/linux/app/cache/cachepipeline.cpp
+++ b/src/gui4/linux/app/cache/cachepipeline.cpp
@@ -25,28 +25,28 @@ CachePipeline::CachePipeline(CommService &commService, AppCache &appCache, QObje
     _commService(commService),
     _appCache(appCache) {
     // --- User ---
-    (void) connect(&_commService, &CommService::userAdded, &_appCache, &AppCache::upsertUser);
-    (void) connect(&_commService, &CommService::userUpdated, &_appCache, &AppCache::upsertUser);
-    (void) connect(&_commService, &CommService::userRemoved, &_appCache, &AppCache::removeUser);
+    (void) connect(&_commService, &CommService::userAdded, &_appCache, &AppCache::upsertUser, Qt::UniqueConnection);
+    (void) connect(&_commService, &CommService::userUpdated, &_appCache, &AppCache::upsertUser, Qt::UniqueConnection);
+    (void) connect(&_commService, &CommService::userRemoved, &_appCache, &AppCache::removeUser, Qt::UniqueConnection);
 
     // --- Account ---
-    (void) connect(&_commService, &CommService::accountAdded, &_appCache, &AppCache::upsertAccount);
-    (void) connect(&_commService, &CommService::accountUpdated, &_appCache, &AppCache::upsertAccount);
-    (void) connect(&_commService, &CommService::accountRemoved, &_appCache, &AppCache::removeAccount);
+    (void) connect(&_commService, &CommService::accountAdded, &_appCache, &AppCache::upsertAccount, Qt::UniqueConnection);
+    (void) connect(&_commService, &CommService::accountUpdated, &_appCache, &AppCache::upsertAccount, Qt::UniqueConnection);
+    (void) connect(&_commService, &CommService::accountRemoved, &_appCache, &AppCache::removeAccount, Qt::UniqueConnection);
 
     // --- Drive ---
-    (void) connect(&_commService, &CommService::driveAdded, &_appCache, &AppCache::upsertDrive);
-    (void) connect(&_commService, &CommService::driveUpdated, &_appCache, &AppCache::upsertDrive);
-    (void) connect(&_commService, &CommService::driveRemoved, &_appCache, &AppCache::removeDrive);
+    (void) connect(&_commService, &CommService::driveAdded, &_appCache, &AppCache::upsertDrive, Qt::UniqueConnection);
+    (void) connect(&_commService, &CommService::driveUpdated, &_appCache, &AppCache::upsertDrive, Qt::UniqueConnection);
+    (void) connect(&_commService, &CommService::driveRemoved, &_appCache, &AppCache::removeDrive, Qt::UniqueConnection);
 
     // --- Sync ---
-    (void) connect(&_commService, &CommService::syncAdded, &_appCache, &AppCache::upsertSync);
-    (void) connect(&_commService, &CommService::syncUpdated, &_appCache, &AppCache::upsertSync);
-    (void) connect(&_commService, &CommService::syncRemoved, &_appCache, &AppCache::removeSync);
+    (void) connect(&_commService, &CommService::syncAdded, &_appCache, &AppCache::upsertSync, Qt::UniqueConnection);
+    (void) connect(&_commService, &CommService::syncUpdated, &_appCache, &AppCache::upsertSync, Qt::UniqueConnection);
+    (void) connect(&_commService, &CommService::syncRemoved, &_appCache, &AppCache::removeSync, Qt::UniqueConnection);
 
     // --- Error ---
-    (void) connect(&_commService, &CommService::errorAdded, &_appCache, &AppCache::upsertError);
-    (void) connect(&_commService, &CommService::errorRemoved, &_appCache, &AppCache::removeError);
+    (void) connect(&_commService, &CommService::errorAdded, &_appCache, &AppCache::upsertError, Qt::UniqueConnection);
+    (void) connect(&_commService, &CommService::errorRemoved, &_appCache, &AppCache::removeError, Qt::UniqueConnection);
 }
 
 } // namespace KDC

--- a/src/gui4/linux/app/cache/cachepipeline.cpp
+++ b/src/gui4/linux/app/cache/cachepipeline.cpp
@@ -1,0 +1,52 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "cachepipeline.h"
+
+namespace KDC {
+
+CachePipeline::CachePipeline(CommService &commService, AppCache &appCache, QObject *const parent) :
+    QObject(parent),
+    _commService(commService),
+    _appCache(appCache) {
+    // --- User ---
+    (void) connect(&_commService, &CommService::userAdded, &_appCache, &AppCache::upsertUser);
+    (void) connect(&_commService, &CommService::userUpdated, &_appCache, &AppCache::upsertUser);
+    (void) connect(&_commService, &CommService::userRemoved, &_appCache, &AppCache::removeUser);
+
+    // --- Account ---
+    (void) connect(&_commService, &CommService::accountAdded, &_appCache, &AppCache::upsertAccount);
+    (void) connect(&_commService, &CommService::accountUpdated, &_appCache, &AppCache::upsertAccount);
+    (void) connect(&_commService, &CommService::accountRemoved, &_appCache, &AppCache::removeAccount);
+
+    // --- Drive ---
+    (void) connect(&_commService, &CommService::driveAdded, &_appCache, &AppCache::upsertDrive);
+    (void) connect(&_commService, &CommService::driveUpdated, &_appCache, &AppCache::upsertDrive);
+    (void) connect(&_commService, &CommService::driveRemoved, &_appCache, &AppCache::removeDrive);
+
+    // --- Sync ---
+    (void) connect(&_commService, &CommService::syncAdded, &_appCache, &AppCache::upsertSync);
+    (void) connect(&_commService, &CommService::syncUpdated, &_appCache, &AppCache::upsertSync);
+    (void) connect(&_commService, &CommService::syncRemoved, &_appCache, &AppCache::removeSync);
+
+    // --- Error ---
+    (void) connect(&_commService, &CommService::errorAdded, &_appCache, &AppCache::upsertError);
+    (void) connect(&_commService, &CommService::errorRemoved, &_appCache, &AppCache::removeError);
+}
+
+} // namespace KDC

--- a/src/gui4/linux/app/cache/cachepipeline.h
+++ b/src/gui4/linux/app/cache/cachepipeline.h
@@ -1,0 +1,46 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "app/cache/appcache.h"
+#include "app/services/commservice.h"
+
+#include <QObject>
+
+namespace KDC {
+
+/**
+ * Owns all signal connections from CommService to AppCache.
+ *
+ * This is the single component responsible for keeping AppCache fed with
+ * server-push events. No service or other object should connect CommService
+ * signals to AppCache directly.
+ */
+class CachePipeline : public QObject {
+        Q_OBJECT
+
+    public:
+        explicit CachePipeline(CommService &commService, AppCache &appCache, QObject *parent = nullptr);
+
+    private:
+        CommService &_commService;
+        AppCache &_appCache;
+};
+
+} // namespace KDC

--- a/src/gui4/linux/app/services/driveservice.cpp
+++ b/src/gui4/linux/app/services/driveservice.cpp
@@ -47,7 +47,7 @@ void DriveService::loadDrives() {
         }
 
         self->endRequest();
-        if (exitInfo.code() != ExitCode::Ok) {
+        if (!exitInfo) {
             self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
             return;
         }
@@ -68,7 +68,7 @@ void DriveService::deleteDrive(const qint64 driveDbId) {
         }
 
         self->endRequest();
-        if (exitInfo.code() != ExitCode::Ok) {
+        if (!exitInfo) {
             self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
         }
     });
@@ -89,7 +89,7 @@ void DriveService::updateDrive(const DriveInfo &driveInfo) {
         }
 
         self->endRequest();
-        if (exitInfo.code() != ExitCode::Ok) {
+        if (!exitInfo) {
             self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
         }
     });

--- a/src/gui4/linux/app/services/driveservice.cpp
+++ b/src/gui4/linux/app/services/driveservice.cpp
@@ -1,0 +1,133 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "driveservice.h"
+#include "serviceutils.h"
+
+#include <QLoggingCategory>
+#include <QPointer>
+
+namespace KDC {
+
+Q_LOGGING_CATEGORY(lcDriveService, "gui.v4.driveservice", QtInfoMsg)
+
+DriveService::DriveService(CommService &commService, AppCache &appCache, QObject *parent) :
+    QObject(parent),
+    _commService(commService),
+    _appCache(appCache) {
+    (void) connect(&_commService, &CommService::driveAdded, &_appCache, &AppCache::upsertDrive);
+    (void) connect(&_commService, &CommService::driveUpdated, &_appCache, &AppCache::upsertDrive);
+    (void) connect(&_commService, &CommService::driveRemoved, &_appCache, &AppCache::removeDrive);
+    (void) connect(&_appCache, &AppCache::selectedDriveDbIdChanged, this, &DriveService::activeDriveDbIdChanged);
+}
+
+void DriveService::loadDrives() {
+    beginRequest();
+    setLastError(QString());
+
+    const QPointer<DriveService> self(this);
+    _commService.requestDriveInfoList([self](const ExitInfo &exitInfo, const std::vector<DriveInfo> &list) {
+        if (!self) {
+            return;
+        }
+
+        self->endRequest();
+        if (exitInfo.code() != ExitCode::Ok) {
+            self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+            return;
+        }
+
+        self->_appCache.replaceDrives(list);
+    });
+}
+
+void DriveService::deleteDrive(const qint64 driveDbId) {
+    beginRequest();
+    setLastError(QString());
+
+    const QPointer<DriveService> self(this);
+    // Cache consistency is signal-driven: we wait for driveRemoved/driveUpdated pushes.
+    _commService.requestDriveDelete(static_cast<DriveDbId>(driveDbId), [self](const ExitInfo &exitInfo) {
+        if (!self) {
+            return;
+        }
+
+        self->endRequest();
+        if (exitInfo.code() != ExitCode::Ok) {
+            self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+        }
+    });
+}
+
+void DriveService::setActiveDrive(const qint64 driveDbId) {
+    _appCache.setSelectedDriveDbId(driveDbId);
+}
+
+void DriveService::updateDrive(const DriveInfo &driveInfo) {
+    beginRequest();
+    setLastError(QString());
+
+    const QPointer<DriveService> self(this);
+    _commService.requestDriveUpdate(driveInfo, [self](const ExitInfo &exitInfo) {
+        if (!self) {
+            return;
+        }
+
+        self->endRequest();
+        if (exitInfo.code() != ExitCode::Ok) {
+            self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+        }
+    });
+}
+
+void DriveService::beginRequest() {
+    ++_pendingRequestCount;
+    setLoading(true);
+}
+
+void DriveService::endRequest() {
+    if (_pendingRequestCount <= 0) {
+        qCWarning(lcDriveService) << "endRequest called with non-positive pending count:" << _pendingRequestCount;
+        _pendingRequestCount = 0;
+        setLoading(false);
+        return;
+    }
+
+    --_pendingRequestCount;
+    if (_pendingRequestCount == 0) {
+        setLoading(false);
+    }
+}
+
+void DriveService::setLoading(const bool loading) {
+    if (_loading == loading) {
+        return;
+    }
+    _loading = loading;
+    emit loadingChanged();
+}
+
+void DriveService::setLastError(const QString &error) {
+    if (_lastError == error) {
+        return;
+    }
+    _lastError = error;
+    emit lastErrorChanged();
+}
+
+} // namespace KDC

--- a/src/gui4/linux/app/services/driveservice.cpp
+++ b/src/gui4/linux/app/services/driveservice.cpp
@@ -29,9 +29,6 @@ DriveService::DriveService(CommService &commService, AppCache &appCache, QObject
     QObject(parent),
     _commService(commService),
     _appCache(appCache) {
-    (void) connect(&_commService, &CommService::driveAdded, &_appCache, &AppCache::upsertDrive);
-    (void) connect(&_commService, &CommService::driveUpdated, &_appCache, &AppCache::upsertDrive);
-    (void) connect(&_commService, &CommService::driveRemoved, &_appCache, &AppCache::removeDrive);
     (void) connect(&_appCache, &AppCache::selectedDriveDbIdChanged, this, &DriveService::activeDriveDbIdChanged);
 }
 

--- a/src/gui4/linux/app/services/driveservice.cpp
+++ b/src/gui4/linux/app/services/driveservice.cpp
@@ -20,7 +20,6 @@
 #include "serviceutils.h"
 
 #include <QLoggingCategory>
-#include <QPointer>
 
 namespace KDC {
 
@@ -40,19 +39,14 @@ void DriveService::loadDrives() {
     beginRequest();
     setLastError({});
 
-    const QPointer<DriveService> self(this);
-    _commService.requestDriveInfoList([self](const ExitInfo &exitInfo, const std::vector<DriveInfo> &list) {
-        if (!self) {
-            return;
-        }
-
-        self->endRequest();
+    _commService.requestDriveInfoList([this](const ExitInfo &exitInfo, const std::vector<DriveInfo> &list) {
+        endRequest();
         if (!exitInfo) {
-            self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+            setLastError(ServiceUtils::formatExitInfo(exitInfo));
             return;
         }
 
-        self->_appCache.replaceDrives(list);
+        _appCache.replaceDrives(list);
     });
 }
 
@@ -60,16 +54,11 @@ void DriveService::deleteDrive(const qint64 driveDbId) {
     beginRequest();
     setLastError(QString());
 
-    const QPointer<DriveService> self(this);
     // Cache consistency is signal-driven: we wait for driveRemoved/driveUpdated pushes.
-    _commService.requestDriveDelete(static_cast<DriveDbId>(driveDbId), [self](const ExitInfo &exitInfo) {
-        if (!self) {
-            return;
-        }
-
-        self->endRequest();
+    _commService.requestDriveDelete(static_cast<DriveDbId>(driveDbId), [this](const ExitInfo &exitInfo) {
+        endRequest();
         if (!exitInfo) {
-            self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+            setLastError(ServiceUtils::formatExitInfo(exitInfo));
         }
     });
 }
@@ -82,15 +71,10 @@ void DriveService::updateDrive(const DriveInfo &driveInfo) {
     beginRequest();
     setLastError({});
 
-    const QPointer<DriveService> self(this);
-    _commService.requestDriveUpdate(driveInfo, [self](const ExitInfo &exitInfo) {
-        if (!self) {
-            return;
-        }
-
-        self->endRequest();
+    _commService.requestDriveUpdate(driveInfo, [this](const ExitInfo &exitInfo) {
+        endRequest();
         if (!exitInfo) {
-            self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+            setLastError(ServiceUtils::formatExitInfo(exitInfo));
         }
     });
 }

--- a/src/gui4/linux/app/services/driveservice.cpp
+++ b/src/gui4/linux/app/services/driveservice.cpp
@@ -80,7 +80,7 @@ void DriveService::setActiveDrive(const qint64 driveDbId) {
 
 void DriveService::updateDrive(const DriveInfo &driveInfo) {
     beginRequest();
-    setLastError(QString());
+    setLastError({});
 
     const QPointer<DriveService> self(this);
     _commService.requestDriveUpdate(driveInfo, [self](const ExitInfo &exitInfo) {

--- a/src/gui4/linux/app/services/driveservice.cpp
+++ b/src/gui4/linux/app/services/driveservice.cpp
@@ -26,7 +26,7 @@ namespace KDC {
 
 Q_LOGGING_CATEGORY(lcDriveService, "gui.v4.driveservice", QtInfoMsg)
 
-DriveService::DriveService(CommService &commService, AppCache &appCache, QObject *parent) :
+DriveService::DriveService(CommService &commService, AppCache &appCache, QObject *const parent) :
     QObject(parent),
     _commService(commService),
     _appCache(appCache) {

--- a/src/gui4/linux/app/services/driveservice.cpp
+++ b/src/gui4/linux/app/services/driveservice.cpp
@@ -38,7 +38,7 @@ DriveService::DriveService(CommService &commService, AppCache &appCache, QObject
 
 void DriveService::loadDrives() {
     beginRequest();
-    setLastError(QString());
+    setLastError({});
 
     const QPointer<DriveService> self(this);
     _commService.requestDriveInfoList([self](const ExitInfo &exitInfo, const std::vector<DriveInfo> &list) {

--- a/src/gui4/linux/app/services/driveservice.h
+++ b/src/gui4/linux/app/services/driveservice.h
@@ -1,0 +1,74 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "app/cache/appcache.h"
+#include "app/services/commservice.h"
+
+#include <QObject>
+#include <QString>
+
+#include <cstdint>
+
+namespace KDC {
+
+/**
+ * High-level drive-oriented facade.
+ *
+ * QML should use the Q_INVOKABLE methods. updateDrive() remains C++-facing until
+ * a stable QML edit contract for DriveInfo is introduced.
+ */
+class DriveService : public QObject {
+        Q_OBJECT
+        Q_PROPERTY(bool loading READ loading NOTIFY loadingChanged)
+        Q_PROPERTY(QString lastError READ lastError NOTIFY lastErrorChanged)
+        Q_PROPERTY(qint64 activeDriveDbId READ activeDriveDbId NOTIFY activeDriveDbIdChanged)
+
+    public:
+        explicit DriveService(CommService &commService, AppCache &appCache, QObject *parent = nullptr);
+
+        bool loading() const { return _loading; }
+        const QString &lastError() const { return _lastError; }
+        qint64 activeDriveDbId() const { return _appCache.selectedDriveDbId(); }
+
+        Q_INVOKABLE void loadDrives();
+        Q_INVOKABLE void deleteDrive(qint64 driveDbId);
+        Q_INVOKABLE void setActiveDrive(qint64 driveDbId);
+
+        void updateDrive(const DriveInfo &driveInfo);
+
+    signals:
+        void loadingChanged();
+        void lastErrorChanged();
+        void activeDriveDbIdChanged();
+
+    private:
+        void beginRequest();
+        void endRequest();
+        void setLoading(bool loading);
+        void setLastError(const QString &error);
+
+        CommService &_commService;
+        AppCache &_appCache;
+        int32_t _pendingRequestCount{0};
+        bool _loading{false};
+        QString _lastError;
+};
+
+} // namespace KDC

--- a/src/gui4/linux/app/services/syncservice.cpp
+++ b/src/gui4/linux/app/services/syncservice.cpp
@@ -142,6 +142,7 @@ void SyncService::deleteSync(const qint64 syncDbId) {
 }
 
 void SyncService::querySyncStatus(const qint64 syncDbId) {
+    beginRequest();
     setLastError(QString());
 
     const QPointer<SyncService> self(this);
@@ -151,6 +152,7 @@ void SyncService::querySyncStatus(const qint64 syncDbId) {
                                            return;
                                        }
 
+                                       self->endRequest();
                                        if (exitInfo.code() != ExitCode::Ok) {
                                            self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
                                            return;

--- a/src/gui4/linux/app/services/syncservice.cpp
+++ b/src/gui4/linux/app/services/syncservice.cpp
@@ -28,7 +28,7 @@ namespace KDC {
 
 Q_LOGGING_CATEGORY(lcSyncService, "gui.v4.syncservice", QtInfoMsg)
 
-SyncService::SyncService(CommService &commService, AppCache &appCache, QObject *parent) :
+SyncService::SyncService(CommService &commService, AppCache &appCache, QObject *const parent) :
     QObject(parent),
     _commService(commService),
     _appCache(appCache) {

--- a/src/gui4/linux/app/services/syncservice.cpp
+++ b/src/gui4/linux/app/services/syncservice.cpp
@@ -30,13 +30,7 @@ Q_LOGGING_CATEGORY(lcSyncService, "gui.v4.syncservice", QtInfoMsg)
 SyncService::SyncService(CommService &commService, AppCache &appCache, QObject *const parent) :
     QObject(parent),
     _commService(commService),
-    _appCache(appCache) {
-    (void) connect(&_commService, &CommService::syncAdded, &_appCache, &AppCache::upsertSync);
-    (void) connect(&_commService, &CommService::syncUpdated, &_appCache, &AppCache::upsertSync);
-    (void) connect(&_commService, &CommService::syncRemoved, &_appCache, &AppCache::removeSync);
-    (void) connect(&_commService, &CommService::errorAdded, &_appCache, &AppCache::upsertError);
-    (void) connect(&_commService, &CommService::errorRemoved, &_appCache, &AppCache::removeError);
-}
+    _appCache(appCache) {}
 
 void SyncService::loadSyncs() {
     beginRequest();

--- a/src/gui4/linux/app/services/syncservice.cpp
+++ b/src/gui4/linux/app/services/syncservice.cpp
@@ -22,7 +22,6 @@
 #include "libcommon/utility/types.h"
 
 #include <QLoggingCategory>
-#include <QPointer>
 
 namespace KDC {
 
@@ -43,19 +42,14 @@ void SyncService::loadSyncs() {
     beginRequest();
     setLastError(QString());
 
-    const QPointer<SyncService> self(this);
-    _commService.requestSyncInfoList([self](const ExitInfo &exitInfo, const std::vector<SyncInfo> &list) {
-        if (!self) {
-            return;
-        }
-
-        self->endRequest();
+    _commService.requestSyncInfoList([this](const ExitInfo &exitInfo, const std::vector<SyncInfo> &list) {
+        endRequest();
         if (exitInfo.code() != ExitCode::Ok) {
-            self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+            setLastError(ServiceUtils::formatExitInfo(exitInfo));
             return;
         }
 
-        self->_appCache.replaceSyncs(list);
+        _appCache.replaceSyncs(list);
     });
 }
 
@@ -73,19 +67,14 @@ void SyncService::addSync(const qint64 userDbId, const qint64 accountId, const q
     request.serverFolderNodeId = QStr2Str(serverFolderNodeId);
     request.liteSync = liteSync;
 
-    const QPointer<SyncService> self(this);
-    _commService.requestSyncAdd(request, [self](const ExitInfo &exitInfo, const SyncInfo &syncInfo) {
-        if (!self) {
-            return;
-        }
-
-        self->endRequest();
+    _commService.requestSyncAdd(request, [this](const ExitInfo &exitInfo, const SyncInfo &syncInfo) {
+        endRequest();
         if (exitInfo.code() != ExitCode::Ok) {
-            self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+            setLastError(ServiceUtils::formatExitInfo(exitInfo));
             return;
         }
 
-        emit self->syncAddCompleted(static_cast<qint64>(syncInfo.dbId()));
+        emit syncAddCompleted(static_cast<qint64>(syncInfo.dbId()));
     });
 }
 
@@ -93,15 +82,10 @@ void SyncService::startSync(const qint64 syncDbId) {
     beginRequest();
     setLastError(QString());
 
-    const QPointer<SyncService> self(this);
-    _commService.requestSyncStart(static_cast<SyncDbId>(syncDbId), [self](const ExitInfo &exitInfo) {
-        if (!self) {
-            return;
-        }
-
-        self->endRequest();
+    _commService.requestSyncStart(static_cast<SyncDbId>(syncDbId), [this](const ExitInfo &exitInfo) {
+        endRequest();
         if (exitInfo.code() != ExitCode::Ok) {
-            self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+            setLastError(ServiceUtils::formatExitInfo(exitInfo));
         }
     });
 }
@@ -110,15 +94,10 @@ void SyncService::stopSync(const qint64 syncDbId) {
     beginRequest();
     setLastError(QString());
 
-    const QPointer<SyncService> self(this);
-    _commService.requestSyncStop(static_cast<SyncDbId>(syncDbId), [self](const ExitInfo &exitInfo) {
-        if (!self) {
-            return;
-        }
-
-        self->endRequest();
+    _commService.requestSyncStop(static_cast<SyncDbId>(syncDbId), [this](const ExitInfo &exitInfo) {
+        endRequest();
         if (exitInfo.code() != ExitCode::Ok) {
-            self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+            setLastError(ServiceUtils::formatExitInfo(exitInfo));
         }
     });
 }
@@ -127,16 +106,11 @@ void SyncService::deleteSync(const qint64 syncDbId) {
     beginRequest();
     setLastError(QString());
 
-    const QPointer<SyncService> self(this);
     // Cache consistency is signal-driven: we wait for syncRemoved/syncUpdated pushes.
-    _commService.requestSyncDelete(static_cast<SyncDbId>(syncDbId), [self](const ExitInfo &exitInfo) {
-        if (!self) {
-            return;
-        }
-
-        self->endRequest();
+    _commService.requestSyncDelete(static_cast<SyncDbId>(syncDbId), [this](const ExitInfo &exitInfo) {
+        endRequest();
         if (exitInfo.code() != ExitCode::Ok) {
-            self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+            setLastError(ServiceUtils::formatExitInfo(exitInfo));
         }
     });
 }
@@ -145,20 +119,15 @@ void SyncService::querySyncStatus(const qint64 syncDbId) {
     beginRequest();
     setLastError(QString());
 
-    const QPointer<SyncService> self(this);
     _commService.requestSyncStatus(static_cast<SyncDbId>(syncDbId),
-                                   [self, syncDbId](const ExitInfo &exitInfo, const SyncStatus status) {
-                                       if (!self) {
-                                           return;
-                                       }
-
-                                       self->endRequest();
+                                   [this, syncDbId](const ExitInfo &exitInfo, const SyncStatus status) {
+                                       endRequest();
                                        if (exitInfo.code() != ExitCode::Ok) {
-                                           self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+                                           setLastError(ServiceUtils::formatExitInfo(exitInfo));
                                            return;
                                        }
 
-                                       emit self->syncStatusReceived(syncDbId, toInt(status));
+                                       emit syncStatusReceived(syncDbId, toInt(status));
                                    });
 }
 
@@ -166,20 +135,15 @@ void SyncService::findGoodPathForNewSync(const QString &basePath) {
     beginRequest();
     setLastError(QString());
 
-    const QPointer<SyncService> self(this);
     _commService.requestFindGoodPathForNewSync(
-            QStr2Path(basePath), [self](const ExitInfo &exitInfo, const GoodPathResult &result) {
-                if (!self) {
-                    return;
-                }
-
-                self->endRequest();
+            QStr2Path(basePath), [this](const ExitInfo &exitInfo, const GoodPathResult &result) {
+                endRequest();
                 if (exitInfo.code() != ExitCode::Ok) {
-                    self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+                    setLastError(ServiceUtils::formatExitInfo(exitInfo));
                     return;
                 }
 
-                emit self->suggestedPathReceived(Path2QStr(result.goodPath), result.errorMessage);
+                emit suggestedPathReceived(Path2QStr(result.goodPath), result.errorMessage);
             });
 }
 
@@ -193,21 +157,16 @@ void SyncService::isPathValidForNewSync(const QString &path, const int32_t syncC
 
     beginRequest();
 
-    const QPointer<SyncService> self(this);
     _commService.requestIsPathValidForNewSync(QStr2Path(path), static_cast<SyncConfiguration>(syncConfiguration),
-                                              [self](const ExitInfo &exitInfo, const bool isValid) {
-                                                  if (!self) {
-                                                      return;
-                                                  }
-
-                                                  self->endRequest();
+                                              [this](const ExitInfo &exitInfo, const bool isValid) {
+                                                  endRequest();
                                                   if (exitInfo.code() != ExitCode::Ok) {
-                                                      self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
-                                                      emit self->pathValidationReceived(false);
+                                                      setLastError(ServiceUtils::formatExitInfo(exitInfo));
+                                                      emit pathValidationReceived(false);
                                                       return;
                                                   }
 
-                                                  emit self->pathValidationReceived(isValid);
+                                                  emit pathValidationReceived(isValid);
                                               });
 }
 

--- a/src/gui4/linux/app/services/syncservice.cpp
+++ b/src/gui4/linux/app/services/syncservice.cpp
@@ -1,0 +1,252 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "syncservice.h"
+#include "serviceutils.h"
+
+#include "libcommon/utility/types.h"
+
+#include <QLoggingCategory>
+#include <QPointer>
+
+namespace KDC {
+
+Q_LOGGING_CATEGORY(lcSyncService, "gui.v4.syncservice", QtInfoMsg)
+
+SyncService::SyncService(CommService &commService, AppCache &appCache, QObject *parent) :
+    QObject(parent),
+    _commService(commService),
+    _appCache(appCache) {
+    (void) connect(&_commService, &CommService::syncAdded, &_appCache, &AppCache::upsertSync);
+    (void) connect(&_commService, &CommService::syncUpdated, &_appCache, &AppCache::upsertSync);
+    (void) connect(&_commService, &CommService::syncRemoved, &_appCache, &AppCache::removeSync);
+    (void) connect(&_commService, &CommService::errorAdded, &_appCache, &AppCache::upsertError);
+    (void) connect(&_commService, &CommService::errorRemoved, &_appCache, &AppCache::removeError);
+}
+
+void SyncService::loadSyncs() {
+    beginRequest();
+    setLastError(QString());
+
+    const QPointer<SyncService> self(this);
+    _commService.requestSyncInfoList([self](const ExitInfo &exitInfo, const std::vector<SyncInfo> &list) {
+        if (!self) {
+            return;
+        }
+
+        self->endRequest();
+        if (exitInfo.code() != ExitCode::Ok) {
+            self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+            return;
+        }
+
+        self->_appCache.replaceSyncs(list);
+    });
+}
+
+void SyncService::addSync(const qint64 userDbId, const qint64 accountId, const qint64 driveId, const QString &localFolderPath,
+                          const QString &serverFolderPath, const QString &serverFolderNodeId, const bool liteSync) {
+    beginRequest();
+    setLastError(QString());
+
+    SyncAddRequest request;
+    request.userDbId = static_cast<UserDbId>(userDbId);
+    request.accountId = static_cast<AccountId>(accountId);
+    request.driveId = static_cast<DriveId>(driveId);
+    request.localFolderPath = QStr2Path(localFolderPath);
+    request.serverFolderPath = QStr2Path(serverFolderPath);
+    request.serverFolderNodeId = QStr2Str(serverFolderNodeId);
+    request.liteSync = liteSync;
+
+    const QPointer<SyncService> self(this);
+    _commService.requestSyncAdd(request, [self](const ExitInfo &exitInfo, const SyncInfo &syncInfo) {
+        if (!self) {
+            return;
+        }
+
+        self->endRequest();
+        if (exitInfo.code() != ExitCode::Ok) {
+            self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+            return;
+        }
+
+        emit self->syncAddCompleted(static_cast<qint64>(syncInfo.dbId()));
+    });
+}
+
+void SyncService::startSync(const qint64 syncDbId) {
+    beginRequest();
+    setLastError(QString());
+
+    const QPointer<SyncService> self(this);
+    _commService.requestSyncStart(static_cast<SyncDbId>(syncDbId), [self](const ExitInfo &exitInfo) {
+        if (!self) {
+            return;
+        }
+
+        self->endRequest();
+        if (exitInfo.code() != ExitCode::Ok) {
+            self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+        }
+    });
+}
+
+void SyncService::stopSync(const qint64 syncDbId) {
+    beginRequest();
+    setLastError(QString());
+
+    const QPointer<SyncService> self(this);
+    _commService.requestSyncStop(static_cast<SyncDbId>(syncDbId), [self](const ExitInfo &exitInfo) {
+        if (!self) {
+            return;
+        }
+
+        self->endRequest();
+        if (exitInfo.code() != ExitCode::Ok) {
+            self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+        }
+    });
+}
+
+void SyncService::deleteSync(const qint64 syncDbId) {
+    beginRequest();
+    setLastError(QString());
+
+    const QPointer<SyncService> self(this);
+    // Cache consistency is signal-driven: we wait for syncRemoved/syncUpdated pushes.
+    _commService.requestSyncDelete(static_cast<SyncDbId>(syncDbId), [self](const ExitInfo &exitInfo) {
+        if (!self) {
+            return;
+        }
+
+        self->endRequest();
+        if (exitInfo.code() != ExitCode::Ok) {
+            self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+        }
+    });
+}
+
+void SyncService::querySyncStatus(const qint64 syncDbId) {
+    setLastError(QString());
+
+    const QPointer<SyncService> self(this);
+    _commService.requestSyncStatus(static_cast<SyncDbId>(syncDbId),
+                                   [self, syncDbId](const ExitInfo &exitInfo, const SyncStatus status) {
+                                       if (!self) {
+                                           return;
+                                       }
+
+                                       if (exitInfo.code() != ExitCode::Ok) {
+                                           self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+                                           return;
+                                       }
+
+                                       emit self->syncStatusReceived(syncDbId, toInt(status));
+                                   });
+}
+
+void SyncService::findGoodPathForNewSync(const QString &basePath) {
+    beginRequest();
+    setLastError(QString());
+
+    const QPointer<SyncService> self(this);
+    _commService.requestFindGoodPathForNewSync(
+            QStr2Path(basePath), [self](const ExitInfo &exitInfo, const GoodPathResult &result) {
+                if (!self) {
+                    return;
+                }
+
+                self->endRequest();
+                if (exitInfo.code() != ExitCode::Ok) {
+                    self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+                    return;
+                }
+
+                emit self->suggestedPathReceived(Path2QStr(result.goodPath), result.errorMessage);
+            });
+}
+
+void SyncService::isPathValidForNewSync(const QString &path, const int32_t syncConfiguration) {
+    setLastError(QString());
+    if (!isValidSyncConfigurationValue(syncConfiguration)) {
+        setLastError(QStringLiteral("Invalid sync configuration value: %1").arg(syncConfiguration));
+        emit pathValidationReceived(false);
+        return;
+    }
+
+    beginRequest();
+
+    const QPointer<SyncService> self(this);
+    _commService.requestIsPathValidForNewSync(QStr2Path(path), static_cast<SyncConfiguration>(syncConfiguration),
+                                              [self](const ExitInfo &exitInfo, const bool isValid) {
+                                                  if (!self) {
+                                                      return;
+                                                  }
+
+                                                  self->endRequest();
+                                                  if (exitInfo.code() != ExitCode::Ok) {
+                                                      self->setLastError(ServiceUtils::formatExitInfo(exitInfo));
+                                                      emit self->pathValidationReceived(false);
+                                                      return;
+                                                  }
+
+                                                  emit self->pathValidationReceived(isValid);
+                                              });
+}
+
+void SyncService::beginRequest() {
+    ++_pendingRequestCount;
+    setLoading(true);
+}
+
+void SyncService::endRequest() {
+    if (_pendingRequestCount <= 0) {
+        qCWarning(lcSyncService) << "endRequest called with non-positive pending count:" << _pendingRequestCount;
+        _pendingRequestCount = 0;
+        setLoading(false);
+        return;
+    }
+
+    --_pendingRequestCount;
+    if (_pendingRequestCount == 0) {
+        setLoading(false);
+    }
+}
+
+bool SyncService::isValidSyncConfigurationValue(const int32_t syncConfiguration) const {
+    return syncConfiguration >= toInt(SyncConfiguration::Classic) &&
+           syncConfiguration < toInt(SyncConfiguration::EnumEnd);
+}
+
+void SyncService::setLoading(const bool loading) {
+    if (_loading == loading) {
+        return;
+    }
+    _loading = loading;
+    emit loadingChanged();
+}
+
+void SyncService::setLastError(const QString &error) {
+    if (_lastError == error) {
+        return;
+    }
+    _lastError = error;
+    emit lastErrorChanged();
+}
+
+} // namespace KDC

--- a/src/gui4/linux/app/services/syncservice.h
+++ b/src/gui4/linux/app/services/syncservice.h
@@ -1,0 +1,78 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "app/cache/appcache.h"
+#include "app/services/commservice.h"
+
+#include <QObject>
+#include <QString>
+
+#include <cstdint>
+
+namespace KDC {
+
+/**
+ * High-level sync-oriented facade exposed to QML.
+ */
+class SyncService : public QObject {
+        Q_OBJECT
+        Q_PROPERTY(bool loading READ loading NOTIFY loadingChanged)
+        Q_PROPERTY(QString lastError READ lastError NOTIFY lastErrorChanged)
+
+    public:
+        explicit SyncService(CommService &commService, AppCache &appCache, QObject *parent = nullptr);
+
+        bool loading() const { return _loading; }
+        const QString &lastError() const { return _lastError; }
+
+        Q_INVOKABLE void loadSyncs();
+        Q_INVOKABLE void addSync(qint64 userDbId, qint64 accountId, qint64 driveId, const QString &localFolderPath,
+                                 const QString &serverFolderPath, const QString &serverFolderNodeId, bool liteSync);
+        Q_INVOKABLE void startSync(qint64 syncDbId);
+        Q_INVOKABLE void stopSync(qint64 syncDbId);
+        Q_INVOKABLE void deleteSync(qint64 syncDbId);
+        Q_INVOKABLE void querySyncStatus(qint64 syncDbId);
+        Q_INVOKABLE void findGoodPathForNewSync(const QString &basePath);
+        Q_INVOKABLE void isPathValidForNewSync(const QString &path, int32_t syncConfiguration);
+
+    signals:
+        void loadingChanged();
+        void lastErrorChanged();
+        void syncStatusReceived(qint64 syncDbId, int32_t status);
+        // The second argument can carry a non-blocking warning message from the backend.
+        void suggestedPathReceived(const QString &goodPath, const QString &warningMessage);
+        void pathValidationReceived(bool isValid);
+        void syncAddCompleted(qint64 syncDbId);
+
+    private:
+        void beginRequest();
+        void endRequest();
+        void setLoading(bool loading);
+        void setLastError(const QString &error);
+        bool isValidSyncConfigurationValue(int32_t syncConfiguration) const;
+
+        CommService &_commService;
+        AppCache &_appCache;
+        int32_t _pendingRequestCount{0};
+        bool _loading{false};
+        QString _lastError;
+};
+
+} // namespace KDC

--- a/src/gui4/linux/app/services/userservice.cpp
+++ b/src/gui4/linux/app/services/userservice.cpp
@@ -28,11 +28,7 @@ Q_LOGGING_CATEGORY(lcUserService, "gui.v4.userservice", QtInfoMsg)
 UserService::UserService(CommService &commService, AppCache &appCache, QObject *const parent) :
     QObject(parent),
     _commService(commService),
-    _appCache(appCache) {
-    (void) connect(&_commService, &CommService::userAdded, &_appCache, &AppCache::upsertUser);
-    (void) connect(&_commService, &CommService::userUpdated, &_appCache, &AppCache::upsertUser);
-    (void) connect(&_commService, &CommService::userRemoved, &_appCache, &AppCache::removeUser);
-}
+    _appCache(appCache) {}
 
 void UserService::loadUsers() {
     beginRequest();

--- a/src/gui4/linux/appclientlinux.cpp
+++ b/src/gui4/linux/appclientlinux.cpp
@@ -27,6 +27,7 @@
 #include <QDir>
 #include <QGuiApplication>
 #include <QLocale>
+#include <QQmlContext>
 #include <QScreen>
 #include <QSysInfo>
 
@@ -47,9 +48,29 @@ AppClientLinux::AppClientLinux(int &argc, char **argv) :
     (void) connect(&_ipcClient, &IpcClient::connected, this, &AppClientLinux::ipcConnected);
     (void) connect(&_ipcClient, &IpcClient::disconnected, this, &AppClientLinux::ipcDisconnected);
     (void) connect(&_ipcClient, &IpcClient::serverSignalReceived, &_signalDispatcher, &SignalDispatcher::dispatch);
+    (void) connect(this, &AppClientLinux::ipcConnected, &_appCache, [this] { _appCache.setConnected(true); });
+    (void) connect(this, &AppClientLinux::ipcDisconnected, &_appCache, [this] {
+        _appCache.setConnected(false);
+        _appCache.clearAll();
+    });
+    (void) connect(this, &AppClientLinux::ipcConnected, this, [this] {
+        _userService.loadUsers();
+        _driveService.loadDrives();
+        _syncService.loadSyncs();
+    });
     (void) connect(this, &QCoreApplication::aboutToQuit, this, [] { qCInfo(lcAppClientLinux) << "Qt aboutToQuit emitted"; });
 
-    qCDebug(lcAppClientLinux) << "IPC signal wiring initialized";
+    _qmlEngine.rootContext()->setContextProperty(QStringLiteral("appCache"), &_appCache);
+    _qmlEngine.rootContext()->setContextProperty(QStringLiteral("userService"), &_userService);
+    _qmlEngine.rootContext()->setContextProperty(QStringLiteral("driveService"), &_driveService);
+    _qmlEngine.rootContext()->setContextProperty(QStringLiteral("syncService"), &_syncService);
+    _qmlEngine.loadFromModule(QStringLiteral("kDrive.UI"), QStringLiteral("Main"));
+    if (_qmlEngine.rootObjects().isEmpty()) {
+        qCCritical(lcAppClientLinux) << "QML root object creation failed";
+        std::exit(EXIT_FAILURE);
+    }
+
+    qCDebug(lcAppClientLinux) << "IPC/cache/QML wiring initialized";
 
 
 #ifdef QT_DEBUG

--- a/src/gui4/linux/appclientlinux.cpp
+++ b/src/gui4/linux/appclientlinux.cpp
@@ -49,11 +49,8 @@ AppClientLinux::AppClientLinux(int &argc, char **argv) :
     (void) connect(&_ipcClient, &IpcClient::disconnected, this, &AppClientLinux::ipcDisconnected);
     (void) connect(&_ipcClient, &IpcClient::serverSignalReceived, &_signalDispatcher, &SignalDispatcher::dispatch);
     (void) connect(this, &AppClientLinux::ipcConnected, &_appCache, [this] { _appCache.setConnected(true); });
-    (void) connect(this, &AppClientLinux::ipcDisconnected, &_appCache, [this] {
-        _appCache.setConnected(false);
-        _appCache.clearAll();
-    });
     (void) connect(this, &AppClientLinux::ipcConnected, this, [this] {
+        // Initial snapshot load. Post-connect disconnects are fatal in IpcClient.
         _userService.loadUsers();
         _driveService.loadDrives();
         _syncService.loadSyncs();

--- a/src/gui4/linux/appclientlinux.h
+++ b/src/gui4/linux/appclientlinux.h
@@ -18,12 +18,18 @@
 
 #pragma once
 
+#include "app/cache/appcache.h"
+#include "app/cache/cachepipeline.h"
 #include "app/services/commservice.h"
+#include "app/services/driveservice.h"
+#include "app/services/syncservice.h"
+#include "app/services/userservice.h"
 #include "communicationlayer/ipcclient.h"
 #include "communicationlayer/signaldispatcher.h"
 
 #include <QApplication>
 #include <QLoggingCategory>
+#include <QQmlApplicationEngine>
 
 namespace KDC {
 
@@ -32,8 +38,9 @@ Q_DECLARE_LOGGING_CATEGORY(lcAppClientLinux)
 /**
  * Top-level application object for the Linux GUI client.
  *
- * Owns the IPC client and the signal dispatcher. On construction, sets up logging,
- * wires IPC signals to the dispatcher, and initiates the connection to the server.
+ * Owns the transport stack, the central app cache, and the cache pipeline.
+ * On construction, sets up logging, wires IPC signals to dispatcher/cache,
+ * and initiates the connection to the server.
  */
 class AppClientLinux : public QApplication {
         Q_OBJECT
@@ -47,6 +54,7 @@ class AppClientLinux : public QApplication {
          */
         SignalDispatcher &signalDispatcher() { return _signalDispatcher; }
         CommService &serverCommService() { return _serverCommService; }
+        AppCache &appCache() { return _appCache; }
 
     signals:
         /** Emitted once the first IPC connection to the server has been successfully established. */
@@ -60,6 +68,12 @@ class AppClientLinux : public QApplication {
         IpcClient _ipcClient{this};
         SignalDispatcher _signalDispatcher{this};
         CommService _serverCommService{_ipcClient, _signalDispatcher, this};
+        AppCache _appCache{this};
+        CachePipeline _cachePipeline{_serverCommService, _appCache, this};
+        UserService _userService{_serverCommService, _appCache, this};
+        DriveService _driveService{_serverCommService, _appCache, this};
+        SyncService _syncService{_serverCommService, _appCache, this};
+        QQmlApplicationEngine _qmlEngine;
 };
 
 } // namespace KDC


### PR DESCRIPTION
## Summary
This PR establishes a centralized cache-first architecture for the Linux GUI by introducing the CachePipeline component as the single wiring point between server events and the central cache. It decouples services from direct cache management, properly injects C++ facades into QML at the engine boundary, and ensures all CommService signals flow through AppCache in a unified, maintainable manner.

## Changes
- Added `CachePipeline` class (`app/cache/cachepipeline.*`) - a dedicated component that owns all signal connections from CommService to AppCache, eliminating scattered wiring across multiple services
- Removed duplicate cache-wiring logic from `UserService`, `DriveService`, and `SyncService` constructors
- Enhanced `AppClientLinux` to set up and inject the AppCache and service facades (userService, driveService, syncService) as QML context properties at the engine boundary via `QQmlApplicationEngine::rootContext()`
- Added QML engine bootstrap logic to `AppClientLinux` - loading UI from the registered QML module ("kDrive.UI", "Main") with proper error handling
- Updated `appclientlinux.h` to include new service and cache headers, and added the QQmlApplicationEngine member
- Enhanced initialization in `AppClientLinux` constructor with IPC-aware cache bootstrap: mark cache connected on first successful IPC connection and trigger initial `loadUsers/loadDrives/loadSyncs` snapshot requests
- Hardened `CachePipeline` signal wiring with `Qt::UniqueConnection` to prevent accidental duplicate connections in future refactors
- Updated AGENTS.md documentation to reflect the new architecture, including cache pipeline responsibility and QML engine bootstrap approach

## Technical Details
**Cache-First Pattern**: The CachePipeline centralizes all CommService-to-AppCache wiring. Services no longer duplicate these signal-slot connections, reducing maintenance burden and preventing accidentally divergent cache updates.

**QML Context Injection**: Rather than exposing backends to QML through direct imports or dynamic property assignment, C++ facades are injected as context properties at engine initialization. This provides stronger type safety for QML bindings and clearer ownership semantics.

**Lifecycle Management**: The Linux transport remains fatal on post-connect TCP failures (`IpcClient` exits the process on disconnect/error after first successful connection). This PR keeps that behavior and focuses on initial bootstrap consistency.

**Single Responsibility**: Each component has a clear role - CommService emits domain events, CachePipeline routes them, AppCache maintains typed snapshots, Services offer UI-friendly methods and respond to cache changes.