### PR TITLE
fix(gui): improve login authentication error wording

### DIFF
--- a/src/gui/adddriveloginwidget.cpp
+++ b/src/gui/adddriveloginwidget.cpp
@@ -117,7 +117,7 @@ void AddDriveLoginWidget::onAuthorizationCodeReceived(const QString &code, const
         qCWarning(lcAddDriveLoginWidget()) << "Error in Requests::requestToken: code=" << exitCode;
 
         CustomMessageBox msgBox(QMessageBox::Warning,
-                                tr("An error occurred during authentication. Please, close the login window and try again.<br>"
+                                tr("An error occurred during authentication. Please close the login window and try again.<br>"
                                    "If the error persists, contact our support team."),
                                 QMessageBox::Ok);
         (void) msgBox.exec();

--- a/src/gui/adddriveloginwidget.cpp
+++ b/src/gui/adddriveloginwidget.cpp
@@ -114,7 +114,8 @@ void AddDriveLoginWidget::onAuthorizationCodeReceived(const QString &code, const
     QString errorDescr;
     const auto exitCode = GuiRequests::requestToken(code, _codeVerifier, _userDbId, error, errorDescr);
     if (exitCode != ExitCode::Ok) {
-        qCWarning(lcAddDriveLoginWidget()) << "Error in Requests::requestToken: code=" << exitCode;
+        qCWarning(lcAddDriveLoginWidget()) << "Error in Requests::requestToken: code=" << exitCode << "error=" << error
+                                          << "errorDescr=" << errorDescr;
 
         CustomMessageBox msgBox(QMessageBox::Warning,
                                 tr("An error occurred during authentication. Please close the login window and try again.<br>"

--- a/src/gui/adddriveloginwidget.cpp
+++ b/src/gui/adddriveloginwidget.cpp
@@ -115,7 +115,7 @@ void AddDriveLoginWidget::onAuthorizationCodeReceived(const QString &code, const
     const auto exitCode = GuiRequests::requestToken(code, _codeVerifier, _userDbId, error, errorDescr);
     if (exitCode != ExitCode::Ok) {
         qCWarning(lcAddDriveLoginWidget()) << "Error in Requests::requestToken: code=" << exitCode << "error=" << error
-                                          << "errorDescr=" << errorDescr;
+                                           << "errorDescr=" << errorDescr;
 
         CustomMessageBox msgBox(QMessageBox::Warning,
                                 tr("An error occurred during authentication. Please close the login window and try again.<br>"
@@ -124,9 +124,10 @@ void AddDriveLoginWidget::onAuthorizationCodeReceived(const QString &code, const
         (void) msgBox.exec();
 
         emit terminated(false);
-    } else {
-        emit terminated();
+        return;
     }
+
+    emit terminated();
 }
 
 void AddDriveLoginWidget::onErrorReceived(const QString error, const QString errorDescr) {

--- a/src/gui/adddriveloginwidget.cpp
+++ b/src/gui/adddriveloginwidget.cpp
@@ -116,7 +116,9 @@ void AddDriveLoginWidget::onAuthorizationCodeReceived(const QString &code, const
     if (exitCode != ExitCode::Ok) {
         qCWarning(lcAddDriveLoginWidget()) << "Error in Requests::requestToken: code=" << exitCode;
 
-        CustomMessageBox msgBox(QMessageBox::Warning, tr("Token request failed: %1 - %2").arg(error, errorDescr),
+        CustomMessageBox msgBox(QMessageBox::Warning,
+                                tr("An error occurred during authentication. Please, close the login window and try again.<br>"
+                                   "If the error persists, contact our support team."),
                                 QMessageBox::Ok);
         (void) msgBox.exec();
 

--- a/src/gui/adddrivewizard.cpp
+++ b/src/gui/adddrivewizard.cpp
@@ -113,7 +113,11 @@ void AddDriveWizard::startNextStep(bool backward) {
 
     _currentStep = (Step) (_currentStep + (backward ? -1 : 1));
 
-    if (_currentStep == Login && backward) {
+    if (_currentStep == None) {
+        // We close the wizard on login error.
+        exit();
+        return;
+    } else if (_currentStep == Login && backward) {
         if (!_addDriveListWidget->isAddUserClicked()) {
             exit();
             return;

--- a/translations/client_de.ts
+++ b/translations/client_de.ts
@@ -224,8 +224,8 @@ Bitte wählen Sie einen anderen Ordner. Wenn Sie fortfahren, wird Lite Sync deak
     </message>
     <message>
         <location filename="../src/gui/adddriveloginwidget.cpp" line="119"/>
-        <source>Token request failed: %1 - %2</source>
-        <translation>Token-Anfrage fehlgeschlagen: %1 - %2</translation>
+        <source>An error occurred during authentication. Please, close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
+        <translation>Bei der Authentifizierung ist ein Fehler aufgetreten. Bitte schließen Sie das Anmeldefenster und versuchen Sie es erneut.&lt;br&gt;Wenn der Fehler weiterhin auftritt, kontaktieren Sie unser Support-Team.</translation>
     </message>
     <message>
         <location filename="../src/gui/adddriveloginwidget.cpp" line="133"/>

--- a/translations/client_de.ts
+++ b/translations/client_de.ts
@@ -224,7 +224,7 @@ Bitte wählen Sie einen anderen Ordner. Wenn Sie fortfahren, wird Lite Sync deak
     </message>
     <message>
         <location filename="../src/gui/adddriveloginwidget.cpp" line="119"/>
-        <source>An error occurred during authentication. Please, close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
+        <source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
         <translation>Bei der Authentifizierung ist ein Fehler aufgetreten. Bitte schließen Sie das Anmeldefenster und versuchen Sie es erneut.&lt;br&gt;Wenn der Fehler weiterhin auftritt, kontaktieren Sie unser Support-Team.</translation>
     </message>
     <message>

--- a/translations/client_es.ts
+++ b/translations/client_es.ts
@@ -224,7 +224,7 @@ Seleccione otra carpeta. Si continúa, Lite Sync se deshabilitará.&lt;br&gt;
     </message>
     <message>
         <location filename="../src/gui/adddriveloginwidget.cpp" line="119"/>
-        <source>An error occurred during authentication. Please, close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
+        <source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
         <translation>Se produjo un error durante la autenticación. Cierre la ventana de inicio de sesión e inténtelo de nuevo.&lt;br&gt;Si el error persiste, contacte con nuestro equipo de soporte.</translation>
     </message>
     <message>

--- a/translations/client_es.ts
+++ b/translations/client_es.ts
@@ -224,8 +224,8 @@ Seleccione otra carpeta. Si continúa, Lite Sync se deshabilitará.&lt;br&gt;
     </message>
     <message>
         <location filename="../src/gui/adddriveloginwidget.cpp" line="119"/>
-        <source>Token request failed: %1 - %2</source>
-        <translation>Error al solicitar el token: %1 – %2</translation>
+        <source>An error occurred during authentication. Please, close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
+        <translation>Se produjo un error durante la autenticación. Cierre la ventana de inicio de sesión e inténtelo de nuevo.&lt;br&gt;Si el error persiste, contacte con nuestro equipo de soporte.</translation>
     </message>
     <message>
         <location filename="../src/gui/adddriveloginwidget.cpp" line="133"/>

--- a/translations/client_fr.ts
+++ b/translations/client_fr.ts
@@ -224,7 +224,7 @@ Veuillez sélectionner un autre dossier. Si vous continuez, Lite Sync sera désa
     </message>
     <message>
         <location filename="../src/gui/adddriveloginwidget.cpp" line="119"/>
-        <source>An error occurred during authentication. Please, close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
+        <source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
         <translation>Une erreur est survenue pendant l&apos;authentification. Veuillez fermer la fenêtre de connexion et réessayer.&lt;br&gt;Si l&apos;erreur persiste, contactez notre équipe de support.</translation>
     </message>
     <message>

--- a/translations/client_fr.ts
+++ b/translations/client_fr.ts
@@ -224,8 +224,8 @@ Veuillez sélectionner un autre dossier. Si vous continuez, Lite Sync sera désa
     </message>
     <message>
         <location filename="../src/gui/adddriveloginwidget.cpp" line="119"/>
-        <source>Token request failed: %1 - %2</source>
-        <translation>Échec de la demande de jeton&#xa0;: %1 - %2</translation>
+        <source>An error occurred during authentication. Please, close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
+        <translation>Une erreur est survenue pendant l&apos;authentification. Veuillez fermer la fenêtre de connexion et réessayer.&lt;br&gt;Si l&apos;erreur persiste, contactez notre équipe de support.</translation>
     </message>
     <message>
         <location filename="../src/gui/adddriveloginwidget.cpp" line="133"/>

--- a/translations/client_it.ts
+++ b/translations/client_it.ts
@@ -224,7 +224,7 @@ Seleziona un&apos;altra cartella. Se continui, Lite Sync verrà disabilitato.&lt
     </message>
     <message>
         <location filename="../src/gui/adddriveloginwidget.cpp" line="119"/>
-        <source>An error occurred during authentication. Please, close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
+        <source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
         <translation>Si è verificato un errore durante l&apos;autenticazione. Chiudi la finestra di accesso e riprova.&lt;br&gt;Se l&apos;errore persiste, contatta il nostro team di supporto.</translation>
     </message>
     <message>

--- a/translations/client_it.ts
+++ b/translations/client_it.ts
@@ -224,8 +224,8 @@ Seleziona un&apos;altra cartella. Se continui, Lite Sync verrà disabilitato.&lt
     </message>
     <message>
         <location filename="../src/gui/adddriveloginwidget.cpp" line="119"/>
-        <source>Token request failed: %1 - %2</source>
-        <translation>Richiesta token non riuscita: %1 – %2</translation>
+        <source>An error occurred during authentication. Please, close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
+        <translation>Si è verificato un errore durante l&apos;autenticazione. Chiudi la finestra di accesso e riprova.&lt;br&gt;Se l&apos;errore persiste, contatta il nostro team di supporto.</translation>
     </message>
     <message>
         <location filename="../src/gui/adddriveloginwidget.cpp" line="133"/>


### PR DESCRIPTION
## What
- replace the login token error popup with a clearer authentication guidance message
- update related Qt translations in German, Spanish, French, and Italian
- keep GUI source text and translation sources aligned

## Why
- the previous message exposed token-request details and was less user-friendly
- the new wording gives actionable guidance and support fallback

## Validation
- verified the old source string is removed from translation files
- verified the new source string is present in all shipped `client_*.ts` files