### PR TITLE
feat(server): notify only on successful sync items

### DIFF
--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -2667,7 +2667,7 @@ void AppServer::addCompletedItem(int syncDbId, const SyncFileItem &item, bool no
     ServerRequests::syncFileItemToSyncFileItemInfo(item, itemInfo);
     sendSyncCompletedItem(syncDbId, itemInfo);
 
-    if (notify) {
+    if (notify && item.status() == SyncFileStatus::Success) {
         // Store notification
         Notification notification;
         notification._syncDbId = syncDbId;


### PR DESCRIPTION
Changed notification logic to store notifications only when 'notify' is true and the item's status is 'SyncFileStatus::Success', instead of just when 'notify' is true. This prevents notifications for unsuccessful syncs.