### PR TITLE
feat(getappversionjob): improve version channel handling

### DIFF
--- a/src/libsyncengine/jobs/network/infomaniak_API/getappversionjob.cpp
+++ b/src/libsyncengine/jobs/network/infomaniak_API/getappversionjob.cpp
@@ -145,6 +145,10 @@ ExitInfo GetAppVersionJob::handleResponse(std::istream &is) {
             return {ExitCode::BackError, ExitCause::MissingReplyData};
 
         const VersionChannel channel = toDistributionChannel(versionType);
+        if (channel == VersionChannel::Unknown) {
+            LOG_INFO(_logger, "Skipping unknown version channel: " << versionType);
+            continue;
+        }
         _versionsInfo[channel].channel = channel;
 
         if (!JsonParserUtility::extractValue(obj, tagKey, _versionsInfo[channel].tag))
@@ -157,8 +161,13 @@ ExitInfo GetAppVersionJob::handleResponse(std::istream &is) {
             return {ExitCode::BackError, ExitCause::MissingReplyData};
 
         if (!_versionsInfo[channel].isValid()) {
-            LOG_WARN(_logger, "Missing mandatory value.");
-            return {ExitCode::BackError, ExitCause::MissingReplyData};
+            if (channel == VersionChannel::Prod) {
+                LOG_ERROR(_logger, "Missing mandatory value for production version");
+                return {ExitCode::BackError, ExitCause::MissingReplyData};
+            } else {
+                LOG_WARN(_logger, "Missing mandatory value for channel: " << versionType);
+                continue;
+            }
         }
     }
 

--- a/src/libsyncengine/jobs/network/infomaniak_API/getappversionjob.cpp
+++ b/src/libsyncengine/jobs/network/infomaniak_API/getappversionjob.cpp
@@ -151,25 +151,21 @@ ExitInfo GetAppVersionJob::handleResponse(std::istream &is) {
         }
         _versionsInfo[channel].channel = channel;
 
-        if (!JsonParserUtility::extractValue(obj, tagKey, _versionsInfo[channel].tag))
-            return {ExitCode::BackError, ExitCause::MissingReplyData};
-        if (!JsonParserUtility::extractValue(obj, buildVersionKey, _versionsInfo[channel].buildVersion))
-            return {ExitCode::BackError, ExitCause::MissingReplyData};
-        if (!JsonParserUtility::extractValue(obj, buildMinOsVersionKey, _versionsInfo[channel].buildMinOsVersion))
-            return {ExitCode::BackError, ExitCause::MissingReplyData};
-        if (!JsonParserUtility::extractValue(obj, downloadUrlKey, _versionsInfo[channel].downloadUrl))
-            return {ExitCode::BackError, ExitCause::MissingReplyData};
+        (void) JsonParserUtility::extractValue(obj, tagKey, _versionsInfo[channel].tag);
+        (void) JsonParserUtility::extractValue(obj, buildVersionKey, _versionsInfo[channel].buildVersion);
+        (void) JsonParserUtility::extractValue(obj, buildMinOsVersionKey, _versionsInfo[channel].buildMinOsVersion);
+        (void) JsonParserUtility::extractValue(obj, downloadUrlKey, _versionsInfo[channel].downloadUrl);
 
         if (!_versionsInfo[channel].isValid()) {
             if (channel == VersionChannel::Prod) {
                 LOG_ERROR(_logger, "Missing mandatory value for production version");
                 _versionsInfo.clear();
                 return {ExitCode::BackError, ExitCause::MissingReplyData};
-            } else {
-                (void) _versionsInfo.erase(channel);
-                LOG_WARN(_logger, "Missing mandatory value for channel: " << versionType);
-                continue;
             }
+
+            (void) _versionsInfo.erase(channel);
+            LOG_WARN(_logger, "Missing mandatory value for channel: " << versionType);
+            continue;
         }
     }
 

