### PR TITLE
ci(release): merge safety checks and upload into one toggle

### DIFF
--- a/.github/workflows/kdrive-desktop-release.yml
+++ b/.github/workflows/kdrive-desktop-release.yml
@@ -28,6 +28,10 @@ on:
         type: boolean
         description: Upload builds to kDrive
         default: true
+      for_testing_only:
+        type: boolean
+        description: For testing only
+        default: false
 
 concurrency:
   group: kDrive-desktop-release-${{ github.head_ref }}
@@ -54,6 +58,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check translations
+        if: ${{ !inputs.for_testing_only }}
         run: |
              cd translations\updateTool
              $result = .\Windows.ps1
@@ -79,6 +84,12 @@ jobs:
                  exit 0
              }
 
+      - name: Skip translations check in testing mode
+        if: ${{ inputs.for_testing_only }}
+        run: |
+             Write-Host "For testing only mode enabled: translations check skipped."
+             "<h1>:warning: For testing only mode: translations check skipped.</h1>" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+
 # Check Release Notes
   check-release-notes:
     runs-on: [ self-hosted, Linux, X64 ]
@@ -91,6 +102,7 @@ jobs:
         uses: ./.github/actions/get_version
 
       - name: Check release notes
+        if: ${{ !inputs.for_testing_only }}
         run: |
           VERSION_NUMBER="${{ steps.get-version.outputs.kDrive_version }}"  # Example: 3.9.20.23
           VERSION_NUMBER="${VERSION_NUMBER%.*}"  # Remove build number for release notes check
@@ -130,6 +142,13 @@ jobs:
             echo "</tr>"
             echo "</table>"
           } >> $GITHUB_STEP_SUMMARY
+        shell: bash
+
+      - name: Skip release notes check in testing mode
+        if: ${{ inputs.for_testing_only }}
+        run: |
+          echo "For testing only mode enabled: release notes check skipped."
+          echo "<h1>:warning: For testing only mode: release notes check skipped.</h1>" >> $GITHUB_STEP_SUMMARY
         shell: bash
 
 # Build apps
@@ -226,7 +245,7 @@ jobs:
           merge-multiple: true
 
       - name: Upload debug files and installers/appimage to kDrive
-        run: powershell ./infomaniak-build-tools/upload-release-to-kDrive.ps1 -version "${{ steps.get-version.outputs.kDrive_version }}" -os "win"
+        run: powershell ./infomaniak-build-tools/upload-release-to-kDrive.ps1 -version "${{ steps.get-version.outputs.kDrive_version }}" -os "win" -SkipReleaseNotesUpload:${{ inputs.for_testing_only }}
 
       - name: Download sentry-cli and login
         run: |
@@ -268,7 +287,7 @@ jobs:
           merge-multiple: true
 
       - name: Upload debug files and installers/appimage to kDrive
-        run: powershell ./infomaniak-build-tools/upload-release-to-kDrive.ps1 -version "${{ steps.get-version.outputs.kDrive_version }}" -os "linux-amd"
+        run: powershell ./infomaniak-build-tools/upload-release-to-kDrive.ps1 -version "${{ steps.get-version.outputs.kDrive_version }}" -os "linux-amd" -SkipReleaseNotesUpload:${{ inputs.for_testing_only }}
 
       - name: Download sentry-cli and login
         run: |
@@ -310,7 +329,7 @@ jobs:
           merge-multiple: true
 
       - name: Upload debug files and installers/appimage to kDrive
-        run: powershell ./infomaniak-build-tools/upload-release-to-kDrive.ps1 -version "${{ steps.get-version.outputs.kDrive_version }}" -os "linux-arm"
+        run: powershell ./infomaniak-build-tools/upload-release-to-kDrive.ps1 -version "${{ steps.get-version.outputs.kDrive_version }}" -os "linux-arm" -SkipReleaseNotesUpload:${{ inputs.for_testing_only }}
 
       - name: Download sentry-cli and login
         run: |
@@ -352,7 +371,7 @@ jobs:
           merge-multiple: true
 
       - name: Upload debug files and installers/appimage to kDrive
