### PR TITLE
feat(winui): add back button + fix splash screen search bar

### DIFF
--- a/src/gui4/windows/kDrive client/kDrive client/App.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/App.xaml.cs
@@ -173,7 +173,6 @@ namespace Infomaniak.kDrive
                 if (options.HasFlag(CreateWindowOptions.CancelOnboarding) || !StartOnboardingIfNeeded())
                 {
                     CurrentWindow = new MainWindow();
-                    CurrentWindow.Closed += CurrentWindow_Closed;
                 }
                 else
                 {
@@ -183,15 +182,6 @@ namespace Infomaniak.kDrive
 
             if (options.HasFlag(CreateWindowOptions.Foreground))
                 Utility.BringCurrentWindowToFront();
-        }
-
-        private void CurrentWindow_Closed(object sender, WindowEventArgs e)
-        {
-            if (sender is Window window && window == CurrentWindow)
-            {
-                e.Handled = true;
-                window.Hide();
-            }
         }
 
         async void OnProcessExit(object? sender, EventArgs e)
@@ -229,8 +219,10 @@ namespace Infomaniak.kDrive
                     Logger.Log(Logger.Level.Info, "OnBoardingWindow is already open, skipping StartOnboarding call.");
                     return;
                 }
-                CurrentWindow?.Close();
+
+                var previousWindow = CurrentWindow;
                 CurrentWindow = new OnBoarding.OnBoardingWindow();
+                previousWindow?.Close();
 
                 ((OnBoarding.OnBoardingWindow)CurrentWindow).Closed += OnOnboardingClosed;
                 Utility.BringCurrentWindowToFront();
@@ -263,7 +255,6 @@ namespace Infomaniak.kDrive
         public static void ExitApplication()
         {
             Logger.Log(Logger.Level.Info, "Exiting application.");
-            (Current as App)!.CurrentWindow?.Close();
             Environment.Exit(0);
         }
 

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/AppNavigationView.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/AppNavigationView.xaml.cs
@@ -6,6 +6,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Data;
 using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Navigation;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -48,6 +49,7 @@ namespace Infomaniak.kDrive.CustomControls
                 typeof(Pages.StoragePage)
             }}
         };