--- a/src/libsyncengine/jobs/network/infomaniak_API/getappversionjob.cpp
+++ b/src/libsyncengine/jobs/network/infomaniak_API/getappversionjob.cpp
@@ -163,8 +163,10 @@ ExitInfo GetAppVersionJob::handleResponse(std::istream &is) {
         if (!_versionsInfo[channel].isValid()) {
             if (channel == VersionChannel::Prod) {
                 LOG_ERROR(_logger, "Missing mandatory value for production version");
+                _versionsInfo.clear();
                 return {ExitCode::BackError, ExitCause::MissingReplyData};
             } else {
+                (void) _versionsInfo.erase(channel);
                 LOG_WARN(_logger, "Missing mandatory value for channel: " << versionType);
                 continue;
             }

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -62,6 +62,8 @@
 #include "test_utility/iohelpertestutilities.h"
 #include "update_detection/file_system_observer/snapshot/snapshotitem.h"
 
+#include <sstream>
+
 using namespace CppUnit;
 
 namespace KDC {
@@ -87,6 +89,48 @@ static const NodeId testDummyFileRemoteId = "98649"; // test_ci/dummy_dir/pictur
 static const std::string desktopTeamTestDriveName = "kDrive Desktop Team";
 static const std::string dummyDirName = "dummy_dir";
 static const std::string dummyFileName = "picture.jpg";
+
+class GetAppVersionJobForTests final : public GetAppVersionJob {
+    public:
+        GetAppVersionJobForTests(const Platform platform, const std::string &appID) :
+            GetAppVersionJob(platform, appID) {}
+
+        ExitInfo parseResponse(const std::string &response) {
+            const std::istringstream iss(response);
+            std::istream is(iss.rdbuf());
+            return handleResponse(is);
+        }
+};
+
+Poco::JSON::Object buildPublishedVersion(const std::string &channel, const bool includeTag = true) {
+    Poco::JSON::Object versionObj;
+    if (includeTag) {
+        (void) versionObj.set("tag", "3.6.4");
+    }
+    (void) versionObj.set("type", channel);
+    (void) versionObj.set("build_version", 20240816);
+    (void) versionObj.set("build_min_os_version", "10.15");
+    (void) versionObj.set("download_link", "https://download.example.com/kDrive.pkg");
+    return versionObj;
+}
+
+std::string buildAppVersionReply(const Poco::JSON::Array &publishedVersions) {
+    Poco::JSON::Object applicationObj;
+    (void) applicationObj.set("min_version", "3.6.0.0");
+    (void) applicationObj.set("published_versions", publishedVersions);
+
+    Poco::JSON::Object dataObj;
+    (void) dataObj.set("prod_version", "production");
+    (void) dataObj.set("application", applicationObj);
+
+    Poco::JSON::Object mainObj;
+    (void) mainObj.set("result", "success");
+    (void) mainObj.set("data", dataObj);
+
+    std::ostringstream out;
+    mainObj.stringify(out);
+    return out.str();
+}
 
 } // namespace
 
@@ -1542,6 +1586,37 @@ void TestNetworkJobs::testGetAppVersionInfo() {
     //     CPPUNIT_ASSERT(job.getVersionInfo(VersionChannel::Prod).isValid());
     //     CPPUNIT_ASSERT(job.getProdVersionInfo().isValid());
     // }
+}
+
+void TestNetworkJobs::testGetAppVersionInfoParsingEdgeCases() {
+    const auto appUid = "1234567890";
+
+    {
+        GetAppVersionJobForTests job(CommonUtility::platform(), appUid);
+        Poco::JSON::Array publishedVersions;
+        (void) publishedVersions.add(buildPublishedVersion("production"));
+        (void) publishedVersions.add(buildPublishedVersion("beta", false));
+        (void) publishedVersions.add(buildPublishedVersion("unknown"));
+
+        const ExitInfo exitInfo = job.parseResponse(buildAppVersionReply(publishedVersions));
+
+        CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, exitInfo.code());
+        CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(1), job.versionsInfo().size());
+        CPPUNIT_ASSERT(job.versionsInfo().contains(VersionChannel::Prod));
+        CPPUNIT_ASSERT(!job.versionsInfo().contains(VersionChannel::Beta));
+    }
+
+    {
+        GetAppVersionJobForTests job(CommonUtility::platform(), appUid);
+        Poco::JSON::Array publishedVersions;
+        (void) publishedVersions.add(buildPublishedVersion("production", false));
+
+        const ExitInfo exitInfo = job.parseResponse(buildAppVersionReply(publishedVersions));
+
+        CPPUNIT_ASSERT_EQUAL(ExitCode::BackError, exitInfo.code());
+        CPPUNIT_ASSERT_EQUAL(ExitCause::MissingReplyData, exitInfo.cause());
+        CPPUNIT_ASSERT(job.versionsInfo().empty());
+    }
 }
 
 void TestNetworkJobs::testDirectDownload() {

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -1600,7 +1600,7 @@ void TestNetworkJobs::testGetAppVersionInfoParsingEdgeCases() {
         const ExitInfo exitInfo = job.parseResponse(buildAppVersionReply(publishedVersions));
 
         CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, exitInfo.code());
-        CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(1), job.versionsInfo().size());
+        CPPUNIT_ASSERT_EQUAL(size_t{1}, job.versionsInfo().size());
         CPPUNIT_ASSERT(job.versionsInfo().contains(VersionChannel::Prod));
         CPPUNIT_ASSERT(!job.versionsInfo().contains(VersionChannel::Beta));
     }

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -96,13 +96,12 @@ class GetAppVersionJobForTests final : public GetAppVersionJob {
             GetAppVersionJob(platform, appID) {}
 
         ExitInfo parseResponse(const std::string &response) {
-            const std::istringstream iss(response);
-            std::istream is(iss.rdbuf());
-            return handleResponse(is);
+            std::istringstream stream(response);
+            return handleResponse(stream);
         }
 };
 