-        run: powershell ./infomaniak-build-tools/upload-release-to-kDrive.ps1 -version "${{ steps.get-version.outputs.kDrive_version }}" -os "macos"
+        run: powershell ./infomaniak-build-tools/upload-release-to-kDrive.ps1 -version "${{ steps.get-version.outputs.kDrive_version }}" -os "macos" -SkipReleaseNotesUpload:${{ inputs.for_testing_only }}
 
       - name: Download sentry-cli and login
         run: |

--- a/.github/workflows/kdrive-desktop-release.yml
+++ b/.github/workflows/kdrive-desktop-release.yml
@@ -24,14 +24,10 @@ on:
           - arm64
           - none
         default: all
-      upload_to_kdrive:
+      enable_safety_checks_and_upload_builds_to_kdrive:
         type: boolean
-        description: Upload builds to kDrive
+        description: Enable safety checks and upload builds to kDrive
         default: true
-      for_testing_only:
-        type: boolean
-        description: For testing only
-        default: false
 
 concurrency:
   group: kDrive-desktop-release-${{ github.head_ref }}
@@ -58,7 +54,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check translations
-        if: ${{ !inputs.for_testing_only }}
+        if: ${{ inputs.enable_safety_checks_and_upload_builds_to_kdrive }}
         run: |
              cd translations\updateTool
              $result = .\Windows.ps1
@@ -84,11 +80,11 @@ jobs:
                  exit 0
              }
 
-      - name: Skip translations check in testing mode
-        if: ${{ inputs.for_testing_only }}
+      - name: Skip translations check
+        if: ${{ !inputs.enable_safety_checks_and_upload_builds_to_kdrive }}
         run: |
-             Write-Host "For testing only mode enabled: translations check skipped."
-             "<h1>:warning: For testing only mode: translations check skipped.</h1>" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+             Write-Host "Safety checks and uploads are disabled: translations check skipped."
+             "<h1>:warning: Safety checks disabled: translations check skipped.</h1>" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
 
 # Check Release Notes
   check-release-notes:
@@ -102,7 +98,7 @@ jobs:
         uses: ./.github/actions/get_version
 
       - name: Check release notes
-        if: ${{ !inputs.for_testing_only }}
+        if: ${{ inputs.enable_safety_checks_and_upload_builds_to_kdrive }}
         run: |
           VERSION_NUMBER="${{ steps.get-version.outputs.kDrive_version }}"  # Example: 3.9.20.23
           VERSION_NUMBER="${VERSION_NUMBER%.*}"  # Remove build number for release notes check
@@ -144,11 +140,11 @@ jobs:
           } >> $GITHUB_STEP_SUMMARY
         shell: bash
 
-      - name: Skip release notes check in testing mode
-        if: ${{ inputs.for_testing_only }}
+      - name: Skip release notes check
+        if: ${{ !inputs.enable_safety_checks_and_upload_builds_to_kdrive }}
         run: |
-          echo "For testing only mode enabled: release notes check skipped."
-          echo "<h1>:warning: For testing only mode: release notes check skipped.</h1>" >> $GITHUB_STEP_SUMMARY
+          echo "Safety checks and uploads are disabled: release notes check skipped."
+          echo "<h1>:warning: Safety checks disabled: release notes check skipped.</h1>" >> $GITHUB_STEP_SUMMARY
         shell: bash
 
 # Build apps
@@ -220,7 +216,7 @@ jobs:
 
 # Upload the installer and sentry artifacts
   upload-to-kDrive-and-sentry-Windows:
-    if: ${{ inputs.build_windows && inputs.upload_to_kdrive }}
+    if: ${{ inputs.build_windows && inputs.enable_safety_checks_and_upload_builds_to_kdrive }}
     needs: [build-Windows]
     runs-on: [self-hosted, Windows, desktop-kdrive-with-gui] # Could be runing on any windows runner, but we use 'desktop-kdrive-with-gui' to avoid monopolizing the runners that are used for the CI builds.
     env:
@@ -245,7 +241,7 @@ jobs:
           merge-multiple: true
 
       - name: Upload debug files and installers/appimage to kDrive
