### PR TITLE
fix(conan): make --update opt-in to ensure deterministic CI builds

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -54,7 +54,7 @@ The exact set of redistributed binaries can vary by platform:
 - **License:** LGPL-3.0 / GPL-2.0 / GPL-3.0 / Commercial
 - **Copyright:** Copyright (C) The Qt Company Ltd. and other contributors
 - **Repository:** https://www.qt.io/
-- **Note:** Declared in `conanfile.py`.This application is built against Qt 6.2.3. Qt is deployed with the application
+- **Note:** Declared in `conanfile.py`. This application is built against Qt 6.2.3. Qt is deployed with the application
   on supported platforms. Qt source packages are available from https://download.qt.io/
 
 ### Poco
@@ -63,7 +63,7 @@ The exact set of redistributed binaries can vary by platform:
 - **License:** BSL-1.0
 - **Copyright:** Copyright (c) 2006-2024, Applied Informatics Software Engineering GmbH and Contributors
 - **Repository:** https://github.com/pocoproject/poco
-- **Note:** Declared in `conanfile.py`.Required by multiple kDrive libraries and redistributed by platform packaging
+- **Note:** Declared in `conanfile.py`. Required by multiple kDrive libraries and redistributed by platform packaging
   scripts.
 
 ### Sentry Native
@@ -72,7 +72,7 @@ The exact set of redistributed binaries can vary by platform:
 - **License:** MIT
 - **Copyright:** Copyright (c) 2019 Sentry
 - **Repository:** https://github.com/getsentry/sentry-native
-- **Note:** Declared in `conanfile.py`.Installed outside Conan according to `infomaniak-build-tools/*/Readme.md` and
+- **Note:** Declared in `conanfile.py`. Installed outside Conan according to `infomaniak-build-tools/*/Readme.md` and
   redistributed with the application. The repository does not pin one single version across all platforms; the Linux
   setup documentation currently references `0.7.9`.
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -3,16 +3,20 @@
 This file lists the main third-party components used and/or redistributed by kDrive Desktop.
 
 The exact set of redistributed binaries can vary by platform:
+
 - Conan-managed dependencies are declared in `conanfile.py`.
-- Additional packaged dependencies are documented in `infomaniak-build-tools/{linux,macos,windows}/Readme.md` and packaging scripts.
+- Additional packaged dependencies are documented in `infomaniak-build-tools/{linux,macos,windows}/Readme.md` and
+  packaging scripts.
 - Vendored sources are stored in `src/3rdparty/`.
-- Build-only tools and local developer prerequisites are intentionally excluded when they are not redistributed with release artifacts.
+- Build-only tools and local developer prerequisites are intentionally excluded when they are not redistributed with
+  release artifacts.
 
 ---
 
 ## Conan-Managed Dependencies
 
 ### xxHash
+
 - **Version:** 0.8.2
 - **License:** BSD-2-Clause
 - **Copyright:** Copyright (c) 2012-2021 Yann Collet
@@ -20,6 +24,7 @@ The exact set of redistributed binaries can vary by platform:
 - **Note:** Declared in `conanfile.py`.
 
 ### log4cplus
+
 - **Version:** 2.1.2
 - **License:** Apache-2.0 OR BSD-2-Clause
 - **Copyright:** Copyright (c) 1999-2021 log4cplus project contributors
@@ -27,6 +32,7 @@ The exact set of redistributed binaries can vary by platform:
 - **Note:** Declared in `conanfile.py`.
 
 ### zlib
+
 - **Version:** [>=1.2.11 <2]
 - **License:** Zlib
 - **Copyright:** Copyright (C) 1995-2024 Jean-loup Gailly and Mark Adler
@@ -34,52 +40,64 @@ The exact set of redistributed binaries can vary by platform:
 - **Note:** Declared in `conanfile.py`; also required by OpenSSL and some platform libzip builds.
 
 ### OpenSSL
+
 - **Version:** 3.2.4
 - **License:** Apache-2.0
 - **Copyright:** Copyright (c) 1998-2024 The OpenSSL Project Authors
 - **Repository:** https://www.openssl.org/
