### PR TITLE
feat(labeler): add Linux UI path detection rule

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -8,6 +8,10 @@ macOS UI:
   - changed-files:
     - any-glob-to-any-file: 'src/gui4/macOS/**'
 
+Linux UI:
+  - changed-files:
+    - any-glob-to-any-file: 'src/gui4/linux/**'
+
 XPC:
   - changed-files:
     - any-glob-to-any-file: ['src/gui4/macOS/kDriveCore/ServerBridge/**', 'extensions/MacOSX/kDriveFinderSync/**', 'src/server/comm/**']


### PR DESCRIPTION
Added a rule in labeler.yml to detect changes in the Linux UI source directory (src/gui4/linux/**), complementing the existing macOS UI detection. No other sections were modified.