-        run: powershell ./infomaniak-build-tools/upload-release-to-kDrive.ps1 -version "${{ steps.get-version.outputs.kDrive_version }}" -os "win" -SkipReleaseNotesUpload:${{ inputs.for_testing_only }}
+        run: powershell ./infomaniak-build-tools/upload-release-to-kDrive.ps1 -version "${{ steps.get-version.outputs.kDrive_version }}" -os "win"
 
       - name: Download sentry-cli and login
         run: |
@@ -262,7 +258,7 @@ jobs:
         shell: powershell
 
   upload-to-kDrive-and-sentry-Linux-amd:
-    if: ${{ (inputs.build_linux == 'all' || inputs.build_linux == 'amd64') && inputs.upload_to_kdrive }}
+    if: ${{ (inputs.build_linux == 'all' || inputs.build_linux == 'amd64') && inputs.enable_safety_checks_and_upload_builds_to_kdrive }}
     needs: [build-Linux-amd]
     runs-on: [self-hosted, Windows, desktop-kdrive-with-gui] # Could be running on any windows runner, but we use 'desktop-kdrive-with-gui' to avoid monopolizing the runners that are used for the CI builds.
     env:
@@ -287,7 +283,7 @@ jobs:
           merge-multiple: true
 
       - name: Upload debug files and installers/appimage to kDrive
-        run: powershell ./infomaniak-build-tools/upload-release-to-kDrive.ps1 -version "${{ steps.get-version.outputs.kDrive_version }}" -os "linux-amd" -SkipReleaseNotesUpload:${{ inputs.for_testing_only }}
+        run: powershell ./infomaniak-build-tools/upload-release-to-kDrive.ps1 -version "${{ steps.get-version.outputs.kDrive_version }}" -os "linux-amd"
 
       - name: Download sentry-cli and login
         run: |
@@ -304,7 +300,7 @@ jobs:
         shell: powershell
 
   upload-to-kDrive-and-sentry-Linux-arm:
-    if: ${{ (inputs.build_linux == 'all' || inputs.build_linux == 'arm64') && inputs.upload_to_kdrive }}
+    if: ${{ (inputs.build_linux == 'all' || inputs.build_linux == 'arm64') && inputs.enable_safety_checks_and_upload_builds_to_kdrive }}
     needs: [build-Linux-arm]
     runs-on: [self-hosted, Windows, desktop-kdrive-with-gui] # Could be running on any windows runner, but we use 'desktop-kdrive-with-gui' to avoid monopolizing the runners that are used for the CI builds.
     env:
@@ -329,7 +325,7 @@ jobs:
           merge-multiple: true
 
       - name: Upload debug files and installers/appimage to kDrive
-        run: powershell ./infomaniak-build-tools/upload-release-to-kDrive.ps1 -version "${{ steps.get-version.outputs.kDrive_version }}" -os "linux-arm" -SkipReleaseNotesUpload:${{ inputs.for_testing_only }}
+        run: powershell ./infomaniak-build-tools/upload-release-to-kDrive.ps1 -version "${{ steps.get-version.outputs.kDrive_version }}" -os "linux-arm"
 
       - name: Download sentry-cli and login
         run: |
@@ -346,7 +342,7 @@ jobs:
         shell: powershell
 
   upload-to-kDrive-and-sentry-macOS:
-    if: ${{ inputs.build_macos && inputs.upload_to_kdrive }}
+    if: ${{ inputs.build_macos && inputs.enable_safety_checks_and_upload_builds_to_kdrive }}
     needs: [build-MacOS]
     runs-on: [self-hosted, Windows, desktop-kdrive-with-gui] # Could be running on any windows runner, but we use 'desktop-kdrive-with-gui' to avoid monopolizing the runners that are used for the CI builds.
     env:
@@ -371,7 +367,7 @@ jobs:
           merge-multiple: true
 
       - name: Upload debug files and installers/appimage to kDrive