-- **Note:** Declared in `conanfile.py`. macOS uses the local `openssl-universal/3.2.4` recipe, other platforms use `openssl/3.2.4`.
+- **Note:** Declared in `conanfile.py`. macOS uses the local `openssl-macos/3.2.4` recipe, other platforms use
+  `openssl/3.2.4`.
+
+### Qt 6
+
+- **Version:** 6.2.3 / 6.8.3
+- **License:** LGPL-3.0 / GPL-2.0 / GPL-3.0 / Commercial
+- **Copyright:** Copyright (C) The Qt Company Ltd. and other contributors
+- **Repository:** https://www.qt.io/
+- **Note:** Declared in `conanfile.py`.This application is built against Qt 6.2.3. Qt is deployed with the application
+  on supported platforms. Qt source packages are available from https://download.qt.io/
+
+### Poco
+
+- **Version:** 1.13.3
+- **License:** BSL-1.0
+- **Copyright:** Copyright (c) 2006-2024, Applied Informatics Software Engineering GmbH and Contributors
+- **Repository:** https://github.com/pocoproject/poco
+- **Note:** Declared in `conanfile.py`.Required by multiple kDrive libraries and redistributed by platform packaging
+  scripts.
+
+### Sentry Native
+
+- **Version:** Build-environment dependent
+- **License:** MIT
+- **Copyright:** Copyright (c) 2019 Sentry
+- **Repository:** https://github.com/getsentry/sentry-native
+- **Note:** Declared in `conanfile.py`.Installed outside Conan according to `infomaniak-build-tools/*/Readme.md` and
+  redistributed with the application. The repository does not pin one single version across all platforms; the Linux
+  setup documentation currently references `0.7.9`.
+
+### Crashpad
+
+- **Version:** Bundled through the Sentry Native crashpad backend
+- **License:** BSD-3-Clause
+- **Copyright:** Copyright 2014 The Crashpad Authors
+- **Repository:** https://chromium.googlesource.com/crashpad/crashpad/
+- **Note:** Declared in `conanfile.py`. The `crashpad_handler` executable is redistributed with the application.
 
 ---
 
 ## Packaged Dependencies Installed Outside Conan
 
-### Qt 6
-- **Version:** 6.2.3
-- **License:** LGPL-3.0 / GPL-2.0 / GPL-3.0 / Commercial
-- **Copyright:** Copyright (C) The Qt Company Ltd. and other contributors
-- **Repository:** https://www.qt.io/
-- **Note:** This application is built against Qt 6.2.3. Qt is deployed with the application on supported platforms. Qt source packages are available from https://download.qt.io/
-
-### Poco
-- **Version:** 1.13.3
-- **License:** BSL-1.0
-- **Copyright:** Copyright (c) 2006-2024, Applied Informatics Software Engineering GmbH and Contributors
-- **Repository:** https://github.com/pocoproject/poco
-- **Note:** Required by multiple kDrive libraries and redistributed by platform packaging scripts.
-
 ### libzip
+
 - **Version:** 1.10.1
 - **License:** BSD-3-Clause
 - **Copyright:** Copyright (C) 1999-2024 Dieter Baron and Thomas Klausner
 - **Repository:** https://libzip.org/
 - **Note:** Used by `libcommon` and `libcommonserver`; redistributed by platform packaging scripts.
 
-### Sentry Native
-- **Version:** Build-environment dependent
-- **License:** MIT
-- **Copyright:** Copyright (c) 2019 Sentry
-- **Repository:** https://github.com/getsentry/sentry-native
-- **Note:** Installed outside Conan according to `infomaniak-build-tools/*/Readme.md` and redistributed with the application. The repository does not pin one single version across all platforms; the Linux setup documentation currently references `0.7.9`.
-
-### Crashpad
-- **Version:** Bundled through the Sentry Native crashpad backend
-- **License:** BSD-3-Clause
-- **Copyright:** Copyright 2014 The Crashpad Authors
-- **Repository:** https://chromium.googlesource.com/crashpad/crashpad/
-- **Note:** The `crashpad_handler` executable is redistributed with the application.
-
 ### Sparkle
+
 - **Version:** 2.6.4
 - **License:** MIT
 - **Copyright:** Copyright (c) Sparkle Project
@@ -91,43 +109,53 @@ The exact set of redistributed binaries can vary by platform:
 ## Vendored Source Dependencies (`src/3rdparty/`)
 
 ### utf8proc
+
 - **License:** MIT
 - **Additional Notice:** Unicode data license applies to `utf8proc_data.c`
-- **Copyright:** Copyright (c) 2014-2021 Steven G. Johnson, Jiahao Chen, Tony Kelman, Jonas Fonseca, and other contributors
+- **Copyright:** Copyright (c) 2014-2021 Steven G. Johnson, Jiahao Chen, Tony Kelman, Jonas Fonseca, and other
+  contributors
 - **Original Copyright:** Copyright (c) 2009, 2013 Public Software Group e. V., Berlin, Germany
 - **Repository:** https://github.com/JuliaStrings/utf8proc
 - **Note:** Built from vendored source on Unix platforms.
 
 ### keychain
+
 - **License:** MIT
 - **Copyright:** Copyright (c) 2019 Hannes Rantzsch, Rene Meusel
 - **Repository:** https://github.com/hrantzsch/keychain
 - **Note:** Built from vendored source.
 
 ### qt-piwik-tracker
+
 - **License:** MIT
 - **Copyright:** Copyright (c) 2014-2025 Patrizio Bekerle
 - **Repository:** https://github.com/pbek/qt-piwik-tracker
 - **Note:** Vendored in `src/3rdparty/` and built as part of `libcommongui`.
 
 ### QProgressIndicator
+
 - **License:** MIT
 - **Copyright:** Copyright (c) 2011 Morgan Leborgne
-- **Note:** Vendored in `src/3rdparty/`. No public upstream repository URL is referenced here because the previously used GitHub link is no longer available.
+- **Note:** Vendored in `src/3rdparty/`. No public upstream repository URL is referenced here because the previously
+  used GitHub link is no longer available.
 
 ### SQLite
