### PR TITLE
fix(build): fail release build when Bullseye deactivation fails

### DIFF
--- a/infomaniak-build-tools/windows/build-drive.ps1
+++ b/infomaniak-build-tools/windows/build-drive.ps1
@@ -109,10 +109,8 @@ function Set-Bullseye-Coverage {
         $cmd = Get-Command cov01.exe -ErrorAction Stop
         & $cmd $cov01Parameter
      } catch {
-         Write-Host "BullseyeCoverage cov01.exe command not found."
-         if ($enable) {
-            exit 1
-         }
+        Write-Host "BullseyeCoverage cov01.exe command not found."
+        exit 1
      }
      
      $outputString = "disabled"
@@ -770,7 +768,11 @@ Set-Bullseye-Coverage $coverage
 Write-Host
 
 if ($LASTEXITCODE -ne 0) {
-    Write-Host "Failed to enable code coverage computation. Aborting." -f Red
+    $outputString = "disabled"
+     if ($enabled) {
+        $outputString = "enabled"
+    }
+    Write-Host "Failed to $str code coverage computation. Aborting." -f Red
     exit $LASTEXITCODE
 }
 

--- a/infomaniak-build-tools/windows/build-drive.ps1
+++ b/infomaniak-build-tools/windows/build-drive.ps1
@@ -767,7 +767,7 @@ if ($upload) {
 
 $res = Set-Bullseye-Coverage $coverage
 if ($res -ne 0) {
-    if ($ci && $buildType -eq "Release") {
+    if (($ci && $buildType -eq "Release") -or $coverage) {
         $outputString = "disable"
         if ($coverage) {
             $outputString = "enable"

--- a/infomaniak-build-tools/windows/build-drive.ps1
+++ b/infomaniak-build-tools/windows/build-drive.ps1
@@ -110,7 +110,7 @@ function Set-Bullseye-Coverage {
         & $cmd $cov01Parameter
      } catch {
         Write-Host "BullseyeCoverage cov01.exe command not found."
-        exit 1
+        return 1
      }
      
      $outputString = "disabled"
@@ -119,6 +119,7 @@ function Set-Bullseye-Coverage {
     }
 
      Write-Host "BullseyeCoverage is $outputString."
+     return 0
 } 
 function Clean {
     param (
@@ -764,16 +765,19 @@ if ($upload) {
 #                                                                                               #
 #################################################################################################
 
-Set-Bullseye-Coverage $coverage
-Write-Host
-
-if ($LASTEXITCODE -ne 0) {
-    $outputString = "disable"
-    if ($coverage) {
-        $outputString = "enable"
+$res = Set-Bullseye-Coverage $coverage
+if ($res -ne 0) {
+    if ($ci) {
+        $outputString = "disable"
+        if ($coverage) {
+            $outputString = "enable"
+        }
+        Write-Host "Failed to $outputString code coverage computation. Aborting." -f Red
+        exit $res
     }
-    Write-Host "Failed to $outputString code coverage computation. Aborting." -f Red
-    exit $LASTEXITCODE
+    else {
+        Write-Host "Ignoring error returned by Set-Bullseye-Coverage because this is not a CI build." -f Yellow
+    }
 }
 
 #################################################################################################

--- a/infomaniak-build-tools/windows/build-drive.ps1
+++ b/infomaniak-build-tools/windows/build-drive.ps1
@@ -768,11 +768,11 @@ Set-Bullseye-Coverage $coverage
 Write-Host
 
 if ($LASTEXITCODE -ne 0) {
-    $outputString = "disabled"
-     if ($enabled) {
-        $outputString = "enabled"
+    $outputString = "disable"
+    if ($coverage) {
+        $outputString = "enable"
     }
-    Write-Host "Failed to $str code coverage computation. Aborting." -f Red
+    Write-Host "Failed to $outputString code coverage computation. Aborting." -f Red
     exit $LASTEXITCODE
 }
 

--- a/infomaniak-build-tools/windows/build-drive.ps1
+++ b/infomaniak-build-tools/windows/build-drive.ps1
@@ -767,7 +767,7 @@ if ($upload) {
 
 $res = Set-Bullseye-Coverage $coverage
 if ($res -ne 0) {
-    if (($ci && $buildType -eq "Release") -or $coverage) {
+    if (($ci -and $buildType -eq "Release") -or $coverage) {
         $outputString = "disable"
         if ($coverage) {
             $outputString = "enable"

--- a/infomaniak-build-tools/windows/build-drive.ps1
+++ b/infomaniak-build-tools/windows/build-drive.ps1
@@ -767,7 +767,7 @@ if ($upload) {
 
 $res = Set-Bullseye-Coverage $coverage
 if ($res -ne 0) {
-    if ($ci) {
+    if ($ci && $buildType -eq "Release") {
         $outputString = "disable"
         if ($coverage) {
             $outputString = "enable"

--- a/version.json
+++ b/version.json
@@ -1,8 +1,8 @@
 {
   "Version": {
-    "major": 9,
-    "minor": 0,
-    "patch": 0,
+    "major": 3,
+    "minor": 8,
+    "patch": 4,
     "build": 1,
     "year": 2026
   }

--- a/version.json
+++ b/version.json
@@ -1,8 +1,8 @@
 {
   "Version": {
-    "major": 3,
-    "minor": 8,
-    "patch": 4,
+    "major": 9,
+    "minor": 0,
+    "patch": 0,
     "build": 1,
     "year": 2026
   }


### PR DESCRIPTION
## Summary
- make the Windows release build fail when Bullseye coverage deactivation cannot be performed
- stop silently continuing when `cov01.exe` is unavailable
- keep the change scoped to `infomaniak-build-tools/windows/build-drive.ps1`