-Poco::JSON::Object buildPublishedVersion(const std::string &channel, const bool includeTag = true) {
+static Poco::JSON::Object buildPublishedVersion(const std::string &channel, const bool includeTag = true) {
     Poco::JSON::Object versionObj;
     if (includeTag) {
         (void) versionObj.set("tag", "3.6.4");
@@ -114,7 +113,7 @@ Poco::JSON::Object buildPublishedVersion(const std::string &channel, const bool 
     return versionObj;
 }
 
-std::string buildAppVersionReply(const Poco::JSON::Array &publishedVersions) {
+static std::string buildAppVersionReply(const Poco::JSON::Array &publishedVersions) {
     Poco::JSON::Object applicationObj;
     (void) applicationObj.set("min_version", "3.6.0.0");
     (void) applicationObj.set("published_versions", publishedVersions);

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -101,7 +101,7 @@ class GetAppVersionJobForTests final : public GetAppVersionJob {
         }
 };
 
-static Poco::JSON::Object buildPublishedVersion(const std::string &channel, const bool includeTag = true) {
+Poco::JSON::Object buildPublishedVersion(const std::string &channel, const bool includeTag = true) {
     Poco::JSON::Object versionObj;
     if (includeTag) {
         (void) versionObj.set("tag", "3.6.4");
@@ -113,7 +113,7 @@ static Poco::JSON::Object buildPublishedVersion(const std::string &channel, cons
     return versionObj;
 }
 
-static std::string buildAppVersionReply(const Poco::JSON::Array &publishedVersions) {
+std::string buildAppVersionReply(const Poco::JSON::Array &publishedVersions) {
     Poco::JSON::Object applicationObj;
     (void) applicationObj.set("min_version", "3.6.0.0");
     (void) applicationObj.set("published_versions", publishedVersions);

--- a/test/libsyncengine/jobs/network/testnetworkjobs.h
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.h
@@ -63,6 +63,7 @@ class TestNetworkJobs : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST(testDriveUploadSessionSynchronousAborted);
         CPPUNIT_TEST(testDriveUploadSessionAsynchronousAborted);
         CPPUNIT_TEST(testGetAppVersionInfo);
+        CPPUNIT_TEST(testGetAppVersionInfoParsingEdgeCases);
         CPPUNIT_TEST(testDirectDownload);
         CPPUNIT_TEST(testDownloadHasEnoughSpace);
         CPPUNIT_TEST(testSearch);
@@ -106,6 +107,7 @@ class TestNetworkJobs : public CppUnit::TestFixture, public TestBase {
         void testDriveUploadSessionSynchronousAborted();
         void testDriveUploadSessionAsynchronousAborted();
         void testGetAppVersionInfo();
+        void testGetAppVersionInfoParsingEdgeCases();
         void testDirectDownload();
         void testDownloadHasEnoughSpace();
         void testSearch();


### PR DESCRIPTION
Unknown channels are now skipped with an info log. Missing mandatory values trigger an error only for the production channel; for others, a warning is logged and processing continues. Logging is now more contextual.