+
 - **License:** Public Domain
 - **Copyright:** The author disclaims copyright to the SQLite amalgamation
 - **Repository:** https://www.sqlite.org/
-- **Note:** The vendored SQLite amalgamation in `src/3rdparty/sqlite3/` is used on macOS and Windows. Linux prefers the system SQLite when available.
+- **Note:** The vendored SQLite amalgamation in `src/3rdparty/sqlite3/` is used on macOS and Windows. Linux prefers the
+  system SQLite when available.
 
 ### QtSingleApplication
+
 - **License:** LGPL-2.1 with Digia Qt LGPL Exception 1.1
 - **Copyright:** Copyright (C) 2014 Digia Plc and/or its subsidiary(-ies)
 - **Repository:** https://github.com/qt-creator/qt-creator
 - **Note:** Vendored from Qt Creator sources.
 
 ### QtLockedFile
+
 - **License:** LGPL-2.1 with Digia Qt LGPL Exception 1.1
 - **Copyright:** Copyright (C) 2014 Digia Plc and/or its subsidiary(-ies)
 - **Repository:** https://github.com/qt-creator/qt-creator
@@ -138,6 +166,7 @@ The exact set of redistributed binaries can vary by platform:
 ## License Texts
 
 ### MIT License
+
 ```
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -159,6 +188,7 @@ SOFTWARE.
 ```
 
 ### BSD 2-Clause License
+
 ```
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
@@ -183,6 +213,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```
 
 ### BSD 3-Clause License
+
 ```
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
@@ -211,6 +242,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```
 
 ### Apache License 2.0
+
 ```
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -226,6 +258,7 @@ limitations under the License.
 ```
 
 ### Zlib License
+
 ```
 This software is provided 'as-is', without any express or implied warranty.
 In no event will the authors be held liable for any damages arising from the
@@ -247,6 +280,7 @@ subject to the following restrictions:
 ```
 
 ### Boost Software License 1.0
+
 ```
 Boost Software License - Version 1.0 - August 17th, 2003
 
@@ -274,6 +308,7 @@ DEALINGS IN THE SOFTWARE.
 ```
 
 ### Unicode Data License
+
 ```
 COPYRIGHT AND PERMISSION NOTICE
 
@@ -311,6 +346,7 @@ authorization of the copyright holder.
 ```
 
 ### Digia Qt LGPL Exception 1.1
+
 ```
 As an additional permission to the GNU Lesser General Public License version
 2.1, the object code form of a "work that uses the Library" may incorporate
@@ -335,6 +371,7 @@ modified version of the Library.
 ```
 
 ### SQLite Public Domain Notice
+
 ```
 The author disclaims copyright to this source code. In place of a legal
 notice, here is a blessing:
@@ -345,17 +382,22 @@ notice, here is a blessing:
 ```
 
 ### GNU Lesser General Public License v2.1
-The full text of the LGPL v2.1 is available in [`src/3rdparty/LICENSE.LGPL`](src/3rdparty/LICENSE.LGPL) and at: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+
+The full text of the LGPL v2.1 is available in [`src/3rdparty/LICENSE.LGPL`](src/3rdparty/LICENSE.LGPL) and
+at: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
 
 ### GNU Lesser General Public License v3.0
+
 The full text of the LGPL v3.0 is available at:
 https://www.gnu.org/licenses/lgpl-3.0.html
 
 ### GNU General Public License v2.0
+
 The full text of the GPL v2.0 is available at:
 https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 
 ### GNU General Public License v3.0
+
 The full text of the GPL v3.0 is available at:
 https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/infomaniak-build-tools/conan/build_dependencies.ps1
+++ b/infomaniak-build-tools/conan/build_dependencies.ps1
@@ -207,7 +207,6 @@ if (-not (Test-Path -Path "infomaniak-build-tools/conan" -PathType Container))
 
 $ConanRemoteBaseFolder = Join-Path $CurrentDir "infomaniak-build-tools/conan"
 $LocalRemoteName = "localrecipes"
-$RecipesFolder = Join-Path $ConanRemoteBaseFolder "recipes"
 
 Log "Current conan home configuration:"
 & $ConanExe config home