+        private const int _maxStackSize = 5;
 
         public AppNavigationView()
         {
@@ -90,8 +92,21 @@ namespace Infomaniak.kDrive.CustomControls
         private void Frame_Navigated(object sender, Microsoft.UI.Xaml.Navigation.NavigationEventArgs e)
         {
             UpdateSelectedItem();
+
+            var frame = (Microsoft.UI.Xaml.Controls.Frame)sender;
+
+            TrimStack(frame.BackStack, _maxStackSize);
+            TrimStack(frame.ForwardStack, _maxStackSize);
         }
 
+        private void TrimStack(IList<PageStackEntry> stack, int maxSize)
+        {
+            while (stack.Count > maxSize)
+            {
+                // Remove oldest entry (index 0 = bottom of stack)
+                stack.RemoveAt(0);
+            }
+        }
 
         private void OnItemInvoked(NavigationView sender, NavigationViewItemInvokedEventArgs args)
         {
@@ -149,7 +164,7 @@ namespace Infomaniak.kDrive.CustomControls
 
         private Visibility GetSyncSelectorVisibility(bool isPaneOpen, IList<Sync> syncs)
         {
-            if(isPaneOpen && syncs.Count > 0)
+            if (isPaneOpen && syncs.Count > 0)
                 return Visibility.Visible;
             else
                 return Visibility.Collapsed;

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/AppTitleBar.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/AppTitleBar.xaml
@@ -13,7 +13,7 @@
           Subtitle="Beta"
           HorizontalContentAlignment="Stretch"
           IsPaneToggleButtonVisible="False"
-          IsBackButtonVisible="True"
+          IsBackButtonVisible="{x:Bind Frame.CanGoBack, Mode=OneWay}"
           BackRequested="TitleBar_BackRequested">
 
     <TitleBar.Resources>

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/AppTitleBar.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/AppTitleBar.xaml
@@ -12,7 +12,9 @@
           Title="kDrive"
           Subtitle="Beta"
           HorizontalContentAlignment="Stretch"
-          IsPaneToggleButtonVisible="False">
+          IsPaneToggleButtonVisible="False"
+          IsBackButtonVisible="True"
+          BackRequested="TitleBar_BackRequested">
 
     <TitleBar.Resources>
         <converters:StringPathToFileNameConverter x:Key="StringPathToFileNameConverter" />

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/AppTitleBar.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/AppTitleBar.xaml
@@ -33,7 +33,7 @@
               HorizontalAlignment="Center"
               VerticalAlignment="Center"
               ColumnSpacing="{StaticResource Infomaniak.Style.Spacing.S}"
-              Visibility="{x:Bind TitleBarContentVisibility(ViewModel.SelectedSync, ViewModel.UpdateRequired), Mode=OneWay}">
+              Visibility="{x:Bind TitleBarContentVisibility(ViewModel.IsInitialized , ViewModel.SelectedSync, ViewModel.UpdateRequired), Mode=OneWay}">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="auto" />
 

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/AppTitleBar.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/AppTitleBar.xaml.cs
@@ -10,6 +10,8 @@ namespace Infomaniak.kDrive.CustomControls
         public AppModel ViewModel { get; } =
            App.ServiceProvider.GetRequiredService<AppModel>();
 
+        private Frame? Frame => ((App.Current as App)?.CurrentWindow as MainWindow)?.AppNavView?.Frame ?? null;
+
         public AppTitleBar()
         {
             InitializeComponent();
@@ -23,6 +25,12 @@ namespace Infomaniak.kDrive.CustomControls
                 return Visibility.Collapsed;
 
             return Visibility.Visible;
+        }
+
+        private void TitleBar_BackRequested(TitleBar sender, object args)
+        {
+            if (Frame is not null && Frame.CanGoBack)
+                Frame?.GoBack();
         }
     }
 }

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/AppTitleBar.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/AppTitleBar.xaml.cs
@@ -15,9 +15,9 @@ namespace Infomaniak.kDrive.CustomControls
             InitializeComponent();
         }
 
