### PR TITLE
feat(logger): logger now display logs in stdcout in debug mode

### DIFF
--- a/src/libcommon/utility/types.h
+++ b/src/libcommon/utility/types.h
@@ -606,7 +606,6 @@ struct VersionInfo {
         uint64_t buildVersion{0}; // Example: 20240816
         std::string buildMinOsVersion; // Optional. Minimum supported version of the OS. Examples: 10.15, 11, server 2005, ...
         std::string downloadUrl; // URL to download the version
-        std::string checksum; // Verify if the downloaded file is correct, and not corrupted. Uses a SHA-256
 
         bool operator==(const VersionInfo &other) const {
             return channel == other.channel && tag == other.tag && buildVersion == other.buildVersion &&

--- a/src/libcommon/utility/types.h
+++ b/src/libcommon/utility/types.h
@@ -606,6 +606,7 @@ struct VersionInfo {
         uint64_t buildVersion{0}; // Example: 20240816
         std::string buildMinOsVersion; // Optional. Minimum supported version of the OS. Examples: 10.15, 11, server 2005, ...
         std::string downloadUrl; // URL to download the version
+        std::string checksum; // Verify if the downloaded file is correct, and not corrupted. Uses a SHA-256
 
         bool operator==(const VersionInfo &other) const {
             return channel == other.channel && tag == other.tag && buildVersion == other.buildVersion &&
@@ -634,6 +635,7 @@ struct VersionInfo {
             buildVersion = 0;
             buildMinOsVersion.clear();
             downloadUrl.clear();
+            checksum.clear();
         }
 
         static const std::string versionInfoChannel;

--- a/src/libcommon/utility/types.h
+++ b/src/libcommon/utility/types.h
@@ -634,7 +634,6 @@ struct VersionInfo {
             buildVersion = 0;
             buildMinOsVersion.clear();
             downloadUrl.clear();
-            checksum.clear();
         }
 
         static const std::string versionInfoChannel;

--- a/src/libcommongui/logger.cpp
+++ b/src/libcommongui/logger.cpp
@@ -169,7 +169,7 @@ void Logger::doLog(const QString &msg) {
         }
     }
 #ifndef NDEBUG
-    std::cout << qPrintable(msg) << '\n';
+    std::cout << qPrintable(msg) << std::endl;
 #endif
     emit logWindowLog(msg);
 }

--- a/src/libcommongui/logger.cpp
+++ b/src/libcommongui/logger.cpp
@@ -29,11 +29,13 @@
 
 #include <iostream>
 
-#ifdef Q_OS_WIN
-#include <io.h> // for stdout
-#ifndef NDEBUG
+#if defined(KD_WINDOWS)
+#include <io.h>
+#if !defined(NDEBUG)
 #include <windows.h>
 #endif
+#else
+#include <unistd.h>
 #endif
 
 static const int logSizeWatcherTimeout = 60000;
@@ -91,8 +93,8 @@ Logger::Logger(QObject *parent) :
 #if defined(Q_OS_WIN) && !defined(NDEBUG)
     if (AllocConsole()) {
         FILE *fp = nullptr;
-        freopen_s(&fp, "CONOUT$", "w", stdout);
-        freopen_s(&fp, "CONOUT$", "w", stderr);
+        (void) freopen_s(&fp, "CONOUT$", "w", stdout);
+        (void) freopen_s(&fp, "CONOUT$", "w", stderr);
         std::cout.clear();
         std::cerr.clear();
     }

--- a/src/libcommongui/logger.cpp
+++ b/src/libcommongui/logger.cpp
@@ -31,6 +31,9 @@
 
 #ifdef Q_OS_WIN
 #include <io.h> // for stdout
+#ifndef NDEBUG
+#include <windows.h>
+#endif
 #endif
 
 static const int logSizeWatcherTimeout = 60000;
@@ -85,6 +88,15 @@ Logger::Logger(QObject *parent) :
     _doFileFlush(false),
     _logExpire(0),
     _logDebug(false) {
+#if defined(Q_OS_WIN) && !defined(NDEBUG)
+    if (AllocConsole()) {
+        FILE *fp = nullptr;
+        freopen_s(&fp, "CONOUT$", "w", stdout);
+        freopen_s(&fp, "CONOUT$", "w", stderr);
+        std::cout.clear();
+        std::cerr.clear();
+    }
+#endif
     qSetMessagePattern(
             "%{time yyyy-MM-dd hh:mm:ss:zzz} "
             "[%{if-debug}D%{endif}%{if-info}I%{endif}%{if-warning}W%{endif}%{if-critical}C%{endif}%{if-fatal}F%{endif}] "
@@ -154,6 +166,9 @@ void Logger::doLog(const QString &msg) {
             if (_doFileFlush) _logstream->flush();
         }
     }
+#ifndef NDEBUG
+    std::cout << qPrintable(msg) << '\n';
+#endif
     emit logWindowLog(msg);
 }
 

--- a/src/libcommongui/logger.cpp
+++ b/src/libcommongui/logger.cpp
@@ -95,6 +95,9 @@ Logger::Logger(QObject *parent) :
         FILE *fp = nullptr;
         (void) freopen_s(&fp, "CONOUT$", "w", stdout);
         (void) freopen_s(&fp, "CONOUT$", "w", stderr);
+
+        // freopen_s may leave the stream in an error state on failure.
+        // Clear C++ stream flags to ensure std::cout/std::cerr remain usable.
         std::cout.clear();
         std::cerr.clear();
     }

--- a/src/libcommonserver/log/customrollingfileappender.cpp
+++ b/src/libcommonserver/log/customrollingfileappender.cpp
@@ -200,7 +200,7 @@ void CustomRollingFileAppender::append(const log4cplus::spi::InternalLoggingEven
         else
             oss << event.getMessage();
 
-        std::cout << LOG4CPLUS_TSTRING_TO_STRING(oss.str());
+        std::cout << LOG4CPLUS_TSTRING_TO_STRING(oss.str()) << std::flush;
 #endif
     } catch (...) {
         // Bug in gcc => std::filesystem::path wstring is crashing with non ASCII characters

--- a/src/libcommonserver/log/customrollingfileappender.cpp
+++ b/src/libcommonserver/log/customrollingfileappender.cpp
@@ -61,6 +61,9 @@
 #ifdef LOG4CPLUS_HAVE_ERRNO_H
 #include <errno.h>
 #endif
+#ifndef NDEBUG
+#include <iostream>
+#endif
 
 namespace log4cplus {
 
@@ -189,6 +192,11 @@ void CustomRollingFileAppender::append(const log4cplus::spi::InternalLoggingEven
 
     try {
         RollingFileAppender::append(event);
+#ifndef NDEBUG
+        log4cplus::tostringstream oss;
+        layout->formatAndAppend(oss, event);
+        std::cout << LOG4CPLUS_TSTRING_TO_STRING(oss.str());
+#endif
     } catch (...) {
         // Bug in gcc => std::filesystem::path wstring is crashing with non ASCII characters
         // Fixed in next gcc-12 version

--- a/src/libcommonserver/log/customrollingfileappender.cpp
+++ b/src/libcommonserver/log/customrollingfileappender.cpp
@@ -21,7 +21,6 @@
 #include "utility/utility.h"
 #include "io/iohelper.h"
 #include "io/filestat.h"
-#include "utility/utility.h"
 
 /*****************************************/
 /********** namespace log4cplus **********/
@@ -194,7 +193,13 @@ void CustomRollingFileAppender::append(const log4cplus::spi::InternalLoggingEven
         RollingFileAppender::append(event);
 #ifndef NDEBUG
         log4cplus::tostringstream oss;
-        layout->formatAndAppend(oss, event);
+
+        // layout is optional in log4cplus, fall back to raw message if not set
+        if (layout)
+            layout->formatAndAppend(oss, event);
+        else
+            oss << event.getMessage();
+
         std::cout << LOG4CPLUS_TSTRING_TO_STRING(oss.str());
 #endif
     } catch (...) {

--- a/src/libcommonserver/log/log.cpp
+++ b/src/libcommonserver/log/log.cpp
@@ -26,6 +26,11 @@
 
 #include <codecvt>
 
+#if defined(KD_WINDOWS) && !defined(NDEBUG)
+#include <windows.h>
+#include <iostream>
+#endif
+
 namespace KDC {
 
 const std::wstring Log::instanceName = L"Main";

--- a/src/libcommonserver/log/log.cpp
+++ b/src/libcommonserver/log/log.cpp
@@ -44,9 +44,9 @@ std::shared_ptr<Log> Log::instance(const log4cplus::tstring &filePath) {
 #if defined(KD_WINDOWS) && !defined(NDEBUG)
     if (AllocConsole()) {
         FILE *fp = nullptr;
-        freopen_s(&fp, "CONOUT$", "w", stdout);
-        freopen_s(&fp, "CONOUT$", "w", stderr);
-        
+        (void) freopen_s(&fp, "CONOUT$", "w", stdout);
+        (void) freopen_s(&fp, "CONOUT$", "w", stderr);
+
         // freopen_s may leave the stream in an error state on failure.
         // Clear C++ stream flags to ensure std::cout/std::cerr remain usable.
         std::cout.clear();

--- a/src/libcommonserver/log/log.cpp
+++ b/src/libcommonserver/log/log.cpp
@@ -48,16 +48,16 @@ Log::~Log() {
 std::shared_ptr<Log> Log::instance(const log4cplus::tstring &filePath) {
     if (_instance == nullptr) {
 #if defined(KD_WINDOWS) && !defined(NDEBUG)
-    if (AllocConsole()) {
-        FILE *fp = nullptr;
-        (void) freopen_s(&fp, "CONOUT$", "w", stdout);
-        (void) freopen_s(&fp, "CONOUT$", "w", stderr);
+        if (AllocConsole()) {
+            FILE *fp = nullptr;
+            (void) freopen_s(&fp, "CONOUT$", "w", stdout);
+            (void) freopen_s(&fp, "CONOUT$", "w", stderr);
 
-        // freopen_s may leave the stream in an error state on failure.
-        // Clear C++ stream flags to ensure std::cout/std::cerr remain usable.
-        std::cout.clear();
-        std::cerr.clear();
-    }
+            // freopen_s may leave the stream in an error state on failure.
+            // Clear C++ stream flags to ensure std::cout/std::cerr remain usable.
+            std::cout.clear();
+            std::cerr.clear();
+        }
 #endif
         if (filePath.empty()) {
             return nullptr;

--- a/src/libcommonserver/log/log.cpp
+++ b/src/libcommonserver/log/log.cpp
@@ -46,6 +46,9 @@ std::shared_ptr<Log> Log::instance(const log4cplus::tstring &filePath) {
         FILE *fp = nullptr;
         freopen_s(&fp, "CONOUT$", "w", stdout);
         freopen_s(&fp, "CONOUT$", "w", stderr);
+        
+        // freopen_s may leave the stream in an error state on failure.
+        // Clear C++ stream flags to ensure std::cout/std::cerr remain usable.
         std::cout.clear();
         std::cerr.clear();
     }

--- a/src/libcommonserver/log/log.cpp
+++ b/src/libcommonserver/log/log.cpp
@@ -41,6 +41,15 @@ Log::~Log() {
 }
 
 std::shared_ptr<Log> Log::instance(const log4cplus::tstring &filePath) {
+#if defined(KD_WINDOWS) && !defined(NDEBUG)
+    if (AllocConsole()) {
+        FILE *fp = nullptr;
+        freopen_s(&fp, "CONOUT$", "w", stdout);
+        freopen_s(&fp, "CONOUT$", "w", stderr);
+        std::cout.clear();
+        std::cerr.clear();
+    }
+#endif
     if (_instance == nullptr) {
         if (filePath.empty()) {
             return nullptr;

--- a/src/libcommonserver/log/log.cpp
+++ b/src/libcommonserver/log/log.cpp
@@ -46,6 +46,7 @@ Log::~Log() {
 }
 
 std::shared_ptr<Log> Log::instance(const log4cplus::tstring &filePath) {
+    if (_instance == nullptr) {
 #if defined(KD_WINDOWS) && !defined(NDEBUG)
     if (AllocConsole()) {
         FILE *fp = nullptr;
@@ -58,7 +59,6 @@ std::shared_ptr<Log> Log::instance(const log4cplus::tstring &filePath) {
         std::cerr.clear();
     }
 #endif
-    if (_instance == nullptr) {
         if (filePath.empty()) {
             return nullptr;
         }


### PR DESCRIPTION
### Enable console logging in Windows debug builds

- Allocate a Windows console in debug mode (`!NDEBUG`)
- Redirect `stdout` and `stderr` to the console
- Output log messages to `std::cout` for easier debugging
- Add required debug-only includes (`windows.h`, `iostream`)