--- a/infomaniak-build-tools/conan/build_dependencies.ps1
+++ b/infomaniak-build-tools/conan/build_dependencies.ps1
@@ -49,7 +49,7 @@
 
 param(
     [Parameter(Mandatory = $false, Position = 0, HelpMessage = "Debug, Release or RelWithDebInfo")]
-    [ValidateSet("Debug","Release", "RelWithDebInfo")]
+    [ValidateSet("Debug", "Release", "RelWithDebInfo")]
     [string]$BuildType = "Debug",
 
     [Parameter(Mandatory = $false, HelpMessage = "Show help message")]
@@ -74,49 +74,74 @@ param(
     [switch]$Update
 )
 
-function Show-Help { Write-Host "Usage: $($MyInvocation.MyCommand.Name) [-Help] [Debug|Release|RelWithDebInfo] [-CI] [-OutputDir <path>] [-MakeRelease] [-CleanCache] [-Update]" ; exit 0 }
-if ($Help) { Show-Help }
+function Show-Help
+{
+    Write-Host "Usage: $( $MyInvocation.MyCommand.Name ) [-Help] [Debug|Release|RelWithDebInfo] [-CI] [-OutputDir <path>] [-MakeRelease] [-CleanCache] [-Update]"; exit 0
+}
+if ($Help)
+{
+    Show-Help
+}
 
 $ErrorActionPreference = "Stop"
 
-function Log { Write-Host "[INFO] $($args -join ' ')" }
-function Err { Write-Error "[ERROR] $($args -join ' ')" ; exit 1 }
+function Log
+{
+    Write-Host "[INFO] $( $args -join ' ' )"
+}
+function Err
+{
+    Write-Error "[ERROR] $( $args -join ' ' )"; exit 1
+}
 
 # Determine repository root and default output directory
 $CurrentDir = (Get-Location).Path
 $DefaultOutputDir = Join-Path $CurrentDir "build-windows"
 
 # If a custom output directory is provided, use it
-if ($OutputDir) {
+if ($OutputDir)
+{
     Log "Using custom output directory: $OutputDir"
-} else {
+}
+else
+{
     $OutputDir = $DefaultOutputDir
     Log "No custom output directory provided. Using default: $OutputDir"
 }
 
 # Remove previous CMakeUserPresets.json if it exists
-if (Test-Path -Path ".\CMakeUserPresets.json") {
+if (Test-Path -Path ".\CMakeUserPresets.json")
+{
     Log "Removing previous CMakeUserPresets.json file."
     Remove-Item -Path ".\CMakeUserPresets.json" -Force
 }
 
 
 
-function Get-ConanExePath {
-    try {
+function Get-ConanExePath
+{
+    try
+    {
         $cmd = Get-Command conan.exe -ErrorAction Stop
-        Log "Conan executable found at: $($cmd.Path)"
+        Log "Conan executable found at: $( $cmd.Path )"
         return $cmd.Path
-    } catch { }
+    }
+    catch
+    {
+    }
 
-    try {
+    try
+    {
         $pythonCmd = Get-Command python -ErrorAction Stop
 
         $venvCheck = & $pythonCmd -c 'import sys; print(sys.prefix != sys.base_prefix)'
-        if($venvCheck.Trim().ToLower() -ne "true") {
+        if ($venvCheck.Trim().ToLower() -ne "true")
+        {
             Write-Warning "Python virtual environment not activated. It is recommended to install conan with a virtual env."
         }
-    } catch {
+    }
+    catch
+    {
         Err "Interpreter 'python' not found. Please install Python 3 and/or add it to the PATH."
         return $null
     }
@@ -133,9 +158,10 @@ exe = os.path.join(prefix, 'Scripts', 'conan.exe')
 print(exe)
 "@
 
-    $rawPath = & $pythonCmd.Path -c $pythonCode 2>$null
+    $rawPath = & $pythonCmd.Path -c $pythonCode 2> $null
     $exePath = $rawPath.Trim()
-    if ($LASTEXITCODE -ne 0 -or -not (Test-Path $exePath)) {
+    if ($LASTEXITCODE -ne 0 -or -not (Test-Path $exePath))
+    {
         Err "Unable to locate 'conan.exe' via Python."
         return $null
     }
@@ -145,7 +171,8 @@ print(exe)
 }
 
 # If we are running in CI mode, we activate the python virtual environment.
-if ($CI) {
+if ($CI)
+{
     # Activate the python virtual environment.
     & "C:\Program Files\Python313\.venv\Scripts\activate.ps1"
 
@@ -153,16 +180,18 @@ if ($CI) {
     & "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
     Log "CI mode enabled."
     $env:SSL_CERT_FILE = (& python -m certifi).Trim() # Because of the CI User on Windows, we need to set the SSL_CERT_FILE environment variable to the certifi bundle.
-    Log "SSL_CERT_FILE set to $($env:SSL_CERT_FILE)"
+    Log "SSL_CERT_FILE set to $( $env:SSL_CERT_FILE )"
 }
 
 # Locate Conan executable
 $ConanExe = Get-ConanExePath
-if (-not $ConanExe) {
+if (-not $ConanExe)
+{
     Err "Conan executable not found. Please ensure Conan is installed and accessible."
 }
 
-function Has-Profile {
+function Has-Profile
+{
     param(
         [string]$ProfileName
     )
@@ -171,31 +200,38 @@ function Has-Profile {
 }
 
 
-if (-not (Test-Path -Path "infomaniak-build-tools/conan" -PathType Container)) {
+if (-not (Test-Path -Path "infomaniak-build-tools/conan" -PathType Container))
+{
     Err "Please run this script from the repository root."
 }
 
 $ConanRemoteBaseFolder = Join-Path $CurrentDir "infomaniak-build-tools/conan"
-$LocalRemoteName       = "localrecipes"
-$RecipesFolder         = Join-Path $ConanRemoteBaseFolder "recipes"
+$LocalRemoteName = "localrecipes"
+$RecipesFolder = Join-Path $ConanRemoteBaseFolder "recipes"
 
 Log "Current conan home configuration:"
 & $ConanExe config home
 
-if ($MakeRelease) {
+if ($MakeRelease)
+{
     $ConanProfile = "infomaniak_release"
-    if (-not (Has-Profile -ProfileName $ConanProfile)) {
+    if (-not (Has-Profile -ProfileName $ConanProfile))
+    {
         Err "Profile '$ConanProfile' does not exist. Please create it."
     }
     $profilePath = & $ConanExe profile path $ConanProfile
-    if (-not (Get-Content $profilePath | Select-String -Pattern 'build_type=(Release|RelWithDebInfo)')) {
+    if (-not (Get-Content $profilePath | Select-String -Pattern 'build_type=(Release|RelWithDebInfo)'))
+    {
         Err "Profile '$ConanProfile' must set build_type to Release or RelWithDebInfo."
     }
-    if (Get-Content $profilePath | Select-String -Pattern 'tools.cmake.cmaketoolchain:user_toolchain') {
+    if (Get-Content $profilePath | Select-String -Pattern 'tools.cmake.cmaketoolchain:user_toolchain')
+    {
         Err "Profile '$ConanProfile' must not set tools.cmake.cmaketoolchain:user_toolchain."
     }
     Log "Using '$ConanProfile' profile for Conan."
-} else {
+}
+else
+{
     $ConanProfile = "default"
     Log "Using '$ConanProfile' profile for Conan."
 }
@@ -203,51 +239,65 @@ if ($MakeRelease) {
 # Define a Conan "Remote" pointing at the on-disk recipe folder.
 $NormalizeRemoteUrl = {
     param([string]$Url)
-    if ([string]::IsNullOrWhiteSpace($Url)) {
+    if ( [string]::IsNullOrWhiteSpace($Url))
+    {
         return ""
     }
     return ($Url -replace '\\', '/').TrimEnd('/')
 }
 
-$ExpectedRemoteUrl = try {
+$ExpectedRemoteUrl = try
+{
     (Resolve-Path -Path $ConanRemoteBaseFolder).Path
-} catch {
+}
+catch
+{
     $ConanRemoteBaseFolder
 }
 $ExpectedRemoteUrlNormalized = & $NormalizeRemoteUrl $ExpectedRemoteUrl
 
 $remotesJson = & $ConanExe remote list --format=json
-if ($LASTEXITCODE -ne 0) {
+if ($LASTEXITCODE -ne 0)
+{
     Err "Failed to list Conan remotes."
 }
 
-try {
+try
+{
     $remotes = $remotesJson | ConvertFrom-Json
-} catch {
+}
+catch
+{
     Err "Failed to parse Conan remotes JSON output."
 }
 
 $matchingRemote = $remotes | Where-Object {
     $_.name -eq $LocalRemoteName -and
-    $_.enabled -eq $true -and
-    (& $NormalizeRemoteUrl $_.url) -eq $ExpectedRemoteUrlNormalized
+            $_.enabled -eq $true -and
+            (& $NormalizeRemoteUrl $_.url) -eq $ExpectedRemoteUrlNormalized
 } | Select-Object -First 1
 
-if ($matchingRemote) {
+if ($matchingRemote)
+{
     Log "Conan remote '$LocalRemoteName' already exists, has the expected URL and is enabled."
-} else {
+}
+else
+{
     $remoteWithSameName = $remotes | Where-Object { $_.name -eq $LocalRemoteName } | Select-Object -First 1
-    if ($remoteWithSameName) {
+    if ($remoteWithSameName)
+    {
         Log "Removing Conan remote '$LocalRemoteName' because URL/enabled state does not match the expected configuration."
         & $ConanExe remote remove $LocalRemoteName
-        if ($LASTEXITCODE -ne 0) {
+        if ($LASTEXITCODE -ne 0)
+        {
             Err "Failed to remove existing Conan remote '$LocalRemoteName'."
         }
     }
 
     Log "Adding Conan remote '$LocalRemoteName' at '$ConanRemoteBaseFolder'."
     & $ConanExe remote add $LocalRemoteName $ConanRemoteBaseFolder
-    if ($LASTEXITCODE -ne 0) {
+    if ($LASTEXITCODE -ne 0)
+    {
         Err "Failed to add local Conan remote."
     }
 }
@@ -265,18 +315,20 @@ $conanInstallArgs = @(
     "-r", $LocalRemoteName,
     "-r", "conancenter",
     "-c", "tools.cmake.cmaketoolchain:generator=Ninja",
-    "-c", "tools.env.virtualenv:powershell=powershell",
-    "-o", "qt/*:qt_login_type=$qt_login_type"
+    "-c", "tools.env.virtualenv:powershell=powershell"
 )
-if ($CI) {
+if ($CI)
+{
     $conanInstallArgs += "-o"
     $conanInstallArgs += "qt/*:qt_login_type=envvars"
 }
-if ($Update) {
+if ($Update)
+{
     $conanInstallArgs += "--update"
 }
 & $ConanExe @conanInstallArgs
-if ($LASTEXITCODE -ne 0) {
+if ($LASTEXITCODE -ne 0)
+{
     Err "Failed to install Conan dependencies."
 }
 
@@ -289,20 +341,22 @@ $newUserPath = ($currentUserPath -split ';' | Where-Object { $_ -notlike "*\.con
 [System.Environment]::SetEnvironmentVariable("Path", $newUserPath, "User")
 Log "previous conan path entries removed."
 
-if ($CleanCache) {
+if ($CleanCache)
+{
     Log "Cleaning Conan cache to save disk space..."
     & $ConanExe cache clean --source --build --temp "*"
     Log "Conan cache cleaned."
 }
 
 # Update user environment variables if requested (programs will need to be restarted to see the changes)
-if ($UpdateEnvironment) {
+if ($UpdateEnvironment)
+{
     Log "Adding new conan path to user Path environment variable..."
     $currentUserPath = [System.Environment]::GetEnvironmentVariable("Path", "User")
     $allowedNames = @("build", "bin")
 
     $conanRoot = Join-Path $env:USERPROFILE ".conan2\p"
-        $conanBinPaths = Get-ChildItem -Path $conanRoot -Recurse -Include *.exe, *.dll | ForEach-Object { $_.Directory.FullName } | Sort-Object -Unique
+    $conanBinPaths = Get-ChildItem -Path $conanRoot -Recurse -Include *.exe, *.dll | ForEach-Object { $_.Directory.FullName } | Sort-Object -Unique
 
     # Get matching directories
     $conanBinPaths = Get-ChildItem -Path $conanRoot -Recurse -Include *.exe, *.dll | Sort-Object -Unique | Where-Object {
@@ -310,22 +364,25 @@ if ($UpdateEnvironment) {
         $parent = $_.Directory.Parent.Name
         $grandparent = $_.Directory.Parent.Parent.Name
         $allowedNames -contains $current -or
-        $allowedNames -contains $parent -or
-        $allowedNames -contains $grandparent
+                $allowedNames -contains $parent -or
+                $allowedNames -contains $grandparent
     } | ForEach-Object { $_.Directory.FullName } | Sort-Object -Unique
 
-    foreach ($path in $conanBinPaths) {
-        if (-not ($newUserPath -split ';' | Where-Object { $_ -eq $path })) {
+    foreach ($path in $conanBinPaths)
+    {
+        if (-not ($newUserPath -split ';' | Where-Object { $_ -eq $path }))
+        {
             Log "Adding '$path' to user Path."
             $newUserPath += ";$path"
         }
     }
-   [System.Environment]::SetEnvironmentVariable("Path", $newUserPath, "User")
-   Log "New user Path set to: $newUserPath"
-   Log "User Path environment variable updated. Please restart your programs to apply the changes."
+    [System.Environment]::SetEnvironmentVariable("Path", $newUserPath, "User")
+    Log "New user Path set to: $newUserPath"
+    Log "User Path environment variable updated. Please restart your programs to apply the changes."
 }
 
-if ($CI)  {
+if ($CI)
+{
     # Exit the python virtual environment.
     deactivate
 }

--- a/infomaniak-build-tools/conan/build_dependencies.ps1
+++ b/infomaniak-build-tools/conan/build_dependencies.ps1
@@ -1,7 +1,7 @@
 #!/usr/bin/env pwsh
 #
 # Infomaniak kDrive - Desktop
-# Copyright (C) 2023-2025 Infomaniak Network SA
+# Copyright (C) 2023-2026 Infomaniak Network SA
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/infomaniak-build-tools/conan/build_dependencies.ps1
+++ b/infomaniak-build-tools/conan/build_dependencies.ps1
@@ -25,7 +25,7 @@
     Infomaniak kDrive Desktop – build dependencies via Conan (Windows only)
 
 .DESCRIPTION
-    Usage: infomaniak-build-tools\conan\build_dependencies.ps1 [-Help] [Debug|Release|RelWithDebInfo] [-CI] [-OutputDir <path>] [-MakeRelease] [-CleanCache]
+    Usage: infomaniak-build-tools\conan\build_dependencies.ps1 [-Help] [Debug|Release|RelWithDebInfo] [-CI] [-OutputDir <path>] [-MakeRelease] [-CleanCache] [-Update]
 
 .PARAMETER BuildType
     Build configuration: Debug (default), Release or RelWithDebInfo.
@@ -41,6 +41,10 @@
 
 .PARAMETER MakeRelease
     Use the 'infomaniak_release' Conan profile.
+
+.PARAMETER Update
+    Ask Conan to check remotes for newer versions/revisions.
+    Disabled by default to keep CI deterministic and avoid local recipe revision/timestamp conflicts.
 #>
 
 param(
@@ -64,10 +68,13 @@ param(
     [switch]$UpdateEnvironment,
 
     [Parameter(Mandatory = $false, HelpMessage = "Clean the Conan cache after installation to save disk space.")]
-    [switch]$CleanCache
+    [switch]$CleanCache,
+
+    [Parameter(Mandatory = $false, HelpMessage = "Ask Conan to check remotes for newer versions/revisions.")]
+    [switch]$Update
 )
 
-function Show-Help { Write-Host "Usage: $($MyInvocation.MyCommand.Name) [-Help] [Debug|Release|RelWithDebInfo] [-CI] [-OutputDir <path>] [-MakeRelease] [-CleanCache]" ; exit 0 }
+function Show-Help { Write-Host "Usage: $($MyInvocation.MyCommand.Name) [-Help] [Debug|Release|RelWithDebInfo] [-CI] [-OutputDir <path>] [-MakeRelease] [-CleanCache] [-Update]" ; exit 0 }
 if ($Help) { Show-Help }
 
 $ErrorActionPreference = "Stop"
@@ -194,23 +201,81 @@ if ($MakeRelease) {
 }
 
 # Define a Conan "Remote" pointing at the on-disk recipe folder.
-$remotes = & $ConanExe remote list
-if (-not ($remotes -match "^$LocalRemoteName.*\[.*Enabled: True.*\]")) {
+$NormalizeRemoteUrl = {
+    param([string]$Url)
+    if ([string]::IsNullOrWhiteSpace($Url)) {
+        return ""
+    }
+    return ($Url -replace '\\', '/').TrimEnd('/')
+}
+
+$ExpectedRemoteUrl = try {
+    (Resolve-Path -Path $ConanRemoteBaseFolder).Path
+} catch {
+    $ConanRemoteBaseFolder
+}
+$ExpectedRemoteUrlNormalized = & $NormalizeRemoteUrl $ExpectedRemoteUrl
+
+$remotesJson = & $ConanExe remote list --format=json
+if ($LASTEXITCODE -ne 0) {
+    Err "Failed to list Conan remotes."
+}
+
+try {
+    $remotes = $remotesJson | ConvertFrom-Json
+} catch {
+    Err "Failed to parse Conan remotes JSON output."
+}
+
+$matchingRemote = $remotes | Where-Object {
+    $_.name -eq $LocalRemoteName -and
+    $_.enabled -eq $true -and
+    (& $NormalizeRemoteUrl $_.url) -eq $ExpectedRemoteUrlNormalized
+} | Select-Object -First 1
+
+if ($matchingRemote) {
+    Log "Conan remote '$LocalRemoteName' already exists, has the expected URL and is enabled."
+} else {
+    $remoteWithSameName = $remotes | Where-Object { $_.name -eq $LocalRemoteName } | Select-Object -First 1
+    if ($remoteWithSameName) {
+        Log "Removing Conan remote '$LocalRemoteName' because URL/enabled state does not match the expected configuration."
+        & $ConanExe remote remove $LocalRemoteName
+        if ($LASTEXITCODE -ne 0) {
+            Err "Failed to remove existing Conan remote '$LocalRemoteName'."
+        }
+    }
+
     Log "Adding Conan remote '$LocalRemoteName' at '$ConanRemoteBaseFolder'."
     & $ConanExe remote add $LocalRemoteName $ConanRemoteBaseFolder
     if ($LASTEXITCODE -ne 0) {
         Err "Failed to add local Conan remote."
     }
-} else {
-    Log "Conan remote '$LocalRemoteName' already exists and is enabled."
 }
 
 # Ensure output directory exists
 New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null # mkdir
 
 Log "Installing Conan dependencies..."
-$qt_login_type = if ($CI) { "envvars" } else { "ini" }
-& $ConanExe install . --update --output-folder="$OutputDir" --build=missing -s:a=build_type="$BuildType" --profile:all="$ConanProfile" -r $LocalRemoteName -r conancenter -c tools.cmake.cmaketoolchain:generator=Ninja -c tools.env.virtualenv:powershell=powershell -o "qt/*:qt_login_type=$qt_login_type"
+$conanInstallArgs = @(
+    "install", ".",
+    "--output-folder=$OutputDir",
+    "--build=missing",
+    "-s:a=build_type=$BuildType",
+    "--profile:all=$ConanProfile",
+    "-r", $LocalRemoteName,
+    "-r", "conancenter",
+    "-c", "tools.cmake.cmaketoolchain:generator=Ninja",
+    "-c", "tools.env.virtualenv:powershell=powershell",
+    "-o", "qt/*:qt_login_type=$qt_login_type"
+)
+if ($CI) {
+    $conanInstallArgs += "-o"
+    $conanInstallArgs += "qt/*:qt_login_type=envvars"
+}
+if ($Update) {
+    $conanInstallArgs += "--update"
+}
+& $ConanExe @conanInstallArgs
 if ($LASTEXITCODE -ne 0) {
     Err "Failed to install Conan dependencies."
 }

--- a/infomaniak-build-tools/conan/build_dependencies.sh
+++ b/infomaniak-build-tools/conan/build_dependencies.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 #
 # Infomaniak kDrive - Desktop
-# Copyright (C) 2023-2025 Infomaniak Network SA
+# Copyright (C) 2023-2026 Infomaniak Network SA
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/infomaniak-build-tools/conan/build_dependencies.sh
+++ b/infomaniak-build-tools/conan/build_dependencies.sh
@@ -26,6 +26,7 @@ build_type="Debug"
 output_dir=""
 clean_conan_cache=false
 use_release_profile=false
+enable_update=false
 # Preserve original arguments for output_dir resolution
 all_args=("$@")
 
@@ -46,13 +47,20 @@ while [[ $# -gt 0 ]]; do
       clean_conan_cache=true
       shift
       ;;
+    --update)
+      enable_update=true
+      shift
+      ;;
     -h|--help)
       cat << EOF >&2
-Usage: $0 [Debug|RelWithDebInfo|Release] [--output-dir=<output_dir>] [--make-release] [--clean-cache] [--help]
+Usage: $0 [Debug|RelWithDebInfo|Release] [--output-dir=<output_dir>] [--make-release] [--clean-cache] [--update] [--help]
   --help               Display this help message.
   --output-dir=<dir>   Set the output directory for the Conan packages.
   --make-release       Use the 'infomaniak_release' Conan profile.
   --clean-cache        Clean the Conan cache (packages sources, build folders, ...) after installation to save disk space.
+  --update             Ask Conan to check remotes for newer versions/revisions.
+                       Disabled by default to keep CI deterministic and avoid
+                       local-recipes revision/timestamp conflicts.
 
 There are three ways to set the output directory (in descending order of priority):
     1. By passing the --output-dir=<dir> parameter.
@@ -255,10 +263,28 @@ log "- Platform: '$platform'"
 log "- Architecture option: '$architecture'"
 log "- Build type: '$build_type'"
 log "- Output directory: '$output_dir'"
+log "- Conan update enabled: '$enable_update'"
 echo
 
 log "Installing dependencies..."
-conan install . --update --output-folder="$output_dir" --build=missing $architecture -s:a=build_type="$build_type" --profile:all="$conan_profile" -r=$local_recipe_remote_name -r=conancenter -vv
+
+conan_install_cmd=(
+  conan install .
+  --output-folder="$output_dir"
+  --build=missing
+  $architecture
+  -s:a=build_type="$build_type"
+  --profile:all="$conan_profile"
+  -r="$local_recipe_remote_name"
+  -r=conancenter
+  -vv
+)
+
+if [[ "$enable_update" == true ]]; then
+  conan_install_cmd+=(--update)
+fi
+
+"${conan_install_cmd[@]}"
 
 
 if [ $? -ne 0 ]; then

--- a/infomaniak-build-tools/conan/recipes/openssl-universal/config.yml
+++ b/infomaniak-build-tools/conan/recipes/openssl-universal/config.yml
@@ -1,3 +1,0 @@
-versions:
-  "3.2.4":
-    folder: 3.2.4


### PR DESCRIPTION
## Summary
The Conan install scripts were unconditionally passing `--update`, which could cause recipe revision/timestamp drift on local recipes after a checkout and introduce non-determinism in CI builds. This PR makes `--update` opt-in via an explicit flag on both the Bash and PowerShell scripts, keeping CI builds reproducible by default while still allowing on-demand remote refresh.

## Changes
- `build_dependencies.sh`: removed hardcoded `--update` from `conan install`; added `--update` flag (sets `enable_update=true`) and logs `Conan update enabled` state at runtime.
- `build_dependencies.ps1`: removed hardcoded `--update`; added `-Update` switch parameter; refactored `conan install` arguments into an array for clarity; improved remote detection to use JSON output and URL normalization instead of regex string matching.
- `build_dependencies.ps1`: cleaned up code style (consistent brace placement, indentation, string interpolation).
- `recipes/openssl-universal/config.yml`: deleted obsolete config file superseded by the `openssl-macos` recipe migration.
- `THIRD_PARTY_NOTICES.md`: updated OpenSSL macOS recipe reference from `openssl-universal` to `openssl-macos`; moved Qt and several other dependencies under the Conan-managed section; improved formatting (blank lines between entries, line wrapping for long lines).

## Technical Details
The root cause was that `--update` forces Conan to contact remotes and refresh recipe metadata, including timestamps. Even when the recipe content is identical, a new timestamp produces a different revision hash, breaking reproducibility after a clean checkout. By making the flag opt-in, CI pipelines that do not pass `--update` are fully deterministic. The PowerShell remote detection was also improved: it now parses `conan remote list --format=json` and normalizes path separators before comparing URLs, replacing the previous fragile regex match against the raw text output.

## Testing
- Bash syntax verified with `bash -n infomaniak-build-tools/conan/build_dependencies.sh`.
- Help output confirmed to include the `--update` option and its description.
- Existing CI call sites for Linux, macOS, and Windows verified to not pass `--update` / `-Update`, so no behavioral change for current pipelines.

## Notes
Manual usage when a remote refresh is needed:
- Linux/macOS: `bash infomaniak-build-tools/conan/build_dependencies.sh Release --update`
- Windows: `powershell ./infomaniak-build-tools/conan/build_dependencies.ps1 Release -Update`