-        run: powershell ./infomaniak-build-tools/upload-release-to-kDrive.ps1 -version "${{ steps.get-version.outputs.kDrive_version }}" -os "macos" -SkipReleaseNotesUpload:${{ inputs.for_testing_only }}
+        run: powershell ./infomaniak-build-tools/upload-release-to-kDrive.ps1 -version "${{ steps.get-version.outputs.kDrive_version }}" -os "macos"
 
       - name: Download sentry-cli and login
         run: |

--- a/infomaniak-build-tools/upload-release-to-kDrive.ps1
+++ b/infomaniak-build-tools/upload-release-to-kDrive.ps1
@@ -20,7 +20,9 @@ param (
     [string]$version,
 
     [ValidateSet('win', 'macos', 'linux-arm', 'linux-amd')]
-    [string] $os
+    [string] $os,
+
+    [switch]$SkipReleaseNotesUpload
 )
 
 if (-not $env:KDRIVE_TOKEN) {
@@ -55,50 +57,54 @@ $headers = @{
     Authorization="Bearer $env:KDRIVE_TOKEN"
 }
 
-# upload release notes
-$languages = @(
-    "de",
-    "en",
-    "es",
-    "fr",
-    "it"
-)
+if ($SkipReleaseNotesUpload) {
+    Write-Host "For testing only mode enabled: release notes upload skipped." -f Yellow
+} else {
+    # upload release notes
+    $languages = @(
+        "de",
+        "en",
+        "es",
+        "fr",
+        "it"
+    )
 
-$simplifiedOs = $os
-if ($simplifiedOs -eq "linux-arm" -Or $simplifiedOs -eq "linux-amd") {
-    $simplifiedOs = "linux"
-}
-
-foreach ($lang in $languages)
-{
-    $fileName = "kDrive-$versionNumber-$simplifiedOs-$lang.html"
-
-    $filePath = ".\release_notes\kDrive-$versionNumber\$fileName"
-    if (-not (Test-Path $filePath)) {
-        Write-Host "❌ File $filePath does not exist, aborting upload." -f Red
-        exit 1
+    $simplifiedOs = $os
+    if ($simplifiedOs -eq "linux-arm" -Or $simplifiedOs -eq "linux-amd") {
+        $simplifiedOs = "linux"
     }
 
-    $size = (Get-ChildItem $filePath | % {[int]($_.length)})
-    if ($size -eq 0) {
-        Write-Host "Unable to get file size for $filePath, aborting upload." -f Red
-        Pop-Location
-        exit 1
+    foreach ($lang in $languages)
+    {
+        $fileName = "kDrive-$versionNumber-$simplifiedOs-$lang.html"
+
+        $filePath = ".\release_notes\kDrive-$versionNumber\$fileName"
+        if (-not (Test-Path $filePath)) {
+            Write-Host "❌ File $filePath does not exist, aborting upload." -f Red
+            exit 1
+        }
+
+        $size = (Get-ChildItem $filePath | % {[int]($_.length)})
+        if ($size -eq 0) {
+            Write-Host "Unable to get file size for $filePath, aborting upload." -f Red
+            Pop-Location
+            exit 1
+        }
+
+        $uri = "https://api.infomaniak.com/3/drive/$env:KDRIVE_ID/upload?directory_id=$env:KDRIVE_DIR_ID&total_size=$size&file_name=$fileName&directory_path=$versionNumber/$buildNumber/release-notes&conflict=version"
+        Write-Host "uploading $filePath to kDrive at $uri"
+        $result = Invoke-RestMethod -Method "POST" -Uri $uri -Header $headers -ContentType 'application/octet-stream' -InFile $filePath
+        Write-Host "Uploaded $filePath to kDrive successfully. $result" -f Green
+        Sleep(5)
+
+        # Upload legacy file name as well so that older versions (pre 3.7.5) can retrieve the latest release notes
+        $legacyFileName = "kDrive-$fullVersionNumber-$simplifiedOs-$lang.html"
+        $uri = "https://api.infomaniak.com/3/drive/$env:KDRIVE_ID/upload?directory_id=$env:KDRIVE_DIR_ID&total_size=$size&file_name=$legacyFileName&directory_path=$versionNumber/$buildNumber/release-notes&conflict=version"
+        Write-Host "uploading $filePath to kDrive at $uri"
+        $result = Invoke-RestMethod -Method "POST" -Uri $uri -Header $headers -ContentType 'application/octet-stream' -InFile $filePath
+        Write-Host "Uploaded $filePath to kDrive successfully. $result" -f Green
+        Sleep(5)
     }
-
-    $uri = "https://api.infomaniak.com/3/drive/$env:KDRIVE_ID/upload?directory_id=$env:KDRIVE_DIR_ID&total_size=$size&file_name=$fileName&directory_path=$versionNumber/$buildNumber/release-notes&conflict=version"
-    Write-Host "uploading $filePath to kDrive at $uri"
-    $result = Invoke-RestMethod -Method "POST" -Uri $uri -Header $headers -ContentType 'application/octet-stream' -InFile $filePath
-    Write-Host "Uploaded $filePath to kDrive successfully. $result" -f Green
-    Sleep(5)
-
-    # Upload legacy file name as well so that older versions (pre 3.7.5) can retrieve the latest release notes
-    $legacyFileName = "kDrive-$fullVersionNumber-$simplifiedOs-$lang.html"
-    $uri = "https://api.infomaniak.com/3/drive/$env:KDRIVE_ID/upload?directory_id=$env:KDRIVE_DIR_ID&total_size=$size&file_name=$legacyFileName&directory_path=$versionNumber/$buildNumber/release-notes&conflict=version"
-    Write-Host "uploading $filePath to kDrive at $uri"
-    $result = Invoke-RestMethod -Method "POST" -Uri $uri -Header $headers -ContentType 'application/octet-stream' -InFile $filePath
-    Write-Host "Uploaded $filePath to kDrive successfully. $result" -f Green
-    Sleep(5)
 }
 
 function Upload-FilesToKDrive {

--- a/infomaniak-build-tools/upload-release-to-kDrive.ps1
+++ b/infomaniak-build-tools/upload-release-to-kDrive.ps1
@@ -20,9 +20,7 @@ param (
     [string]$version,
 
     [ValidateSet('win', 'macos', 'linux-arm', 'linux-amd')]
-    [string] $os,
-
-    [switch]$SkipReleaseNotesUpload
+    [string] $os
 )
 
 if (-not $env:KDRIVE_TOKEN) {
@@ -57,54 +55,50 @@ $headers = @{
     Authorization="Bearer $env:KDRIVE_TOKEN"
 }
 
-if ($SkipReleaseNotesUpload) {
-    Write-Host "For testing only mode enabled: release notes upload skipped." -f Yellow
-} else {
-    # upload release notes
-    $languages = @(
-        "de",
-        "en",
-        "es",
-        "fr",
-        "it"
-    )
+# upload release notes
+$languages = @(
+    "de",
+    "en",
+    "es",
+    "fr",
+    "it"
+)
 
-    $simplifiedOs = $os
-    if ($simplifiedOs -eq "linux-arm" -Or $simplifiedOs -eq "linux-amd") {
-        $simplifiedOs = "linux"
+$simplifiedOs = $os
+if ($simplifiedOs -eq "linux-arm" -Or $simplifiedOs -eq "linux-amd") {
+    $simplifiedOs = "linux"
+}
+
+foreach ($lang in $languages)
+{
+    $fileName = "kDrive-$versionNumber-$simplifiedOs-$lang.html"
+
+    $filePath = ".\release_notes\kDrive-$versionNumber\$fileName"
+    if (-not (Test-Path $filePath)) {
+        Write-Host "❌ File $filePath does not exist, aborting upload." -f Red
+        exit 1
     }
 
-    foreach ($lang in $languages)
-    {
-        $fileName = "kDrive-$versionNumber-$simplifiedOs-$lang.html"
-
-        $filePath = ".\release_notes\kDrive-$versionNumber\$fileName"
-        if (-not (Test-Path $filePath)) {
-            Write-Host "❌ File $filePath does not exist, aborting upload." -f Red
-            exit 1
-        }
-
-        $size = (Get-ChildItem $filePath | % {[int]($_.length)})
-        if ($size -eq 0) {
-            Write-Host "Unable to get file size for $filePath, aborting upload." -f Red
-            Pop-Location
-            exit 1
-        }
-
-        $uri = "https://api.infomaniak.com/3/drive/$env:KDRIVE_ID/upload?directory_id=$env:KDRIVE_DIR_ID&total_size=$size&file_name=$fileName&directory_path=$versionNumber/$buildNumber/release-notes&conflict=version"
-        Write-Host "uploading $filePath to kDrive at $uri"
-        $result = Invoke-RestMethod -Method "POST" -Uri $uri -Header $headers -ContentType 'application/octet-stream' -InFile $filePath
-        Write-Host "Uploaded $filePath to kDrive successfully. $result" -f Green
-        Sleep(5)
-
-        # Upload legacy file name as well so that older versions (pre 3.7.5) can retrieve the latest release notes
-        $legacyFileName = "kDrive-$fullVersionNumber-$simplifiedOs-$lang.html"
-        $uri = "https://api.infomaniak.com/3/drive/$env:KDRIVE_ID/upload?directory_id=$env:KDRIVE_DIR_ID&total_size=$size&file_name=$legacyFileName&directory_path=$versionNumber/$buildNumber/release-notes&conflict=version"
-        Write-Host "uploading $filePath to kDrive at $uri"
-        $result = Invoke-RestMethod -Method "POST" -Uri $uri -Header $headers -ContentType 'application/octet-stream' -InFile $filePath
-        Write-Host "Uploaded $filePath to kDrive successfully. $result" -f Green
-        Sleep(5)
+    $size = (Get-ChildItem $filePath | % {[int]($_.length)})
+    if ($size -eq 0) {
+        Write-Host "Unable to get file size for $filePath, aborting upload." -f Red
+        Pop-Location
+        exit 1
     }
+
+    $uri = "https://api.infomaniak.com/3/drive/$env:KDRIVE_ID/upload?directory_id=$env:KDRIVE_DIR_ID&total_size=$size&file_name=$fileName&directory_path=$versionNumber/$buildNumber/release-notes&conflict=version"
+    Write-Host "uploading $filePath to kDrive at $uri"
+    $result = Invoke-RestMethod -Method "POST" -Uri $uri -Header $headers -ContentType 'application/octet-stream' -InFile $filePath
+    Write-Host "Uploaded $filePath to kDrive successfully. $result" -f Green
+    Sleep(5)
+
+    # Upload legacy file name as well so that older versions (pre 3.7.5) can retrieve the latest release notes
+    $legacyFileName = "kDrive-$fullVersionNumber-$simplifiedOs-$lang.html"
+    $uri = "https://api.infomaniak.com/3/drive/$env:KDRIVE_ID/upload?directory_id=$env:KDRIVE_DIR_ID&total_size=$size&file_name=$legacyFileName&directory_path=$versionNumber/$buildNumber/release-notes&conflict=version"
+    Write-Host "uploading $filePath to kDrive at $uri"
+    $result = Invoke-RestMethod -Method "POST" -Uri $uri -Header $headers -ContentType 'application/octet-stream' -InFile $filePath
+    Write-Host "Uploaded $filePath to kDrive successfully. $result" -f Green
+    Sleep(5)
 }
 
 function Upload-FilesToKDrive {


### PR DESCRIPTION
﻿## Summary
This draft PR simplifies the release workflow control into a single checkbox.
## Changes
- Replace the two workflow dispatch inputs (`upload_to_kdrive` and `for_testing_only`) with one boolean input:
  - `enable_safety_checks_and_upload_builds_to_kdrive`
  - description: "Enable safety checks and upload builds to kDrive"
  - default: checked (`true`)
- When enabled (`true`):
  - translation checks run
  - release notes checks run
  - upload jobs run and upload binaries + release notes
- When disabled (`false`):
  - translation checks are skipped
  - release notes checks are skipped
  - all upload jobs are skipped (no binaries, no release notes upload)
- Remove the temporary `-SkipReleaseNotesUpload` workflow wiring and revert the PowerShell script to its standard behavior when invoked.
## Why
This creates a single, explicit release safety gate and avoids inconsistent combinations between test mode and upload mode.
