### PR TITLE
feat(i18n): add Polish localization support

### DIFF
--- a/infomaniak-build-tools/linux/build-release-appimage.sh
+++ b/infomaniak-build-tools/linux/build-release-appimage.sh
@@ -254,7 +254,7 @@ function clean_app_directory() {
   find . -mindepth 1 -maxdepth 1 \( -type f -o -type l \) ! -name "libqsqlite.so" -delete
   cd /app
 
-  # Clean translations - keep only de, es, fr, it, sv, pt, en
+  # Clean translations - keep only de, es, fr, it, sv, pt, pl, en
   echo "  Cleaning translations..."
   cd ./usr/translations
 
@@ -263,9 +263,9 @@ function clean_app_directory() {
 
   # For other Qt translations, keep only supported languages
   for prefix in qt qtbase qtconnectivity qtdeclarative qtlocation qtmultimedia qtserialport qtwebsockets; do
-    # Remove all except de, es, fr, it, sv, pt, en
+    # Remove all except de, es, fr, it, sv, pt, pl, en
     find . -mindepth 1 -maxdepth 1 \( -type f -o -type l \) -name "${prefix}_*.qm" \
-      ! -name "*_de.qm" ! -name "*_es.qm" ! -name "*_fr.qm" ! -name "*_it.qm" ! -name "*_sv.qm" ! -name "*_pt.qm" ! -name "*_en.qm" -delete
+      ! -name "*_de.qm" ! -name "*_es.qm" ! -name "*_fr.qm" ! -name "*_it.qm" ! -name "*_sv.qm" ! -name "*_pt.qm" ! -name "*_pl.qm" ! -name "*_en.qm" -delete
   done
 
   cd /app

--- a/infomaniak-build-tools/linux/build-release-appimage.sh
+++ b/infomaniak-build-tools/linux/build-release-appimage.sh
@@ -254,7 +254,7 @@ function clean_app_directory() {
   find . -mindepth 1 -maxdepth 1 \( -type f -o -type l \) ! -name "libqsqlite.so" -delete
   cd /app
 
-  # Clean translations - keep only de, es, fr, it, sv, en
+  # Clean translations - keep only de, es, fr, it, sv, pt, en
   echo "  Cleaning translations..."
   cd ./usr/translations
 
@@ -263,9 +263,9 @@ function clean_app_directory() {
 
   # For other Qt translations, keep only supported languages
   for prefix in qt qtbase qtconnectivity qtdeclarative qtlocation qtmultimedia qtserialport qtwebsockets; do
-    # Remove all except de, es, fr, it, sv, en
+    # Remove all except de, es, fr, it, sv, pt, en
     find . -mindepth 1 -maxdepth 1 \( -type f -o -type l \) -name "${prefix}_*.qm" \
-      ! -name "*_de.qm" ! -name "*_es.qm" ! -name "*_fr.qm" ! -name "*_it.qm" ! -name "*_sv.qm" ! -name "*_en.qm" -delete
+      ! -name "*_de.qm" ! -name "*_es.qm" ! -name "*_fr.qm" ! -name "*_it.qm" ! -name "*_sv.qm" ! -name "*_pt.qm" ! -name "*_en.qm" -delete
   done
 
   cd /app

--- a/infomaniak-build-tools/linux/build-release-appimage.sh
+++ b/infomaniak-build-tools/linux/build-release-appimage.sh
@@ -254,7 +254,7 @@ function clean_app_directory() {
   find . -mindepth 1 -maxdepth 1 \( -type f -o -type l \) ! -name "libqsqlite.so" -delete
   cd /app
 
-  # Clean translations - keep only de, es, fr, it, en
+  # Clean translations - keep only de, es, fr, it, sv, en
   echo "  Cleaning translations..."
   cd ./usr/translations
 
@@ -263,9 +263,9 @@ function clean_app_directory() {
 
   # For other Qt translations, keep only supported languages
   for prefix in qt qtbase qtconnectivity qtdeclarative qtlocation qtmultimedia qtserialport qtwebsockets; do
-    # Remove all except de, es, fr, it, en
+    # Remove all except de, es, fr, it, sv, en
     find . -mindepth 1 -maxdepth 1 \( -type f -o -type l \) -name "${prefix}_*.qm" \
-      ! -name "*_de.qm" ! -name "*_es.qm" ! -name "*_fr.qm" ! -name "*_it.qm" ! -name "*_en.qm" -delete
+      ! -name "*_de.qm" ! -name "*_es.qm" ! -name "*_fr.qm" ! -name "*_it.qm" ! -name "*_sv.qm" ! -name "*_en.qm" -delete
   done
 
   cd /app

--- a/src/gui/guiutility.cpp
+++ b/src/gui/guiutility.cpp
@@ -626,6 +626,8 @@ QLocale GuiUtility::languageToQLocale(Language language) {
             return QLocale::Italian;
         case Language::Swedish:
             return QLocale::Swedish;
+        case Language::Portuguese:
+            return QLocale::Portuguese;
         default:
             return QLocale();
     }

--- a/src/gui/guiutility.cpp
+++ b/src/gui/guiutility.cpp
@@ -628,6 +628,8 @@ QLocale GuiUtility::languageToQLocale(Language language) {
             return QLocale::Swedish;
         case Language::Portuguese:
             return QLocale::Portuguese;
+        case Language::Polish:
+            return QLocale::Polish;
         default:
             return QLocale();
     }

--- a/src/gui/guiutility.cpp
+++ b/src/gui/guiutility.cpp
@@ -624,6 +624,8 @@ QLocale GuiUtility::languageToQLocale(Language language) {
             return QLocale::German;
         case Language::Italian:
             return QLocale::Italian;
+        case Language::Swedish:
+            return QLocale::Swedish;
         default:
             return QLocale();
     }

--- a/src/gui/preferenceswidget.cpp
+++ b/src/gui/preferenceswidget.cpp
@@ -510,6 +510,7 @@ void PreferencesWidget::retranslateUi() const {
     _languageSelectorComboBox->addItem(tr("Italian"), toInt(Language::Italian));
     _languageSelectorComboBox->addItem(tr("Swedish"), toInt(Language::Swedish));
     _languageSelectorComboBox->addItem(tr("Portuguese"), toInt(Language::Portuguese));
+    _languageSelectorComboBox->addItem(tr("Polish"), toInt(Language::Polish));
     const int languageIndex =
             _languageSelectorComboBox->findData(toInt(ParametersCache::instance()->parametersInfo().language()));
     _languageSelectorComboBox->setCurrentIndex(languageIndex);

--- a/src/gui/preferenceswidget.cpp
+++ b/src/gui/preferenceswidget.cpp
@@ -508,6 +508,7 @@ void PreferencesWidget::retranslateUi() const {
     _languageSelectorComboBox->addItem(tr("German"), toInt(Language::German));
     _languageSelectorComboBox->addItem(tr("Spanish"), toInt(Language::Spanish));
     _languageSelectorComboBox->addItem(tr("Italian"), toInt(Language::Italian));
+    _languageSelectorComboBox->addItem(tr("Swedish"), toInt(Language::Swedish));
     const int languageIndex =
             _languageSelectorComboBox->findData(toInt(ParametersCache::instance()->parametersInfo().language()));
     _languageSelectorComboBox->setCurrentIndex(languageIndex);

--- a/src/gui/preferenceswidget.cpp
+++ b/src/gui/preferenceswidget.cpp
@@ -509,6 +509,7 @@ void PreferencesWidget::retranslateUi() const {
     _languageSelectorComboBox->addItem(tr("Spanish"), toInt(Language::Spanish));
     _languageSelectorComboBox->addItem(tr("Italian"), toInt(Language::Italian));
     _languageSelectorComboBox->addItem(tr("Swedish"), toInt(Language::Swedish));
+    _languageSelectorComboBox->addItem(tr("Portuguese"), toInt(Language::Portuguese));
     const int languageIndex =
             _languageSelectorComboBox->findData(toInt(ParametersCache::instance()->parametersInfo().language()));
     _languageSelectorComboBox->setCurrentIndex(languageIndex);

--- a/src/libcommon/utility/cstypes.h
+++ b/src/libcommon/utility/cstypes.h
@@ -188,6 +188,7 @@ enum class Language {
     Italian,
     Swedish,
     Portuguese,
+    Polish,
     EnumEnd
 };
 

--- a/src/libcommon/utility/cstypes.h
+++ b/src/libcommon/utility/cstypes.h
@@ -186,6 +186,7 @@ enum class Language {
     German,
     Spanish,
     Italian,
+    Swedish,
     EnumEnd
 };
 

--- a/src/libcommon/utility/cstypes.h
+++ b/src/libcommon/utility/cstypes.h
@@ -187,6 +187,7 @@ enum class Language {
     Spanish,
     Italian,
     Swedish,
+    Portuguese,
     EnumEnd
 };
 

--- a/src/libcommon/utility/types.cpp
+++ b/src/libcommon/utility/types.cpp
@@ -539,6 +539,8 @@ std::string toString(const Language e) {
             return "Italian";
         case Language::Swedish:
             return "Swedish";
+        case Language::Portuguese:
+            return "Portuguese";
         default:
             return noConversionStr;
     }

--- a/src/libcommon/utility/types.cpp
+++ b/src/libcommon/utility/types.cpp
@@ -537,6 +537,8 @@ std::string toString(const Language e) {
             return "Spanish";
         case Language::Italian:
             return "Italian";
+        case Language::Swedish:
+            return "Swedish";
         default:
             return noConversionStr;
     }

--- a/src/libcommon/utility/types.cpp
+++ b/src/libcommon/utility/types.cpp
@@ -541,6 +541,8 @@ std::string toString(const Language e) {
             return "Swedish";
         case Language::Portuguese:
             return "Portuguese";
+        case Language::Polish:
+            return "Polish";
         default:
             return noConversionStr;
     }

--- a/src/libcommon/utility/utility.cpp
+++ b/src/libcommon/utility/utility.cpp
@@ -97,6 +97,7 @@ const QString CommonUtility::germanCode = "de";
 const QString CommonUtility::spanishCode = "es";
 const QString CommonUtility::italianCode = "it";
 const QString CommonUtility::swedishCode = "sv";
+const QString CommonUtility::portugueseCode = "pt";
 
 static std::random_device rd;
 static std::default_random_engine gen(rd());
@@ -805,8 +806,8 @@ bool CommonUtility::languageCodeIsEnglish(const QString &languageCode) {
 }
 
 bool CommonUtility::isSupportedLanguage(const QString &languageCode) {
-    static const std::unordered_set<QString> supportedLanguages = {englishCode, frenchCode,  germanCode,
-                                                                   italianCode, spanishCode, swedishCode};
+    static const std::unordered_set<QString> supportedLanguages = {englishCode, frenchCode,  germanCode,    italianCode,
+                                                                   spanishCode, swedishCode, portugueseCode};
     return supportedLanguages.contains(languageCode);
 }
 
@@ -828,6 +829,8 @@ QString CommonUtility::languageCode(const Language language) {
             return spanishCode;
         case Language::Swedish:
             return swedishCode;
+        case Language::Portuguese:
+            return portugueseCode;
         case Language::English:
             break;
         case Language::EnumEnd:

--- a/src/libcommon/utility/utility.cpp
+++ b/src/libcommon/utility/utility.cpp
@@ -98,6 +98,7 @@ const QString CommonUtility::spanishCode = "es";
 const QString CommonUtility::italianCode = "it";
 const QString CommonUtility::swedishCode = "sv";
 const QString CommonUtility::portugueseCode = "pt";
+const QString CommonUtility::polishCode = "pl";
 
 static std::random_device rd;
 static std::default_random_engine gen(rd());
@@ -806,8 +807,8 @@ bool CommonUtility::languageCodeIsEnglish(const QString &languageCode) {
 }
 
 bool CommonUtility::isSupportedLanguage(const QString &languageCode) {
-    static const std::unordered_set<QString> supportedLanguages = {englishCode, frenchCode,  germanCode,    italianCode,
-                                                                   spanishCode, swedishCode, portugueseCode};
+    static const std::unordered_set<QString> supportedLanguages = {englishCode, frenchCode,  germanCode,     italianCode,
+                                                                   spanishCode, swedishCode, portugueseCode, polishCode};
     return supportedLanguages.contains(languageCode);
 }
 
@@ -831,6 +832,8 @@ QString CommonUtility::languageCode(const Language language) {
             return swedishCode;
         case Language::Portuguese:
             return portugueseCode;
+        case Language::Polish:
+            return polishCode;
         case Language::English:
             break;
         case Language::EnumEnd:

--- a/src/libcommon/utility/utility.cpp
+++ b/src/libcommon/utility/utility.cpp
@@ -96,6 +96,7 @@ const QString CommonUtility::frenchCode = "fr";
 const QString CommonUtility::germanCode = "de";
 const QString CommonUtility::spanishCode = "es";
 const QString CommonUtility::italianCode = "it";
+const QString CommonUtility::swedishCode = "sv";
 
 static std::random_device rd;
 static std::default_random_engine gen(rd());
@@ -804,7 +805,8 @@ bool CommonUtility::languageCodeIsEnglish(const QString &languageCode) {
 }
 
 bool CommonUtility::isSupportedLanguage(const QString &languageCode) {
-    static const std::unordered_set<QString> supportedLanguages = {englishCode, frenchCode, germanCode, italianCode, spanishCode};
+    static const std::unordered_set<QString> supportedLanguages = {englishCode, frenchCode,  germanCode,
+                                                                   italianCode, spanishCode, swedishCode};
     return supportedLanguages.contains(languageCode);
 }
 
@@ -824,6 +826,8 @@ QString CommonUtility::languageCode(const Language language) {
             return italianCode;
         case Language::Spanish:
             return spanishCode;
+        case Language::Swedish:
+            return swedishCode;
         case Language::English:
             break;
         case Language::EnumEnd:
@@ -1134,7 +1138,7 @@ void CommonUtility::initAppImageEnvironment() {
             if (setenv("GIO_MODULE_DIR", gioModuleDir.c_str(), 1) == -1) {
                 const int err = errno;
                 qWarning() << "Failed to set GIO_MODULE_DIR to " << gioModuleDir.c_str() << " (errno " << err << ": "
-                          << strerror(err) << ")";
+                           << strerror(err) << ")";
             }
         } else {
             qWarning() << "APPDIR environment variable is not set, AppImage environment may be incomplete";

--- a/src/libcommon/utility/utility.h
+++ b/src/libcommon/utility/utility.h
@@ -111,6 +111,7 @@ struct COMMON_EXPORT CommonUtility {
         static const QString germanCode;
         static const QString spanishCode;
         static const QString italianCode;
+        static const QString swedishCode;
         static QString languageCode(Language language);
         static QStringList languageCodeList(Language enforcedLocale);
         static void setupTranslations(QCoreApplication *app, Language enforcedLocale);
@@ -165,7 +166,7 @@ struct COMMON_EXPORT CommonUtility {
         static int setenv(const char *const name, const char *const value, const int overwrite);
 
 #if defined(KD_LINUX)
-         // Sets the working directory path and configures GIO_MODULE_DIR to prevent loading incompatible system GIO modules.
+        // Sets the working directory path and configures GIO_MODULE_DIR to prevent loading incompatible system GIO modules.
         static void initAppImageEnvironment();
 #endif
 

--- a/src/libcommon/utility/utility.h
+++ b/src/libcommon/utility/utility.h
@@ -112,6 +112,7 @@ struct COMMON_EXPORT CommonUtility {
         static const QString spanishCode;
         static const QString italianCode;
         static const QString swedishCode;
+        static const QString portugueseCode;
         static QString languageCode(Language language);
         static QStringList languageCodeList(Language enforcedLocale);
         static void setupTranslations(QCoreApplication *app, Language enforcedLocale);

--- a/src/libcommon/utility/utility.h
+++ b/src/libcommon/utility/utility.h
@@ -113,6 +113,7 @@ struct COMMON_EXPORT CommonUtility {
         static const QString italianCode;
         static const QString swedishCode;
         static const QString portugueseCode;
+        static const QString polishCode;
         static QString languageCode(Language language);
         static QStringList languageCodeList(Language enforcedLocale);
         static void setupTranslations(QCoreApplication *app, Language enforcedLocale);

--- a/src/server/migration/migrationparams.cpp
+++ b/src/server/migration/migrationparams.cpp
@@ -109,6 +109,8 @@ Language MigrationParams::strToLanguage(QString lang) {
         return Language::Italian;
     } else if (lang == "sv") {
         return Language::Swedish;
+    } else if (lang == "pt") {
+        return Language::Portuguese;
     } else {
         return Language::Default;
     }

--- a/src/server/migration/migrationparams.cpp
+++ b/src/server/migration/migrationparams.cpp
@@ -107,6 +107,8 @@ Language MigrationParams::strToLanguage(QString lang) {
         return Language::Spanish;
     } else if (lang == "it") {
         return Language::Italian;
+    } else if (lang == "sv") {
+        return Language::Swedish;
     } else {
         return Language::Default;
     }

--- a/src/server/migration/migrationparams.cpp
+++ b/src/server/migration/migrationparams.cpp
@@ -111,6 +111,8 @@ Language MigrationParams::strToLanguage(QString lang) {
         return Language::Swedish;
     } else if (lang == "pt") {
         return Language::Portuguese;
+    } else if (lang == "pl") {
+        return Language::Polish;
     } else {
         return Language::Default;
     }

--- a/test/libcommon/utility/testutility.cpp
+++ b/test/libcommon/utility/testutility.cpp
@@ -487,6 +487,7 @@ void TestUtility::testLanguageCode() {
     CPPUNIT_ASSERT_EQUAL(std::string("it"), CommonUtility::languageCode(Language::Italian).toStdString());
     CPPUNIT_ASSERT_EQUAL(std::string("sv"), CommonUtility::languageCode(Language::Swedish).toStdString());
     CPPUNIT_ASSERT_EQUAL(std::string("pt"), CommonUtility::languageCode(Language::Portuguese).toStdString());
+    CPPUNIT_ASSERT_EQUAL(std::string("pl"), CommonUtility::languageCode(Language::Polish).toStdString());
 
     const auto systemLanguage = QLocale::languageToCode(QLocale::system().language());
     CPPUNIT_ASSERT_EQUAL(systemLanguage.toStdString(), CommonUtility::languageCode(Language::Default).toStdString());
@@ -503,6 +504,7 @@ void TestUtility::testIsSupportedLanguage() {
     CPPUNIT_ASSERT_EQUAL(true, CommonUtility::isSupportedLanguage("it"));
     CPPUNIT_ASSERT_EQUAL(true, CommonUtility::isSupportedLanguage("sv"));
     CPPUNIT_ASSERT_EQUAL(true, CommonUtility::isSupportedLanguage("pt"));
+    CPPUNIT_ASSERT_EQUAL(true, CommonUtility::isSupportedLanguage("pl"));
     CPPUNIT_ASSERT_EQUAL(false, CommonUtility::isSupportedLanguage("ita"));
     CPPUNIT_ASSERT_EQUAL(false, CommonUtility::isSupportedLanguage("zc"));
     CPPUNIT_ASSERT_EQUAL(false, CommonUtility::isSupportedLanguage(""));

--- a/test/libcommon/utility/testutility.cpp
+++ b/test/libcommon/utility/testutility.cpp
@@ -486,6 +486,7 @@ void TestUtility::testLanguageCode() {
     CPPUNIT_ASSERT_EQUAL(std::string("es"), CommonUtility::languageCode(Language::Spanish).toStdString());
     CPPUNIT_ASSERT_EQUAL(std::string("it"), CommonUtility::languageCode(Language::Italian).toStdString());
     CPPUNIT_ASSERT_EQUAL(std::string("sv"), CommonUtility::languageCode(Language::Swedish).toStdString());
+    CPPUNIT_ASSERT_EQUAL(std::string("pt"), CommonUtility::languageCode(Language::Portuguese).toStdString());
 
     const auto systemLanguage = QLocale::languageToCode(QLocale::system().language());
     CPPUNIT_ASSERT_EQUAL(systemLanguage.toStdString(), CommonUtility::languageCode(Language::Default).toStdString());
@@ -501,6 +502,7 @@ void TestUtility::testIsSupportedLanguage() {
     CPPUNIT_ASSERT_EQUAL(true, CommonUtility::isSupportedLanguage("es"));
     CPPUNIT_ASSERT_EQUAL(true, CommonUtility::isSupportedLanguage("it"));
     CPPUNIT_ASSERT_EQUAL(true, CommonUtility::isSupportedLanguage("sv"));
+    CPPUNIT_ASSERT_EQUAL(true, CommonUtility::isSupportedLanguage("pt"));
     CPPUNIT_ASSERT_EQUAL(false, CommonUtility::isSupportedLanguage("ita"));
     CPPUNIT_ASSERT_EQUAL(false, CommonUtility::isSupportedLanguage("zc"));
     CPPUNIT_ASSERT_EQUAL(false, CommonUtility::isSupportedLanguage(""));

--- a/test/libcommon/utility/testutility.cpp
+++ b/test/libcommon/utility/testutility.cpp
@@ -485,6 +485,7 @@ void TestUtility::testLanguageCode() {
     CPPUNIT_ASSERT_EQUAL(std::string("de"), CommonUtility::languageCode(Language::German).toStdString());
     CPPUNIT_ASSERT_EQUAL(std::string("es"), CommonUtility::languageCode(Language::Spanish).toStdString());
     CPPUNIT_ASSERT_EQUAL(std::string("it"), CommonUtility::languageCode(Language::Italian).toStdString());
+    CPPUNIT_ASSERT_EQUAL(std::string("sv"), CommonUtility::languageCode(Language::Swedish).toStdString());
 
     const auto systemLanguage = QLocale::languageToCode(QLocale::system().language());
     CPPUNIT_ASSERT_EQUAL(systemLanguage.toStdString(), CommonUtility::languageCode(Language::Default).toStdString());
@@ -499,6 +500,7 @@ void TestUtility::testIsSupportedLanguage() {
     CPPUNIT_ASSERT_EQUAL(true, CommonUtility::isSupportedLanguage("de"));
     CPPUNIT_ASSERT_EQUAL(true, CommonUtility::isSupportedLanguage("es"));
     CPPUNIT_ASSERT_EQUAL(true, CommonUtility::isSupportedLanguage("it"));
+    CPPUNIT_ASSERT_EQUAL(true, CommonUtility::isSupportedLanguage("sv"));
     CPPUNIT_ASSERT_EQUAL(false, CommonUtility::isSupportedLanguage("ita"));
     CPPUNIT_ASSERT_EQUAL(false, CommonUtility::isSupportedLanguage("zc"));
     CPPUNIT_ASSERT_EQUAL(false, CommonUtility::isSupportedLanguage(""));

--- a/translations/client_de.ts
+++ b/translations/client_de.ts
@@ -2022,6 +2022,11 @@ Bitte verwenden Sie den folgenden Link, um die Protokolle an den Support zu send
         <translation>Portugiesisch</translation>
     </message>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="513"/>
+        <source>Polish</source>
+        <translation>Polnisch</translation>
+    </message>
+    <message>
         <location filename="../src/gui/preferenceswidget.cpp" line="466"/>
         <source>Unable to open folder %1.</source>
         <translation>Ordner %1 kann nicht geöffnet werden.</translation>

--- a/translations/client_de.ts
+++ b/translations/client_de.ts
@@ -2017,6 +2017,11 @@ Bitte verwenden Sie den folgenden Link, um die Protokolle an den Support zu send
         <translation>Schwedisch</translation>
     </message>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="512"/>
+        <source>Portuguese</source>
+        <translation>Portugiesisch</translation>
+    </message>
+    <message>
         <location filename="../src/gui/preferenceswidget.cpp" line="466"/>
         <source>Unable to open folder %1.</source>
         <translation>Ordner %1 kann nicht geöffnet werden.</translation>

--- a/translations/client_de.ts
+++ b/translations/client_de.ts
@@ -2012,6 +2012,11 @@ Bitte verwenden Sie den folgenden Link, um die Protokolle an den Support zu send
         <translation>Proxy-Server</translation>
     </message>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="511"/>
+        <source>Swedish</source>
+        <translation>Schwedisch</translation>
+    </message>
+    <message>
         <location filename="../src/gui/preferenceswidget.cpp" line="466"/>
         <source>Unable to open folder %1.</source>
         <translation>Ordner %1 kann nicht geöffnet werden.</translation>

--- a/translations/client_es.ts
+++ b/translations/client_es.ts
@@ -2010,6 +2010,11 @@ Por favor, utilice el siguiente enlace para enviar los registros al soporte: &lt
         <translation>Servidor proxy</translation>
     </message>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="511"/>
+        <source>Swedish</source>
+        <translation>Sueco</translation>
+    </message>
+    <message>
         <location filename="../src/gui/preferenceswidget.cpp" line="466"/>
         <source>Unable to open folder %1.</source>
         <translation>No se puede abrir la carpeta %1.</translation>

--- a/translations/client_es.ts
+++ b/translations/client_es.ts
@@ -2015,6 +2015,11 @@ Por favor, utilice el siguiente enlace para enviar los registros al soporte: &lt
         <translation>Sueco</translation>
     </message>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="512"/>
+        <source>Portuguese</source>
+        <translation>Portugués</translation>
+    </message>
+    <message>
         <location filename="../src/gui/preferenceswidget.cpp" line="466"/>
         <source>Unable to open folder %1.</source>
         <translation>No se puede abrir la carpeta %1.</translation>

--- a/translations/client_es.ts
+++ b/translations/client_es.ts
@@ -2020,6 +2020,11 @@ Por favor, utilice el siguiente enlace para enviar los registros al soporte: &lt
         <translation>Portugués</translation>
     </message>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="513"/>
+        <source>Polish</source>
+        <translation>Polaco</translation>
+    </message>
+    <message>
         <location filename="../src/gui/preferenceswidget.cpp" line="466"/>
         <source>Unable to open folder %1.</source>
         <translation>No se puede abrir la carpeta %1.</translation>

--- a/translations/client_fr.ts
+++ b/translations/client_fr.ts
@@ -2011,6 +2011,11 @@ Veuillez utiliser le lien suivant pour envoyer les logs au support: &lt;a style=
         <translation>Serveur proxy</translation>
     </message>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="511"/>
+        <source>Swedish</source>
+        <translation>Suédois</translation>
+    </message>
+    <message>
         <location filename="../src/gui/preferenceswidget.cpp" line="466"/>
         <source>Unable to open folder %1.</source>
         <translation>Impossible d&apos;ouvrir le dossier %1.</translation>

--- a/translations/client_fr.ts
+++ b/translations/client_fr.ts
@@ -2021,6 +2021,11 @@ Veuillez utiliser le lien suivant pour envoyer les logs au support: &lt;a style=
         <translation>Portugais</translation>
     </message>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="513"/>
+        <source>Polish</source>
+        <translation>Polonais</translation>
+    </message>
+    <message>
         <location filename="../src/gui/preferenceswidget.cpp" line="466"/>
         <source>Unable to open folder %1.</source>
         <translation>Impossible d&apos;ouvrir le dossier %1.</translation>

--- a/translations/client_fr.ts
+++ b/translations/client_fr.ts
@@ -2016,6 +2016,11 @@ Veuillez utiliser le lien suivant pour envoyer les logs au support: &lt;a style=
         <translation>Suédois</translation>
     </message>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="512"/>
+        <source>Portuguese</source>
+        <translation>Portugais</translation>
+    </message>
+    <message>
         <location filename="../src/gui/preferenceswidget.cpp" line="466"/>
         <source>Unable to open folder %1.</source>
         <translation>Impossible d&apos;ouvrir le dossier %1.</translation>

--- a/translations/client_it.ts
+++ b/translations/client_it.ts
@@ -2021,6 +2021,11 @@ Accedi alla versione web per verificare lo stato del tuo kDrive oppure contatta 
         <translation>Portoghese</translation>
     </message>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="513"/>
+        <source>Polish</source>
+        <translation>Polacco</translation>
+    </message>
+    <message>
         <location filename="../src/gui/preferenceswidget.cpp" line="466"/>
         <source>Unable to open folder %1.</source>
         <translation>Impossibile aprire la cartella %1.</translation>

--- a/translations/client_it.ts
+++ b/translations/client_it.ts
@@ -2016,6 +2016,11 @@ Accedi alla versione web per verificare lo stato del tuo kDrive oppure contatta 
         <translation>Svedese</translation>
     </message>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="512"/>
+        <source>Portuguese</source>
+        <translation>Portoghese</translation>
+    </message>
+    <message>
         <location filename="../src/gui/preferenceswidget.cpp" line="466"/>
         <source>Unable to open folder %1.</source>
         <translation>Impossibile aprire la cartella %1.</translation>

--- a/translations/client_it.ts
+++ b/translations/client_it.ts
@@ -2011,6 +2011,11 @@ Accedi alla versione web per verificare lo stato del tuo kDrive oppure contatta 
         <translation>Server proxy</translation>
     </message>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="511"/>
+        <source>Swedish</source>
+        <translation>Svedese</translation>
+    </message>
+    <message>
         <location filename="../src/gui/preferenceswidget.cpp" line="466"/>
         <source>Unable to open folder %1.</source>
         <translation>Impossibile aprire la cartella %1.</translation>

--- a/translations/client_pl.ts
+++ b/translations/client_pl.ts
@@ -880,7 +880,7 @@ Wybierz inny folder. Jeśli kontynuujesz, funkcja Lite Sync zostanie wyłączona
         <message>
             <location filename="../src/gui/debuggingdialog.h" line="70" />
             <source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
-            <translation>Cały folder jest duży (&amp;gt; 100 MB) i udostępnienie go może zająć trochę czasu. Aby skrócić czas udostępniania, zalecamy udostępnienie tylko ostatniej sesji kDrive.</translation>
+            <translation>Cały folder jest duży (&gt; 100 MB) i udostępnienie go może zająć trochę czasu. Aby skrócić czas udostępniania, zalecamy udostępnienie tylko ostatniej sesji kDrive.</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="600" />
@@ -1644,7 +1644,7 @@ Proszę skorzystać z poniższego linku, aby przesłać logi do działu pomocy t
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="406" />
             <source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
-            <translation>Nie można rozpocząć synchronizacji (błąd %1).&lt;br&gt;Należy zezwolić na&lt;br&gt;:- kDrive w Ustawieniach systemu &amp;gt;&amp;gt; Ogólne &amp;gt;&amp;gt; Elementy logowania i rozszerzenia &amp;gt;&amp;gt; Rozszerzenia zabezpieczeń punktów&lt;br&gt;końcowych - Rozszerzenie kDrive LiteSync w Ustawieniach systemu &amp;gt;&amp;gt; Prywatność i bezpieczeństwo &amp;gt;&amp;gt; Pełny dostęp do dysku.</translation>
+            <translation>Nie można rozpocząć synchronizacji (błąd %1).&lt;br&gt;Należy zezwolić na&lt;br&gt;:- kDrive w Ustawieniach systemu &gt;&gt; Ogólne &gt;&gt; Elementy logowania i rozszerzenia &gt;&gt; Rozszerzenia zabezpieczeń punktów&lt;br&gt;końcowych - Rozszerzenie kDrive LiteSync w Ustawieniach systemu &gt;&gt; Prywatność i bezpieczeństwo &gt;&gt; Pełny dostęp do dysku.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="419" />
@@ -3012,7 +3012,7 @@ Proszę skorzystać z poniższego linku, aby przesłać logi do działu pomocy t
         <message>
             <location filename="../src/gui/guiutility.cpp" line="336" />
             <source>Sync in progress (%1 of %2)</source>
-            <translation>Trwa synchronizacja (1% z 2%)</translation>
+            <translation>Trwa synchronizacja (%1 z %2)</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="340" />

--- a/translations/client_pl.ts
+++ b/translations/client_pl.ts
@@ -1,44 +1,44 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="sv_SE">
+<TS version="2.1" language="pl_PL">
     <context>
         <name>KDC::AboutDialog</name>
         <message>
             <location filename="../src/gui/aboutdialog.cpp" line="73" />
             <source>About</source>
-            <translation>Om</translation>
+            <translation>Informacje</translation>
         </message>
         <message>
             <location filename="../src/gui/aboutdialog.cpp" line="112" />
             <source>CLOSE</source>
-            <translation>STÄNG</translation>
+            <translation>ZAMKNIJ</translation>
         </message>
         <message>
             <location filename="../src/gui/aboutdialog.cpp" line="123" />
             <source>Version %1. For more information visit &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
-            <translation>Version %1. För mer information, besök &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
+            <translation>Wersja %1. Więcej informacji można znaleźć na stronie &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/aboutdialog.cpp" line="126" />
             <source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
-            <translation>Copyright 2019–%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
+            <translation>Prawa autorskie 2019–%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/aboutdialog.cpp" line="127" />
             <source>Distributed by %1 and licensed under the &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
-            <translation>Distribueras av %1 och licensieras enligt &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 och %2-logotypen är registrerade varumärken som tillhör %1.&lt;br&gt;&lt;br&gt;</translation>
+            <translation>Dystrybucja: %1; na licencji &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 oraz logo %2 są zastrzeżonymi znakami towarowymi firmy %1.&lt;br&gt;&lt;br&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/aboutdialog.cpp" line="151" />
             <location filename="../src/gui/aboutdialog.cpp" line="162" />
             <location filename="../src/gui/aboutdialog.cpp" line="171" />
             <source>Unable to open folder %1.</source>
-            <translation>Det går inte att öppna mappen %1.</translation>
+            <translation>Nie można otworzyć folderu %1.</translation>
         </message>
         <message>
             <location filename="../src/gui/aboutdialog.cpp" line="132" />
             <source>&lt;p&gt;&lt;small&gt;Built from &lt;a style="color: #489EF3" href="%1"&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
-            <translation>&lt;p&gt;&lt;small&gt;Kompilerad från &lt;a style="color: #489EF3" href="%1"&gt;Git-källkod&lt;/a&gt; den %2, %3 med Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
+            <translation>&lt;p&gt;&lt;small&gt;Skompilowano ze &lt;a style="color: #489EF3" href="%1"&gt;źródeł Git&lt;/a&gt; w dniu %2, %3 przy użyciu Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
         </message>
     </context>
     <context>
@@ -46,7 +46,7 @@
         <message>
             <location filename="../src/gui/abstractfileitemwidget.cpp" line="177" />
             <source>Unable to open folder path %1.</source>
-            <translation>Det går inte att öppna mappsökvägen %1.</translation>
+            <translation>Nie można otworzyć ścieżki folderu %1.</translation>
         </message>
     </context>
     <context>
@@ -54,27 +54,27 @@
         <message>
             <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55" />
             <source>Synchronization will start and you will be able to add files to your %1 folder.</source>
-            <translation>Synkroniseringen startar och du kan lägga till filer i mappen %1.</translation>
+            <translation>Rozpocznie się synchronizacja i będzie można dodawać pliki do folderu %1.</translation>
         </message>
         <message>
             <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99" />
             <source>Your kDrive is ready!</source>
-            <translation>Din kDrive är klar!</translation>
+            <translation>Twój kDrive jest gotowy!</translation>
         </message>
         <message>
             <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123" />
             <source>OPEN FOLDER</source>
-            <translation>ÖPPNA MAPP</translation>
+            <translation>OTWÓRZ FOLDER</translation>
         </message>
         <message>
             <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130" />
             <source>PARAMETERS</source>
-            <translation>INSTÄLLNINGAR</translation>
+            <translation>USTAWIENIA</translation>
         </message>
         <message>
             <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138" />
             <source>Synchronize another drive</source>
-            <translation>Synkronisera en annan enhet</translation>
+            <translation>Zsynchronizuj inny dysk</translation>
         </message>
     </context>
     <context>
@@ -82,32 +82,32 @@
         <message>
             <location filename="../src/gui/adddrivelistwidget.cpp" line="170" />
             <source>Cancel</source>
-            <translation>Avbryt</translation>
+            <translation>Anuluj</translation>
         </message>
         <message>
             <location filename="../src/gui/adddrivelistwidget.cpp" line="177" />
             <source>NEXT</source>
-            <translation>NÄSTA</translation>
+            <translation>DALEJ</translation>
         </message>
         <message>
             <location filename="../src/gui/adddrivelistwidget.cpp" line="196" />
             <source>Select the kDrive you want to synchronize</source>
-            <translation>Välj den kDrive du vill synkronisera</translation>
+            <translation>Wybierz urządzenie kDrive, które chcesz zsynchronizować</translation>
         </message>
         <message>
             <location filename="../src/gui/adddrivelistwidget.cpp" line="234" />
             <source>Get kDrive for free</source>
-            <translation>Skaffa kDrive gratis</translation>
+            <translation>Pobierz kDrive za darmo</translation>
         </message>
         <message>
             <location filename="../src/gui/adddrivelistwidget.cpp" line="244" />
             <source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
-            <translation>Spara dina bilder, dokument och e-postmeddelanden i Schweiz hos ett oberoende företag som respekterar din integritet. Läs mer</translation>
+            <translation>Przechowuj swoje zdjęcia, dokumenty i wiadomości e-mail w Szwajcarii, korzystając z usług niezależnej firmy, która szanuje prywatność. Dowiedz się więcej</translation>
         </message>
         <message>
             <location filename="../src/gui/adddrivelistwidget.cpp" line="263" />
             <source>Test for free</source>
-            <translation>Testa gratis</translation>
+            <translation>Wypróbuj za darmo</translation>
         </message>
     </context>
     <context>
@@ -115,42 +115,42 @@
         <message>
             <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147" />
             <source>Conserve your computer space</source>
-            <translation>Spara utrymme på datorn</translation>
+            <translation>Oszczędzaj miejsce na komputerze</translation>
         </message>
         <message>
             <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167" />
             <source>Decide which files should be available online or locally</source>
-            <translation>Bestäm vilka filer som ska vara tillgängliga online eller lokalt</translation>
+            <translation>Zdecyduj, które pliki mają być dostępne online lub lokalnie</translation>
         </message>
         <message>
             <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187" />
             <source>LATER</source>
-            <translation>SENARE</translation>
+            <translation>PÓŹNIEJ</translation>
         </message>
         <message>
             <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193" />
             <source>YES</source>
-            <translation>JA</translation>
+            <translation>TAK</translation>
         </message>
         <message>
             <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125" />
             <source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-            <translation>Lite Sync synkroniserar alla dina filer utan att ta upp utrymme på din dator. Du kan bläddra bland filerna i ditt kDrive och ladda ner dem lokalt när du vill. &lt;a style="%1" href="%2"&gt;Läs mer&lt;/a&gt;</translation>
+            <translation>Lite Sync synchronizuje wszystkie Twoje pliki bez zajmowania miejsca na komputerze. Możesz przeglądać pliki w kDrive i pobierać je lokalnie w dowolnym momencie. &lt;a style="%1" href="%2"&gt;Dowiedz się więcej&lt;/a&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207" />
             <source>Unable to open link %1.</source>
-            <translation>Det går inte att öppna länken %1.</translation>
+            <translation>Nie można otworzyć linku %1.</translation>
         </message>
         <message>
             <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112" />
             <source>Would you like to activate Lite Sync (Beta) ?</source>
-            <translation>Vill du aktivera Lite Sync (Beta)?</translation>
+            <translation>Czy chcesz włączyć funkcję Lite Sync (wersja beta)?</translation>
         </message>
         <message>
             <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114" />
             <source>Would you like to activate Lite Sync ?</source>
-            <translation>Vill du aktivera Lite Sync?</translation>
+            <translation>Czy chcesz włączyć funkcję Lite Sync?</translation>
         </message>
     </context>
     <context>
@@ -158,51 +158,51 @@
         <message>
             <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65" />
             <source>Location of your %1 kDrive</source>
-            <translation>Plats för din %1 kDrive</translation>
+            <translation>Lokalizacja dysku %1 kDrive</translation>
         </message>
         <message>
             <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155" />
             <source>Edit folder</source>
-            <translation>Ändra mapp</translation>
+            <translation>Edytuj folder</translation>
         </message>
         <message>
             <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246" />
             <source>END</source>
-            <translation>SLUTFÖR</translation>
+            <translation>ZAKOŃCZ</translation>
         </message>
         <message>
             <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297" />
             <source>Select folder</source>
-            <translation>Välj mapp</translation>
+            <translation>Wybierz folder</translation>
         </message>
         <message>
             <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264" />
             <source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
-            <translation>Innehållet i mappen &lt;b&gt;%1&lt;/b&gt; kommer att synkroniseras i din kDrive</translation>
+            <translation>Zawartość folderu &lt;b&gt;%1&lt;/b&gt; zostanie zsynchronizowana w Twoim kDrive</translation>
         </message>
         <message>
             <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212" />
             <source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
-            <translation>När konfigurationen är klar hittar du alla dina filer i den här mappen. Du kan lägga in nya filer där för att synkronisera dem till din kDrive.</translation>
+            <translation>Po zakończeniu konfiguracji wszystkie pliki znajdziesz w tym folderze. Możesz wrzucić tam nowe pliki, aby zsynchronizować je z usługą kDrive.</translation>
         </message>
         <message>
             <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284" />
             <source>This folder is not compatible with Lite Sync.&lt;br&gt; 
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt; 
 &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-            <translation>Den här mappen är inte kompatibel med Lite Sync.&lt;br&gt; 
-Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&gt; 
-&lt;a style="%1" href="%2"&gt;Läs mer&lt;/a&gt;</translation>
+            <translation>Ten folder nie jest zgodny z Lite Sync.&lt;br&gt; 
+Wybierz inny folder. Jeśli kontynuujesz, funkcja Lite Sync zostanie wyłączona.&lt;br&gt; 
+&lt;a style="%1" href="%2"&gt;Dowiedz się więcej&lt;/a&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377" />
             <source>Unable to open link %1.</source>
-            <translation>Det går inte att öppna länken %1.</translation>
+            <translation>Nie można otworzyć linku %1.</translation>
         </message>
         <message>
             <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246" />
             <source>CONTINUE</source>
-            <translation>FORTSÄTT</translation>
+            <translation>KONTYNUUJ</translation>
         </message>
     </context>
     <context>
@@ -210,32 +210,32 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/adddriveloginwidget.cpp" line="69" />
             <source>Log in from your browser</source>
-            <translation>Logga in från din webbläsare</translation>
+            <translation>Zaloguj się w przeglądarce</translation>
         </message>
         <message>
             <location filename="../src/gui/adddriveloginwidget.cpp" line="75" />
             <source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
-            <translation>Din webbläsare bör öppnas automatiskt för att slutföra anslutningen. När anslutningen är upprättad återgår du automatiskt till kDrive.</translation>
+            <translation>Przeglądarka powinna otworzyć się automatycznie, aby nawiązać połączenie. Po nawiązaniu połączenia nastąpi automatyczny powrót do serwisu kDrive.</translation>
         </message>
         <message>
             <location filename="../src/gui/adddriveloginwidget.cpp" line="85" />
             <source>Open the login page</source>
-            <translation>Öppna inloggningssidan</translation>
+            <translation>Otwórz stronę logowania</translation>
         </message>
         <message>
             <location filename="../src/gui/adddriveloginwidget.cpp" line="119" />
             <source>Token request failed: %1 - %2</source>
-            <translation>Begäran om token misslyckades: %1 - %2</translation>
+            <translation>Wystąpił błąd podczas żądania tokenu: %1 - %2</translation>
         </message>
         <message>
             <location filename="../src/gui/adddriveloginwidget.cpp" line="133" />
             <source>Login failed: %1 - %2</source>
-            <translation>Inloggningen misslyckades: %1 - %2</translation>
+            <translation>Nie udało się zalogować: %1 - %2</translation>
         </message>
         <message>
             <location filename="../src/gui/adddriveloginwidget.cpp" line="141" />
             <source>Failed to open the login page in your web browser</source>
-            <translation>Det gick inte att öppna inloggningssidan i din webbläsare</translation>
+            <translation>Nie udało się otworzyć strony logowania w przeglądarce internetowej</translation>
         </message>
     </context>
     <context>
@@ -243,27 +243,27 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129" />
             <source>Select kDrive folders to synchronize on your desktop</source>
-            <translation>Välj vilka kDrive-mappar som ska synkroniseras på din dator</translation>
+            <translation>Wybierz foldery kDrive, które chcesz zsynchronizować na pulpicie</translation>
         </message>
         <message>
             <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174" />
             <source>CONTINUE</source>
-            <translation>FORTSÄTT</translation>
+            <translation>KONTYNUUJ</translation>
         </message>
         <message>
             <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187" />
             <source>Space available on your computer : %1</source>
-            <translation>Ledigt utrymme på din dator: %1</translation>
+            <translation>Wolne miejsce na komputerze: %1</translation>
         </message>
         <message>
             <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206" />
             <source>An error occurred while loading the list of subfolders.</source>
-            <translation>Ett fel uppstod vid inläsningen av listan över undermappar.</translation>
+            <translation>Wystąpił błąd podczas ładowania listy podfolderów.</translation>
         </message>
         <message>
             <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210" />
             <source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
-            <translation>Det går inte att ladda listan över undermappar&lt;br&gt;. Din kDrive kan vara under underhåll. Logga in på &lt;a style="%1" href="%2"&gt;webbversionen&lt;/a&gt; för att kontrollera statusen för din kDrive, eller kontakta din administratör.</translation>
+            <translation>Nie można załadować listy podfolderów. Być może Twoje konto kDrive jest obecnie w trakcie konserwacji.&lt;br&gt;Zaloguj się do &lt;a style="%1" href="%2"&gt;wersji&lt;/a&gt; &lt;a style="%1" href="%2"&gt;internetowej&lt;/a&gt;, aby sprawdzić stan swojego konta kDrive, lub skontaktuj się z administratorem.</translation>
         </message>
     </context>
     <context>
@@ -271,17 +271,17 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/adddrivewizard.cpp" line="222" />
             <source>Failed to create local folder %1</source>
-            <translation>Det gick inte att skapa den lokala mappen %1</translation>
+            <translation>Nie udało się utworzyć folderu lokalnego %1</translation>
         </message>
         <message>
             <location filename="../src/gui/adddrivewizard.cpp" line="233" />
             <source>Failed to create new synchronization</source>
-            <translation>Det gick inte att skapa en ny synkronisering</translation>
+            <translation>Nie udało się utworzyć nowej synchronizacji</translation>
         </message>
         <message>
             <location filename="../src/gui/adddrivewizard.cpp" line="266" />
             <source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
-            <translation>kDrive %1 är redan synkroniserat på den här datorn. Vill du fortsätta ändå?</translation>
+            <translation>Aplikacja kDrive %1 jest już zsynchronizowana na tym komputerze. Czy mimo to chcesz kontynuować?</translation>
         </message>
     </context>
     <context>
@@ -289,17 +289,17 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/appclient.cpp" line="100" />
             <source>kDrive client is run with bad parameters!</source>
-            <translation>kDrive-klienten körs med felaktiga parametrar!</translation>
+            <translation>Program kDrive został uruchomiony z nieprawidłowymi parametrami!</translation>
         </message>
         <message>
             <location filename="../src/gui/appclient.cpp" line="109" />
             <source>kDrive client is already running!</source>
-            <translation>kDrive-klienten är redan igång!</translation>
+            <translation>Klient kDrive już działa!</translation>
         </message>
         <message>
             <location filename="../src/gui/appclient.cpp" line="719" />
             <source>The user %1 is not connected. Please log in again.</source>
-            <translation>Användaren %1 är inte inloggad. Logga in igen.</translation>
+            <translation>Użytkownik %1 nie jest zalogowany. Zaloguj się ponownie.</translation>
         </message>
     </context>
     <context>
@@ -307,67 +307,67 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/server/appserver.cpp" line="1679" />
             <source>Share link copied to clipboard</source>
-            <translation>Delningslänken har kopierats till urklipp</translation>
+            <translation>Link do udostępnienia skopiowano do schowka</translation>
         </message>
         <message numerus="yes">
             <location filename="../src/server/appserver.cpp" line="3759" />
             <source>%1 and %n other file(s) have been removed.</source>
             <translation>
-                <numerusform>%1 och %n annan fil har tagits bort.</numerusform>
-                <numerusform>%1 och %n andra filer har tagits bort.</numerusform>
+                <numerusform>%1 oraz %n inny plik zostały usunięte.</numerusform>
+                <numerusform>%1 oraz %n innych plików zostało usuniętych.</numerusform>
             </translation>
         </message>
         <message>
             <location filename="../src/server/appserver.cpp" line="3761" />
             <source>%1 has been removed.</source>
             <comment>%1 names a file.</comment>
-            <translation>%1 har tagits bort.</translation>
+            <translation>%1 został usunięty.</translation>
         </message>
         <message numerus="yes">
             <location filename="../src/server/appserver.cpp" line="3766" />
             <source>%1 and %n other file(s) have been added.</source>
             <translation>
-                <numerusform>%1 och %n annan fil har lagts till.</numerusform>
-                <numerusform>%1 och %n andra filer har lagts till.</numerusform>
+                <numerusform>%1 oraz %n inny plik zostały dodane.</numerusform>
+                <numerusform>%1 oraz %n innych plików zostało dodanych.</numerusform>
             </translation>
         </message>
         <message>
             <location filename="../src/server/appserver.cpp" line="3768" />
             <source>%1 has been added.</source>
             <comment>%1 names a file.</comment>
-            <translation>%1 har lagts till.</translation>
+            <translation>Dodano %1.</translation>
         </message>
         <message numerus="yes">
             <location filename="../src/server/appserver.cpp" line="3773" />
             <source>%1 and %n other file(s) have been updated.</source>
             <translation>
-                <numerusform>%1 och %n annan fil har uppdaterats.</numerusform>
-                <numerusform>%1 och %n andra filer har uppdaterats.</numerusform>
+                <numerusform>%1 oraz %n inny plik zostały zaktualizowane.</numerusform>
+                <numerusform>%1 oraz %n innych plików zostało zaktualizowanych.</numerusform>
             </translation>
         </message>
         <message>
             <location filename="../src/server/appserver.cpp" line="3775" />
             <source>%1 has been updated.</source>
             <comment>%1 names a file.</comment>
-            <translation>%1 har uppdaterats.</translation>
+            <translation>%1 zostało zaktualizowane.</translation>
         </message>
         <message numerus="yes">
             <location filename="../src/server/appserver.cpp" line="3780" />
             <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
             <translation>
-                <numerusform>%1 har flyttats till %2 och %n annan fil har flyttats.</numerusform>
-                <numerusform>%1 har flyttats till %2 och %n andra filer har flyttats.</numerusform>
+                <numerusform>%1 został przeniesiony do %2, a %n inny plik został przeniesiony.</numerusform>
+                <numerusform>%1 został przeniesiony do %2, a %n innych plików zostało przeniesionych.</numerusform>
             </translation>
         </message>
         <message>
             <location filename="../src/server/appserver.cpp" line="3783" />
             <source>%1 has been moved to %2.</source>
-            <translation>%1 har flyttats till %2.</translation>
+            <translation>%1 zostało przeniesione do %2.</translation>
         </message>
         <message>
             <location filename="../src/server/appserver.cpp" line="3791" />
             <source>Sync Activity</source>
-            <translation>Synkroniseringsaktivitet</translation>
+            <translation>Synchronizacja działań</translation>
         </message>
     </context>
     <context>
@@ -375,7 +375,7 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102" />
             <source>No subfolders currently on the server.</source>
-            <translation>Det finns för närvarande inga undermappar på servern.</translation>
+            <translation>Obecnie na serwerze nie ma żadnych podfolderów.</translation>
         </message>
     </context>
     <context>
@@ -383,67 +383,67 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/betaprogramdialog.cpp" line="69" />
             <source>Quit the beta program</source>
-            <translation>Avsluta betaprogrammet</translation>
+            <translation>Wyjdź z programu beta</translation>
         </message>
         <message>
             <location filename="../src/gui/betaprogramdialog.cpp" line="69" />
             <source>Join the beta program</source>
-            <translation>Anmäl dig till betaprogrammet</translation>
+            <translation>Dołącz do programu beta</translation>
         </message>
         <message>
             <location filename="../src/gui/betaprogramdialog.cpp" line="77" />
             <source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
-            <translation>Få tillgång till nya versioner av applikationen innan de släpps till allmänheten och bidra till att förbättra applikationen genom att skicka oss dina synpunkter.</translation>
+            <translation>Zyskaj wczesny dostęp do nowych wersji aplikacji, zanim zostaną one udostępnione szerokiej publiczności, i pomóż nam ulepszać aplikację, przesyłając nam swoje uwagi.</translation>
         </message>
         <message>
             <location filename="../src/gui/betaprogramdialog.cpp" line="87" />
             <source>Benefit from application beta updates</source>
-            <translation>Dra nytta av uppdateringar av betaversionen av appen</translation>
+            <translation>Skorzystaj z aktualizacji wersji beta aplikacji</translation>
         </message>
         <message>
             <location filename="../src/gui/betaprogramdialog.cpp" line="91" />
             <source>No</source>
-            <translation>Nej</translation>
+            <translation>Nie</translation>
         </message>
         <message>
             <location filename="../src/gui/betaprogramdialog.cpp" line="92" />
             <source>Public beta version</source>
-            <translation>Offentlig betaversion</translation>
+            <translation>Publiczna wersja beta</translation>
         </message>
         <message>
             <location filename="../src/gui/betaprogramdialog.cpp" line="93" />
             <source>Internal beta version</source>
-            <translation>Intern betaversion</translation>
+            <translation>Wewnętrzna wersja beta</translation>
         </message>
         <message>
             <location filename="../src/gui/betaprogramdialog.cpp" line="141" />
             <source>I understand</source>
-            <translation>Jag förstår</translation>
+            <translation>Rozumiem</translation>
         </message>
         <message>
             <location filename="../src/gui/betaprogramdialog.cpp" line="147" />
             <source>Are you sure you want to leave the beta program?</source>
-            <translation>Är du säker på att du vill lämna betaprogrammet?</translation>
+            <translation>Czy na pewno chcesz opuścić program beta?</translation>
         </message>
         <message>
             <location filename="../src/gui/betaprogramdialog.cpp" line="161" />
             <source>Save</source>
-            <translation>Spara</translation>
+            <translation>Zapisz</translation>
         </message>
         <message>
             <location filename="../src/gui/betaprogramdialog.cpp" line="167" />
             <source>Cancel</source>
-            <translation>Avbryt</translation>
+            <translation>Anuluj</translation>
         </message>
         <message>
             <location filename="../src/gui/betaprogramdialog.cpp" line="228" />
             <source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
-            <translation>Din nuvarande version av appen kan vara för ny; ditt val träder i kraft när nästa uppdatering blir tillgänglig.</translation>
+            <translation>Obecna wersja aplikacji może być zbyt nowa; wybrane ustawienia zaczną obowiązywać po udostępnieniu kolejnej aktualizacji.</translation>
         </message>
         <message>
             <location filename="../src/gui/betaprogramdialog.cpp" line="233" />
             <source>Beta versions may leave unexpectedly or cause instabilities.</source>
-            <translation>Betaversioner kan stängas ner utan förvarning eller orsaka instabilitet.</translation>
+            <translation>Wersje beta mogą się niespodziewanie zamknąć lub powodować niestabilność działania.</translation>
         </message>
     </context>
     <context>
@@ -451,113 +451,113 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/clientgui.cpp" line="189" />
             <source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
-            <translation>Det gick inte att lösa konflikterna för %1 objekt i synkroniseringsmappen: %2</translation>
+            <translation>Nie udało się rozwiązać konfliktu(-ów) dotyczących %1 elementu(-ów) w folderze synchronizacji: %2</translation>
         </message>
         <message>
             <location filename="../src/gui/clientgui.cpp" line="242" />
             <source>Please sign in</source>
-            <translation>Logga in</translation>
+            <translation>Zaloguj się</translation>
         </message>
         <message>
             <location filename="../src/gui/clientgui.cpp" line="292" />
             <source>Folder %1: %2</source>
-            <translation>Mappen %1: %2</translation>
+            <translation>Folder %1: %2</translation>
         </message>
         <message>
             <location filename="../src/gui/clientgui.cpp" line="298" />
             <source>There are no sync folders configured.</source>
-            <translation>Det finns inga synkroniseringsmappar konfigurerade.</translation>
+            <translation>Nie skonfigurowano żadnych folderów synchronizacji.</translation>
         </message>
         <message>
             <location filename="../src/gui/clientgui.cpp" line="1426" />
             <source>Synthesis</source>
-            <translation>Sammanfattning</translation>
+            <translation>Podsumowanie</translation>
         </message>
         <message>
             <location filename="../src/gui/clientgui.cpp" line="1427" />
             <source>Preferences</source>
             <translatorcomment>Préférences</translatorcomment>
-            <translation>Inställningar</translation>
+            <translation>Preferencje</translation>
         </message>
         <message>
             <location filename="../src/gui/clientgui.cpp" line="1428" />
             <source>Quit</source>
-            <translation>Avsluta</translation>
+            <translation>Zakończ</translation>
         </message>
         <message>
             <location filename="../src/gui/clientgui.cpp" line="673" />
             <source>Undefined State.</source>
-            <translation>Odefinierat tillstånd.</translation>
+            <translation>Stan nieokreślony.</translation>
         </message>
         <message>
             <location filename="../src/gui/clientgui.cpp" line="676" />
             <source>Waiting to start syncing.</source>
-            <translation>Väntar på att synkroniseringen ska starta.</translation>
+            <translation>Oczekiwanie na rozpoczęcie synchronizacji.</translation>
         </message>
         <message>
             <location filename="../src/gui/clientgui.cpp" line="679" />
             <source>Sync is running.</source>
-            <translation>Synkroniseringen pågår.</translation>
+            <translation>Synchronizacja trwa.</translation>
         </message>
         <message>
             <location filename="../src/gui/clientgui.cpp" line="683" />
             <source>Sync was successful, unresolved conflicts.</source>
-            <translation>Synkroniseringen lyckades, men det finns olösta konflikter.</translation>
+            <translation>Synchronizacja przebiegła pomyślnie, pozostały nierozwiązane konflikty.</translation>
         </message>
         <message>
             <location filename="../src/gui/clientgui.cpp" line="685" />
             <source>Last Sync was successful.</source>
-            <translation>Den senaste synkroniseringen genomfördes utan problem.</translation>
+            <translation>Ostatnia synchronizacja zakończyła się powodzeniem.</translation>
         </message>
         <message>
             <location filename="../src/gui/clientgui.cpp" line="692" />
             <source>User Abort.</source>
-            <translation>Användaren avbryter.</translation>
+            <translation>Anulowanie przez użytkownika.</translation>
         </message>
         <message>
             <location filename="../src/gui/clientgui.cpp" line="696" />
             <source>Sync is paused.</source>
-            <translation>Synkroniseringen är pausad.</translation>
+            <translation>Synchronizacja została wstrzymana.</translation>
         </message>
         <message>
             <location filename="../src/gui/clientgui.cpp" line="705" />
             <source>%1 (Sync is paused)</source>
-            <translation>%1 (Synkroniseringen är pausad)</translation>
+            <translation>%1 (Synchronizacja została wstrzymana)</translation>
         </message>
         <message>
             <location filename="../src/gui/clientgui.cpp" line="1261" />
             <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-            <translation>Vill du verkligen ta bort synkroniseringarna för kontot &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Obs!&lt;/b&gt; Detta raderar inga filer.</translation>
+            <translation>Czy na pewno chcesz usunąć synchronizacje konta &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Uwaga: Nie&lt;/b&gt; spowoduje to usunięcia żadnych plików.</translation>
         </message>
         <message>
             <location filename="../src/gui/clientgui.cpp" line="1265" />
             <source>REMOVE ALL SYNCHRONIZATIONS</source>
-            <translation>TA BORT ALLA SYNKRONISERINGAR</translation>
+            <translation>USUŃ WSZYSTKIE SYNCHRONIZACJE</translation>
         </message>
         <message>
             <location filename="../src/gui/clientgui.cpp" line="1266" />
             <source>CANCEL</source>
-            <translation>AVBRYT</translation>
+            <translation>ANULUJ</translation>
         </message>
         <message>
             <location filename="../src/gui/clientgui.cpp" line="1594" />
             <source>Failed to start synchronizations!</source>
-            <translation>Det gick inte att starta synkroniseringarna!</translation>
+            <translation>Nie udało się uruchomić synchronizacji!</translation>
         </message>
         <message>
             <location filename="../src/gui/clientgui.cpp" line="849" />
             <source>Unable to open folder path %1.</source>
-            <translation>Det går inte att öppna mappsökvägen %1.</translation>
+            <translation>Nie można otworzyć ścieżki folderu %1.</translation>
         </message>
         <message>
             <location filename="../src/gui/clientgui.cpp" line="116" />
             <source>Unable to initialize kDrive client</source>
-            <translation>Det går inte att starta kDrive-klienten</translation>
+            <translation>Nie można zainicjować klienta kDrive</translation>
         </message>
         <message>
             <location filename="../src/gui/clientgui.cpp" line="255" />
             <source>Synchronization is paused</source>
-            <translation>Synkroniseringen är pausad</translation>
+            <translation>Synchronizacja została wstrzymana</translation>
         </message>
     </context>
     <context>
@@ -565,22 +565,22 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86" />
             <source>Summary of your local folder synchronization</source>
-            <translation>Sammanfattning av synkroniseringen av din lokala mapp</translation>
+            <translation>Podsumowanie synchronizacji folderów lokalnych</translation>
         </message>
         <message>
             <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95" />
             <source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
-            <translation>Innehållet i mappen på din dator kommer att synkroniseras med mappen på den valda kDrive-enheten och vice versa.</translation>
+            <translation>Zawartość folderu na Twoim komputerze zostanie zsynchronizowana z folderem na wybranym serwerze kDrive i odwrotnie.</translation>
         </message>
         <message>
             <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184" />
             <source>CANCEL</source>
-            <translation>AVBRYT</translation>
+            <translation>ANULUJ</translation>
         </message>
         <message>
             <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191" />
             <source>SYNCHRONIZE</source>
-            <translation>SYNKRONISERA</translation>
+            <translation>SYNCHRONIZUJ</translation>
         </message>
     </context>
     <context>
@@ -589,104 +589,104 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="96" />
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="120" />
             <source>Before finishing</source>
-            <translation>Innan du avslutar</translation>
+            <translation>Zanim skończymy</translation>
         </message>
         <message>
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="107" />
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="131" />
             <source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
-            <translation>Följ dessa steg för att säkerställa att Lite Sync fungerar korrekt på din dator och för att slutföra konfigurationen av kDrive.</translation>
+            <translation>Wykonaj poniższe czynności, aby upewnić się, że program Lite Sync działa poprawnie na Twoim komputerze, oraz aby zakończyć konfigurację serwisu kDrive.</translation>
         </message>
         <message>
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="208" />
             <source>Open your Mac's &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-            <translation>Öppna &lt;b&gt;inställningarna under ”Allmänt”&lt;/b&gt; på din Mac eller  &lt;a style="%1" href="%2"&gt;klicka här&lt;/a&gt;</translation>
+            <translation>Otwórz &lt;b&gt;ustawienia ogólne&lt;/b&gt; komputera Mac lub &lt;a style="%1" href="%2"&gt;kliknij tutaj&lt;/a&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="212" />
             <source>Open your Mac's &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-            <translation>Öppna &lt;b&gt;inställningarna för sekretess och säkerhet&lt;/b&gt; på din Mac eller  &lt;a style="%1" href="%2"&gt;klicka här&lt;/a&gt;</translation>
+            <translation>Otwórz &lt;b&gt;ustawienia prywatności i bezpieczeństwa&lt;/b&gt; na komputerze Mac lub &lt;a style="%1" href="%2"&gt;kliknij tutaj&lt;/a&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="216" />
             <source>Open your Mac's &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-            <translation>Öppna &lt;b&gt;inställningarna&lt;/b&gt; för &lt;b&gt;Säkerhet och integritet&lt;/b&gt; på din Mac eller  &lt;a style="%1" href="%2"&gt;klicka här&lt;/a&gt;</translation>
+            <translation>Otwórz &lt;b&gt;ustawienia „Bezpieczeństwo i prywatność”&lt;/b&gt; na komputerze Mac lub &lt;a style="%1" href="%2"&gt;kliknij tutaj&lt;/a&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="246" />
             <source>Go to &lt;b&gt;"Login Items &amp; Extensions"&lt;/b&gt; section and then to &lt;b&gt;"Endpoint Security Extensions"&lt;/b&gt;</source>
-            <translation>Gå till avsnittet &lt;b&gt;”Inloggningsobjekt och tillägg”&lt;/b&gt; och sedan till &lt;b&gt;”Endpoint Security-tillägg”&lt;/b&gt;</translation>
+            <translation>Przejdź do sekcji &lt;b&gt;„Elementy logowania i rozszerzenia”,&lt;/b&gt; a następnie do &lt;b&gt;„Rozszerzenia Endpoint Security”&lt;/b&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="263" />
             <source>Authorize the kDrive application</source>
-            <translation>Godkänn appen kDrive</translation>
+            <translation>Zezwól aplikacji kDrive</translation>
         </message>
         <message>
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="272" />
             <source>Go to &lt;b&gt;"Security"&lt;/b&gt; section</source>
-            <translation>Gå till avsnittet &lt;b&gt;”Säkerhet”&lt;/b&gt;</translation>
+            <translation>Przejdź do sekcji &lt;b&gt;„Bezpieczeństwo”&lt;/b&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="289" />
             <source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
-            <translation>Godkänn kDrive-appen i rutan där det står att kDrive har blockerats</translation>
+            <translation>Zezwól aplikacji kDrive w oknie informującym, że kDrive zostało zablokowane</translation>
         </message>
         <message>
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="299" />
             <source>Unlock the padlock &lt;img src=":/client/resources/icons/actions/lock.png"&gt; and authorize the kDrive application</source>
-            <translation>Lås upp hänglåset &lt;img src=":/client/resources/icons/actions/lock.png"&gt; och godkänn kDrive-appen</translation>
+            <translation>Odblokuj kłódkę &lt;img src=":/client/resources/icons/actions/lock.png"&gt; i autoryzuj aplikację kDrive</translation>
         </message>
         <message>
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="344" />
             <source>Go to &lt;b&gt;"Privacy &amp; Security"&lt;/b&gt; section and click on &lt;b&gt;"Full Disk Access"&lt;/b&gt; or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-            <translation>Gå till avsnittet &lt;b&gt;”Sekretess och säkerhet”&lt;/b&gt; och klicka på &lt;b&gt;”Fullständig disktillgång”&lt;/b&gt; eller &lt;a style="%1" href="%2"&gt;klicka här&lt;/a&gt;</translation>
+            <translation>Przejdź do sekcji &lt;b&gt;„Prywatność i bezpieczeństwo”&lt;/b&gt; i kliknij opcję &lt;b&gt;„Pełny dostęp do dysku”&lt;/b&gt; lub &lt;a style="%1" href="%2"&gt;kliknij tutaj&lt;/a&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="348" />
             <source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;"Privacy"&lt;/b&gt; tab or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-            <translation>Öppna fliken &lt;b&gt;”Sekretess”&lt;/b&gt; i inställningarna för säkerhet och sekretess, eller &lt;a style="%1" href="%2"&gt;klicka här&lt;/a&gt;</translation>
+            <translation>Wciąż w ustawieniach „Bezpieczeństwo i prywatność” otwórz zakładkę &lt;b&gt;„Prywatność”&lt;/b&gt; lub &lt;a style="%1" href="%2"&gt;kliknij tutaj&lt;/a&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="376" />
             <source>Check the "kDrive LiteSync Extension" box then the "kDrive.app" box (if not already checked)</source>
-            <translation>Markera rutan ”kDrive LiteSync Extension” och sedan rutan ”kDrive.app” (om den inte redan är markerad)</translation>
+            <translation>Zaznacz pole „kDrive LiteSync Extension”, a następnie pole „kDrive.app” (jeśli nie jest jeszcze zaznaczone)</translation>
         </message>
         <message>
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="393" />
             <source>A restart of the app might be proposed, in this case accept it</source>
-            <translation>Det kan hända att appen föreslår en omstart; i så fall godkänner du den</translation>
+            <translation>Może pojawić się propozycja ponownego uruchomienia aplikacji; w takim przypadku należy ją zaakceptować</translation>
         </message>
         <message>
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="399" />
             <source>Check the "kDrive LiteSync Extension" box (and "kDrive.app" if it exists) in &lt;b&gt;"Full Disk Access"&lt;/b&gt;</source>
-            <translation>Markera rutan ”kDrive LiteSync Extension” (och ”kDrive.app” om den finns) under &lt;b&gt;”Fullständig diskåtkomst”&lt;/b&gt;</translation>
+            <translation>Zaznacz pole „kDrive LiteSync Extension” (oraz „kDrive.app”, jeśli istnieje) w &lt;b&gt;sekcji „Pełny dostęp do dysku”&lt;/b&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="495" />
             <source>STEP 1</source>
-            <translation>STEG 1</translation>
+            <translation>KROK 1</translation>
         </message>
         <message>
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="495" />
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="496" />
             <source>(Done)</source>
-            <translation>(Klart)</translation>
+            <translation>(Gotowe)</translation>
         </message>
         <message>
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="496" />
             <source>STEP 2</source>
-            <translation>STEG 2</translation>
+            <translation>KROK 2</translation>
         </message>
         <message>
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="499" />
             <source>STEPS PERFORMED</source>
-            <translation>UTFÖRDA STEG</translation>
+            <translation>WYKONANE CZYNNOŚCI</translation>
         </message>
         <message>
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="501" />
             <source>END</source>
-            <translation>SLUTFÖR</translation>
+            <translation>ZAKOŃCZ</translation>
         </message>
     </context>
     <context>
@@ -694,22 +694,22 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/custommessagebox.cpp" line="101" />
             <source>OK</source>
-            <translation>OKEJ</translation>
+            <translation>OK</translation>
         </message>
         <message>
             <location filename="../src/gui/custommessagebox.cpp" line="111" />
             <source>CANCEL</source>
-            <translation>AVBRYT</translation>
+            <translation>ANULUJ</translation>
         </message>
         <message>
             <location filename="../src/gui/custommessagebox.cpp" line="121" />
             <source>YES</source>
-            <translation>JA</translation>
+            <translation>TAK</translation>
         </message>
         <message>
             <location filename="../src/gui/custommessagebox.cpp" line="131" />
             <source>NO</source>
-            <translation>NEJ</translation>
+            <translation>NIE</translation>
         </message>
     </context>
     <context>
@@ -717,12 +717,12 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/debugreporter.cpp" line="37" />
             <source>Sending of debugging information</source>
-            <translation>Översändning av felsökningsinformation</translation>
+            <translation>Wysyłanie informacji dotyczących debugowania</translation>
         </message>
         <message>
             <location filename="../src/gui/debugreporter.cpp" line="37" />
             <source>Cancel</source>
-            <translation>Avbryt</translation>
+            <translation>Anuluj</translation>
         </message>
     </context>
     <context>
@@ -730,194 +730,194 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="46" />
             <source>Info</source>
-            <translation>Info</translation>
+            <translation>Informacje</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="45" />
             <source>Debug</source>
-            <translation>Felsökning</translation>
+            <translation>Debugowanie</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="47" />
             <source>Warning</source>
-            <translation>Varning</translation>
+            <translation>Ostrzeżenie</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="48" />
             <source>Error</source>
-            <translation>Fel</translation>
+            <translation>Błąd</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="49" />
             <source>Fatal</source>
-            <translation>Dödlig</translation>
+            <translation>Śmiertelny</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="74" />
             <source>Debugging settings</source>
-            <translation>Felsökningsinställningar</translation>
+            <translation>Ustawienia debugowania</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="90" />
             <source>Save debugging information in a folder on my computer (Recommended)</source>
-            <translation>Spara felsökningsinformation i en mapp på min dator (rekommenderas)</translation>
+            <translation>Zapisz informacje dotyczące debugowania w folderze na moim komputerze (zalecane)</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="104" />
             <source>This information enables IT support to determine the origin of an incident.</source>
-            <translation>Med hjälp av denna information kan IT-supporten fastställa var ett fel har sitt ursprung.</translation>
+            <translation>Informacje te pozwalają działowi wsparcia IT ustalić przyczynę incydentu.</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="114" />
             <source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
-            <translation>&lt;a style="%1" href="%2"&gt;Öppna felsökningsmappen&lt;/a&gt;</translation>
+            <translation>&lt;a style="%1" href="%2"&gt;Otwórz folder debugowania&lt;/a&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="143" />
             <source>Debug level</source>
-            <translation>Felsökningsnivå</translation>
+            <translation>Poziom debugowania</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="152" />
             <source>The trace level lets you choose the extent of the debugging information recorded</source>
-            <translation>Med spårningsnivån kan du välja hur mycket felsökningsinformation som ska registreras</translation>
+            <translation>Poziom śledzenia pozwala wybrać zakres rejestrowanych informacji dotyczących debugowania</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="179" />
             <source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
-            <translation>Den utökade fullständiga loggen samlar in en detaljerad historik som kan användas för felsökning. Om du aktiverar den kan det göra att kDrive-programmet går långsammare.</translation>
+            <translation>Rozszerzony dziennik pełny gromadzi szczegółową historię, którą można wykorzystać do debugowania. Jego włączenie może spowolnić działanie aplikacji kDrive.</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="183" />
             <source>Extended Full Log</source>
-            <translation>Utökad fullständig logg</translation>
+            <translation>Rozszerzony pełny dziennik</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="206" />
             <source>Delete logs older than %1 days</source>
-            <translation>Ta bort loggar som är äldre än %1 dagar</translation>
+            <translation>Usuń logi starsze niż %1 dni</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="225" />
             <source>Share the debug folder with Infomaniak support.</source>
-            <translation>Skicka debug-mappen till Infomaniaks support.</translation>
+            <translation>Prześlij folder debugowania do działu pomocy technicznej Infomaniak.</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="249" />
             <source>The last session is the periode since the last kDrive start.</source>
-            <translation>Den sista sessionen är tidsperioden sedan kDrive senast startades.</translation>
+            <translation>Ostatnia sesja to okres od ostatniego uruchomienia programu kDrive.</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="253" />
             <source>Share only the last kDrive session</source>
-            <translation>Dela endast den senaste kDrive-sessionen</translation>
+            <translation>Udostępnij tylko ostatnią sesję kDrive</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="284" />
             <source>  Loading</source>
-            <translation>  Laddar</translation>
+            <translation>  Ładowanie</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="293" />
             <source>Cancel</source>
-            <translation>Avbryt</translation>
+            <translation>Anuluj</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="319" />
             <source>SAVE</source>
-            <translation>SPARA</translation>
+            <translation>ZAPISZ</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="326" />
             <source>CANCEL</source>
-            <translation>AVBRYT</translation>
+            <translation>ANULUJ</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="470" />
             <source>Failed to share</source>
-            <translation>Det gick inte att dela</translation>
+            <translation>Nie udało się udostępnić</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="480" />
             <source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
-            <translation>1. Kontrollera att du är inloggad &lt;br&gt;2. Kontrollera att du har konfigurerat minst en kDrive</translation>
+            <translation>1. Sprawdź, czy jesteś zalogowany &lt;br&gt;2. Sprawdź, czy skonfigurowałeś co najmniej jeden serwer kDrive</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="485" />
             <source> (Connexion interrupted)</source>
-            <translation> (Anslutningen avbröts)</translation>
+            <translation> (Przerwano połączenie)</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="492" />
             <source>Share the folder with SwissTransfer &lt;br&gt;</source>
-            <translation>Dela mappen med SwissTransfer &lt;br&gt;</translation>
+            <translation>Udostępnij folder za pomocą SwissTransfer &lt;br&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="493" />
             <source> 1. We automatically compressed your log &lt;a style="%1" href="%2"&gt;here&lt;/a&gt;.&lt;br&gt;</source>
-            <translation> 1. Vi har automatiskt komprimerat din logg &lt;a style="%1" href="%2"&gt;här&lt;/a&gt;.&lt;br&gt;</translation>
+            <translation> 1. Automatycznie skompresowaliśmy &lt;a style="%1" href="%2"&gt;tutaj&lt;/a&gt; Twój plik dziennika.&lt;br&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="495" />
             <source> 2. Transfer the archive with &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
-            <translation> 2. Skicka arkivet via &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
+            <translation> 2. Prześlij archiwum za pomocą serwisu &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="497" />
             <source> 3. Share the link with &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
-            <translation> 3. Dela länken med &lt;a style="%1" href="%2"&gt;support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
+            <translation> 3. Prześlij link na adres&lt;a style="%1" href="%2"&gt;support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="527" />
             <source>Last upload the %1</source>
-            <translation>Senaste uppladdning: %1</translation>
+            <translation>Ostatnie przesłanie: %1</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="555" />
             <source>Sharing has been cancelled</source>
-            <translation>Delningen har avbrutits</translation>
+            <translation>Udostępnianie zostało anulowane</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.h" line="70" />
             <source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
-            <translation>Hela mappen är stor (&gt; 100 MB) och det kan ta en stund att dela den. För att minska delningstiden rekommenderar vi att du endast delar den senaste kDrive-sessionen.</translation>
+            <translation>Cały folder jest duży (&amp;gt; 100 MB) i udostępnienie go może zająć trochę czasu. Aby skrócić czas udostępniania, zalecamy udostępnienie tylko ostatniej sesji kDrive.</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="600" />
             <source>%1/%2/%3 at %4h%5m and %6s</source>
             <extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
-            <translation>%1/%2/%3 kl. %4:%5 och %6 sekunder</translation>
+            <translation>%1/%2/%3 o godz. %4:%5 i %6 s</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="643" />
             <source>Do you want to save your modifications?</source>
-            <translation>Vill du spara dina ändringar?</translation>
+            <translation>Czy chcesz zapisać wprowadzone zmiany?</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="698" />
             <location filename="../src/gui/debuggingdialog.cpp" line="704" />
             <source>Unable to open folder %1.</source>
-            <translation>Det går inte att öppna mappen %1.</translation>
+            <translation>Nie można otworzyć folderu %1.</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="711" />
             <source>  Share</source>
-            <translation>  Dela</translation>
+            <translation>  Udostępnij</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="721" />
             <source>  Sharing | step 1/2 %1%</source>
-            <translation>  Dela | steg 1/2 %1%</translation>
+            <translation>  Udostępnianie | krok 1/2 %1%</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="730" />
             <source>  Sharing | step 2/2 %1%</source>
-            <translation>  Dela | steg 2/2 %1%</translation>
+            <translation>  Udostępnianie | krok 2/2 %1%</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="740" />
             <source>  Canceling...</source>
-            <translation>  Avbryter...</translation>
+            <translation>  Anulowanie...</translation>
         </message>
     </context>
     <context>
@@ -925,152 +925,152 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="1118" />
             <source>Folders</source>
-            <translation>Mappar</translation>
+            <translation>Foldery</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="1120" />
             <source>Notifications</source>
-            <translation>Meddelanden</translation>
+            <translation>Powiadomienia</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="1123" />
             <source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
-            <translation>Ett meddelande visas så snart en ny mapp har synkroniserats eller ändrats</translation>
+            <translation>Gdy tylko nowy folder zostanie zsynchronizowany lub zmodyfikowany, pojawi się powiadomienie</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="1124" />
             <source>Connected with</source>
-            <translation>I samband med</translation>
+            <translation>Związane z</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="981" />
             <source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-            <translation>Vill du verkligen sluta synkronisera mappen &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Obs!&lt;/b&gt; Detta kommer &lt;b&gt;inte&lt;/b&gt; att radera några filer.</translation>
+            <translation>Czy na pewno chcesz przerwać synchronizację folderu &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Uwaga: Nie&lt;/b&gt; spowoduje to usunięcia żadnych plików.</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="356" />
             <source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
-            <translation>Denna åtgärd kan ta allt från några sekunder till några minuter, beroende på mappens storlek.</translation>
+            <translation>Operacja ta może potrwać od kilku sekund do kilku minut, w zależności od rozmiaru folderu.</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="360" />
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="391" />
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="986" />
             <source>CANCEL</source>
-            <translation>AVBRYT</translation>
+            <translation>ANULUJ</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="645" />
             <source>New local folder synchronization failed!</source>
-            <translation>Synkroniseringen av den nya lokala mappen misslyckades!</translation>
+            <translation>Nie udało się zsynchronizować nowego folderu lokalnego!</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="823" />
             <source>Lite Sync activation failed.</source>
-            <translation>Aktiveringen av Lite Sync misslyckades.</translation>
+            <translation>Aktywacja funkcji Lite Sync nie powiodła się.</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="841" />
             <source>Lite Sync deactivation failed.</source>
-            <translation>Det gick inte att inaktivera Lite Sync.</translation>
+            <translation>Nie udało się wyłączyć funkcji Lite Sync.</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="985" />
             <source>REMOVE FOLDER SYNC CONNECTION</source>
-            <translation>TA BORT SYNKRONISERINGSFÖRBINDELSEN FÖR MAPPEN</translation>
+            <translation>USUŃ POŁĄCZENIE SYNCHRONIZACJI FOLDERÓW</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="1048" />
             <source>An error occurred while loading the list of subfolders.</source>
-            <translation>Ett fel uppstod vid inläsningen av listan över undermappar.</translation>
+            <translation>Wystąpił błąd podczas ładowania listy podfolderów.</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="1121" />
             <source>Enable the notifications for this kDrive</source>
-            <translation>Aktivera aviseringar för denna kDrive</translation>
+            <translation>Włącz powiadomienia dla tego kDrive</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="359" />
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="390" />
             <source>CONFIRM</source>
-            <translation>BEKRÄFTA</translation>
+            <translation>POTWIERDŹ</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="120" />
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="1117" />
             <source>Synchronization errors and information.</source>
-            <translation>Synkroniseringsfel och information.</translation>
+            <translation>Błędy synchronizacji i informacje.</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="144" />
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="1119" />
             <source>Synchronize a local folder</source>
-            <translation>Synkronisera en lokal mapp</translation>
+            <translation>Zsynchronizuj folder lokalny</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="355" />
             <source>Do you really want to turn on Lite Sync?</source>
-            <translation>Vill du verkligen aktivera Lite Sync?</translation>
+            <translation>Czy na pewno chcesz włączyć funkcję Lite Sync?</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="382" />
             <source>Do you really want to turn off Lite Sync?</source>
-            <translation>Vill du verkligen stänga av Lite Sync?</translation>
+            <translation>Czy na pewno chcesz wyłączyć funkcję Lite Sync?</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="384" />
             <source>You don't have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
-            <translation>Du har inte tillräckligt med utrymme för att synkronisera alla filer på din kDrive (%1 saknas). Om du inaktiverar Lite Sync måste du välja vilka mappar som ska synkroniseras på din dator. Under tiden kommer synkroniseringen av din kDrive att pausas.</translation>
+            <translation>Nie masz wystarczającej ilości miejsca, aby zsynchronizować wszystkie pliki z kDrive (brakuje %1). Jeśli wyłączysz funkcję Lite Sync, musisz wybrać foldery, które chcesz zsynchronizować na swoim komputerze. W międzyczasie synchronizacja kDrive zostanie wstrzymana.</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="388" />
             <source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
-            <translation>Om du stänger av Lite Sync kommer alla filer att laddas ner till din dator.</translation>
+            <translation>Jeśli wyłączysz funkcję Lite Sync, wszystkie pliki zostaną pobrane na Twój komputer.</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="627" />
             <source>Failed to create new synchronization</source>
-            <translation>Det gick inte att skapa en ny synkronisering</translation>
+            <translation>Nie udało się utworzyć nowej synchronizacji</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="819" />
             <source>Lite Sync activated.</source>
-            <translation>Lite Sync är aktiverat.</translation>
+            <translation>Włączono funkcję Lite Sync.</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="837" />
             <source>Lite Sync deactivated.</source>
-            <translation>Lite Sync är inaktiverat.</translation>
+            <translation>Funkcja Lite Sync została wyłączona.</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="899" />
             <source>This drive is being deleted.</source>
-            <translation>Den här enheten raderas.</translation>
+            <translation>Ten dysk jest właśnie usuwany.</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="962" />
             <source>Impossible to open item %1</source>
-            <translation>Det går inte att öppna objekt %1</translation>
+            <translation>Nie można otworzyć elementu %1</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="1007" />
             <source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
-            <translation>Det gick inte att avbryta synkroniseringen av mappen &lt;i&gt;%1&lt;/i&gt;.</translation>
+            <translation>Nie udało się zatrzymać synchronizacji folderu &lt;i&gt;%1&lt;/i&gt;.</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="1125" />
             <source>Remove all synchronizations</source>
-            <translation>Ta bort alla synkroniseringar</translation>
+            <translation>Usuń wszystkie synchronizacje</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="1126" />
             <source>Search in your kDrive</source>
-            <translation>Sök i din kDrive</translation>
+            <translation>Wyszukaj w swoim kDrive</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="1127" />
             <source>Search</source>
-            <translation>Sök</translation>
+            <translation>Wyszukaj</translation>
         </message>
     </context>
     <context>
@@ -1078,12 +1078,12 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/driveselectionwidget.cpp" line="216" />
             <source>Synchronize a kDrive</source>
-            <translation>Synkronisera en kDrive</translation>
+            <translation>Zsynchronizuj kDrive</translation>
         </message>
         <message>
             <location filename="../src/gui/driveselectionwidget.cpp" line="150" />
             <source>Add a kDrive</source>
-            <translation>Lägg till en kDrive</translation>
+            <translation>Dodaj kDrive</translation>
         </message>
     </context>
     <context>
@@ -1091,17 +1091,17 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/errortabwidget.cpp" line="179" />
             <source>Resolve</source>
-            <translation>Lösa</translation>
+            <translation>Rozwiązać</translation>
         </message>
         <message>
             <location filename="../src/gui/errortabwidget.cpp" line="180" />
             <source>Conflicted item(s)</source>
-            <translation>Konflikterande objekt</translation>
+            <translation>Elementy powodujące konflikt</translation>
         </message>
         <message>
             <location filename="../src/gui/errortabwidget.cpp" line="181" />
             <source>Item(s) with unsupported characters</source>
-            <translation>Objekt med tecken som inte stöds</translation>
+            <translation>Elementy zawierające znaki nieobsługiwane</translation>
         </message>
         <message>
             <location filename="../src/gui/errortabwidget.cpp" line="92" />
@@ -1109,27 +1109,27 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
             <location filename="../src/gui/errortabwidget.cpp" line="178" />
             <location filename="../src/gui/errortabwidget.cpp" line="186" />
             <source>Clear history</source>
-            <translation>Rensa historiken</translation>
+            <translation>Wyczyść historię</translation>
         </message>
         <message>
             <location filename="../src/gui/errortabwidget.cpp" line="176" />
             <source>To Resolve</source>
-            <translation>Att lösa</translation>
+            <translation>Aby rozwiązać</translation>
         </message>
         <message>
             <location filename="../src/gui/errortabwidget.cpp" line="184" />
             <source>Automatically resolved</source>
-            <translation>Löst automatiskt</translation>
+            <translation>Rozwiązano automatycznie</translation>
         </message>
         <message>
             <location filename="../src/gui/errortabwidget.cpp" line="185" />
             <source>problem(s) solved</source>
-            <translation>problem löst</translation>
+            <translation>rozwiązane problemy</translation>
         </message>
         <message>
             <location filename="../src/gui/errortabwidget.cpp" line="177" />
             <source>problem(s) detected</source>
-            <translation>problem har upptäckts</translation>
+            <translation>wykryto problem(y)</translation>
         </message>
     </context>
     <context>
@@ -1138,18 +1138,18 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
             <location filename="../src/gui/errorsmenubarwidget.cpp" line="84" />
             <location filename="../src/gui/errorsmenubarwidget.cpp" line="103" />
             <source>Synchronization conflicts or errors</source>
-            <translation>Synkroniseringskonflikter eller fel</translation>
+            <translation>Konflikty lub błędy synchronizacji</translation>
         </message>
         <message>
             <location filename="../src/gui/errorsmenubarwidget.cpp" line="86" />
             <location filename="../src/gui/errorsmenubarwidget.cpp" line="105" />
             <source>Errors</source>
-            <translation>Fel</translation>
+            <translation>Błędy</translation>
         </message>
         <message>
             <location filename="../src/gui/errorsmenubarwidget.cpp" line="101" />
             <source>Back to preferences</source>
-            <translation>Tillbaka till inställningar</translation>
+            <translation>Powrót do ustawień</translation>
         </message>
     </context>
     <context>
@@ -1157,30 +1157,30 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/errorspopup.cpp" line="73" />
             <source>Some files couldn't be synchronized on the following kDrive(s) :</source>
-            <translation>Vissa filer kunde inte synkroniseras på följande kDrive-enheter:</translation>
+            <translation>Nie udało się zsynchronizować niektórych plików na następujących urządzeniach kDrive:</translation>
         </message>
         <message>
             <location filename="../src/gui/errorspopup.cpp" line="95" />
             <source> (%1 error(s))</source>
-            <translation> (%1 fel)</translation>
+            <translation> (%1 błąd(ów))</translation>
         </message>
         <message>
             <location filename="../src/gui/errorspopup.cpp" line="101" />
             <source> (%1 information(s))</source>
-            <translation> (%1 uppgift(er))</translation>
+            <translation> (%1 informacja(i))</translation>
         </message>
         <message>
             <location filename="../src/gui/errorspopup.cpp" line="107" />
             <source> (%1 error(s) and %2 information(s))</source>
-            <translation> (%1 fel och %2 uppgifter)</translation>
+            <translation> (%1 błąd(ów) i %2 informacja(i))</translation>
         </message>
         <message numerus="yes">
             <location filename="../src/gui/errorspopup.cpp" line="147" />
             <source>Generic errors (%n warning(s) or error(s))</source>
             <comment>Number of warnings or errors</comment>
             <translation>
-                <numerusform>Allmänna fel (%n varning eller fel)</numerusform>
-                <numerusform>Allmänna fel (%n varningar eller fel)</numerusform>
+                <numerusform>Błędy ogólne (%n ostrzeżenie lub błąd)</numerusform>
+                <numerusform>Błędy ogólne (%n ostrzeżenia lub błędy)</numerusform>
             </translation>
         </message>
     </context>
@@ -1189,57 +1189,57 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/fileexclusiondialog.cpp" line="78" />
             <source>Excluded files</source>
-            <translation>Undantagna filer</translation>
+            <translation>Pliki wykluczone</translation>
         </message>
         <message>
             <location filename="../src/gui/fileexclusiondialog.cpp" line="86" />
             <source>Add files or folders that will not be synchronized on your computer.</source>
-            <translation>Lägg till filer eller mappar som inte ska synkroniseras på din dator.</translation>
+            <translation>Dodaj pliki lub foldery, które nie będą synchronizowane na Twoim komputerze.</translation>
         </message>
         <message>
             <location filename="../src/gui/fileexclusiondialog.cpp" line="97" />
             <source>Add</source>
-            <translation>Lägg till</translation>
+            <translation>Dodaj</translation>
         </message>
         <message>
             <location filename="../src/gui/fileexclusiondialog.cpp" line="109" />
             <source>NAME</source>
-            <translation>NAMN</translation>
+            <translation>IMIĘ</translation>
         </message>
         <message>
             <location filename="../src/gui/fileexclusiondialog.cpp" line="114" />
             <source>WARNING</source>
-            <translation>VARNING</translation>
+            <translation>OSTRZEŻENIE</translation>
         </message>
         <message>
             <location filename="../src/gui/fileexclusiondialog.cpp" line="149" />
             <source>SAVE</source>
-            <translation>SPARA</translation>
+            <translation>ZAPISZ</translation>
         </message>
         <message>
             <location filename="../src/gui/fileexclusiondialog.cpp" line="156" />
             <source>CANCEL</source>
-            <translation>AVBRYT</translation>
+            <translation>ANULUJ</translation>
         </message>
         <message>
             <location filename="../src/gui/fileexclusiondialog.cpp" line="304" />
             <source>Do you want to save your modifications?</source>
-            <translation>Vill du spara dina ändringar?</translation>
+            <translation>Czy chcesz zapisać wprowadzone zmiany?</translation>
         </message>
         <message>
             <location filename="../src/gui/fileexclusiondialog.cpp" line="353" />
             <source>Exclusion template already exists!</source>
-            <translation>Mallen för uteslutning finns redan!</translation>
+            <translation>Szablon wykluczenia już istnieje!</translation>
         </message>
         <message>
             <location filename="../src/gui/fileexclusiondialog.cpp" line="374" />
             <source>Do you really want to delete?</source>
-            <translation>Vill du verkligen ta bort det?</translation>
+            <translation>Czy na pewno chcesz usunąć?</translation>
         </message>
         <message>
             <location filename="../src/gui/fileexclusiondialog.cpp" line="434" />
             <source>Cannot save changes!</source>
-            <translation>Det går inte att spara ändringarna!</translation>
+            <translation>Nie można zapisać zmian!</translation>
         </message>
     </context>
     <context>
@@ -1247,12 +1247,12 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/fileexclusionnamedialog.cpp" line="58" />
             <source>VALIDATE</source>
-            <translation>BEKRÄFTA</translation>
+            <translation>ZATWIERDŹ</translation>
         </message>
         <message>
             <location filename="../src/gui/fileexclusionnamedialog.cpp" line="65" />
             <source>CANCEL</source>
-            <translation>AVBRYT</translation>
+            <translation>ANULUJ</translation>
         </message>
     </context>
     <context>
@@ -1261,67 +1261,67 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
             <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67" />
             <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73" />
             <source>Unable to open link %1.</source>
-            <translation>Det går inte att öppna länken %1.</translation>
+            <translation>Nie można otworzyć linku %1.</translation>
         </message>
         <message>
             <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122" />
             <source>Solve conflict(s)</source>
-            <translation>Lösa konflikter</translation>
+            <translation>Rozwiązywanie konfliktów</translation>
         </message>
         <message>
             <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140" />
             <source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
-            <translation>&lt;b&gt;Vad vill du göra med den/de %1 objektet/objekten som är i konflikt?&lt;/b&gt;</translation>
+            <translation>&lt;b&gt;Co chcesz zrobić z %1 elementem (elementami) powodującym konflikt?&lt;/b&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143" />
             <source>Save my changes and replace other users' versions.</source>
-            <translation>Spara mina ändringar och ersätt andra användares versioner.</translation>
+            <translation>Zapisz moje zmiany i zastąp wersje innych użytkowników.</translation>
         </message>
         <message>
             <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147" />
             <source>Undo my changes and keep other users' versions.</source>
-            <translation>Ångra mina ändringar och behåll andra användares versioner.</translation>
+            <translation>Cofnij moje zmiany i zachowaj wersje innych użytkowników.</translation>
         </message>
         <message>
             <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169" />
             <source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
-            <translation>Dina ändringar kan raderas permanent. De går inte att återställa via kDrive-webbappen.</translation>
+            <translation>Twoje zmiany mogą zostać trwale usunięte. Nie da się ich przywrócić za pomocą aplikacji internetowej kDrive.</translation>
         </message>
         <message>
             <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171" />
             <source>&lt;a style=%1 href="%2"&gt;Learn more&lt;/a&gt;</source>
-            <translation>&lt;a style=%1 href="%2"&gt;Läs mer&lt;/a&gt;</translation>
+            <translation>&lt;a style=%1 href="%2"&gt;Dowiedz się więcej&lt;/a&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175" />
             <source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
-            <translation>Dina ändringar kommer att raderas permanent. De kan inte återställas via kDrive-webbappen.</translation>
+            <translation>Twoje zmiany zostaną trwale usunięte. Nie będzie można ich przywrócić za pomocą aplikacji internetowej kDrive.</translation>
         </message>
         <message>
             <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191" />
             <source>Show item(s)</source>
-            <translation>Visa objekt</translation>
+            <translation>Pokaż produkty</translation>
         </message>
         <message>
             <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228" />
             <source>VALIDATE</source>
-            <translation>BEKRÄFTA</translation>
+            <translation>ZATWIERDŹ</translation>
         </message>
         <message>
             <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234" />
             <source>CANCEL</source>
-            <translation>AVBRYT</translation>
+            <translation>ANULUJ</translation>
         </message>
         <message>
             <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251" />
             <source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
-            <translation>Flera användare har gjort ändringar i dessa filer på olika ställen (online på kDrive, på en dator eller i en mobil). Mappar som innehåller dessa filer kan också ha raderats.&lt;br&gt;</translation>
+            <translation>Pliki te zostały zmodyfikowane przez kilku użytkowników w różnych miejscach (online w serwisie kDrive, na komputerze lub urządzeniu mobilnym). Foldery zawierające te pliki mogły również zostać usunięte.&lt;br&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253" />
             <source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Learn more&lt;/a&gt;</source>
-            <translation>Den lokala versionen av din artikel &lt;b&gt;är inte synkroniserad&lt;/b&gt; med kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Läs mer&lt;/a&gt;</translation>
+            <translation>Lokalna wersja Twojego elementu &lt;b&gt;nie jest zsynchronizowana&lt;/b&gt; z kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Dowiedz się więcej&lt;/a&gt;</translation>
         </message>
     </context>
     <context>
@@ -1329,68 +1329,68 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/folderitemwidget.cpp" line="458" />
             <source>More actions</source>
-            <translation>Fler åtgärder</translation>
+            <translation>Więcej działań</translation>
         </message>
         <message>
             <location filename="../src/gui/folderitemwidget.cpp" line="188" />
             <location filename="../src/gui/folderitemwidget.cpp" line="476" />
             <source>Synchronized into &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</source>
-            <translation>Synkroniserad till &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</translation>
+            <translation>Zsynchronizowano do &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/folderitemwidget.cpp" line="343" />
             <source>Activate Lite Sync</source>
-            <translation>Aktivera Lite Sync</translation>
+            <translation>Włącz Lite Sync</translation>
         </message>
         <message>
             <location filename="../src/gui/folderitemwidget.cpp" line="345" />
             <source>Activate Lite Sync (Beta)</source>
-            <translation>Aktivera Lite Sync (Beta)</translation>
+            <translation>Włącz Lite Sync (wersja beta)</translation>
         </message>
         <message>
             <location filename="../src/gui/folderitemwidget.cpp" line="481" />
             <source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
-            <translation>Mappar som inte är markerade flyttas till papperskorgen om de innehåller objekt som är offline. Mappar som synkroniserats till kDrive förblir tillgängliga online.</translation>
+            <translation>Foldery, które nie zostały zaznaczone, zostaną przeniesione do kosza, o ile zawierają elementy dostępne w trybie offline. Foldery zsynchronizowane z kDrive pozostaną dostępne online.</translation>
         </message>
         <message>
             <location filename="../src/gui/folderitemwidget.cpp" line="485" />
             <source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
-            <translation>Mappar som inte är markerade kommer att flyttas till papperskorgen. Mappar som synkroniserats till kDrive kommer att förbli tillgängliga online.</translation>
+            <translation>Foldery, które nie zostały zaznaczone, zostaną przeniesione do kosza. Foldery zsynchronizowane z kDrive pozostaną dostępne online.</translation>
         </message>
         <message>
             <location filename="../src/gui/folderitemwidget.cpp" line="488" />
             <source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
-            <translation>Mappar som inte är markerade kommer att raderas &lt;b&gt;permanent&lt;/b&gt; från datorn. Mappar som synkroniserats till kDrive kommer att finnas kvar online.</translation>
+            <translation>Foldery, które nie zostały zaznaczone, zostaną &lt;b&gt;trwale&lt;/b&gt; usunięte z komputera. Foldery zsynchronizowane z kDrive pozostaną dostępne online.</translation>
         </message>
         <message>
             <location filename="../src/gui/folderitemwidget.cpp" line="493" />
             <source>Cancel</source>
-            <translation>Avbryt</translation>
+            <translation>Anuluj</translation>
         </message>
         <message>
             <location filename="../src/gui/folderitemwidget.cpp" line="494" />
             <source>VALIDATE</source>
-            <translation>BEKRÄFTA</translation>
+            <translation>ZATWIERDŹ</translation>
         </message>
         <message>
             <location filename="../src/gui/folderitemwidget.cpp" line="365" />
             <source>Pause synchronization</source>
-            <translation>Pausa synkroniseringen</translation>
+            <translation>Wstrzymaj synchronizację</translation>
         </message>
         <message>
             <location filename="../src/gui/folderitemwidget.cpp" line="354" />
             <source>Deactivate Lite Sync</source>
-            <translation>Inaktivera Lite Sync</translation>
+            <translation>Wyłącz Lite Sync</translation>
         </message>
         <message>
             <location filename="../src/gui/folderitemwidget.cpp" line="375" />
             <source>Resume synchronization</source>
-            <translation>Fortsätt synkroniseringen</translation>
+            <translation>Wznowienie synchronizacji</translation>
         </message>
         <message>
             <location filename="../src/gui/folderitemwidget.cpp" line="386" />
             <source>Remove synchronization</source>
-            <translation>Avaktivera synkronisering</translation>
+            <translation>Wyłącz synchronizację</translation>
         </message>
     </context>
     <context>
@@ -1398,7 +1398,7 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/genericerroritemwidget.cpp" line="85" />
             <source>Unable to open folder path %1.</source>
-            <translation>Det går inte att öppna mappsökvägen %1.</translation>
+            <translation>Nie można otworzyć ścieżki folderu %1.</translation>
         </message>
     </context>
     <context>
@@ -1406,22 +1406,22 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/litesyncappdialog.cpp" line="48" />
             <source>Application Id</source>
-            <translation>Applikations-ID</translation>
+            <translation>Identyfikator aplikacji</translation>
         </message>
         <message>
             <location filename="../src/gui/litesyncappdialog.cpp" line="98" />
             <source>Application Name</source>
-            <translation>Programnamn</translation>
+            <translation>Nazwa aplikacji</translation>
         </message>
         <message>
             <location filename="../src/gui/litesyncappdialog.cpp" line="121" />
             <source>VALIDATE</source>
-            <translation>BEKRÄFTA</translation>
+            <translation>ZATWIERDŹ</translation>
         </message>
         <message>
             <location filename="../src/gui/litesyncappdialog.cpp" line="128" />
             <source>CANCEL</source>
-            <translation>AVBRYT</translation>
+            <translation>ANULUJ</translation>
         </message>
     </context>
     <context>
@@ -1429,47 +1429,47 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/litesyncdialog.cpp" line="91" />
             <source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are "online". Add them in the list below to avoid this behaviour.</source>
-            <translation>Vissa appar (säkerhetskopieringsappar, antivirusprogram...) får åtkomst till dina filer, vilket gör att de laddas ner när de är ”uppkopplade”. Lägg till dem i listan nedan för att undvika detta.</translation>
+            <translation>Niektóre aplikacje (do tworzenia kopii zapasowych, antywirusowe...) uzyskują dostęp do Twoich plików, co powoduje ich pobieranie, gdy są one „online”. Dodaj je do poniższej listy, aby uniknąć tego zjawiska.</translation>
         </message>
         <message>
             <location filename="../src/gui/litesyncdialog.cpp" line="103" />
             <source>Add</source>
-            <translation>Lägg till</translation>
+            <translation>Dodaj</translation>
         </message>
         <message>
             <location filename="../src/gui/litesyncdialog.cpp" line="115" />
             <source>APPLICATION ID</source>
-            <translation>APPLIKATIONS-ID</translation>
+            <translation>ID WNIOSKU</translation>
         </message>
         <message>
             <location filename="../src/gui/litesyncdialog.cpp" line="120" />
             <source>NAME</source>
-            <translation>NAMN</translation>
+            <translation>IMIĘ</translation>
         </message>
         <message>
             <location filename="../src/gui/litesyncdialog.cpp" line="154" />
             <source>SAVE</source>
-            <translation>SPARA</translation>
+            <translation>ZAPISZ</translation>
         </message>
         <message>
             <location filename="../src/gui/litesyncdialog.cpp" line="161" />
             <source>CANCEL</source>
-            <translation>AVBRYT</translation>
+            <translation>ANULUJ</translation>
         </message>
         <message>
             <location filename="../src/gui/litesyncdialog.cpp" line="295" />
             <source>Do you want to save your modifications?</source>
-            <translation>Vill du spara dina ändringar?</translation>
+            <translation>Czy chcesz zapisać wprowadzone zmiany?</translation>
         </message>
         <message>
             <location filename="../src/gui/litesyncdialog.cpp" line="337" />
             <source>Do you really want to delete?</source>
-            <translation>Vill du verkligen ta bort det?</translation>
+            <translation>Czy na pewno chcesz usunąć?</translation>
         </message>
         <message>
             <location filename="../src/gui/litesyncdialog.cpp" line="374" />
             <source>Cannot save changes!</source>
-            <translation>Det går inte att spara ändringarna!</translation>
+            <translation>Nie można zapisać zmian!</translation>
         </message>
     </context>
     <context>
@@ -1477,52 +1477,52 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/localfolderdialog.cpp" line="63" />
             <source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
-            <translation>Vilken mapp på din dator vill du&lt;br&gt;synkronisera?</translation>
+            <translation>Który folder na komputerze chcesz&lt;br&gt;zsynchronizować?</translation>
         </message>
         <message>
             <location filename="../src/gui/localfolderdialog.cpp" line="72" />
             <source>The content of this folder will be synchronized on the kDrive</source>
-            <translation>Innehållet i den här mappen kommer att synkroniseras på kDrive</translation>
+            <translation>Zawartość tego folderu zostanie zsynchronizowana w usłudze kDrive</translation>
         </message>
         <message>
             <location filename="../src/gui/localfolderdialog.cpp" line="91" />
             <source>Select a folder</source>
-            <translation>Välj en mapp</translation>
+            <translation>Wybierz folder</translation>
         </message>
         <message>
             <location filename="../src/gui/localfolderdialog.cpp" line="131" />
             <source>Edit folder</source>
-            <translation>Ändra mapp</translation>
+            <translation>Edytuj folder</translation>
         </message>
         <message>
             <location filename="../src/gui/localfolderdialog.cpp" line="166" />
             <source>CANCEL</source>
-            <translation>AVBRYT</translation>
+            <translation>ANULUJ</translation>
         </message>
         <message>
             <location filename="../src/gui/localfolderdialog.cpp" line="173" />
             <source>CONTINUE</source>
-            <translation>FORTSÄTT</translation>
+            <translation>KONTYNUUJ</translation>
         </message>
         <message>
             <location filename="../src/gui/localfolderdialog.cpp" line="210" />
             <source>This folder is not compatible with Lite Sync.&lt;br&gt;
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt;
 &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-            <translation>Den här mappen är inte kompatibel med Lite Sync.&lt;br&gt;
-Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&gt;
+            <translation>Ten folder nie jest zgodny z aplikacją Lite Sync.&lt;br&gt;
+Wybierz inny folder. Jeśli kontynuujesz, aplikacja Lite Sync zostanie wyłączona.&lt;br&gt;
 
-&lt;a style="%1" href="%2"&gt;Läs mer&lt;/a&gt;</translation>
+&lt;a style="%1" href="%2"&gt;Dowiedz się więcej&lt;/a&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/localfolderdialog.cpp" line="233" />
             <source>Select folder</source>
-            <translation>Välj mapp</translation>
+            <translation>Wybierz folder</translation>
         </message>
         <message>
             <location filename="../src/gui/localfolderdialog.cpp" line="292" />
             <source>Unable to open link %1.</source>
-            <translation>Det går inte att öppna länken %1.</translation>
+            <translation>Nie można otworzyć linku %1.</translation>
         </message>
     </context>
     <context>
@@ -1530,12 +1530,12 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/libcommongui/logger.cpp" line="189" />
             <source>Error</source>
-            <translation>Fel</translation>
+            <translation>Błąd</translation>
         </message>
         <message>
             <location filename="../src/libcommongui/logger.cpp" line="189" />
             <source>&lt;nobr&gt;File '%1'&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
-            <translation>&lt;nobr&gt;Filen &amp;#x27;%1&amp;#x27;&lt;br/&gt;kan inte öppnas för skrivning.&lt;br/&gt;&lt;br/&gt;Logginformationen kan &lt;b&gt;inte&lt;/b&gt; sparas!&lt;/nobr&gt;</translation>
+            <translation>&lt;nobr&gt;Nie można otworzyć&lt;br/&gt;pliku „%1” w trybie zapisu. &lt;b&gt;Nie&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;można zapisać danych dziennika!&lt;/nobr&gt;</translation>
         </message>
     </context>
     <context>
@@ -1543,12 +1543,12 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/mainmenubarwidget.cpp" line="115" />
             <source>Preferences</source>
-            <translation>Inställningar</translation>
+            <translation>Preferencje</translation>
         </message>
         <message>
             <location filename="../src/gui/mainmenubarwidget.cpp" line="116" />
             <source>Help</source>
-            <translation>Hjälp</translation>
+            <translation>Pomoc</translation>
         </message>
     </context>
     <context>
@@ -1556,24 +1556,24 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="1082" />
             <source>Unable to open folder path %1.</source>
-            <translation>Det går inte att öppna mappsökvägen %1.</translation>
+            <translation>Nie można otworzyć ścieżki folderu %1.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="1096" />
             <source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
-            <translation>Överföringen är klar!&lt;br&gt;Ange referensnummer &lt;b&gt;%1&lt;/b&gt; i felrapporter.</translation>
+            <translation>Przesłanie zakończone! W&lt;br&gt;zgłoszeniach błędów proszę podać identyfikator &lt;b&gt;%1&lt;/b&gt;.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="1118" />
             <source>No kDrive configured!</source>
-            <translation>kDrive är inte konfigurerat!</translation>
+            <translation>Nie skonfigurowano programu kDrive!</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="1097" />
             <source>Transmission failed!
 Please, use the following link to send the logs to the support: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</source>
-            <translation>Överföringen misslyckades!
-Använd följande länk för att skicka loggfilerna till supporten: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</translation>
+            <translation>Przesyłanie nie powiodło się!
+Proszę skorzystać z poniższego linku, aby przesłać logi do działu pomocy technicznej: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="337" />
@@ -1582,365 +1582,365 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
             <location filename="../src/gui/parametersdialog.cpp" line="546" />
             <location filename="../src/gui/parametersdialog.cpp" line="560" />
             <source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-            <translation>Ett tekniskt fel har uppstått (fel %1).&lt;br&gt;Rensa historiken och kontakta vår support om felet kvarstår.</translation>
+            <translation>Wystąpił błąd techniczny (błąd %1).&lt;br&gt;Proszę wyczyścić historię, a jeśli błąd nadal występuje, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="342" />
             <source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
-            <translation>Det verkar som om tidsgränsen för din nätverksanslutning är inställd på ett för lågt värde för att programmet ska fungera korrekt (fel %1).&lt;br&gt;Kontrollera din nätverkskonfiguration.</translation>
+            <translation>Wygląda na to, że limit czasu połączenia sieciowego jest ustawiony na zbyt niską wartość, co uniemożliwia prawidłowe działanie aplikacji (błąd %1).&lt;br&gt;Sprawdź ustawienia sieciowe.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="347" />
             <location filename="../src/gui/parametersdialog.cpp" line="516" />
             <source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
-            <translation>Det går inte att ansluta till kDrive-servern (fel %1).&lt;br&gt;Försöker ansluta igen. Kontrollera din internetanslutning och din brandvägg.</translation>
+            <translation>Nie można połączyć się z serwerem kDrive (błąd %1).&lt;br&gt;Próbuję ponownie nawiązać połączenie. Sprawdź połączenie internetowe i ustawienia zapory sieciowej.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="352" />
             <source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
-            <translation>Ett inloggningsproblem har uppstått (fel %1).&lt;br&gt;Logga in igen. Om felet kvarstår, kontakta vår support.</translation>
+            <translation>Wystąpił problem z logowaniem (błąd %1).&lt;br&gt;Zaloguj się ponownie, a jeśli błąd nadal występuje, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="356" />
             <source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
-            <translation>En ny version av appen finns tillgänglig. Uppdatera&lt;br&gt;appen för att kunna fortsätta använda den.</translation>
+            <translation>Dostępna jest nowa wersja aplikacji. Aby móc nadal z&lt;br&gt;niej korzystać, należy ją zaktualizować.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="360" />
             <source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
-            <translation>Uppladdningen av loggen misslyckades (fel %1).&lt;br&gt;Försök igen senare.</translation>
+            <translation>Przesyłanie dziennika nie powiodło się (błąd %1).&lt;br&gt;Spróbuj ponownie później.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="385" />
             <source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
-            <translation>Synkroniseringsmappen är inte längre tillgänglig (fel %1).&lt;br&gt;Synkroniseringen återupptas så snart mappen blir tillgänglig.</translation>
+            <translation>Nie ma już dostępu do folderu synchronizacji (błąd %1).&lt;br&gt;Synchronizacja zostanie wznowiona, gdy tylko folder będzie ponownie dostępny.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="532" />
             <source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
-            <translation>Synkroniseringsmappen har ersatts eller flyttats på ett sätt som förhindrar synkronisering (fel %1).&lt;br&gt;Detta kan inträffa efter att mappen har kopierats, flyttats eller återställts.&lt;br&gt;För att åtgärda detta, skapa en ny synkronisering med en ny mapp.&lt;br&gt;Obs! Om det finns osynkroniserade ändringar i den gamla mappen måste du kopiera dem manuellt till den nya.</translation>
+            <translation>Folder synchronizacji został zastąpiony lub przeniesiony w sposób uniemożliwiający synchronizację (błąd %1). Może&lt;br&gt;się to zdarzyć po skopiowaniu, przeniesieniu lub przywróceniu folderu.&lt;br&gt;Aby to naprawić, należy utworzyć nową synchronizację z nowym folderem.&lt;br&gt;Uwaga: jeśli w starym folderze znajdują się niezsynchronizowane zmiany, należy je ręcznie skopiować do nowego folderu.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="397" />
             <source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
-            <translation>Det finns inte tillräckligt med minne kvar på din dator.&lt;br&gt;Synkroniseringen har avbrutits.</translation>
+            <translation>Na komputerze zabrakło pamięci.&lt;br&gt;Synchronizacja została zatrzymana.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="320" />
             <source>kDrive needs to have write access to your computer's temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
-            <translation>kDrive måste ha skrivbehörighet till datorns temporära katalog.&lt;br&gt;Starta om kDrive-appen för att lösa problemet.</translation>
+            <translation>Aplikacja kDrive musi mieć uprawnienia do zapisu w katalogu tymczasowym komputera.&lt;br&gt;Aby rozwiązać ten problem, uruchom ponownie aplikację kDrive.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="330" />
             <location filename="../src/gui/parametersdialog.cpp" line="487" />
             <source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-            <translation>Ett tekniskt fel har uppstått.&lt;br&gt;Synkroniseringen återupptas så snart som möjligt. Kontakta vår support om felet kvarstår.</translation>
+            <translation>Wystąpił błąd techniczny.&lt;br&gt;Synchronizacja zostanie wznowiona tak szybko, jak to możliwe. Jeśli błąd nie ustąpi, prosimy o kontakt z naszym zespołem pomocy technicznej.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="401" />
             <source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing '/etc/sysctl.conf'.</source>
-            <translation>Antalet inotify-övervakningar är otillräckligt (fel %1).&lt;br&gt;Du kan öka detta antal genom att redigera filen &amp;#x27;/etc/sysctl.conf&amp;#x27;.</translation>
+            <translation>Liczba obserwacji inotify jest niewystarczająca (błąd %1).&lt;br&gt;Można zwiększyć tę liczbę, edytując plik „/etc/sysctl.conf”.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="406" />
             <source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
-            <translation>Det går inte att starta synkroniseringen (fel %1).&lt;br&gt;Du måste ge behörighet till:&lt;br&gt;– kDrive i Systeminställningar &gt;&gt; Allmänt &gt;&gt; Inloggningsobjekt och tillägg &gt;&gt; Tillägg för&lt;br&gt;Endpoint Security– kDrive LiteSync-tillägget i Systeminställningar &gt;&gt; Sekretess och säkerhet &gt;&gt; Fullständig disktillgång.</translation>
+            <translation>Nie można rozpocząć synchronizacji (błąd %1).&lt;br&gt;Należy zezwolić na&lt;br&gt;:- kDrive w Ustawieniach systemu &amp;gt;&amp;gt; Ogólne &amp;gt;&amp;gt; Elementy logowania i rozszerzenia &amp;gt;&amp;gt; Rozszerzenia zabezpieczeń punktów&lt;br&gt;końcowych - Rozszerzenie kDrive LiteSync w Ustawieniach systemu &amp;gt;&amp;gt; Prywatność i bezpieczeństwo &amp;gt;&amp;gt; Pełny dostęp do dysku.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="419" />
             <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-            <translation>Det går inte att starta tillägget Lite Sync (fel %1).&lt;br&gt;Kontrollera att tillägget Lite Sync är installerat och att tjänsten Windows Search är aktiverad.&lt;br&gt;Rensa historiken, starta om datorn och kontakta vår support om felet kvarstår.</translation>
+            <translation>Nie można uruchomić wtyczki Lite Sync (błąd %1).&lt;br&gt;Sprawdź, czy rozszerzenie Lite Sync jest zainstalowane, a usługa Windows Search włączona.&lt;br&gt;Wyczyść historię, uruchom ponownie przeglądarkę, a jeśli błąd nadal występuje, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="424" />
             <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-            <translation>Det går inte att starta tillägget Lite Sync (fel %1).&lt;br&gt;Kontrollera att tillägget Lite Sync har rätt behörigheter och är igång.&lt;br&gt;Rensa historiken, starta om och kontakta vår support om felet kvarstår.</translation>
+            <translation>Nie można uruchomić wtyczki Lite Sync (błąd %1).&lt;br&gt;Sprawdź, czy rozszerzenie Lite Sync ma odpowiednie uprawnienia i czy jest uruchomione.&lt;br&gt;Wyczyść historię, uruchom ponownie przeglądarkę, a jeśli błąd nadal występuje, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="429" />
             <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-            <translation>Det går inte att starta Lite Sync-tillägget (fel %1).&lt;br&gt;Rensa historiken, starta om och kontakta vår support om felet kvarstår.</translation>
+            <translation>Nie można uruchomić wtyczki Lite Sync (błąd %1).&lt;br&gt;Proszę wyczyścić historię, ponownie uruchomić program, a jeśli błąd nadal występuje, skontaktować się z naszym zespołem pomocy technicznej.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="435" />
             <source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
-            <translation>En fil eller mapp i din synkroniseringsmapp verkar vara skadad.&lt;br&gt;Synkroniseringen har avbrutits.</translation>
+            <translation>Wygląda na to, że plik lub folder w folderze synchronizacji jest uszkodzony.&lt;br&gt;Synchronizacja została zatrzymana.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="449" />
             <source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-            <translation>kDrive är i underhållsläge.&lt;br&gt;Synkroniseringen kommer att återupptas så snart som möjligt. Kontakta vår support om felet kvarstår.</translation>
+            <translation>Serwer kDrive znajduje się w trybie konserwacji.&lt;br&gt;Synchronizacja zostanie wznowiona tak szybko, jak to możliwe. Jeśli błąd nadal występuje, prosimy o kontakt z naszym zespołem pomocy technicznej.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="455" />
             <source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-            <translation>kDrive är blockerat.&lt;br&gt;Förnya kDrive. Om inga åtgärder vidtas kommer uppgifterna att raderas permanent och det går inte att återställa dem.</translation>
+            <translation>Usługa kDrive została zablokowana.&lt;br&gt;Proszę odnowić subskrypcję kDrive. Jeśli nie podejmiesz żadnych działań, dane zostaną trwale usunięte i nie będzie możliwości ich odzyskania.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="460" />
             <source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-            <translation>kDrive är spärrat.&lt;br&gt;Kontakta en administratör för att återställa kDrive. Om inga åtgärder vidtas kommer uppgifterna att raderas permanent och det går inte att återställa dem.</translation>
+            <translation>Konto kDrive zostało zablokowane.&lt;br&gt;Skontaktuj się z administratorem w celu odblokowania konta kDrive. Jeśli nie podejmiesz żadnych działań, dane zostaną trwale usunięte i nie będzie możliwości ich odzyskania.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="466" />
             <source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-            <translation>kDrive startar upp.&lt;br&gt;Synkroniseringen kommer att återupptas så snart som möjligt. Kontakta vår support om felet kvarstår.</translation>
+            <translation>Usługa kDrive się uruchamia.&lt;br&gt;Synchronizacja zostanie wznowiona tak szybko, jak to możliwe. Jeśli błąd nadal występuje, prosimy o kontakt z naszym zespołem pomocy technicznej.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="475" />
             <source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
-            <translation>kDrive är inaktivt.&lt;br&gt;Logga in på &lt;a style="%1" href="%2"&gt;web&lt;/a&gt;versionen för att kontrollera statusen för ditt kDrive, eller kontakta din administratör.</translation>
+            <translation>Usługa kDrive jest wyłączona.&lt;br&gt;Zaloguj się do &lt;a style="%1" href="%2"&gt;wersji&lt;/a&gt; &lt;a style="%1" href="%2"&gt;internetowej&lt;/a&gt;, aby sprawdzić stan usługi kDrive, lub skontaktuj się z administratorem.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="479" />
             <source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive's status, or contact your administrator.</source>
-            <translation>kDrive är inaktivt.&lt;br&gt;Logga in på webbversionen för att kontrollera statusen för ditt kDrive, eller kontakta din administratör.</translation>
+            <translation>Usługa kDrive jest wyłączona.&lt;br&gt;Zaloguj się do wersji internetowej, aby sprawdzić stan usługi kDrive, lub skontaktuj się z administratorem.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="483" />
             <source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
-            <translation>Du har inte behörighet att komma åt denna kDrive.&lt;br&gt;Synkroniseringen har pausats. Kontakta en administratör.</translation>
+            <translation>Nie masz uprawnień dostępu do tego konta kDrive.&lt;br&gt;Synchronizacja została wstrzymana. Skontaktuj się z administratorem.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="493" />
             <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-            <translation>Ett tekniskt fel har uppstått (fel %1).&lt;br&gt;Synkroniseringen återupptas så snart som möjligt. Kontakta vår support om felet kvarstår.</translation>
+            <translation>Wystąpił błąd techniczny (błąd %1).&lt;br&gt;Synchronizacja zostanie wznowiona tak szybko, jak to możliwe. Jeśli błąd nie ustąpi, prosimy o kontakt z naszym zespołem pomocy technicznej.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="512" />
             <source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-            <translation>Nätverksanslutningarna har avbrutits av kärnan (fel %1).&lt;br&gt;Rensa historiken och kontakta vår support om felet kvarstår.</translation>
+            <translation>Jądro systemu przerwało połączenia sieciowe (błąd %1).&lt;br&gt;Proszę wyczyścić historię, a jeśli błąd nadal występuje, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="522" />
             <source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
-            <translation>Tyvärr gick det inte att överföra din gamla konfiguration.&lt;br&gt;Programmet kommer att använda en tom konfiguration.</translation>
+            <translation>Niestety nie udało się przenieść starej konfiguracji.&lt;br&gt;Aplikacja będzie korzystać z pustej konfiguracji.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="526" />
             <source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
-            <translation>Tyvärr gick det inte att överföra din gamla proxykonfiguration, eftersom SOCKS5-proxyservrar inte stöds för närvarande.&lt;br&gt;Programmet kommer istället att använda systemets proxyinställningar.</translation>
+            <translation>Niestety nie udało się przenieść Twojej poprzedniej konfiguracji proxy; serwery proxy SOCKS5 nie są obecnie obsługiwane.&lt;br&gt;Aplikacja będzie korzystać z ustawień proxy systemu.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="539" />
             <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
-            <translation>Ett tekniskt fel har uppstått (fel %1).&lt;br&gt;Synkroniseringen har startats om. Rensa historiken och kontakta vår support om felet kvarstår.</translation>
+            <translation>Wystąpił błąd techniczny (błąd %1).&lt;br&gt;Synchronizacja została wznowiona. Proszę wyczyścić historię, a jeśli błąd nadal występuje, prosimy o kontakt z naszym zespołem pomocy technicznej.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="550" />
             <source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
-            <translation>Ett fel har uppstått vid åtkomst till synkroniseringsdatabasen (fel %1).&lt;br&gt;Synkroniseringen har avbrutits.</translation>
+            <translation>Wystąpił błąd podczas uzyskiwania dostępu do bazy danych synchronizacji (błąd %1).&lt;br&gt;Synchronizacja została zatrzymana.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="564" />
             <source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
-            <translation>Ett inloggningsproblem har uppstått (fel %1).&lt;br&gt;Tokenet är ogiltigt eller har återkallats.</translation>
+            <translation>Wystąpił problem z logowaniem (błąd %1).&lt;br&gt;Token jest nieprawidłowy lub został unieważniony.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="569" />
             <source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
-            <translation>Nästlade synkroniseringar är inte tillåtna (fel %1).&lt;br&gt;Du bör endast behålla synkroniseringar där mapparna inte är nästlade.</translation>
+            <translation>Zabronione jest zagnieżdżanie synchronizacji (błąd %1).&lt;br&gt;Należy zachować wyłącznie te synchronizacje, których foldery nie są zagnieżdżone.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="573" />
             <source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
-            <translation>Synkroniseringsmappen på den fjärranslutna kDrive-enheten finns inte längre eller är inte längre tillgänglig (fel %1).&lt;br&gt;Du måste återställa den, återställa åtkomsträttigheterna eller ta bort och skapa synkroniseringen på nytt.</translation>
+            <translation>Folder synchronizacji na zdalnym serwerze kDrive nie istnieje już lub nie ma do niego dostępu (błąd %1).&lt;br&gt;Należy go przywrócić, przywrócić do niego uprawnienia dostępu lub usunąć i utworzyć synchronizację od nowa.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="580" />
             <source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
-            <translation>Fel vid tolkning av filnamn (fel %1).&lt;br&gt;Specialtecken som dubbla citattecken, bakstreck eller radbrytningar kan orsaka fel vid tolkningen.</translation>
+            <translation>Błąd analizy nazwy pliku (błąd %1). Znaki&lt;br&gt;specjalne, takie jak cudzysłowy, ukośniki odwrotne lub znaki końca linii, mogą powodować błędy analizy.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="722" />
             <source>You are not allowed to move item to "%1".&lt;br&gt;It will be restored into its original parent folder.</source>
-            <translation>Du får inte flytta objektet till &amp;quot;%1&amp;quot;.&lt;br&gt;Det kommer att återställas till sin ursprungliga överordnade mapp.</translation>
+            <translation>Nie można przenieść elementu do folderu „%1”. Zostanie&lt;br&gt;on przywrócony do pierwotnego folderu nadrzędnego.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="814" />
             <source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
-            <translation>Det finns inte tillräckligt med utrymme kvar på din dator.&lt;br&gt;Nedladdningen har avbrutits.</translation>
+            <translation>Na komputerze zabrakło miejsca.&lt;br&gt;Pobieranie zostało przerwane.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="609" />
             <source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
-            <translation>Denna komponent har flyttats till en annan plats.&lt;br&gt;Den lokala åtgärden har avbrutits.</translation>
+            <translation>Ten element został przeniesiony w inne miejsce.&lt;br&gt;Operacja lokalna została anulowana.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="618" />
             <source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
-            <translation>Det finns redan ett element med samma namn på den här platsen.&lt;br&gt;Det lokala elementet har bytt namn.</translation>
+            <translation>W tej lokalizacji istnieje już element o tej samej nazwie.&lt;br&gt;Nazwa lokalnego elementu została zmieniona.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="614" />
             <source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
-            <translation>Det finns redan ett element med samma namn på den här platsen.&lt;br&gt;Den lokala åtgärden har avbrutits.</translation>
+            <translation>W tej lokalizacji istnieje już element o tej samej nazwie.&lt;br&gt;Operacja lokalna została anulowana.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="393" />
             <source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
-            <translation>Det finns inte tillräckligt med utrymme kvar på din dator.&lt;br&gt;Synkroniseringen har avbrutits.</translation>
+            <translation>Na komputerze zabrakło miejsca.&lt;br&gt;Synchronizacja została zatrzymana.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="622" />
             <source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
-            <translation>Filen redigerades samtidigt av en annan användare.&lt;br&gt;Dina ändringar har sparats i en kopia.</translation>
+            <translation>Plik został zmieniony w tym samym czasie przez innego użytkownika.&lt;br&gt;Twoje zmiany zostały zapisane w kopii.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="626" />
             <source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
-            <translation>En annan användare har flyttat en överordnad mapp till målplatsen.&lt;br&gt;Den lokala åtgärden har avbrutits.</translation>
+            <translation>Inny użytkownik przeniósł folder nadrzędny miejsca docelowego.&lt;br&gt;Operacja lokalna została anulowana.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="692" />
             <source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
-            <translation>Artikelnamnet innehåller endast mellanslag.&lt;br&gt;Det har tillfälligt lagts till på svartlistan.</translation>
+            <translation>Nazwa pozycji zawiera wyłącznie spacje.&lt;br&gt;Została ona tymczasowo umieszczona na czarnej liście.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="703" />
             <source>Either you are not allowed to create an item, or another item already exists with the same name.&lt;br&gt;The item has been excluded from synchronization.</source>
-            <translation>Antingen har du inte behörighet att skapa ett objekt, eller så finns det redan ett objekt med samma namn.&lt;br&gt;Objektet har undantagits från synkroniseringen.</translation>
+            <translation>Albo nie masz uprawnień do utworzenia elementu, albo istnieje już inny element o tej samej nazwie.&lt;br&gt;Element został wykluczony z synchronizacji.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="708" />
             <source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
-            <translation>Du har inte behörighet att redigera objektet.&lt;br&gt;Filen med dina ändringar har bytt namn och har undantagits från synkroniseringen.</translation>
+            <translation>Nie masz uprawnień do edycji tego elementu.&lt;br&gt;Plik zawierający wprowadzone zmiany został przemianowany i wykluczony z synchronizacji.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="716" />
             <source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
-            <translation>Du får inte byta namn på objektet.&lt;br&gt;Det återställs till sitt ursprungliga namn.</translation>
+            <translation>Nie można zmienić nazwy tego elementu. Zostanie&lt;br&gt;on przywrócony pod pierwotną nazwą.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="727" />
             <source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
-            <translation>Du får inte ta bort objektet.&lt;br&gt;Det återställs till sin ursprungliga plats.</translation>
+            <translation>Nie można usunąć tego elementu. Zostanie&lt;br&gt;on przywrócony do pierwotnej lokalizacji.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="732" />
             <source>Failed to move this item to trash, it has been blacklisted.</source>
-            <translation>Det gick inte att flytta objektet till papperskorgen; det har lagts till i svartlistan.</translation>
+            <translation>Nie udało się przenieść tego elementu do kosza; został on dodany do czarnej listy.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="748" />
             <source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
-            <translation>Filen har ändrats lokalt samtidigt som den har raderats på den fjärranslutna kDrive-enheten. En&lt;br&gt;lokal kopia har sparats i räddningsmappen.</translation>
+            <translation>Plik został zmodyfikowany lokalnie, podczas gdy na zdalnym serwerze kDrive został usunięty.&lt;br&gt;Lokalna kopia została zapisana w folderze awaryjnym.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="765" />
             <source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
-            <translation>Den åtgärd som utförts på objektet är inte tillåten.&lt;br&gt;Objektet har tillfälligt lagts till i svartlistan.</translation>
+            <translation>Wykonanie tej operacji na tym elemencie jest zabronione.&lt;br&gt;Element został tymczasowo umieszczony na czarnej liście.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="771" />
             <source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
-            <translation>Åtgärden som utfördes på detta objekt misslyckades.&lt;br&gt;Objektet har tillfälligt lagts till i svartlistan.</translation>
+            <translation>Operacja wykonana na tym elemencie nie powiodła się.&lt;br&gt;Element został tymczasowo umieszczony na czarnej liście.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="776" />
             <source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
-            <translation>Filen är för stor för att laddas upp. Den har tillfälligt blockerats.</translation>
+            <translation>Plik jest zbyt duży, aby można go było przesłać. Został tymczasowo zablokowany.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="782" />
             <source>Impossible to download the file.</source>
-            <translation>Det går inte att ladda ner filen.</translation>
+            <translation>Nie można pobrać pliku.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="779" />
             <source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
-            <translation>Du har överskridit din kvot. Öka din lagringskvot för att återaktivera filuppladdning.</translation>
+            <translation>Przekroczyłeś limit miejsca. Zwiększ limit miejsca, aby ponownie umożliwić przesyłanie plików.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="389" />
             <source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
-            <translation>Enheten som innehåller din synkroniseringsmapp är inte längre ansluten (fel %1).&lt;br&gt;Anslut den igen för att återuppta synkroniseringen.</translation>
+            <translation>Dysk zawierający folder synchronizacji nie jest już podłączony (błąd %1).&lt;br&gt;Podłącz go ponownie, aby wznowić synchronizację.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="413" />
             <source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
-            <translation>Det går inte att starta synkroniseringen (fel %1).&lt;br&gt;Processen LiteSyncExt körs inte just nu. Synkroniseringen återupptas så snart processen har startats.</translation>
+            <translation>Nie można rozpocząć synchronizacji (błąd %1).&lt;br&gt;Proces LiteSyncExt nie jest obecnie uruchomiony. Synchronizacja zostanie wznowiona zaraz po jego uruchomieniu.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="649" />
             <source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
-            <translation>Ett befintligt objekt har ett identiskt namn med samma versaler och gemener.&lt;br&gt;Det har tillfälligt blockerats.</translation>
+            <translation>Istniejący element ma identyczną nazwę z zachowaniem tej samej wielkości liter (wszystkie litery są wielkie lub małe).&lt;br&gt;Został on tymczasowo umieszczony na czarnej liście.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="656" />
             <source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
-            <translation>Produktnamnet innehåller ett tecken som inte stöds.&lt;br&gt;Det har tillfälligt blockerats.</translation>
+            <translation>Nazwa pozycji zawiera znak, który nie jest obsługiwany.&lt;br&gt;Została ona tymczasowo umieszczona na czarnej liście.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="662" />
             <source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-            <translation>Objektnamnet slutar med ett mellanslag, vilket inte är tillåtet i ditt operativsystem.&lt;br&gt;Det har tillfälligt lagts till i svartlistan.</translation>
+            <translation>Nazwa elementu kończy się spacją, co jest niedozwolone w Twoim systemie operacyjnym.&lt;br&gt;Została ona tymczasowo umieszczona na czarnej liście.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="668" />
             <source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-            <translation>Det här objektnamnet är reserverat av ditt operativsystem.&lt;br&gt;Det har tillfälligt lagts till i svartlistan.</translation>
+            <translation>Ta nazwa elementu jest zarezerwowana przez system operacyjny.&lt;br&gt;Została tymczasowo umieszczona na czarnej liście.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="674" />
             <source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
-            <translation>Artikelnamnet är för långt.&lt;br&gt;Det har tillfälligt blockerats.</translation>
+            <translation>Nazwa produktu jest zbyt długa.&lt;br&gt;Została tymczasowo umieszczona na czarnej liście.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="680" />
             <source>The item path is too long.&lt;br&gt;It has been ignored.</source>
-            <translation>Sökvägen är för lång.&lt;br&gt;Den har ignorerats.</translation>
+            <translation>Ścieżka do elementu jest zbyt długa.&lt;br&gt;Została pominięta.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="686" />
             <source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
-            <translation>Objektnamnet innehåller ett nytt Unicode-tecken som ännu inte stöds av ditt filsystem.&lt;br&gt;Det har uteslutits från synkroniseringen.</translation>
+            <translation>Nazwa elementu zawiera znak Unicode, który nie jest jeszcze obsługiwany przez system plików.&lt;br&gt;Została ona wykluczona z synchronizacji.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="735" />
             <source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
-            <translation>Det gick inte att synkronisera det här objektet. Det har tillfälligt lagts till i svartlistan.&lt;br&gt;Ett nytt försök att synkronisera det kommer att göras om en timme eller nästa gång programmet startas.</translation>
+            <translation>Nie udało się zsynchronizować tego elementu. Został on tymczasowo umieszczony na czarnej liście.&lt;br&gt;Kolejna próba synchronizacji zostanie podjęta za godzinę lub przy następnym uruchomieniu aplikacji.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="740" />
             <source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
-            <translation>Denna post har undantagits från synkroniseringen genom en anpassad mall.&lt;br&gt;Du kan inaktivera denna typ av avisering under Inställningar</translation>
+            <translation>Ten element został wykluczony z synchronizacji przez szablon niestandardowy.&lt;br&gt;Możesz wyłączyć tego typu powiadomienia w ustawieniach</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="745" />
             <source>This item has been excluded from sync because it is a hard link.</source>
-            <translation>Den här posten har uteslutits från synkroniseringen eftersom det är en hård länk.</translation>
+            <translation>Ten element został wykluczony z synchronizacji, ponieważ jest to dowiązanie twarde.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="785" />
             <source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
-            <translation>Den här artikeln är för närvarande upptagen av en annan användare som är inloggad.&lt;br&gt;Vi försöker ladda upp dina ändringar igen senare.</translation>
+            <translation>Ten element jest obecnie zablokowany przez innego użytkownika online.&lt;br&gt;Spróbujemy ponownie przesłać Twoje zmiany później.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="790" />
             <location filename="../src/gui/parametersdialog.cpp" line="834" />
             <source>Synchronization error.</source>
-            <translation>Synkroniseringsfel.</translation>
+            <translation>Błąd synchronizacji.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="810" />
             <source>Can't access item.&lt;br&gt;Please fix the read and write permissions.</source>
-            <translation>Det går inte att komma åt objektet.&lt;br&gt;Kontrollera läs- och skrivbehörigheterna.</translation>
+            <translation>Nie można uzyskać dostępu do elementu.&lt;br&gt;Proszę poprawić uprawnienia do odczytu i zapisu.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="818" />
             <source>System error.</source>
-            <translation>Systemfel.</translation>
+            <translation>Błąd systemu.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="825" />
             <source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
-            <translation>Objektet finns redan på den andra sidan.&lt;br&gt;Det har tillfälligt blockerats.</translation>
+            <translation>Ten element istnieje już po drugiej stronie.&lt;br&gt;Został tymczasowo umieszczony na czarnej liście.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="840" />
             <source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-            <translation>Ett tekniskt fel har uppstått.&lt;br&gt;Rensa historiken och kontakta vår support om felet kvarstår.</translation>
+            <translation>Wystąpił błąd techniczny.&lt;br&gt;Proszę wyczyścić historię, a jeśli błąd nadal występuje, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
         </message>
     </context>
     <context>
@@ -1948,7 +1948,7 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <message>
             <location filename="../src/gui/preferencesblocwidget.cpp" line="187" />
             <source>This synchronization is being deleted.</source>
-            <translation>Denna synkronisering raderas.</translation>
+            <translation>Ta synchronizacja zostanie usunięta.</translation>
         </message>
     </context>
     <context>
@@ -1956,12 +1956,12 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <message>
             <location filename="../src/gui/preferencesmenubarwidget.cpp" line="63" />
             <source>Back to drive list</source>
-            <translation>Tillbaka till listan över körningar</translation>
+            <translation>Powrót do listy dysków</translation>
         </message>
         <message>
             <location filename="../src/gui/preferencesmenubarwidget.cpp" line="64" />
             <source>Preferences</source>
-            <translation>Inställningar</translation>
+            <translation>Preferencje</translation>
         </message>
     </context>
     <context>
@@ -1969,77 +1969,77 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="491" />
             <source>General</source>
-            <translation>Allmänt</translation>
+            <translation>Ogólne</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="493" />
             <source>Activate dark theme</source>
-            <translation>Aktivera mörkt tema</translation>
+            <translation>Włącz ciemny motyw</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="495" />
             <source>Activate monochrome icons</source>
-            <translation>Aktivera monokroma ikoner</translation>
+            <translation>Włącz monochromatyczne ikony</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="496" />
             <source>Launch kDrive at startup</source>
-            <translation>Starta kDrive vid uppstart</translation>
+            <translation>Uruchamiaj kDrive przy starcie systemu</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="516" />
             <source>Advanced</source>
-            <translation>Avancerat</translation>
+            <translation>Zaawansowane</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="517" />
             <source>Debugging information</source>
-            <translation>Felsökningsinformation</translation>
+            <translation>Informacje debugowania</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="519" />
             <source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
-            <translation>&lt;a style="%1" href="%2"&gt;Öppna felsökningsmappen&lt;/a&gt;</translation>
+            <translation>&lt;a style="%1" href="%2"&gt;Otwórz folder debugowania&lt;/a&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="520" />
             <source>Files to exclude</source>
-            <translation>Filer att exkludera</translation>
+            <translation>Pliki do wykluczenia</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="521" />
             <source>Proxy server</source>
-            <translation>Proxyserver</translation>
+            <translation>Serwer proxy</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="511" />
             <source>Swedish</source>
-            <translation>Svenska</translation>
+            <translation>Szwedzki</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="512" />
             <source>Portuguese</source>
-            <translation>Portugisiska</translation>
+            <translation>Portugalski</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="513" />
             <source>Polish</source>
-            <translation>Polska</translation>
+            <translation>Polski</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="466" />
             <source>Unable to open folder %1.</source>
-            <translation>Det går inte att öppna mappen %1.</translation>
+            <translation>Nie można otworzyć folderu %1.</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="478" />
             <source>Unable to open link %1.</source>
-            <translation>Det går inte att öppna länken %1.</translation>
+            <translation>Nie można otworzyć linku %1.</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="483" />
             <source>Invalid link %1.</source>
-            <translation>Ogiltig länk %1.</translation>
+            <translation>Nieprawidłowy link %1.</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="523" />
@@ -2049,62 +2049,62 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="497" />
             <source>Language</source>
-            <translation>Språk</translation>
+            <translation>Język</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="490" />
             <source>Some process failed to run.</source>
-            <translation>Någon process kunde inte köras.</translation>
+            <translation>Nie udało się uruchomić jakiegoś procesu.</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="498" />
             <source>Move deleted files to my computer's trash</source>
-            <translation>Flytta borttagna filer till datorns papperskorg</translation>
+            <translation>Przenoś usunięte pliki do kosza na komputerze</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="499" />
             <source>Some files or folders may not be moved to the computer's trash.</source>
-            <translation>Vissa filer eller mappar kanske inte kan flyttas till datorns papperskorg.</translation>
+            <translation>Niektórych plików lub folderów nie da się przenieść do kosza komputera.</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="500" />
             <source>You can always retrieve already synced files from the kDrive web application trash.</source>
-            <translation>Du kan alltid återställa redan synkroniserade filer från papperskorgen i kDrives webbapp.</translation>
+            <translation>Zawsze możesz odzyskać wcześniej zsynchronizowane pliki z kosza aplikacji webowej kDrive.</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="502" />
             <source>&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-            <translation>&lt;a style="%1" href="%2"&gt;Läs mer&lt;/a&gt;</translation>
+            <translation>&lt;a style="%1" href="%2"&gt;Dowiedz się więcej&lt;/a&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="506" />
             <source>English</source>
-            <translation>Engelska</translation>
+            <translation>Angielski</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="507" />
             <source>French</source>
-            <translation>Franska</translation>
+            <translation>Francuski</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="508" />
             <source>German</source>
-            <translation>Tyska</translation>
+            <translation>Niemiecki</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="509" />
             <source>Spanish</source>
-            <translation>Spanska</translation>
+            <translation>Hiszpański</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="510" />
             <source>Italian</source>
-            <translation>Italienska</translation>
+            <translation>Włoski</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="505" />
             <source>Default</source>
-            <translation>Standard</translation>
+            <translation>Domyślny</translation>
         </message>
     </context>
     <context>
@@ -2112,7 +2112,7 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <message>
             <location filename="../src/gui/progressbarwidget.cpp" line="70" />
             <source>%1 in use</source>
-            <translation>%1 används</translation>
+            <translation>%1 w użyciu</translation>
         </message>
     </context>
     <context>
@@ -2120,77 +2120,77 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <message>
             <location filename="../src/gui/proxyserverdialog.cpp" line="50" />
             <source>HTTP(S) Proxy</source>
-            <translation>HTTP(S)-proxy</translation>
+            <translation>Serwer proxy HTTP(S)</translation>
         </message>
         <message>
             <location filename="../src/gui/proxyserverdialog.cpp" line="73" />
             <source>Proxy server</source>
-            <translation>Proxyserver</translation>
+            <translation>Serwer proxy</translation>
         </message>
         <message>
             <location filename="../src/gui/proxyserverdialog.cpp" line="85" />
             <source>No proxy server</source>
-            <translation>Ingen proxyserver</translation>
+            <translation>Brak serwera proxy</translation>
         </message>
         <message>
             <location filename="../src/gui/proxyserverdialog.cpp" line="90" />
             <source>Use system parameters</source>
-            <translation>Använd systemparametrar</translation>
+            <translation>Użyj parametrów systemowych</translation>
         </message>
         <message>
             <location filename="../src/gui/proxyserverdialog.cpp" line="95" />
             <source>Indicate a proxy manually</source>
-            <translation>Ange en fullmaktsinnehavare manuellt</translation>
+            <translation>Wprowadź pełnomocnika ręcznie</translation>
         </message>
         <message>
             <location filename="../src/gui/proxyserverdialog.cpp" line="131" />
             <source>Port</source>
-            <translation>Hamn</translation>
+            <translation>Port</translation>
         </message>
         <message>
             <location filename="../src/gui/proxyserverdialog.cpp" line="144" />
             <source>Address of the proxy server</source>
-            <translation>Proxyserverns adress</translation>
+            <translation>Adres serwera proxy</translation>
         </message>
         <message>
             <location filename="../src/gui/proxyserverdialog.cpp" line="150" />
             <source>Authentication needed</source>
-            <translation>Inloggning krävs</translation>
+            <translation>Wymagane uwierzytelnienie</translation>
         </message>
         <message>
             <location filename="../src/gui/proxyserverdialog.cpp" line="165" />
             <source>User</source>
-            <translation>Användare</translation>
+            <translation>Użytkownik</translation>
         </message>
         <message>
             <location filename="../src/gui/proxyserverdialog.cpp" line="171" />
             <source>Password</source>
-            <translation>Lösenord</translation>
+            <translation>Hasło</translation>
         </message>
         <message>
             <location filename="../src/gui/proxyserverdialog.cpp" line="185" />
             <source>SAVE</source>
-            <translation>SPARA</translation>
+            <translation>ZAPISZ</translation>
         </message>
         <message>
             <location filename="../src/gui/proxyserverdialog.cpp" line="192" />
             <source>CANCEL</source>
-            <translation>AVBRYT</translation>
+            <translation>ANULUJ</translation>
         </message>
         <message>
             <location filename="../src/gui/proxyserverdialog.cpp" line="286" />
             <source>Do you want to save your modifications?</source>
-            <translation>Vill du spara dina ändringar?</translation>
+            <translation>Czy chcesz zapisać wprowadzone zmiany?</translation>
         </message>
         <message>
             <location filename="../src/gui/proxyserverdialog.cpp" line="295" />
             <source>Unable to save, all mandatory fields are not completed!</source>
-            <translation>Det går inte att spara, eftersom alla obligatoriska fält inte är ifyllda!</translation>
+            <translation>Nie można zapisać danych, ponieważ nie wszystkie pola obowiązkowe zostały wypełnione!</translation>
         </message>
         <message>
             <location filename="../src/gui/proxyserverdialog.cpp" line="316" />
             <source>Proxy not found, save anyway?</source>
-            <translation>Proxy hittades inte, vill du spara ändå?</translation>
+            <translation>Nie znaleziono serwera proxy. Czy chcesz zapisać mimo to?</translation>
         </message>
     </context>
     <context>
@@ -2198,27 +2198,27 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <message>
             <location filename="../src/gui/resourcesmanagerdialog.cpp" line="55" />
             <source>Resources Manager</source>
-            <translation>Resursansvarig</translation>
+            <translation>Kierownik ds. zasobów</translation>
         </message>
         <message>
             <location filename="../src/gui/resourcesmanagerdialog.cpp" line="65" />
             <source>Maximum CPU usage allowed</source>
-            <translation>Högsta tillåtna CPU-användning</translation>
+            <translation>Maksymalne dopuszczalne obciążenie procesora</translation>
         </message>
         <message>
             <location filename="../src/gui/resourcesmanagerdialog.cpp" line="96" />
             <source>SAVE</source>
-            <translation>SPARA</translation>
+            <translation>ZAPISZ</translation>
         </message>
         <message>
             <location filename="../src/gui/resourcesmanagerdialog.cpp" line="103" />
             <source>CANCEL</source>
-            <translation>AVBRYT</translation>
+            <translation>ANULUJ</translation>
         </message>
         <message>
             <location filename="../src/gui/resourcesmanagerdialog.cpp" line="122" />
             <source>Do you want to save your modifications?</source>
-            <translation>Vill du spara dina ändringar?</translation>
+            <translation>Czy chcesz zapisać wprowadzone zmiany?</translation>
         </message>
     </context>
     <context>
@@ -2226,37 +2226,37 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <message>
             <location filename="../src/gui/serverbasefolderdialog.cpp" line="81" />
             <source>Select a folder on your kDrive</source>
-            <translation>Välj en mapp på din kDrive</translation>
+            <translation>Wybierz folder na swoim kDrive</translation>
         </message>
         <message>
             <location filename="../src/gui/serverbasefolderdialog.cpp" line="90" />
             <source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
-            <translation>Innehållet i den valda mappen kommer att synkroniseras till mappen &lt;b&gt;%1&lt;/b&gt;.</translation>
+            <translation>Zawartość wybranego folderu zostanie zsynchronizowana z folderem &lt;b&gt;%1&lt;/b&gt;.</translation>
         </message>
         <message>
             <location filename="../src/gui/serverbasefolderdialog.cpp" line="134" />
             <source>CONTINUE</source>
-            <translation>FORTSÄTT</translation>
+            <translation>KONTYNUUJ</translation>
         </message>
         <message>
             <location filename="../src/gui/serverbasefolderdialog.cpp" line="150" />
             <source>Space available on your computer for the current folder : %1</source>
-            <translation>Ledig utrymme på din dator för den aktuella mappen: %1</translation>
+            <translation>Miejsce dostępne na komputerze dla bieżącego folderu: %1</translation>
         </message>
         <message>
             <location filename="../src/gui/serverbasefolderdialog.cpp" line="190" />
             <source>This folder is already being synced.</source>
-            <translation>Den här mappen synkroniseras redan.</translation>
+            <translation>Ten folder jest już synchronizowany.</translation>
         </message>
         <message>
             <location filename="../src/gui/serverbasefolderdialog.cpp" line="204" />
             <source>CONFIRM</source>
-            <translation>BEKRÄFTA</translation>
+            <translation>POTWIERDŹ</translation>
         </message>
         <message>
             <location filename="../src/gui/serverbasefolderdialog.cpp" line="205" />
             <source>CANCEL</source>
-            <translation>AVBRYT</translation>
+            <translation>ANULUJ</translation>
         </message>
     </context>
     <context>
@@ -2264,17 +2264,17 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <message>
             <location filename="../src/gui/serverfoldersdialog.cpp" line="80" />
             <source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
-            <translation>Mappen &lt;b&gt;%1&lt;/b&gt; innehåller undermappar.&lt;br&gt; Välj de som du vill synkronisera</translation>
+            <translation>Folder &lt;b&gt;%1&lt;/b&gt; zawiera podfoldery;&lt;br&gt; wybierz te, które chcesz zsynchronizować</translation>
         </message>
         <message>
             <location filename="../src/gui/serverfoldersdialog.cpp" line="110" />
             <source>CONTINUE</source>
-            <translation>FORTSÄTT</translation>
+            <translation>KONTYNUUJ</translation>
         </message>
         <message>
             <location filename="../src/gui/serverfoldersdialog.cpp" line="146" />
             <source>No subfolders currently on the server.</source>
-            <translation>Det finns för närvarande inga undermappar på servern.</translation>
+            <translation>Obecnie na serwerze nie ma żadnych podfolderów.</translation>
         </message>
     </context>
     <context>
@@ -2282,34 +2282,34 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <message>
             <location filename="../src/gui/statusbarwidget.cpp" line="178" />
             <source>Resume kDrive "%1" synchronization</source>
-            <translation>Återuppta synkroniseringen av kDrive &amp;quot;%1&amp;quot;</translation>
+            <translation>Wznowić synchronizację kDrive „%1”</translation>
         </message>
         <message>
             <location filename="../src/gui/statusbarwidget.cpp" line="180" />
             <source>Resume all kDrives synchronization</source>
-            <translation>Återuppta all synkronisering av kDrives</translation>
+            <translation>Wznowić synchronizację wszystkich dysków kDrive</translation>
         </message>
         <message>
             <location filename="../src/gui/statusbarwidget.cpp" line="183" />
             <source>Pause kDrive "%1" synchronization</source>
-            <translation>Avbryt synkroniseringen av kDrive &amp;quot;%1&amp;quot;</translation>
+            <translation>Wstrzymaj synchronizację kDrive „%1”</translation>
         </message>
         <message>
             <location filename="../src/gui/statusbarwidget.cpp" line="184" />
             <location filename="../src/gui/statusbarwidget.cpp" line="321" />
             <source>Pause synchronization</source>
-            <translation>Pausa synkroniseringen</translation>
+            <translation>Wstrzymaj synchronizację</translation>
         </message>
         <message>
             <location filename="../src/gui/statusbarwidget.cpp" line="185" />
             <source>Pause all kDrives synchronization</source>
-            <translation>Pausa all synkronisering av kDrives</translation>
+            <translation>Wstrzymaj synchronizację wszystkich kDrives</translation>
         </message>
         <message>
             <location filename="../src/gui/statusbarwidget.cpp" line="179" />
             <location filename="../src/gui/statusbarwidget.cpp" line="322" />
             <source>Resume synchronization</source>
-            <translation>Fortsätt synkroniseringen</translation>
+            <translation>Wznowienie synchronizacji</translation>
         </message>
     </context>
     <context>
@@ -2317,32 +2317,32 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <message>
             <location filename="../src/gui/synchronizeditemwidget.cpp" line="333" />
             <source>Copy share link</source>
-            <translation>Kopiera delningslänken</translation>
+            <translation>Skopiuj link do udostępnienia</translation>
         </message>
         <message>
             <location filename="../src/gui/synchronizeditemwidget.cpp" line="342" />
             <source>Display on kdrive.infomaniak.com</source>
-            <translation>Visas på kdrive.infomaniak.com</translation>
+            <translation>Wyświetl na stronie kdrive.infomaniak.com</translation>
         </message>
         <message>
             <location filename="../src/gui/synchronizeditemwidget.cpp" line="387" />
             <source>Show in folder</source>
-            <translation>Visa i mappen</translation>
+            <translation>Pokaż w folderze</translation>
         </message>
         <message>
             <location filename="../src/gui/synchronizeditemwidget.cpp" line="388" />
             <source>More actions</source>
-            <translation>Fler åtgärder</translation>
+            <translation>Więcej działań</translation>
         </message>
         <message>
             <location filename="../src/gui/synchronizeditemwidget.cpp" line="317" />
             <source>Open</source>
-            <translation>Öppna</translation>
+            <translation>Otwórz</translation>
         </message>
         <message>
             <location filename="../src/gui/synchronizeditemwidget.cpp" line="325" />
             <source>Add to favorites</source>
-            <translation>Lägg till i favoriter</translation>
+            <translation>Dodaj do ulubionych</translation>
         </message>
     </context>
     <context>
@@ -2351,119 +2351,119 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
             <location filename="../src/gui/synthesisbar.cpp" line="495" />
             <location filename="../src/gui/synthesisbar.cpp" line="502" />
             <source>Never</source>
-            <translation>Aldrig</translation>
+            <translation>Nigdy</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesisbar.cpp" line="496" />
             <source>During 1 hour</source>
-            <translation>Under 1 timme</translation>
+            <translation>W ciągu godziny</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesisbar.cpp" line="497" />
             <location filename="../src/gui/synthesisbar.cpp" line="504" />
             <source>Until tomorrow 8:00AM</source>
-            <translation>Fram till imorgon kl. 08.00</translation>
+            <translation>Do jutra do godziny 8:00 rano</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesisbar.cpp" line="498" />
             <source>During 3 days</source>
-            <translation>Under tre dagar</translation>
+            <translation>Przez 3 dni</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesisbar.cpp" line="499" />
             <source>During 1 week</source>
-            <translation>Under en vecka</translation>
+            <translation>W ciągu tygodnia</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesisbar.cpp" line="500" />
             <location filename="../src/gui/synthesisbar.cpp" line="507" />
             <source>Always</source>
-            <translation>Alltid</translation>
+            <translation>Zawsze</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesisbar.cpp" line="503" />
             <source>For 1 more hour</source>
-            <translation>I ytterligare 1 timme</translation>
+            <translation>Jeszcze przez 1 godzinę</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesisbar.cpp" line="505" />
             <source>For 3 more days</source>
-            <translation>I ytterligare 3 dagar</translation>
+            <translation>Jeszcze przez 3 dni</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesisbar.cpp" line="506" />
             <source>For 1 more week</source>
-            <translation>Ytterligare en vecka</translation>
+            <translation>Jeszcze przez 1 tydzień</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesisbar.cpp" line="149" />
             <source>Unable to open folder url %1.</source>
-            <translation>Det går inte att öppna mappen med adressen %1.</translation>
+            <translation>Nie można otworzyć folderu o adresie URL %1.</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesisbar.cpp" line="219" />
             <source>Open in folder</source>
-            <translation>Öppna i mappen</translation>
+            <translation>Otwórz w folderze</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesisbar.cpp" line="257" />
             <source>Open %1 web version</source>
-            <translation>Öppna webbversionen av %1</translation>
+            <translation>Otwórz wersję internetową %1</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesisbar.cpp" line="267" />
             <source>Drive parameters</source>
-            <translation>Drivparametrar</translation>
+            <translation>Parametry napędu</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesisbar.cpp" line="280" />
             <source>Notifications disabled until %1</source>
-            <translation>Meddelanden är inaktiverade fram till %1</translation>
+            <translation>Powiadomienia wyłączone do %1</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesisbar.cpp" line="281" />
             <source>Disable Notifications</source>
-            <translation>Inaktivera aviseringar</translation>
+            <translation>Wyłącz powiadomienia</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesisbar.cpp" line="314" />
             <source>Application preferences</source>
-            <translation>Inställningar för applikationen</translation>
+            <translation>Ustawienia aplikacji</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesisbar.cpp" line="322" />
             <source>Need help</source>
-            <translation>Behöver du hjälp?</translation>
+            <translation>Potrzebujesz pomocy?</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesisbar.cpp" line="330" />
             <source>Send feedbacks</source>
-            <translation>Skicka synpunkter</translation>
+            <translation>Prześlij opinię</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesisbar.cpp" line="338" />
             <source>Quit kDrive</source>
-            <translation>Avsluta kDrive</translation>
+            <translation>Zamknij kDrive</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesisbar.cpp" line="401" />
             <source>Unable to access web site %1.</source>
-            <translation>Det går inte att komma åt webbplatsen %1.</translation>
+            <translation>Nie można uzyskać dostępu do strony internetowej %1.</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesisbar.cpp" line="492" />
             <source>Show errors and informations</source>
-            <translation>Visa fel och information</translation>
+            <translation>Pokaż błędy i informacje</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesisbar.cpp" line="493" />
             <source>Show informations</source>
-            <translation>Visa information</translation>
+            <translation>Pokaż informacje</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesisbar.cpp" line="494" />
             <source>More actions</source>
-            <translation>Fler åtgärder</translation>
+            <translation>Więcej działań</translation>
         </message>
     </context>
     <context>
@@ -2471,98 +2471,98 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <message>
             <location filename="../src/gui/synthesispopover.cpp" line="1181" />
             <source>Update kDrive App</source>
-            <translation>Uppdatera kDrive-appen</translation>
+            <translation>Zaktualizuj aplikację kDrive</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesispopover.cpp" line="1182" />
             <source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
-            <translation>Denna version av kDrive-appen stöds inte längre. Uppdatera appen för att få tillgång till de senaste funktionerna och förbättringarna.</translation>
+            <translation>Ta wersja aplikacji kDrive nie jest już obsługiwana. Aby uzyskać dostęp do najnowszych funkcji i ulepszeń, zaktualizuj aplikację.</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesispopover.cpp" line="978" />
             <source>Update</source>
-            <translation>Uppdatering</translation>
+            <translation>Aktualizacja</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesispopover.cpp" line="1187" />
             <source>Please download the latest version on the website.</source>
-            <translation>Ladda gärna ner den senaste versionen från webbplatsen.</translation>
+            <translation>Proszę pobrać najnowszą wersję ze strony internetowej.</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesispopover.cpp" line="981" />
             <source>Update download in progress</source>
-            <translation>Uppdateringen hämtas just nu</translation>
+            <translation>Trwa pobieranie aktualizacji</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesispopover.cpp" line="984" />
             <source>Looking for update...</source>
-            <translation>Väntar på uppdatering...</translation>
+            <translation>Czekam na aktualizację...</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesispopover.cpp" line="987" />
             <source>Manual update</source>
-            <translation>Manuell uppdatering</translation>
+            <translation>Ręczna aktualizacja</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesispopover.cpp" line="990" />
             <source>Unavailable</source>
-            <translation>Ej tillgängligt</translation>
+            <translation>Niedostępne</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesispopover.cpp" line="1200" />
             <source>You can synchronize files &lt;a style="%1" href="%2"&gt;from your computer&lt;/a&gt; or on &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
-            <translation>Du kan synkronisera filer &lt;a style="%1" href="%2"&gt;från din dator&lt;/a&gt; eller från &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
+            <translation>Możesz zsynchronizować pliki &lt;a style="%1" href="%2"&gt;z komputera&lt;/a&gt; lub ze strony &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesispopover.cpp" line="446" />
             <source>Synchronized</source>
-            <translation>Synkroniserad</translation>
+            <translation>Zsynchronizowane</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesispopover.cpp" line="450" />
             <source>Favorites</source>
-            <translation>Favoriter</translation>
+            <translation>Ulubione</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesispopover.cpp" line="454" />
             <source>Activity</source>
-            <translation>Aktivitet</translation>
+            <translation>Zajęcia</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesispopover.cpp" line="1133" />
             <location filename="../src/gui/synthesispopover.cpp" line="1180" />
             <source>Not implemented!</source>
-            <translation>Har inte implementerats!</translation>
+            <translation>Nie zaimplementowano!</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesispopover.cpp" line="1184" />
             <source>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Click here to download manually&lt;/a&gt;</source>
-            <translation>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Klicka här för att ladda ner manuellt&lt;/a&gt;</translation>
+            <translation>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Kliknij tutaj, aby pobrać plik ręcznie&lt;/a&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesispopover.cpp" line="1193" />
             <source>No synchronized folder for this Drive!</source>
-            <translation>Det finns ingen synkroniserad mapp för den här Drive-kontot!</translation>
+            <translation>Brak zsynchronizowanego folderu dla tego dysku!</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesispopover.cpp" line="1196" />
             <source>No kDrive configured!</source>
-            <translation>kDrive är inte konfigurerat!</translation>
+            <translation>Nie skonfigurowano programu kDrive!</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesispopover.cpp" line="1161" />
             <source>Unable to open link %1.</source>
-            <translation>Det går inte att öppna länken %1.</translation>
+            <translation>Nie można otworzyć linku %1.</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesispopover.cpp" line="1173" />
             <source>Invalid link %1.</source>
-            <translation>Ogiltig länk %1.</translation>
+            <translation>Nieprawidłowy link %1.</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesispopover.cpp" line="586" />
             <source>Unable to open folder url %1.</source>
-            <translation>Det går inte att öppna mappen med adressen %1.</translation>
+            <translation>Nie można otworzyć folderu o adresie URL %1.</translation>
         </message>
     </context>
     <context>
@@ -2570,22 +2570,22 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <message>
             <location filename="../src/gui/updater/updatedialog.cpp" line="61" />
             <source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
-            <translation>&lt;p&gt;Den nya versionen &lt;b&gt;%1&lt;/b&gt; av %2-klienten är tillgänglig och har hämtats.&lt;/p&gt;&lt;p&gt;Den installerade versionen är %3.&lt;/p&gt;</translation>
+            <translation>&lt;p&gt;Nowa wersja &lt;b&gt;%1&lt;/b&gt; klienta %2 jest już dostępna i została pobrana.&lt;/p&gt;&lt;p&gt;Zainstalowana wersja to %3.&lt;/p&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/updater/updatedialog.cpp" line="95" />
             <source>Skip this version</source>
-            <translation>Hoppa över den här versionen</translation>
+            <translation>Pomiń tę wersję</translation>
         </message>
         <message>
             <location filename="../src/gui/updater/updatedialog.cpp" line="103" />
             <source>Remind me later</source>
-            <translation>Påminn mig senare</translation>
+            <translation>Przypomnij mi później</translation>
         </message>
         <message>
             <location filename="../src/gui/updater/updatedialog.cpp" line="109" />
             <source>Install update</source>
-            <translation>Installera uppdatering</translation>
+            <translation>Zainstaluj aktualizację</translation>
         </message>
     </context>
     <context>
@@ -2593,12 +2593,12 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <message>
             <location filename="../src/server/updater/updatemanager.cpp" line="86" />
             <source>New update available.</source>
-            <translation>En ny uppdatering finns tillgänglig.</translation>
+            <translation>Dostępna jest nowa aktualizacja.</translation>
         </message>
         <message>
             <location filename="../src/server/updater/updatemanager.cpp" line="87" />
             <source>Version %1 is available for download.</source>
-            <translation>Version %1 finns tillgänglig för nedladdning.</translation>
+            <translation>Wersja %1 jest dostępna do pobrania.</translation>
         </message>
     </context>
     <context>
@@ -2606,7 +2606,7 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <message>
             <location filename="../src/gui/userselectionwidget.cpp" line="131" />
             <source>Add an account</source>
-            <translation>Lägg till ett konto</translation>
+            <translation>Dodaj konto</translation>
         </message>
     </context>
     <context>
@@ -2619,87 +2619,87 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <message>
             <location filename="../src/gui/versionwidget.cpp" line="169" />
             <source>&lt;a style="%1" href="%2"&gt;Show release note&lt;/a&gt;</source>
-            <translation>&lt;a style="%1" href="%2"&gt;Visa informationsnot&lt;/a&gt;</translation>
+            <translation>&lt;a style="%1" href="%2"&gt;Pokaż informacje o aktualizacji&lt;/a&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/versionwidget.cpp" line="172" />
             <source>Version</source>
-            <translation>Version</translation>
+            <translation>Wersja</translation>
         </message>
         <message>
             <location filename="../src/gui/versionwidget.cpp" line="173" />
             <source>UPDATE</source>
-            <translation>UPPDATERING</translation>
+            <translation>AKTUALIZACJA</translation>
         </message>
         <message>
             <location filename="../src/gui/versionwidget.cpp" line="197" />
             <source>%1 is up to date!</source>
-            <translation>%1 är uppdaterad!</translation>
+            <translation>%1 jest aktualne!</translation>
         </message>
         <message>
             <location filename="../src/gui/versionwidget.cpp" line="201" />
             <source>Checking update on server...</source>
-            <translation>Kontrollerar uppdateringar på servern...</translation>
+            <translation>Sprawdzam aktualizacje na serwerze...</translation>
         </message>
         <message>
             <location filename="../src/gui/versionwidget.cpp" line="205" />
             <source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style="%2" href="%3"&gt;here&lt;/a&gt;.</source>
-            <translation>En uppdatering finns tillgänglig: %1.&lt;br&gt;Ladda ner den &lt;a style="%2" href="%3"&gt;här&lt;/a&gt;.</translation>
+            <translation>Dostępna jest aktualizacja: %1.&lt;br&gt;Pobierz ją stąd.</translation>
         </message>
         <message>
             <location filename="../src/gui/versionwidget.cpp" line="212" />
             <source>An update is available: %1</source>
-            <translation>En uppdatering finns tillgänglig: %1</translation>
+            <translation>Dostępna jest aktualizacja: %1</translation>
         </message>
         <message>
             <location filename="../src/gui/versionwidget.cpp" line="218" />
             <source>Downloading %1. Please wait...</source>
-            <translation>Hämtar %1. Vänta...</translation>
+            <translation>Pobieranie %1. Proszę czekać...</translation>
         </message>
         <message>
             <location filename="../src/gui/versionwidget.cpp" line="223" />
             <source>Could not check for new updates.</source>
-            <translation>Det gick inte att söka efter nya uppdateringar.</translation>
+            <translation>Nie udało się sprawdzić dostępności nowych aktualizacji.</translation>
         </message>
         <message>
             <location filename="../src/gui/versionwidget.cpp" line="227" />
             <source>An error occurred during update.</source>
-            <translation>Ett fel uppstod under uppdateringen.</translation>
+            <translation>Podczas aktualizacji wystąpił błąd.</translation>
         </message>
         <message>
             <location filename="../src/gui/versionwidget.cpp" line="231" />
             <source>Could not download update.</source>
-            <translation>Det gick inte att ladda ner uppdateringen.</translation>
+            <translation>Nie udało się pobrać aktualizacji.</translation>
         </message>
         <message>
             <location filename="../src/gui/versionwidget.cpp" line="235" />
             <source>Update disabled.</source>
-            <translation>Uppdateringen är inaktiverad.</translation>
+            <translation>Funkcja aktualizacji została wyłączona.</translation>
         </message>
         <message>
             <location filename="../src/gui/versionwidget.cpp" line="251" />
             <source>Beta program</source>
-            <translation>Betaprogram</translation>
+            <translation>Program beta</translation>
         </message>
         <message>
             <location filename="../src/gui/versionwidget.cpp" line="252" />
             <source>Get early access to new versions of the application</source>
-            <translation>Få tidig tillgång till nya versioner av applikationen</translation>
+            <translation>Zyskaj wczesny dostęp do nowych wersji aplikacji</translation>
         </message>
         <message>
             <location filename="../src/gui/versionwidget.cpp" line="256" />
             <source>Join</source>
-            <translation>Gå med</translation>
+            <translation>Dołącz</translation>
         </message>
         <message>
             <location filename="../src/gui/versionwidget.cpp" line="259" />
             <source>Modify</source>
-            <translation>Ändra</translation>
+            <translation>Zmodyfikuj</translation>
         </message>
         <message>
             <location filename="../src/gui/versionwidget.cpp" line="259" />
             <source>Quit</source>
-            <translation>Avsluta</translation>
+            <translation>Zakończ</translation>
         </message>
     </context>
     <context>
@@ -2707,122 +2707,122 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <message>
             <location filename="../src/gui/parameterscache.cpp" line="59" />
             <source>Unable to save parameters, please retry later.</source>
-            <translation>Det gick inte att spara parametrarna. Försök igen senare.</translation>
+            <translation>Nie można zapisać parametrów. Spróbuj ponownie później.</translation>
         </message>
         <message>
             <location filename="../src/gui/parameterscache.cpp" line="60" />
             <source>Unable to save parameters!</source>
-            <translation>Det går inte att spara parametrarna!</translation>
+            <translation>Nie można zapisać parametrów!</translation>
         </message>
         <message>
             <location filename="../src/server/requests/serverrequests.cpp" line="461" />
             <source>The parent folder is a sync folder or contained in one</source>
-            <translation>Överordnad mapp är en synkroniseringsmapp eller ingår i en sådan</translation>
+            <translation>Folder nadrzędny jest folderem synchronizacji lub znajduje się w takim folderze</translation>
         </message>
         <message>
             <location filename="../src/server/requests/serverrequests.cpp" line="495" />
             <source>Can't find a valid path</source>
-            <translation>Det går inte att hitta en giltig sökväg</translation>
+            <translation>Nie można znaleźć prawidłowej ścieżki</translation>
         </message>
         <message>
             <location filename="../src/server/requests/serverrequests.cpp" line="2109" />
             <source>No valid folder selected!</source>
-            <translation>Ingen giltig mapp har valts!</translation>
+            <translation>Nie wybrano żadnego prawidłowego folderu!</translation>
         </message>
         <message>
             <location filename="../src/server/requests/serverrequests.cpp" line="2120" />
             <source>The selected path does not exist!</source>
-            <translation>Den valda sökvägen finns inte!</translation>
+            <translation>Wybrana ścieżka nie istnieje!</translation>
         </message>
         <message>
             <location filename="../src/server/requests/serverrequests.cpp" line="2125" />
             <source>The selected path is not a folder!</source>
-            <translation>Den valda sökvägen är ingen mapp!</translation>
+            <translation>Wybrana ścieżka nie jest folderem!</translation>
         </message>
         <message>
             <location filename="../src/server/requests/serverrequests.cpp" line="2130" />
             <source>You have no permission to write to the selected folder!</source>
-            <translation>Du har inte behörighet att skriva till den valda mappen!</translation>
+            <translation>Nie masz uprawnień do zapisu w wybranym folderze!</translation>
         </message>
         <message>
             <location filename="../src/server/requests/serverrequests.cpp" line="2160" />
             <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
-            <translation>Den lokala mappen %1 innehåller en mapp som redan är synkroniserad. Välj en annan!</translation>
+            <translation>Folder lokalny %1 zawiera folder, który został już zsynchronizowany. Wybierz inny!</translation>
         </message>
         <message>
             <location filename="../src/server/requests/serverrequests.cpp" line="2168" />
             <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
-            <translation>Den lokala mappen %1 finns i en mapp som redan är synkroniserad. Välj en annan mapp!</translation>
+            <translation>Folder lokalny %1 znajduje się w folderze, który został już zsynchronizowany. Wybierz inny!</translation>
         </message>
         <message>
             <location filename="../src/server/requests/serverrequests.cpp" line="2176" />
             <source>The local folder %1 is already synced. Please pick another one!</source>
-            <translation>Den lokala mappen %1 är redan synkroniserad. Välj en annan!</translation>
+            <translation>Lokalny folder %1 został już zsynchronizowany. Wybierz inny!</translation>
         </message>
         <message>
             <location filename="../src/gui/folderitemwidget.cpp" line="42" />
             <source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
-            <translation>Lite sync (Beta) är aktiverat. Filerna från kDrive sparas i molnet och tar inte upp lagringsutrymme på din dator.</translation>
+            <translation>Włączono funkcję Lite sync (wersja beta). Pliki z serwisu kDrive pozostają w chmurze i nie zajmują miejsca na dysku komputera.</translation>
         </message>
         <message>
             <location filename="../src/gui/folderitemwidget.cpp" line="45" />
             <source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
-            <translation>Lite sync (Beta) är inaktiverat. kDrive-filerna använder lagringsutrymmet på din dator.</translation>
+            <translation>Funkcja Lite sync (wersja beta) jest wyłączona. Pliki kDrive zajmują miejsce na dysku komputera.</translation>
         </message>
         <message>
             <location filename="../src/gui/folderitemwidget.cpp" line="48" />
             <source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
-            <translation>Lite-synkronisering är aktiverad. Filerna från kDrive sparas i molnet och tar inte upp lagringsutrymme på din dator.</translation>
+            <translation>Włączono funkcję Lite Sync. Pliki z serwisu kDrive pozostają w chmurze i nie zajmują miejsca na dysku komputera.</translation>
         </message>
         <message>
             <location filename="../src/gui/folderitemwidget.cpp" line="50" />
             <source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
-            <translation>Lite sync är inaktiverat. kDrive-filerna använder lagringsutrymmet på din dator.</translation>
+            <translation>Funkcja Lite Sync jest wyłączona. Pliki kDrive zajmują miejsce na dysku komputera.</translation>
         </message>
         <message>
             <location filename="../src/server/comm/extensionjob.cpp" line="1175" />
             <source>Make available locally</source>
-            <translation>Gör tillgängligt lokalt</translation>
+            <translation>Udostępnij lokalnie</translation>
         </message>
         <message>
             <location filename="../src/server/comm/extensionjob.cpp" line="1179" />
             <source>Free up local space</source>
-            <translation>Frigör lokalt lagringsutrymme</translation>
+            <translation>Zwolnij miejsce na dysku lokalnym</translation>
         </message>
         <message>
             <location filename="../src/server/comm/extensionjob.cpp" line="1183" />
             <source>Cancel free up local space</source>
-            <translation>Avbryt för att frigöra lokalt utrymme</translation>
+            <translation>Anuluj, aby zwolnić miejsce na dysku</translation>
         </message>
         <message>
             <location filename="../src/server/comm/extensionjob.cpp" line="1187" />
             <source>Cancel make available locally</source>
-            <translation>Avbryt lokal tillgängliggöring</translation>
+            <translation>Anuluj udostępnianie lokalne</translation>
         </message>
         <message>
             <location filename="../src/server/comm/extensionjob.cpp" line="1191" />
             <source>Resharing this file is not allowed</source>
-            <translation>Det är inte tillåtet att vidarebefordra den här filen</translation>
+            <translation>Ponowne udostępnianie tego pliku jest zabronione</translation>
         </message>
         <message>
             <location filename="../src/server/comm/extensionjob.cpp" line="1192" />
             <source>Resharing this folder is not allowed</source>
-            <translation>Det är inte tillåtet att dela den här mappen vidare</translation>
+            <translation>Ponowne udostępnianie tego folderu jest zabronione</translation>
         </message>
         <message>
             <location filename="../src/server/comm/extensionjob.cpp" line="1196" />
             <source>Copy public share link</source>
-            <translation>Kopiera länken till den offentliga delningen</translation>
+            <translation>Skopiuj link do publicznego udostępnienia</translation>
         </message>
         <message>
             <location filename="../src/server/comm/extensionjob.cpp" line="1200" />
             <source>Copy private share link</source>
-            <translation>Kopiera länken till den privata delningen</translation>
+            <translation>Skopiuj prywatny link do udostępnienia</translation>
         </message>
         <message>
             <location filename="../src/server/comm/extensionjob.cpp" line="1204" />
             <source>Open in browser</source>
-            <translation>Öppna i webbläsaren</translation>
+            <translation>Otwórz w przeglądarce</translation>
         </message>
     </context>
     <context>
@@ -2830,7 +2830,7 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <message>
             <location filename="../src/server/appserver.cpp" line="133" />
             <source>kDrive application will close due to a fatal error.</source>
-            <translation>kDrive-programmet kommer att stängas på grund av ett allvarligt fel.</translation>
+            <translation>Aplikacja kDrive zostanie zamknięta z powodu poważnego błędu.</translation>
         </message>
     </context>
     <context>
@@ -2859,48 +2859,48 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
             <location filename="../src/libcommongui/utility/utility.cpp" line="41" />
             <source>%n year(s)</source>
             <translation>
-                <numerusform>%n år</numerusform>
-                <numerusform>%n år</numerusform>
+                <numerusform>%n rok</numerusform>
+                <numerusform>%n lat</numerusform>
             </translation>
         </message>
         <message numerus="yes">
             <location filename="../src/libcommongui/utility/utility.cpp" line="42" />
             <source>%n month(s)</source>
             <translation>
-                <numerusform>%n månad</numerusform>
-                <numerusform>%n månader</numerusform>
+                <numerusform>%n miesiąc</numerusform>
+                <numerusform>%n miesięcy</numerusform>
             </translation>
         </message>
         <message numerus="yes">
             <location filename="../src/libcommongui/utility/utility.cpp" line="43" />
             <source>%n day(s)</source>
             <translation>
-                <numerusform>%n dag</numerusform>
-                <numerusform>%n dagar</numerusform>
+                <numerusform>%n dzień</numerusform>
+                <numerusform>%n dni</numerusform>
             </translation>
         </message>
         <message numerus="yes">
             <location filename="../src/libcommongui/utility/utility.cpp" line="44" />
             <source>%n hour(s)</source>
             <translation>
-                <numerusform>%n timme</numerusform>
-                <numerusform>%n timmar</numerusform>
+                <numerusform>%n godzina</numerusform>
+                <numerusform>%n godzin</numerusform>
             </translation>
         </message>
         <message numerus="yes">
             <location filename="../src/libcommongui/utility/utility.cpp" line="45" />
             <source>%n minute(s)</source>
             <translation>
+                <numerusform>%n minuta</numerusform>
                 <numerusform>%n minut</numerusform>
-                <numerusform>%n minuter</numerusform>
             </translation>
         </message>
         <message numerus="yes">
             <location filename="../src/libcommongui/utility/utility.cpp" line="46" />
             <source>%n second(s)</source>
             <translation>
+                <numerusform>%n sekunda</numerusform>
                 <numerusform>%n sekund</numerusform>
-                <numerusform>%n sekunder</numerusform>
             </translation>
         </message>
     </context>
@@ -2909,12 +2909,12 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <message>
             <location filename="../src/gui/mainclient.cpp" line="49" />
             <source>System Tray not available</source>
-            <translation>Systemfältet är inte tillgängligt</translation>
+            <translation>Pasek zadań nie jest dostępny</translation>
         </message>
         <message>
             <location filename="../src/gui/mainclient.cpp" line="48" />
             <source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as 'trayer' and try again.</source>
-            <translation>%1 kräver ett fungerande systemfält. Om du använder XFCE, följ &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;dessa instruktioner&lt;/a&gt;. I annat fall bör du installera ett program för systemfältet, till exempel ”trayer”, och försöka igen.</translation>
+            <translation>%1 wymaga działającego paska zadań. Jeśli korzystasz z środowiska XFCE, postępuj zgodnie z &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;poniższymi instrukcjami&lt;/a&gt;. W przeciwnym razie zainstaluj aplikację do obsługi paska zadań, np. „trayer”, i spróbuj ponownie.</translation>
         </message>
     </context>
     <context>
@@ -2922,121 +2922,121 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <message>
             <location filename="../src/gui/guiutility.cpp" line="84" />
             <source>Could not open browser</source>
-            <translation>Det gick inte att öppna webbläsaren</translation>
+            <translation>Nie udało się otworzyć przeglądarki</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="85" />
             <source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
-            <translation>Det uppstod ett fel när webbläsaren startades för att öppna webbadressen %1. Kanske har ingen standardwebbläsare angetts?</translation>
+            <translation>Wystąpił błąd podczas uruchamiania przeglądarki w celu przejścia do adresu URL %1. Być może nie skonfigurowano domyślnej przeglądarki?</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="104" />
             <source>Could not open email client</source>
-            <translation>Det gick inte att öppna e-postprogrammet</translation>
+            <translation>Nie udało się uruchomić klienta poczty elektronicznej</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="105" />
             <source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
-            <translation>Det uppstod ett fel när e-postprogrammet startades för att skapa ett nytt meddelande. Kanske har inget standardprogram för e-post konfigurerats?</translation>
+            <translation>Wystąpił błąd podczas uruchamiania klienta poczty e-mail w celu utworzenia nowej wiadomości. Być może nie skonfigurowano domyślnego klienta poczty e-mail?</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="324" />
             <source>You are not connected anymore. &lt;a style="%1" href="%2"&gt;Log in&lt;/a&gt;</source>
-            <translation>Du är inte inloggad längre. &lt;a style="%1" href="%2"&gt;Logga in&lt;/a&gt;</translation>
+            <translation>Nie masz już połączenia. &lt;a style="%1" href="%2"&gt;Zaloguj się&lt;/a&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="347" />
             <source>Sync in progress (Step %1/%2).</source>
-            <translation>Synkronisering pågår (Steg %1/%2).</translation>
+            <translation>Trwa synchronizacja (Krok %1/%2).</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="353" />
             <source>Sync in progress.</source>
-            <translation>Synkronisering pågår.</translation>
+            <translation>Trwa synchronizacja.</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="364" />
             <source>Some files couldn't be synchronized. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-            <translation>Vissa filer kunde inte synkroniseras. &lt;a style="%1" href="%2"&gt;Läs mer&lt;/a&gt;</translation>
+            <translation>Niektórych plików nie udało się zsynchronizować. &lt;a style="%1" href="%2"&gt;Dowiedz się więcej&lt;/a&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="370" />
             <source>Synchronization pausing ...</source>
-            <translation>Synkroniseringen pausas ...</translation>
+            <translation>Wstrzymywanie synchronizacji...</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="570" />
             <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
-            <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan inte väljas eftersom en annan synkronisering använder samma mapp.</translation>
+            <translation>Nie można wybrać folderu &lt;b&gt;%1,&lt;/b&gt; ponieważ inna synchronizacja korzysta z tego samego folderu.</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="576" />
             <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-            <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan inte väljas eftersom den innehåller den synkroniserade mappen &lt;b&gt;%2&lt;/b&gt;.</translation>
+            <translation>Nie można zaznaczyć folderu &lt;b&gt;%1,&lt;/b&gt; ponieważ zawiera on zsynchronizowany folder &lt;b&gt;%2&lt;/b&gt;.</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="584" />
             <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-            <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan inte väljas eftersom den ingår i den synkroniserade mappen &lt;b&gt;%2&lt;/b&gt;.</translation>
+            <translation>Nie można zaznaczyć folderu &lt;b&gt;%1,&lt;/b&gt; ponieważ znajduje się on w folderze synchronizowanym &lt;b&gt;%2&lt;/b&gt;.</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="595" />
             <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
-            <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan inte väljas som synkroniseringsmapp. Välj en annan mapp.</translation>
+            <translation>Folderu &lt;b&gt;%1&lt;/b&gt; nie można wybrać jako folderu do synchronizacji. Wybierz inny folder.</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="599" />
             <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
-            <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan inte väljas som synkroniseringsmapp. Välj en annan mapp. Föreslagen mapp: &lt;b&gt;%2&lt;/b&gt;</translation>
+            <translation>Folder &lt;b&gt;%1&lt;/b&gt; nie może zostać wybrany jako folder synchronizacji. Wybierz inny folder. Sugerowany folder: &lt;b&gt;%2&lt;/b&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="641" />
             <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
-            <translation>Du har uteslutit mer än %1 mappar. Observera att detta kommer att påverka synkroniseringsprestandan.</translation>
+            <translation>Wykluczyłeś ponad %1 folderów. Pamiętaj, że wpłynie to na wydajność synchronizacji.</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="650" />
             <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
-            <translation>Du kan inte utesluta fler än %1 mappar. Avmarkera mapparna på högre nivå.</translation>
+            <translation>Nie można wykluczyć więcej niż %1 folderów. Proszę odznaczyć foldery wyższego poziomu.</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="351" />
             <source>Synchronization starting</source>
-            <translation>Synkroniseringen påbörjas</translation>
+            <translation>Rozpoczyna się synchronizacja</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="374" />
             <source>Synchronization paused.</source>
-            <translation>Synkroniseringen har pausats.</translation>
+            <translation>Synchronizacja została wstrzymana.</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="336" />
             <source>Sync in progress (%1 of %2)</source>
-            <translation>Synkronisering pågår (%1 av %2)</translation>
+            <translation>Trwa synchronizacja (1% z 2%)</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="340" />
             <source>Sync in progress (%1 of %2)
 %3 left...</source>
-            <translation>Synkronisering pågår (%1 av %2)
-%3 kvar...</translation>
+            <translation>Trwa synchronizacja (%1 z %2)
+Zostało %3...</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="358" />
             <source>You are up to date, unresolved conflicts.</source>
-            <translation>Du har aktuella, olösta konflikter.</translation>
+            <translation>Masz zaległości w postaci nierozwiązanych konfliktów.</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="360" />
             <source>You are up to date!</source>
-            <translation>Nu är du uppdaterad!</translation>
+            <translation>Jesteś na bieżąco!</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="329" />
             <source>No folder to synchronize
 You can add one from the kDrive settings.</source>
-            <translation>Ingen mapp att synkronisera
-Du kan lägga till en i kDrive-inställningarna.</translation>
+            <translation>Brak folderu do synchronizacji
+Możesz dodać folder w ustawieniach kDrive.</translation>
         </message>
     </context>
 </TS>

--- a/translations/client_pt.ts
+++ b/translations/client_pt.ts
@@ -1,44 +1,44 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="sv_SE">
+<TS version="2.1" language="pt_PT">
     <context>
         <name>KDC::AboutDialog</name>
         <message>
             <location filename="../src/gui/aboutdialog.cpp" line="73" />
             <source>About</source>
-            <translation>Om</translation>
+            <translation>Sobre</translation>
         </message>
         <message>
             <location filename="../src/gui/aboutdialog.cpp" line="112" />
             <source>CLOSE</source>
-            <translation>STÄNG</translation>
+            <translation>FECHAR</translation>
         </message>
         <message>
             <location filename="../src/gui/aboutdialog.cpp" line="123" />
             <source>Version %1. For more information visit &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
-            <translation>Version %1. För mer information, besök &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
+            <translation>Versão %1. Para mais informações, visite &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/aboutdialog.cpp" line="126" />
             <source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
-            <translation>Copyright 2019–%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
+            <translation>Direitos de autor 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/aboutdialog.cpp" line="127" />
             <source>Distributed by %1 and licensed under the &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
-            <translation>Distribueras av %1 och licensieras enligt &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 och %2-logotypen är registrerade varumärken som tillhör %1.&lt;br&gt;&lt;br&gt;</translation>
+            <translation>Distribuído por %1 e licenciado ao abrigo da &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 e o logótipo %2 são marcas registadas da %1.&lt;br&gt;&lt;br&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/aboutdialog.cpp" line="151" />
             <location filename="../src/gui/aboutdialog.cpp" line="162" />
             <location filename="../src/gui/aboutdialog.cpp" line="171" />
             <source>Unable to open folder %1.</source>
-            <translation>Det går inte att öppna mappen %1.</translation>
+            <translation>Nao foi possivel abrir a pasta %1.</translation>
         </message>
         <message>
             <location filename="../src/gui/aboutdialog.cpp" line="132" />
             <source>&lt;p&gt;&lt;small&gt;Built from &lt;a style="color: #489EF3" href="%1"&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
-            <translation>&lt;p&gt;&lt;small&gt;Kompilerad från &lt;a style="color: #489EF3" href="%1"&gt;Git-källkod&lt;/a&gt; den %2, %3 med Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
+            <translation>&lt;p&gt;&lt;small&gt;Compilado a partir &lt;a style="color: #489EF3" href="%1"&gt;das fontes do Git&lt;/a&gt; em %2, %3 utilizando o Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
         </message>
     </context>
     <context>
@@ -46,7 +46,7 @@
         <message>
             <location filename="../src/gui/abstractfileitemwidget.cpp" line="177" />
             <source>Unable to open folder path %1.</source>
-            <translation>Det går inte att öppna mappsökvägen %1.</translation>
+            <translation>Nao foi possivel abrir o caminho da pasta %1.</translation>
         </message>
     </context>
     <context>
@@ -54,27 +54,27 @@
         <message>
             <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55" />
             <source>Synchronization will start and you will be able to add files to your %1 folder.</source>
-            <translation>Synkroniseringen startar och du kan lägga till filer i mappen %1.</translation>
+            <translation>A sincronização irá iniciar e poderá adicionar ficheiros à sua pasta %1.</translation>
         </message>
         <message>
             <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99" />
             <source>Your kDrive is ready!</source>
-            <translation>Din kDrive är klar!</translation>
+            <translation>O seu kDrive está pronto!</translation>
         </message>
         <message>
             <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123" />
             <source>OPEN FOLDER</source>
-            <translation>ÖPPNA MAPP</translation>
+            <translation>ABRIR PASTA</translation>
         </message>
         <message>
             <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130" />
             <source>PARAMETERS</source>
-            <translation>INSTÄLLNINGAR</translation>
+            <translation>PARAMETROS</translation>
         </message>
         <message>
             <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138" />
             <source>Synchronize another drive</source>
-            <translation>Synkronisera en annan enhet</translation>
+            <translation>Sincronizar outra unidade</translation>
         </message>
     </context>
     <context>
@@ -82,32 +82,32 @@
         <message>
             <location filename="../src/gui/adddrivelistwidget.cpp" line="170" />
             <source>Cancel</source>
-            <translation>Avbryt</translation>
+            <translation>Cancelar</translation>
         </message>
         <message>
             <location filename="../src/gui/adddrivelistwidget.cpp" line="177" />
             <source>NEXT</source>
-            <translation>NÄSTA</translation>
+            <translation>SEGUINTE</translation>
         </message>
         <message>
             <location filename="../src/gui/adddrivelistwidget.cpp" line="196" />
             <source>Select the kDrive you want to synchronize</source>
-            <translation>Välj den kDrive du vill synkronisera</translation>
+            <translation>Selecione o kDrive que pretende sincronizar</translation>
         </message>
         <message>
             <location filename="../src/gui/adddrivelistwidget.cpp" line="234" />
             <source>Get kDrive for free</source>
-            <translation>Skaffa kDrive gratis</translation>
+            <translation>Obter o kDrive gratuitamente</translation>
         </message>
         <message>
             <location filename="../src/gui/adddrivelistwidget.cpp" line="244" />
             <source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
-            <translation>Spara dina bilder, dokument och e-postmeddelanden i Schweiz hos ett oberoende företag som respekterar din integritet. Läs mer</translation>
+            <translation>Guarde as suas fotografias, documentos e e-mails na Suíça, através de uma empresa independente que respeita a privacidade. Saiba mais</translation>
         </message>
         <message>
             <location filename="../src/gui/adddrivelistwidget.cpp" line="263" />
             <source>Test for free</source>
-            <translation>Testa gratis</translation>
+            <translation>Experimentar gratuitamente</translation>
         </message>
     </context>
     <context>
@@ -115,42 +115,42 @@
         <message>
             <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147" />
             <source>Conserve your computer space</source>
-            <translation>Spara utrymme på datorn</translation>
+            <translation>Poupe espaco no seu computador</translation>
         </message>
         <message>
             <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167" />
             <source>Decide which files should be available online or locally</source>
-            <translation>Bestäm vilka filer som ska vara tillgängliga online eller lokalt</translation>
+            <translation>Decida que ficheiros devem estar disponiveis online ou localmente</translation>
         </message>
         <message>
             <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187" />
             <source>LATER</source>
-            <translation>SENARE</translation>
+            <translation>MAIS TARDE</translation>
         </message>
         <message>
             <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193" />
             <source>YES</source>
-            <translation>JA</translation>
+            <translation>SIM</translation>
         </message>
         <message>
             <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125" />
             <source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-            <translation>Lite Sync synkroniserar alla dina filer utan att ta upp utrymme på din dator. Du kan bläddra bland filerna i ditt kDrive och ladda ner dem lokalt när du vill. &lt;a style="%1" href="%2"&gt;Läs mer&lt;/a&gt;</translation>
+            <translation>O Lite Sync sincroniza todos os seus ficheiros sem ocupar espaço no seu computador. Pode navegar pelos ficheiros no seu kDrive e descarregá-los para o seu computador sempre que quiser. &lt;a style="%1" href="%2"&gt;Saiba mais&lt;/a&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207" />
             <source>Unable to open link %1.</source>
-            <translation>Det går inte att öppna länken %1.</translation>
+            <translation>Nao foi possivel abrir a ligacao %1.</translation>
         </message>
         <message>
             <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112" />
             <source>Would you like to activate Lite Sync (Beta) ?</source>
-            <translation>Vill du aktivera Lite Sync (Beta)?</translation>
+            <translation>Gostaria de ativar o Lite Sync (Beta)?</translation>
         </message>
         <message>
             <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114" />
             <source>Would you like to activate Lite Sync ?</source>
-            <translation>Vill du aktivera Lite Sync?</translation>
+            <translation>Gostaria de ativar o Lite Sync?</translation>
         </message>
     </context>
     <context>
@@ -158,51 +158,51 @@
         <message>
             <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65" />
             <source>Location of your %1 kDrive</source>
-            <translation>Plats för din %1 kDrive</translation>
+            <translation>Localização do seu %1 kDrive</translation>
         </message>
         <message>
             <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155" />
             <source>Edit folder</source>
-            <translation>Ändra mapp</translation>
+            <translation>Editar pasta</translation>
         </message>
         <message>
             <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246" />
             <source>END</source>
-            <translation>SLUTFÖR</translation>
+            <translation>CONCLUIR</translation>
         </message>
         <message>
             <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297" />
             <source>Select folder</source>
-            <translation>Välj mapp</translation>
+            <translation>Selecionar pasta</translation>
         </message>
         <message>
             <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264" />
             <source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
-            <translation>Innehållet i mappen &lt;b&gt;%1&lt;/b&gt; kommer att synkroniseras i din kDrive</translation>
+            <translation>O conteúdo da pasta &lt;b&gt;%1&lt;/b&gt; será sincronizado no seu kDrive</translation>
         </message>
         <message>
             <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212" />
             <source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
-            <translation>När konfigurationen är klar hittar du alla dina filer i den här mappen. Du kan lägga in nya filer där för att synkronisera dem till din kDrive.</translation>
+            <translation>Encontrará todos os seus ficheiros nesta pasta quando a configuração estiver concluída. Pode colocar novos ficheiros nessa pasta para os sincronizar com o seu kDrive.</translation>
         </message>
         <message>
             <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284" />
             <source>This folder is not compatible with Lite Sync.&lt;br&gt; 
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt; 
 &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-            <translation>Den här mappen är inte kompatibel med Lite Sync.&lt;br&gt; 
-Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&gt; 
-&lt;a style="%1" href="%2"&gt;Läs mer&lt;/a&gt;</translation>
+            <translation>Esta pasta não é compatível com o Lite Sync.&lt;br&gt; 
+Selecione outra pasta. Se continuar, o Lite Sync será desativado.&lt;br&gt; 
+&lt;a style="%1" href="%2"&gt;Saiba mais&lt;/a&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377" />
             <source>Unable to open link %1.</source>
-            <translation>Det går inte att öppna länken %1.</translation>
+            <translation>Nao foi possivel abrir a ligacao %1.</translation>
         </message>
         <message>
             <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246" />
             <source>CONTINUE</source>
-            <translation>FORTSÄTT</translation>
+            <translation>CONTINUAR</translation>
         </message>
     </context>
     <context>
@@ -210,32 +210,32 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/adddriveloginwidget.cpp" line="69" />
             <source>Log in from your browser</source>
-            <translation>Logga in från din webbläsare</translation>
+            <translation>Inicie sessao no seu navegador</translation>
         </message>
         <message>
             <location filename="../src/gui/adddriveloginwidget.cpp" line="75" />
             <source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
-            <translation>Din webbläsare bör öppnas automatiskt för att slutföra anslutningen. När anslutningen är upprättad återgår du automatiskt till kDrive.</translation>
+            <translation>O seu navegador deverá abrir automaticamente para concluir a ligação. Assim que estiver ligado, voltará automaticamente ao kDrive.</translation>
         </message>
         <message>
             <location filename="../src/gui/adddriveloginwidget.cpp" line="85" />
             <source>Open the login page</source>
-            <translation>Öppna inloggningssidan</translation>
+            <translation>Abrir a página de início de sessão</translation>
         </message>
         <message>
             <location filename="../src/gui/adddriveloginwidget.cpp" line="119" />
             <source>Token request failed: %1 - %2</source>
-            <translation>Begäran om token misslyckades: %1 - %2</translation>
+            <translation>Falha na solicitação do token: %1 - %2</translation>
         </message>
         <message>
             <location filename="../src/gui/adddriveloginwidget.cpp" line="133" />
             <source>Login failed: %1 - %2</source>
-            <translation>Inloggningen misslyckades: %1 - %2</translation>
+            <translation>Falha no início de sessão: %1 - %2</translation>
         </message>
         <message>
             <location filename="../src/gui/adddriveloginwidget.cpp" line="141" />
             <source>Failed to open the login page in your web browser</source>
-            <translation>Det gick inte att öppna inloggningssidan i din webbläsare</translation>
+            <translation>Não foi possível abrir a página de início de sessão no seu navegador</translation>
         </message>
     </context>
     <context>
@@ -243,27 +243,27 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129" />
             <source>Select kDrive folders to synchronize on your desktop</source>
-            <translation>Välj vilka kDrive-mappar som ska synkroniseras på din dator</translation>
+            <translation>Selecione as pastas do kDrive que pretende sincronizar no seu ambiente de trabalho</translation>
         </message>
         <message>
             <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174" />
             <source>CONTINUE</source>
-            <translation>FORTSÄTT</translation>
+            <translation>CONTINUAR</translation>
         </message>
         <message>
             <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187" />
             <source>Space available on your computer : %1</source>
-            <translation>Ledigt utrymme på din dator: %1</translation>
+            <translation>Espaço disponível no seu computador: %1</translation>
         </message>
         <message>
             <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206" />
             <source>An error occurred while loading the list of subfolders.</source>
-            <translation>Ett fel uppstod vid inläsningen av listan över undermappar.</translation>
+            <translation>Ocorreu um erro ao carregar a lista de subpastas.</translation>
         </message>
         <message>
             <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210" />
             <source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
-            <translation>Det går inte att ladda listan över undermappar&lt;br&gt;. Din kDrive kan vara under underhåll. Logga in på &lt;a style="%1" href="%2"&gt;webbversionen&lt;/a&gt; för att kontrollera statusen för din kDrive, eller kontakta din administratör.</translation>
+            <translation>Não foi possível carregar a lista de subpastas. O seu kDrive poderá estar em manutenção.&lt;br&gt;Por favor, inicie sessão na &lt;a style="%1" href="%2"&gt;versão&lt;/a&gt; &lt;a style="%1" href="%2"&gt;web&lt;/a&gt; para verificar o estado do seu kDrive ou contacte o seu administrador.</translation>
         </message>
     </context>
     <context>
@@ -271,17 +271,17 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/adddrivewizard.cpp" line="222" />
             <source>Failed to create local folder %1</source>
-            <translation>Det gick inte att skapa den lokala mappen %1</translation>
+            <translation>Não foi possível criar a pasta local %1</translation>
         </message>
         <message>
             <location filename="../src/gui/adddrivewizard.cpp" line="233" />
             <source>Failed to create new synchronization</source>
-            <translation>Det gick inte att skapa en ny synkronisering</translation>
+            <translation>Não foi possível criar uma nova sincronização</translation>
         </message>
         <message>
             <location filename="../src/gui/adddrivewizard.cpp" line="266" />
             <source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
-            <translation>kDrive %1 är redan synkroniserat på den här datorn. Vill du fortsätta ändå?</translation>
+            <translation>O kDrive %1 já está sincronizado neste computador. Deseja continuar na mesma?</translation>
         </message>
     </context>
     <context>
@@ -289,17 +289,17 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/appclient.cpp" line="100" />
             <source>kDrive client is run with bad parameters!</source>
-            <translation>kDrive-klienten körs med felaktiga parametrar!</translation>
+            <translation>O cliente kDrive está a ser executado com parâmetros incorretos!</translation>
         </message>
         <message>
             <location filename="../src/gui/appclient.cpp" line="109" />
             <source>kDrive client is already running!</source>
-            <translation>kDrive-klienten är redan igång!</translation>
+            <translation>O cliente kDrive já está em execução!</translation>
         </message>
         <message>
             <location filename="../src/gui/appclient.cpp" line="719" />
             <source>The user %1 is not connected. Please log in again.</source>
-            <translation>Användaren %1 är inte inloggad. Logga in igen.</translation>
+            <translation>O utilizador %1 não está conectado. Por favor, inicie sessão novamente.</translation>
         </message>
     </context>
     <context>
@@ -307,67 +307,67 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/server/appserver.cpp" line="1679" />
             <source>Share link copied to clipboard</source>
-            <translation>Delningslänken har kopierats till urklipp</translation>
+            <translation>O link para partilhar foi copiado para a área de transferência</translation>
         </message>
         <message numerus="yes">
             <location filename="../src/server/appserver.cpp" line="3759" />
             <source>%1 and %n other file(s) have been removed.</source>
             <translation>
-                <numerusform>%1 och %n annan fil har tagits bort.</numerusform>
-                <numerusform>%1 och %n andra filer har tagits bort.</numerusform>
+                <numerusform>%1 e mais %n ficheiro foram removidos.</numerusform>
+                <numerusform>%1 e mais %n ficheiros foram removidos.</numerusform>
             </translation>
         </message>
         <message>
             <location filename="../src/server/appserver.cpp" line="3761" />
             <source>%1 has been removed.</source>
             <comment>%1 names a file.</comment>
-            <translation>%1 har tagits bort.</translation>
+            <translation>O %1 foi removido.</translation>
         </message>
         <message numerus="yes">
             <location filename="../src/server/appserver.cpp" line="3766" />
             <source>%1 and %n other file(s) have been added.</source>
             <translation>
-                <numerusform>%1 och %n annan fil har lagts till.</numerusform>
-                <numerusform>%1 och %n andra filer har lagts till.</numerusform>
+                <numerusform>%1 e mais %n ficheiro foram adicionados.</numerusform>
+                <numerusform>%1 e mais %n ficheiros foram adicionados.</numerusform>
             </translation>
         </message>
         <message>
             <location filename="../src/server/appserver.cpp" line="3768" />
             <source>%1 has been added.</source>
             <comment>%1 names a file.</comment>
-            <translation>%1 har lagts till.</translation>
+            <translation>O %1 foi adicionado.</translation>
         </message>
         <message numerus="yes">
             <location filename="../src/server/appserver.cpp" line="3773" />
             <source>%1 and %n other file(s) have been updated.</source>
             <translation>
-                <numerusform>%1 och %n annan fil har uppdaterats.</numerusform>
-                <numerusform>%1 och %n andra filer har uppdaterats.</numerusform>
+                <numerusform>%1 e mais %n ficheiro foram atualizados.</numerusform>
+                <numerusform>%1 e mais %n ficheiros foram atualizados.</numerusform>
             </translation>
         </message>
         <message>
             <location filename="../src/server/appserver.cpp" line="3775" />
             <source>%1 has been updated.</source>
             <comment>%1 names a file.</comment>
-            <translation>%1 har uppdaterats.</translation>
+            <translation>O %1 foi atualizado.</translation>
         </message>
         <message numerus="yes">
             <location filename="../src/server/appserver.cpp" line="3780" />
             <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
             <translation>
-                <numerusform>%1 har flyttats till %2 och %n annan fil har flyttats.</numerusform>
-                <numerusform>%1 har flyttats till %2 och %n andra filer har flyttats.</numerusform>
+                <numerusform>%1 foi movido para %2 e mais %n ficheiro foi movido.</numerusform>
+                <numerusform>%1 foi movido para %2 e mais %n ficheiros foram movidos.</numerusform>
             </translation>
         </message>
         <message>
             <location filename="../src/server/appserver.cpp" line="3783" />
             <source>%1 has been moved to %2.</source>
-            <translation>%1 har flyttats till %2.</translation>
+            <translation>O %1 foi transferido para o %2.</translation>
         </message>
         <message>
             <location filename="../src/server/appserver.cpp" line="3791" />
             <source>Sync Activity</source>
-            <translation>Synkroniseringsaktivitet</translation>
+            <translation>Atividade de sincronização</translation>
         </message>
     </context>
     <context>
@@ -375,7 +375,7 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102" />
             <source>No subfolders currently on the server.</source>
-            <translation>Det finns för närvarande inga undermappar på servern.</translation>
+            <translation>Não existem subpastas no servidor neste momento.</translation>
         </message>
     </context>
     <context>
@@ -383,67 +383,67 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/betaprogramdialog.cpp" line="69" />
             <source>Quit the beta program</source>
-            <translation>Avsluta betaprogrammet</translation>
+            <translation>Sair do programa beta</translation>
         </message>
         <message>
             <location filename="../src/gui/betaprogramdialog.cpp" line="69" />
             <source>Join the beta program</source>
-            <translation>Anmäl dig till betaprogrammet</translation>
+            <translation>Participe no programa beta</translation>
         </message>
         <message>
             <location filename="../src/gui/betaprogramdialog.cpp" line="77" />
             <source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
-            <translation>Få tillgång till nya versioner av applikationen innan de släpps till allmänheten och bidra till att förbättra applikationen genom att skicka oss dina synpunkter.</translation>
+            <translation>Tenha acesso antecipado às novas versões da aplicação antes do seu lançamento ao público em geral e contribua para a sua melhoria enviando-nos os seus comentários.</translation>
         </message>
         <message>
             <location filename="../src/gui/betaprogramdialog.cpp" line="87" />
             <source>Benefit from application beta updates</source>
-            <translation>Dra nytta av uppdateringar av betaversionen av appen</translation>
+            <translation>Aproveite as atualizações da versão beta da aplicação</translation>
         </message>
         <message>
             <location filename="../src/gui/betaprogramdialog.cpp" line="91" />
             <source>No</source>
-            <translation>Nej</translation>
+            <translation>Não</translation>
         </message>
         <message>
             <location filename="../src/gui/betaprogramdialog.cpp" line="92" />
             <source>Public beta version</source>
-            <translation>Offentlig betaversion</translation>
+            <translation>Versão beta pública</translation>
         </message>
         <message>
             <location filename="../src/gui/betaprogramdialog.cpp" line="93" />
             <source>Internal beta version</source>
-            <translation>Intern betaversion</translation>
+            <translation>Versão beta interna</translation>
         </message>
         <message>
             <location filename="../src/gui/betaprogramdialog.cpp" line="141" />
             <source>I understand</source>
-            <translation>Jag förstår</translation>
+            <translation>Eu compreendo</translation>
         </message>
         <message>
             <location filename="../src/gui/betaprogramdialog.cpp" line="147" />
             <source>Are you sure you want to leave the beta program?</source>
-            <translation>Är du säker på att du vill lämna betaprogrammet?</translation>
+            <translation>Tem a certeza de que quer sair do programa beta?</translation>
         </message>
         <message>
             <location filename="../src/gui/betaprogramdialog.cpp" line="161" />
             <source>Save</source>
-            <translation>Spara</translation>
+            <translation>Guardar</translation>
         </message>
         <message>
             <location filename="../src/gui/betaprogramdialog.cpp" line="167" />
             <source>Cancel</source>
-            <translation>Avbryt</translation>
+            <translation>Cancelar</translation>
         </message>
         <message>
             <location filename="../src/gui/betaprogramdialog.cpp" line="228" />
             <source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
-            <translation>Din nuvarande version av appen kan vara för ny; ditt val träder i kraft när nästa uppdatering blir tillgänglig.</translation>
+            <translation>A versão atual da aplicação pode ser demasiado recente; a sua escolha entrará em vigor assim que estiver disponível a próxima atualização.</translation>
         </message>
         <message>
             <location filename="../src/gui/betaprogramdialog.cpp" line="233" />
             <source>Beta versions may leave unexpectedly or cause instabilities.</source>
-            <translation>Betaversioner kan stängas ner utan förvarning eller orsaka instabilitet.</translation>
+            <translation>As versões beta podem encerrar inesperadamente ou causar instabilidades.</translation>
         </message>
     </context>
     <context>
@@ -451,113 +451,113 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/clientgui.cpp" line="189" />
             <source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
-            <translation>Det gick inte att lösa konflikterna för %1 objekt i synkroniseringsmappen: %2</translation>
+            <translation>Não foi possível resolver o(s) conflito(s) em %1 item(ns) na pasta de sincronização: %2</translation>
         </message>
         <message>
             <location filename="../src/gui/clientgui.cpp" line="242" />
             <source>Please sign in</source>
-            <translation>Logga in</translation>
+            <translation>Por favor, inicie sessão</translation>
         </message>
         <message>
             <location filename="../src/gui/clientgui.cpp" line="292" />
             <source>Folder %1: %2</source>
-            <translation>Mappen %1: %2</translation>
+            <translation>Pasta %1: %2</translation>
         </message>
         <message>
             <location filename="../src/gui/clientgui.cpp" line="298" />
             <source>There are no sync folders configured.</source>
-            <translation>Det finns inga synkroniseringsmappar konfigurerade.</translation>
+            <translation>Não há pastas de sincronização configuradas.</translation>
         </message>
         <message>
             <location filename="../src/gui/clientgui.cpp" line="1426" />
             <source>Synthesis</source>
-            <translation>Sammanfattning</translation>
+            <translation>Síntese</translation>
         </message>
         <message>
             <location filename="../src/gui/clientgui.cpp" line="1427" />
             <source>Preferences</source>
             <translatorcomment>Préférences</translatorcomment>
-            <translation>Inställningar</translation>
+            <translation>Preferencias</translation>
         </message>
         <message>
             <location filename="../src/gui/clientgui.cpp" line="1428" />
             <source>Quit</source>
-            <translation>Avsluta</translation>
+            <translation>Sair</translation>
         </message>
         <message>
             <location filename="../src/gui/clientgui.cpp" line="673" />
             <source>Undefined State.</source>
-            <translation>Odefinierat tillstånd.</translation>
+            <translation>Estado indefinido.</translation>
         </message>
         <message>
             <location filename="../src/gui/clientgui.cpp" line="676" />
             <source>Waiting to start syncing.</source>
-            <translation>Väntar på att synkroniseringen ska starta.</translation>
+            <translation>A aguardar o início da sincronização.</translation>
         </message>
         <message>
             <location filename="../src/gui/clientgui.cpp" line="679" />
             <source>Sync is running.</source>
-            <translation>Synkroniseringen pågår.</translation>
+            <translation>A sincronização está em curso.</translation>
         </message>
         <message>
             <location filename="../src/gui/clientgui.cpp" line="683" />
             <source>Sync was successful, unresolved conflicts.</source>
-            <translation>Synkroniseringen lyckades, men det finns olösta konflikter.</translation>
+            <translation>A sincronização foi bem-sucedida, mas existem conflitos por resolver.</translation>
         </message>
         <message>
             <location filename="../src/gui/clientgui.cpp" line="685" />
             <source>Last Sync was successful.</source>
-            <translation>Den senaste synkroniseringen genomfördes utan problem.</translation>
+            <translation>A última sincronização foi bem-sucedida.</translation>
         </message>
         <message>
             <location filename="../src/gui/clientgui.cpp" line="692" />
             <source>User Abort.</source>
-            <translation>Användaren avbryter.</translation>
+            <translation>Interrupção pelo utilizador.</translation>
         </message>
         <message>
             <location filename="../src/gui/clientgui.cpp" line="696" />
             <source>Sync is paused.</source>
-            <translation>Synkroniseringen är pausad.</translation>
+            <translation>A sincronização está em pausa.</translation>
         </message>
         <message>
             <location filename="../src/gui/clientgui.cpp" line="705" />
             <source>%1 (Sync is paused)</source>
-            <translation>%1 (Synkroniseringen är pausad)</translation>
+            <translation>%1 (A sincronização está em pausa)</translation>
         </message>
         <message>
             <location filename="../src/gui/clientgui.cpp" line="1261" />
             <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-            <translation>Vill du verkligen ta bort synkroniseringarna för kontot &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Obs!&lt;/b&gt; Detta raderar inga filer.</translation>
+            <translation>Quer mesmo remover as sincronizações da conta &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Nota:&lt;/b&gt; Isto &lt;b&gt;não&lt;/b&gt; irá eliminar quaisquer ficheiros.</translation>
         </message>
         <message>
             <location filename="../src/gui/clientgui.cpp" line="1265" />
             <source>REMOVE ALL SYNCHRONIZATIONS</source>
-            <translation>TA BORT ALLA SYNKRONISERINGAR</translation>
+            <translation>REMOVER TODAS AS SINCRONIZAÇÕES</translation>
         </message>
         <message>
             <location filename="../src/gui/clientgui.cpp" line="1266" />
             <source>CANCEL</source>
-            <translation>AVBRYT</translation>
+            <translation>CANCELAR</translation>
         </message>
         <message>
             <location filename="../src/gui/clientgui.cpp" line="1594" />
             <source>Failed to start synchronizations!</source>
-            <translation>Det gick inte att starta synkroniseringarna!</translation>
+            <translation>Não foi possível iniciar as sincronizações!</translation>
         </message>
         <message>
             <location filename="../src/gui/clientgui.cpp" line="849" />
             <source>Unable to open folder path %1.</source>
-            <translation>Det går inte att öppna mappsökvägen %1.</translation>
+            <translation>Nao foi possivel abrir o caminho da pasta %1.</translation>
         </message>
         <message>
             <location filename="../src/gui/clientgui.cpp" line="116" />
             <source>Unable to initialize kDrive client</source>
-            <translation>Det går inte att starta kDrive-klienten</translation>
+            <translation>Não foi possível inicializar o cliente kDrive</translation>
         </message>
         <message>
             <location filename="../src/gui/clientgui.cpp" line="255" />
             <source>Synchronization is paused</source>
-            <translation>Synkroniseringen är pausad</translation>
+            <translation>A sincronização está em pausa</translation>
         </message>
     </context>
     <context>
@@ -565,22 +565,22 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86" />
             <source>Summary of your local folder synchronization</source>
-            <translation>Sammanfattning av synkroniseringen av din lokala mapp</translation>
+            <translation>Resumo da sincronização da sua pasta local</translation>
         </message>
         <message>
             <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95" />
             <source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
-            <translation>Innehållet i mappen på din dator kommer att synkroniseras med mappen på den valda kDrive-enheten och vice versa.</translation>
+            <translation>O conteúdo da pasta no seu computador será sincronizado com a pasta do kDrive selecionado e vice-versa.</translation>
         </message>
         <message>
             <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184" />
             <source>CANCEL</source>
-            <translation>AVBRYT</translation>
+            <translation>CANCELAR</translation>
         </message>
         <message>
             <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191" />
             <source>SYNCHRONIZE</source>
-            <translation>SYNKRONISERA</translation>
+            <translation>SINCRONIZAR</translation>
         </message>
     </context>
     <context>
@@ -589,104 +589,104 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="96" />
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="120" />
             <source>Before finishing</source>
-            <translation>Innan du avslutar</translation>
+            <translation>Antes de terminar</translation>
         </message>
         <message>
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="107" />
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="131" />
             <source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
-            <translation>Följ dessa steg för att säkerställa att Lite Sync fungerar korrekt på din dator och för att slutföra konfigurationen av kDrive.</translation>
+            <translation>Siga os passos abaixo para garantir que o Lite Sync funcione corretamente no seu computador e para concluir a configuração do kDrive.</translation>
         </message>
         <message>
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="208" />
             <source>Open your Mac's &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-            <translation>Öppna &lt;b&gt;inställningarna under ”Allmänt”&lt;/b&gt; på din Mac eller  &lt;a style="%1" href="%2"&gt;klicka här&lt;/a&gt;</translation>
+            <translation>Abra &lt;b&gt;as definições gerais&lt;/b&gt; do seu Mac ou  &lt;a style="%1" href="%2"&gt;clique aqui&lt;/a&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="212" />
             <source>Open your Mac's &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-            <translation>Öppna &lt;b&gt;inställningarna för sekretess och säkerhet&lt;/b&gt; på din Mac eller  &lt;a style="%1" href="%2"&gt;klicka här&lt;/a&gt;</translation>
+            <translation>Abra &lt;b&gt;as definições de Privacidade e Segurança&lt;/b&gt; do seu Mac ou  &lt;a style="%1" href="%2"&gt;clique aqui&lt;/a&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="216" />
             <source>Open your Mac's &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-            <translation>Öppna &lt;b&gt;inställningarna&lt;/b&gt; för &lt;b&gt;Säkerhet och integritet&lt;/b&gt; på din Mac eller  &lt;a style="%1" href="%2"&gt;klicka här&lt;/a&gt;</translation>
+            <translation>Abra &lt;b&gt;as definições de&lt;/b&gt; &lt;b&gt;Segurança e Privacidade&lt;/b&gt; do seu Mac ou &lt;a style="%1" href="%2"&gt;clique aqui&lt;/a&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="246" />
             <source>Go to &lt;b&gt;"Login Items &amp; Extensions"&lt;/b&gt; section and then to &lt;b&gt;"Endpoint Security Extensions"&lt;/b&gt;</source>
-            <translation>Gå till avsnittet &lt;b&gt;”Inloggningsobjekt och tillägg”&lt;/b&gt; och sedan till &lt;b&gt;”Endpoint Security-tillägg”&lt;/b&gt;</translation>
+            <translation>Vá à secção &lt;b&gt;«Itens de início de sessão e extensões»&lt;/b&gt; e, em seguida, a &lt;b&gt;«Extensões de segurança de terminais»&lt;/b&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="263" />
             <source>Authorize the kDrive application</source>
-            <translation>Godkänn appen kDrive</translation>
+            <translation>Autorizar a aplicação kDrive</translation>
         </message>
         <message>
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="272" />
             <source>Go to &lt;b&gt;"Security"&lt;/b&gt; section</source>
-            <translation>Gå till avsnittet &lt;b&gt;”Säkerhet”&lt;/b&gt;</translation>
+            <translation>Vá para a secção &lt;b&gt;«Segurança»&lt;/b&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="289" />
             <source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
-            <translation>Godkänn kDrive-appen i rutan där det står att kDrive har blockerats</translation>
+            <translation>Autorize a aplicação kDrive na janela que indica que o kDrive foi bloqueado</translation>
         </message>
         <message>
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="299" />
             <source>Unlock the padlock &lt;img src=":/client/resources/icons/actions/lock.png"&gt; and authorize the kDrive application</source>
-            <translation>Lås upp hänglåset &lt;img src=":/client/resources/icons/actions/lock.png"&gt; och godkänn kDrive-appen</translation>
+            <translation>Desbloqueie o cadeado &lt;img src=":/client/resources/icons/actions/lock.png"&gt; e autorize a aplicação kDrive</translation>
         </message>
         <message>
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="344" />
             <source>Go to &lt;b&gt;"Privacy &amp; Security"&lt;/b&gt; section and click on &lt;b&gt;"Full Disk Access"&lt;/b&gt; or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-            <translation>Gå till avsnittet &lt;b&gt;”Sekretess och säkerhet”&lt;/b&gt; och klicka på &lt;b&gt;”Fullständig disktillgång”&lt;/b&gt; eller &lt;a style="%1" href="%2"&gt;klicka här&lt;/a&gt;</translation>
+            <translation>Vá à secção &lt;b&gt;«Privacidade e Segurança»&lt;/b&gt; e clique em &lt;b&gt;«Acesso total ao disco»&lt;/b&gt; ou &lt;a style="%1" href="%2"&gt;clique aqui&lt;/a&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="348" />
             <source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;"Privacy"&lt;/b&gt; tab or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-            <translation>Öppna fliken &lt;b&gt;”Sekretess”&lt;/b&gt; i inställningarna för säkerhet och sekretess, eller &lt;a style="%1" href="%2"&gt;klicka här&lt;/a&gt;</translation>
+            <translation>Ainda nas definições de Segurança e Privacidade, abra o separador &lt;b&gt;«Privacidade»&lt;/b&gt; ou &lt;a style="%1" href="%2"&gt;clique aqui&lt;/a&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="376" />
             <source>Check the "kDrive LiteSync Extension" box then the "kDrive.app" box (if not already checked)</source>
-            <translation>Markera rutan ”kDrive LiteSync Extension” och sedan rutan ”kDrive.app” (om den inte redan är markerad)</translation>
+            <translation>Marque a caixa «kDrive LiteSync Extension» e, em seguida, a caixa «kDrive.app» (se ainda não estiver marcada)</translation>
         </message>
         <message>
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="393" />
             <source>A restart of the app might be proposed, in this case accept it</source>
-            <translation>Det kan hända att appen föreslår en omstart; i så fall godkänner du den</translation>
+            <translation>Pode ser sugerido que reinicie a aplicação; nesse caso, aceite</translation>
         </message>
         <message>
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="399" />
             <source>Check the "kDrive LiteSync Extension" box (and "kDrive.app" if it exists) in &lt;b&gt;"Full Disk Access"&lt;/b&gt;</source>
-            <translation>Markera rutan ”kDrive LiteSync Extension” (och ”kDrive.app” om den finns) under &lt;b&gt;”Fullständig diskåtkomst”&lt;/b&gt;</translation>
+            <translation>Marque a caixa «kDrive LiteSync Extension» (e «kDrive.app», se existir) em &lt;b&gt;«Acesso total ao disco»&lt;/b&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="495" />
             <source>STEP 1</source>
-            <translation>STEG 1</translation>
+            <translation>PASSO 1</translation>
         </message>
         <message>
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="495" />
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="496" />
             <source>(Done)</source>
-            <translation>(Klart)</translation>
+            <translation>(Concluído)</translation>
         </message>
         <message>
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="496" />
             <source>STEP 2</source>
-            <translation>STEG 2</translation>
+            <translation>PASSO 2</translation>
         </message>
         <message>
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="499" />
             <source>STEPS PERFORMED</source>
-            <translation>UTFÖRDA STEG</translation>
+            <translation>ETAPAS REALIZADAS</translation>
         </message>
         <message>
             <location filename="../src/gui/customextensionsetupwidget.cpp" line="501" />
             <source>END</source>
-            <translation>SLUTFÖR</translation>
+            <translation>CONCLUIR</translation>
         </message>
     </context>
     <context>
@@ -694,22 +694,22 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/custommessagebox.cpp" line="101" />
             <source>OK</source>
-            <translation>OKEJ</translation>
+            <translation>OK</translation>
         </message>
         <message>
             <location filename="../src/gui/custommessagebox.cpp" line="111" />
             <source>CANCEL</source>
-            <translation>AVBRYT</translation>
+            <translation>CANCELAR</translation>
         </message>
         <message>
             <location filename="../src/gui/custommessagebox.cpp" line="121" />
             <source>YES</source>
-            <translation>JA</translation>
+            <translation>SIM</translation>
         </message>
         <message>
             <location filename="../src/gui/custommessagebox.cpp" line="131" />
             <source>NO</source>
-            <translation>NEJ</translation>
+            <translation>NAO</translation>
         </message>
     </context>
     <context>
@@ -717,12 +717,12 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/debugreporter.cpp" line="37" />
             <source>Sending of debugging information</source>
-            <translation>Översändning av felsökningsinformation</translation>
+            <translation>Envio de informações de depuração</translation>
         </message>
         <message>
             <location filename="../src/gui/debugreporter.cpp" line="37" />
             <source>Cancel</source>
-            <translation>Avbryt</translation>
+            <translation>Cancelar</translation>
         </message>
     </context>
     <context>
@@ -730,194 +730,194 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="46" />
             <source>Info</source>
-            <translation>Info</translation>
+            <translation>Informações</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="45" />
             <source>Debug</source>
-            <translation>Felsökning</translation>
+            <translation>Depuração</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="47" />
             <source>Warning</source>
-            <translation>Varning</translation>
+            <translation>Aviso</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="48" />
             <source>Error</source>
-            <translation>Fel</translation>
+            <translation>Erro</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="49" />
             <source>Fatal</source>
-            <translation>Dödlig</translation>
+            <translation>Fatal</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="74" />
             <source>Debugging settings</source>
-            <translation>Felsökningsinställningar</translation>
+            <translation>Configurações de depuração</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="90" />
             <source>Save debugging information in a folder on my computer (Recommended)</source>
-            <translation>Spara felsökningsinformation i en mapp på min dator (rekommenderas)</translation>
+            <translation>Guardar as informações de depuração numa pasta no meu computador (Recomendado)</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="104" />
             <source>This information enables IT support to determine the origin of an incident.</source>
-            <translation>Med hjälp av denna information kan IT-supporten fastställa var ett fel har sitt ursprung.</translation>
+            <translation>Essas informações permitem que o suporte de TI determine a origem de uma incidência.</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="114" />
             <source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
-            <translation>&lt;a style="%1" href="%2"&gt;Öppna felsökningsmappen&lt;/a&gt;</translation>
+            <translation>&lt;a style="%1" href="%2"&gt;Abrir a pasta de depuração&lt;/a&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="143" />
             <source>Debug level</source>
-            <translation>Felsökningsnivå</translation>
+            <translation>Nível de depuração</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="152" />
             <source>The trace level lets you choose the extent of the debugging information recorded</source>
-            <translation>Med spårningsnivån kan du välja hur mycket felsökningsinformation som ska registreras</translation>
+            <translation>O nível de rastreio permite-lhe escolher a extensão das informações de depuração registadas</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="179" />
             <source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
-            <translation>Den utökade fullständiga loggen samlar in en detaljerad historik som kan användas för felsökning. Om du aktiverar den kan det göra att kDrive-programmet går långsammare.</translation>
+            <translation>O registo completo alargado recolhe um histórico detalhado que pode ser utilizado para depuração. A sua ativação pode tornar a aplicação kDrive mais lenta.</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="183" />
             <source>Extended Full Log</source>
-            <translation>Utökad fullständig logg</translation>
+            <translation>Registo completo alargado</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="206" />
             <source>Delete logs older than %1 days</source>
-            <translation>Ta bort loggar som är äldre än %1 dagar</translation>
+            <translation>Eliminar registos com mais de %1 dias</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="225" />
             <source>Share the debug folder with Infomaniak support.</source>
-            <translation>Skicka debug-mappen till Infomaniaks support.</translation>
+            <translation>Partilhe a pasta de depuração com o apoio técnico da Infomaniak.</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="249" />
             <source>The last session is the periode since the last kDrive start.</source>
-            <translation>Den sista sessionen är tidsperioden sedan kDrive senast startades.</translation>
+            <translation>A última sessão corresponde ao período decorrido desde o último arranque do kDrive.</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="253" />
             <source>Share only the last kDrive session</source>
-            <translation>Dela endast den senaste kDrive-sessionen</translation>
+            <translation>Partilhar apenas a última sessão do kDrive</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="284" />
             <source>  Loading</source>
-            <translation>  Laddar</translation>
+            <translation>  A carregar</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="293" />
             <source>Cancel</source>
-            <translation>Avbryt</translation>
+            <translation>Cancelar</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="319" />
             <source>SAVE</source>
-            <translation>SPARA</translation>
+            <translation>GUARDAR</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="326" />
             <source>CANCEL</source>
-            <translation>AVBRYT</translation>
+            <translation>CANCELAR</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="470" />
             <source>Failed to share</source>
-            <translation>Det gick inte att dela</translation>
+            <translation>Não foi possível partilhar</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="480" />
             <source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
-            <translation>1. Kontrollera att du är inloggad &lt;br&gt;2. Kontrollera att du har konfigurerat minst en kDrive</translation>
+            <translation>1. Verifique se está com a sessão iniciada &lt;br&gt;2. Verifique se configurou pelo menos um kDrive</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="485" />
             <source> (Connexion interrupted)</source>
-            <translation> (Anslutningen avbröts)</translation>
+            <translation> (Conexão interrompida)</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="492" />
             <source>Share the folder with SwissTransfer &lt;br&gt;</source>
-            <translation>Dela mappen med SwissTransfer &lt;br&gt;</translation>
+            <translation>Partilhe a pasta com o SwissTransfer &lt;br&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="493" />
             <source> 1. We automatically compressed your log &lt;a style="%1" href="%2"&gt;here&lt;/a&gt;.&lt;br&gt;</source>
-            <translation> 1. Vi har automatiskt komprimerat din logg &lt;a style="%1" href="%2"&gt;här&lt;/a&gt;.&lt;br&gt;</translation>
+            <translation> 1. Comprimimos automaticamente o seu registo &lt;a style="%1" href="%2"&gt;aqui&lt;/a&gt;.&lt;br&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="495" />
             <source> 2. Transfer the archive with &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
-            <translation> 2. Skicka arkivet via &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
+            <translation> 2. Transfira o arquivo através do &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="497" />
             <source> 3. Share the link with &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
-            <translation> 3. Dela länken med &lt;a style="%1" href="%2"&gt;support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
+            <translation> 3. Partilhe o link com&lt;a style="%1" href="%2"&gt;support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="527" />
             <source>Last upload the %1</source>
-            <translation>Senaste uppladdning: %1</translation>
+            <translation>Último envio: %1</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="555" />
             <source>Sharing has been cancelled</source>
-            <translation>Delningen har avbrutits</translation>
+            <translation>A partilha foi cancelada</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.h" line="70" />
             <source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
-            <translation>Hela mappen är stor (&gt; 100 MB) och det kan ta en stund att dela den. För att minska delningstiden rekommenderar vi att du endast delar den senaste kDrive-sessionen.</translation>
+            <translation>A pasta completa é grande (&amp;gt; 100 MB) e pode demorar algum tempo a partilhar. Para reduzir o tempo de partilha, recomendamos que partilhe apenas a última sessão do kDrive.</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="600" />
             <source>%1/%2/%3 at %4h%5m and %6s</source>
             <extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
-            <translation>%1/%2/%3 kl. %4:%5 och %6 sekunder</translation>
+            <translation>%1/%2/%3 às %4h%5m e %6s</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="643" />
             <source>Do you want to save your modifications?</source>
-            <translation>Vill du spara dina ändringar?</translation>
+            <translation>Quer guardar as suas alterações?</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="698" />
             <location filename="../src/gui/debuggingdialog.cpp" line="704" />
             <source>Unable to open folder %1.</source>
-            <translation>Det går inte att öppna mappen %1.</translation>
+            <translation>Nao foi possivel abrir a pasta %1.</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="711" />
             <source>  Share</source>
-            <translation>  Dela</translation>
+            <translation>  Partilhar</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="721" />
             <source>  Sharing | step 1/2 %1%</source>
-            <translation>  Dela | steg 1/2 %1%</translation>
+            <translation>  Partilha | passo 1/2 %1%</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="730" />
             <source>  Sharing | step 2/2 %1%</source>
-            <translation>  Dela | steg 2/2 %1%</translation>
+            <translation>  Partilha | passo 2/2 %1%</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="740" />
             <source>  Canceling...</source>
-            <translation>  Avbryter...</translation>
+            <translation>  A cancelar...</translation>
         </message>
     </context>
     <context>
@@ -925,152 +925,152 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="1118" />
             <source>Folders</source>
-            <translation>Mappar</translation>
+            <translation>Pastas</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="1120" />
             <source>Notifications</source>
-            <translation>Meddelanden</translation>
+            <translation>Notificações</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="1123" />
             <source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
-            <translation>Ett meddelande visas så snart en ny mapp har synkroniserats eller ändrats</translation>
+            <translation>Será exibida uma notificação assim que uma nova pasta for sincronizada ou alterada</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="1124" />
             <source>Connected with</source>
-            <translation>I samband med</translation>
+            <translation>Relacionado com</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="981" />
             <source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-            <translation>Vill du verkligen sluta synkronisera mappen &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Obs!&lt;/b&gt; Detta kommer &lt;b&gt;inte&lt;/b&gt; att radera några filer.</translation>
+            <translation>Quer mesmo deixar de sincronizar a pasta &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Nota:&lt;/b&gt; Isto &lt;b&gt;não&lt;/b&gt; irá eliminar nenhum ficheiro.</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="356" />
             <source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
-            <translation>Denna åtgärd kan ta allt från några sekunder till några minuter, beroende på mappens storlek.</translation>
+            <translation>Esta operação pode demorar entre alguns segundos e alguns minutos, dependendo do tamanho da pasta.</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="360" />
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="391" />
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="986" />
             <source>CANCEL</source>
-            <translation>AVBRYT</translation>
+            <translation>CANCELAR</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="645" />
             <source>New local folder synchronization failed!</source>
-            <translation>Synkroniseringen av den nya lokala mappen misslyckades!</translation>
+            <translation>A sincronização da nova pasta local falhou!</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="823" />
             <source>Lite Sync activation failed.</source>
-            <translation>Aktiveringen av Lite Sync misslyckades.</translation>
+            <translation>A ativação do Lite Sync falhou.</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="841" />
             <source>Lite Sync deactivation failed.</source>
-            <translation>Det gick inte att inaktivera Lite Sync.</translation>
+            <translation>Falha na desativação do Lite Sync.</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="985" />
             <source>REMOVE FOLDER SYNC CONNECTION</source>
-            <translation>TA BORT SYNKRONISERINGSFÖRBINDELSEN FÖR MAPPEN</translation>
+            <translation>REMOVER A LIGAÇÃO DE SINCRONIZAÇÃO DA PASTA</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="1048" />
             <source>An error occurred while loading the list of subfolders.</source>
-            <translation>Ett fel uppstod vid inläsningen av listan över undermappar.</translation>
+            <translation>Ocorreu um erro ao carregar a lista de subpastas.</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="1121" />
             <source>Enable the notifications for this kDrive</source>
-            <translation>Aktivera aviseringar för denna kDrive</translation>
+            <translation>Ativar as notificações para este kDrive</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="359" />
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="390" />
             <source>CONFIRM</source>
-            <translation>BEKRÄFTA</translation>
+            <translation>CONFIRMAR</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="120" />
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="1117" />
             <source>Synchronization errors and information.</source>
-            <translation>Synkroniseringsfel och information.</translation>
+            <translation>Erros de sincronização e informações.</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="144" />
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="1119" />
             <source>Synchronize a local folder</source>
-            <translation>Synkronisera en lokal mapp</translation>
+            <translation>Sincronizar uma pasta local</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="355" />
             <source>Do you really want to turn on Lite Sync?</source>
-            <translation>Vill du verkligen aktivera Lite Sync?</translation>
+            <translation>Quer mesmo ativar o Lite Sync?</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="382" />
             <source>Do you really want to turn off Lite Sync?</source>
-            <translation>Vill du verkligen stänga av Lite Sync?</translation>
+            <translation>Quer mesmo desativar o Lite Sync?</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="384" />
             <source>You don't have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
-            <translation>Du har inte tillräckligt med utrymme för att synkronisera alla filer på din kDrive (%1 saknas). Om du inaktiverar Lite Sync måste du välja vilka mappar som ska synkroniseras på din dator. Under tiden kommer synkroniseringen av din kDrive att pausas.</translation>
+            <translation>Não tem espaço suficiente para sincronizar todos os ficheiros do seu kDrive (faltam %1). Se desativar o Lite Sync, terá de selecionar as pastas que pretende sincronizar no seu computador. Entretanto, a sincronização do seu kDrive ficará em pausa.</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="388" />
             <source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
-            <translation>Om du stänger av Lite Sync kommer alla filer att laddas ner till din dator.</translation>
+            <translation>Se desativar o Lite Sync, todos os ficheiros serão transferidos para o seu computador.</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="627" />
             <source>Failed to create new synchronization</source>
-            <translation>Det gick inte att skapa en ny synkronisering</translation>
+            <translation>Não foi possível criar uma nova sincronização</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="819" />
             <source>Lite Sync activated.</source>
-            <translation>Lite Sync är aktiverat.</translation>
+            <translation>Lite Sync ativado.</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="837" />
             <source>Lite Sync deactivated.</source>
-            <translation>Lite Sync är inaktiverat.</translation>
+            <translation>O Lite Sync está desativado.</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="899" />
             <source>This drive is being deleted.</source>
-            <translation>Den här enheten raderas.</translation>
+            <translation>Esta unidade está a ser eliminada.</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="962" />
             <source>Impossible to open item %1</source>
-            <translation>Det går inte att öppna objekt %1</translation>
+            <translation>Não é possível abrir o item %1</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="1007" />
             <source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
-            <translation>Det gick inte att avbryta synkroniseringen av mappen &lt;i&gt;%1&lt;/i&gt;.</translation>
+            <translation>Não foi possível interromper a sincronização da pasta &lt;i&gt;%1&lt;/i&gt;.</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="1125" />
             <source>Remove all synchronizations</source>
-            <translation>Ta bort alla synkroniseringar</translation>
+            <translation>Remover todas as sincronizações</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="1126" />
             <source>Search in your kDrive</source>
-            <translation>Sök i din kDrive</translation>
+            <translation>Pesquisar no seu kDrive</translation>
         </message>
         <message>
             <location filename="../src/gui/drivepreferenceswidget.cpp" line="1127" />
             <source>Search</source>
-            <translation>Sök</translation>
+            <translation>Pesquisar</translation>
         </message>
     </context>
     <context>
@@ -1078,12 +1078,12 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/driveselectionwidget.cpp" line="216" />
             <source>Synchronize a kDrive</source>
-            <translation>Synkronisera en kDrive</translation>
+            <translation>Sincronizar um kDrive</translation>
         </message>
         <message>
             <location filename="../src/gui/driveselectionwidget.cpp" line="150" />
             <source>Add a kDrive</source>
-            <translation>Lägg till en kDrive</translation>
+            <translation>Adicionar um kDrive</translation>
         </message>
     </context>
     <context>
@@ -1091,17 +1091,17 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/errortabwidget.cpp" line="179" />
             <source>Resolve</source>
-            <translation>Lösa</translation>
+            <translation>Resolução</translation>
         </message>
         <message>
             <location filename="../src/gui/errortabwidget.cpp" line="180" />
             <source>Conflicted item(s)</source>
-            <translation>Konflikterande objekt</translation>
+            <translation>Elemento(s) em conflito</translation>
         </message>
         <message>
             <location filename="../src/gui/errortabwidget.cpp" line="181" />
             <source>Item(s) with unsupported characters</source>
-            <translation>Objekt med tecken som inte stöds</translation>
+            <translation>Item(s) com caracteres não suportados</translation>
         </message>
         <message>
             <location filename="../src/gui/errortabwidget.cpp" line="92" />
@@ -1109,27 +1109,27 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
             <location filename="../src/gui/errortabwidget.cpp" line="178" />
             <location filename="../src/gui/errortabwidget.cpp" line="186" />
             <source>Clear history</source>
-            <translation>Rensa historiken</translation>
+            <translation>Limpar histórico</translation>
         </message>
         <message>
             <location filename="../src/gui/errortabwidget.cpp" line="176" />
             <source>To Resolve</source>
-            <translation>Att lösa</translation>
+            <translation>Para resolver</translation>
         </message>
         <message>
             <location filename="../src/gui/errortabwidget.cpp" line="184" />
             <source>Automatically resolved</source>
-            <translation>Löst automatiskt</translation>
+            <translation>Resolvido automaticamente</translation>
         </message>
         <message>
             <location filename="../src/gui/errortabwidget.cpp" line="185" />
             <source>problem(s) solved</source>
-            <translation>problem löst</translation>
+            <translation>problema(s) resolvido(s)</translation>
         </message>
         <message>
             <location filename="../src/gui/errortabwidget.cpp" line="177" />
             <source>problem(s) detected</source>
-            <translation>problem har upptäckts</translation>
+            <translation>foram detetados problemas</translation>
         </message>
     </context>
     <context>
@@ -1138,18 +1138,18 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
             <location filename="../src/gui/errorsmenubarwidget.cpp" line="84" />
             <location filename="../src/gui/errorsmenubarwidget.cpp" line="103" />
             <source>Synchronization conflicts or errors</source>
-            <translation>Synkroniseringskonflikter eller fel</translation>
+            <translation>Conflitos ou erros de sincronização</translation>
         </message>
         <message>
             <location filename="../src/gui/errorsmenubarwidget.cpp" line="86" />
             <location filename="../src/gui/errorsmenubarwidget.cpp" line="105" />
             <source>Errors</source>
-            <translation>Fel</translation>
+            <translation>Erros</translation>
         </message>
         <message>
             <location filename="../src/gui/errorsmenubarwidget.cpp" line="101" />
             <source>Back to preferences</source>
-            <translation>Tillbaka till inställningar</translation>
+            <translation>Voltar às preferências</translation>
         </message>
     </context>
     <context>
@@ -1157,30 +1157,30 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/errorspopup.cpp" line="73" />
             <source>Some files couldn't be synchronized on the following kDrive(s) :</source>
-            <translation>Vissa filer kunde inte synkroniseras på följande kDrive-enheter:</translation>
+            <translation>Não foi possível sincronizar alguns ficheiros nos seguintes kDrive(s):</translation>
         </message>
         <message>
             <location filename="../src/gui/errorspopup.cpp" line="95" />
             <source> (%1 error(s))</source>
-            <translation> (%1 fel)</translation>
+            <translation> (%1 erro(s))</translation>
         </message>
         <message>
             <location filename="../src/gui/errorspopup.cpp" line="101" />
             <source> (%1 information(s))</source>
-            <translation> (%1 uppgift(er))</translation>
+            <translation> (%1 informação(s))</translation>
         </message>
         <message>
             <location filename="../src/gui/errorspopup.cpp" line="107" />
             <source> (%1 error(s) and %2 information(s))</source>
-            <translation> (%1 fel och %2 uppgifter)</translation>
+            <translation> (%1 erro(s) e %2 informação(ões))</translation>
         </message>
         <message numerus="yes">
             <location filename="../src/gui/errorspopup.cpp" line="147" />
             <source>Generic errors (%n warning(s) or error(s))</source>
             <comment>Number of warnings or errors</comment>
             <translation>
-                <numerusform>Allmänna fel (%n varning eller fel)</numerusform>
-                <numerusform>Allmänna fel (%n varningar eller fel)</numerusform>
+                <numerusform>Erros genericos (%n aviso ou erro)</numerusform>
+                <numerusform>Erros genericos (%n avisos ou erros)</numerusform>
             </translation>
         </message>
     </context>
@@ -1189,57 +1189,57 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/fileexclusiondialog.cpp" line="78" />
             <source>Excluded files</source>
-            <translation>Undantagna filer</translation>
+            <translation>Ficheiros excluídos</translation>
         </message>
         <message>
             <location filename="../src/gui/fileexclusiondialog.cpp" line="86" />
             <source>Add files or folders that will not be synchronized on your computer.</source>
-            <translation>Lägg till filer eller mappar som inte ska synkroniseras på din dator.</translation>
+            <translation>Adicione ficheiros ou pastas que não serão sincronizados no seu computador.</translation>
         </message>
         <message>
             <location filename="../src/gui/fileexclusiondialog.cpp" line="97" />
             <source>Add</source>
-            <translation>Lägg till</translation>
+            <translation>Adicionar</translation>
         </message>
         <message>
             <location filename="../src/gui/fileexclusiondialog.cpp" line="109" />
             <source>NAME</source>
-            <translation>NAMN</translation>
+            <translation>NOME</translation>
         </message>
         <message>
             <location filename="../src/gui/fileexclusiondialog.cpp" line="114" />
             <source>WARNING</source>
-            <translation>VARNING</translation>
+            <translation>AVISO</translation>
         </message>
         <message>
             <location filename="../src/gui/fileexclusiondialog.cpp" line="149" />
             <source>SAVE</source>
-            <translation>SPARA</translation>
+            <translation>GUARDAR</translation>
         </message>
         <message>
             <location filename="../src/gui/fileexclusiondialog.cpp" line="156" />
             <source>CANCEL</source>
-            <translation>AVBRYT</translation>
+            <translation>CANCELAR</translation>
         </message>
         <message>
             <location filename="../src/gui/fileexclusiondialog.cpp" line="304" />
             <source>Do you want to save your modifications?</source>
-            <translation>Vill du spara dina ändringar?</translation>
+            <translation>Quer guardar as suas alterações?</translation>
         </message>
         <message>
             <location filename="../src/gui/fileexclusiondialog.cpp" line="353" />
             <source>Exclusion template already exists!</source>
-            <translation>Mallen för uteslutning finns redan!</translation>
+            <translation>O modelo de exclusão já existe!</translation>
         </message>
         <message>
             <location filename="../src/gui/fileexclusiondialog.cpp" line="374" />
             <source>Do you really want to delete?</source>
-            <translation>Vill du verkligen ta bort det?</translation>
+            <translation>Quer mesmo eliminar?</translation>
         </message>
         <message>
             <location filename="../src/gui/fileexclusiondialog.cpp" line="434" />
             <source>Cannot save changes!</source>
-            <translation>Det går inte att spara ändringarna!</translation>
+            <translation>Não é possível guardar as alterações!</translation>
         </message>
     </context>
     <context>
@@ -1247,12 +1247,12 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/fileexclusionnamedialog.cpp" line="58" />
             <source>VALIDATE</source>
-            <translation>BEKRÄFTA</translation>
+            <translation>VALIDAR</translation>
         </message>
         <message>
             <location filename="../src/gui/fileexclusionnamedialog.cpp" line="65" />
             <source>CANCEL</source>
-            <translation>AVBRYT</translation>
+            <translation>CANCELAR</translation>
         </message>
     </context>
     <context>
@@ -1261,67 +1261,67 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
             <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67" />
             <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73" />
             <source>Unable to open link %1.</source>
-            <translation>Det går inte att öppna länken %1.</translation>
+            <translation>Nao foi possivel abrir a ligacao %1.</translation>
         </message>
         <message>
             <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122" />
             <source>Solve conflict(s)</source>
-            <translation>Lösa konflikter</translation>
+            <translation>Resolver conflitos</translation>
         </message>
         <message>
             <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140" />
             <source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
-            <translation>&lt;b&gt;Vad vill du göra med den/de %1 objektet/objekten som är i konflikt?&lt;/b&gt;</translation>
+            <translation>&lt;b&gt;O que pretende fazer com o(s) item(ns) em conflito %1?&lt;/b&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143" />
             <source>Save my changes and replace other users' versions.</source>
-            <translation>Spara mina ändringar och ersätt andra användares versioner.</translation>
+            <translation>Guardar as minhas alterações e substituir as versões dos outros utilizadores.</translation>
         </message>
         <message>
             <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147" />
             <source>Undo my changes and keep other users' versions.</source>
-            <translation>Ångra mina ändringar och behåll andra användares versioner.</translation>
+            <translation>Anular as minhas alterações e manter as versões dos outros utilizadores.</translation>
         </message>
         <message>
             <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169" />
             <source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
-            <translation>Dina ändringar kan raderas permanent. De går inte att återställa via kDrive-webbappen.</translation>
+            <translation>As suas alterações podem ser eliminadas definitivamente. Não é possível recuperá-las a partir da aplicação web kDrive.</translation>
         </message>
         <message>
             <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171" />
             <source>&lt;a style=%1 href="%2"&gt;Learn more&lt;/a&gt;</source>
-            <translation>&lt;a style=%1 href="%2"&gt;Läs mer&lt;/a&gt;</translation>
+            <translation>&lt;a style=%1 href="%2"&gt;Saiba mais&lt;/a&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175" />
             <source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
-            <translation>Dina ändringar kommer att raderas permanent. De kan inte återställas via kDrive-webbappen.</translation>
+            <translation>As suas alterações serão eliminadas definitivamente. Não é possível recuperá-las a partir da aplicação web do kDrive.</translation>
         </message>
         <message>
             <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191" />
             <source>Show item(s)</source>
-            <translation>Visa objekt</translation>
+            <translation>Mostrar item(s)</translation>
         </message>
         <message>
             <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228" />
             <source>VALIDATE</source>
-            <translation>BEKRÄFTA</translation>
+            <translation>VALIDAR</translation>
         </message>
         <message>
             <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234" />
             <source>CANCEL</source>
-            <translation>AVBRYT</translation>
+            <translation>CANCELAR</translation>
         </message>
         <message>
             <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251" />
             <source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
-            <translation>Flera användare har gjort ändringar i dessa filer på olika ställen (online på kDrive, på en dator eller i en mobil). Mappar som innehåller dessa filer kan också ha raderats.&lt;br&gt;</translation>
+            <translation>Vários utilizadores introduziram alterações nestes ficheiros em vários locais (online no kDrive, num computador ou num dispositivo móvel). As pastas que contêm estes ficheiros também podem ter sido eliminadas.&lt;br&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253" />
             <source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Learn more&lt;/a&gt;</source>
-            <translation>Den lokala versionen av din artikel &lt;b&gt;är inte synkroniserad&lt;/b&gt; med kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Läs mer&lt;/a&gt;</translation>
+            <translation>A versão local do seu item &lt;b&gt;não está sincronizada&lt;/b&gt; com o kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Saiba mais&lt;/a&gt;</translation>
         </message>
     </context>
     <context>
@@ -1329,68 +1329,68 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/folderitemwidget.cpp" line="458" />
             <source>More actions</source>
-            <translation>Fler åtgärder</translation>
+            <translation>Mais ações</translation>
         </message>
         <message>
             <location filename="../src/gui/folderitemwidget.cpp" line="188" />
             <location filename="../src/gui/folderitemwidget.cpp" line="476" />
             <source>Synchronized into &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</source>
-            <translation>Synkroniserad till &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</translation>
+            <translation>Sincronizado em &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/folderitemwidget.cpp" line="343" />
             <source>Activate Lite Sync</source>
-            <translation>Aktivera Lite Sync</translation>
+            <translation>Ativar o Lite Sync</translation>
         </message>
         <message>
             <location filename="../src/gui/folderitemwidget.cpp" line="345" />
             <source>Activate Lite Sync (Beta)</source>
-            <translation>Aktivera Lite Sync (Beta)</translation>
+            <translation>Ativar o Lite Sync (Beta)</translation>
         </message>
         <message>
             <location filename="../src/gui/folderitemwidget.cpp" line="481" />
             <source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
-            <translation>Mappar som inte är markerade flyttas till papperskorgen om de innehåller objekt som är offline. Mappar som synkroniserats till kDrive förblir tillgängliga online.</translation>
+            <translation>As pastas não selecionadas serão movidas para a lixeira, desde que contenham itens offline. As pastas sincronizadas com o kDrive permanecerão disponíveis online.</translation>
         </message>
         <message>
             <location filename="../src/gui/folderitemwidget.cpp" line="485" />
             <source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
-            <translation>Mappar som inte är markerade kommer att flyttas till papperskorgen. Mappar som synkroniserats till kDrive kommer att förbli tillgängliga online.</translation>
+            <translation>As pastas não selecionadas serão movidas para a lixeira. As pastas sincronizadas com o kDrive permanecerão disponíveis online.</translation>
         </message>
         <message>
             <location filename="../src/gui/folderitemwidget.cpp" line="488" />
             <source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
-            <translation>Mappar som inte är markerade kommer att raderas &lt;b&gt;permanent&lt;/b&gt; från datorn. Mappar som synkroniserats till kDrive kommer att finnas kvar online.</translation>
+            <translation>As pastas não selecionadas serão eliminadas &lt;b&gt;definitivamente&lt;/b&gt; do computador. As pastas sincronizadas com o kDrive permanecerão disponíveis online.</translation>
         </message>
         <message>
             <location filename="../src/gui/folderitemwidget.cpp" line="493" />
             <source>Cancel</source>
-            <translation>Avbryt</translation>
+            <translation>Cancelar</translation>
         </message>
         <message>
             <location filename="../src/gui/folderitemwidget.cpp" line="494" />
             <source>VALIDATE</source>
-            <translation>BEKRÄFTA</translation>
+            <translation>VALIDAR</translation>
         </message>
         <message>
             <location filename="../src/gui/folderitemwidget.cpp" line="365" />
             <source>Pause synchronization</source>
-            <translation>Pausa synkroniseringen</translation>
+            <translation>Pausar a sincronização</translation>
         </message>
         <message>
             <location filename="../src/gui/folderitemwidget.cpp" line="354" />
             <source>Deactivate Lite Sync</source>
-            <translation>Inaktivera Lite Sync</translation>
+            <translation>Desativar o Lite Sync</translation>
         </message>
         <message>
             <location filename="../src/gui/folderitemwidget.cpp" line="375" />
             <source>Resume synchronization</source>
-            <translation>Fortsätt synkroniseringen</translation>
+            <translation>Retomar a sincronização</translation>
         </message>
         <message>
             <location filename="../src/gui/folderitemwidget.cpp" line="386" />
             <source>Remove synchronization</source>
-            <translation>Avaktivera synkronisering</translation>
+            <translation>Desativar a sincronização</translation>
         </message>
     </context>
     <context>
@@ -1398,7 +1398,7 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/genericerroritemwidget.cpp" line="85" />
             <source>Unable to open folder path %1.</source>
-            <translation>Det går inte att öppna mappsökvägen %1.</translation>
+            <translation>Nao foi possivel abrir o caminho da pasta %1.</translation>
         </message>
     </context>
     <context>
@@ -1406,22 +1406,22 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/litesyncappdialog.cpp" line="48" />
             <source>Application Id</source>
-            <translation>Applikations-ID</translation>
+            <translation>ID da aplicação</translation>
         </message>
         <message>
             <location filename="../src/gui/litesyncappdialog.cpp" line="98" />
             <source>Application Name</source>
-            <translation>Programnamn</translation>
+            <translation>Nome da aplicação</translation>
         </message>
         <message>
             <location filename="../src/gui/litesyncappdialog.cpp" line="121" />
             <source>VALIDATE</source>
-            <translation>BEKRÄFTA</translation>
+            <translation>VALIDAR</translation>
         </message>
         <message>
             <location filename="../src/gui/litesyncappdialog.cpp" line="128" />
             <source>CANCEL</source>
-            <translation>AVBRYT</translation>
+            <translation>CANCELAR</translation>
         </message>
     </context>
     <context>
@@ -1429,47 +1429,47 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/litesyncdialog.cpp" line="91" />
             <source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are "online". Add them in the list below to avoid this behaviour.</source>
-            <translation>Vissa appar (säkerhetskopieringsappar, antivirusprogram...) får åtkomst till dina filer, vilket gör att de laddas ner när de är ”uppkopplade”. Lägg till dem i listan nedan för att undvika detta.</translation>
+            <translation>Algumas aplicações (de cópia de segurança, antivírus...) acedem aos seus ficheiros, o que leva à sua transferência quando estão «online». Adicione-as à lista abaixo para evitar este comportamento.</translation>
         </message>
         <message>
             <location filename="../src/gui/litesyncdialog.cpp" line="103" />
             <source>Add</source>
-            <translation>Lägg till</translation>
+            <translation>Adicionar</translation>
         </message>
         <message>
             <location filename="../src/gui/litesyncdialog.cpp" line="115" />
             <source>APPLICATION ID</source>
-            <translation>APPLIKATIONS-ID</translation>
+            <translation>ID DA APLICAÇÃO</translation>
         </message>
         <message>
             <location filename="../src/gui/litesyncdialog.cpp" line="120" />
             <source>NAME</source>
-            <translation>NAMN</translation>
+            <translation>NOME</translation>
         </message>
         <message>
             <location filename="../src/gui/litesyncdialog.cpp" line="154" />
             <source>SAVE</source>
-            <translation>SPARA</translation>
+            <translation>GUARDAR</translation>
         </message>
         <message>
             <location filename="../src/gui/litesyncdialog.cpp" line="161" />
             <source>CANCEL</source>
-            <translation>AVBRYT</translation>
+            <translation>CANCELAR</translation>
         </message>
         <message>
             <location filename="../src/gui/litesyncdialog.cpp" line="295" />
             <source>Do you want to save your modifications?</source>
-            <translation>Vill du spara dina ändringar?</translation>
+            <translation>Quer guardar as suas alterações?</translation>
         </message>
         <message>
             <location filename="../src/gui/litesyncdialog.cpp" line="337" />
             <source>Do you really want to delete?</source>
-            <translation>Vill du verkligen ta bort det?</translation>
+            <translation>Quer mesmo eliminar?</translation>
         </message>
         <message>
             <location filename="../src/gui/litesyncdialog.cpp" line="374" />
             <source>Cannot save changes!</source>
-            <translation>Det går inte att spara ändringarna!</translation>
+            <translation>Não é possível guardar as alterações!</translation>
         </message>
     </context>
     <context>
@@ -1477,52 +1477,52 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/localfolderdialog.cpp" line="63" />
             <source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
-            <translation>Vilken mapp på din dator vill du&lt;br&gt;synkronisera?</translation>
+            <translation>Que pasta do seu computador gostaria de&lt;br&gt;sincronizar?</translation>
         </message>
         <message>
             <location filename="../src/gui/localfolderdialog.cpp" line="72" />
             <source>The content of this folder will be synchronized on the kDrive</source>
-            <translation>Innehållet i den här mappen kommer att synkroniseras på kDrive</translation>
+            <translation>O conteúdo desta pasta será sincronizado no kDrive</translation>
         </message>
         <message>
             <location filename="../src/gui/localfolderdialog.cpp" line="91" />
             <source>Select a folder</source>
-            <translation>Välj en mapp</translation>
+            <translation>Selecione uma pasta</translation>
         </message>
         <message>
             <location filename="../src/gui/localfolderdialog.cpp" line="131" />
             <source>Edit folder</source>
-            <translation>Ändra mapp</translation>
+            <translation>Editar pasta</translation>
         </message>
         <message>
             <location filename="../src/gui/localfolderdialog.cpp" line="166" />
             <source>CANCEL</source>
-            <translation>AVBRYT</translation>
+            <translation>CANCELAR</translation>
         </message>
         <message>
             <location filename="../src/gui/localfolderdialog.cpp" line="173" />
             <source>CONTINUE</source>
-            <translation>FORTSÄTT</translation>
+            <translation>CONTINUAR</translation>
         </message>
         <message>
             <location filename="../src/gui/localfolderdialog.cpp" line="210" />
             <source>This folder is not compatible with Lite Sync.&lt;br&gt;
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt;
 &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-            <translation>Den här mappen är inte kompatibel med Lite Sync.&lt;br&gt;
-Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&gt;
+            <translation>Esta pasta não é compatível com o Lite Sync.&lt;br&gt;
+Selecione outra pasta. Se continuar, o Lite Sync será desativado.&lt;br&gt;
 
-&lt;a style="%1" href="%2"&gt;Läs mer&lt;/a&gt;</translation>
+&lt;a style="%1" href="%2"&gt;Saiba mais&lt;/a&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/localfolderdialog.cpp" line="233" />
             <source>Select folder</source>
-            <translation>Välj mapp</translation>
+            <translation>Selecionar pasta</translation>
         </message>
         <message>
             <location filename="../src/gui/localfolderdialog.cpp" line="292" />
             <source>Unable to open link %1.</source>
-            <translation>Det går inte att öppna länken %1.</translation>
+            <translation>Nao foi possivel abrir a ligacao %1.</translation>
         </message>
     </context>
     <context>
@@ -1530,12 +1530,12 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/libcommongui/logger.cpp" line="189" />
             <source>Error</source>
-            <translation>Fel</translation>
+            <translation>Erro</translation>
         </message>
         <message>
             <location filename="../src/libcommongui/logger.cpp" line="189" />
             <source>&lt;nobr&gt;File '%1'&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
-            <translation>&lt;nobr&gt;Filen &amp;#x27;%1&amp;#x27;&lt;br/&gt;kan inte öppnas för skrivning.&lt;br/&gt;&lt;br/&gt;Logginformationen kan &lt;b&gt;inte&lt;/b&gt; sparas!&lt;/nobr&gt;</translation>
+            <translation>&lt;nobr&gt;Não é possível abrir o&lt;br/&gt;ficheiro «%1» para gravação. &lt;b&gt;Não&lt;/b&gt; é&lt;br/&gt;&lt;br/&gt;possível guardar o registo!&lt;/nobr&gt;</translation>
         </message>
     </context>
     <context>
@@ -1543,12 +1543,12 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/mainmenubarwidget.cpp" line="115" />
             <source>Preferences</source>
-            <translation>Inställningar</translation>
+            <translation>Preferencias</translation>
         </message>
         <message>
             <location filename="../src/gui/mainmenubarwidget.cpp" line="116" />
             <source>Help</source>
-            <translation>Hjälp</translation>
+            <translation>Ajuda</translation>
         </message>
     </context>
     <context>
@@ -1556,24 +1556,24 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="1082" />
             <source>Unable to open folder path %1.</source>
-            <translation>Det går inte att öppna mappsökvägen %1.</translation>
+            <translation>Nao foi possivel abrir o caminho da pasta %1.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="1096" />
             <source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
-            <translation>Överföringen är klar!&lt;br&gt;Ange referensnummer &lt;b&gt;%1&lt;/b&gt; i felrapporter.</translation>
+            <translation>Envio concluído!&lt;br&gt;Por favor, indique o identificador &lt;b&gt;%1&lt;/b&gt; nos relatórios de erros.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="1118" />
             <source>No kDrive configured!</source>
-            <translation>kDrive är inte konfigurerat!</translation>
+            <translation>O kDrive não está configurado!</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="1097" />
             <source>Transmission failed!
 Please, use the following link to send the logs to the support: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</source>
-            <translation>Överföringen misslyckades!
-Använd följande länk för att skicka loggfilerna till supporten: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</translation>
+            <translation>Falha na transmissão!
+Por favor, utilize o seguinte link para enviar os registos para o apoio técnico: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="337" />
@@ -1582,365 +1582,365 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
             <location filename="../src/gui/parametersdialog.cpp" line="546" />
             <location filename="../src/gui/parametersdialog.cpp" line="560" />
             <source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-            <translation>Ett tekniskt fel har uppstått (fel %1).&lt;br&gt;Rensa historiken och kontakta vår support om felet kvarstår.</translation>
+            <translation>Ocorreu um erro técnico (erro %1).&lt;br&gt;Por favor, limpe o histórico e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="342" />
             <source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
-            <translation>Det verkar som om tidsgränsen för din nätverksanslutning är inställd på ett för lågt värde för att programmet ska fungera korrekt (fel %1).&lt;br&gt;Kontrollera din nätverkskonfiguration.</translation>
+            <translation>Parece que a sua ligação de rede está configurada com um tempo de espera demasiado curto para que a aplicação funcione corretamente (erro %1).&lt;br&gt;Verifique a sua configuração de rede.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="347" />
             <location filename="../src/gui/parametersdialog.cpp" line="516" />
             <source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
-            <translation>Det går inte att ansluta till kDrive-servern (fel %1).&lt;br&gt;Försöker ansluta igen. Kontrollera din internetanslutning och din brandvägg.</translation>
+            <translation>Não é possível estabelecer ligação ao servidor kDrive (erro %1).&lt;br&gt;A tentar restabelecer a ligação. Verifique a sua ligação à Internet e a sua firewall.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="352" />
             <source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
-            <translation>Ett inloggningsproblem har uppstått (fel %1).&lt;br&gt;Logga in igen. Om felet kvarstår, kontakta vår support.</translation>
+            <translation>Ocorreu um problema ao iniciar sessão (erro %1).&lt;br&gt;Por favor, inicie sessão novamente e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="356" />
             <source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
-            <translation>En ny version av appen finns tillgänglig. Uppdatera&lt;br&gt;appen för att kunna fortsätta använda den.</translation>
+            <translation>Está disponível uma nova versão da aplicação.&lt;br&gt;Por favor, atualize a aplicação para continuar a utilizá-la.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="360" />
             <source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
-            <translation>Uppladdningen av loggen misslyckades (fel %1).&lt;br&gt;Försök igen senare.</translation>
+            <translation>A publicação do registo falhou (erro %1).&lt;br&gt;Por favor, tente novamente mais tarde.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="385" />
             <source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
-            <translation>Synkroniseringsmappen är inte längre tillgänglig (fel %1).&lt;br&gt;Synkroniseringen återupptas så snart mappen blir tillgänglig.</translation>
+            <translation>Já não é possível aceder à pasta de sincronização (erro %1).&lt;br&gt;A sincronização será retomada assim que for possível aceder à pasta.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="532" />
             <source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
-            <translation>Synkroniseringsmappen har ersatts eller flyttats på ett sätt som förhindrar synkronisering (fel %1).&lt;br&gt;Detta kan inträffa efter att mappen har kopierats, flyttats eller återställts.&lt;br&gt;För att åtgärda detta, skapa en ny synkronisering med en ny mapp.&lt;br&gt;Obs! Om det finns osynkroniserade ändringar i den gamla mappen måste du kopiera dem manuellt till den nya.</translation>
+            <translation>A pasta de sincronização foi substituída ou movida de forma a impedir a sincronização (erro %1).&lt;br&gt;Isto pode acontecer após copiar, mover ou restaurar a pasta.&lt;br&gt;Para resolver este problema, crie uma nova sincronização com uma nova pasta.&lt;br&gt;Nota: se houver alterações não sincronizadas na pasta antiga, terá de as copiar manualmente para a nova.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="397" />
             <source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
-            <translation>Det finns inte tillräckligt med minne kvar på din dator.&lt;br&gt;Synkroniseringen har avbrutits.</translation>
+            <translation>Não há memória suficiente no seu computador.&lt;br&gt;A sincronização foi interrompida.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="320" />
             <source>kDrive needs to have write access to your computer's temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
-            <translation>kDrive måste ha skrivbehörighet till datorns temporära katalog.&lt;br&gt;Starta om kDrive-appen för att lösa problemet.</translation>
+            <translation>O kDrive precisa de ter acesso de escrita ao diretório temporário do seu computador.&lt;br&gt;Reinicie a aplicação kDrive para resolver este problema.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="330" />
             <location filename="../src/gui/parametersdialog.cpp" line="487" />
             <source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-            <translation>Ett tekniskt fel har uppstått.&lt;br&gt;Synkroniseringen återupptas så snart som möjligt. Kontakta vår support om felet kvarstår.</translation>
+            <translation>Ocorreu um erro técnico.&lt;br&gt;A sincronização será retomada assim que possível. Se o erro persistir, contacte a nossa equipa de apoio.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="401" />
             <source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing '/etc/sysctl.conf'.</source>
-            <translation>Antalet inotify-övervakningar är otillräckligt (fel %1).&lt;br&gt;Du kan öka detta antal genom att redigera filen &amp;#x27;/etc/sysctl.conf&amp;#x27;.</translation>
+            <translation>O número de observações inotify é insuficiente (erro %1).&lt;br&gt;Pode aumentar este número editando o ficheiro «/etc/sysctl.conf».</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="406" />
             <source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
-            <translation>Det går inte att starta synkroniseringen (fel %1).&lt;br&gt;Du måste ge behörighet till:&lt;br&gt;– kDrive i Systeminställningar &gt;&gt; Allmänt &gt;&gt; Inloggningsobjekt och tillägg &gt;&gt; Tillägg för&lt;br&gt;Endpoint Security– kDrive LiteSync-tillägget i Systeminställningar &gt;&gt; Sekretess och säkerhet &gt;&gt; Fullständig disktillgång.</translation>
+            <translation>Não foi possível iniciar a sincronização (erro %1).&lt;br&gt;Deve autorizar: - o kDrive em «Definições do sistema» &amp;gt;&amp;gt; «Geral» &amp;gt;&amp;gt; «Itens de&lt;br&gt;início de sessão e extensões» &amp;gt;&amp;gt; «Extensões de segurança de terminais»&lt;br&gt;; - a extensão kDrive LiteSync em «Definições do sistema» &amp;gt;&amp;gt; «Privacidade e segurança» &amp;gt;&amp;gt; «Acesso total ao disco».</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="419" />
             <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-            <translation>Det går inte att starta tillägget Lite Sync (fel %1).&lt;br&gt;Kontrollera att tillägget Lite Sync är installerat och att tjänsten Windows Search är aktiverad.&lt;br&gt;Rensa historiken, starta om datorn och kontakta vår support om felet kvarstår.</translation>
+            <translation>Não foi possível iniciar o plugin Lite Sync (erro %1).&lt;br&gt;Verifique se a extensão Lite Sync está instalada e se o serviço Windows Search está ativado.&lt;br&gt;Limpe o histórico, reinicie o computador e, se o erro persistir, contacte a nossa equipa de suporte.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="424" />
             <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-            <translation>Det går inte att starta tillägget Lite Sync (fel %1).&lt;br&gt;Kontrollera att tillägget Lite Sync har rätt behörigheter och är igång.&lt;br&gt;Rensa historiken, starta om och kontakta vår support om felet kvarstår.</translation>
+            <translation>Não foi possível iniciar o plugin Lite Sync (erro %1).&lt;br&gt;Verifique se a extensão Lite Sync tem as permissões corretas e se está em execução.&lt;br&gt;Limpe o histórico, reinicie e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="429" />
             <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-            <translation>Det går inte att starta Lite Sync-tillägget (fel %1).&lt;br&gt;Rensa historiken, starta om och kontakta vår support om felet kvarstår.</translation>
+            <translation>Não foi possível iniciar o plugin Lite Sync (erro %1).&lt;br&gt;Limpe o histórico, reinicie e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="435" />
             <source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
-            <translation>En fil eller mapp i din synkroniseringsmapp verkar vara skadad.&lt;br&gt;Synkroniseringen har avbrutits.</translation>
+            <translation>Parece que um ficheiro ou pasta dentro da sua pasta de sincronização está corrompido.&lt;br&gt;A sincronização foi interrompida.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="449" />
             <source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-            <translation>kDrive är i underhållsläge.&lt;br&gt;Synkroniseringen kommer att återupptas så snart som möjligt. Kontakta vår support om felet kvarstår.</translation>
+            <translation>O kDrive está em modo de manutenção.&lt;br&gt;A sincronização será reiniciada assim que possível. Se o erro persistir, contacte a nossa equipa de apoio.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="455" />
             <source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-            <translation>kDrive är blockerat.&lt;br&gt;Förnya kDrive. Om inga åtgärder vidtas kommer uppgifterna att raderas permanent och det går inte att återställa dem.</translation>
+            <translation>O kDrive está bloqueado.&lt;br&gt;Por favor, atualize o kDrive. Se não forem tomadas medidas, os dados serão eliminados definitivamente e será impossível recuperá-los.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="460" />
             <source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-            <translation>kDrive är spärrat.&lt;br&gt;Kontakta en administratör för att återställa kDrive. Om inga åtgärder vidtas kommer uppgifterna att raderas permanent och det går inte att återställa dem.</translation>
+            <translation>O kDrive está bloqueado.&lt;br&gt;Contacte um administrador para renovar o kDrive. Se não forem tomadas medidas, os dados serão eliminados definitivamente e será impossível recuperá-los.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="466" />
             <source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-            <translation>kDrive startar upp.&lt;br&gt;Synkroniseringen kommer att återupptas så snart som möjligt. Kontakta vår support om felet kvarstår.</translation>
+            <translation>O kDrive está a iniciar-se.&lt;br&gt;A sincronização será reiniciada assim que possível. Se o erro persistir, contacte a nossa equipa de apoio.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="475" />
             <source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
-            <translation>kDrive är inaktivt.&lt;br&gt;Logga in på &lt;a style="%1" href="%2"&gt;web&lt;/a&gt;versionen för att kontrollera statusen för ditt kDrive, eller kontakta din administratör.</translation>
+            <translation>O kDrive está inativo.&lt;br&gt;Por favor, inicie sessão na &lt;a style="%1" href="%2"&gt;versão&lt;/a&gt; &lt;a style="%1" href="%2"&gt;web&lt;/a&gt; para verificar o estado do seu kDrive ou contacte o seu administrador.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="479" />
             <source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive's status, or contact your administrator.</source>
-            <translation>kDrive är inaktivt.&lt;br&gt;Logga in på webbversionen för att kontrollera statusen för ditt kDrive, eller kontakta din administratör.</translation>
+            <translation>O kDrive está inativo.&lt;br&gt;Por favor, inicie sessão na versão web para verificar o estado do seu kDrive ou contacte o seu administrador.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="483" />
             <source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
-            <translation>Du har inte behörighet att komma åt denna kDrive.&lt;br&gt;Synkroniseringen har pausats. Kontakta en administratör.</translation>
+            <translation>Não tem autorização para aceder a este kDrive.&lt;br&gt;A sincronização foi suspensa. Contacte um administrador.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="493" />
             <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-            <translation>Ett tekniskt fel har uppstått (fel %1).&lt;br&gt;Synkroniseringen återupptas så snart som möjligt. Kontakta vår support om felet kvarstår.</translation>
+            <translation>Ocorreu um erro técnico (erro %1).&lt;br&gt;A sincronização será retomada assim que possível. Se o erro persistir, contacte a nossa equipa de apoio.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="512" />
             <source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-            <translation>Nätverksanslutningarna har avbrutits av kärnan (fel %1).&lt;br&gt;Rensa historiken och kontakta vår support om felet kvarstår.</translation>
+            <translation>As ligações de rede foram interrompidas pelo kernel (erro %1).&lt;br&gt;Por favor, limpe o histórico e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="522" />
             <source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
-            <translation>Tyvärr gick det inte att överföra din gamla konfiguration.&lt;br&gt;Programmet kommer att använda en tom konfiguration.</translation>
+            <translation>Infelizmente, não foi possível migrar a sua configuração anterior.&lt;br&gt;A aplicação irá utilizar uma configuração em branco.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="526" />
             <source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
-            <translation>Tyvärr gick det inte att överföra din gamla proxykonfiguration, eftersom SOCKS5-proxyservrar inte stöds för närvarande.&lt;br&gt;Programmet kommer istället att använda systemets proxyinställningar.</translation>
+            <translation>Infelizmente, não foi possível migrar a sua configuração de proxy anterior; os proxies SOCKS5 não são suportados neste momento.&lt;br&gt;A aplicação utilizará, em vez disso, as definições de proxy do sistema.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="539" />
             <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
-            <translation>Ett tekniskt fel har uppstått (fel %1).&lt;br&gt;Synkroniseringen har startats om. Rensa historiken och kontakta vår support om felet kvarstår.</translation>
+            <translation>Ocorreu um erro técnico (erro %1).&lt;br&gt;A sincronização foi reiniciada. Por favor, limpe o histórico e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="550" />
             <source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
-            <translation>Ett fel har uppstått vid åtkomst till synkroniseringsdatabasen (fel %1).&lt;br&gt;Synkroniseringen har avbrutits.</translation>
+            <translation>Ocorreu um erro ao aceder à base de dados de sincronização (erro %1).&lt;br&gt;A sincronização foi interrompida.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="564" />
             <source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
-            <translation>Ett inloggningsproblem har uppstått (fel %1).&lt;br&gt;Tokenet är ogiltigt eller har återkallats.</translation>
+            <translation>Ocorreu um problema ao iniciar sessão (erro %1).&lt;br&gt;Token inválido ou revogado.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="569" />
             <source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
-            <translation>Nästlade synkroniseringar är inte tillåtna (fel %1).&lt;br&gt;Du bör endast behålla synkroniseringar där mapparna inte är nästlade.</translation>
+            <translation>Não são permitidas sincronizações aninhadas (erro %1).&lt;br&gt;Deve manter apenas as sincronizações cujas pastas não estejam aninhadas.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="573" />
             <source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
-            <translation>Synkroniseringsmappen på den fjärranslutna kDrive-enheten finns inte längre eller är inte längre tillgänglig (fel %1).&lt;br&gt;Du måste återställa den, återställa åtkomsträttigheterna eller ta bort och skapa synkroniseringen på nytt.</translation>
+            <translation>A pasta de sincronização no kDrive remoto já não existe ou já não está acessível (erro %1).&lt;br&gt;É necessário restaurá-la, restabelecer os direitos de acesso ou eliminar/recriar a sincronização.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="580" />
             <source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
-            <translation>Fel vid tolkning av filnamn (fel %1).&lt;br&gt;Specialtecken som dubbla citattecken, bakstreck eller radbrytningar kan orsaka fel vid tolkningen.</translation>
+            <translation>Erro na análise do nome do ficheiro (erro %1).&lt;br&gt;Caracteres especiais, como aspas duplas, barras invertidas ou retornos de linha, podem causar falhas na análise.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="722" />
             <source>You are not allowed to move item to "%1".&lt;br&gt;It will be restored into its original parent folder.</source>
-            <translation>Du får inte flytta objektet till &amp;quot;%1&amp;quot;.&lt;br&gt;Det kommer att återställas till sin ursprungliga överordnade mapp.</translation>
+            <translation>Não é permitido mover o item para «%1».&lt;br&gt;O item será restaurado na sua pasta principal original.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="814" />
             <source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
-            <translation>Det finns inte tillräckligt med utrymme kvar på din dator.&lt;br&gt;Nedladdningen har avbrutits.</translation>
+            <translation>Não há espaço suficiente no seu computador.&lt;br&gt;O download foi cancelado.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="609" />
             <source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
-            <translation>Denna komponent har flyttats till en annan plats.&lt;br&gt;Den lokala åtgärden har avbrutits.</translation>
+            <translation>Este elemento foi movido para outro local.&lt;br&gt;A operação local foi cancelada.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="618" />
             <source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
-            <translation>Det finns redan ett element med samma namn på den här platsen.&lt;br&gt;Det lokala elementet har bytt namn.</translation>
+            <translation>Já existe um elemento com o mesmo nome neste local.&lt;br&gt;O elemento local foi renomeado.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="614" />
             <source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
-            <translation>Det finns redan ett element med samma namn på den här platsen.&lt;br&gt;Den lokala åtgärden har avbrutits.</translation>
+            <translation>Já existe um elemento com o mesmo nome neste local.&lt;br&gt;A operação local foi cancelada.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="393" />
             <source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
-            <translation>Det finns inte tillräckligt med utrymme kvar på din dator.&lt;br&gt;Synkroniseringen har avbrutits.</translation>
+            <translation>Não há espaço suficiente no seu computador.&lt;br&gt;A sincronização foi interrompida.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="622" />
             <source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
-            <translation>Filen redigerades samtidigt av en annan användare.&lt;br&gt;Dina ändringar har sparats i en kopia.</translation>
+            <translation>O ficheiro foi modificado ao mesmo tempo por outro utilizador.&lt;br&gt;As suas alterações foram guardadas numa cópia.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="626" />
             <source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
-            <translation>En annan användare har flyttat en överordnad mapp till målplatsen.&lt;br&gt;Den lokala åtgärden har avbrutits.</translation>
+            <translation>Outro utilizador moveu uma pasta pai do destino.&lt;br&gt;A operação local foi cancelada.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="692" />
             <source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
-            <translation>Artikelnamnet innehåller endast mellanslag.&lt;br&gt;Det har tillfälligt lagts till på svartlistan.</translation>
+            <translation>O nome do artigo contém apenas espaços.&lt;br&gt;Foi temporariamente colocado na lista negra.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="703" />
             <source>Either you are not allowed to create an item, or another item already exists with the same name.&lt;br&gt;The item has been excluded from synchronization.</source>
-            <translation>Antingen har du inte behörighet att skapa ett objekt, eller så finns det redan ett objekt med samma namn.&lt;br&gt;Objektet har undantagits från synkroniseringen.</translation>
+            <translation>Ou não tem permissão para criar um item, ou já existe outro item com o mesmo nome.&lt;br&gt;O item foi excluído da sincronização.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="708" />
             <source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
-            <translation>Du har inte behörighet att redigera objektet.&lt;br&gt;Filen med dina ändringar har bytt namn och har undantagits från synkroniseringen.</translation>
+            <translation>Não tem permissão para editar este item.&lt;br&gt;O ficheiro que contém as suas alterações foi renomeado e excluído da sincronização.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="716" />
             <source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
-            <translation>Du får inte byta namn på objektet.&lt;br&gt;Det återställs till sitt ursprungliga namn.</translation>
+            <translation>Não é permitido renomear o item.&lt;br&gt;Este será restaurado com o seu nome original.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="727" />
             <source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
-            <translation>Du får inte ta bort objektet.&lt;br&gt;Det återställs till sin ursprungliga plats.</translation>
+            <translation>Não é permitido eliminar este item.&lt;br&gt;Será restaurado na sua localização original.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="732" />
             <source>Failed to move this item to trash, it has been blacklisted.</source>
-            <translation>Det gick inte att flytta objektet till papperskorgen; det har lagts till i svartlistan.</translation>
+            <translation>Não foi possível mover este item para a lixeira; foi colocado na lista negra.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="748" />
             <source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
-            <translation>Filen har ändrats lokalt samtidigt som den har raderats på den fjärranslutna kDrive-enheten. En&lt;br&gt;lokal kopia har sparats i räddningsmappen.</translation>
+            <translation>O ficheiro foi alterado localmente, embora tenha sido eliminado no kDrive remoto. A&lt;br&gt;cópia local foi guardada na pasta de recuperação.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="765" />
             <source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
-            <translation>Den åtgärd som utförts på objektet är inte tillåten.&lt;br&gt;Objektet har tillfälligt lagts till i svartlistan.</translation>
+            <translation>A operação realizada no item está proibida.&lt;br&gt;O item foi temporariamente colocado na lista negra.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="771" />
             <source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
-            <translation>Åtgärden som utfördes på detta objekt misslyckades.&lt;br&gt;Objektet har tillfälligt lagts till i svartlistan.</translation>
+            <translation>A operação realizada neste item falhou.&lt;br&gt;O item foi temporariamente colocado na lista negra.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="776" />
             <source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
-            <translation>Filen är för stor för att laddas upp. Den har tillfälligt blockerats.</translation>
+            <translation>O ficheiro é demasiado grande para ser carregado. Foi temporariamente colocado na lista negra.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="782" />
             <source>Impossible to download the file.</source>
-            <translation>Det går inte att ladda ner filen.</translation>
+            <translation>Não é possível descarregar o ficheiro.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="779" />
             <source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
-            <translation>Du har överskridit din kvot. Öka din lagringskvot för att återaktivera filuppladdning.</translation>
+            <translation>Excedeste a tua quota. Aumenta a tua quota de espaço para reativar o envio de ficheiros.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="389" />
             <source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
-            <translation>Enheten som innehåller din synkroniseringsmapp är inte längre ansluten (fel %1).&lt;br&gt;Anslut den igen för att återuppta synkroniseringen.</translation>
+            <translation>A unidade que contém a sua pasta de sincronização já não está ligada (erro %1).&lt;br&gt;Volte a ligá-la para retomar a sincronização.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="413" />
             <source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
-            <translation>Det går inte att starta synkroniseringen (fel %1).&lt;br&gt;Processen LiteSyncExt körs inte just nu. Synkroniseringen återupptas så snart processen har startats.</translation>
+            <translation>Não foi possível iniciar a sincronização (erro %1).&lt;br&gt;O processo LiteSyncExt não está a ser executado neste momento. A sincronização será retomada assim que for iniciado.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="649" />
             <source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
-            <translation>Ett befintligt objekt har ett identiskt namn med samma versaler och gemener.&lt;br&gt;Det har tillfälligt blockerats.</translation>
+            <translation>Existe um item com um nome idêntico, com as mesmas opções de maiúsculas e minúsculas.&lt;br&gt;Esse item foi temporariamente colocado na lista negra.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="656" />
             <source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
-            <translation>Produktnamnet innehåller ett tecken som inte stöds.&lt;br&gt;Det har tillfälligt blockerats.</translation>
+            <translation>O nome do artigo contém um caractere não suportado.&lt;br&gt;Foi temporariamente colocado na lista negra.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="662" />
             <source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-            <translation>Objektnamnet slutar med ett mellanslag, vilket inte är tillåtet i ditt operativsystem.&lt;br&gt;Det har tillfälligt lagts till i svartlistan.</translation>
+            <translation>O nome do item termina com um espaço, o que é proibido no seu sistema operativo.&lt;br&gt;Foi temporariamente colocado na lista negra.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="668" />
             <source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-            <translation>Det här objektnamnet är reserverat av ditt operativsystem.&lt;br&gt;Det har tillfälligt lagts till i svartlistan.</translation>
+            <translation>Este nome de item está reservado pelo seu sistema operativo.&lt;br&gt;Foi temporariamente colocado na lista negra.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="674" />
             <source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
-            <translation>Artikelnamnet är för långt.&lt;br&gt;Det har tillfälligt blockerats.</translation>
+            <translation>O nome do artigo é demasiado longo.&lt;br&gt;Foi temporariamente colocado na lista negra.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="680" />
             <source>The item path is too long.&lt;br&gt;It has been ignored.</source>
-            <translation>Sökvägen är för lång.&lt;br&gt;Den har ignorerats.</translation>
+            <translation>O caminho do item é demasiado longo.&lt;br&gt;Foi ignorado.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="686" />
             <source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
-            <translation>Objektnamnet innehåller ett nytt Unicode-tecken som ännu inte stöds av ditt filsystem.&lt;br&gt;Det har uteslutits från synkroniseringen.</translation>
+            <translation>O nome do item contém um caractere Unicode recente que ainda não é suportado pelo seu sistema de ficheiros.&lt;br&gt;Foi excluído da sincronização.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="735" />
             <source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
-            <translation>Det gick inte att synkronisera det här objektet. Det har tillfälligt lagts till i svartlistan.&lt;br&gt;Ett nytt försök att synkronisera det kommer att göras om en timme eller nästa gång programmet startas.</translation>
+            <translation>Não foi possível sincronizar este item. Foi temporariamente colocado na lista negra. Será feita&lt;br&gt;uma nova tentativa de sincronização dentro de uma hora ou na próxima vez que a aplicação for iniciada.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="740" />
             <source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
-            <translation>Denna post har undantagits från synkroniseringen genom en anpassad mall.&lt;br&gt;Du kan inaktivera denna typ av avisering under Inställningar</translation>
+            <translation>Este item foi excluído da sincronização por um modelo personalizado.&lt;br&gt;Pode desativar este tipo de notificação nas Preferências</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="745" />
             <source>This item has been excluded from sync because it is a hard link.</source>
-            <translation>Den här posten har uteslutits från synkroniseringen eftersom det är en hård länk.</translation>
+            <translation>Este item foi excluído da sincronização porque é um link físico.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="785" />
             <source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
-            <translation>Den här artikeln är för närvarande upptagen av en annan användare som är inloggad.&lt;br&gt;Vi försöker ladda upp dina ändringar igen senare.</translation>
+            <translation>Este item está atualmente bloqueado por outro utilizador online.&lt;br&gt;Voltaremos a tentar carregar as suas alterações mais tarde.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="790" />
             <location filename="../src/gui/parametersdialog.cpp" line="834" />
             <source>Synchronization error.</source>
-            <translation>Synkroniseringsfel.</translation>
+            <translation>Erro de sincronização.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="810" />
             <source>Can't access item.&lt;br&gt;Please fix the read and write permissions.</source>
-            <translation>Det går inte att komma åt objektet.&lt;br&gt;Kontrollera läs- och skrivbehörigheterna.</translation>
+            <translation>Não é possível aceder ao item.&lt;br&gt;Por favor, corrija as permissões de leitura e escrita.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="818" />
             <source>System error.</source>
-            <translation>Systemfel.</translation>
+            <translation>Erro do sistema.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="825" />
             <source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
-            <translation>Objektet finns redan på den andra sidan.&lt;br&gt;Det har tillfälligt blockerats.</translation>
+            <translation>O item já existe no outro lado.&lt;br&gt;Foi temporariamente colocado na lista negra.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="840" />
             <source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-            <translation>Ett tekniskt fel har uppstått.&lt;br&gt;Rensa historiken och kontakta vår support om felet kvarstår.</translation>
+            <translation>Ocorreu um erro técnico.&lt;br&gt;Limpe o histórico e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
         </message>
     </context>
     <context>
@@ -1948,7 +1948,7 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <message>
             <location filename="../src/gui/preferencesblocwidget.cpp" line="187" />
             <source>This synchronization is being deleted.</source>
-            <translation>Denna synkronisering raderas.</translation>
+            <translation>Esta sincronização está a ser eliminada.</translation>
         </message>
     </context>
     <context>
@@ -1956,12 +1956,12 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <message>
             <location filename="../src/gui/preferencesmenubarwidget.cpp" line="63" />
             <source>Back to drive list</source>
-            <translation>Tillbaka till listan över körningar</translation>
+            <translation>Voltar à lista de unidades</translation>
         </message>
         <message>
             <location filename="../src/gui/preferencesmenubarwidget.cpp" line="64" />
             <source>Preferences</source>
-            <translation>Inställningar</translation>
+            <translation>Preferencias</translation>
         </message>
     </context>
     <context>
@@ -1969,72 +1969,72 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="491" />
             <source>General</source>
-            <translation>Allmänt</translation>
+            <translation>Geral</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="493" />
             <source>Activate dark theme</source>
-            <translation>Aktivera mörkt tema</translation>
+            <translation>Ativar tema escuro</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="495" />
             <source>Activate monochrome icons</source>
-            <translation>Aktivera monokroma ikoner</translation>
+            <translation>Ativar icones monocromaticos</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="496" />
             <source>Launch kDrive at startup</source>
-            <translation>Starta kDrive vid uppstart</translation>
+            <translation>Iniciar o kDrive no arranque</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="516" />
             <source>Advanced</source>
-            <translation>Avancerat</translation>
+            <translation>Avancado</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="517" />
             <source>Debugging information</source>
-            <translation>Felsökningsinformation</translation>
+            <translation>Informacoes de depuracao</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="519" />
             <source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
-            <translation>&lt;a style="%1" href="%2"&gt;Öppna felsökningsmappen&lt;/a&gt;</translation>
+            <translation>&lt;a style="%1" href="%2"&gt;Abrir a pasta de depuração&lt;/a&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="520" />
             <source>Files to exclude</source>
-            <translation>Filer att exkludera</translation>
+            <translation>Ficheiros a excluir</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="521" />
             <source>Proxy server</source>
-            <translation>Proxyserver</translation>
+            <translation>Servidor proxy</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="511" />
             <source>Swedish</source>
-            <translation>Svenska</translation>
+            <translation>Sueco</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="512" />
             <source>Portuguese</source>
-            <translation>Portugisiska</translation>
+            <translation>Português</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="466" />
             <source>Unable to open folder %1.</source>
-            <translation>Det går inte att öppna mappen %1.</translation>
+            <translation>Nao foi possivel abrir a pasta %1.</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="478" />
             <source>Unable to open link %1.</source>
-            <translation>Det går inte att öppna länken %1.</translation>
+            <translation>Nao foi possivel abrir a ligacao %1.</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="483" />
             <source>Invalid link %1.</source>
-            <translation>Ogiltig länk %1.</translation>
+            <translation>Ligacao invalida %1.</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="523" />
@@ -2044,62 +2044,62 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="497" />
             <source>Language</source>
-            <translation>Språk</translation>
+            <translation>Idioma</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="490" />
             <source>Some process failed to run.</source>
-            <translation>Någon process kunde inte köras.</translation>
+            <translation>Algum processo não foi executado.</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="498" />
             <source>Move deleted files to my computer's trash</source>
-            <translation>Flytta borttagna filer till datorns papperskorg</translation>
+            <translation>Mover os ficheiros eliminados para o Lixo do meu computador</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="499" />
             <source>Some files or folders may not be moved to the computer's trash.</source>
-            <translation>Vissa filer eller mappar kanske inte kan flyttas till datorns papperskorg.</translation>
+            <translation>Alguns ficheiros ou pastas podem nao ser movidos para o Lixo do computador.</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="500" />
             <source>You can always retrieve already synced files from the kDrive web application trash.</source>
-            <translation>Du kan alltid återställa redan synkroniserade filer från papperskorgen i kDrives webbapp.</translation>
+            <translation>Pode sempre recuperar ficheiros ja sincronizados no Lixo da aplicacao web kDrive.</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="502" />
             <source>&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-            <translation>&lt;a style="%1" href="%2"&gt;Läs mer&lt;/a&gt;</translation>
+            <translation>&lt;a style="%1" href="%2"&gt;Saiba mais&lt;/a&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="506" />
             <source>English</source>
-            <translation>Engelska</translation>
+            <translation>Ingles</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="507" />
             <source>French</source>
-            <translation>Franska</translation>
+            <translation>Frances</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="508" />
             <source>German</source>
-            <translation>Tyska</translation>
+            <translation>Alemao</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="509" />
             <source>Spanish</source>
-            <translation>Spanska</translation>
+            <translation>Espanhol</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="510" />
             <source>Italian</source>
-            <translation>Italienska</translation>
+            <translation>Italiano</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="505" />
             <source>Default</source>
-            <translation>Standard</translation>
+            <translation>Predefinido</translation>
         </message>
     </context>
     <context>
@@ -2107,7 +2107,7 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <message>
             <location filename="../src/gui/progressbarwidget.cpp" line="70" />
             <source>%1 in use</source>
-            <translation>%1 används</translation>
+            <translation>%1 em uso</translation>
         </message>
     </context>
     <context>
@@ -2115,77 +2115,77 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <message>
             <location filename="../src/gui/proxyserverdialog.cpp" line="50" />
             <source>HTTP(S) Proxy</source>
-            <translation>HTTP(S)-proxy</translation>
+            <translation>Proxy HTTP(S)</translation>
         </message>
         <message>
             <location filename="../src/gui/proxyserverdialog.cpp" line="73" />
             <source>Proxy server</source>
-            <translation>Proxyserver</translation>
+            <translation>Servidor proxy</translation>
         </message>
         <message>
             <location filename="../src/gui/proxyserverdialog.cpp" line="85" />
             <source>No proxy server</source>
-            <translation>Ingen proxyserver</translation>
+            <translation>Sem servidor proxy</translation>
         </message>
         <message>
             <location filename="../src/gui/proxyserverdialog.cpp" line="90" />
             <source>Use system parameters</source>
-            <translation>Använd systemparametrar</translation>
+            <translation>Utilizar parâmetros do sistema</translation>
         </message>
         <message>
             <location filename="../src/gui/proxyserverdialog.cpp" line="95" />
             <source>Indicate a proxy manually</source>
-            <translation>Ange en fullmaktsinnehavare manuellt</translation>
+            <translation>Indicar um representante manualmente</translation>
         </message>
         <message>
             <location filename="../src/gui/proxyserverdialog.cpp" line="131" />
             <source>Port</source>
-            <translation>Hamn</translation>
+            <translation>Porto</translation>
         </message>
         <message>
             <location filename="../src/gui/proxyserverdialog.cpp" line="144" />
             <source>Address of the proxy server</source>
-            <translation>Proxyserverns adress</translation>
+            <translation>Endereço do servidor proxy</translation>
         </message>
         <message>
             <location filename="../src/gui/proxyserverdialog.cpp" line="150" />
             <source>Authentication needed</source>
-            <translation>Inloggning krävs</translation>
+            <translation>É necessária autenticação</translation>
         </message>
         <message>
             <location filename="../src/gui/proxyserverdialog.cpp" line="165" />
             <source>User</source>
-            <translation>Användare</translation>
+            <translation>Utilizador</translation>
         </message>
         <message>
             <location filename="../src/gui/proxyserverdialog.cpp" line="171" />
             <source>Password</source>
-            <translation>Lösenord</translation>
+            <translation>Palavra-passe</translation>
         </message>
         <message>
             <location filename="../src/gui/proxyserverdialog.cpp" line="185" />
             <source>SAVE</source>
-            <translation>SPARA</translation>
+            <translation>GUARDAR</translation>
         </message>
         <message>
             <location filename="../src/gui/proxyserverdialog.cpp" line="192" />
             <source>CANCEL</source>
-            <translation>AVBRYT</translation>
+            <translation>CANCELAR</translation>
         </message>
         <message>
             <location filename="../src/gui/proxyserverdialog.cpp" line="286" />
             <source>Do you want to save your modifications?</source>
-            <translation>Vill du spara dina ändringar?</translation>
+            <translation>Quer guardar as suas alterações?</translation>
         </message>
         <message>
             <location filename="../src/gui/proxyserverdialog.cpp" line="295" />
             <source>Unable to save, all mandatory fields are not completed!</source>
-            <translation>Det går inte att spara, eftersom alla obligatoriska fält inte är ifyllda!</translation>
+            <translation>Não é possível guardar, pois nem todos os campos obrigatórios foram preenchidos!</translation>
         </message>
         <message>
             <location filename="../src/gui/proxyserverdialog.cpp" line="316" />
             <source>Proxy not found, save anyway?</source>
-            <translation>Proxy hittades inte, vill du spara ändå?</translation>
+            <translation>Não foi encontrado nenhum proxy. Deseja guardar na mesma?</translation>
         </message>
     </context>
     <context>
@@ -2193,27 +2193,27 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <message>
             <location filename="../src/gui/resourcesmanagerdialog.cpp" line="55" />
             <source>Resources Manager</source>
-            <translation>Resursansvarig</translation>
+            <translation>Gestor de Recursos</translation>
         </message>
         <message>
             <location filename="../src/gui/resourcesmanagerdialog.cpp" line="65" />
             <source>Maximum CPU usage allowed</source>
-            <translation>Högsta tillåtna CPU-användning</translation>
+            <translation>Utilização máxima permitida da CPU</translation>
         </message>
         <message>
             <location filename="../src/gui/resourcesmanagerdialog.cpp" line="96" />
             <source>SAVE</source>
-            <translation>SPARA</translation>
+            <translation>GUARDAR</translation>
         </message>
         <message>
             <location filename="../src/gui/resourcesmanagerdialog.cpp" line="103" />
             <source>CANCEL</source>
-            <translation>AVBRYT</translation>
+            <translation>CANCELAR</translation>
         </message>
         <message>
             <location filename="../src/gui/resourcesmanagerdialog.cpp" line="122" />
             <source>Do you want to save your modifications?</source>
-            <translation>Vill du spara dina ändringar?</translation>
+            <translation>Quer guardar as suas alterações?</translation>
         </message>
     </context>
     <context>
@@ -2221,37 +2221,37 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <message>
             <location filename="../src/gui/serverbasefolderdialog.cpp" line="81" />
             <source>Select a folder on your kDrive</source>
-            <translation>Välj en mapp på din kDrive</translation>
+            <translation>Selecione uma pasta no seu kDrive</translation>
         </message>
         <message>
             <location filename="../src/gui/serverbasefolderdialog.cpp" line="90" />
             <source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
-            <translation>Innehållet i den valda mappen kommer att synkroniseras till mappen &lt;b&gt;%1&lt;/b&gt;.</translation>
+            <translation>O conteúdo da pasta selecionada será sincronizado com a pasta &lt;b&gt;%1&lt;/b&gt;.</translation>
         </message>
         <message>
             <location filename="../src/gui/serverbasefolderdialog.cpp" line="134" />
             <source>CONTINUE</source>
-            <translation>FORTSÄTT</translation>
+            <translation>CONTINUAR</translation>
         </message>
         <message>
             <location filename="../src/gui/serverbasefolderdialog.cpp" line="150" />
             <source>Space available on your computer for the current folder : %1</source>
-            <translation>Ledig utrymme på din dator för den aktuella mappen: %1</translation>
+            <translation>Espaço disponível no seu computador para a pasta atual: %1</translation>
         </message>
         <message>
             <location filename="../src/gui/serverbasefolderdialog.cpp" line="190" />
             <source>This folder is already being synced.</source>
-            <translation>Den här mappen synkroniseras redan.</translation>
+            <translation>Esta pasta já está a ser sincronizada.</translation>
         </message>
         <message>
             <location filename="../src/gui/serverbasefolderdialog.cpp" line="204" />
             <source>CONFIRM</source>
-            <translation>BEKRÄFTA</translation>
+            <translation>CONFIRMAR</translation>
         </message>
         <message>
             <location filename="../src/gui/serverbasefolderdialog.cpp" line="205" />
             <source>CANCEL</source>
-            <translation>AVBRYT</translation>
+            <translation>CANCELAR</translation>
         </message>
     </context>
     <context>
@@ -2259,17 +2259,17 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <message>
             <location filename="../src/gui/serverfoldersdialog.cpp" line="80" />
             <source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
-            <translation>Mappen &lt;b&gt;%1&lt;/b&gt; innehåller undermappar.&lt;br&gt; Välj de som du vill synkronisera</translation>
+            <translation>A pasta &lt;b&gt;%1&lt;/b&gt; contém subpastas;&lt;br&gt; selecione as que deseja sincronizar</translation>
         </message>
         <message>
             <location filename="../src/gui/serverfoldersdialog.cpp" line="110" />
             <source>CONTINUE</source>
-            <translation>FORTSÄTT</translation>
+            <translation>CONTINUAR</translation>
         </message>
         <message>
             <location filename="../src/gui/serverfoldersdialog.cpp" line="146" />
             <source>No subfolders currently on the server.</source>
-            <translation>Det finns för närvarande inga undermappar på servern.</translation>
+            <translation>Não existem subpastas no servidor neste momento.</translation>
         </message>
     </context>
     <context>
@@ -2277,34 +2277,34 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <message>
             <location filename="../src/gui/statusbarwidget.cpp" line="178" />
             <source>Resume kDrive "%1" synchronization</source>
-            <translation>Återuppta synkroniseringen av kDrive &amp;quot;%1&amp;quot;</translation>
+            <translation>Retomar a sincronização do kDrive &amp;quot;%1&amp;quot;</translation>
         </message>
         <message>
             <location filename="../src/gui/statusbarwidget.cpp" line="180" />
             <source>Resume all kDrives synchronization</source>
-            <translation>Återuppta all synkronisering av kDrives</translation>
+            <translation>Retomar toda a sincronização do kDrives</translation>
         </message>
         <message>
             <location filename="../src/gui/statusbarwidget.cpp" line="183" />
             <source>Pause kDrive "%1" synchronization</source>
-            <translation>Avbryt synkroniseringen av kDrive &amp;quot;%1&amp;quot;</translation>
+            <translation>Suspender a sincronização do kDrive &amp;quot;%1&amp;quot;</translation>
         </message>
         <message>
             <location filename="../src/gui/statusbarwidget.cpp" line="184" />
             <location filename="../src/gui/statusbarwidget.cpp" line="321" />
             <source>Pause synchronization</source>
-            <translation>Pausa synkroniseringen</translation>
+            <translation>Pausar a sincronização</translation>
         </message>
         <message>
             <location filename="../src/gui/statusbarwidget.cpp" line="185" />
             <source>Pause all kDrives synchronization</source>
-            <translation>Pausa all synkronisering av kDrives</translation>
+            <translation>Suspender toda a sincronização do kDrives</translation>
         </message>
         <message>
             <location filename="../src/gui/statusbarwidget.cpp" line="179" />
             <location filename="../src/gui/statusbarwidget.cpp" line="322" />
             <source>Resume synchronization</source>
-            <translation>Fortsätt synkroniseringen</translation>
+            <translation>Retomar a sincronização</translation>
         </message>
     </context>
     <context>
@@ -2312,32 +2312,32 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <message>
             <location filename="../src/gui/synchronizeditemwidget.cpp" line="333" />
             <source>Copy share link</source>
-            <translation>Kopiera delningslänken</translation>
+            <translation>Copiar link de partilha</translation>
         </message>
         <message>
             <location filename="../src/gui/synchronizeditemwidget.cpp" line="342" />
             <source>Display on kdrive.infomaniak.com</source>
-            <translation>Visas på kdrive.infomaniak.com</translation>
+            <translation>Exibir em kdrive.infomaniak.com</translation>
         </message>
         <message>
             <location filename="../src/gui/synchronizeditemwidget.cpp" line="387" />
             <source>Show in folder</source>
-            <translation>Visa i mappen</translation>
+            <translation>Mostrar na pasta</translation>
         </message>
         <message>
             <location filename="../src/gui/synchronizeditemwidget.cpp" line="388" />
             <source>More actions</source>
-            <translation>Fler åtgärder</translation>
+            <translation>Mais ações</translation>
         </message>
         <message>
             <location filename="../src/gui/synchronizeditemwidget.cpp" line="317" />
             <source>Open</source>
-            <translation>Öppna</translation>
+            <translation>Abrir</translation>
         </message>
         <message>
             <location filename="../src/gui/synchronizeditemwidget.cpp" line="325" />
             <source>Add to favorites</source>
-            <translation>Lägg till i favoriter</translation>
+            <translation>Adicionar aos favoritos</translation>
         </message>
     </context>
     <context>
@@ -2346,119 +2346,119 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
             <location filename="../src/gui/synthesisbar.cpp" line="495" />
             <location filename="../src/gui/synthesisbar.cpp" line="502" />
             <source>Never</source>
-            <translation>Aldrig</translation>
+            <translation>Nunca</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesisbar.cpp" line="496" />
             <source>During 1 hour</source>
-            <translation>Under 1 timme</translation>
+            <translation>Durante 1 hora</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesisbar.cpp" line="497" />
             <location filename="../src/gui/synthesisbar.cpp" line="504" />
             <source>Until tomorrow 8:00AM</source>
-            <translation>Fram till imorgon kl. 08.00</translation>
+            <translation>Até amanhã às 8h00</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesisbar.cpp" line="498" />
             <source>During 3 days</source>
-            <translation>Under tre dagar</translation>
+            <translation>Durante 3 dias</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesisbar.cpp" line="499" />
             <source>During 1 week</source>
-            <translation>Under en vecka</translation>
+            <translation>Durante uma semana</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesisbar.cpp" line="500" />
             <location filename="../src/gui/synthesisbar.cpp" line="507" />
             <source>Always</source>
-            <translation>Alltid</translation>
+            <translation>Sempre</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesisbar.cpp" line="503" />
             <source>For 1 more hour</source>
-            <translation>I ytterligare 1 timme</translation>
+            <translation>Por mais 1 hora</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesisbar.cpp" line="505" />
             <source>For 3 more days</source>
-            <translation>I ytterligare 3 dagar</translation>
+            <translation>Ainda por mais 3 dias</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesisbar.cpp" line="506" />
             <source>For 1 more week</source>
-            <translation>Ytterligare en vecka</translation>
+            <translation>Por mais uma semana</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesisbar.cpp" line="149" />
             <source>Unable to open folder url %1.</source>
-            <translation>Det går inte att öppna mappen med adressen %1.</translation>
+            <translation>Não foi possível abrir a URL da pasta %1.</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesisbar.cpp" line="219" />
             <source>Open in folder</source>
-            <translation>Öppna i mappen</translation>
+            <translation>Abrir na pasta</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesisbar.cpp" line="257" />
             <source>Open %1 web version</source>
-            <translation>Öppna webbversionen av %1</translation>
+            <translation>Abrir a versão web do %1</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesisbar.cpp" line="267" />
             <source>Drive parameters</source>
-            <translation>Drivparametrar</translation>
+            <translation>Parâmetros do acionamento</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesisbar.cpp" line="280" />
             <source>Notifications disabled until %1</source>
-            <translation>Meddelanden är inaktiverade fram till %1</translation>
+            <translation>Notificações desativadas até %1</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesisbar.cpp" line="281" />
             <source>Disable Notifications</source>
-            <translation>Inaktivera aviseringar</translation>
+            <translation>Desativar notificações</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesisbar.cpp" line="314" />
             <source>Application preferences</source>
-            <translation>Inställningar för applikationen</translation>
+            <translation>Preferências da aplicação</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesisbar.cpp" line="322" />
             <source>Need help</source>
-            <translation>Behöver du hjälp?</translation>
+            <translation>Precisa de ajuda</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesisbar.cpp" line="330" />
             <source>Send feedbacks</source>
-            <translation>Skicka synpunkter</translation>
+            <translation>Enviar comentários</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesisbar.cpp" line="338" />
             <source>Quit kDrive</source>
-            <translation>Avsluta kDrive</translation>
+            <translation>Sair do kDrive</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesisbar.cpp" line="401" />
             <source>Unable to access web site %1.</source>
-            <translation>Det går inte att komma åt webbplatsen %1.</translation>
+            <translation>Não é possível aceder ao site %1.</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesisbar.cpp" line="492" />
             <source>Show errors and informations</source>
-            <translation>Visa fel och information</translation>
+            <translation>Mostrar erros e informações</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesisbar.cpp" line="493" />
             <source>Show informations</source>
-            <translation>Visa information</translation>
+            <translation>Mostrar informações</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesisbar.cpp" line="494" />
             <source>More actions</source>
-            <translation>Fler åtgärder</translation>
+            <translation>Mais ações</translation>
         </message>
     </context>
     <context>
@@ -2466,98 +2466,98 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <message>
             <location filename="../src/gui/synthesispopover.cpp" line="1181" />
             <source>Update kDrive App</source>
-            <translation>Uppdatera kDrive-appen</translation>
+            <translation>Atualizar a aplicação kDrive</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesispopover.cpp" line="1182" />
             <source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
-            <translation>Denna version av kDrive-appen stöds inte längre. Uppdatera appen för att få tillgång till de senaste funktionerna och förbättringarna.</translation>
+            <translation>Esta versão da aplicação kDrive já não é suportada. Para aceder às funcionalidades e melhorias mais recentes, atualize a aplicação.</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesispopover.cpp" line="978" />
             <source>Update</source>
-            <translation>Uppdatering</translation>
+            <translation>Atualização</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesispopover.cpp" line="1187" />
             <source>Please download the latest version on the website.</source>
-            <translation>Ladda gärna ner den senaste versionen från webbplatsen.</translation>
+            <translation>Por favor, descarregue a versão mais recente no site.</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesispopover.cpp" line="981" />
             <source>Update download in progress</source>
-            <translation>Uppdateringen hämtas just nu</translation>
+            <translation>Download da atualização em curso</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesispopover.cpp" line="984" />
             <source>Looking for update...</source>
-            <translation>Väntar på uppdatering...</translation>
+            <translation>À procura de atualizações...</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesispopover.cpp" line="987" />
             <source>Manual update</source>
-            <translation>Manuell uppdatering</translation>
+            <translation>Atualização manual</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesispopover.cpp" line="990" />
             <source>Unavailable</source>
-            <translation>Ej tillgängligt</translation>
+            <translation>Indisponível</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesispopover.cpp" line="1200" />
             <source>You can synchronize files &lt;a style="%1" href="%2"&gt;from your computer&lt;/a&gt; or on &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
-            <translation>Du kan synkronisera filer &lt;a style="%1" href="%2"&gt;från din dator&lt;/a&gt; eller från &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
+            <translation>Pode sincronizar ficheiros &lt;a style="%1" href="%2"&gt;a partir do seu computador&lt;/a&gt; ou em &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesispopover.cpp" line="446" />
             <source>Synchronized</source>
-            <translation>Synkroniserad</translation>
+            <translation>Sincronizado</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesispopover.cpp" line="450" />
             <source>Favorites</source>
-            <translation>Favoriter</translation>
+            <translation>Favoritos</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesispopover.cpp" line="454" />
             <source>Activity</source>
-            <translation>Aktivitet</translation>
+            <translation>Atividade</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesispopover.cpp" line="1133" />
             <location filename="../src/gui/synthesispopover.cpp" line="1180" />
             <source>Not implemented!</source>
-            <translation>Har inte implementerats!</translation>
+            <translation>Não implementado!</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesispopover.cpp" line="1184" />
             <source>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Click here to download manually&lt;/a&gt;</source>
-            <translation>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Klicka här för att ladda ner manuellt&lt;/a&gt;</translation>
+            <translation>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Clique aqui para fazer o download manualmente&lt;/a&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesispopover.cpp" line="1193" />
             <source>No synchronized folder for this Drive!</source>
-            <translation>Det finns ingen synkroniserad mapp för den här Drive-kontot!</translation>
+            <translation>Não existe nenhuma pasta sincronizada para este Drive!</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesispopover.cpp" line="1196" />
             <source>No kDrive configured!</source>
-            <translation>kDrive är inte konfigurerat!</translation>
+            <translation>O kDrive não está configurado!</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesispopover.cpp" line="1161" />
             <source>Unable to open link %1.</source>
-            <translation>Det går inte att öppna länken %1.</translation>
+            <translation>Nao foi possivel abrir a ligacao %1.</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesispopover.cpp" line="1173" />
             <source>Invalid link %1.</source>
-            <translation>Ogiltig länk %1.</translation>
+            <translation>Ligacao invalida %1.</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesispopover.cpp" line="586" />
             <source>Unable to open folder url %1.</source>
-            <translation>Det går inte att öppna mappen med adressen %1.</translation>
+            <translation>Não foi possível abrir a URL da pasta %1.</translation>
         </message>
     </context>
     <context>
@@ -2565,22 +2565,22 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <message>
             <location filename="../src/gui/updater/updatedialog.cpp" line="61" />
             <source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
-            <translation>&lt;p&gt;Den nya versionen &lt;b&gt;%1&lt;/b&gt; av %2-klienten är tillgänglig och har hämtats.&lt;/p&gt;&lt;p&gt;Den installerade versionen är %3.&lt;/p&gt;</translation>
+            <translation>&lt;p&gt;A nova versão &lt;b&gt;%1&lt;/b&gt; do Cliente %2 está disponível e já foi descarregada.&lt;/p&gt;&lt;p&gt;A versão instalada é a %3.&lt;/p&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/updater/updatedialog.cpp" line="95" />
             <source>Skip this version</source>
-            <translation>Hoppa över den här versionen</translation>
+            <translation>Ignorar esta versão</translation>
         </message>
         <message>
             <location filename="../src/gui/updater/updatedialog.cpp" line="103" />
             <source>Remind me later</source>
-            <translation>Påminn mig senare</translation>
+            <translation>Lembra-me mais tarde</translation>
         </message>
         <message>
             <location filename="../src/gui/updater/updatedialog.cpp" line="109" />
             <source>Install update</source>
-            <translation>Installera uppdatering</translation>
+            <translation>Instalar atualização</translation>
         </message>
     </context>
     <context>
@@ -2588,12 +2588,12 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <message>
             <location filename="../src/server/updater/updatemanager.cpp" line="86" />
             <source>New update available.</source>
-            <translation>En ny uppdatering finns tillgänglig.</translation>
+            <translation>Está disponível uma nova atualização.</translation>
         </message>
         <message>
             <location filename="../src/server/updater/updatemanager.cpp" line="87" />
             <source>Version %1 is available for download.</source>
-            <translation>Version %1 finns tillgänglig för nedladdning.</translation>
+            <translation>A versão %1 está disponível para download.</translation>
         </message>
     </context>
     <context>
@@ -2601,7 +2601,7 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <message>
             <location filename="../src/gui/userselectionwidget.cpp" line="131" />
             <source>Add an account</source>
-            <translation>Lägg till ett konto</translation>
+            <translation>Adicionar uma conta</translation>
         </message>
     </context>
     <context>
@@ -2614,87 +2614,87 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <message>
             <location filename="../src/gui/versionwidget.cpp" line="169" />
             <source>&lt;a style="%1" href="%2"&gt;Show release note&lt;/a&gt;</source>
-            <translation>&lt;a style="%1" href="%2"&gt;Visa informationsnot&lt;/a&gt;</translation>
+            <translation>&lt;a style="%1" href="%2"&gt;Mostrar notas de lançamento&lt;/a&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/versionwidget.cpp" line="172" />
             <source>Version</source>
-            <translation>Version</translation>
+            <translation>Versão</translation>
         </message>
         <message>
             <location filename="../src/gui/versionwidget.cpp" line="173" />
             <source>UPDATE</source>
-            <translation>UPPDATERING</translation>
+            <translation>ATUALIZAÇÃO</translation>
         </message>
         <message>
             <location filename="../src/gui/versionwidget.cpp" line="197" />
             <source>%1 is up to date!</source>
-            <translation>%1 är uppdaterad!</translation>
+            <translation>O %1 está atualizado!</translation>
         </message>
         <message>
             <location filename="../src/gui/versionwidget.cpp" line="201" />
             <source>Checking update on server...</source>
-            <translation>Kontrollerar uppdateringar på servern...</translation>
+            <translation>A verificar se há atualizações no servidor...</translation>
         </message>
         <message>
             <location filename="../src/gui/versionwidget.cpp" line="205" />
             <source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style="%2" href="%3"&gt;here&lt;/a&gt;.</source>
-            <translation>En uppdatering finns tillgänglig: %1.&lt;br&gt;Ladda ner den &lt;a style="%2" href="%3"&gt;här&lt;/a&gt;.</translation>
+            <translation>Está disponível uma atualização: %1.&lt;br&gt;Faça o download &lt;a style="%2" href="%3"&gt;aqui&lt;/a&gt;.</translation>
         </message>
         <message>
             <location filename="../src/gui/versionwidget.cpp" line="212" />
             <source>An update is available: %1</source>
-            <translation>En uppdatering finns tillgänglig: %1</translation>
+            <translation>Está disponível uma atualização: %1</translation>
         </message>
         <message>
             <location filename="../src/gui/versionwidget.cpp" line="218" />
             <source>Downloading %1. Please wait...</source>
-            <translation>Hämtar %1. Vänta...</translation>
+            <translation>A descarregar %1. Por favor, aguarde...</translation>
         </message>
         <message>
             <location filename="../src/gui/versionwidget.cpp" line="223" />
             <source>Could not check for new updates.</source>
-            <translation>Det gick inte att söka efter nya uppdateringar.</translation>
+            <translation>Não foi possível verificar se existem novas atualizações.</translation>
         </message>
         <message>
             <location filename="../src/gui/versionwidget.cpp" line="227" />
             <source>An error occurred during update.</source>
-            <translation>Ett fel uppstod under uppdateringen.</translation>
+            <translation>Ocorreu um erro durante a atualização.</translation>
         </message>
         <message>
             <location filename="../src/gui/versionwidget.cpp" line="231" />
             <source>Could not download update.</source>
-            <translation>Det gick inte att ladda ner uppdateringen.</translation>
+            <translation>Não foi possível descarregar a atualização.</translation>
         </message>
         <message>
             <location filename="../src/gui/versionwidget.cpp" line="235" />
             <source>Update disabled.</source>
-            <translation>Uppdateringen är inaktiverad.</translation>
+            <translation>Atualização desativada.</translation>
         </message>
         <message>
             <location filename="../src/gui/versionwidget.cpp" line="251" />
             <source>Beta program</source>
-            <translation>Betaprogram</translation>
+            <translation>Programa beta</translation>
         </message>
         <message>
             <location filename="../src/gui/versionwidget.cpp" line="252" />
             <source>Get early access to new versions of the application</source>
-            <translation>Få tidig tillgång till nya versioner av applikationen</translation>
+            <translation>Obtenha acesso antecipado às novas versões da aplicação</translation>
         </message>
         <message>
             <location filename="../src/gui/versionwidget.cpp" line="256" />
             <source>Join</source>
-            <translation>Gå med</translation>
+            <translation>Junte-se a nós</translation>
         </message>
         <message>
             <location filename="../src/gui/versionwidget.cpp" line="259" />
             <source>Modify</source>
-            <translation>Ändra</translation>
+            <translation>Modificar</translation>
         </message>
         <message>
             <location filename="../src/gui/versionwidget.cpp" line="259" />
             <source>Quit</source>
-            <translation>Avsluta</translation>
+            <translation>Sair</translation>
         </message>
     </context>
     <context>
@@ -2702,122 +2702,122 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <message>
             <location filename="../src/gui/parameterscache.cpp" line="59" />
             <source>Unable to save parameters, please retry later.</source>
-            <translation>Det gick inte att spara parametrarna. Försök igen senare.</translation>
+            <translation>Não foi possível guardar os parâmetros. Por favor, tente novamente mais tarde.</translation>
         </message>
         <message>
             <location filename="../src/gui/parameterscache.cpp" line="60" />
             <source>Unable to save parameters!</source>
-            <translation>Det går inte att spara parametrarna!</translation>
+            <translation>Não é possível guardar os parâmetros!</translation>
         </message>
         <message>
             <location filename="../src/server/requests/serverrequests.cpp" line="461" />
             <source>The parent folder is a sync folder or contained in one</source>
-            <translation>Överordnad mapp är en synkroniseringsmapp eller ingår i en sådan</translation>
+            <translation>A pasta principal é uma pasta de sincronização ou está incluída numa</translation>
         </message>
         <message>
             <location filename="../src/server/requests/serverrequests.cpp" line="495" />
             <source>Can't find a valid path</source>
-            <translation>Det går inte att hitta en giltig sökväg</translation>
+            <translation>Não é possível encontrar um caminho válido</translation>
         </message>
         <message>
             <location filename="../src/server/requests/serverrequests.cpp" line="2109" />
             <source>No valid folder selected!</source>
-            <translation>Ingen giltig mapp har valts!</translation>
+            <translation>Não foi selecionada nenhuma pasta válida!</translation>
         </message>
         <message>
             <location filename="../src/server/requests/serverrequests.cpp" line="2120" />
             <source>The selected path does not exist!</source>
-            <translation>Den valda sökvägen finns inte!</translation>
+            <translation>O caminho selecionado não existe!</translation>
         </message>
         <message>
             <location filename="../src/server/requests/serverrequests.cpp" line="2125" />
             <source>The selected path is not a folder!</source>
-            <translation>Den valda sökvägen är ingen mapp!</translation>
+            <translation>O caminho selecionado não é uma pasta!</translation>
         </message>
         <message>
             <location filename="../src/server/requests/serverrequests.cpp" line="2130" />
             <source>You have no permission to write to the selected folder!</source>
-            <translation>Du har inte behörighet att skriva till den valda mappen!</translation>
+            <translation>Não tem permissão para gravar na pasta selecionada!</translation>
         </message>
         <message>
             <location filename="../src/server/requests/serverrequests.cpp" line="2160" />
             <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
-            <translation>Den lokala mappen %1 innehåller en mapp som redan är synkroniserad. Välj en annan!</translation>
+            <translation>A pasta local %1 contém uma pasta que já está sincronizada. Por favor, escolha outra!</translation>
         </message>
         <message>
             <location filename="../src/server/requests/serverrequests.cpp" line="2168" />
             <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
-            <translation>Den lokala mappen %1 finns i en mapp som redan är synkroniserad. Välj en annan mapp!</translation>
+            <translation>A pasta local %1 está incluída numa pasta já sincronizada. Por favor, escolha outra!</translation>
         </message>
         <message>
             <location filename="../src/server/requests/serverrequests.cpp" line="2176" />
             <source>The local folder %1 is already synced. Please pick another one!</source>
-            <translation>Den lokala mappen %1 är redan synkroniserad. Välj en annan!</translation>
+            <translation>A pasta local %1 já está sincronizada. Escolha outra!</translation>
         </message>
         <message>
             <location filename="../src/gui/folderitemwidget.cpp" line="42" />
             <source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
-            <translation>Lite sync (Beta) är aktiverat. Filerna från kDrive sparas i molnet och tar inte upp lagringsutrymme på din dator.</translation>
+            <translation>A sincronização Lite (Beta) está ativada. Os ficheiros do kDrive permanecem na nuvem e não ocupam espaço de armazenamento no seu computador.</translation>
         </message>
         <message>
             <location filename="../src/gui/folderitemwidget.cpp" line="45" />
             <source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
-            <translation>Lite sync (Beta) är inaktiverat. kDrive-filerna använder lagringsutrymmet på din dator.</translation>
+            <translation>O Lite sync (Beta) está desativado. Os ficheiros do kDrive ocupam espaço de armazenamento no seu computador.</translation>
         </message>
         <message>
             <location filename="../src/gui/folderitemwidget.cpp" line="48" />
             <source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
-            <translation>Lite-synkronisering är aktiverad. Filerna från kDrive sparas i molnet och tar inte upp lagringsutrymme på din dator.</translation>
+            <translation>A sincronização Lite está ativada. Os ficheiros do kDrive permanecem na nuvem e não ocupam espaço de armazenamento no seu computador.</translation>
         </message>
         <message>
             <location filename="../src/gui/folderitemwidget.cpp" line="50" />
             <source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
-            <translation>Lite sync är inaktiverat. kDrive-filerna använder lagringsutrymmet på din dator.</translation>
+            <translation>A sincronização Lite está desativada. Os ficheiros do kDrive ocupam espaço de armazenamento no seu computador.</translation>
         </message>
         <message>
             <location filename="../src/server/comm/extensionjob.cpp" line="1175" />
             <source>Make available locally</source>
-            <translation>Gör tillgängligt lokalt</translation>
+            <translation>Disponibilizar localmente</translation>
         </message>
         <message>
             <location filename="../src/server/comm/extensionjob.cpp" line="1179" />
             <source>Free up local space</source>
-            <translation>Frigör lokalt lagringsutrymme</translation>
+            <translation>Liberte espaço no disco local</translation>
         </message>
         <message>
             <location filename="../src/server/comm/extensionjob.cpp" line="1183" />
             <source>Cancel free up local space</source>
-            <translation>Avbryt för att frigöra lokalt utrymme</translation>
+            <translation>Cancelar para libertar espaço local</translation>
         </message>
         <message>
             <location filename="../src/server/comm/extensionjob.cpp" line="1187" />
             <source>Cancel make available locally</source>
-            <translation>Avbryt lokal tillgängliggöring</translation>
+            <translation>Cancelar disponibilização local</translation>
         </message>
         <message>
             <location filename="../src/server/comm/extensionjob.cpp" line="1191" />
             <source>Resharing this file is not allowed</source>
-            <translation>Det är inte tillåtet att vidarebefordra den här filen</translation>
+            <translation>Não é permitido partilhar novamente este ficheiro</translation>
         </message>
         <message>
             <location filename="../src/server/comm/extensionjob.cpp" line="1192" />
             <source>Resharing this folder is not allowed</source>
-            <translation>Det är inte tillåtet att dela den här mappen vidare</translation>
+            <translation>Não é permitido partilhar novamente esta pasta</translation>
         </message>
         <message>
             <location filename="../src/server/comm/extensionjob.cpp" line="1196" />
             <source>Copy public share link</source>
-            <translation>Kopiera länken till den offentliga delningen</translation>
+            <translation>Copiar link de partilha pública</translation>
         </message>
         <message>
             <location filename="../src/server/comm/extensionjob.cpp" line="1200" />
             <source>Copy private share link</source>
-            <translation>Kopiera länken till den privata delningen</translation>
+            <translation>Copiar link de partilha privada</translation>
         </message>
         <message>
             <location filename="../src/server/comm/extensionjob.cpp" line="1204" />
             <source>Open in browser</source>
-            <translation>Öppna i webbläsaren</translation>
+            <translation>Abrir no navegador</translation>
         </message>
     </context>
     <context>
@@ -2825,7 +2825,7 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <message>
             <location filename="../src/server/appserver.cpp" line="133" />
             <source>kDrive application will close due to a fatal error.</source>
-            <translation>kDrive-programmet kommer att stängas på grund av ett allvarligt fel.</translation>
+            <translation>A aplicação kDrive irá fechar devido a um erro grave.</translation>
         </message>
     </context>
     <context>
@@ -2854,48 +2854,48 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
             <location filename="../src/libcommongui/utility/utility.cpp" line="41" />
             <source>%n year(s)</source>
             <translation>
-                <numerusform>%n år</numerusform>
-                <numerusform>%n år</numerusform>
+                <numerusform>%n ano</numerusform>
+                <numerusform>%n anos</numerusform>
             </translation>
         </message>
         <message numerus="yes">
             <location filename="../src/libcommongui/utility/utility.cpp" line="42" />
             <source>%n month(s)</source>
             <translation>
-                <numerusform>%n månad</numerusform>
-                <numerusform>%n månader</numerusform>
+                <numerusform>%n mes</numerusform>
+                <numerusform>%n meses</numerusform>
             </translation>
         </message>
         <message numerus="yes">
             <location filename="../src/libcommongui/utility/utility.cpp" line="43" />
             <source>%n day(s)</source>
             <translation>
-                <numerusform>%n dag</numerusform>
-                <numerusform>%n dagar</numerusform>
+                <numerusform>%n dia</numerusform>
+                <numerusform>%n dias</numerusform>
             </translation>
         </message>
         <message numerus="yes">
             <location filename="../src/libcommongui/utility/utility.cpp" line="44" />
             <source>%n hour(s)</source>
             <translation>
-                <numerusform>%n timme</numerusform>
-                <numerusform>%n timmar</numerusform>
+                <numerusform>%n hora</numerusform>
+                <numerusform>%n horas</numerusform>
             </translation>
         </message>
         <message numerus="yes">
             <location filename="../src/libcommongui/utility/utility.cpp" line="45" />
             <source>%n minute(s)</source>
             <translation>
-                <numerusform>%n minut</numerusform>
-                <numerusform>%n minuter</numerusform>
+                <numerusform>%n minuto</numerusform>
+                <numerusform>%n minutos</numerusform>
             </translation>
         </message>
         <message numerus="yes">
             <location filename="../src/libcommongui/utility/utility.cpp" line="46" />
             <source>%n second(s)</source>
             <translation>
-                <numerusform>%n sekund</numerusform>
-                <numerusform>%n sekunder</numerusform>
+                <numerusform>%n segundo</numerusform>
+                <numerusform>%n segundos</numerusform>
             </translation>
         </message>
     </context>
@@ -2904,12 +2904,12 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <message>
             <location filename="../src/gui/mainclient.cpp" line="49" />
             <source>System Tray not available</source>
-            <translation>Systemfältet är inte tillgängligt</translation>
+            <translation>A bandeja do sistema não está disponível</translation>
         </message>
         <message>
             <location filename="../src/gui/mainclient.cpp" line="48" />
             <source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as 'trayer' and try again.</source>
-            <translation>%1 kräver ett fungerande systemfält. Om du använder XFCE, följ &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;dessa instruktioner&lt;/a&gt;. I annat fall bör du installera ett program för systemfältet, till exempel ”trayer”, och försöka igen.</translation>
+            <translation>O %1 requer uma bandeja do sistema funcional. Se estiver a utilizar o XFCE, siga &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;estas instruções&lt;/a&gt;. Caso contrário, instale uma aplicação de bandeja do sistema, como o «trayer», e tente novamente.</translation>
         </message>
     </context>
     <context>
@@ -2917,121 +2917,121 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <message>
             <location filename="../src/gui/guiutility.cpp" line="84" />
             <source>Could not open browser</source>
-            <translation>Det gick inte att öppna webbläsaren</translation>
+            <translation>Não foi possível abrir o navegador</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="85" />
             <source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
-            <translation>Det uppstod ett fel när webbläsaren startades för att öppna webbadressen %1. Kanske har ingen standardwebbläsare angetts?</translation>
+            <translation>Ocorreu um erro ao iniciar o navegador para aceder ao URL %1. Será que não está configurado nenhum navegador predefinido?</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="104" />
             <source>Could not open email client</source>
-            <translation>Det gick inte att öppna e-postprogrammet</translation>
+            <translation>Não foi possível abrir o cliente de e-mail</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="105" />
             <source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
-            <translation>Det uppstod ett fel när e-postprogrammet startades för att skapa ett nytt meddelande. Kanske har inget standardprogram för e-post konfigurerats?</translation>
+            <translation>Ocorreu um erro ao iniciar o cliente de e-mail para criar uma nova mensagem. Será que não está configurado nenhum cliente de e-mail predefinido?</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="324" />
             <source>You are not connected anymore. &lt;a style="%1" href="%2"&gt;Log in&lt;/a&gt;</source>
-            <translation>Du är inte inloggad längre. &lt;a style="%1" href="%2"&gt;Logga in&lt;/a&gt;</translation>
+            <translation>Já não está conectado. &lt;a style="%1" href="%2"&gt;Inicie sessão&lt;/a&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="347" />
             <source>Sync in progress (Step %1/%2).</source>
-            <translation>Synkronisering pågår (Steg %1/%2).</translation>
+            <translation>Sincronização em curso (Passo %1/%2).</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="353" />
             <source>Sync in progress.</source>
-            <translation>Synkronisering pågår.</translation>
+            <translation>Sincronização em curso.</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="364" />
             <source>Some files couldn't be synchronized. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-            <translation>Vissa filer kunde inte synkroniseras. &lt;a style="%1" href="%2"&gt;Läs mer&lt;/a&gt;</translation>
+            <translation>Alguns ficheiros não puderam ser sincronizados. &lt;a style="%1" href="%2"&gt;Saiba mais&lt;/a&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="370" />
             <source>Synchronization pausing ...</source>
-            <translation>Synkroniseringen pausas ...</translation>
+            <translation>A sincronização está em pausa...</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="570" />
             <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
-            <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan inte väljas eftersom en annan synkronisering använder samma mapp.</translation>
+            <translation>A pasta &lt;b&gt;%1&lt;/b&gt; não pode ser selecionada porque outra sincronização está a utilizar a mesma pasta.</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="576" />
             <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-            <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan inte väljas eftersom den innehåller den synkroniserade mappen &lt;b&gt;%2&lt;/b&gt;.</translation>
+            <translation>A pasta &lt;b&gt;%1&lt;/b&gt; não pode ser selecionada porque contém a pasta sincronizada &lt;b&gt;%2&lt;/b&gt;.</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="584" />
             <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-            <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan inte väljas eftersom den ingår i den synkroniserade mappen &lt;b&gt;%2&lt;/b&gt;.</translation>
+            <translation>A pasta &lt;b&gt;%1&lt;/b&gt; não pode ser selecionada porque está incluída na pasta sincronizada &lt;b&gt;%2&lt;/b&gt;.</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="595" />
             <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
-            <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan inte väljas som synkroniseringsmapp. Välj en annan mapp.</translation>
+            <translation>A pasta &lt;b&gt;%1&lt;/b&gt; não pode ser selecionada como pasta de sincronização. Por favor, selecione outra pasta.</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="599" />
             <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
-            <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan inte väljas som synkroniseringsmapp. Välj en annan mapp. Föreslagen mapp: &lt;b&gt;%2&lt;/b&gt;</translation>
+            <translation>A pasta &lt;b&gt;%1&lt;/b&gt; não pode ser selecionada como pasta de sincronização. Por favor, selecione outra pasta. Pasta sugerida: &lt;b&gt;%2&lt;/b&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="641" />
             <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
-            <translation>Du har uteslutit mer än %1 mappar. Observera att detta kommer att påverka synkroniseringsprestandan.</translation>
+            <translation>Excluiu mais de %1 pastas; tenha em atenção que isto irá afetar o desempenho da sincronização.</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="650" />
             <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
-            <translation>Du kan inte utesluta fler än %1 mappar. Avmarkera mapparna på högre nivå.</translation>
+            <translation>Não é possível excluir mais do que %1 pastas. Desmarque as pastas de nível superior.</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="351" />
             <source>Synchronization starting</source>
-            <translation>Synkroniseringen påbörjas</translation>
+            <translation>A sincronização está a começar</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="374" />
             <source>Synchronization paused.</source>
-            <translation>Synkroniseringen har pausats.</translation>
+            <translation>A sincronização foi interrompida.</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="336" />
             <source>Sync in progress (%1 of %2)</source>
-            <translation>Synkronisering pågår (%1 av %2)</translation>
+            <translation>Sincronização em curso (1% de 2%)</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="340" />
             <source>Sync in progress (%1 of %2)
 %3 left...</source>
-            <translation>Synkronisering pågår (%1 av %2)
-%3 kvar...</translation>
+            <translation>Sincronização em curso (%1 de %2)
+Faltam %3...</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="358" />
             <source>You are up to date, unresolved conflicts.</source>
-            <translation>Du har aktuella, olösta konflikter.</translation>
+            <translation>Estás em dia com os conflitos pendentes.</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="360" />
             <source>You are up to date!</source>
-            <translation>Nu är du uppdaterad!</translation>
+            <translation>Já está tudo em dia!</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="329" />
             <source>No folder to synchronize
 You can add one from the kDrive settings.</source>
-            <translation>Ingen mapp att synkronisera
-Du kan lägga till en i kDrive-inställningarna.</translation>
+            <translation>Não existe nenhuma pasta para sincronizar
+Pode adicionar uma nas definições do kDrive.</translation>
         </message>
     </context>
 </TS>

--- a/translations/client_pt.ts
+++ b/translations/client_pt.ts
@@ -880,7 +880,7 @@ Selecione outra pasta. Se continuar, o Lite Sync será desativado.&lt;br&gt;
         <message>
             <location filename="../src/gui/debuggingdialog.h" line="70" />
             <source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
-            <translation>A pasta completa é grande (&amp;gt; 100 MB) e pode demorar algum tempo a partilhar. Para reduzir o tempo de partilha, recomendamos que partilhe apenas a última sessão do kDrive.</translation>
+            <translation>A pasta completa é grande (&gt; 100 MB) e pode demorar algum tempo a partilhar. Para reduzir o tempo de partilha, recomendamos que partilhe apenas a última sessão do kDrive.</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="600" />
@@ -1644,7 +1644,7 @@ Por favor, utilize o seguinte link para enviar os registos para o apoio técnico
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="406" />
             <source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
-            <translation>Não foi possível iniciar a sincronização (erro %1).&lt;br&gt;Deve autorizar: - o kDrive em «Definições do sistema» &amp;gt;&amp;gt; «Geral» &amp;gt;&amp;gt; «Itens de&lt;br&gt;início de sessão e extensões» &amp;gt;&amp;gt; «Extensões de segurança de terminais»&lt;br&gt;; - a extensão kDrive LiteSync em «Definições do sistema» &amp;gt;&amp;gt; «Privacidade e segurança» &amp;gt;&amp;gt; «Acesso total ao disco».</translation>
+            <translation>Não foi possível iniciar a sincronização (erro %1).&lt;br&gt;Deve autorizar: - o kDrive em «Definições do sistema» &gt;&gt; «Geral» &gt;&gt; «Itens de&lt;br&gt;início de sessão e extensões» &gt;&gt; «Extensões de segurança de terminais»&lt;br&gt;; - a extensão kDrive LiteSync em «Definições do sistema» &gt;&gt; «Privacidade e segurança» &gt;&gt; «Acesso total ao disco».</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="419" />
@@ -2282,7 +2282,7 @@ Por favor, utilize o seguinte link para enviar os registos para o apoio técnico
         <message>
             <location filename="../src/gui/statusbarwidget.cpp" line="178" />
             <source>Resume kDrive "%1" synchronization</source>
-            <translation>Retomar a sincronização do kDrive &amp;quot;%1&amp;quot;</translation>
+            <translation>Retomar a sincronização do kDrive &quot;%1&quot;</translation>
         </message>
         <message>
             <location filename="../src/gui/statusbarwidget.cpp" line="180" />
@@ -2292,7 +2292,7 @@ Por favor, utilize o seguinte link para enviar os registos para o apoio técnico
         <message>
             <location filename="../src/gui/statusbarwidget.cpp" line="183" />
             <source>Pause kDrive "%1" synchronization</source>
-            <translation>Suspender a sincronização do kDrive &amp;quot;%1&amp;quot;</translation>
+            <translation>Suspender a sincronização do kDrive &quot;%1&quot;</translation>
         </message>
         <message>
             <location filename="../src/gui/statusbarwidget.cpp" line="184" />

--- a/translations/client_pt.ts
+++ b/translations/client_pt.ts
@@ -2022,6 +2022,11 @@ Por favor, utilize o seguinte link para enviar os registos para o apoio técnico
             <translation>Português</translation>
         </message>
         <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="513" />
+            <source>Polish</source>
+            <translation>Polaco</translation>
+        </message>
+        <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="466" />
             <source>Unable to open folder %1.</source>
             <translation>Não foi possível abrir a pasta %1.</translation>

--- a/translations/client_pt.ts
+++ b/translations/client_pt.ts
@@ -33,7 +33,7 @@
             <location filename="../src/gui/aboutdialog.cpp" line="162" />
             <location filename="../src/gui/aboutdialog.cpp" line="171" />
             <source>Unable to open folder %1.</source>
-            <translation>Nao foi possivel abrir a pasta %1.</translation>
+            <translation>Não foi possível abrir a pasta %1.</translation>
         </message>
         <message>
             <location filename="../src/gui/aboutdialog.cpp" line="132" />
@@ -46,7 +46,7 @@
         <message>
             <location filename="../src/gui/abstractfileitemwidget.cpp" line="177" />
             <source>Unable to open folder path %1.</source>
-            <translation>Nao foi possivel abrir o caminho da pasta %1.</translation>
+            <translation>Não foi possível abrir o caminho da pasta %1.</translation>
         </message>
     </context>
     <context>
@@ -69,7 +69,7 @@
         <message>
             <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130" />
             <source>PARAMETERS</source>
-            <translation>PARAMETROS</translation>
+            <translation>PARÂMETROS</translation>
         </message>
         <message>
             <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138" />
@@ -140,7 +140,7 @@
         <message>
             <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207" />
             <source>Unable to open link %1.</source>
-            <translation>Nao foi possivel abrir a ligacao %1.</translation>
+            <translation>Não foi possível abrir a ligação %1.</translation>
         </message>
         <message>
             <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112" />
@@ -197,7 +197,7 @@ Selecione outra pasta. Se continuar, o Lite Sync será desativado.&lt;br&gt;
         <message>
             <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377" />
             <source>Unable to open link %1.</source>
-            <translation>Nao foi possivel abrir a ligacao %1.</translation>
+            <translation>Não foi possível abrir a ligação %1.</translation>
         </message>
         <message>
             <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246" />
@@ -477,7 +477,7 @@ Selecione outra pasta. Se continuar, o Lite Sync será desativado.&lt;br&gt;
             <location filename="../src/gui/clientgui.cpp" line="1427" />
             <source>Preferences</source>
             <translatorcomment>Préférences</translatorcomment>
-            <translation>Preferencias</translation>
+            <translation>Preferências</translation>
         </message>
         <message>
             <location filename="../src/gui/clientgui.cpp" line="1428" />
@@ -547,7 +547,7 @@ Selecione outra pasta. Se continuar, o Lite Sync será desativado.&lt;br&gt;
         <message>
             <location filename="../src/gui/clientgui.cpp" line="849" />
             <source>Unable to open folder path %1.</source>
-            <translation>Nao foi possivel abrir o caminho da pasta %1.</translation>
+            <translation>Não foi possível abrir o caminho da pasta %1.</translation>
         </message>
         <message>
             <location filename="../src/gui/clientgui.cpp" line="116" />
@@ -897,7 +897,7 @@ Selecione outra pasta. Se continuar, o Lite Sync será desativado.&lt;br&gt;
             <location filename="../src/gui/debuggingdialog.cpp" line="698" />
             <location filename="../src/gui/debuggingdialog.cpp" line="704" />
             <source>Unable to open folder %1.</source>
-            <translation>Nao foi possivel abrir a pasta %1.</translation>
+            <translation>Não foi possível abrir a pasta %1.</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="711" />
@@ -1261,7 +1261,7 @@ Selecione outra pasta. Se continuar, o Lite Sync será desativado.&lt;br&gt;
             <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67" />
             <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73" />
             <source>Unable to open link %1.</source>
-            <translation>Nao foi possivel abrir a ligacao %1.</translation>
+            <translation>Não foi possível abrir a ligação %1.</translation>
         </message>
         <message>
             <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122" />
@@ -1398,7 +1398,7 @@ Selecione outra pasta. Se continuar, o Lite Sync será desativado.&lt;br&gt;
         <message>
             <location filename="../src/gui/genericerroritemwidget.cpp" line="85" />
             <source>Unable to open folder path %1.</source>
-            <translation>Nao foi possivel abrir o caminho da pasta %1.</translation>
+            <translation>Não foi possível abrir o caminho da pasta %1.</translation>
         </message>
     </context>
     <context>
@@ -1522,7 +1522,7 @@ Selecione outra pasta. Se continuar, o Lite Sync será desativado.&lt;br&gt;
         <message>
             <location filename="../src/gui/localfolderdialog.cpp" line="292" />
             <source>Unable to open link %1.</source>
-            <translation>Nao foi possivel abrir a ligacao %1.</translation>
+            <translation>Não foi possível abrir a ligação %1.</translation>
         </message>
     </context>
     <context>
@@ -1543,7 +1543,7 @@ Selecione outra pasta. Se continuar, o Lite Sync será desativado.&lt;br&gt;
         <message>
             <location filename="../src/gui/mainmenubarwidget.cpp" line="115" />
             <source>Preferences</source>
-            <translation>Preferencias</translation>
+            <translation>Preferências</translation>
         </message>
         <message>
             <location filename="../src/gui/mainmenubarwidget.cpp" line="116" />
@@ -1556,7 +1556,7 @@ Selecione outra pasta. Se continuar, o Lite Sync será desativado.&lt;br&gt;
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="1082" />
             <source>Unable to open folder path %1.</source>
-            <translation>Nao foi possivel abrir o caminho da pasta %1.</translation>
+            <translation>Não foi possível abrir o caminho da pasta %1.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="1096" />
@@ -1961,7 +1961,7 @@ Por favor, utilize o seguinte link para enviar os registos para o apoio técnico
         <message>
             <location filename="../src/gui/preferencesmenubarwidget.cpp" line="64" />
             <source>Preferences</source>
-            <translation>Preferencias</translation>
+            <translation>Preferências</translation>
         </message>
     </context>
     <context>
@@ -2024,12 +2024,12 @@ Por favor, utilize o seguinte link para enviar os registos para o apoio técnico
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="466" />
             <source>Unable to open folder %1.</source>
-            <translation>Nao foi possivel abrir a pasta %1.</translation>
+            <translation>Não foi possível abrir a pasta %1.</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="478" />
             <source>Unable to open link %1.</source>
-            <translation>Nao foi possivel abrir a ligacao %1.</translation>
+            <translation>Não foi possível abrir a ligação %1.</translation>
         </message>
         <message>
             <location filename="../src/gui/preferenceswidget.cpp" line="483" />
@@ -2547,7 +2547,7 @@ Por favor, utilize o seguinte link para enviar os registos para o apoio técnico
         <message>
             <location filename="../src/gui/synthesispopover.cpp" line="1161" />
             <source>Unable to open link %1.</source>
-            <translation>Nao foi possivel abrir a ligacao %1.</translation>
+            <translation>Não foi possível abrir a ligação %1.</translation>
         </message>
         <message>
             <location filename="../src/gui/synthesispopover.cpp" line="1173" />
@@ -3007,7 +3007,7 @@ Por favor, utilize o seguinte link para enviar os registos para o apoio técnico
         <message>
             <location filename="../src/gui/guiutility.cpp" line="336" />
             <source>Sync in progress (%1 of %2)</source>
-            <translation>Sincronização em curso (1% de 2%)</translation>
+            <translation>Sincronização em curso (%1 de %2)</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="340" />

--- a/translations/client_sv.ts
+++ b/translations/client_sv.ts
@@ -1,0 +1,3032 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sv_SE">
+    <context>
+        <name>KDC::AboutDialog</name>
+        <message>
+            <location filename="../src/gui/aboutdialog.cpp" line="73" />
+            <source>About</source>
+            <translation>Om</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/aboutdialog.cpp" line="112" />
+            <source>CLOSE</source>
+            <translation>STÄNG</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/aboutdialog.cpp" line="123" />
+            <source>Version %1. For more information visit &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
+            <translation>Version %1. För mer information, besök &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/aboutdialog.cpp" line="126" />
+            <source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
+            <translation>Copyright 2019–%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/aboutdialog.cpp" line="127" />
+            <source>Distributed by %1 and licensed under the &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
+            <translation>Distribueras av %1 och licensieras enligt &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 och %2-logotypen är registrerade varumärken som tillhör %1.&lt;br&gt;&lt;br&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/aboutdialog.cpp" line="151" />
+            <location filename="../src/gui/aboutdialog.cpp" line="162" />
+            <location filename="../src/gui/aboutdialog.cpp" line="171" />
+            <source>Unable to open folder %1.</source>
+            <translation>Det går inte att öppna mappen %1.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/aboutdialog.cpp" line="132" />
+            <source>&lt;p&gt;&lt;small&gt;Built from &lt;a style="color: #489EF3" href="%1"&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
+            <translation>&lt;p&gt;&lt;small&gt;Kompilerad från &lt;a style="color: #489EF3" href="%1"&gt;Git-källkod&lt;/a&gt; den %2, %3 med Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::AbstractFileItemWidget</name>
+        <message>
+            <location filename="../src/gui/abstractfileitemwidget.cpp" line="177" />
+            <source>Unable to open folder path %1.</source>
+            <translation>Det går inte att öppna mappsökvägen %1.</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::AddDriveConfirmationWidget</name>
+        <message>
+            <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55" />
+            <source>Synchronization will start and you will be able to add files to your %1 folder.</source>
+            <translation>Synkroniseringen startar och du kan lägga till filer i mappen %1.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99" />
+            <source>Your kDrive is ready!</source>
+            <translation>Din kDrive är klar!</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123" />
+            <source>OPEN FOLDER</source>
+            <translation>ÖPPNA MAPP</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130" />
+            <source>PARAMETERS</source>
+            <translation>INSTÄLLNINGAR</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138" />
+            <source>Synchronize another drive</source>
+            <translation>Synkronisera en annan enhet</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::AddDriveListWidget</name>
+        <message>
+            <location filename="../src/gui/adddrivelistwidget.cpp" line="170" />
+            <source>Cancel</source>
+            <translation>Avbryt</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddrivelistwidget.cpp" line="177" />
+            <source>NEXT</source>
+            <translation>NÄSTA</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddrivelistwidget.cpp" line="196" />
+            <source>Select the kDrive you want to synchronize</source>
+            <translation>Välj den kDrive du vill synkronisera</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddrivelistwidget.cpp" line="234" />
+            <source>Get kDrive for free</source>
+            <translation>Skaffa kDrive gratis</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddrivelistwidget.cpp" line="244" />
+            <source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
+            <translation>Spara dina bilder, dokument och e-postmeddelanden i Schweiz hos ett oberoende företag som respekterar din integritet. Läs mer</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddrivelistwidget.cpp" line="263" />
+            <source>Test for free</source>
+            <translation>Testa gratis</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::AddDriveLiteSyncWidget</name>
+        <message>
+            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147" />
+            <source>Conserve your computer space</source>
+            <translation>Spara utrymme på datorn</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167" />
+            <source>Decide which files should be available online or locally</source>
+            <translation>Bestäm vilka filer som ska vara tillgängliga online eller lokalt</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187" />
+            <source>LATER</source>
+            <translation>SENARE</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193" />
+            <source>YES</source>
+            <translation>JA</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125" />
+            <source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+            <translation>Lite Sync synkroniserar alla dina filer utan att ta upp utrymme på din dator. Du kan bläddra bland filerna i ditt kDrive och ladda ner dem lokalt när du vill. &lt;a style="%1" href="%2"&gt;Läs mer&lt;/a&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207" />
+            <source>Unable to open link %1.</source>
+            <translation>Det går inte att öppna länken %1.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112" />
+            <source>Would you like to activate Lite Sync (Beta) ?</source>
+            <translation>Vill du aktivera Lite Sync (Beta)?</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114" />
+            <source>Would you like to activate Lite Sync ?</source>
+            <translation>Vill du aktivera Lite Sync?</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::AddDriveLocalFolderWidget</name>
+        <message>
+            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65" />
+            <source>Location of your %1 kDrive</source>
+            <translation>Plats för din %1 kDrive</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155" />
+            <source>Edit folder</source>
+            <translation>Ändra mapp</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246" />
+            <source>END</source>
+            <translation>SLUTFÖR</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297" />
+            <source>Select folder</source>
+            <translation>Välj mapp</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264" />
+            <source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
+            <translation>Innehållet i mappen &lt;b&gt;%1&lt;/b&gt; kommer att synkroniseras i din kDrive</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212" />
+            <source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
+            <translation>När konfigurationen är klar hittar du alla dina filer i den här mappen. Du kan lägga in nya filer där för att synkronisera dem till din kDrive.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284" />
+            <source>This folder is not compatible with Lite Sync.&lt;br&gt; 
+Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt; 
+&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+            <translation>Den här mappen är inte kompatibel med Lite Sync.&lt;br&gt; 
+Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&gt; 
+&lt;a style="%1" href="%2"&gt;Läs mer&lt;/a&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377" />
+            <source>Unable to open link %1.</source>
+            <translation>Det går inte att öppna länken %1.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246" />
+            <source>CONTINUE</source>
+            <translation>FORTSÄTT</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::AddDriveLoginWidget</name>
+        <message>
+            <location filename="../src/gui/adddriveloginwidget.cpp" line="69" />
+            <source>Log in from your browser</source>
+            <translation>Logga in från din webbläsare</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddriveloginwidget.cpp" line="75" />
+            <source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
+            <translation>Din webbläsare bör öppnas automatiskt för att slutföra anslutningen. När anslutningen är upprättad återgår du automatiskt till kDrive.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddriveloginwidget.cpp" line="85" />
+            <source>Open the login page</source>
+            <translation>Öppna inloggningssidan</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddriveloginwidget.cpp" line="119" />
+            <source>Token request failed: %1 - %2</source>
+            <translation>Begäran om token misslyckades: %1 - %2</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddriveloginwidget.cpp" line="133" />
+            <source>Login failed: %1 - %2</source>
+            <translation>Inloggningen misslyckades: %1 - %2</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddriveloginwidget.cpp" line="141" />
+            <source>Failed to open the login page in your web browser</source>
+            <translation>Det gick inte att öppna inloggningssidan i din webbläsare</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::AddDriveServerFoldersWidget</name>
+        <message>
+            <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129" />
+            <source>Select kDrive folders to synchronize on your desktop</source>
+            <translation>Välj vilka kDrive-mappar som ska synkroniseras på din dator</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174" />
+            <source>CONTINUE</source>
+            <translation>FORTSÄTT</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187" />
+            <source>Space available on your computer : %1</source>
+            <translation>Ledigt utrymme på din dator: %1</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206" />
+            <source>An error occurred while loading the list of subfolders.</source>
+            <translation>Ett fel uppstod vid inläsningen av listan över undermappar.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210" />
+            <source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
+            <translation>Det går inte att ladda listan över undermappar&lt;br&gt;. Din kDrive kan vara under underhåll. Logga in på &lt;a style="%1" href="%2"&gt;web&lt;/a&gt;bversionen för att kontrollera statusen för din kDrive, eller kontakta din administratör.</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::AddDriveWizard</name>
+        <message>
+            <location filename="../src/gui/adddrivewizard.cpp" line="222" />
+            <source>Failed to create local folder %1</source>
+            <translation>Det gick inte att skapa den lokala mappen %1</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddrivewizard.cpp" line="233" />
+            <source>Failed to create new synchronization</source>
+            <translation>Det gick inte att skapa en ny synkronisering</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddrivewizard.cpp" line="266" />
+            <source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
+            <translation>kDrive %1 är redan synkroniserat på den här datorn. Vill du fortsätta ändå?</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::AppClient</name>
+        <message>
+            <location filename="../src/gui/appclient.cpp" line="100" />
+            <source>kDrive client is run with bad parameters!</source>
+            <translation>kDrive-klienten körs med felaktiga parametrar!</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/appclient.cpp" line="109" />
+            <source>kDrive client is already running!</source>
+            <translation>kDrive-klienten är redan igång!</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/appclient.cpp" line="719" />
+            <source>The user %1 is not connected. Please log in again.</source>
+            <translation>Användaren %1 är inte inloggad. Logga in igen.</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::AppServer</name>
+        <message>
+            <location filename="../src/server/appserver.cpp" line="1679" />
+            <source>Share link copied to clipboard</source>
+            <translation>Delningslänken har kopierats till urklipp</translation>
+        </message>
+        <message numerus="yes">
+            <location filename="../src/server/appserver.cpp" line="3759" />
+            <source>%1 and %n other file(s) have been removed.</source>
+            <translation>
+                <numerusform>%1 och %n annan fil har tagits bort.</numerusform>
+                <numerusform>%1 och %n andra filer har tagits bort.</numerusform>
+            </translation>
+        </message>
+        <message>
+            <location filename="../src/server/appserver.cpp" line="3761" />
+            <source>%1 has been removed.</source>
+            <comment>%1 names a file.</comment>
+            <translation>%1 har tagits bort.</translation>
+        </message>
+        <message numerus="yes">
+            <location filename="../src/server/appserver.cpp" line="3766" />
+            <source>%1 and %n other file(s) have been added.</source>
+            <translation>
+                <numerusform>%1 och %n annan fil har lagts till.</numerusform>
+                <numerusform>%1 och %n andra filer har lagts till.</numerusform>
+            </translation>
+        </message>
+        <message>
+            <location filename="../src/server/appserver.cpp" line="3768" />
+            <source>%1 has been added.</source>
+            <comment>%1 names a file.</comment>
+            <translation>%1 har lagts till.</translation>
+        </message>
+        <message numerus="yes">
+            <location filename="../src/server/appserver.cpp" line="3773" />
+            <source>%1 and %n other file(s) have been updated.</source>
+            <translation>
+                <numerusform>%1 och %n annan fil har uppdaterats.</numerusform>
+                <numerusform>%1 och %n andra filer har uppdaterats.</numerusform>
+            </translation>
+        </message>
+        <message>
+            <location filename="../src/server/appserver.cpp" line="3775" />
+            <source>%1 has been updated.</source>
+            <comment>%1 names a file.</comment>
+            <translation>%1 har uppdaterats.</translation>
+        </message>
+        <message numerus="yes">
+            <location filename="../src/server/appserver.cpp" line="3780" />
+            <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
+            <translation>
+                <numerusform>%1 har flyttats till %2 och %n annan fil har flyttats.</numerusform>
+                <numerusform>%1 har flyttats till %2 och %n andra filer har flyttats.</numerusform>
+            </translation>
+        </message>
+        <message>
+            <location filename="../src/server/appserver.cpp" line="3783" />
+            <source>%1 has been moved to %2.</source>
+            <translation>%1 har flyttats till %2.</translation>
+        </message>
+        <message>
+            <location filename="../src/server/appserver.cpp" line="3791" />
+            <source>Sync Activity</source>
+            <translation>Synkroniseringsaktivitet</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::BaseFolderTreeItemWidget</name>
+        <message>
+            <location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102" />
+            <source>No subfolders currently on the server.</source>
+            <translation>Det finns för närvarande inga undermappar på servern.</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::BetaProgramDialog</name>
+        <message>
+            <location filename="../src/gui/betaprogramdialog.cpp" line="69" />
+            <source>Quit the beta program</source>
+            <translation>Avsluta betaprogrammet</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/betaprogramdialog.cpp" line="69" />
+            <source>Join the beta program</source>
+            <translation>Anmäl dig till betaprogrammet</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/betaprogramdialog.cpp" line="77" />
+            <source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
+            <translation>Få tillgång till nya versioner av applikationen innan de släpps till allmänheten och bidra till att förbättra applikationen genom att skicka oss dina synpunkter.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/betaprogramdialog.cpp" line="87" />
+            <source>Benefit from application beta updates</source>
+            <translation>Dra nytta av uppdateringar av betaversionen av appen</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/betaprogramdialog.cpp" line="91" />
+            <source>No</source>
+            <translation>Nej</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/betaprogramdialog.cpp" line="92" />
+            <source>Public beta version</source>
+            <translation>Offentlig betaversion</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/betaprogramdialog.cpp" line="93" />
+            <source>Internal beta version</source>
+            <translation>Intern betaversion</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/betaprogramdialog.cpp" line="141" />
+            <source>I understand</source>
+            <translation>Jag förstår</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/betaprogramdialog.cpp" line="147" />
+            <source>Are you sure you want to leave the beta program?</source>
+            <translation>Är du säker på att du vill lämna betaprogrammet?</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/betaprogramdialog.cpp" line="161" />
+            <source>Save</source>
+            <translation>Spara</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/betaprogramdialog.cpp" line="167" />
+            <source>Cancel</source>
+            <translation>Avbryt</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/betaprogramdialog.cpp" line="228" />
+            <source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
+            <translation>Din nuvarande version av appen kan vara för ny; ditt val träder i kraft när nästa uppdatering blir tillgänglig.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/betaprogramdialog.cpp" line="233" />
+            <source>Beta versions may leave unexpectedly or cause instabilities.</source>
+            <translation>Betaversioner kan stängas ner utan förvarning eller orsaka instabilitet.</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::ClientGui</name>
+        <message>
+            <location filename="../src/gui/clientgui.cpp" line="189" />
+            <source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
+            <translation>Det gick inte att lösa konflikterna för %1 objekt i synkroniseringsmappen: %2</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/clientgui.cpp" line="242" />
+            <source>Please sign in</source>
+            <translation>Logga in</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/clientgui.cpp" line="292" />
+            <source>Folder %1: %2</source>
+            <translation>Mappen %1: %2</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/clientgui.cpp" line="298" />
+            <source>There are no sync folders configured.</source>
+            <translation>Det finns inga synkroniseringsmappar konfigurerade.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/clientgui.cpp" line="1426" />
+            <source>Synthesis</source>
+            <translation>Sammanfattning</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/clientgui.cpp" line="1427" />
+            <source>Preferences</source>
+            <translatorcomment>Préférences</translatorcomment>
+            <translation>Inställningar</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/clientgui.cpp" line="1428" />
+            <source>Quit</source>
+            <translation>Avsluta</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/clientgui.cpp" line="673" />
+            <source>Undefined State.</source>
+            <translation>Odefinierat tillstånd.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/clientgui.cpp" line="676" />
+            <source>Waiting to start syncing.</source>
+            <translation>Väntar på att synkroniseringen ska starta.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/clientgui.cpp" line="679" />
+            <source>Sync is running.</source>
+            <translation>Synkroniseringen pågår.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/clientgui.cpp" line="683" />
+            <source>Sync was successful, unresolved conflicts.</source>
+            <translation>Synkroniseringen lyckades, men det finns olösta konflikter.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/clientgui.cpp" line="685" />
+            <source>Last Sync was successful.</source>
+            <translation>Den senaste synkroniseringen genomfördes utan problem.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/clientgui.cpp" line="692" />
+            <source>User Abort.</source>
+            <translation>Användaren avbryter.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/clientgui.cpp" line="696" />
+            <source>Sync is paused.</source>
+            <translation>Synkroniseringen är pausad.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/clientgui.cpp" line="705" />
+            <source>%1 (Sync is paused)</source>
+            <translation>%1 (Synkroniseringen är pausad)</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/clientgui.cpp" line="1261" />
+            <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+            <translation>Vill du verkligen ta bort synkroniseringarna för kontot &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Obs!&lt;/b&gt; Detta raderar inga filer.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/clientgui.cpp" line="1265" />
+            <source>REMOVE ALL SYNCHRONIZATIONS</source>
+            <translation>TA BORT ALLA SYNKRONISERINGAR</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/clientgui.cpp" line="1266" />
+            <source>CANCEL</source>
+            <translation>AVBRYT</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/clientgui.cpp" line="1594" />
+            <source>Failed to start synchronizations!</source>
+            <translation>Det gick inte att starta synkroniseringarna!</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/clientgui.cpp" line="849" />
+            <source>Unable to open folder path %1.</source>
+            <translation>Det går inte att öppna mappsökvägen %1.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/clientgui.cpp" line="116" />
+            <source>Unable to initialize kDrive client</source>
+            <translation>Det går inte att starta kDrive-klienten</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/clientgui.cpp" line="255" />
+            <source>Synchronization is paused</source>
+            <translation>Synkroniseringen är pausad</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::ConfirmSynchronizationDialog</name>
+        <message>
+            <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86" />
+            <source>Summary of your local folder synchronization</source>
+            <translation>Sammanfattning av synkroniseringen av din lokala mapp</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95" />
+            <source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
+            <translation>Innehållet i mappen på din dator kommer att synkroniseras med mappen på den valda kDrive-enheten och vice versa.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184" />
+            <source>CANCEL</source>
+            <translation>AVBRYT</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191" />
+            <source>SYNCHRONIZE</source>
+            <translation>SYNKRONISERA</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::CustomExtensionSetupWidget</name>
+        <message>
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="96" />
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="120" />
+            <source>Before finishing</source>
+            <translation>Innan du avslutar</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="107" />
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="131" />
+            <source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
+            <translation>Följ dessa steg för att säkerställa att Lite Sync fungerar korrekt på din dator och för att slutföra konfigurationen av kDrive.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="208" />
+            <source>Open your Mac's &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+            <translation>Öppna &lt;b&gt;inställningarna under ”Allmänt”&lt;/b&gt; på din Mac eller  &lt;a style="%1" href="%2"&gt;klicka här&lt;/a&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="212" />
+            <source>Open your Mac's &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+            <translation>Öppna &lt;b&gt;inställningarna för sekretess och säkerhet&lt;/b&gt; på din Mac eller  &lt;a style="%1" href="%2"&gt;klicka här&lt;/a&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="216" />
+            <source>Open your Mac's &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+            <translation>Öppna &lt;b&gt;inställningarna&lt;/b&gt; för &lt;b&gt;Säkerhet och integritet&lt;/b&gt; på din Mac eller  &lt;a style="%1" href="%2"&gt;klicka här&lt;/a&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="246" />
+            <source>Go to &lt;b&gt;"Login Items &amp; Extensions"&lt;/b&gt; section and then to &lt;b&gt;"Endpoint Security Extensions"&lt;/b&gt;</source>
+            <translation>Gå till avsnittet &lt;b&gt;”Inloggningsobjekt och tillägg”&lt;/b&gt; och sedan till &lt;b&gt;”Endpoint Security-tillägg”&lt;/b&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="263" />
+            <source>Authorize the kDrive application</source>
+            <translation>Godkänn appen kDrive</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="272" />
+            <source>Go to &lt;b&gt;"Security"&lt;/b&gt; section</source>
+            <translation>Gå till avsnittet &lt;b&gt;”Säkerhet”&lt;/b&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="289" />
+            <source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
+            <translation>Godkänn kDrive-appen i rutan där det står att kDrive har blockerats</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="299" />
+            <source>Unlock the padlock &lt;img src=":/client/resources/icons/actions/lock.png"&gt; and authorize the kDrive application</source>
+            <translation>Lås upp hänglåset &lt;img src=":/client/resources/icons/actions/lock.png"&gt; och godkänn kDrive-appen</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="344" />
+            <source>Go to &lt;b&gt;"Privacy &amp; Security"&lt;/b&gt; section and click on &lt;b&gt;"Full Disk Access"&lt;/b&gt; or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+            <translation>Gå till avsnittet &lt;b&gt;”Sekretess och säkerhet”&lt;/b&gt; och klicka på &lt;b&gt;”Fullständig disktillgång”&lt;/b&gt; eller &lt;a style="%1" href="%2"&gt;klicka här&lt;/a&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="348" />
+            <source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;"Privacy"&lt;/b&gt; tab or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+            <translation>Öppna fliken &lt;b&gt;”Sekretess”&lt;/b&gt; i inställningarna för säkerhet och sekretess, eller &lt;a style="%1" href="%2"&gt;klicka här&lt;/a&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="376" />
+            <source>Check the "kDrive LiteSync Extension" box then the "kDrive.app" box (if not already checked)</source>
+            <translation>Markera rutan ”kDrive LiteSync Extension” och sedan rutan ”kDrive.app” (om den inte redan är markerad)</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="393" />
+            <source>A restart of the app might be proposed, in this case accept it</source>
+            <translation>Det kan hända att appen föreslår en omstart; i så fall godkänner du den</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="399" />
+            <source>Check the "kDrive LiteSync Extension" box (and "kDrive.app" if it exists) in &lt;b&gt;"Full Disk Access"&lt;/b&gt;</source>
+            <translation>Markera rutan ”kDrive LiteSync Extension” (och ”kDrive.app” om den finns) under &lt;b&gt;”Fullständig diskåtkomst”&lt;/b&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="495" />
+            <source>STEP 1</source>
+            <translation>STEG 1</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="495" />
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="496" />
+            <source>(Done)</source>
+            <translation>(Klart)</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="496" />
+            <source>STEP 2</source>
+            <translation>STEG 2</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="499" />
+            <source>STEPS PERFORMED</source>
+            <translation>UTFÖRDA STEG</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="501" />
+            <source>END</source>
+            <translation>SLUTFÖR</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::CustomMessageBox</name>
+        <message>
+            <location filename="../src/gui/custommessagebox.cpp" line="101" />
+            <source>OK</source>
+            <translation>OKEJ</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/custommessagebox.cpp" line="111" />
+            <source>CANCEL</source>
+            <translation>AVBRYT</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/custommessagebox.cpp" line="121" />
+            <source>YES</source>
+            <translation>JA</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/custommessagebox.cpp" line="131" />
+            <source>NO</source>
+            <translation>NEJ</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::DebugReporter</name>
+        <message>
+            <location filename="../src/gui/debugreporter.cpp" line="37" />
+            <source>Sending of debugging information</source>
+            <translation>Översändning av felsökningsinformation</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debugreporter.cpp" line="37" />
+            <source>Cancel</source>
+            <translation>Avbryt</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::DebuggingDialog</name>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="46" />
+            <source>Info</source>
+            <translation>Info</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="45" />
+            <source>Debug</source>
+            <translation>Felsökning</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="47" />
+            <source>Warning</source>
+            <translation>Varning</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="48" />
+            <source>Error</source>
+            <translation>Fel</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="49" />
+            <source>Fatal</source>
+            <translation>Dödlig</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="74" />
+            <source>Debugging settings</source>
+            <translation>Felsökningsinställningar</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="90" />
+            <source>Save debugging information in a folder on my computer (Recommended)</source>
+            <translation>Spara felsökningsinformation i en mapp på min dator (rekommenderas)</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="104" />
+            <source>This information enables IT support to determine the origin of an incident.</source>
+            <translation>Med hjälp av denna information kan IT-supporten fastställa var ett fel har sitt ursprung.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="114" />
+            <source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
+            <translation>&lt;a style="%1" href="%2"&gt;Öppna felsökningsmappen&lt;/a&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="143" />
+            <source>Debug level</source>
+            <translation>Felsökningsnivå</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="152" />
+            <source>The trace level lets you choose the extent of the debugging information recorded</source>
+            <translation>Med spårningsnivån kan du välja hur mycket felsökningsinformation som ska registreras</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="179" />
+            <source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
+            <translation>Den utökade fullständiga loggen samlar in en detaljerad historik som kan användas för felsökning. Om du aktiverar den kan det göra att kDrive-programmet går långsammare.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="183" />
+            <source>Extended Full Log</source>
+            <translation>Utökad fullständig logg</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="206" />
+            <source>Delete logs older than %1 days</source>
+            <translation>Ta bort loggar som är äldre än %1 dagar</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="225" />
+            <source>Share the debug folder with Infomaniak support.</source>
+            <translation>Skicka debug-mappen till Infomaniaks support.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="249" />
+            <source>The last session is the periode since the last kDrive start.</source>
+            <translation>Den sista sessionen är tidsperioden sedan kDrive senast startades.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="253" />
+            <source>Share only the last kDrive session</source>
+            <translation>Dela endast den senaste kDrive-sessionen</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="284" />
+            <source>  Loading</source>
+            <translation>  Laddar</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="293" />
+            <source>Cancel</source>
+            <translation>Avbryt</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="319" />
+            <source>SAVE</source>
+            <translation>SPARA</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="326" />
+            <source>CANCEL</source>
+            <translation>AVBRYT</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="470" />
+            <source>Failed to share</source>
+            <translation>Det gick inte att dela</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="480" />
+            <source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
+            <translation>1. Kontrollera att du är inloggad &lt;br&gt;2. Kontrollera att du har konfigurerat minst en kDrive</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="485" />
+            <source> (Connexion interrupted)</source>
+            <translation> (Anslutningen avbröts)</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="492" />
+            <source>Share the folder with SwissTransfer &lt;br&gt;</source>
+            <translation>Dela mappen med SwissTransfer &lt;br&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="493" />
+            <source> 1. We automatically compressed your log &lt;a style="%1" href="%2"&gt;here&lt;/a&gt;.&lt;br&gt;</source>
+            <translation> 1. Vi har automatiskt komprimerat din logg &lt;a style="%1" href="%2"&gt;här&lt;/a&gt;.&lt;br&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="495" />
+            <source> 2. Transfer the archive with &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
+            <translation> 2. Skicka arkivet via &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="497" />
+            <source> 3. Share the link with &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
+            <translation> 3. Dela länken med&lt;a style="%1" href="%2"&gt;support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="527" />
+            <source>Last upload the %1</source>
+            <translation>Senaste uppladdning: %1</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="555" />
+            <source>Sharing has been cancelled</source>
+            <translation>Delningen har avbrutits</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.h" line="70" />
+            <source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
+            <translation>Hela mappen är stor (&amp;gt; 100 MB) och det kan ta en stund att dela den. För att minska delningstiden rekommenderar vi att du endast delar den senaste kDrive-sessionen.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="600" />
+            <source>%1/%2/%3 at %4h%5m and %6s</source>
+            <extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
+            <translation>%1/%2/%3 kl. %4:%5 och %6 sekunder</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="643" />
+            <source>Do you want to save your modifications?</source>
+            <translation>Vill du spara dina ändringar?</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="698" />
+            <location filename="../src/gui/debuggingdialog.cpp" line="704" />
+            <source>Unable to open folder %1.</source>
+            <translation>Det går inte att öppna mappen %1.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="711" />
+            <source>  Share</source>
+            <translation>  Dela</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="721" />
+            <source>  Sharing | step 1/2 %1%</source>
+            <translation>  Dela | steg 1/2 %1%</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="730" />
+            <source>  Sharing | step 2/2 %1%</source>
+            <translation>  Dela | steg 2/2 %1%</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="740" />
+            <source>  Canceling...</source>
+            <translation>  Avbryter...</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::DrivePreferencesWidget</name>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1118" />
+            <source>Folders</source>
+            <translation>Mappar</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1120" />
+            <source>Notifications</source>
+            <translation>Meddelanden</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1123" />
+            <source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
+            <translation>Ett meddelande visas så snart en ny mapp har synkroniserats eller ändrats</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1124" />
+            <source>Connected with</source>
+            <translation>I samband med</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="981" />
+            <source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+            <translation>Vill du verkligen sluta synkronisera mappen &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Obs!&lt;/b&gt; Detta kommer &lt;b&gt;inte&lt;/b&gt; att radera några filer.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="356" />
+            <source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
+            <translation>Denna åtgärd kan ta allt från några sekunder till några minuter, beroende på mappens storlek.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="360" />
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="391" />
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="986" />
+            <source>CANCEL</source>
+            <translation>AVBRYT</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="645" />
+            <source>New local folder synchronization failed!</source>
+            <translation>Synkroniseringen av den nya lokala mappen misslyckades!</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="823" />
+            <source>Lite Sync activation failed.</source>
+            <translation>Aktiveringen av Lite Sync misslyckades.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="841" />
+            <source>Lite Sync deactivation failed.</source>
+            <translation>Det gick inte att inaktivera Lite Sync.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="985" />
+            <source>REMOVE FOLDER SYNC CONNECTION</source>
+            <translation>TA BORT SYNKRONISERINGSFÖRBINDELSEN FÖR MAPPEN</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1048" />
+            <source>An error occurred while loading the list of subfolders.</source>
+            <translation>Ett fel uppstod vid inläsningen av listan över undermappar.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1121" />
+            <source>Enable the notifications for this kDrive</source>
+            <translation>Aktivera aviseringar för denna kDrive</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="359" />
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="390" />
+            <source>CONFIRM</source>
+            <translation>BEKRÄFTA</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="120" />
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1117" />
+            <source>Synchronization errors and information.</source>
+            <translation>Synkroniseringsfel och information.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="144" />
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1119" />
+            <source>Synchronize a local folder</source>
+            <translation>Synkronisera en lokal mapp</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="355" />
+            <source>Do you really want to turn on Lite Sync?</source>
+            <translation>Vill du verkligen aktivera Lite Sync?</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="382" />
+            <source>Do you really want to turn off Lite Sync?</source>
+            <translation>Vill du verkligen stänga av Lite Sync?</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="384" />
+            <source>You don't have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
+            <translation>Du har inte tillräckligt med utrymme för att synkronisera alla filer på din kDrive (%1 saknas). Om du inaktiverar Lite Sync måste du välja vilka mappar som ska synkroniseras på din dator. Under tiden kommer synkroniseringen av din kDrive att pausas.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="388" />
+            <source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
+            <translation>Om du stänger av Lite Sync kommer alla filer att laddas ner till din dator.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="627" />
+            <source>Failed to create new synchronization</source>
+            <translation>Det gick inte att skapa en ny synkronisering</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="819" />
+            <source>Lite Sync activated.</source>
+            <translation>Lite Sync är aktiverat.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="837" />
+            <source>Lite Sync deactivated.</source>
+            <translation>Lite Sync är inaktiverat.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="899" />
+            <source>This drive is being deleted.</source>
+            <translation>Den här enheten raderas.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="962" />
+            <source>Impossible to open item %1</source>
+            <translation>Det går inte att öppna objekt %1</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1007" />
+            <source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
+            <translation>Det gick inte att avbryta synkroniseringen av mappen &lt;i&gt;%1&lt;/i&gt;.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1125" />
+            <source>Remove all synchronizations</source>
+            <translation>Ta bort alla synkroniseringar</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1126" />
+            <source>Search in your kDrive</source>
+            <translation>Sök i din kDrive</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1127" />
+            <source>Search</source>
+            <translation>Sök</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::DriveSelectionWidget</name>
+        <message>
+            <location filename="../src/gui/driveselectionwidget.cpp" line="216" />
+            <source>Synchronize a kDrive</source>
+            <translation>Synkronisera en kDrive</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/driveselectionwidget.cpp" line="150" />
+            <source>Add a kDrive</source>
+            <translation>Lägg till en kDrive</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::ErrorTabWidget</name>
+        <message>
+            <location filename="../src/gui/errortabwidget.cpp" line="179" />
+            <source>Resolve</source>
+            <translation>Lösa</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/errortabwidget.cpp" line="180" />
+            <source>Conflicted item(s)</source>
+            <translation>Konflikterande objekt</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/errortabwidget.cpp" line="181" />
+            <source>Item(s) with unsupported characters</source>
+            <translation>Objekt med tecken som inte stöds</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/errortabwidget.cpp" line="92" />
+            <location filename="../src/gui/errortabwidget.cpp" line="135" />
+            <location filename="../src/gui/errortabwidget.cpp" line="178" />
+            <location filename="../src/gui/errortabwidget.cpp" line="186" />
+            <source>Clear history</source>
+            <translation>Rensa historiken</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/errortabwidget.cpp" line="176" />
+            <source>To Resolve</source>
+            <translation>Att lösa</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/errortabwidget.cpp" line="184" />
+            <source>Automatically resolved</source>
+            <translation>Löst automatiskt</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/errortabwidget.cpp" line="185" />
+            <source>problem(s) solved</source>
+            <translation>problem löst</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/errortabwidget.cpp" line="177" />
+            <source>problem(s) detected</source>
+            <translation>problem har upptäckts</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::ErrorsMenuBarWidget</name>
+        <message>
+            <location filename="../src/gui/errorsmenubarwidget.cpp" line="84" />
+            <location filename="../src/gui/errorsmenubarwidget.cpp" line="103" />
+            <source>Synchronization conflicts or errors</source>
+            <translation>Synkroniseringskonflikter eller fel</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/errorsmenubarwidget.cpp" line="86" />
+            <location filename="../src/gui/errorsmenubarwidget.cpp" line="105" />
+            <source>Errors</source>
+            <translation>Fel</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/errorsmenubarwidget.cpp" line="101" />
+            <source>Back to preferences</source>
+            <translation>Tillbaka till inställningar</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::ErrorsPopup</name>
+        <message>
+            <location filename="../src/gui/errorspopup.cpp" line="73" />
+            <source>Some files couldn't be synchronized on the following kDrive(s) :</source>
+            <translation>Vissa filer kunde inte synkroniseras på följande kDrive-enheter:</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/errorspopup.cpp" line="95" />
+            <source> (%1 error(s))</source>
+            <translation> (%1 fel)</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/errorspopup.cpp" line="101" />
+            <source> (%1 information(s))</source>
+            <translation> (%1 uppgift(er))</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/errorspopup.cpp" line="107" />
+            <source> (%1 error(s) and %2 information(s))</source>
+            <translation> (%1 fel och %2 uppgifter)</translation>
+        </message>
+        <message numerus="yes">
+            <location filename="../src/gui/errorspopup.cpp" line="147" />
+            <source>Generic errors (%n warning(s) or error(s))</source>
+            <comment>Number of warnings or errors</comment>
+            <translation>
+                <numerusform>Allmänna fel (%n varning eller fel)</numerusform>
+                <numerusform>Allmänna fel (%n varningar eller fel)</numerusform>
+            </translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::FileExclusionDialog</name>
+        <message>
+            <location filename="../src/gui/fileexclusiondialog.cpp" line="78" />
+            <source>Excluded files</source>
+            <translation>Undantagna filer</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fileexclusiondialog.cpp" line="86" />
+            <source>Add files or folders that will not be synchronized on your computer.</source>
+            <translation>Lägg till filer eller mappar som inte ska synkroniseras på din dator.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fileexclusiondialog.cpp" line="97" />
+            <source>Add</source>
+            <translation>Lägg till</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fileexclusiondialog.cpp" line="109" />
+            <source>NAME</source>
+            <translation>NAMN</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fileexclusiondialog.cpp" line="114" />
+            <source>WARNING</source>
+            <translation>VARNING</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fileexclusiondialog.cpp" line="149" />
+            <source>SAVE</source>
+            <translation>SPARA</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fileexclusiondialog.cpp" line="156" />
+            <source>CANCEL</source>
+            <translation>AVBRYT</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fileexclusiondialog.cpp" line="304" />
+            <source>Do you want to save your modifications?</source>
+            <translation>Vill du spara dina ändringar?</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fileexclusiondialog.cpp" line="353" />
+            <source>Exclusion template already exists!</source>
+            <translation>Mallen för uteslutning finns redan!</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fileexclusiondialog.cpp" line="374" />
+            <source>Do you really want to delete?</source>
+            <translation>Vill du verkligen ta bort det?</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fileexclusiondialog.cpp" line="434" />
+            <source>Cannot save changes!</source>
+            <translation>Det går inte att spara ändringarna!</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::FileExclusionNameDialog</name>
+        <message>
+            <location filename="../src/gui/fileexclusionnamedialog.cpp" line="58" />
+            <source>VALIDATE</source>
+            <translation>BEKRÄFTA</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fileexclusionnamedialog.cpp" line="65" />
+            <source>CANCEL</source>
+            <translation>AVBRYT</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::FixConflictingFilesDialog</name>
+        <message>
+            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67" />
+            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73" />
+            <source>Unable to open link %1.</source>
+            <translation>Det går inte att öppna länken %1.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122" />
+            <source>Solve conflict(s)</source>
+            <translation>Lösa konflikter</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140" />
+            <source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
+            <translation>&lt;b&gt;Vad vill du göra med den/de %1 objektet/objekten som är i konflikt?&lt;/b&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143" />
+            <source>Save my changes and replace other users' versions.</source>
+            <translation>Spara mina ändringar och ersätt andra användares versioner.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147" />
+            <source>Undo my changes and keep other users' versions.</source>
+            <translation>Ångra mina ändringar och behåll andra användares versioner.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169" />
+            <source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
+            <translation>Dina ändringar kan raderas permanent. De går inte att återställa via kDrive-webbappen.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171" />
+            <source>&lt;a style=%1 href="%2"&gt;Learn more&lt;/a&gt;</source>
+            <translation>&lt;a style=%1 href="%2"&gt;Läs mer&lt;/a&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175" />
+            <source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
+            <translation>Dina ändringar kommer att raderas permanent. De kan inte återställas via kDrive-webbappen.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191" />
+            <source>Show item(s)</source>
+            <translation>Visa objekt</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228" />
+            <source>VALIDATE</source>
+            <translation>BEKRÄFTA</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234" />
+            <source>CANCEL</source>
+            <translation>AVBRYT</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251" />
+            <source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
+            <translation>Flera användare har gjort ändringar i dessa filer på olika ställen (online på kDrive, på en dator eller i en mobil). Mappar som innehåller dessa filer kan också ha raderats.&lt;br&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253" />
+            <source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Learn more&lt;/a&gt;</source>
+            <translation>Den lokala versionen av din artikel &lt;b&gt;är inte synkroniserad&lt;/b&gt; med kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Läs mer&lt;/a&gt;</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::FolderItemWidget</name>
+        <message>
+            <location filename="../src/gui/folderitemwidget.cpp" line="458" />
+            <source>More actions</source>
+            <translation>Fler åtgärder</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/folderitemwidget.cpp" line="188" />
+            <location filename="../src/gui/folderitemwidget.cpp" line="476" />
+            <source>Synchronized into &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</source>
+            <translation>Synkroniserad till &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/folderitemwidget.cpp" line="343" />
+            <source>Activate Lite Sync</source>
+            <translation>Aktivera Lite Sync</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/folderitemwidget.cpp" line="345" />
+            <source>Activate Lite Sync (Beta)</source>
+            <translation>Aktivera Lite Sync (Beta)</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/folderitemwidget.cpp" line="481" />
+            <source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
+            <translation>Mappar som inte är markerade flyttas till papperskorgen om de innehåller objekt som är offline. Mappar som synkroniserats till kDrive förblir tillgängliga online.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/folderitemwidget.cpp" line="485" />
+            <source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
+            <translation>Mappar som inte är markerade kommer att flyttas till papperskorgen. Mappar som synkroniserats till kDrive kommer att förbli tillgängliga online.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/folderitemwidget.cpp" line="488" />
+            <source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
+            <translation>Mappar som inte är markerade kommer att raderas &lt;b&gt;permanent&lt;/b&gt; från datorn. Mappar som synkroniserats till kDrive kommer att finnas kvar online.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/folderitemwidget.cpp" line="493" />
+            <source>Cancel</source>
+            <translation>Avbryt</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/folderitemwidget.cpp" line="494" />
+            <source>VALIDATE</source>
+            <translation>BEKRÄFTA</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/folderitemwidget.cpp" line="365" />
+            <source>Pause synchronization</source>
+            <translation>Pausa synkroniseringen</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/folderitemwidget.cpp" line="354" />
+            <source>Deactivate Lite Sync</source>
+            <translation>Inaktivera Lite Sync</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/folderitemwidget.cpp" line="375" />
+            <source>Resume synchronization</source>
+            <translation>Fortsätt synkroniseringen</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/folderitemwidget.cpp" line="386" />
+            <source>Remove synchronization</source>
+            <translation>Avaktivera synkronisering</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::GenericErrorItemWidget</name>
+        <message>
+            <location filename="../src/gui/genericerroritemwidget.cpp" line="85" />
+            <source>Unable to open folder path %1.</source>
+            <translation>Det går inte att öppna mappsökvägen %1.</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::LiteSyncAppDialog</name>
+        <message>
+            <location filename="../src/gui/litesyncappdialog.cpp" line="48" />
+            <source>Application Id</source>
+            <translation>Applikations-ID</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/litesyncappdialog.cpp" line="98" />
+            <source>Application Name</source>
+            <translation>Programnamn</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/litesyncappdialog.cpp" line="121" />
+            <source>VALIDATE</source>
+            <translation>BEKRÄFTA</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/litesyncappdialog.cpp" line="128" />
+            <source>CANCEL</source>
+            <translation>AVBRYT</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::LiteSyncDialog</name>
+        <message>
+            <location filename="../src/gui/litesyncdialog.cpp" line="91" />
+            <source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are "online". Add them in the list below to avoid this behaviour.</source>
+            <translation>Vissa appar (säkerhetskopieringsappar, antivirusprogram...) får åtkomst till dina filer, vilket gör att de laddas ner när de är ”uppkopplade”. Lägg till dem i listan nedan för att undvika detta.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/litesyncdialog.cpp" line="103" />
+            <source>Add</source>
+            <translation>Lägg till</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/litesyncdialog.cpp" line="115" />
+            <source>APPLICATION ID</source>
+            <translation>APPLIKATIONS-ID</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/litesyncdialog.cpp" line="120" />
+            <source>NAME</source>
+            <translation>NAMN</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/litesyncdialog.cpp" line="154" />
+            <source>SAVE</source>
+            <translation>SPARA</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/litesyncdialog.cpp" line="161" />
+            <source>CANCEL</source>
+            <translation>AVBRYT</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/litesyncdialog.cpp" line="295" />
+            <source>Do you want to save your modifications?</source>
+            <translation>Vill du spara dina ändringar?</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/litesyncdialog.cpp" line="337" />
+            <source>Do you really want to delete?</source>
+            <translation>Vill du verkligen ta bort det?</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/litesyncdialog.cpp" line="374" />
+            <source>Cannot save changes!</source>
+            <translation>Det går inte att spara ändringarna!</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::LocalFolderDialog</name>
+        <message>
+            <location filename="../src/gui/localfolderdialog.cpp" line="63" />
+            <source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
+            <translation>Vilken mapp på din dator vill du&lt;br&gt;synkronisera?</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/localfolderdialog.cpp" line="72" />
+            <source>The content of this folder will be synchronized on the kDrive</source>
+            <translation>Innehållet i den här mappen kommer att synkroniseras på kDrive</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/localfolderdialog.cpp" line="91" />
+            <source>Select a folder</source>
+            <translation>Välj en mapp</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/localfolderdialog.cpp" line="131" />
+            <source>Edit folder</source>
+            <translation>Ändra mapp</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/localfolderdialog.cpp" line="166" />
+            <source>CANCEL</source>
+            <translation>AVBRYT</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/localfolderdialog.cpp" line="173" />
+            <source>CONTINUE</source>
+            <translation>FORTSÄTT</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/localfolderdialog.cpp" line="210" />
+            <source>This folder is not compatible with Lite Sync.&lt;br&gt;
+Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt;
+&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+            <translation>Den här mappen är inte kompatibel med Lite Sync.&lt;br&gt;
+Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&gt;
+
+&lt;a style="%1" href="%2"&gt;Läs mer&lt;/a&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/localfolderdialog.cpp" line="233" />
+            <source>Select folder</source>
+            <translation>Välj mapp</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/localfolderdialog.cpp" line="292" />
+            <source>Unable to open link %1.</source>
+            <translation>Det går inte att öppna länken %1.</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::Logger</name>
+        <message>
+            <location filename="../src/libcommongui/logger.cpp" line="189" />
+            <source>Error</source>
+            <translation>Fel</translation>
+        </message>
+        <message>
+            <location filename="../src/libcommongui/logger.cpp" line="189" />
+            <source>&lt;nobr&gt;File '%1'&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
+            <translation>&lt;nobr&gt;Filen &amp;#x27;%1&amp;#x27;&lt;br/&gt;kan inte öppnas för skrivning.&lt;br/&gt;&lt;br/&gt;Logginformationen kan &lt;b&gt;inte&lt;/b&gt; sparas!&lt;/nobr&gt;</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::MainMenuBarWidget</name>
+        <message>
+            <location filename="../src/gui/mainmenubarwidget.cpp" line="115" />
+            <source>Preferences</source>
+            <translation>Inställningar</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/mainmenubarwidget.cpp" line="116" />
+            <source>Help</source>
+            <translation>Hjälp</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::ParametersDialog</name>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="1082" />
+            <source>Unable to open folder path %1.</source>
+            <translation>Det går inte att öppna mappsökvägen %1.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="1096" />
+            <source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
+            <translation>Överföringen är klar!&lt;br&gt;Ange referensnummer &lt;b&gt;%1&lt;/b&gt; i felrapporter.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="1118" />
+            <source>No kDrive configured!</source>
+            <translation>kDrive är inte konfigurerat!</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="1097" />
+            <source>Transmission failed!
+Please, use the following link to send the logs to the support: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</source>
+            <translation>Överföringen misslyckades!
+Använd följande länk för att skicka loggfilerna till supporten: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="337" />
+            <location filename="../src/gui/parametersdialog.cpp" line="440" />
+            <location filename="../src/gui/parametersdialog.cpp" line="506" />
+            <location filename="../src/gui/parametersdialog.cpp" line="546" />
+            <location filename="../src/gui/parametersdialog.cpp" line="560" />
+            <source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+            <translation>Ett tekniskt fel har uppstått (fel %1).&lt;br&gt;Rensa historiken och kontakta vår support om felet kvarstår.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="342" />
+            <source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
+            <translation>Det verkar som om tidsgränsen för din nätverksanslutning är inställd på ett för lågt värde för att programmet ska fungera korrekt (fel %1).&lt;br&gt;Kontrollera din nätverkskonfiguration.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="347" />
+            <location filename="../src/gui/parametersdialog.cpp" line="516" />
+            <source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
+            <translation>Det går inte att ansluta till kDrive-servern (fel %1).&lt;br&gt;Försöker ansluta igen. Kontrollera din internetanslutning och din brandvägg.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="352" />
+            <source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
+            <translation>Ett inloggningsproblem har uppstått (fel %1).&lt;br&gt;Logga in igen. Om felet kvarstår, kontakta vår support.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="356" />
+            <source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
+            <translation>En ny version av appen finns tillgänglig. Uppdatera&lt;br&gt;appen för att kunna fortsätta använda den.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="360" />
+            <source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
+            <translation>Uppladdningen av loggen misslyckades (fel %1).&lt;br&gt;Försök igen senare.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="385" />
+            <source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
+            <translation>Synkroniseringsmappen är inte längre tillgänglig (fel %1).&lt;br&gt;Synkroniseringen återupptas så snart mappen blir tillgänglig.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="532" />
+            <source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
+            <translation>Synkroniseringsmappen har ersatts eller flyttats på ett sätt som förhindrar synkronisering (fel %1).&lt;br&gt;Detta kan inträffa efter att mappen har kopierats, flyttats eller återställts.&lt;br&gt;För att åtgärda detta, skapa en ny synkronisering med en ny mapp.&lt;br&gt;Obs! Om det finns osynkroniserade ändringar i den gamla mappen måste du kopiera dem manuellt till den nya.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="397" />
+            <source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
+            <translation>Det finns inte tillräckligt med minne kvar på din dator.&lt;br&gt;Synkroniseringen har avbrutits.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="320" />
+            <source>kDrive needs to have write access to your computer's temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
+            <translation>kDrive måste ha skrivbehörighet till datorns temporära katalog.&lt;br&gt;Starta om kDrive-appen för att lösa problemet.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="330" />
+            <location filename="../src/gui/parametersdialog.cpp" line="487" />
+            <source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+            <translation>Ett tekniskt fel har uppstått.&lt;br&gt;Synkroniseringen återupptas så snart som möjligt. Kontakta vår support om felet kvarstår.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="401" />
+            <source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing '/etc/sysctl.conf'.</source>
+            <translation>Antalet inotify-övervakningar är otillräckligt (fel %1).&lt;br&gt;Du kan öka detta antal genom att redigera filen &amp;#x27;/etc/sysctl.conf&amp;#x27;.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="406" />
+            <source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
+            <translation>Det går inte att starta synkroniseringen (fel %1).&lt;br&gt;Du måste ge behörighet till:&lt;br&gt;– kDrive i Systeminställningar &amp;gt;&amp;gt; Allmänt &amp;gt;&amp;gt; Inloggningsobjekt och tillägg &amp;gt;&amp;gt; Tillägg för&lt;br&gt;Endpoint Security– kDrive LiteSync-tillägget i Systeminställningar &amp;gt;&amp;gt; Sekretess och säkerhet &amp;gt;&amp;gt; Fullständig disktillgång.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="419" />
+            <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+            <translation>Det går inte att starta tillägget Lite Sync (fel %1).&lt;br&gt;Kontrollera att tillägget Lite Sync är installerat och att tjänsten Windows Search är aktiverad.&lt;br&gt;Rensa historiken, starta om datorn och kontakta vår support om felet kvarstår.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="424" />
+            <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+            <translation>Det går inte att starta tillägget Lite Sync (fel %1).&lt;br&gt;Kontrollera att tillägget Lite Sync har rätt behörigheter och är igång.&lt;br&gt;Rensa historiken, starta om och kontakta vår support om felet kvarstår.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="429" />
+            <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+            <translation>Det går inte att starta Lite Sync-tillägget (fel %1).&lt;br&gt;Rensa historiken, starta om och kontakta vår support om felet kvarstår.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="435" />
+            <source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
+            <translation>En fil eller mapp i din synkroniseringsmapp verkar vara skadad.&lt;br&gt;Synkroniseringen har avbrutits.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="449" />
+            <source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+            <translation>kDrive är i underhållsläge.&lt;br&gt;Synkroniseringen kommer att återupptas så snart som möjligt. Kontakta vår support om felet kvarstår.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="455" />
+            <source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+            <translation>kDrive är blockerat.&lt;br&gt;Förnya kDrive. Om inga åtgärder vidtas kommer uppgifterna att raderas permanent och det går inte att återställa dem.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="460" />
+            <source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+            <translation>kDrive är spärrat.&lt;br&gt;Kontakta en administratör för att återställa kDrive. Om inga åtgärder vidtas kommer uppgifterna att raderas permanent och det går inte att återställa dem.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="466" />
+            <source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+            <translation>kDrive startar upp.&lt;br&gt;Synkroniseringen kommer att återupptas så snart som möjligt. Kontakta vår support om felet kvarstår.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="475" />
+            <source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
+            <translation>kDrive är inaktivt.&lt;br&gt;Logga in på &lt;a style="%1" href="%2"&gt;web&lt;/a&gt;bversionen för att kontrollera statusen för ditt kDrive, eller kontakta din administratör.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="479" />
+            <source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive's status, or contact your administrator.</source>
+            <translation>kDrive är inaktivt.&lt;br&gt;Logga in på webbversionen för att kontrollera statusen för ditt kDrive, eller kontakta din administratör.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="483" />
+            <source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
+            <translation>Du har inte behörighet att komma åt denna kDrive.&lt;br&gt;Synkroniseringen har pausats. Kontakta en administratör.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="493" />
+            <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+            <translation>Ett tekniskt fel har uppstått (fel %1).&lt;br&gt;Synkroniseringen återupptas så snart som möjligt. Kontakta vår support om felet kvarstår.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="512" />
+            <source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+            <translation>Nätverksanslutningarna har avbrutits av kärnan (fel %1).&lt;br&gt;Rensa historiken och kontakta vår support om felet kvarstår.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="522" />
+            <source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
+            <translation>Tyvärr gick det inte att överföra din gamla konfiguration.&lt;br&gt;Programmet kommer att använda en tom konfiguration.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="526" />
+            <source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
+            <translation>Tyvärr gick det inte att överföra din gamla proxykonfiguration, eftersom SOCKS5-proxyservrar inte stöds för närvarande.&lt;br&gt;Programmet kommer istället att använda systemets proxyinställningar.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="539" />
+            <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
+            <translation>Ett tekniskt fel har uppstått (fel %1).&lt;br&gt;Synkroniseringen har startats om. Rensa historiken och kontakta vår support om felet kvarstår.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="550" />
+            <source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
+            <translation>Ett fel har uppstått vid åtkomst till synkroniseringsdatabasen (fel %1).&lt;br&gt;Synkroniseringen har avbrutits.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="564" />
+            <source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
+            <translation>Ett inloggningsproblem har uppstått (fel %1).&lt;br&gt;Tokenet är ogiltigt eller har återkallats.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="569" />
+            <source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
+            <translation>Nästlade synkroniseringar är inte tillåtna (fel %1).&lt;br&gt;Du bör endast behålla synkroniseringar där mapparna inte är nästlade.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="573" />
+            <source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
+            <translation>Synkroniseringsmappen på den fjärranslutna kDrive-enheten finns inte längre eller är inte längre tillgänglig (fel %1).&lt;br&gt;Du måste återställa den, återställa åtkomsträttigheterna eller ta bort och skapa synkroniseringen på nytt.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="580" />
+            <source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
+            <translation>Fel vid tolkning av filnamn (fel %1).&lt;br&gt;Specialtecken som dubbla citattecken, bakstreck eller radbrytningar kan orsaka fel vid tolkningen.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="722" />
+            <source>You are not allowed to move item to "%1".&lt;br&gt;It will be restored into its original parent folder.</source>
+            <translation>Du får inte flytta objektet till &amp;quot;%1&amp;quot;.&lt;br&gt;Det kommer att återställas till sin ursprungliga överordnade mapp.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="814" />
+            <source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
+            <translation>Det finns inte tillräckligt med utrymme kvar på din dator.&lt;br&gt;Nedladdningen har avbrutits.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="609" />
+            <source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
+            <translation>Denna komponent har flyttats till en annan plats.&lt;br&gt;Den lokala åtgärden har avbrutits.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="618" />
+            <source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
+            <translation>Det finns redan ett element med samma namn på den här platsen.&lt;br&gt;Det lokala elementet har bytt namn.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="614" />
+            <source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
+            <translation>Det finns redan ett element med samma namn på den här platsen.&lt;br&gt;Den lokala åtgärden har avbrutits.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="393" />
+            <source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
+            <translation>Det finns inte tillräckligt med utrymme kvar på din dator.&lt;br&gt;Synkroniseringen har avbrutits.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="622" />
+            <source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
+            <translation>Filen redigerades samtidigt av en annan användare.&lt;br&gt;Dina ändringar har sparats i en kopia.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="626" />
+            <source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
+            <translation>En annan användare har flyttat en överordnad mapp till målplatsen.&lt;br&gt;Den lokala åtgärden har avbrutits.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="692" />
+            <source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
+            <translation>Artikelnamnet innehåller endast mellanslag.&lt;br&gt;Det har tillfälligt lagts till på svartlistan.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="703" />
+            <source>Either you are not allowed to create an item, or another item already exists with the same name.&lt;br&gt;The item has been excluded from synchronization.</source>
+            <translation>Antingen har du inte behörighet att skapa ett objekt, eller så finns det redan ett objekt med samma namn.&lt;br&gt;Objektet har undantagits från synkroniseringen.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="708" />
+            <source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
+            <translation>Du har inte behörighet att redigera objektet.&lt;br&gt;Filen med dina ändringar har bytt namn och har undantagits från synkroniseringen.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="716" />
+            <source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
+            <translation>Du får inte byta namn på objektet.&lt;br&gt;Det återställs till sitt ursprungliga namn.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="727" />
+            <source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
+            <translation>Du får inte ta bort objektet.&lt;br&gt;Det återställs till sin ursprungliga plats.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="732" />
+            <source>Failed to move this item to trash, it has been blacklisted.</source>
+            <translation>Det gick inte att flytta objektet till papperskorgen; det har lagts till i svartlistan.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="748" />
+            <source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
+            <translation>Filen har ändrats lokalt samtidigt som den har raderats på den fjärranslutna kDrive-enheten. En&lt;br&gt;lokal kopia har sparats i räddningsmappen.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="765" />
+            <source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
+            <translation>Den åtgärd som utförts på objektet är inte tillåten.&lt;br&gt;Objektet har tillfälligt lagts till i svartlistan.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="771" />
+            <source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
+            <translation>Åtgärden som utfördes på detta objekt misslyckades.&lt;br&gt;Objektet har tillfälligt lagts till i svartlistan.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="776" />
+            <source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
+            <translation>Filen är för stor för att laddas upp. Den har tillfälligt blockerats.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="782" />
+            <source>Impossible to download the file.</source>
+            <translation>Det går inte att ladda ner filen.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="779" />
+            <source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
+            <translation>Du har överskridit din kvot. Öka din lagringskvot för att återaktivera filuppladdning.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="389" />
+            <source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
+            <translation>Enheten som innehåller din synkroniseringsmapp är inte längre ansluten (fel %1).&lt;br&gt;Anslut den igen för att återuppta synkroniseringen.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="413" />
+            <source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
+            <translation>Det går inte att starta synkroniseringen (fel %1).&lt;br&gt;Processen LiteSyncExt körs inte just nu. Synkroniseringen återupptas så snart processen har startats.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="649" />
+            <source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
+            <translation>Ett befintligt objekt har ett identiskt namn med samma versaler och gemener.&lt;br&gt;Det har tillfälligt blockerats.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="656" />
+            <source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
+            <translation>Produktnamnet innehåller ett tecken som inte stöds.&lt;br&gt;Det har tillfälligt blockerats.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="662" />
+            <source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+            <translation>Objektnamnet slutar med ett mellanslag, vilket inte är tillåtet i ditt operativsystem.&lt;br&gt;Det har tillfälligt lagts till i svartlistan.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="668" />
+            <source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+            <translation>Det här objektnamnet är reserverat av ditt operativsystem.&lt;br&gt;Det har tillfälligt lagts till i svartlistan.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="674" />
+            <source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
+            <translation>Artikelnamnet är för långt.&lt;br&gt;Det har tillfälligt blockerats.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="680" />
+            <source>The item path is too long.&lt;br&gt;It has been ignored.</source>
+            <translation>Sökvägen är för lång.&lt;br&gt;Den har ignorerats.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="686" />
+            <source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+            <translation>Objektnamnet innehåller ett nytt Unicode-tecken som ännu inte stöds av ditt filsystem.&lt;br&gt;Det har uteslutits från synkroniseringen.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="735" />
+            <source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
+            <translation>Det gick inte att synkronisera det här objektet. Det har tillfälligt lagts till i svartlistan.&lt;br&gt;Ett nytt försök att synkronisera det kommer att göras om en timme eller nästa gång programmet startas.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="740" />
+            <source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
+            <translation>Denna post har undantagits från synkroniseringen genom en anpassad mall.&lt;br&gt;Du kan inaktivera denna typ av avisering under Inställningar</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="745" />
+            <source>This item has been excluded from sync because it is a hard link.</source>
+            <translation>Den här posten har uteslutits från synkroniseringen eftersom det är en hård länk.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="785" />
+            <source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
+            <translation>Den här artikeln är för närvarande upptagen av en annan användare som är inloggad.&lt;br&gt;Vi försöker ladda upp dina ändringar igen senare.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="790" />
+            <location filename="../src/gui/parametersdialog.cpp" line="834" />
+            <source>Synchronization error.</source>
+            <translation>Synkroniseringsfel.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="810" />
+            <source>Can't access item.&lt;br&gt;Please fix the read and write permissions.</source>
+            <translation>Det går inte att komma åt objektet.&lt;br&gt;Kontrollera läs- och skrivbehörigheterna.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="818" />
+            <source>System error.</source>
+            <translation>Systemfel.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="825" />
+            <source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
+            <translation>Objektet finns redan på den andra sidan.&lt;br&gt;Det har tillfälligt blockerats.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="840" />
+            <source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+            <translation>Ett tekniskt fel har uppstått.&lt;br&gt;Rensa historiken och kontakta vår support om felet kvarstår.</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::PreferencesBlocWidget</name>
+        <message>
+            <location filename="../src/gui/preferencesblocwidget.cpp" line="187" />
+            <source>This synchronization is being deleted.</source>
+            <translation>Denna synkronisering raderas.</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::PreferencesMenuBarWidget</name>
+        <message>
+            <location filename="../src/gui/preferencesmenubarwidget.cpp" line="63" />
+            <source>Back to drive list</source>
+            <translation>Tillbaka till listan över körningar</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferencesmenubarwidget.cpp" line="64" />
+            <source>Preferences</source>
+            <translation>Inställningar</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::PreferencesWidget</name>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="491" />
+            <source>General</source>
+            <translation>Allmänt</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="493" />
+            <source>Activate dark theme</source>
+            <translation>Aktivera mörkt tema</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="495" />
+            <source>Activate monochrome icons</source>
+            <translation>Aktivera monokroma ikoner</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="496" />
+            <source>Launch kDrive at startup</source>
+            <translation>Starta kDrive vid uppstart</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="516" />
+            <source>Advanced</source>
+            <translation>Avancerat</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="517" />
+            <source>Debugging information</source>
+            <translation>Felsökningsinformation</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="519" />
+            <source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
+            <translation>&lt;a style="%1" href="%2"&gt;Öppna felsökningsmappen&lt;/a&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="520" />
+            <source>Files to exclude</source>
+            <translation>Filer att exkludera</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="521" />
+            <source>Proxy server</source>
+            <translation>Proxyserver</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="511" />
+            <source>Swedish</source>
+            <translation>Svenska</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="466" />
+            <source>Unable to open folder %1.</source>
+            <translation>Det går inte att öppna mappen %1.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="478" />
+            <source>Unable to open link %1.</source>
+            <translation>Det går inte att öppna länken %1.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="483" />
+            <source>Invalid link %1.</source>
+            <translation>Ogiltig länk %1.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="523" />
+            <source>Lite Sync</source>
+            <translation>Lite Sync</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="497" />
+            <source>Language</source>
+            <translation>Språk</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="490" />
+            <source>Some process failed to run.</source>
+            <translation>Någon process kunde inte köras.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="498" />
+            <source>Move deleted files to my computer's trash</source>
+            <translation>Flytta borttagna filer till datorns papperskorg</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="499" />
+            <source>Some files or folders may not be moved to the computer's trash.</source>
+            <translation>Vissa filer eller mappar kanske inte kan flyttas till datorns papperskorg.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="500" />
+            <source>You can always retrieve already synced files from the kDrive web application trash.</source>
+            <translation>Du kan alltid återställa redan synkroniserade filer från papperskorgen i kDrives webbapp.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="502" />
+            <source>&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+            <translation>&lt;a style="%1" href="%2"&gt;Läs mer&lt;/a&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="506" />
+            <source>English</source>
+            <translation>Engelska</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="507" />
+            <source>French</source>
+            <translation>Franska</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="508" />
+            <source>German</source>
+            <translation>Tyska</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="509" />
+            <source>Spanish</source>
+            <translation>Spanska</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="510" />
+            <source>Italian</source>
+            <translation>Italienska</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="505" />
+            <source>Default</source>
+            <translation>Standard</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::ProgressBarWidget</name>
+        <message>
+            <location filename="../src/gui/progressbarwidget.cpp" line="70" />
+            <source>%1 in use</source>
+            <translation>%1 används</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::ProxyServerDialog</name>
+        <message>
+            <location filename="../src/gui/proxyserverdialog.cpp" line="50" />
+            <source>HTTP(S) Proxy</source>
+            <translation>HTTP(S)-proxy</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/proxyserverdialog.cpp" line="73" />
+            <source>Proxy server</source>
+            <translation>Proxyserver</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/proxyserverdialog.cpp" line="85" />
+            <source>No proxy server</source>
+            <translation>Ingen proxyserver</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/proxyserverdialog.cpp" line="90" />
+            <source>Use system parameters</source>
+            <translation>Använd systemparametrar</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/proxyserverdialog.cpp" line="95" />
+            <source>Indicate a proxy manually</source>
+            <translation>Ange en fullmaktsinnehavare manuellt</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/proxyserverdialog.cpp" line="131" />
+            <source>Port</source>
+            <translation>Hamn</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/proxyserverdialog.cpp" line="144" />
+            <source>Address of the proxy server</source>
+            <translation>Proxyserverns adress</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/proxyserverdialog.cpp" line="150" />
+            <source>Authentication needed</source>
+            <translation>Inloggning krävs</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/proxyserverdialog.cpp" line="165" />
+            <source>User</source>
+            <translation>Användare</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/proxyserverdialog.cpp" line="171" />
+            <source>Password</source>
+            <translation>Lösenord</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/proxyserverdialog.cpp" line="185" />
+            <source>SAVE</source>
+            <translation>SPARA</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/proxyserverdialog.cpp" line="192" />
+            <source>CANCEL</source>
+            <translation>AVBRYT</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/proxyserverdialog.cpp" line="286" />
+            <source>Do you want to save your modifications?</source>
+            <translation>Vill du spara dina ändringar?</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/proxyserverdialog.cpp" line="295" />
+            <source>Unable to save, all mandatory fields are not completed!</source>
+            <translation>Det går inte att spara, eftersom alla obligatoriska fält inte är ifyllda!</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/proxyserverdialog.cpp" line="316" />
+            <source>Proxy not found, save anyway?</source>
+            <translation>Proxy hittades inte, vill du spara ändå?</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::ResourcesManagerDialog</name>
+        <message>
+            <location filename="../src/gui/resourcesmanagerdialog.cpp" line="55" />
+            <source>Resources Manager</source>
+            <translation>Resursansvarig</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/resourcesmanagerdialog.cpp" line="65" />
+            <source>Maximum CPU usage allowed</source>
+            <translation>Högsta tillåtna CPU-användning</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/resourcesmanagerdialog.cpp" line="96" />
+            <source>SAVE</source>
+            <translation>SPARA</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/resourcesmanagerdialog.cpp" line="103" />
+            <source>CANCEL</source>
+            <translation>AVBRYT</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/resourcesmanagerdialog.cpp" line="122" />
+            <source>Do you want to save your modifications?</source>
+            <translation>Vill du spara dina ändringar?</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::ServerBaseFolderDialog</name>
+        <message>
+            <location filename="../src/gui/serverbasefolderdialog.cpp" line="81" />
+            <source>Select a folder on your kDrive</source>
+            <translation>Välj en mapp på din kDrive</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/serverbasefolderdialog.cpp" line="90" />
+            <source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
+            <translation>Innehållet i den valda mappen kommer att synkroniseras till mappen &lt;b&gt;%1&lt;/b&gt;.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/serverbasefolderdialog.cpp" line="134" />
+            <source>CONTINUE</source>
+            <translation>FORTSÄTT</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/serverbasefolderdialog.cpp" line="150" />
+            <source>Space available on your computer for the current folder : %1</source>
+            <translation>Ledig utrymme på din dator för den aktuella mappen: %1</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/serverbasefolderdialog.cpp" line="190" />
+            <source>This folder is already being synced.</source>
+            <translation>Den här mappen synkroniseras redan.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/serverbasefolderdialog.cpp" line="204" />
+            <source>CONFIRM</source>
+            <translation>BEKRÄFTA</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/serverbasefolderdialog.cpp" line="205" />
+            <source>CANCEL</source>
+            <translation>AVBRYT</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::ServerFoldersDialog</name>
+        <message>
+            <location filename="../src/gui/serverfoldersdialog.cpp" line="80" />
+            <source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
+            <translation>Mappen &lt;b&gt;%1&lt;/b&gt; innehåller undermappar.&lt;br&gt; Välj de som du vill synkronisera</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/serverfoldersdialog.cpp" line="110" />
+            <source>CONTINUE</source>
+            <translation>FORTSÄTT</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/serverfoldersdialog.cpp" line="146" />
+            <source>No subfolders currently on the server.</source>
+            <translation>Det finns för närvarande inga undermappar på servern.</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::StatusBarWidget</name>
+        <message>
+            <location filename="../src/gui/statusbarwidget.cpp" line="178" />
+            <source>Resume kDrive "%1" synchronization</source>
+            <translation>Återuppta synkroniseringen av kDrive &amp;quot;%1&amp;quot;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/statusbarwidget.cpp" line="180" />
+            <source>Resume all kDrives synchronization</source>
+            <translation>Återuppta all synkronisering av kDrives</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/statusbarwidget.cpp" line="183" />
+            <source>Pause kDrive "%1" synchronization</source>
+            <translation>Avbryt synkroniseringen av kDrive &amp;quot;%1&amp;quot;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/statusbarwidget.cpp" line="184" />
+            <location filename="../src/gui/statusbarwidget.cpp" line="321" />
+            <source>Pause synchronization</source>
+            <translation>Pausa synkroniseringen</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/statusbarwidget.cpp" line="185" />
+            <source>Pause all kDrives synchronization</source>
+            <translation>Pausa all synkronisering av kDrives</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/statusbarwidget.cpp" line="179" />
+            <location filename="../src/gui/statusbarwidget.cpp" line="322" />
+            <source>Resume synchronization</source>
+            <translation>Fortsätt synkroniseringen</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::SynchronizedItemWidget</name>
+        <message>
+            <location filename="../src/gui/synchronizeditemwidget.cpp" line="333" />
+            <source>Copy share link</source>
+            <translation>Kopiera delningslänken</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synchronizeditemwidget.cpp" line="342" />
+            <source>Display on kdrive.infomaniak.com</source>
+            <translation>Visas på kdrive.infomaniak.com</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synchronizeditemwidget.cpp" line="387" />
+            <source>Show in folder</source>
+            <translation>Visa i mappen</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synchronizeditemwidget.cpp" line="388" />
+            <source>More actions</source>
+            <translation>Fler åtgärder</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synchronizeditemwidget.cpp" line="317" />
+            <source>Open</source>
+            <translation>Öppna</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synchronizeditemwidget.cpp" line="325" />
+            <source>Add to favorites</source>
+            <translation>Lägg till i favoriter</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::SynthesisBar</name>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="495" />
+            <location filename="../src/gui/synthesisbar.cpp" line="502" />
+            <source>Never</source>
+            <translation>Aldrig</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="496" />
+            <source>During 1 hour</source>
+            <translation>Under 1 timme</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="497" />
+            <location filename="../src/gui/synthesisbar.cpp" line="504" />
+            <source>Until tomorrow 8:00AM</source>
+            <translation>Fram till imorgon kl. 08.00</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="498" />
+            <source>During 3 days</source>
+            <translation>Under tre dagar</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="499" />
+            <source>During 1 week</source>
+            <translation>Under en vecka</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="500" />
+            <location filename="../src/gui/synthesisbar.cpp" line="507" />
+            <source>Always</source>
+            <translation>Alltid</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="503" />
+            <source>For 1 more hour</source>
+            <translation>I ytterligare 1 timme</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="505" />
+            <source>For 3 more days</source>
+            <translation>I ytterligare 3 dagar</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="506" />
+            <source>For 1 more week</source>
+            <translation>Ytterligare en vecka</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="149" />
+            <source>Unable to open folder url %1.</source>
+            <translation>Det går inte att öppna mappen med adressen %1.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="219" />
+            <source>Open in folder</source>
+            <translation>Öppna i mappen</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="257" />
+            <source>Open %1 web version</source>
+            <translation>Öppna webbversionen av %1</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="267" />
+            <source>Drive parameters</source>
+            <translation>Drivparametrar</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="280" />
+            <source>Notifications disabled until %1</source>
+            <translation>Meddelanden är inaktiverade fram till %1</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="281" />
+            <source>Disable Notifications</source>
+            <translation>Inaktivera aviseringar</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="314" />
+            <source>Application preferences</source>
+            <translation>Inställningar för applikationen</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="322" />
+            <source>Need help</source>
+            <translation>Behöver du hjälp?</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="330" />
+            <source>Send feedbacks</source>
+            <translation>Skicka synpunkter</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="338" />
+            <source>Quit kDrive</source>
+            <translation>Avsluta kDrive</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="401" />
+            <source>Unable to access web site %1.</source>
+            <translation>Det går inte att komma åt webbplatsen %1.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="492" />
+            <source>Show errors and informations</source>
+            <translation>Visa fel och information</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="493" />
+            <source>Show informations</source>
+            <translation>Visa information</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="494" />
+            <source>More actions</source>
+            <translation>Fler åtgärder</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::SynthesisPopover</name>
+        <message>
+            <location filename="../src/gui/synthesispopover.cpp" line="1181" />
+            <source>Update kDrive App</source>
+            <translation>Uppdatera kDrive-appen</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesispopover.cpp" line="1182" />
+            <source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
+            <translation>Denna version av kDrive-appen stöds inte längre. Uppdatera appen för att få tillgång till de senaste funktionerna och förbättringarna.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesispopover.cpp" line="978" />
+            <source>Update</source>
+            <translation>Uppdatering</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesispopover.cpp" line="1187" />
+            <source>Please download the latest version on the website.</source>
+            <translation>Ladda gärna ner den senaste versionen från webbplatsen.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesispopover.cpp" line="981" />
+            <source>Update download in progress</source>
+            <translation>Uppdateringen hämtas just nu</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesispopover.cpp" line="984" />
+            <source>Looking for update...</source>
+            <translation>Väntar på uppdatering...</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesispopover.cpp" line="987" />
+            <source>Manual update</source>
+            <translation>Manuell uppdatering</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesispopover.cpp" line="990" />
+            <source>Unavailable</source>
+            <translation>Ej tillgängligt</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesispopover.cpp" line="1200" />
+            <source>You can synchronize files &lt;a style="%1" href="%2"&gt;from your computer&lt;/a&gt; or on &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
+            <translation>Du kan synkronisera filer &lt;a style="%1" href="%2"&gt;från din dator&lt;/a&gt; eller från &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesispopover.cpp" line="446" />
+            <source>Synchronized</source>
+            <translation>Synkroniserad</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesispopover.cpp" line="450" />
+            <source>Favorites</source>
+            <translation>Favoriter</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesispopover.cpp" line="454" />
+            <source>Activity</source>
+            <translation>Aktivitet</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesispopover.cpp" line="1133" />
+            <location filename="../src/gui/synthesispopover.cpp" line="1180" />
+            <source>Not implemented!</source>
+            <translation>Har inte implementerats!</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesispopover.cpp" line="1184" />
+            <source>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Click here to download manually&lt;/a&gt;</source>
+            <translation>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Klicka här för att ladda ner manuellt&lt;/a&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesispopover.cpp" line="1193" />
+            <source>No synchronized folder for this Drive!</source>
+            <translation>Det finns ingen synkroniserad mapp för den här Drive-kontot!</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesispopover.cpp" line="1196" />
+            <source>No kDrive configured!</source>
+            <translation>kDrive är inte konfigurerat!</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesispopover.cpp" line="1161" />
+            <source>Unable to open link %1.</source>
+            <translation>Det går inte att öppna länken %1.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesispopover.cpp" line="1173" />
+            <source>Invalid link %1.</source>
+            <translation>Ogiltig länk %1.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesispopover.cpp" line="586" />
+            <source>Unable to open folder url %1.</source>
+            <translation>Det går inte att öppna mappen med adressen %1.</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::UpdateDialog</name>
+        <message>
+            <location filename="../src/gui/updater/updatedialog.cpp" line="61" />
+            <source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
+            <translation>&lt;p&gt;Den nya versionen &lt;b&gt;%1&lt;/b&gt; av %2-klienten är tillgänglig och har hämtats.&lt;/p&gt;&lt;p&gt;Den installerade versionen är %3.&lt;/p&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/updater/updatedialog.cpp" line="95" />
+            <source>Skip this version</source>
+            <translation>Hoppa över den här versionen</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/updater/updatedialog.cpp" line="103" />
+            <source>Remind me later</source>
+            <translation>Påminn mig senare</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/updater/updatedialog.cpp" line="109" />
+            <source>Install update</source>
+            <translation>Installera uppdatering</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::UpdateManager</name>
+        <message>
+            <location filename="../src/server/updater/updatemanager.cpp" line="86" />
+            <source>New update available.</source>
+            <translation>En ny uppdatering finns tillgänglig.</translation>
+        </message>
+        <message>
+            <location filename="../src/server/updater/updatemanager.cpp" line="87" />
+            <source>Version %1 is available for download.</source>
+            <translation>Version %1 finns tillgänglig för nedladdning.</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::UserSelectionWidget</name>
+        <message>
+            <location filename="../src/gui/userselectionwidget.cpp" line="131" />
+            <source>Add an account</source>
+            <translation>Lägg till ett konto</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::VersionWidget</name>
+        <message>
+            <location filename="../src/gui/versionwidget.cpp" line="295" />
+            <source>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</source>
+            <translation>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/versionwidget.cpp" line="169" />
+            <source>&lt;a style="%1" href="%2"&gt;Show release note&lt;/a&gt;</source>
+            <translation>&lt;a style="%1" href="%2"&gt;Visa informationsnot&lt;/a&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/versionwidget.cpp" line="172" />
+            <source>Version</source>
+            <translation>Version</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/versionwidget.cpp" line="173" />
+            <source>UPDATE</source>
+            <translation>UPPDATERING</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/versionwidget.cpp" line="197" />
+            <source>%1 is up to date!</source>
+            <translation>%1 är uppdaterad!</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/versionwidget.cpp" line="201" />
+            <source>Checking update on server...</source>
+            <translation>Kontrollerar uppdateringar på servern...</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/versionwidget.cpp" line="205" />
+            <source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style="%2" href="%3"&gt;here&lt;/a&gt;.</source>
+            <translation>En uppdatering finns tillgänglig: %1.&lt;br&gt;Ladda ner den &lt;a style="%2" href="%3"&gt;här&lt;/a&gt;.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/versionwidget.cpp" line="212" />
+            <source>An update is available: %1</source>
+            <translation>En uppdatering finns tillgänglig: %1</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/versionwidget.cpp" line="218" />
+            <source>Downloading %1. Please wait...</source>
+            <translation>Hämtar %1. Vänta...</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/versionwidget.cpp" line="223" />
+            <source>Could not check for new updates.</source>
+            <translation>Det gick inte att söka efter nya uppdateringar.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/versionwidget.cpp" line="227" />
+            <source>An error occurred during update.</source>
+            <translation>Ett fel uppstod under uppdateringen.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/versionwidget.cpp" line="231" />
+            <source>Could not download update.</source>
+            <translation>Det gick inte att ladda ner uppdateringen.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/versionwidget.cpp" line="235" />
+            <source>Update disabled.</source>
+            <translation>Uppdateringen är inaktiverad.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/versionwidget.cpp" line="251" />
+            <source>Beta program</source>
+            <translation>Betaprogram</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/versionwidget.cpp" line="252" />
+            <source>Get early access to new versions of the application</source>
+            <translation>Få tidig tillgång till nya versioner av applikationen</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/versionwidget.cpp" line="256" />
+            <source>Join</source>
+            <translation>Gå med</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/versionwidget.cpp" line="259" />
+            <source>Modify</source>
+            <translation>Ändra</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/versionwidget.cpp" line="259" />
+            <source>Quit</source>
+            <translation>Avsluta</translation>
+        </message>
+    </context>
+    <context>
+        <name>QObject</name>
+        <message>
+            <location filename="../src/gui/parameterscache.cpp" line="59" />
+            <source>Unable to save parameters, please retry later.</source>
+            <translation>Det gick inte att spara parametrarna. Försök igen senare.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parameterscache.cpp" line="60" />
+            <source>Unable to save parameters!</source>
+            <translation>Det går inte att spara parametrarna!</translation>
+        </message>
+        <message>
+            <location filename="../src/server/requests/serverrequests.cpp" line="461" />
+            <source>The parent folder is a sync folder or contained in one</source>
+            <translation>Överordnad mapp är en synkroniseringsmapp eller ingår i en sådan</translation>
+        </message>
+        <message>
+            <location filename="../src/server/requests/serverrequests.cpp" line="495" />
+            <source>Can't find a valid path</source>
+            <translation>Det går inte att hitta en giltig sökväg</translation>
+        </message>
+        <message>
+            <location filename="../src/server/requests/serverrequests.cpp" line="2109" />
+            <source>No valid folder selected!</source>
+            <translation>Ingen giltig mapp har valts!</translation>
+        </message>
+        <message>
+            <location filename="../src/server/requests/serverrequests.cpp" line="2120" />
+            <source>The selected path does not exist!</source>
+            <translation>Den valda sökvägen finns inte!</translation>
+        </message>
+        <message>
+            <location filename="../src/server/requests/serverrequests.cpp" line="2125" />
+            <source>The selected path is not a folder!</source>
+            <translation>Den valda sökvägen är ingen mapp!</translation>
+        </message>
+        <message>
+            <location filename="../src/server/requests/serverrequests.cpp" line="2130" />
+            <source>You have no permission to write to the selected folder!</source>
+            <translation>Du har inte behörighet att skriva till den valda mappen!</translation>
+        </message>
+        <message>
+            <location filename="../src/server/requests/serverrequests.cpp" line="2160" />
+            <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
+            <translation>Den lokala mappen %1 innehåller en mapp som redan är synkroniserad. Välj en annan!</translation>
+        </message>
+        <message>
+            <location filename="../src/server/requests/serverrequests.cpp" line="2168" />
+            <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
+            <translation>Den lokala mappen %1 finns i en mapp som redan är synkroniserad. Välj en annan mapp!</translation>
+        </message>
+        <message>
+            <location filename="../src/server/requests/serverrequests.cpp" line="2176" />
+            <source>The local folder %1 is already synced. Please pick another one!</source>
+            <translation>Den lokala mappen %1 är redan synkroniserad. Välj en annan!</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/folderitemwidget.cpp" line="42" />
+            <source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
+            <translation>Lite sync (Beta) är aktiverat. Filerna från kDrive sparas i molnet och tar inte upp lagringsutrymme på din dator.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/folderitemwidget.cpp" line="45" />
+            <source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
+            <translation>Lite sync (Beta) är inaktiverat. kDrive-filerna använder lagringsutrymmet på din dator.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/folderitemwidget.cpp" line="48" />
+            <source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
+            <translation>Lite-synkronisering är aktiverad. Filerna från kDrive sparas i molnet och tar inte upp lagringsutrymme på din dator.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/folderitemwidget.cpp" line="50" />
+            <source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
+            <translation>Lite sync är inaktiverat. kDrive-filerna använder lagringsutrymmet på din dator.</translation>
+        </message>
+        <message>
+            <location filename="../src/server/comm/extensionjob.cpp" line="1175" />
+            <source>Make available locally</source>
+            <translation>Gör tillgängligt lokalt</translation>
+        </message>
+        <message>
+            <location filename="../src/server/comm/extensionjob.cpp" line="1179" />
+            <source>Free up local space</source>
+            <translation>Frigör lokalt lagringsutrymme</translation>
+        </message>
+        <message>
+            <location filename="../src/server/comm/extensionjob.cpp" line="1183" />
+            <source>Cancel free up local space</source>
+            <translation>Avbryt för att frigöra lokalt utrymme</translation>
+        </message>
+        <message>
+            <location filename="../src/server/comm/extensionjob.cpp" line="1187" />
+            <source>Cancel make available locally</source>
+            <translation>Avbryt lokal tillgängliggöring</translation>
+        </message>
+        <message>
+            <location filename="../src/server/comm/extensionjob.cpp" line="1191" />
+            <source>Resharing this file is not allowed</source>
+            <translation>Det är inte tillåtet att vidarebefordra den här filen</translation>
+        </message>
+        <message>
+            <location filename="../src/server/comm/extensionjob.cpp" line="1192" />
+            <source>Resharing this folder is not allowed</source>
+            <translation>Det är inte tillåtet att dela den här mappen vidare</translation>
+        </message>
+        <message>
+            <location filename="../src/server/comm/extensionjob.cpp" line="1196" />
+            <source>Copy public share link</source>
+            <translation>Kopiera länken till den offentliga delningen</translation>
+        </message>
+        <message>
+            <location filename="../src/server/comm/extensionjob.cpp" line="1200" />
+            <source>Copy private share link</source>
+            <translation>Kopiera länken till den privata delningen</translation>
+        </message>
+        <message>
+            <location filename="../src/server/comm/extensionjob.cpp" line="1204" />
+            <source>Open in browser</source>
+            <translation>Öppna i webbläsaren</translation>
+        </message>
+    </context>
+    <context>
+        <name>SharedTools::QtSingleApplication</name>
+        <message>
+            <location filename="../src/server/appserver.cpp" line="133" />
+            <source>kDrive application will close due to a fatal error.</source>
+            <translation>kDrive-programmet kommer att stängas på grund av ett allvarligt fel.</translation>
+        </message>
+    </context>
+    <context>
+        <name>Utility</name>
+        <message>
+            <location filename="../src/libcommongui/utility/utility.cpp" line="97" />
+            <source>%L1 GB</source>
+            <translation>%L1 GB</translation>
+        </message>
+        <message>
+            <location filename="../src/libcommongui/utility/utility.cpp" line="101" />
+            <source>%L1 MB</source>
+            <translation>%L1 MB</translation>
+        </message>
+        <message>
+            <location filename="../src/libcommongui/utility/utility.cpp" line="105" />
+            <source>%L1 KB</source>
+            <translation>%L1 KB</translation>
+        </message>
+        <message>
+            <location filename="../src/libcommongui/utility/utility.cpp" line="108" />
+            <source>%L1 B</source>
+            <translation>%L1 B</translation>
+        </message>
+        <message numerus="yes">
+            <location filename="../src/libcommongui/utility/utility.cpp" line="41" />
+            <source>%n year(s)</source>
+            <translation>
+                <numerusform>%n år</numerusform>
+                <numerusform>%n år</numerusform>
+            </translation>
+        </message>
+        <message numerus="yes">
+            <location filename="../src/libcommongui/utility/utility.cpp" line="42" />
+            <source>%n month(s)</source>
+            <translation>
+                <numerusform>%n månad</numerusform>
+                <numerusform>%n månader</numerusform>
+            </translation>
+        </message>
+        <message numerus="yes">
+            <location filename="../src/libcommongui/utility/utility.cpp" line="43" />
+            <source>%n day(s)</source>
+            <translation>
+                <numerusform>%n dag</numerusform>
+                <numerusform>%n dagar</numerusform>
+            </translation>
+        </message>
+        <message numerus="yes">
+            <location filename="../src/libcommongui/utility/utility.cpp" line="44" />
+            <source>%n hour(s)</source>
+            <translation>
+                <numerusform>%n timme</numerusform>
+                <numerusform>%n timmar</numerusform>
+            </translation>
+        </message>
+        <message numerus="yes">
+            <location filename="../src/libcommongui/utility/utility.cpp" line="45" />
+            <source>%n minute(s)</source>
+            <translation>
+                <numerusform>%n minut</numerusform>
+                <numerusform>%n minuter</numerusform>
+            </translation>
+        </message>
+        <message numerus="yes">
+            <location filename="../src/libcommongui/utility/utility.cpp" line="46" />
+            <source>%n second(s)</source>
+            <translation>
+                <numerusform>%n sekund</numerusform>
+                <numerusform>%n sekunder</numerusform>
+            </translation>
+        </message>
+    </context>
+    <context>
+        <name>main.cpp</name>
+        <message>
+            <location filename="../src/gui/mainclient.cpp" line="49" />
+            <source>System Tray not available</source>
+            <translation>Systemfältet är inte tillgängligt</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/mainclient.cpp" line="48" />
+            <source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as 'trayer' and try again.</source>
+            <translation>%1 kräver ett fungerande systemfält. Om du använder XFCE, följ &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;dessa instruktioner&lt;/a&gt;. I annat fall bör du installera ett program för systemfältet, till exempel ”trayer”, och försöka igen.</translation>
+        </message>
+    </context>
+    <context>
+        <name>utility</name>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="84" />
+            <source>Could not open browser</source>
+            <translation>Det gick inte att öppna webbläsaren</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="85" />
+            <source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
+            <translation>Det uppstod ett fel när webbläsaren startades för att öppna webbadressen %1. Kanske har ingen standardwebbläsare angetts?</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="104" />
+            <source>Could not open email client</source>
+            <translation>Det gick inte att öppna e-postprogrammet</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="105" />
+            <source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
+            <translation>Det uppstod ett fel när e-postprogrammet startades för att skapa ett nytt meddelande. Kanske har inget standardprogram för e-post konfigurerats?</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="324" />
+            <source>You are not connected anymore. &lt;a style="%1" href="%2"&gt;Log in&lt;/a&gt;</source>
+            <translation>Du är inte inloggad längre. &lt;a style="%1" href="%2"&gt;Logga in&lt;/a&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="347" />
+            <source>Sync in progress (Step %1/%2).</source>
+            <translation>Synkronisering pågår (Steg %1/%2).</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="353" />
+            <source>Sync in progress.</source>
+            <translation>Synkronisering pågår.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="364" />
+            <source>Some files couldn't be synchronized. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+            <translation>Vissa filer kunde inte synkroniseras. &lt;a style="%1" href="%2"&gt;Läs mer&lt;/a&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="370" />
+            <source>Synchronization pausing ...</source>
+            <translation>Synkroniseringen pausas ...</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="570" />
+            <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
+            <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan inte väljas eftersom en annan synkronisering använder samma mapp.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="576" />
+            <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+            <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan inte väljas eftersom den innehåller den synkroniserade mappen &lt;b&gt;%2&lt;/b&gt;.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="584" />
+            <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+            <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan inte väljas eftersom den ingår i den synkroniserade mappen &lt;b&gt;%2&lt;/b&gt;.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="595" />
+            <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
+            <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan inte väljas som synkroniseringsmapp. Välj en annan mapp.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="599" />
+            <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
+            <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan inte väljas som synkroniseringsmapp. Välj en annan mapp. Föreslagen mapp: &lt;b&gt;%2&lt;/b&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="641" />
+            <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
+            <translation>Du har uteslutit mer än %1 mappar. Observera att detta kommer att påverka synkroniseringsprestandan.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="650" />
+            <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
+            <translation>Du kan inte utesluta fler än 1 % av mapparna. Avmarkera mapparna på högre nivå.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="351" />
+            <source>Synchronization starting</source>
+            <translation>Synkroniseringen påbörjas</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="374" />
+            <source>Synchronization paused.</source>
+            <translation>Synkroniseringen har pausats.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="336" />
+            <source>Sync in progress (%1 of %2)</source>
+            <translation>Synkronisering pågår (1 % av 2 %)</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="340" />
+            <source>Sync in progress (%1 of %2)
+%3 left...</source>
+            <translation>Synkronisering pågår (%1 av %2)
+%3 kvar...</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="358" />
+            <source>You are up to date, unresolved conflicts.</source>
+            <translation>Du har aktuella, olösta konflikter.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="360" />
+            <source>You are up to date!</source>
+            <translation>Nu är du uppdaterad!</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="329" />
+            <source>No folder to synchronize
+You can add one from the kDrive settings.</source>
+            <translation>Ingen mapp att synkronisera
+Du kan lägga till en i kDrive-inställningarna.</translation>
+        </message>
+    </context>
+</TS>

--- a/translations/client_sv.ts
+++ b/translations/client_sv.ts
@@ -263,7 +263,7 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210" />
             <source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
-            <translation>Det går inte att ladda listan över undermappar&lt;br&gt;. Din kDrive kan vara under underhåll. Logga in på &lt;a style="%1" href="%2"&gt;web&lt;/a&gt;bversionen för att kontrollera statusen för din kDrive, eller kontakta din administratör.</translation>
+            <translation>Det går inte att ladda listan över undermappar&lt;br&gt;. Din kDrive kan vara under underhåll. Logga in på &lt;a style="%1" href="%2"&gt;webbversionen&lt;/a&gt; för att kontrollera statusen för din kDrive, eller kontakta din administratör.</translation>
         </message>
     </context>
     <context>
@@ -865,7 +865,7 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="497" />
             <source> 3. Share the link with &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
-            <translation> 3. Dela länken med&lt;a style="%1" href="%2"&gt;support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
+            <translation> 3. Dela länken med &lt;a style="%1" href="%2"&gt;support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="527" />
@@ -880,7 +880,7 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <message>
             <location filename="../src/gui/debuggingdialog.h" line="70" />
             <source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
-            <translation>Hela mappen är stor (&amp;gt; 100 MB) och det kan ta en stund att dela den. För att minska delningstiden rekommenderar vi att du endast delar den senaste kDrive-sessionen.</translation>
+            <translation>Hela mappen är stor (&gt; 100 MB) och det kan ta en stund att dela den. För att minska delningstiden rekommenderar vi att du endast delar den senaste kDrive-sessionen.</translation>
         </message>
         <message>
             <location filename="../src/gui/debuggingdialog.cpp" line="600" />
@@ -1644,7 +1644,7 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="406" />
             <source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
-            <translation>Det går inte att starta synkroniseringen (fel %1).&lt;br&gt;Du måste ge behörighet till:&lt;br&gt;– kDrive i Systeminställningar &amp;gt;&amp;gt; Allmänt &amp;gt;&amp;gt; Inloggningsobjekt och tillägg &amp;gt;&amp;gt; Tillägg för&lt;br&gt;Endpoint Security– kDrive LiteSync-tillägget i Systeminställningar &amp;gt;&amp;gt; Sekretess och säkerhet &amp;gt;&amp;gt; Fullständig disktillgång.</translation>
+            <translation>Det går inte att starta synkroniseringen (fel %1).&lt;br&gt;Du måste ge behörighet till:&lt;br&gt;– kDrive i Systeminställningar &gt;&gt; Allmänt &gt;&gt; Inloggningsobjekt och tillägg &gt;&gt; Tillägg för&lt;br&gt;Endpoint Security– kDrive LiteSync-tillägget i Systeminställningar &gt;&gt; Sekretess och säkerhet &gt;&gt; Fullständig disktillgång.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="419" />
@@ -1689,7 +1689,7 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="475" />
             <source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
-            <translation>kDrive är inaktivt.&lt;br&gt;Logga in på &lt;a style="%1" href="%2"&gt;web&lt;/a&gt;bversionen för att kontrollera statusen för ditt kDrive, eller kontakta din administratör.</translation>
+            <translation>kDrive är inaktivt.&lt;br&gt;Logga in på &lt;a style="%1" href="%2"&gt;web&lt;/a&gt;versionen för att kontrollera statusen för ditt kDrive, eller kontakta din administratör.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="479" />
@@ -2987,7 +2987,7 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <message>
             <location filename="../src/gui/guiutility.cpp" line="650" />
             <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
-            <translation>Du kan inte utesluta fler än 1 % av mapparna. Avmarkera mapparna på högre nivå.</translation>
+            <translation>Du kan inte utesluta fler än %1 mappar. Avmarkera mapparna på högre nivå.</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="351" />
@@ -3002,7 +3002,7 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <message>
             <location filename="../src/gui/guiutility.cpp" line="336" />
             <source>Sync in progress (%1 of %2)</source>
-            <translation>Synkronisering pågår (1 % av 2 %)</translation>
+            <translation>Synkronisering pågår (%1 av %2)</translation>
         </message>
         <message>
             <location filename="../src/gui/guiutility.cpp" line="340" />

--- a/translations/update_ui_translations.py
+++ b/translations/update_ui_translations.py
@@ -70,7 +70,7 @@ def fill_missing_translations(git_dir_path, language):
     
     
 
-languages = ["de", "es", "fr", "it", "sv"]
+languages = ["de", "es", "fr", "it", "sv", "pt"]
 
 for language in languages:
     fill_missing_translations(args.git_dir_path, language)

--- a/translations/update_ui_translations.py
+++ b/translations/update_ui_translations.py
@@ -81,7 +81,7 @@ def fill_missing_translations(git_dir_path, language):
     
     
 
-languages = ["de", "es", "fr", "it", "sv", "pt"]
+languages = ["de", "es", "fr", "it", "sv", "pt", "pl"]
 
 for language in languages:
     fill_missing_translations(args.git_dir_path, language)

--- a/translations/update_ui_translations.py
+++ b/translations/update_ui_translations.py
@@ -70,7 +70,7 @@ def fill_missing_translations(git_dir_path, language):
     
     
 
-languages = ["de", "es", "fr", "it"]
+languages = ["de", "es", "fr", "it", "sv"]
 
 for language in languages:
     fill_missing_translations(args.git_dir_path, language)

--- a/translations/update_ui_translations.py
+++ b/translations/update_ui_translations.py
@@ -42,6 +42,15 @@ if not deepl_key:
 
 translator = deepl.Translator(deepl_key)
 
+DEEPL_LANGUAGE_CODES = {
+    "de": "DE",
+    "es": "ES",
+    "fr": "FR",
+    "it": "IT",
+    "sv": "SV",
+    "pt": "PT-PT",
+}
+
 def fill_missing_translations(git_dir_path, language):
     file_name = f"client_{language}.ts"
     file_path = Path(git_dir_path) / "translations" / file_name
@@ -53,12 +62,14 @@ def fill_missing_translations(git_dir_path, language):
 
     print(f"Detecting missing translations in client_{language}.ts ...")
 
+    deepl_target = DEEPL_LANGUAGE_CODES.get(language, language.upper())
+
     for context in contexts:
         messages = context.find_all("message")
         for message in messages:
             if not message.translation.text:
                     source_text = message.source.get_text()
-                    message.translation.string = html.unescape(translator.translate_text(source_text, target_lang=language).text)
+                    message.translation.string = html.unescape(translator.translate_text(source_text, target_lang=deepl_target).text)
                     del message.translation["type"] # Mark translation as finished
                     changes[(message.location.get("filename"), message.location.get("line"))] = message.translation
 


### PR DESCRIPTION
Depends on #1834 

## Summary
- add full Polish Qt translation file (`translations/client_pl.ts`)
- add Polish language support in shared language enum and runtime language mapping
- expose Polish in the desktop preferences language selector
- handle migration of persisted `pl` language value
- extend utility tests for Polish language code and supported-language checks
- update translation tooling and Linux AppImage translation filtering to include Polish
- add `Polish` language label translations in existing locale files (`fr`, `de`, `es`, `it`, `sv`, `pt`, `pl`)

## Validation
- `python3 /tmp/validate_ts_pl.py`
  - `client_pl.ts 557 0 1 pl_PL`
  - `client_pt.ts 557 0 1 pt_PT`
  - `client_fr.ts 557 0 1 fr_FR`
  - `client_de.ts 557 0 1 de_DE`
  - `client_es.ts 557 0 1 es_ES`
  - `client_it.ts 557 0 1 it_IT`
  - `client_sv.ts 557 0 1 sv_SE`
- diagnostics run on touched C++ files: no blocking errors reported

## Notes
- this branch is based on the current Portuguese localization branch state and includes the Polish follow-up commit.