-        private Visibility TitleBarContentVisibility(Sync? selectedSync, bool isUpdateRequired)
+        private Visibility TitleBarContentVisibility(bool isModelInitialized, Sync? selectedSync, bool isUpdateRequired)
         {
-            if (isUpdateRequired)
+            if (!isModelInitialized || isUpdateRequired)
                 return Visibility.Collapsed;
             if (selectedSync is null)
                 return Visibility.Collapsed;

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/LottiePlayer.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/LottiePlayer.xaml.cs
@@ -10,10 +10,47 @@ namespace Infomaniak.kDrive.CustomControls
     public sealed partial class LottiePlayer : UserControl
     {
         private int _currentPlayCount = 0;
+        private bool _isDisposed = false;
 
         public LottiePlayer()
         {
             this.InitializeComponent();
+            this.Unloaded += LottiePlayer_Unloaded;
+        }
+
+        private void LottiePlayer_Unloaded(object sender, RoutedEventArgs e)
+        {
+            Cleanup();
+        }
+
+        /// <summary>
+        /// Stops animations and releases resources to prevent memory leaks
+        /// </summary>
+        public void Cleanup()
+        {
+            if (_isDisposed)
+                return;
+
+            _isDisposed = true;
+
+            try
+            {
+                // Stop any running animation
+                AnimatedVisualPlayer?.Stop();
+
+                // Clear the visual source to release animation data
+                if (VisualSource != null)
+                {
+                    VisualSource.UriSource = null;
+                }
+
+                // Detach event handlers
+                this.Unloaded -= LottiePlayer_Unloaded;
+            }
+            catch (Exception ex)
+            {
+                Logger.Log(Logger.Level.Warning, $"Error during LottiePlayer cleanup: {ex.Message}");
+            }
         }
 
         // DependencyProperty
@@ -47,6 +84,9 @@ namespace Infomaniak.kDrive.CustomControls
         {
             if (d is LottiePlayer lottiePlayer && e.NewValue is Uri)
             {
+                if (lottiePlayer._isDisposed)
+                    return;
+
                 try
                 {
                     await lottiePlayer.UpdateLottieAsync();
@@ -60,6 +100,9 @@ namespace Infomaniak.kDrive.CustomControls
 
         private async Task UpdateLottieAsync()
         {
+            if (_isDisposed)
+                return;
+
             string fullPath = Path.Combine(AppContext.BaseDirectory, UriSource.LocalPath.TrimStart('\\', '/')).Replace("/", "\\");
             StorageFile file = await StorageFile.GetFileFromPathAsync(fullPath);
             await VisualSource.SetSourceAsync(file);
@@ -68,10 +111,13 @@ namespace Infomaniak.kDrive.CustomControls
 
         private async Task PlayAnimationAsync()
         {
+            if (_isDisposed)
+                return;
+
             if (PlayCount > 0)
             {
                 _currentPlayCount = 0;
-                while (_currentPlayCount < PlayCount)
+                while (_currentPlayCount < PlayCount && !_isDisposed)
                 {
                     await AnimatedVisualPlayer.PlayAsync(0, 1, false);
                     _currentPlayCount++;

--- a/src/gui4/windows/kDrive client/kDrive client/MainWindow.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/MainWindow.xaml.cs
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+using H.NotifyIcon;
 using Infomaniak.kDrive.CustomControls;
 using Infomaniak.kDrive.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
@@ -72,6 +73,13 @@ namespace Infomaniak.kDrive
 
         private void MainWindow_Closed(object sender, WindowEventArgs args)
         {
+            if ((App.Current as App)?.CurrentWindow == this)
+            {
+                args.Handled = true;
+                this.Hide();
+                return;
+            }
+
             ViewModel.PropertyChanged -= ViewModel_PropertyChanged;
             Closed -= MainWindow_Closed;
             this.Content.PointerPressed -= OnPointerPressed;

--- a/src/gui4/windows/kDrive client/kDrive client/MainWindow.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/MainWindow.xaml.cs
@@ -21,6 +21,7 @@ using Infomaniak.kDrive.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
 using System;
 using System.ComponentModel;
 
@@ -42,13 +43,38 @@ namespace Infomaniak.kDrive
             AppWindow.TitleBar.PreferredTheme = Microsoft.UI.Windowing.TitleBarTheme.UseDefaultAppMode;
             ViewModel.PropertyChanged += ViewModel_PropertyChanged;
             Closed += MainWindow_Closed;
+            this.Content.PointerPressed += OnPointerPressed;
+
             UpdateControlsVisibility();
+        }
+
+        private void OnPointerPressed(object sender, PointerRoutedEventArgs e)
+        {
+            var props = e.GetCurrentPoint(null).Properties;
+
+            if (props.IsXButton1Pressed) // Mouse Back button
+            {
+                if (AppNavView?.Frame?.CanGoBack == true)
+                {
+                    AppNavView?.Frame?.GoBack();
+                    e.Handled = true;
+                }
+            }
+            else if (props.IsXButton2Pressed) // Mouse Forward button
+            {
+                if (AppNavView?.Frame?.CanGoForward == true)
+                {
+                    AppNavView?.Frame?.GoForward();
+                    e.Handled = true;
+                }
+            }
         }
 
         private void MainWindow_Closed(object sender, WindowEventArgs args)
         {
             ViewModel.PropertyChanged -= ViewModel_PropertyChanged;
             Closed -= MainWindow_Closed;
+            this.Content.PointerPressed -= OnPointerPressed;
         }
 
         private void ViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/src/gui4/windows/kDrive client/kDrive client/OnBoardingWindow.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/OnBoardingWindow.xaml.cs
@@ -67,6 +67,7 @@ namespace Infomaniak.kDrive.OnBoarding
         private async void OnBoardingWindow_Closed(object sender, WindowEventArgs args)
         {
             LottiePlayer.ActualThemeChanged -= LottiePlayer_ActualThemeChanged;
+            LottiePlayer?.Cleanup();
             await _onBoardingViewModel.DisposeAsync();
         }
 

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/HomePage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/HomePage.xaml.cs
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-using Infomaniak.kDrive.Pages.Settings;
 using Infomaniak.kDrive.Types;
 using Infomaniak.kDrive.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
@@ -24,6 +23,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 
 namespace Infomaniak.kDrive.Pages
@@ -99,6 +99,45 @@ namespace Infomaniak.kDrive.Pages
         protected override void OnNavigatedFrom(NavigationEventArgs e)
         {
             DetachHandlers();
+            CleanupLottiePlayers();
+        }
+
+        private void CleanupLottiePlayers()
+        {
+            try
+            {
+                // Find and cleanup all LottiePlayer controls in the visual tree
+                var lottiePlayers = FindVisualChildren<CustomControls.LottiePlayer>(this);
+                foreach (var player in lottiePlayers)
+                {
+                    player?.Cleanup();
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Log(Logger.Level.Warning, $"Error cleaning up Lottie players: {ex.Message}");
+            }
+        }
+
+        private static IEnumerable<T> FindVisualChildren<T>(DependencyObject parent) where T : DependencyObject
+        {
+            if (parent == null)
+                yield break;
+
+            int childCount = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetChildrenCount(parent);
+            for (int i = 0; i < childCount; i++)
+            {
+                var child = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetChild(parent, i);
+                if (child is T typedChild)
+                {
+                    yield return typedChild;
+                }
+
+                foreach (var descendant in FindVisualChildren<T>(child))
+                {
+                    yield return descendant;
+                }
+            }
         }
 
         private void DetachHandlers()

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/App.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/App.cs
@@ -279,20 +279,20 @@ namespace Infomaniak.kDrive.ViewModels
                         return false;
                     }
 
-                    if (!await serverCommService.RefreshUpdaterVersionInfo(null, cts.Token))
+                    Logger.Log(Logger.Level.Info, "All server data loaded successfully.");
+                    IsInitialized = true;
+
+                    _ = serverCommService.RefreshUpdaterVersionInfo(null, CancellationToken.None).ContinueWith(task =>
                     {
                         Logger.Log(Logger.Level.Error, "Failed to refresh updater version info during AppModel initialization.");
                         // This is not critical, we can continue without this info
-                    }
+                    });
 
-                    if (!await serverCommService.ActivateLoadInfo(CancellationToken.None))
+                    _ = serverCommService.ActivateLoadInfo(CancellationToken.None).ContinueWith(task =>
                     {
                         Logger.Log(Logger.Level.Error, "Failed to ActivateLoadInfo during AppModel initialization.");
                         // This is not critical, we can continue without this info
-                    }
-
-                    Logger.Log(Logger.Level.Info, "All server data loaded successfully.");
-                    IsInitialized = true;
+                    });
                     return true;
                 }
             }

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/App.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/App.cs
@@ -282,16 +282,19 @@ namespace Infomaniak.kDrive.ViewModels
                     Logger.Log(Logger.Level.Info, "All server data loaded successfully.");
                     IsInitialized = true;
 
-                    _ = serverCommService.RefreshUpdaterVersionInfo(null, CancellationToken.None).ContinueWith(task =>
+
+                    // Refresh updater version info and load info in parallel, they are not critical for the app to function and can be slow to load
+                    _ = Task.Run(async () =>
                     {
-                        Logger.Log(Logger.Level.Error, "Failed to refresh updater version info during AppModel initialization.");
-                        // This is not critical, we can continue without this info
+                        if (!await serverCommService.RefreshUpdaterVersionInfo(null, cts.Token))
+                            Logger.Log(Logger.Level.Warning, "RefreshUpdaterVersionInfo returned false during AppModel initialization.");
+
                     });
 
-                    _ = serverCommService.ActivateLoadInfo(CancellationToken.None).ContinueWith(task =>
+                    _ = Task.Run(async () =>
                     {
-                        Logger.Log(Logger.Level.Error, "Failed to ActivateLoadInfo during AppModel initialization.");
-                        // This is not critical, we can continue without this info
+                        if (!await serverCommService.ActivateLoadInfo(cts.Token))
+                            Logger.Log(Logger.Level.Warning, "Failed to ActivateLoadInfo during AppModel initialization.");
                     });
                     return true;
                 }

--- a/src/libcommon/utility/types.h
+++ b/src/libcommon/utility/types.h
@@ -550,6 +550,7 @@ struct ExitInfo {
             // Example: "ExitInfo{Ok-Unknown}"
             return "ExitInfo{" + toString(code()) + "-" + toString(cause()) + srcLocStr() + "}";
         }
+        constexpr operator bool() const { return _code == ExitCode::Ok || _code == ExitCode::TokenRefreshed; }
         constexpr explicit operator int() const { return toInt(_code) * 100 + toInt(_cause); }
         constexpr bool operator==(const ExitInfo &other) const { return _code == other._code && _cause == other._cause; }
         constexpr bool operator!=(const ExitInfo &other) const { return !(*this == other); }

--- a/src/libcommon/utility/types.h
+++ b/src/libcommon/utility/types.h
@@ -550,7 +550,6 @@ struct ExitInfo {
             // Example: "ExitInfo{Ok-Unknown}"
             return "ExitInfo{" + toString(code()) + "-" + toString(cause()) + srcLocStr() + "}";
         }
-        constexpr operator bool() const { return _code == ExitCode::Ok || _code == ExitCode::TokenRefreshed; }
         constexpr explicit operator int() const { return toInt(_code) * 100 + toInt(_cause); }
         constexpr bool operator==(const ExitInfo &other) const { return _code == other._code && _cause == other._cause; }
         constexpr bool operator!=(const ExitInfo &other) const { return !(*this == other); }


### PR DESCRIPTION
## Navigation and Window Management Improvements

### Navigation enhancements

* Added support for **mouse back/forward buttons** in `MainWindow` to navigate the frame history.
* Ensured proper cleanup of navigation-related event handlers when the window is closed.

### Title bar improvements

* Updated `AppTitleBar` to dynamically show or hide the back button based on navigation state.
* Added support for handling back navigation requests directly from the title bar, improving consistency in navigation behavior.

### Navigation stack optimization

* Introduced a limit on the size of back/forward navigation stacks in `AppNavigationView`.
* This prevents unbounded memory growth and improves long-term performance.

### Window lifecycle cleanup

* Refactored window creation and closing logic to:

  * Remove redundant event handlers
  * Prefer **hiding windows instead of closing them**
* This reduces potential side effects and improves overall UX stability.

---

## Resource and Memory Management

### Lottie animation cleanup

* Added a `Cleanup` method in `LottiePlayer` to:

  * Stop ongoing animations
  * Release associated resources when the control is unloaded

* This cleanup is now consistently triggered when:

  * The control is unloaded
  * The onboarding window is closed or navigated away from
  * The home page is left

### Visual tree cleanup

* Introduced a recursive cleanup utility to locate and dispose all `LottiePlayer` instances in the visual tree.
* Ensures no orphaned animations remain active, preventing memory leaks.

---

## Asynchronous Initialization Improvements

* Updated `AppModel` initialization to move non-critical operations (such as server info refresh) to background execution.
* This improves startup performance and allows the application to become usable sooner.
