### PR TITLE
feat(i18n): add Finnish localization support

### DIFF
--- a/infomaniak-build-tools/linux/build-release-appimage.sh
+++ b/infomaniak-build-tools/linux/build-release-appimage.sh
@@ -254,7 +254,7 @@ function clean_app_directory() {
   find . -mindepth 1 -maxdepth 1 \( -type f -o -type l \) ! -name "libqsqlite.so" -delete
   cd /app
 
-  # Clean translations - keep only de, es, fr, it, sv, pt, pl, nb, en
+  # Clean translations - keep only de, es, fr, it, sv, pt, pl, nb, fi, en
   echo "  Cleaning translations..."
   cd ./usr/translations
 
@@ -263,9 +263,9 @@ function clean_app_directory() {
 
   # For other Qt translations, keep only supported languages
   for prefix in qt qtbase qtconnectivity qtdeclarative qtlocation qtmultimedia qtserialport qtwebsockets; do
-    # Remove all except de, es, fr, it, sv, pt, pl, nb, en
+    # Remove all except de, es, fr, it, sv, pt, pl, nb, fi, en
     find . -mindepth 1 -maxdepth 1 \( -type f -o -type l \) -name "${prefix}_*.qm" \
-      ! -name "*_de.qm" ! -name "*_es.qm" ! -name "*_fr.qm" ! -name "*_it.qm" ! -name "*_sv.qm" ! -name "*_pt.qm" ! -name "*_pl.qm" ! -name "*_nb.qm" ! -name "*_en.qm" -delete
+      ! -name "*_de.qm" ! -name "*_es.qm" ! -name "*_fr.qm" ! -name "*_it.qm" ! -name "*_sv.qm" ! -name "*_pt.qm" ! -name "*_pl.qm" ! -name "*_nb.qm" ! -name "*_fi.qm" ! -name "*_en.qm" -delete
   done
 
   cd /app

--- a/src/gui/guiutility.cpp
+++ b/src/gui/guiutility.cpp
@@ -632,6 +632,8 @@ QLocale GuiUtility::languageToQLocale(Language language) {
             return QLocale::Polish;
         case Language::Norwegian:
             return QLocale::NorwegianBokmal;
+        case Language::Finnish:
+            return QLocale::Finnish;
         default:
             return QLocale();
     }

--- a/src/gui/preferenceswidget.cpp
+++ b/src/gui/preferenceswidget.cpp
@@ -512,6 +512,7 @@ void PreferencesWidget::retranslateUi() const {
     _languageSelectorComboBox->addItem(tr("Portuguese"), toInt(Language::Portuguese));
     _languageSelectorComboBox->addItem(tr("Polish"), toInt(Language::Polish));
     _languageSelectorComboBox->addItem(tr("Norwegian"), toInt(Language::Norwegian));
+    _languageSelectorComboBox->addItem(tr("Finnish"), toInt(Language::Finnish));
     const int languageIndex =
             _languageSelectorComboBox->findData(toInt(ParametersCache::instance()->parametersInfo().language()));
     _languageSelectorComboBox->setCurrentIndex(languageIndex);

--- a/src/libcommon/utility/cstypes.h
+++ b/src/libcommon/utility/cstypes.h
@@ -190,6 +190,7 @@ enum class Language {
     Portuguese,
     Polish,
     Norwegian,
+    Finnish,
     EnumEnd
 };
 

--- a/src/libcommon/utility/types.cpp
+++ b/src/libcommon/utility/types.cpp
@@ -545,6 +545,8 @@ std::string toString(const Language e) {
             return "Polish";
         case Language::Norwegian:
             return "Norwegian";
+        case Language::Finnish:
+            return "Finnish";
         default:
             return noConversionStr;
     }

--- a/src/libcommon/utility/utility.cpp
+++ b/src/libcommon/utility/utility.cpp
@@ -100,6 +100,7 @@ const QString CommonUtility::swedishCode = "sv";
 const QString CommonUtility::portugueseCode = "pt";
 const QString CommonUtility::polishCode = "pl";
 const QString CommonUtility::norwegianCode = "nb";
+const QString CommonUtility::finnishCode = "fi";
 
 static std::random_device rd;
 static std::default_random_engine gen(rd());
@@ -808,9 +809,9 @@ bool CommonUtility::languageCodeIsEnglish(const QString &languageCode) {
 }
 
 bool CommonUtility::isSupportedLanguage(const QString &languageCode) {
-    static const std::unordered_set<QString> supportedLanguages = {englishCode,    frenchCode,  germanCode,
-                                                                   italianCode,    spanishCode, swedishCode,
-                                                                   portugueseCode, polishCode,  norwegianCode};
+    static const std::unordered_set<QString> supportedLanguages = {englishCode,   frenchCode,  germanCode,     italianCode,
+                                                                   spanishCode,   swedishCode, portugueseCode, polishCode,
+                                                                   norwegianCode, finnishCode};
     return supportedLanguages.contains(languageCode);
 }
 
@@ -838,6 +839,8 @@ QString CommonUtility::languageCode(const Language language) {
             return polishCode;
         case Language::Norwegian:
             return norwegianCode;
+        case Language::Finnish:
+            return finnishCode;
         case Language::English:
             break;
         case Language::EnumEnd:

--- a/src/libcommon/utility/utility.h
+++ b/src/libcommon/utility/utility.h
@@ -115,6 +115,7 @@ struct COMMON_EXPORT CommonUtility {
         static const QString portugueseCode;
         static const QString polishCode;
         static const QString norwegianCode;
+        static const QString finnishCode;
         static QString languageCode(Language language);
         static QStringList languageCodeList(Language enforcedLocale);
         static void setupTranslations(QCoreApplication *app, Language enforcedLocale);

--- a/src/server/migration/migrationparams.cpp
+++ b/src/server/migration/migrationparams.cpp
@@ -115,6 +115,8 @@ Language MigrationParams::strToLanguage(QString lang) {
         return Language::Polish;
     } else if (lang == "nb" || lang == "no") {
         return Language::Norwegian;
+    } else if (lang == "fi") {
+        return Language::Finnish;
     } else {
         return Language::Default;
     }

--- a/test/libcommon/utility/testutility.cpp
+++ b/test/libcommon/utility/testutility.cpp
@@ -489,6 +489,7 @@ void TestUtility::testLanguageCode() {
     CPPUNIT_ASSERT_EQUAL(std::string("pt"), CommonUtility::languageCode(Language::Portuguese).toStdString());
     CPPUNIT_ASSERT_EQUAL(std::string("pl"), CommonUtility::languageCode(Language::Polish).toStdString());
     CPPUNIT_ASSERT_EQUAL(std::string("nb"), CommonUtility::languageCode(Language::Norwegian).toStdString());
+    CPPUNIT_ASSERT_EQUAL(std::string("fi"), CommonUtility::languageCode(Language::Finnish).toStdString());
 
     const auto systemLanguage = QLocale::languageToCode(QLocale::system().language());
     CPPUNIT_ASSERT_EQUAL(systemLanguage.toStdString(), CommonUtility::languageCode(Language::Default).toStdString());
@@ -507,6 +508,7 @@ void TestUtility::testIsSupportedLanguage() {
     CPPUNIT_ASSERT_EQUAL(true, CommonUtility::isSupportedLanguage("pt"));
     CPPUNIT_ASSERT_EQUAL(true, CommonUtility::isSupportedLanguage("pl"));
     CPPUNIT_ASSERT_EQUAL(true, CommonUtility::isSupportedLanguage("nb"));
+    CPPUNIT_ASSERT_EQUAL(true, CommonUtility::isSupportedLanguage("fi"));
     CPPUNIT_ASSERT_EQUAL(false, CommonUtility::isSupportedLanguage("ita"));
     CPPUNIT_ASSERT_EQUAL(false, CommonUtility::isSupportedLanguage("zc"));
     CPPUNIT_ASSERT_EQUAL(false, CommonUtility::isSupportedLanguage(""));

--- a/translations/client_de.ts
+++ b/translations/client_de.ts
@@ -880,7 +880,7 @@ Bitte wählen Sie einen anderen Ordner. Wenn Sie fortfahren, wird Lite Sync deak
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="597"/>
         <source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
-        <translation type="unfinished"></translation>
+        <translation>Das erweiterte vollständige Protokoll wird über die Umgebungsvariable KDRIVE_FORCE_EXTENDED_LOG aktiviert. Setzen Sie sie auf 0, um es zu deaktivieren.</translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.h" line="70"/>
@@ -2917,6 +2917,19 @@ Bitte verwenden Sie den folgenden Link, um die Protokolle an den Support zu send
             <numerusform>%n Sekunde(n)</numerusform>
             <numerusform>%n Sekunde(n)</numerusform>
         </translation>
+    </message>
+</context>
+<context>
+    <name>main.cpp</name>
+    <message>
+        <location filename="../src/gui/mainclient.cpp" line="49"/>
+        <source>System Tray not available</source>
+        <translation>Systemleiste nicht verfügbar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/mainclient.cpp" line="48"/>
+        <source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as &apos;trayer&apos; and try again.</source>
+        <translation>%1 benötigt eine funktionierende Systemablage (System Tray). Wenn Sie XFCE verwenden, folgen Sie bitte &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;diesen Anweisungen&lt;/a&gt;. Andernfalls installieren Sie bitte eine System-Tray-Anwendung wie „trayer" und versuchen Sie es erneut.</translation>
     </message>
 </context>
 <context>

--- a/translations/client_de.ts
+++ b/translations/client_de.ts
@@ -305,12 +305,12 @@ Bitte wählen Sie einen anderen Ordner. Wenn Sie fortfahren, wird Lite Sync deak
 <context>
     <name>KDC::AppServer</name>
     <message>
-        <location filename="../src/server/appserver.cpp" line="1679"/>
+        <location filename="../src/server/appserver.cpp" line="1685"/>
         <source>Share link copied to clipboard</source>
         <translation>Freigabelink in die Zwischenablage kopiert</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/server/appserver.cpp" line="3759"/>
+        <location filename="../src/server/appserver.cpp" line="3773"/>
         <source>%1 and %n other file(s) have been removed.</source>
         <translation>
             <numerusform>%1 und %n andere Datei(en) wurde(n) gelöscht.</numerusform>
@@ -318,13 +318,13 @@ Bitte wählen Sie einen anderen Ordner. Wenn Sie fortfahren, wird Lite Sync deak
         </translation>
     </message>
     <message>
-        <location filename="../src/server/appserver.cpp" line="3761"/>
+        <location filename="../src/server/appserver.cpp" line="3775"/>
         <source>%1 has been removed.</source>
         <comment>%1 names a file.</comment>
         <translation>%1 wurde gelöscht.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/server/appserver.cpp" line="3766"/>
+        <location filename="../src/server/appserver.cpp" line="3780"/>
         <source>%1 and %n other file(s) have been added.</source>
         <translation>
             <numerusform>%1 und %n andere Datei(en) wurde(n) hinzugefügt.</numerusform>
@@ -332,13 +332,13 @@ Bitte wählen Sie einen anderen Ordner. Wenn Sie fortfahren, wird Lite Sync deak
         </translation>
     </message>
     <message>
-        <location filename="../src/server/appserver.cpp" line="3768"/>
+        <location filename="../src/server/appserver.cpp" line="3782"/>
         <source>%1 has been added.</source>
         <comment>%1 names a file.</comment>
         <translation>%1 wurde hinzugefügt.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/server/appserver.cpp" line="3773"/>
+        <location filename="../src/server/appserver.cpp" line="3787"/>
         <source>%1 and %n other file(s) have been updated.</source>
         <translation>
             <numerusform>%1 und %n andere Datei(en) wurde(n) aktualisiert.</numerusform>
@@ -346,13 +346,13 @@ Bitte wählen Sie einen anderen Ordner. Wenn Sie fortfahren, wird Lite Sync deak
         </translation>
     </message>
     <message>
-        <location filename="../src/server/appserver.cpp" line="3775"/>
+        <location filename="../src/server/appserver.cpp" line="3789"/>
         <source>%1 has been updated.</source>
         <comment>%1 names a file.</comment>
         <translation>%1 wurde aktualisiert.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/server/appserver.cpp" line="3780"/>
+        <location filename="../src/server/appserver.cpp" line="3794"/>
         <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
         <translation>
             <numerusform>%1 wurde zu %2 verschoben und %n andere Datei(en) wurde(n) verschoben.</numerusform>
@@ -360,12 +360,12 @@ Bitte wählen Sie einen anderen Ordner. Wenn Sie fortfahren, wird Lite Sync deak
         </translation>
     </message>
     <message>
-        <location filename="../src/server/appserver.cpp" line="3783"/>
+        <location filename="../src/server/appserver.cpp" line="3797"/>
         <source>%1 has been moved to %2.</source>
         <translation>%1 wurde zu %2 verschoben.</translation>
     </message>
     <message>
-        <location filename="../src/server/appserver.cpp" line="3791"/>
+        <location filename="../src/server/appserver.cpp" line="3805"/>
         <source>Sync Activity</source>
         <translation>Synchronisierungsaktivität</translation>
     </message>
@@ -464,17 +464,17 @@ Bitte wählen Sie einen anderen Ordner. Wenn Sie fortfahren, wird Lite Sync deak
         <translation>Es wurden keine Synchronisierungsordner konfiguriert.</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1426"/>
+        <location filename="../src/gui/clientgui.cpp" line="1422"/>
         <source>Synthesis</source>
         <translation>Synthese</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1427"/>
+        <location filename="../src/gui/clientgui.cpp" line="1423"/>
         <source>Preferences</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1428"/>
+        <location filename="../src/gui/clientgui.cpp" line="1424"/>
         <source>Quit</source>
         <translation>Beenden</translation>
     </message>
@@ -519,22 +519,22 @@ Bitte wählen Sie einen anderen Ordner. Wenn Sie fortfahren, wird Lite Sync deak
         <translation>%1 (Synchronisierung wurde angehalten)</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1261"/>
+        <location filename="../src/gui/clientgui.cpp" line="1257"/>
         <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
         <translation>Möchten Sie die Synchronisierungen des Kontos &lt;i&gt;%1&lt;/i&gt; wirklich entfernen?&lt;br&gt;&lt;b&gt;Hinweis:&lt;/b&gt; Dadurch werden &lt;b&gt;keine&lt;/b&gt; Dateien gelöscht.</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1265"/>
+        <location filename="../src/gui/clientgui.cpp" line="1261"/>
         <source>REMOVE ALL SYNCHRONIZATIONS</source>
         <translation>ALLE SYNC. ENTFERNEN</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1266"/>
+        <location filename="../src/gui/clientgui.cpp" line="1262"/>
         <source>CANCEL</source>
         <translation>ABBRECHEN</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1594"/>
+        <location filename="../src/gui/clientgui.cpp" line="1590"/>
         <source>Failed to start synchronizations!</source>
         <translation>Synchronisierungen konnten nicht gestartet werden!</translation>
     </message>
@@ -792,90 +792,95 @@ Bitte wählen Sie einen anderen Ordner. Wenn Sie fortfahren, wird Lite Sync deak
         <translation>Erweitertes vollständiges Protokoll</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="206"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="207"/>
         <source>Delete logs older than %1 days</source>
         <translation>Protokolle löschen, die älter als %1 Tage sind</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="225"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="226"/>
         <source>Share the debug folder with Infomaniak support.</source>
         <translation>Geben Sie den Debug-Ordner für den Infomaniak-Support frei.</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="249"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="250"/>
         <source>The last session is the periode since the last kDrive start.</source>
         <translation>Die letzte Sitzung ist der Zeitraum seit dem letzten kDrive-Start.</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="253"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="254"/>
         <source>Share only the last kDrive session</source>
         <translation>Teilen Sie nur die letzte kDrive-Sitzung</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="284"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="285"/>
         <source>  Loading</source>
         <translation>  Wird geladen</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="293"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="294"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="319"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="320"/>
         <source>SAVE</source>
         <translation>SPEICHERN</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="326"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="327"/>
         <source>CANCEL</source>
         <translation>ABBRECHEN</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="470"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="471"/>
         <source>Failed to share</source>
         <translation>Teilen fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="480"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="481"/>
         <source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
         <translation>1. Überprüfen Sie, ob Sie angemeldet sind &lt;br&gt;2. Überprüfen Sie, ob Sie mindestens ein kDrive konfiguriert haben</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="485"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="486"/>
         <source> (Connexion interrupted)</source>
         <translation> (Verbindung unterbrochen)</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="492"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="493"/>
         <source>Share the folder with SwissTransfer &lt;br&gt;</source>
         <translation>Teilen Sie den Ordner mit SwissTransfer &lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="493"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="494"/>
         <source> 1. We automatically compressed your log &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;here&lt;/a&gt;.&lt;br&gt;</source>
         <translation> 1. Wir haben Ihr Protokoll &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;hier&lt;/a&gt; automatisch komprimiert.&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="495"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="496"/>
         <source> 2. Transfer the archive with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
         <translation> 2. Übertragen Sie das Archiv mit &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="497"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="498"/>
         <source> 3. Share the link with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
         <translation> 3. Teilen Sie den Link mit &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="527"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="528"/>
         <source>Last upload the %1</source>
         <translatorcomment>Letzte Hochladung am %1</translatorcomment>
         <translation>Letztes Hochladen von %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="555"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="556"/>
         <source>Sharing has been cancelled</source>
         <translation>Die Freigabe wurde abgebrochen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="597"/>
+        <source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.h" line="70"/>
@@ -883,40 +888,40 @@ Bitte wählen Sie einen anderen Ordner. Wenn Sie fortfahren, wird Lite Sync deak
         <translation>Der gesamte Ordner ist groß (&gt; 100 MB) und kann einige Zeit für die Freigabe benötigen. Um die Freigabezeit zu reduzieren, empfehlen wir, nur die letzte kDrive-Sitzung freizugeben.</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="600"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="611"/>
         <source>%1/%2/%3 at %4h%5m and %6s</source>
         <extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
         <translatorcomment>ie: Letzte Hochladung am 29.01.24 um 13:04:06 Uhr</translatorcomment>
         <translation>%2.%1.%3 um %4:%5:%6 Uhr</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="643"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="654"/>
         <source>Do you want to save your modifications?</source>
         <translation>Wollen Sie Ihre Änderungen speichern?</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="698"/>
-        <location filename="../src/gui/debuggingdialog.cpp" line="704"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="709"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="715"/>
         <source>Unable to open folder %1.</source>
         <translation>Ordner %1 kann nicht geöffnet werden.</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="711"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="722"/>
         <source>  Share</source>
         <translation>  Teilen</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="721"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="732"/>
         <source>  Sharing | step 1/2 %1%</source>
         <translation>  Teilen | Schritt 1/2 %1%</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="730"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="741"/>
         <source>  Sharing | step 2/2 %1%</source>
         <translation>  Teilen | Schritt 2/2 %1%</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="740"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="751"/>
         <source>  Canceling...</source>
         <translation>  Stornieren...</translation>
     </message>
@@ -1987,27 +1992,32 @@ Bitte verwenden Sie den folgenden Link, um die Protokolle an den Support zu send
         <translation>kDrive beim Start öffnen</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="516"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="515"/>
+        <source>Finnish</source>
+        <translation>Finnisch</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="521"/>
         <source>Advanced</source>
         <translation>Erweitert</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="517"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="522"/>
         <source>Debugging information</source>
         <translation>Debugging-Informationen</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="519"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="524"/>
         <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
         <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Debugging-Ordner öffnen&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="520"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="525"/>
         <source>Files to exclude</source>
         <translation>Auszuschliessende Dateien</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="521"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="526"/>
         <source>Proxy server</source>
         <translation>Proxy-Server</translation>
     </message>
@@ -2047,7 +2057,7 @@ Bitte verwenden Sie den folgenden Link, um die Protokolle an den Support zu send
         <translation>Ungültiger Link %1.</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="523"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="528"/>
         <source>Lite Sync</source>
         <translation>Lite Sync</translation>
     </message>
@@ -2730,37 +2740,37 @@ Bitte verwenden Sie den folgenden Link, um die Protokolle an den Support zu send
         <translation>Kann keinen gültigen Pfad finden</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2109"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2108"/>
         <source>No valid folder selected!</source>
         <translation>Kein gültiger Ordner ausgewählt!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2120"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2119"/>
         <source>The selected path does not exist!</source>
         <translation>Der ausgewählte Pfad existiert nicht!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2125"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2124"/>
         <source>The selected path is not a folder!</source>
         <translation>Der ausgewählte Pfad ist kein Ordner!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2130"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2129"/>
         <source>You have no permission to write to the selected folder!</source>
         <translation>Sie haben keine Schreibberechtigung für den ausgewählten Ordner!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2160"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2159"/>
         <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
         <translation>Der lokale Ordner %1 enthält einen bereits synchronisierten Ordner. Bitte wählen Sie einen anderen!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2168"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2167"/>
         <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
         <translation>Der lokale Ordner %1 befindet sich in einem bereits synchronisierten Ordner. Bitte wählen Sie einen anderen!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2176"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2175"/>
         <source>The local folder %1 is already synced. Please pick another one!</source>
         <translation>Der lokale Ordner %1 ist bereits synchronisiert. Bitte wählen Sie einen anderen!</translation>
     </message>
@@ -2910,19 +2920,6 @@ Bitte verwenden Sie den folgenden Link, um die Protokolle an den Support zu send
     </message>
 </context>
 <context>
-    <name>main.cpp</name>
-    <message>
-        <location filename="../src/gui/mainclient.cpp" line="49"/>
-        <source>System Tray not available</source>
-        <translation>Systemleiste nicht verfügbar</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/mainclient.cpp" line="48"/>
-        <source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as &apos;trayer&apos; and try again.</source>
-        <translation>%1 benötigt eine funktionierende Systemablage (System Tray). Wenn Sie XFCE verwenden, folgen Sie bitte &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;diesen Anweisungen&lt;/a&gt;. Andernfalls installieren Sie bitte eine System-Tray-Anwendung wie „trayer“ und versuchen Sie es erneut.</translation>
-    </message>
-</context>
-<context>
     <name>utility</name>
     <message>
         <location filename="../src/gui/guiutility.cpp" line="84"/>
@@ -3009,12 +3006,12 @@ Sie können eines über die kDrive-Einstellungen hinzufügen.</translation>
         <translation>Der Ordner &lt;b&gt;%1&lt;/b&gt; kann nicht als Synchronisationsordner ausgewählt werden. Bitte wählen Sie einen anderen Ordner. Vorgeschlagener Ordner: &lt;b&gt;%2&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/guiutility.cpp" line="641"/>
+        <location filename="../src/gui/guiutility.cpp" line="651"/>
         <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
         <translation>Sie haben mehr als %1 Ordner ausgeschlossen. Bitte beachten Sie, dass dies die Synchronisierungsleistung beeinträchtigt.</translation>
     </message>
     <message>
-        <location filename="../src/gui/guiutility.cpp" line="650"/>
+        <location filename="../src/gui/guiutility.cpp" line="660"/>
         <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
         <translation>Sie können maximal %1 Ordner ausschließen. Bitte deaktivieren Sie die übergeordneten Ordner.</translation>
     </message>

--- a/translations/client_es.ts
+++ b/translations/client_es.ts
@@ -305,12 +305,12 @@ Seleccione otra carpeta. Si continúa, Lite Sync se deshabilitará.&lt;br&gt;
 <context>
     <name>KDC::AppServer</name>
     <message>
-        <location filename="../src/server/appserver.cpp" line="1679"/>
+        <location filename="../src/server/appserver.cpp" line="1685"/>
         <source>Share link copied to clipboard</source>
         <translation>Enlace compartido copiado en el portapapeles</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/server/appserver.cpp" line="3759"/>
+        <location filename="../src/server/appserver.cpp" line="3773"/>
         <source>%1 and %n other file(s) have been removed.</source>
         <translation>
             <numerusform>%1 y otros %n archivo(s) han sido borrados.</numerusform>
@@ -318,13 +318,13 @@ Seleccione otra carpeta. Si continúa, Lite Sync se deshabilitará.&lt;br&gt;
         </translation>
     </message>
     <message>
-        <location filename="../src/server/appserver.cpp" line="3761"/>
+        <location filename="../src/server/appserver.cpp" line="3775"/>
         <source>%1 has been removed.</source>
         <comment>%1 names a file.</comment>
         <translation>%1 ha sido eliminado.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/server/appserver.cpp" line="3766"/>
+        <location filename="../src/server/appserver.cpp" line="3780"/>
         <source>%1 and %n other file(s) have been added.</source>
         <translation>
             <numerusform>%1 y % otros archivo(s) han sido añadidos.</numerusform>
@@ -332,13 +332,13 @@ Seleccione otra carpeta. Si continúa, Lite Sync se deshabilitará.&lt;br&gt;
         </translation>
     </message>
     <message>
-        <location filename="../src/server/appserver.cpp" line="3768"/>
+        <location filename="../src/server/appserver.cpp" line="3782"/>
         <source>%1 has been added.</source>
         <comment>%1 names a file.</comment>
         <translation>%1 ha sido añadido.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/server/appserver.cpp" line="3773"/>
+        <location filename="../src/server/appserver.cpp" line="3787"/>
         <source>%1 and %n other file(s) have been updated.</source>
         <translation>
             <numerusform>%1 y otros %n archivo(s) han sido actualizados.</numerusform>
@@ -346,13 +346,13 @@ Seleccione otra carpeta. Si continúa, Lite Sync se deshabilitará.&lt;br&gt;
         </translation>
     </message>
     <message>
-        <location filename="../src/server/appserver.cpp" line="3775"/>
+        <location filename="../src/server/appserver.cpp" line="3789"/>
         <source>%1 has been updated.</source>
         <comment>%1 names a file.</comment>
         <translation>%1 ha sido actualizado.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/server/appserver.cpp" line="3780"/>
+        <location filename="../src/server/appserver.cpp" line="3794"/>
         <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
         <translation>
             <numerusform>%1 ha sido movido a %2 y otros %n archivo(s) han sido movidos.</numerusform>
@@ -360,12 +360,12 @@ Seleccione otra carpeta. Si continúa, Lite Sync se deshabilitará.&lt;br&gt;
         </translation>
     </message>
     <message>
-        <location filename="../src/server/appserver.cpp" line="3783"/>
+        <location filename="../src/server/appserver.cpp" line="3797"/>
         <source>%1 has been moved to %2.</source>
         <translation>%1 ha sido movido a %2.</translation>
     </message>
     <message>
-        <location filename="../src/server/appserver.cpp" line="3791"/>
+        <location filename="../src/server/appserver.cpp" line="3805"/>
         <source>Sync Activity</source>
         <translation>Actividad de sincronización</translation>
     </message>
@@ -464,17 +464,17 @@ Seleccione otra carpeta. Si continúa, Lite Sync se deshabilitará.&lt;br&gt;
         <translation>No hay carpetas de sincronización configuradas.</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1426"/>
+        <location filename="../src/gui/clientgui.cpp" line="1422"/>
         <source>Synthesis</source>
         <translation>Síntesis</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1427"/>
+        <location filename="../src/gui/clientgui.cpp" line="1423"/>
         <source>Preferences</source>
         <translation>Preferencias</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1428"/>
+        <location filename="../src/gui/clientgui.cpp" line="1424"/>
         <source>Quit</source>
         <translation>Salir</translation>
     </message>
@@ -519,22 +519,22 @@ Seleccione otra carpeta. Si continúa, Lite Sync se deshabilitará.&lt;br&gt;
         <translation>%1 (sincronización en pausa)</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1261"/>
+        <location filename="../src/gui/clientgui.cpp" line="1257"/>
         <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
         <translation>¿Realmente desea eliminar las sincronizaciones de la cuenta &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Nota:&lt;/b&gt; Esto &lt;b&gt;no&lt;/b&gt; eliminará ningún archivo.</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1265"/>
+        <location filename="../src/gui/clientgui.cpp" line="1261"/>
         <source>REMOVE ALL SYNCHRONIZATIONS</source>
         <translation>ELIMINAR TODAS LAS SINC.</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1266"/>
+        <location filename="../src/gui/clientgui.cpp" line="1262"/>
         <source>CANCEL</source>
         <translation>CANCELAR</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1594"/>
+        <location filename="../src/gui/clientgui.cpp" line="1590"/>
         <source>Failed to start synchronizations!</source>
         <translation>¡Error al iniciar las sincronizaciones!</translation>
     </message>
@@ -792,89 +792,94 @@ Seleccione otra carpeta. Si continúa, Lite Sync se deshabilitará.&lt;br&gt;
         <translation>Registro completo extendido</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="206"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="207"/>
         <source>Delete logs older than %1 days</source>
         <translation>Eliminar registros de más de %1 días</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="225"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="226"/>
         <source>Share the debug folder with Infomaniak support.</source>
         <translation>Comparte la carpeta de depuración con el soporte de Infomaniak.</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="249"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="250"/>
         <source>The last session is the periode since the last kDrive start.</source>
         <translation>La última sesión es el período desde el último inicio de kDrive.</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="253"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="254"/>
         <source>Share only the last kDrive session</source>
         <translation>Comparte solo la última sesión de kDrive</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="284"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="285"/>
         <source>  Loading</source>
         <translation>  Cargando</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="293"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="294"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="319"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="320"/>
         <source>SAVE</source>
         <translation>GUARDAR</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="326"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="327"/>
         <source>CANCEL</source>
         <translation>CANCELAR</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="470"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="471"/>
         <source>Failed to share</source>
         <translation>No se pudo compartir</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="480"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="481"/>
         <source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
         <translation>1. Verifique que haya iniciado sesión &lt;br&gt;2. Comprueba que tienes configurado al menos un kDrive</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="485"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="486"/>
         <source> (Connexion interrupted)</source>
         <translation> (Conexión interrumpida)</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="492"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="493"/>
         <source>Share the folder with SwissTransfer &lt;br&gt;</source>
         <translation>Compartir la carpeta con SwissTransfer &lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="493"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="494"/>
         <source> 1. We automatically compressed your log &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;here&lt;/a&gt;.&lt;br&gt;</source>
         <translation> 1. Comprimimos automáticamente su registro &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;aquí&lt;/a&gt;.&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="495"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="496"/>
         <source> 2. Transfer the archive with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
         <translation> 2. Transfiera el archivo con &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="497"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="498"/>
         <source> 3. Share the link with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
         <translation> 3. Comparte el enlace con &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="527"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="528"/>
         <source>Last upload the %1</source>
         <translation>Última carga el %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="555"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="556"/>
         <source>Sharing has been cancelled</source>
         <translation>Compartir ha sido cancelado</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="597"/>
+        <source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.h" line="70"/>
@@ -882,39 +887,39 @@ Seleccione otra carpeta. Si continúa, Lite Sync se deshabilitará.&lt;br&gt;
         <translation>La carpeta completa es grande (&gt; 100 MB) y puede tardar algún tiempo en compartirse. Para reducir el tiempo de compartición, le recomendamos que comparta sólo la última sesión de kDrive.</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="600"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="611"/>
         <source>%1/%2/%3 at %4h%5m and %6s</source>
         <extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
         <translation>%2/%1/%3 a las %4:%5 y %6s</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="643"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="654"/>
         <source>Do you want to save your modifications?</source>
         <translation>¿Deseas guardar tus cambios?</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="698"/>
-        <location filename="../src/gui/debuggingdialog.cpp" line="704"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="709"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="715"/>
         <source>Unable to open folder %1.</source>
         <translation>No se puede abrir la carpeta %1.</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="711"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="722"/>
         <source>  Share</source>
         <translation>  Compartir</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="721"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="732"/>
         <source>  Sharing | step 1/2 %1%</source>
         <translation>  Compartir | paso 1/2 %1%</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="730"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="741"/>
         <source>  Sharing | step 2/2 %1%</source>
         <translation>  Compartir | paso 2/2 %1%</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="740"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="751"/>
         <source>  Canceling...</source>
         <translation>  Cancelado...</translation>
     </message>
@@ -1985,27 +1990,32 @@ Por favor, utilice el siguiente enlace para enviar los registros al soporte: &lt
         <translation>Ejecutar kDrive al arrancar</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="516"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="515"/>
+        <source>Finnish</source>
+        <translation>Finlandés</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="521"/>
         <source>Advanced</source>
         <translation>Avanzado</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="517"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="522"/>
         <source>Debugging information</source>
         <translation>Información de depuración</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="519"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="524"/>
         <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
         <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Abrir carpeta de depuración&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="520"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="525"/>
         <source>Files to exclude</source>
         <translation>Archivos a excluir</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="521"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="526"/>
         <source>Proxy server</source>
         <translation>Servidor proxy</translation>
     </message>
@@ -2045,7 +2055,7 @@ Por favor, utilice el siguiente enlace para enviar los registros al soporte: &lt
         <translation>Enlace %1 no válido.</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="523"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="528"/>
         <source>Lite Sync</source>
         <translation>Lite Sync</translation>
     </message>
@@ -2728,37 +2738,37 @@ Por favor, utilice el siguiente enlace para enviar los registros al soporte: &lt
         <translation>No se puede encontrar una ruta válida</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2109"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2108"/>
         <source>No valid folder selected!</source>
         <translation>¡No se ha seleccionado una carpeta válida!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2120"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2119"/>
         <source>The selected path does not exist!</source>
         <translation>¡La ruta seleccionada no existe!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2125"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2124"/>
         <source>The selected path is not a folder!</source>
         <translation>¡La ruta seleccionada no es una carpeta!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2130"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2129"/>
         <source>You have no permission to write to the selected folder!</source>
         <translation>¡No tienes permiso para escribir en la carpeta seleccionada!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2160"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2159"/>
         <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
         <translation>La carpeta local %1 contiene una carpeta ya sincronizada.¡Elige otra!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2168"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2167"/>
         <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
         <translation>La carpeta local %1 está contenida en una carpeta ya sincronizada.¡Elige otra!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2176"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2175"/>
         <source>The local folder %1 is already synced. Please pick another one!</source>
         <translation>La carpeta local %1 ya está sincronizada. ¡Seleccione otra!</translation>
     </message>
@@ -2908,19 +2918,6 @@ Por favor, utilice el siguiente enlace para enviar los registros al soporte: &lt
     </message>
 </context>
 <context>
-    <name>main.cpp</name>
-    <message>
-        <location filename="../src/gui/mainclient.cpp" line="49"/>
-        <source>System Tray not available</source>
-        <translation>Bandeja del sistema no disponible</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/mainclient.cpp" line="48"/>
-        <source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as &apos;trayer&apos; and try again.</source>
-        <translation>%1 requiere una bandeja del sistema funcional. Si está utilizando XFCE, siga &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;estas instrucciones&lt;/a&gt;. De lo contrario, instale una aplicación de bandeja del sistema como «trayer» e inténtelo de nuevo.</translation>
-    </message>
-</context>
-<context>
     <name>utility</name>
     <message>
         <location filename="../src/gui/guiutility.cpp" line="84"/>
@@ -3007,12 +3004,12 @@ quedan %3...</translation>
         <translation>La carpeta &lt;b&gt;%1&lt;/b&gt; no puede seleccionarse como carpeta de sincronización. Por favor, seleccione otra carpeta. Carpeta sugerida: &lt;b&gt;%2&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/guiutility.cpp" line="641"/>
+        <location filename="../src/gui/guiutility.cpp" line="651"/>
         <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
         <translation>Ha excluido más de %1 carpetas, tenga en cuenta que esto afectará el rendimiento de la sincronización.</translation>
     </message>
     <message>
-        <location filename="../src/gui/guiutility.cpp" line="650"/>
+        <location filename="../src/gui/guiutility.cpp" line="660"/>
         <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
         <translation>No se pueden excluir más de %1 carpetas. Desmarque las carpetas de nivel superior.</translation>
     </message>

--- a/translations/client_es.ts
+++ b/translations/client_es.ts
@@ -879,7 +879,7 @@ Seleccione otra carpeta. Si continúa, Lite Sync se deshabilitará.&lt;br&gt;
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="597"/>
         <source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
-        <translation type="unfinished"></translation>
+        <translation>El registro completo extendido se activa mediante la variable de entorno KDRIVE_FORCE_EXTENDED_LOG. Establézcala en 0 para desactivarlo.</translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.h" line="70"/>
@@ -2915,6 +2915,19 @@ Por favor, utilice el siguiente enlace para enviar los registros al soporte: &lt
             <numerusform>%n segundo(s)</numerusform>
             <numerusform>%n segundo(s)</numerusform>
         </translation>
+    </message>
+</context>
+<context>
+    <name>main.cpp</name>
+    <message>
+        <location filename="../src/gui/mainclient.cpp" line="49"/>
+        <source>System Tray not available</source>
+        <translation>Bandeja del sistema no disponible</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/mainclient.cpp" line="48"/>
+        <source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as &apos;trayer&apos; and try again.</source>
+        <translation>%1 requiere una bandeja del sistema funcional. Si está utilizando XFCE, siga &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;estas instrucciones&lt;/a&gt;. De lo contrario, instale una aplicación de bandeja del sistema como «trayer» e inténtelo de nuevo.</translation>
     </message>
 </context>
 <context>

--- a/translations/client_fi.ts
+++ b/translations/client_fi.ts
@@ -1,3035 +1,3020 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="fi_FI">
+<TS language="fi_FI" version="2.1">
 <context>
-    <name>KDC::AboutDialog</name>
-    <message>
-        <location filename="../src/gui/aboutdialog.cpp" line="73"/>
-        <source>About</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/aboutdialog.cpp" line="112"/>
-        <source>CLOSE</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/aboutdialog.cpp" line="123"/>
-        <source>Version %1. For more information visit &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/aboutdialog.cpp" line="126"/>
-        <source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/aboutdialog.cpp" line="127"/>
-        <source>Distributed by %1 and licensed under the &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/aboutdialog.cpp" line="132"/>
-        <source>&lt;p&gt;&lt;small&gt;Built from &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/aboutdialog.cpp" line="151"/>
-        <location filename="../src/gui/aboutdialog.cpp" line="162"/>
-        <location filename="../src/gui/aboutdialog.cpp" line="171"/>
-        <source>Unable to open folder %1.</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::AboutDialog</name>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="73"/>
+<source>About</source>
+<translation>Tietoja</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="112"/>
+<source>CLOSE</source>
+<translation>SULJE</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="123"/>
+<source>Version %1. For more information visit &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
+<translation>Versio %1. Lisätietoja: &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="126"/>
+<source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
+<translation>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="127"/>
+<source>Distributed by %1 and licensed under the &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
+<translation>%1 jakaa ja lisensoi &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;-lisenssin alla.&lt;br&gt;&lt;br&gt;%2 ja %2-logo ovat %1:n rekisteröityjä tavaramerkkejä.&lt;br&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="132"/>
+<source>&lt;p&gt;&lt;small&gt;Built from &lt;a style="color: #489EF3" href="%1"&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
+<translation>&lt;p&gt;&lt;small&gt;Rakennettu &lt;a style="color: #489EF3" href="%1"&gt;Git-lähteistä&lt;/a&gt; %2, %3 käyttäen Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="151"/>
+<location filename="../src/gui/aboutdialog.cpp" line="162"/>
+<location filename="../src/gui/aboutdialog.cpp" line="171"/>
+<source>Unable to open folder %1.</source>
+<translation>Kansiota %1 ei voi avata.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AbstractFileItemWidget</name>
-    <message>
-        <location filename="../src/gui/abstractfileitemwidget.cpp" line="177"/>
-        <source>Unable to open folder path %1.</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::AbstractFileItemWidget</name>
+<message>
+<location filename="../src/gui/abstractfileitemwidget.cpp" line="177"/>
+<source>Unable to open folder path %1.</source>
+<translation>Kansion polkua %1 ei voi avata.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveConfirmationWidget</name>
-    <message>
-        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55"/>
-        <source>Synchronization will start and you will be able to add files to your %1 folder.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99"/>
-        <source>Your kDrive is ready!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123"/>
-        <source>OPEN FOLDER</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130"/>
-        <source>PARAMETERS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138"/>
-        <source>Synchronize another drive</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::AddDriveConfirmationWidget</name>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55"/>
+<source>Synchronization will start and you will be able to add files to your %1 folder.</source>
+<translation>Synkronointi käynnistyy ja voit lisätä tiedostoja %1-kansioon.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99"/>
+<source>Your kDrive is ready!</source>
+<translation>kDrive on valmis!</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123"/>
+<source>OPEN FOLDER</source>
+<translation>AVAA KANSIO</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130"/>
+<source>PARAMETERS</source>
+<translation>ASETUKSET</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138"/>
+<source>Synchronize another drive</source>
+<translation>Synkronoi toinen asema</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveListWidget</name>
-    <message>
-        <location filename="../src/gui/adddrivelistwidget.cpp" line="170"/>
-        <source>Cancel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddrivelistwidget.cpp" line="177"/>
-        <source>NEXT</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddrivelistwidget.cpp" line="196"/>
-        <source>Select the kDrive you want to synchronize</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddrivelistwidget.cpp" line="234"/>
-        <source>Get kDrive for free</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddrivelistwidget.cpp" line="244"/>
-        <source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddrivelistwidget.cpp" line="263"/>
-        <source>Test for free</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::AddDriveListWidget</name>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="170"/>
+<source>Cancel</source>
+<translation>Peruuta</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="177"/>
+<source>NEXT</source>
+<translation>SEURAAVA</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="196"/>
+<source>Select the kDrive you want to synchronize</source>
+<translation>Valitse synkronoitava kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="234"/>
+<source>Get kDrive for free</source>
+<translation>Hanki kDrive ilmaiseksi</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="244"/>
+<source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
+<translation>Tallenna kuvasi, asiakirjasi ja sähköpostisi Sveitsiin riippumattomassa yrityksessä, joka kunnioittaa yksityisyyttä. Lue lisää</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="263"/>
+<source>Test for free</source>
+<translation>Kokeile ilmaiseksi</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveLiteSyncWidget</name>
-    <message>
-        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112"/>
-        <source>Would you like to activate Lite Sync (Beta) ?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114"/>
-        <source>Would you like to activate Lite Sync ?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
-        <source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147"/>
-        <source>Conserve your computer space</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167"/>
-        <source>Decide which files should be available online or locally</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187"/>
-        <source>LATER</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193"/>
-        <source>YES</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207"/>
-        <source>Unable to open link %1.</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::AddDriveLiteSyncWidget</name>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112"/>
+<source>Would you like to activate Lite Sync (Beta) ?</source>
+<translation>Haluatko aktivoida Lite Sync (Beta)?</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114"/>
+<source>Would you like to activate Lite Sync ?</source>
+<translation>Haluatko aktivoida Lite Sync?</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
+<source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Lite Sync synkronoi kaikki tiedostosi käyttämättä tietokoneen tallennustilaa. Voit selata kDrive-tiedostojasi ja ladata ne paikallisesti milloin tahansa. &lt;a style="%1" href="%2"&gt;Lue lisää&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147"/>
+<source>Conserve your computer space</source>
+<translation>Säästä tietokoneen tallennustilaa</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167"/>
+<source>Decide which files should be available online or locally</source>
+<translation>Päätä, mitkä tiedostot ovat saatavilla verkossa tai paikallisesti</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187"/>
+<source>LATER</source>
+<translation>MYÖHEMMIN</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193"/>
+<source>YES</source>
+<translation>KYLLÄ</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207"/>
+<source>Unable to open link %1.</source>
+<translation>Linkkiä %1 ei voi avata.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveLocalFolderWidget</name>
-    <message>
-        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65"/>
-        <source>Location of your %1 kDrive</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155"/>
-        <source>Edit folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212"/>
-        <source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
-        <source>END</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
-        <source>CONTINUE</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
-        <source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284"/>
-        <source>This folder is not compatible with Lite Sync.&lt;br&gt; 
+<name>KDC::AddDriveLocalFolderWidget</name>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65"/>
+<source>Location of your %1 kDrive</source>
+<translation>%1 kDrive -aseman sijainti</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155"/>
+<source>Edit folder</source>
+<translation>Muokkaa kansiota</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212"/>
+<source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
+<translation>Löydät kaikki tiedostosi tästä kansiosta konfiguroinnin jälkeen. Voit lisätä uusia tiedostoja kansioon synkronoidaksesi ne kDriveen.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+<source>END</source>
+<translation>LOPETA</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+<source>CONTINUE</source>
+<translation>JATKA</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
+<source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
+<translation>&lt;b&gt;%1&lt;/b&gt;-kansion sisältö synkronoidaan kDriveen</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284"/>
+<source>This folder is not compatible with Lite Sync.&lt;br&gt; 
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt; 
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
-        <source>Select folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377"/>
-        <source>Unable to open link %1.</source>
-        <translation type="unfinished"></translation>
-    </message>
+&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Tämä kansio ei ole yhteensopiva Lite Sync -toiminnon kanssa.&lt;br&gt; 
+Valitse toinen kansio. Jos jatkat, Lite Sync poistetaan käytöstä.&lt;br&gt; 
+&lt;a style="%1" href="%2"&gt;Lue lisää&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
+<source>Select folder</source>
+<translation>Valitse kansio</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377"/>
+<source>Unable to open link %1.</source>
+<translation>Linkkiä %1 ei voi avata.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveLoginWidget</name>
-    <message>
-        <location filename="../src/gui/adddriveloginwidget.cpp" line="69"/>
-        <source>Log in from your browser</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddriveloginwidget.cpp" line="75"/>
-        <source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
-        <source>Open the login page</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddriveloginwidget.cpp" line="119"/>
-        <source>Token request failed: %1 - %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddriveloginwidget.cpp" line="133"/>
-        <source>Login failed: %1 - %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddriveloginwidget.cpp" line="141"/>
-        <source>Failed to open the login page in your web browser</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::AddDriveLoginWidget</name>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="69"/>
+<source>Log in from your browser</source>
+<translation>Kirjaudu sisään selaimella</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="75"/>
+<source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
+<translation>Selaimesi avautuu automaattisesti yhteyden muodostamiseksi. Kun olet kirjautunut, palaat automaattisesti kDriveen.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
+<source>Open the login page</source>
+<translation>Avaa kirjautumissivu</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="119"/>
+<source>Token request failed: %1 - %2</source>
+<translation>Tunnuksen pyyntö epäonnistui: %1 - %2</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="133"/>
+<source>Login failed: %1 - %2</source>
+<translation>Kirjautuminen epäonnistui: %1 - %2</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="141"/>
+<source>Failed to open the login page in your web browser</source>
+<translation>Kirjautumissivun avaaminen selaimessa epäonnistui</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveServerFoldersWidget</name>
-    <message>
-        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129"/>
-        <source>Select kDrive folders to synchronize on your desktop</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174"/>
-        <source>CONTINUE</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187"/>
-        <source>Space available on your computer : %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206"/>
-        <source>An error occurred while loading the list of subfolders.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210"/>
-        <source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::AddDriveServerFoldersWidget</name>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129"/>
+<source>Select kDrive folders to synchronize on your desktop</source>
+<translation>Valitse synkronoitavat kDrive-kansiot tietokoneellesi</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174"/>
+<source>CONTINUE</source>
+<translation>JATKA</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187"/>
+<source>Space available on your computer : %1</source>
+<translation>Tietokoneella vapaata tilaa: %1</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206"/>
+<source>An error occurred while loading the list of subfolders.</source>
+<translation>Alikansioiden listan lataaminen epäonnistui.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210"/>
+<source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
+<translation>Alikansioiden listaa ei voi ladata. kDrive saattaa olla huoltotilassa.&lt;br&gt;Kirjaudu &lt;a style="%1" href="%2"&gt;verkkoversiooon&lt;/a&gt; tarkistaaksesi kDriven tilan tai ota yhteyttä järjestelmänvalvojaasi.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveWizard</name>
-    <message>
-        <location filename="../src/gui/adddrivewizard.cpp" line="222"/>
-        <source>Failed to create local folder %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddrivewizard.cpp" line="233"/>
-        <source>Failed to create new synchronization</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddrivewizard.cpp" line="266"/>
-        <source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::AddDriveWizard</name>
+<message>
+<location filename="../src/gui/adddrivewizard.cpp" line="222"/>
+<source>Failed to create local folder %1</source>
+<translation>Paikallisen kansion %1 luominen epäonnistui</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivewizard.cpp" line="233"/>
+<source>Failed to create new synchronization</source>
+<translation>Uuden synkronoinnin luominen epäonnistui</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivewizard.cpp" line="266"/>
+<source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
+<translation>kDrive %1 on jo synkronoitu tällä tietokoneella. Jatketaanko?</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AppClient</name>
-    <message>
-        <location filename="../src/gui/appclient.cpp" line="100"/>
-        <source>kDrive client is run with bad parameters!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/appclient.cpp" line="109"/>
-        <source>kDrive client is already running!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/appclient.cpp" line="719"/>
-        <source>The user %1 is not connected. Please log in again.</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::AppClient</name>
+<message>
+<location filename="../src/gui/appclient.cpp" line="100"/>
+<source>kDrive client is run with bad parameters!</source>
+<translation>kDrive-asiakas käynnistettiin virheellisillä parametreillä!</translation>
+</message>
+<message>
+<location filename="../src/gui/appclient.cpp" line="109"/>
+<source>kDrive client is already running!</source>
+<translation>kDrive-asiakas on jo käynnissä!</translation>
+</message>
+<message>
+<location filename="../src/gui/appclient.cpp" line="719"/>
+<source>The user %1 is not connected. Please log in again.</source>
+<translation>Käyttäjä %1 ei ole kirjautunut. Kirjaudu uudelleen.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AppServer</name>
-    <message>
-        <location filename="../src/server/appserver.cpp" line="1685"/>
-        <source>Share link copied to clipboard</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/server/appserver.cpp" line="3773"/>
-        <source>%1 and %n other file(s) have been removed.</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/server/appserver.cpp" line="3775"/>
-        <source>%1 has been removed.</source>
-        <comment>%1 names a file.</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/server/appserver.cpp" line="3780"/>
-        <source>%1 and %n other file(s) have been added.</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/server/appserver.cpp" line="3782"/>
-        <source>%1 has been added.</source>
-        <comment>%1 names a file.</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/server/appserver.cpp" line="3787"/>
-        <source>%1 and %n other file(s) have been updated.</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/server/appserver.cpp" line="3789"/>
-        <source>%1 has been updated.</source>
-        <comment>%1 names a file.</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/server/appserver.cpp" line="3794"/>
-        <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/server/appserver.cpp" line="3797"/>
-        <source>%1 has been moved to %2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/server/appserver.cpp" line="3805"/>
-        <source>Sync Activity</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::AppServer</name>
+<message>
+<location filename="../src/server/appserver.cpp" line="1685"/>
+<source>Share link copied to clipboard</source>
+<translation>Jakolinkki kopioitu leikepöydälle</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3773"/>
+<source>%1 and %n other file(s) have been removed.</source>
+<translation>
+<numerusform>%1 ja %n muu tiedosto on poistettu.</numerusform><numerusform>%1 ja %n muuta tiedostoa on poistettu.</numerusform></translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3775"/>
+<source>%1 has been removed.</source>
+<comment>%1 names a file.</comment>
+<translation>%1 on poistettu.</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3780"/>
+<source>%1 and %n other file(s) have been added.</source>
+<translation>
+<numerusform>%1 ja %n muu tiedosto on lisätty.</numerusform><numerusform>%1 ja %n muuta tiedostoa on lisätty.</numerusform></translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3782"/>
+<source>%1 has been added.</source>
+<comment>%1 names a file.</comment>
+<translation>%1 on lisätty.</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3787"/>
+<source>%1 and %n other file(s) have been updated.</source>
+<translation>
+<numerusform>%1 ja %n muu tiedosto on päivitetty.</numerusform><numerusform>%1 ja %n muuta tiedostoa on päivitetty.</numerusform></translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3789"/>
+<source>%1 has been updated.</source>
+<comment>%1 names a file.</comment>
+<translation>%1 on päivitetty.</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3794"/>
+<source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
+<translation>
+<numerusform>%1 on siirretty kohteeseen %2 ja %n muu tiedosto on siirretty.</numerusform><numerusform>%1 on siirretty kohteeseen %2 ja %n muuta tiedostoa on siirretty.</numerusform></translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3797"/>
+<source>%1 has been moved to %2.</source>
+<translation>%1 on siirretty kohteeseen %2.</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3805"/>
+<source>Sync Activity</source>
+<translation>Synkronointiaktiviteetti</translation>
+</message>
 </context>
 <context>
-    <name>KDC::BaseFolderTreeItemWidget</name>
-    <message>
-        <location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102"/>
-        <source>No subfolders currently on the server.</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::BaseFolderTreeItemWidget</name>
+<message>
+<location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102"/>
+<source>No subfolders currently on the server.</source>
+<translation>Palvelimella ei ole alikansioita tällä hetkellä.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::BetaProgramDialog</name>
-    <message>
-        <location filename="../src/gui/betaprogramdialog.cpp" line="69"/>
-        <source>Quit the beta program</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/betaprogramdialog.cpp" line="69"/>
-        <source>Join the beta program</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/betaprogramdialog.cpp" line="77"/>
-        <source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/betaprogramdialog.cpp" line="87"/>
-        <source>Benefit from application beta updates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/betaprogramdialog.cpp" line="91"/>
-        <source>No</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/betaprogramdialog.cpp" line="92"/>
-        <source>Public beta version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/betaprogramdialog.cpp" line="93"/>
-        <source>Internal beta version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/betaprogramdialog.cpp" line="141"/>
-        <source>I understand</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/betaprogramdialog.cpp" line="147"/>
-        <source>Are you sure you want to leave the beta program?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/betaprogramdialog.cpp" line="161"/>
-        <source>Save</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/betaprogramdialog.cpp" line="167"/>
-        <source>Cancel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/betaprogramdialog.cpp" line="228"/>
-        <source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/betaprogramdialog.cpp" line="233"/>
-        <source>Beta versions may leave unexpectedly or cause instabilities.</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::BetaProgramDialog</name>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="69"/>
+<source>Quit the beta program</source>
+<translation>Poistu beta-ohjelmasta</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="69"/>
+<source>Join the beta program</source>
+<translation>Liity beta-ohjelmaan</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="77"/>
+<source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
+<translation>Saa varhainen pääsy sovelluksen uusiin versioihin ennen niiden julkaisua ja osallistu sovelluksen kehittämiseen lähettämällä kommenttisi.</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="87"/>
+<source>Benefit from application beta updates</source>
+<translation>Hyödy sovelluksen beta-päivityksistä</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="91"/>
+<source>No</source>
+<translation>Ei</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="92"/>
+<source>Public beta version</source>
+<translation>Julkinen beta-versio</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="93"/>
+<source>Internal beta version</source>
+<translation>Sisäinen beta-versio</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="141"/>
+<source>I understand</source>
+<translation>Ymmärrän</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="147"/>
+<source>Are you sure you want to leave the beta program?</source>
+<translation>Oletko varma, että haluat poistua beta-ohjelmasta?</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="161"/>
+<source>Save</source>
+<translation>Tallenna</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="167"/>
+<source>Cancel</source>
+<translation>Peruuta</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="228"/>
+<source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
+<translation>Sovelluksesi nykyinen versio saattaa olla liian uusi; valintasi astuu voimaan seuraavan päivityksen yhteydessä.</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="233"/>
+<source>Beta versions may leave unexpectedly or cause instabilities.</source>
+<translation>Beta-versiot saattavat kaatua odottamatta tai aiheuttaa epävakautta.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ClientGui</name>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="116"/>
-        <source>Unable to initialize kDrive client</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="189"/>
-        <source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="242"/>
-        <source>Please sign in</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="255"/>
-        <source>Synchronization is paused</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="292"/>
-        <source>Folder %1: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="298"/>
-        <source>There are no sync folders configured.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="673"/>
-        <source>Undefined State.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="676"/>
-        <source>Waiting to start syncing.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="679"/>
-        <source>Sync is running.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="683"/>
-        <source>Sync was successful, unresolved conflicts.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="685"/>
-        <source>Last Sync was successful.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="692"/>
-        <source>User Abort.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="696"/>
-        <source>Sync is paused.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="705"/>
-        <source>%1 (Sync is paused)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="849"/>
-        <source>Unable to open folder path %1.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="1257"/>
-        <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="1261"/>
-        <source>REMOVE ALL SYNCHRONIZATIONS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="1262"/>
-        <source>CANCEL</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="1422"/>
-        <source>Synthesis</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="1423"/>
-        <source>Preferences</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="1424"/>
-        <source>Quit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="1590"/>
-        <source>Failed to start synchronizations!</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::ClientGui</name>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="116"/>
+<source>Unable to initialize kDrive client</source>
+<translation>kDrive-asiakkaan alustaminen epäonnistui</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="189"/>
+<source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
+<translation>Ristiriitojen korjaaminen kohteessa %1 synkronointikansiossa epäonnistui: %2</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="242"/>
+<source>Please sign in</source>
+<translation>Kirjaudu sisään</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="255"/>
+<source>Synchronization is paused</source>
+<translation>Synkronointi on keskeytetty</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="292"/>
+<source>Folder %1: %2</source>
+<translation>Kansio %1: %2</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="298"/>
+<source>There are no sync folders configured.</source>
+<translation>Synkronointikansioita ei ole määritetty.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="673"/>
+<source>Undefined State.</source>
+<translation>Määrittelemätön tila.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="676"/>
+<source>Waiting to start syncing.</source>
+<translation>Odotetaan synkronoinnin käynnistymistä.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="679"/>
+<source>Sync is running.</source>
+<translation>Synkronointi käynnissä.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="683"/>
+<source>Sync was successful, unresolved conflicts.</source>
+<translation>Synkronointi onnistui, ratkaisemattomia ristiriitoja.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="685"/>
+<source>Last Sync was successful.</source>
+<translation>Viimeisin synkronointi onnistui.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="692"/>
+<source>User Abort.</source>
+<translation>Käyttäjä keskeytti.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="696"/>
+<source>Sync is paused.</source>
+<translation>Synkronointi on keskeytetty.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="705"/>
+<source>%1 (Sync is paused)</source>
+<translation>%1 (Synkronointi keskeytetty)</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="849"/>
+<source>Unable to open folder path %1.</source>
+<translation>Kansion polkua %1 ei voi avata.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1257"/>
+<source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+<translation>Haluatko todella poistaa tilin &lt;i&gt;%1&lt;/i&gt; synkronoinnit?&lt;br&gt;&lt;b&gt;Huom:&lt;/b&gt; Tämä &lt;b&gt;ei&lt;/b&gt; poista tiedostoja.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1261"/>
+<source>REMOVE ALL SYNCHRONIZATIONS</source>
+<translation>POISTA KAIKKI SYNKRONOINNIT</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1262"/>
+<source>CANCEL</source>
+<translation>PERUUTA</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1422"/>
+<source>Synthesis</source>
+<translation>Yhteenveto</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1423"/>
+<source>Preferences</source>
+<translation>Asetukset</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1424"/>
+<source>Quit</source>
+<translation>Lopeta</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1590"/>
+<source>Failed to start synchronizations!</source>
+<translation>Synkronointien käynnistäminen epäonnistui!</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ConfirmSynchronizationDialog</name>
-    <message>
-        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86"/>
-        <source>Summary of your local folder synchronization</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95"/>
-        <source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184"/>
-        <source>CANCEL</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191"/>
-        <source>SYNCHRONIZE</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::ConfirmSynchronizationDialog</name>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86"/>
+<source>Summary of your local folder synchronization</source>
+<translation>Yhteenveto paikallisen kansion synkronoinnista</translation>
+</message>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95"/>
+<source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
+<translation>Tietokoneesi kansion sisältö synkronoidaan valitun kDriven kansioon ja päinvastoin.</translation>
+</message>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184"/>
+<source>CANCEL</source>
+<translation>PERUUTA</translation>
+</message>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191"/>
+<source>SYNCHRONIZE</source>
+<translation>SYNKRONOI</translation>
+</message>
 </context>
 <context>
-    <name>KDC::CustomExtensionSetupWidget</name>
-    <message>
-        <location filename="../src/gui/customextensionsetupwidget.cpp" line="96"/>
-        <location filename="../src/gui/customextensionsetupwidget.cpp" line="120"/>
-        <source>Before finishing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/customextensionsetupwidget.cpp" line="107"/>
-        <location filename="../src/gui/customextensionsetupwidget.cpp" line="131"/>
-        <source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/customextensionsetupwidget.cpp" line="208"/>
-        <source>Open your Mac&apos;s &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/customextensionsetupwidget.cpp" line="212"/>
-        <source>Open your Mac&apos;s &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/customextensionsetupwidget.cpp" line="216"/>
-        <source>Open your Mac&apos;s &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/customextensionsetupwidget.cpp" line="246"/>
-        <source>Go to &lt;b&gt;&quot;Login Items &amp; Extensions&quot;&lt;/b&gt; section and then to &lt;b&gt;&quot;Endpoint Security Extensions&quot;&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/customextensionsetupwidget.cpp" line="263"/>
-        <source>Authorize the kDrive application</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/customextensionsetupwidget.cpp" line="272"/>
-        <source>Go to &lt;b&gt;&quot;Security&quot;&lt;/b&gt; section</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/customextensionsetupwidget.cpp" line="289"/>
-        <source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/customextensionsetupwidget.cpp" line="299"/>
-        <source>Unlock the padlock &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; and authorize the kDrive application</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/customextensionsetupwidget.cpp" line="344"/>
-        <source>Go to &lt;b&gt;&quot;Privacy &amp; Security&quot;&lt;/b&gt; section and click on &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt; or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/customextensionsetupwidget.cpp" line="348"/>
-        <source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;&quot;Privacy&quot;&lt;/b&gt; tab or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/customextensionsetupwidget.cpp" line="376"/>
-        <source>Check the &quot;kDrive LiteSync Extension&quot; box then the &quot;kDrive.app&quot; box (if not already checked)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/customextensionsetupwidget.cpp" line="393"/>
-        <source>A restart of the app might be proposed, in this case accept it</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/customextensionsetupwidget.cpp" line="399"/>
-        <source>Check the &quot;kDrive LiteSync Extension&quot; box (and &quot;kDrive.app&quot; if it exists) in &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
-        <source>STEP 1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
-        <location filename="../src/gui/customextensionsetupwidget.cpp" line="496"/>
-        <source>(Done)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/customextensionsetupwidget.cpp" line="496"/>
-        <source>STEP 2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/customextensionsetupwidget.cpp" line="499"/>
-        <source>STEPS PERFORMED</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/customextensionsetupwidget.cpp" line="501"/>
-        <source>END</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::CustomExtensionSetupWidget</name>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="96"/>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="120"/>
+<source>Before finishing</source>
+<translation>Ennen viimeistelyä</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="107"/>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="131"/>
+<source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
+<translation>Suorita seuraavat vaiheet varmistaaksesi, että Lite Sync toimii oikein tietokoneellasi ja viimeistelläksesi kDriven konfiguroinnin.</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="208"/>
+<source>Open your Mac's &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Avaa Macin &lt;b&gt;Yleiset asetukset&lt;/b&gt; tai &lt;a style="%1" href="%2"&gt;napsauta tästä&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="212"/>
+<source>Open your Mac's &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Avaa Macin &lt;b&gt;Tietosuoja- ja turva-asetukset&lt;/b&gt; tai &lt;a style="%1" href="%2"&gt;napsauta tästä&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="216"/>
+<source>Open your Mac's &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Avaa Macin &lt;b&gt;Turvallisuus- ja tietosuoja-asetukset&lt;/b&gt; tai &lt;a style="%1" href="%2"&gt;napsauta tästä&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="246"/>
+<source>Go to &lt;b&gt;"Login Items &amp; Extensions"&lt;/b&gt; section and then to &lt;b&gt;"Endpoint Security Extensions"&lt;/b&gt;</source>
+<translation>Siirry &lt;b&gt;"Kirjautumisobjektit ja laajennukset"&lt;/b&gt;-osioon ja sitten &lt;b&gt;"Endpoint Security Extensions"&lt;/b&gt;-osioon</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="263"/>
+<source>Authorize the kDrive application</source>
+<translation>Valtuuta kDrive-sovellus</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="272"/>
+<source>Go to &lt;b&gt;"Security"&lt;/b&gt; section</source>
+<translation>Siirry &lt;b&gt;"Turvallisuus"&lt;/b&gt;-osioon</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="289"/>
+<source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
+<translation>Valtuuta kDrive-sovellus ruudussa, jossa ilmoitetaan kDriven olevan estetty</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="299"/>
+<source>Unlock the padlock &lt;img src=":/client/resources/icons/actions/lock.png"&gt; and authorize the kDrive application</source>
+<translation>Avaa lukko &lt;img src=":/client/resources/icons/actions/lock.png"&gt; ja valtuuta kDrive-sovellus</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="344"/>
+<source>Go to &lt;b&gt;"Privacy &amp; Security"&lt;/b&gt; section and click on &lt;b&gt;"Full Disk Access"&lt;/b&gt; or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Siirry &lt;b&gt;"Tietosuoja ja turvallisuus"&lt;/b&gt;-osioon ja napsauta &lt;b&gt;"Täysi levynkäyttöoikeus"&lt;/b&gt; tai &lt;a style="%1" href="%2"&gt;napsauta tästä&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="348"/>
+<source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;"Privacy"&lt;/b&gt; tab or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Turvallisuus- ja tietosuoja-asetuksissa avaa &lt;b&gt;"Tietosuoja"&lt;/b&gt;-välilehti tai &lt;a style="%1" href="%2"&gt;napsauta tästä&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="376"/>
+<source>Check the "kDrive LiteSync Extension" box then the "kDrive.app" box (if not already checked)</source>
+<translation>Valitse "kDrive LiteSync Extension" -ruutu ja sitten "kDrive.app"-ruutu (jos ei vielä valittu)</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="393"/>
+<source>A restart of the app might be proposed, in this case accept it</source>
+<translation>Sovelluksen uudelleenkäynnistystä saatetaan ehdottaa; hyväksy se siinä tapauksessa</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="399"/>
+<source>Check the "kDrive LiteSync Extension" box (and "kDrive.app" if it exists) in &lt;b&gt;"Full Disk Access"&lt;/b&gt;</source>
+<translation>Valitse "kDrive LiteSync Extension" -ruutu (ja "kDrive.app", jos se on olemassa) kohdassa &lt;b&gt;"Täysi levynkäyttöoikeus"&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
+<source>STEP 1</source>
+<translation>VAIHE 1</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="496"/>
+<source>(Done)</source>
+<translation>(Valmis)</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="496"/>
+<source>STEP 2</source>
+<translation>VAIHE 2</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="499"/>
+<source>STEPS PERFORMED</source>
+<translation>VAIHEET SUORITETTU</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="501"/>
+<source>END</source>
+<translation>LOPETA</translation>
+</message>
 </context>
 <context>
-    <name>KDC::CustomMessageBox</name>
-    <message>
-        <location filename="../src/gui/custommessagebox.cpp" line="101"/>
-        <source>OK</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/custommessagebox.cpp" line="111"/>
-        <source>CANCEL</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/custommessagebox.cpp" line="121"/>
-        <source>YES</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/custommessagebox.cpp" line="131"/>
-        <source>NO</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::CustomMessageBox</name>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="101"/>
+<source>OK</source>
+<translation>OK</translation>
+</message>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="111"/>
+<source>CANCEL</source>
+<translation>PERUUTA</translation>
+</message>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="121"/>
+<source>YES</source>
+<translation>KYLLÄ</translation>
+</message>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="131"/>
+<source>NO</source>
+<translation>EI</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DebugReporter</name>
-    <message>
-        <location filename="../src/gui/debugreporter.cpp" line="37"/>
-        <source>Sending of debugging information</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/debugreporter.cpp" line="37"/>
-        <source>Cancel</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::DebugReporter</name>
+<message>
+<location filename="../src/gui/debugreporter.cpp" line="37"/>
+<source>Sending of debugging information</source>
+<translation>Lähetetään virheenkorjaustietoja</translation>
+</message>
+<message>
+<location filename="../src/gui/debugreporter.cpp" line="37"/>
+<source>Cancel</source>
+<translation>Peruuta</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DebuggingDialog</name>
-    <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="45"/>
-        <source>Debug</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="46"/>
-        <source>Info</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="47"/>
-        <source>Warning</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="48"/>
-        <source>Error</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="49"/>
-        <source>Fatal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="74"/>
-        <source>Debugging settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="90"/>
-        <source>Save debugging information in a folder on my computer (Recommended)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="104"/>
-        <source>This information enables IT support to determine the origin of an incident.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="114"/>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="143"/>
-        <source>Debug level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="152"/>
-        <source>The trace level lets you choose the extent of the debugging information recorded</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="179"/>
-        <source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="183"/>
-        <source>Extended Full Log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="207"/>
-        <source>Delete logs older than %1 days</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="226"/>
-        <source>Share the debug folder with Infomaniak support.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="250"/>
-        <source>The last session is the periode since the last kDrive start.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="254"/>
-        <source>Share only the last kDrive session</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="285"/>
-        <source>  Loading</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="294"/>
-        <source>Cancel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="320"/>
-        <source>SAVE</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="327"/>
-        <source>CANCEL</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="471"/>
-        <source>Failed to share</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="481"/>
-        <source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="486"/>
-        <source> (Connexion interrupted)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="493"/>
-        <source>Share the folder with SwissTransfer &lt;br&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="494"/>
-        <source> 1. We automatically compressed your log &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;here&lt;/a&gt;.&lt;br&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="496"/>
-        <source> 2. Transfer the archive with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="498"/>
-        <source> 3. Share the link with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="528"/>
-        <source>Last upload the %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="556"/>
-        <source>Sharing has been cancelled</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="597"/>
-        <source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="611"/>
-        <source>%1/%2/%3 at %4h%5m and %6s</source>
-        <extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="654"/>
-        <source>Do you want to save your modifications?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="709"/>
-        <location filename="../src/gui/debuggingdialog.cpp" line="715"/>
-        <source>Unable to open folder %1.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="722"/>
-        <source>  Share</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="732"/>
-        <source>  Sharing | step 1/2 %1%</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="741"/>
-        <source>  Sharing | step 2/2 %1%</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="751"/>
-        <source>  Canceling...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/debuggingdialog.h" line="70"/>
-        <source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::DebuggingDialog</name>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="45"/>
+<source>Debug</source>
+<translation>Virheenkorjaus</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="46"/>
+<source>Info</source>
+<translation>Tiedot</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="47"/>
+<source>Warning</source>
+<translation>Varoitus</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="48"/>
+<source>Error</source>
+<translation>Virhe</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="49"/>
+<source>Fatal</source>
+<translation>Kriittinen</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="74"/>
+<source>Debugging settings</source>
+<translation>Virheenkorjausasetukset</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="90"/>
+<source>Save debugging information in a folder on my computer (Recommended)</source>
+<translation>Tallenna virheenkorjaustiedot kansioon tietokoneellani (Suositeltu)</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="104"/>
+<source>This information enables IT support to determine the origin of an incident.</source>
+<translation>Nämä tiedot auttavat IT-tukea selvittämään tapauksen alkuperän.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="114"/>
+<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;Avaa virheenkorjauskansio&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="143"/>
+<source>Debug level</source>
+<translation>Virheenkorjaustaso</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="152"/>
+<source>The trace level lets you choose the extent of the debugging information recorded</source>
+<translation>Jäljitystaso antaa sinun valita tallennettavien virheenkorjaustietojen laajuuden</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="179"/>
+<source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
+<translation>Laajennettu täysloki kerää yksityiskohtaisen historian virheenkorjausta varten. Sen käyttöönotto voi hidastaa kDrive-sovellusta.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="183"/>
+<source>Extended Full Log</source>
+<translation>Laajennettu täysloki</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="207"/>
+<source>Delete logs older than %1 days</source>
+<translation>Poista lokeja, jotka ovat vanhempia kuin %1 päivää</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="226"/>
+<source>Share the debug folder with Infomaniak support.</source>
+<translation>Jaa virheenkorjauskansio Infomaniakille.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="250"/>
+<source>The last session is the periode since the last kDrive start.</source>
+<translation>Viimeinen istunto on ajanjakso viimeisimmästä kDriven käynnistyksestä.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="254"/>
+<source>Share only the last kDrive session</source>
+<translation>Jaa vain viimeisin kDrive-istunto</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="285"/>
+<source>  Loading</source>
+<translation>  Ladataan</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="294"/>
+<source>Cancel</source>
+<translation>Peruuta</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="320"/>
+<source>SAVE</source>
+<translation>TALLENNA</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="327"/>
+<source>CANCEL</source>
+<translation>PERUUTA</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="471"/>
+<source>Failed to share</source>
+<translation>Jakaminen epäonnistui</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="481"/>
+<source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
+<translation>1. Tarkista, että olet kirjautunut sisään &lt;br&gt;2. Tarkista, että olet määrittänyt vähintään yhden kDriven</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="486"/>
+<source> (Connexion interrupted)</source>
+<translation> (Yhteys katkaistu)</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="493"/>
+<source>Share the folder with SwissTransfer &lt;br&gt;</source>
+<translation>Jaa kansio SwissTransferillä &lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="494"/>
+<source> 1. We automatically compressed your log &lt;a style="%1" href="%2"&gt;here&lt;/a&gt;.&lt;br&gt;</source>
+<translation> 1. Pakkasimme lokisi automaattisesti &lt;a style="%1" href="%2"&gt;tähän&lt;/a&gt;.&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="496"/>
+<source> 2. Transfer the archive with &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
+<translation> 2. Siirrä arkisto &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;-palvelun avulla&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="498"/>
+<source> 3. Share the link with &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
+<translation> 3. Jaa linkki osoitteeseen &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="528"/>
+<source>Last upload the %1</source>
+<translation>Viimeisin lähetys %1</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="556"/>
+<source>Sharing has been cancelled</source>
+<translation>Jakaminen on peruutettu</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="597"/>
+<source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
+<translation>Laajennettu täysloki on aktivoitu KDRIVE_FORCE_EXTENDED_LOG-ympäristömuuttujalla. Aseta se arvoon 0 poistaaksesi sen käytöstä.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="611"/>
+<source>%1/%2/%3 at %4h%5m and %6s</source>
+<extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
+<translation>%1/%2/%3 klo %4:%5:%6</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="654"/>
+<source>Do you want to save your modifications?</source>
+<translation>Haluatko tallentaa muutokset?</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="709"/>
+<location filename="../src/gui/debuggingdialog.cpp" line="715"/>
+<source>Unable to open folder %1.</source>
+<translation>Kansiota %1 ei voi avata.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="722"/>
+<source>  Share</source>
+<translation>  Jaa</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="732"/>
+<source>  Sharing | step 1/2 %1%</source>
+<translation>  Jaetaan | vaihe 1/2 %1%</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="741"/>
+<source>  Sharing | step 2/2 %1%</source>
+<translation>  Jaetaan | vaihe 2/2 %1%</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="751"/>
+<source>  Canceling...</source>
+<translation>  Peruutetaan...</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.h" line="70"/>
+<source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
+<translation>Koko kansio on suuri (&gt; 100 Mt) ja jakaminen voi kestää jonkin aikaa. Jakamisajan lyhentämiseksi suosittelemme jakamaan vain viimeisimmän kDrive-istunnon.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DrivePreferencesWidget</name>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
-        <source>Synchronization errors and information.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
-        <source>Synchronize a local folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
-        <source>Do you really want to turn on Lite Sync?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="356"/>
-        <source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
-        <source>CONFIRM</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="360"/>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="391"/>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="986"/>
-        <source>CANCEL</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="382"/>
-        <source>Do you really want to turn off Lite Sync?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="384"/>
-        <source>You don&apos;t have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="388"/>
-        <source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="627"/>
-        <source>Failed to create new synchronization</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
-        <source>New local folder synchronization failed!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="819"/>
-        <source>Lite Sync activated.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
-        <source>Lite Sync activation failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="837"/>
-        <source>Lite Sync deactivated.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
-        <source>Lite Sync deactivation failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="899"/>
-        <source>This drive is being deleted.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="962"/>
-        <source>Impossible to open item %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
-        <source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
-        <source>REMOVE FOLDER SYNC CONNECTION</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1007"/>
-        <source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
-        <source>An error occurred while loading the list of subfolders.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
-        <source>Folders</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
-        <source>Notifications</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
-        <source>Enable the notifications for this kDrive</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
-        <source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
-        <source>Connected with</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1125"/>
-        <source>Remove all synchronizations</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1126"/>
-        <source>Search in your kDrive</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1127"/>
-        <source>Search</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::DrivePreferencesWidget</name>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
+<source>Synchronization errors and information.</source>
+<translation>Synkronointivirheet ja tiedot.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
+<source>Synchronize a local folder</source>
+<translation>Synkronoi paikallinen kansio</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
+<source>Do you really want to turn on Lite Sync?</source>
+<translation>Haluatko todella ottaa Lite Sync käyttöön?</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="356"/>
+<source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
+<translation>Tämä toiminto voi kestää muutamasta sekunnista muutamaan minuuttiin kansion koosta riippuen.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
+<source>CONFIRM</source>
+<translation>VAHVISTA</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="360"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="391"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="986"/>
+<source>CANCEL</source>
+<translation>PERUUTA</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="382"/>
+<source>Do you really want to turn off Lite Sync?</source>
+<translation>Haluatko todella poistaa Lite Sync käytöstä?</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="384"/>
+<source>You don't have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
+<translation>Sinulla ei ole tarpeeksi tilaa kaikkien kDrive-tiedostojen synkronointiin (%1 puuttuu). Jos poistat Lite Sync käytöstä, sinun on valittava synkronoitavat kansiot tietokoneellasi. Sillä välin kDriven synkronointi keskeytetään.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="388"/>
+<source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
+<translation>Jos poistat Lite Sync käytöstä, kaikki tiedostot ladataan tietokoneellesi.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="627"/>
+<source>Failed to create new synchronization</source>
+<translation>Uuden synkronoinnin luominen epäonnistui</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
+<source>New local folder synchronization failed!</source>
+<translation>Uuden paikallisen kansion synkronointi epäonnistui!</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="819"/>
+<source>Lite Sync activated.</source>
+<translation>Lite Sync aktivoitu.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
+<source>Lite Sync activation failed.</source>
+<translation>Lite Sync -aktivointi epäonnistui.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="837"/>
+<source>Lite Sync deactivated.</source>
+<translation>Lite Sync poistettu käytöstä.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
+<source>Lite Sync deactivation failed.</source>
+<translation>Lite Sync -deaktivointi epäonnistui.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="899"/>
+<source>This drive is being deleted.</source>
+<translation>Tämä asema poistetaan.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="962"/>
+<source>Impossible to open item %1</source>
+<translation>Kohteen %1 avaaminen ei onnistu</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
+<source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+<translation>Haluatko todella lopettaa kansion &lt;i&gt;%1&lt;/i&gt; synkronoinnin?&lt;br&gt;&lt;b&gt;Huom:&lt;/b&gt; Tämä &lt;b&gt;ei&lt;/b&gt; poista tiedostoja.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
+<source>REMOVE FOLDER SYNC CONNECTION</source>
+<translation>POISTA KANSION SYNKRONOINTIYHTEYS</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1007"/>
+<source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
+<translation>Kansion &lt;i&gt;%1&lt;/i&gt; synkronoinnin pysäyttäminen epäonnistui.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
+<source>An error occurred while loading the list of subfolders.</source>
+<translation>Alikansioiden listan lataaminen epäonnistui.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
+<source>Folders</source>
+<translation>Kansiot</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
+<source>Notifications</source>
+<translation>Ilmoitukset</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
+<source>Enable the notifications for this kDrive</source>
+<translation>Ota tämän kDriven ilmoitukset käyttöön</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
+<source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
+<translation>Ilmoitus näytetään heti, kun uusi kansio on synkronoitu tai muokattu</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
+<source>Connected with</source>
+<translation>Yhdistetty:</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1125"/>
+<source>Remove all synchronizations</source>
+<translation>Poista kaikki synkronoinnit</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1126"/>
+<source>Search in your kDrive</source>
+<translation>Hae kDrivesta</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1127"/>
+<source>Search</source>
+<translation>Haku</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DriveSelectionWidget</name>
-    <message>
-        <location filename="../src/gui/driveselectionwidget.cpp" line="150"/>
-        <source>Add a kDrive</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
-        <source>Synchronize a kDrive</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::DriveSelectionWidget</name>
+<message>
+<location filename="../src/gui/driveselectionwidget.cpp" line="150"/>
+<source>Add a kDrive</source>
+<translation>Lisää kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
+<source>Synchronize a kDrive</source>
+<translation>Synkronoi kDrive</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ErrorTabWidget</name>
-    <message>
-        <location filename="../src/gui/errortabwidget.cpp" line="92"/>
-        <location filename="../src/gui/errortabwidget.cpp" line="135"/>
-        <location filename="../src/gui/errortabwidget.cpp" line="178"/>
-        <location filename="../src/gui/errortabwidget.cpp" line="186"/>
-        <source>Clear history</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/errortabwidget.cpp" line="176"/>
-        <source>To Resolve</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/errortabwidget.cpp" line="177"/>
-        <source>problem(s) detected</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/errortabwidget.cpp" line="179"/>
-        <source>Resolve</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/errortabwidget.cpp" line="180"/>
-        <source>Conflicted item(s)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/errortabwidget.cpp" line="181"/>
-        <source>Item(s) with unsupported characters</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/errortabwidget.cpp" line="184"/>
-        <source>Automatically resolved</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/errortabwidget.cpp" line="185"/>
-        <source>problem(s) solved</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::ErrorTabWidget</name>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="92"/>
+<location filename="../src/gui/errortabwidget.cpp" line="135"/>
+<location filename="../src/gui/errortabwidget.cpp" line="178"/>
+<location filename="../src/gui/errortabwidget.cpp" line="186"/>
+<source>Clear history</source>
+<translation>Tyhjennä historia</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="176"/>
+<source>To Resolve</source>
+<translation>Ratkaistavana</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="177"/>
+<source>problem(s) detected</source>
+<translation>havaittu ongelma(t)</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="179"/>
+<source>Resolve</source>
+<translation>Ratkaise</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="180"/>
+<source>Conflicted item(s)</source>
+<translation>Ristiriitainen kohde (kohteet)</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="181"/>
+<source>Item(s) with unsupported characters</source>
+<translation>Kohde(et), joissa on ei-tuettuja merkkejä</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="184"/>
+<source>Automatically resolved</source>
+<translation>Automaattisesti ratkaistu</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="185"/>
+<source>problem(s) solved</source>
+<translation>ratkaistut ongelma(t)</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ErrorsMenuBarWidget</name>
-    <message>
-        <location filename="../src/gui/errorsmenubarwidget.cpp" line="84"/>
-        <location filename="../src/gui/errorsmenubarwidget.cpp" line="103"/>
-        <source>Synchronization conflicts or errors</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/errorsmenubarwidget.cpp" line="86"/>
-        <location filename="../src/gui/errorsmenubarwidget.cpp" line="105"/>
-        <source>Errors</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/errorsmenubarwidget.cpp" line="101"/>
-        <source>Back to preferences</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::ErrorsMenuBarWidget</name>
+<message>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="84"/>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="103"/>
+<source>Synchronization conflicts or errors</source>
+<translation>Synkronointiristiriidat tai -virheet</translation>
+</message>
+<message>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="86"/>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="105"/>
+<source>Errors</source>
+<translation>Virheet</translation>
+</message>
+<message>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="101"/>
+<source>Back to preferences</source>
+<translation>Takaisin asetuksiin</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ErrorsPopup</name>
-    <message>
-        <location filename="../src/gui/errorspopup.cpp" line="73"/>
-        <source>Some files couldn&apos;t be synchronized on the following kDrive(s) :</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/errorspopup.cpp" line="95"/>
-        <source> (%1 error(s))</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/errorspopup.cpp" line="101"/>
-        <source> (%1 information(s))</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/errorspopup.cpp" line="107"/>
-        <source> (%1 error(s) and %2 information(s))</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gui/errorspopup.cpp" line="147"/>
-        <source>Generic errors (%n warning(s) or error(s))</source>
-        <comment>Number of warnings or errors</comment>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
+<name>KDC::ErrorsPopup</name>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="73"/>
+<source>Some files couldn't be synchronized on the following kDrive(s) :</source>
+<translation>Joitakin tiedostoja ei voitu synkronoida seuraavilla kDrive-asemilla:</translation>
+</message>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="95"/>
+<source> (%1 error(s))</source>
+<translation> (%1 virhe(ttä))</translation>
+</message>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="101"/>
+<source> (%1 information(s))</source>
+<translation> (%1 tiedote(tta))</translation>
+</message>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="107"/>
+<source> (%1 error(s) and %2 information(s))</source>
+<translation> (%1 virhe(ttä) ja %2 tiedote(tta))</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/gui/errorspopup.cpp" line="147"/>
+<source>Generic errors (%n warning(s) or error(s))</source>
+<comment>Number of warnings or errors</comment>
+<translation>
+<numerusform>Yleiset virheet (%n varoitus tai virhe)</numerusform><numerusform>Yleiset virheet (%n varoitusta tai virhettä)</numerusform></translation>
+</message>
 </context>
 <context>
-    <name>KDC::FileExclusionDialog</name>
-    <message>
-        <location filename="../src/gui/fileexclusiondialog.cpp" line="78"/>
-        <source>Excluded files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/fileexclusiondialog.cpp" line="86"/>
-        <source>Add files or folders that will not be synchronized on your computer.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/fileexclusiondialog.cpp" line="97"/>
-        <source>Add</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/fileexclusiondialog.cpp" line="109"/>
-        <source>NAME</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/fileexclusiondialog.cpp" line="114"/>
-        <source>WARNING</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/fileexclusiondialog.cpp" line="149"/>
-        <source>SAVE</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/fileexclusiondialog.cpp" line="156"/>
-        <source>CANCEL</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/fileexclusiondialog.cpp" line="304"/>
-        <source>Do you want to save your modifications?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/fileexclusiondialog.cpp" line="353"/>
-        <source>Exclusion template already exists!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/fileexclusiondialog.cpp" line="374"/>
-        <source>Do you really want to delete?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/fileexclusiondialog.cpp" line="434"/>
-        <source>Cannot save changes!</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::FileExclusionDialog</name>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="78"/>
+<source>Excluded files</source>
+<translation>Poissuljetut tiedostot</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="86"/>
+<source>Add files or folders that will not be synchronized on your computer.</source>
+<translation>Lisää tiedostoja tai kansioita, joita ei synkronoida tietokoneellesi.</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="97"/>
+<source>Add</source>
+<translation>Lisää</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="109"/>
+<source>NAME</source>
+<translation>NIMI</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="114"/>
+<source>WARNING</source>
+<translation>VAROITUS</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="149"/>
+<source>SAVE</source>
+<translation>TALLENNA</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="156"/>
+<source>CANCEL</source>
+<translation>PERUUTA</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="304"/>
+<source>Do you want to save your modifications?</source>
+<translation>Haluatko tallentaa muutokset?</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="353"/>
+<source>Exclusion template already exists!</source>
+<translation>Poissulkumalli on jo olemassa!</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="374"/>
+<source>Do you really want to delete?</source>
+<translation>Haluatko todella poistaa?</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="434"/>
+<source>Cannot save changes!</source>
+<translation>Muutoksia ei voi tallentaa!</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FileExclusionNameDialog</name>
-    <message>
-        <location filename="../src/gui/fileexclusionnamedialog.cpp" line="58"/>
-        <source>VALIDATE</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/fileexclusionnamedialog.cpp" line="65"/>
-        <source>CANCEL</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::FileExclusionNameDialog</name>
+<message>
+<location filename="../src/gui/fileexclusionnamedialog.cpp" line="58"/>
+<source>VALIDATE</source>
+<translation>VAHVISTA</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusionnamedialog.cpp" line="65"/>
+<source>CANCEL</source>
+<translation>PERUUTA</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FixConflictingFilesDialog</name>
-    <message>
-        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67"/>
-        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73"/>
-        <source>Unable to open link %1.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122"/>
-        <source>Solve conflict(s)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140"/>
-        <source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143"/>
-        <source>Save my changes and replace other users&apos; versions.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147"/>
-        <source>Undo my changes and keep other users&apos; versions.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169"/>
-        <source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171"/>
-        <source>&lt;a style=%1 href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175"/>
-        <source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191"/>
-        <source>Show item(s)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228"/>
-        <source>VALIDATE</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234"/>
-        <source>CANCEL</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251"/>
-        <source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253"/>
-        <source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::FixConflictingFilesDialog</name>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67"/>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73"/>
+<source>Unable to open link %1.</source>
+<translation>Linkkiä %1 ei voi avata.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122"/>
+<source>Solve conflict(s)</source>
+<translation>Ratkaise ristiriita(t)</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140"/>
+<source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
+<translation>&lt;b&gt;Mitä haluat tehdä %1 ristiriitaiselle kohteelle?&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143"/>
+<source>Save my changes and replace other users' versions.</source>
+<translation>Tallenna muutokseni ja korvaa muiden käyttäjien versiot.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147"/>
+<source>Undo my changes and keep other users' versions.</source>
+<translation>Kumoa muutokseni ja säilytä muiden käyttäjien versiot.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169"/>
+<source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
+<translation>Muutoksesi voidaan poistaa pysyvästi. Niitä ei voi palauttaa kDrive-verkkosovelluksesta.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171"/>
+<source>&lt;a style=%1 href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>&lt;a style=%1 href="%2"&gt;Lue lisää&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175"/>
+<source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
+<translation>Muutoksesi poistetaan pysyvästi. Niitä ei voi palauttaa kDrive-verkkosovelluksesta.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191"/>
+<source>Show item(s)</source>
+<translation>Näytä kohde(et)</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228"/>
+<source>VALIDATE</source>
+<translation>VAHVISTA</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234"/>
+<source>CANCEL</source>
+<translation>PERUUTA</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251"/>
+<source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
+<translation>Useat käyttäjät ovat muokanneet näitä tiedostoja useissa paikoissa (kDrivessa verkossa, tietokoneella tai mobiililaitteella). Myös nämä tiedostot sisältävät kansiot on saatettu poistaa.&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253"/>
+<source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Learn more&lt;/a&gt;</source>
+<translation>Kohteesi paikallinen versio &lt;b&gt;ei ole synkronoitu&lt;/b&gt; kDriven kanssa. &lt;a style="color: #489EF3" href="%1"&gt;Lue lisää&lt;/a&gt;</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FolderItemWidget</name>
-    <message>
-        <location filename="../src/gui/folderitemwidget.cpp" line="188"/>
-        <location filename="../src/gui/folderitemwidget.cpp" line="476"/>
-        <source>Synchronized into &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/folderitemwidget.cpp" line="343"/>
-        <source>Activate Lite Sync</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/folderitemwidget.cpp" line="345"/>
-        <source>Activate Lite Sync (Beta)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/folderitemwidget.cpp" line="354"/>
-        <source>Deactivate Lite Sync</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/folderitemwidget.cpp" line="365"/>
-        <source>Pause synchronization</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/folderitemwidget.cpp" line="375"/>
-        <source>Resume synchronization</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/folderitemwidget.cpp" line="386"/>
-        <source>Remove synchronization</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/folderitemwidget.cpp" line="458"/>
-        <source>More actions</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/folderitemwidget.cpp" line="481"/>
-        <source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/folderitemwidget.cpp" line="485"/>
-        <source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/folderitemwidget.cpp" line="488"/>
-        <source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/folderitemwidget.cpp" line="493"/>
-        <source>Cancel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/folderitemwidget.cpp" line="494"/>
-        <source>VALIDATE</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::FolderItemWidget</name>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="188"/>
+<location filename="../src/gui/folderitemwidget.cpp" line="476"/>
+<source>Synchronized into &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</source>
+<translation>Synkronoitu kohteeseen &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="343"/>
+<source>Activate Lite Sync</source>
+<translation>Ota Lite Sync käyttöön</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="345"/>
+<source>Activate Lite Sync (Beta)</source>
+<translation>Ota Lite Sync (Beta) käyttöön</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="354"/>
+<source>Deactivate Lite Sync</source>
+<translation>Poista Lite Sync käytöstä</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="365"/>
+<source>Pause synchronization</source>
+<translation>Keskeytä synkronointi</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="375"/>
+<source>Resume synchronization</source>
+<translation>Jatka synkronointia</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="386"/>
+<source>Remove synchronization</source>
+<translation>Poista synkronointi</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="458"/>
+<source>More actions</source>
+<translation>Lisää toimintoja</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="481"/>
+<source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
+<translation>Valitsemattomat kansiot siirretään roskakoriin, jos ne sisältävät offline-kohteita. kDriveen synkronoidut kansiot pysyvät saatavilla verkossa.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="485"/>
+<source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
+<translation>Valitsemattomat kansiot siirretään roskakoriin. kDriveen synkronoidut kansiot pysyvät saatavilla verkossa.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="488"/>
+<source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
+<translation>Valitsemattomat kansiot poistetaan &lt;b&gt;pysyvästi&lt;/b&gt; tietokoneelta. kDriveen synkronoidut kansiot pysyvät saatavilla verkossa.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="493"/>
+<source>Cancel</source>
+<translation>Peruuta</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="494"/>
+<source>VALIDATE</source>
+<translation>VAHVISTA</translation>
+</message>
 </context>
 <context>
-    <name>KDC::GenericErrorItemWidget</name>
-    <message>
-        <location filename="../src/gui/genericerroritemwidget.cpp" line="85"/>
-        <source>Unable to open folder path %1.</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::GenericErrorItemWidget</name>
+<message>
+<location filename="../src/gui/genericerroritemwidget.cpp" line="85"/>
+<source>Unable to open folder path %1.</source>
+<translation>Kansion polkua %1 ei voi avata.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::LiteSyncAppDialog</name>
-    <message>
-        <location filename="../src/gui/litesyncappdialog.cpp" line="48"/>
-        <source>Application Id</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/litesyncappdialog.cpp" line="98"/>
-        <source>Application Name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/litesyncappdialog.cpp" line="121"/>
-        <source>VALIDATE</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/litesyncappdialog.cpp" line="128"/>
-        <source>CANCEL</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::LiteSyncAppDialog</name>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="48"/>
+<source>Application Id</source>
+<translation>Sovelluksen tunnus</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="98"/>
+<source>Application Name</source>
+<translation>Sovelluksen nimi</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="121"/>
+<source>VALIDATE</source>
+<translation>VAHVISTA</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="128"/>
+<source>CANCEL</source>
+<translation>PERUUTA</translation>
+</message>
 </context>
 <context>
-    <name>KDC::LiteSyncDialog</name>
-    <message>
-        <location filename="../src/gui/litesyncdialog.cpp" line="91"/>
-        <source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are &quot;online&quot;. Add them in the list below to avoid this behaviour.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/litesyncdialog.cpp" line="103"/>
-        <source>Add</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/litesyncdialog.cpp" line="115"/>
-        <source>APPLICATION ID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/litesyncdialog.cpp" line="120"/>
-        <source>NAME</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/litesyncdialog.cpp" line="154"/>
-        <source>SAVE</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/litesyncdialog.cpp" line="161"/>
-        <source>CANCEL</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/litesyncdialog.cpp" line="295"/>
-        <source>Do you want to save your modifications?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/litesyncdialog.cpp" line="337"/>
-        <source>Do you really want to delete?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/litesyncdialog.cpp" line="374"/>
-        <source>Cannot save changes!</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::LiteSyncDialog</name>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="91"/>
+<source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are "online". Add them in the list below to avoid this behaviour.</source>
+<translation>Jotkut sovellukset (varmuuskopiointi, virustorjunta...) käyttävät tiedostojasi, mikä johtaa niiden lataamiseen, kun ne ovat "verkossa". Lisää ne alla olevaan luetteloon tämän käyttäytymisen välttämiseksi.</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="103"/>
+<source>Add</source>
+<translation>Lisää</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="115"/>
+<source>APPLICATION ID</source>
+<translation>SOVELLUKSEN TUNNUS</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="120"/>
+<source>NAME</source>
+<translation>NIMI</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="154"/>
+<source>SAVE</source>
+<translation>TALLENNA</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="161"/>
+<source>CANCEL</source>
+<translation>PERUUTA</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="295"/>
+<source>Do you want to save your modifications?</source>
+<translation>Haluatko tallentaa muutokset?</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="337"/>
+<source>Do you really want to delete?</source>
+<translation>Haluatko todella poistaa?</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="374"/>
+<source>Cannot save changes!</source>
+<translation>Muutoksia ei voi tallentaa!</translation>
+</message>
 </context>
 <context>
-    <name>KDC::LocalFolderDialog</name>
-    <message>
-        <location filename="../src/gui/localfolderdialog.cpp" line="63"/>
-        <source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/localfolderdialog.cpp" line="72"/>
-        <source>The content of this folder will be synchronized on the kDrive</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/localfolderdialog.cpp" line="91"/>
-        <source>Select a folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/localfolderdialog.cpp" line="131"/>
-        <source>Edit folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/localfolderdialog.cpp" line="166"/>
-        <source>CANCEL</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/localfolderdialog.cpp" line="173"/>
-        <source>CONTINUE</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/localfolderdialog.cpp" line="210"/>
-        <source>This folder is not compatible with Lite Sync.&lt;br&gt;
+<name>KDC::LocalFolderDialog</name>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="63"/>
+<source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
+<translation>Minkä tietokoneen kansion haluat&lt;br&gt;synkronoida?</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="72"/>
+<source>The content of this folder will be synchronized on the kDrive</source>
+<translation>Tämän kansion sisältö synkronoidaan kDriveen</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="91"/>
+<source>Select a folder</source>
+<translation>Valitse kansio</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="131"/>
+<source>Edit folder</source>
+<translation>Muokkaa kansiota</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="166"/>
+<source>CANCEL</source>
+<translation>PERUUTA</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="173"/>
+<source>CONTINUE</source>
+<translation>JATKA</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="210"/>
+<source>This folder is not compatible with Lite Sync.&lt;br&gt;
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt;
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/localfolderdialog.cpp" line="233"/>
-        <source>Select folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/localfolderdialog.cpp" line="292"/>
-        <source>Unable to open link %1.</source>
-        <translation type="unfinished"></translation>
-    </message>
+&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Tämä kansio ei ole yhteensopiva Lite Sync -toiminnon kanssa.&lt;br&gt;
+Valitse toinen kansio. Jos jatkat, Lite Sync poistetaan käytöstä.&lt;br&gt;
+&lt;a style="%1" href="%2"&gt;Lue lisää&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="233"/>
+<source>Select folder</source>
+<translation>Valitse kansio</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="292"/>
+<source>Unable to open link %1.</source>
+<translation>Linkkiä %1 ei voi avata.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::Logger</name>
-    <message>
-        <location filename="../src/libcommongui/logger.cpp" line="189"/>
-        <source>Error</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/libcommongui/logger.cpp" line="189"/>
-        <source>&lt;nobr&gt;File &apos;%1&apos;&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::Logger</name>
+<message>
+<location filename="../src/libcommongui/logger.cpp" line="189"/>
+<source>Error</source>
+<translation>Virhe</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/logger.cpp" line="189"/>
+<source>&lt;nobr&gt;File '%1'&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
+<translation>&lt;nobr&gt;Tiedostoa '%1'&lt;br/&gt;ei voi avata kirjoittamista varten.&lt;br/&gt;&lt;br/&gt;Lokia &lt;b&gt;ei&lt;/b&gt; voi tallentaa!&lt;/nobr&gt;</translation>
+</message>
 </context>
 <context>
-    <name>KDC::MainMenuBarWidget</name>
-    <message>
-        <location filename="../src/gui/mainmenubarwidget.cpp" line="115"/>
-        <source>Preferences</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/mainmenubarwidget.cpp" line="116"/>
-        <source>Help</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::MainMenuBarWidget</name>
+<message>
+<location filename="../src/gui/mainmenubarwidget.cpp" line="115"/>
+<source>Preferences</source>
+<translation>Asetukset</translation>
+</message>
+<message>
+<location filename="../src/gui/mainmenubarwidget.cpp" line="116"/>
+<source>Help</source>
+<translation>Ohje</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ParametersDialog</name>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="320"/>
-        <source>kDrive needs to have write access to your computer&apos;s temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="330"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="487"/>
-        <source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="337"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="440"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="506"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="546"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="560"/>
-        <source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="342"/>
-        <source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="347"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="516"/>
-        <source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="352"/>
-        <source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="356"/>
-        <source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="360"/>
-        <source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="385"/>
-        <source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="389"/>
-        <source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="393"/>
-        <source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="397"/>
-        <source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="401"/>
-        <source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing &apos;/etc/sysctl.conf&apos;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="406"/>
-        <source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="413"/>
-        <source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="419"/>
-        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="424"/>
-        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="429"/>
-        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="435"/>
-        <source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="449"/>
-        <source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="455"/>
-        <source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="460"/>
-        <source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="466"/>
-        <source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="475"/>
-        <source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="479"/>
-        <source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive&apos;s status, or contact your administrator.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="483"/>
-        <source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="493"/>
-        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="512"/>
-        <source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="522"/>
-        <source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="526"/>
-        <source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="532"/>
-        <source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="539"/>
-        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="550"/>
-        <source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="564"/>
-        <source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="569"/>
-        <source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="573"/>
-        <source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="580"/>
-        <source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="609"/>
-        <source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="614"/>
-        <source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="618"/>
-        <source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="622"/>
-        <source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="626"/>
-        <source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="649"/>
-        <source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="656"/>
-        <source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="662"/>
-        <source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="668"/>
-        <source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="674"/>
-        <source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="680"/>
-        <source>The item path is too long.&lt;br&gt;It has been ignored.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="686"/>
-        <source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="692"/>
-        <source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="703"/>
-        <source>Either you are not allowed to create an item, or another item already exists with the same name.&lt;br&gt;The item has been excluded from synchronization.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="708"/>
-        <source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="716"/>
-        <source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="722"/>
-        <source>You are not allowed to move item to &quot;%1&quot;.&lt;br&gt;It will be restored into its original parent folder.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="727"/>
-        <source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="732"/>
-        <source>Failed to move this item to trash, it has been blacklisted.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="735"/>
-        <source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="740"/>
-        <source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="745"/>
-        <source>This item has been excluded from sync because it is a hard link.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="748"/>
-        <source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="765"/>
-        <source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="771"/>
-        <source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="776"/>
-        <source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="779"/>
-        <source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="782"/>
-        <source>Impossible to download the file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="785"/>
-        <source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="790"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="834"/>
-        <source>Synchronization error.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="810"/>
-        <source>Can&apos;t access item.&lt;br&gt;Please fix the read and write permissions.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="814"/>
-        <source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="818"/>
-        <source>System error.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="825"/>
-        <source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="840"/>
-        <source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1082"/>
-        <source>Unable to open folder path %1.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1096"/>
-        <source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1097"/>
-        <source>Transmission failed!
-Please, use the following link to send the logs to the support: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1118"/>
-        <source>No kDrive configured!</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::ParametersDialog</name>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="320"/>
+<source>kDrive needs to have write access to your computer's temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
+<translation>kDrivella on oltava kirjoitusoikeus tietokoneesi väliaikaiseen hakemistoon.&lt;br&gt;Käynnistä kDrive-sovellus uudelleen ratkaistaksesi tämän ongelman.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="330"/>
+<location filename="../src/gui/parametersdialog.cpp" line="487"/>
+<source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+<translation>Tekninen virhe on tapahtunut.&lt;br&gt;Synkronointi jatkuu mahdollisimman pian. Ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="337"/>
+<location filename="../src/gui/parametersdialog.cpp" line="440"/>
+<location filename="../src/gui/parametersdialog.cpp" line="506"/>
+<location filename="../src/gui/parametersdialog.cpp" line="546"/>
+<location filename="../src/gui/parametersdialog.cpp" line="560"/>
+<source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+<translation>Tekninen virhe on tapahtunut (virhe %1).&lt;br&gt;Tyhjennä historia ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="342"/>
+<source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
+<translation>Verkkoyhteyden aikakatkaisuarvo näyttää olevan liian pieni sovelluksen oikeaa toimintaa varten (virhe %1).&lt;br&gt;Tarkista verkkoasetuksesi.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="347"/>
+<location filename="../src/gui/parametersdialog.cpp" line="516"/>
+<source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
+<translation>kDrive-palvelimeen ei saada yhteyttä (virhe %1).&lt;br&gt;Yritetään yhdistää uudelleen. Tarkista Internet-yhteys ja palomuuri.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="352"/>
+<source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
+<translation>Kirjautumisvirhe (virhe %1).&lt;br&gt;Kirjaudu uudelleen ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="356"/>
+<source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
+<translation>Sovelluksesta on saatavilla uusi versio.&lt;br&gt;Päivitä sovellus jatkaaksesi sen käyttöä.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="360"/>
+<source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
+<translation>Lokin lähetys epäonnistui (virhe %1).&lt;br&gt;Yritä myöhemmin uudelleen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="385"/>
+<source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
+<translation>Synkronointikansio ei ole enää käytettävissä (virhe %1).&lt;br&gt;Synkronointi jatkuu heti, kun kansio on taas käytettävissä.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="389"/>
+<source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
+<translation>Synkronointikansion sisältävä asema ei ole enää yhteydessä (virhe %1).&lt;br&gt;Yhdistä se uudelleen jatkaaksesi synkronointia.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="393"/>
+<source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
+<translation>Tietokoneellasi ei ole tarpeeksi tilaa.&lt;br&gt;Synkronointi on pysäytetty.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="397"/>
+<source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
+<translation>Tietokoneellasi ei ole tarpeeksi muistia.&lt;br&gt;Synkronointi on pysäytetty.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="401"/>
+<source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing '/etc/sysctl.conf'.</source>
+<translation>Inotify-tarkkailijamäärä on riittämätön (virhe %1).&lt;br&gt;Voit kasvattaa tätä lukua muokkaamalla '/etc/sysctl.conf'-tiedostoa.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="406"/>
+<source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
+<translation>Synkronointia ei voi käynnistää (virhe %1).&lt;br&gt;Sinun on sallittava:&lt;br&gt;- kDrive kohdassa Järjestelmäasetukset &gt;&gt; Yleiset &gt;&gt; Kirjautumisobjektit ja laajennukset &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension kohdassa Järjestelmäasetukset &gt;&gt; Tietosuoja ja turvallisuus &gt;&gt; Täysi levynkäyttöoikeus.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="413"/>
+<source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
+<translation>Synkronointia ei voi käynnistää (virhe %1).&lt;br&gt;LiteSyncExt-prosessi ei ole käynnissä. Synkronointi jatkuu heti, kun se käynnistyy.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="419"/>
+<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+<translation>Lite Sync -laajennusta ei voi käynnistää (virhe %1).&lt;br&gt;Tarkista, että Lite Sync -laajennus on asennettu ja Windowsin hakupalvelu on käytössä.&lt;br&gt;Tyhjennä historia, käynnistä uudelleen ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="424"/>
+<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+<translation>Lite Sync -laajennusta ei voi käynnistää (virhe %1).&lt;br&gt;Tarkista, että Lite Sync -laajennuksella on oikeat käyttöoikeudet ja se on käynnissä.&lt;br&gt;Tyhjennä historia, käynnistä uudelleen ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="429"/>
+<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+<translation>Lite Sync -laajennusta ei voi käynnistää (virhe %1).&lt;br&gt;Tyhjennä historia, käynnistä uudelleen ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="435"/>
+<source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
+<translation>Synkronointikansiossa oleva tiedosto tai kansio näyttää vioittuneelta.&lt;br&gt;Synkronointi on pysäytetty.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="449"/>
+<source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+<translation>kDrive on huoltotilassa.&lt;br&gt;Synkronointi alkaa uudelleen mahdollisimman pian. Ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="455"/>
+<source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+<translation>kDrive on estetty.&lt;br&gt;Uudista kDrive. Jos toimenpiteitä ei tehdä, tiedot poistetaan pysyvästi eikä niitä voi palauttaa.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="460"/>
+<source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+<translation>kDrive on estetty.&lt;br&gt;Ota yhteyttä järjestelmänvalvojaan kDriven uudistamiseksi. Jos toimenpiteitä ei tehdä, tiedot poistetaan pysyvästi eikä niitä voi palauttaa.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="466"/>
+<source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+<translation>kDrive herää.&lt;br&gt;Synkronointi alkaa uudelleen mahdollisimman pian. Ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="475"/>
+<source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
+<translation>kDrive on lepotilassa.&lt;br&gt;Kirjaudu &lt;a style="%1" href="%2"&gt;verkkoversiooon&lt;/a&gt; tarkistaaksesi kDriven tilan tai ota yhteyttä järjestelmänvalvojaasi.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="479"/>
+<source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive's status, or contact your administrator.</source>
+<translation>kDrive on lepotilassa.&lt;br&gt;Kirjaudu verkkoversiooon tarkistaaksesi kDriven tilan tai ota yhteyttä järjestelmänvalvojaasi.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="483"/>
+<source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
+<translation>Sinulla ei ole oikeutta käyttää tätä kDrivea.&lt;br&gt;Synkronointi on keskeytetty. Ota yhteyttä järjestelmänvalvojaan.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="493"/>
+<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+<translation>Tekninen virhe on tapahtunut (virhe %1).&lt;br&gt;Synkronointi jatkuu mahdollisimman pian. Ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="512"/>
+<source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+<translation>Käyttöjärjestelmän ydin katkaisi verkkoyhteydet (virhe %1).&lt;br&gt;Tyhjennä historia ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="522"/>
+<source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
+<translation>Vanhaa konfiguraatiota ei valitettavasti voitu siirtää.&lt;br&gt;Sovellus käyttää tyhjää konfiguraatiota.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="526"/>
+<source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
+<translation>Vanhaa välityspalvelinasetusten konfiguraatiota ei valitettavasti voitu siirtää, SOCKS5-välityspalvelimia ei tueta tällä hetkellä.&lt;br&gt;Sovellus käyttää järjestelmän välityspalvelinasetuksia.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="532"/>
+<source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
+<translation>Synkronointikansio on korvattu tai siirretty tavalla, joka estää synkronoinnin (virhe %1).&lt;br&gt;Tämä voi tapahtua kansion kopioinnin, siirtämisen tai palauttamisen jälkeen.&lt;br&gt;Korjataksesi tämän, luo uusi synkronointi uuteen kansioon.&lt;br&gt;Huom: jos vanhassa kansiossa on synkronoimattomia muutoksia, ne täytyy kopioida manuaalisesti uuteen kansioon.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="539"/>
+<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
+<translation>Tekninen virhe on tapahtunut (virhe %1).&lt;br&gt;Synkronointi on käynnistetty uudelleen. Tyhjennä historia ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="550"/>
+<source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
+<translation>Synkronointitietokannan käyttämisessä tapahtui virhe (virhe %1).&lt;br&gt;Synkronointi on pysäytetty.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="564"/>
+<source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
+<translation>Kirjautumisvirhe (virhe %1).&lt;br&gt;Tunnus on virheellinen tai peruutettu.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="569"/>
+<source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
+<translation>Sisäkkäiset synkronoinnit ovat kiellettyjä (virhe %1).&lt;br&gt;Säilytä vain synkronoinnit, joiden kansiot eivät ole sisäkkäisiä.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="573"/>
+<source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
+<translation>kDriven etäpalvelimella oleva synkronointikansio ei ole enää olemassa tai käytettävissä (virhe %1).&lt;br&gt;Sinun on palautettava se tai annettava sille takaisin käyttöoikeudet tai poistettava/luotava synkronointi uudelleen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="580"/>
+<source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
+<translation>Tiedostonimen jäsennysvirhe (virhe %1).&lt;br&gt;Erikoismerkit kuten lainausmerkit, kenoviivat tai rivinvaihdot voivat aiheuttaa jäsennysvirheitä.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="609"/>
+<source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
+<translation>Tämä elementti on siirretty muualle.&lt;br&gt;Paikallinen toiminto on peruutettu.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="614"/>
+<source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
+<translation>Samanlaisella nimellä oleva elementti on jo olemassa tässä sijainnissa.&lt;br&gt;Paikallinen toiminto on peruutettu.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="618"/>
+<source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
+<translation>Samanlaisella nimellä oleva elementti on jo olemassa tässä sijainnissa.&lt;br&gt;Paikallinen elementti on nimetty uudelleen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="622"/>
+<source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
+<translation>Toinen käyttäjä muokkasi tiedostoa samanaikaisesti.&lt;br&gt;Muutoksesi on tallennettu kopioon.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="626"/>
+<source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
+<translation>Toinen käyttäjä on siirtänyt kohteen ylätason kansion.&lt;br&gt;Paikallinen toiminto on peruutettu.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="649"/>
+<source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Olemassa olevalla kohteella on sama nimi samoilla kirjainkoolla.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="656"/>
+<source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Kohteen nimi sisältää ei-tuetun merkin.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="662"/>
+<source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Kohteen nimi päättyy välilyöntiin, mikä on kiellettyä käyttöjärjestelmässäsi.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="668"/>
+<source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Tämä nimi on varattu käyttöjärjestelmässäsi.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="674"/>
+<source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Kohteen nimi on liian pitkä.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="680"/>
+<source>The item path is too long.&lt;br&gt;It has been ignored.</source>
+<translation>Kohteen polku on liian pitkä.&lt;br&gt;Se on ohitettu.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="686"/>
+<source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+<translation>Kohteen nimi sisältää uuden Unicode-merkin, jota tiedostojärjestelmäsi ei vielä tue.&lt;br&gt;Se on suljettu pois synkronoinnista.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="692"/>
+<source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Kohteen nimi sisältää vain välilyöntejä.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="703"/>
+<source>Either you are not allowed to create an item, or another item already exists with the same name.&lt;br&gt;The item has been excluded from synchronization.</source>
+<translation>Sinulla ei ole oikeutta luoda kohdetta tai samalla nimellä on jo olemassa oleva kohde.&lt;br&gt;Kohde on suljettu pois synkronoinnista.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="708"/>
+<source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
+<translation>Sinulla ei ole oikeutta muokata kohdetta.&lt;br&gt;Muutoksesi sisältävä tiedosto on nimetty uudelleen ja suljettu pois synkronoinnista.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="716"/>
+<source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
+<translation>Sinulla ei ole oikeutta nimetä kohdetta uudelleen.&lt;br&gt;Se palautetaan alkuperäisellä nimellään.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="722"/>
+<source>You are not allowed to move item to "%1".&lt;br&gt;It will be restored into its original parent folder.</source>
+<translation>Sinulla ei ole oikeutta siirtää kohdetta kohteeseen "%1".&lt;br&gt;Se palautetaan alkuperäiseen yläkansioonsa.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="727"/>
+<source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
+<translation>Sinulla ei ole oikeutta poistaa kohdetta.&lt;br&gt;Se palautetaan alkuperäiseen sijaintiinsa.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="732"/>
+<source>Failed to move this item to trash, it has been blacklisted.</source>
+<translation>Kohteen siirtäminen roskakoriin epäonnistui, se on lisätty estolistalle.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="735"/>
+<source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
+<translation>Kohteen synkronointi epäonnistui. Se on lisätty väliaikaisesti estolistalle.&lt;br&gt;Synkronointia yritetään uudelleen tunnin kuluttua tai seuraavalla sovelluksen käynnistyksellä.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="740"/>
+<source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
+<translation>Tämä kohde on suljettu synkronoinnista mukautetun mallin avulla.&lt;br&gt;Voit poistaa tämän tyyppiset ilmoitukset käytöstä Asetuksissa</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="745"/>
+<source>This item has been excluded from sync because it is a hard link.</source>
+<translation>Tämä kohde on suljettu synkronoinnista, koska se on kova linkki.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="748"/>
+<source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
+<translation>Tiedostoa on muokattu paikallisesti, kun se on poistettu etä-kDrivesta.&lt;br&gt;Paikallinen kopio on tallennettu pelastuskansioon.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="765"/>
+<source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
+<translation>Kohteelle suoritettu toiminto on kielletty.&lt;br&gt;Kohde on lisätty väliaikaisesti estolistalle.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="771"/>
+<source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
+<translation>Kohteelle suoritettu toiminto epäonnistui.&lt;br&gt;Kohde on lisätty väliaikaisesti estolistalle.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="776"/>
+<source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
+<translation>Tiedosto on liian suuri ladattavaksi. Se on lisätty väliaikaisesti estolistalle.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="779"/>
+<source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
+<translation>Olet ylittänyt kiintiösi. Kasvata tallennustilaasi ottaaksesi tiedostojen lataamisen uudelleen käyttöön.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="782"/>
+<source>Impossible to download the file.</source>
+<translation>Tiedostoa ei voi ladata.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="785"/>
+<source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
+<translation>Toinen käyttäjä on tällä hetkellä lukinnut tämän kohteen verkossa.&lt;br&gt;Yritämme ladata muutoksesi myöhemmin uudelleen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="790"/>
+<location filename="../src/gui/parametersdialog.cpp" line="834"/>
+<source>Synchronization error.</source>
+<translation>Synkronointivirhe.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="810"/>
+<source>Can't access item.&lt;br&gt;Please fix the read and write permissions.</source>
+<translation>Kohdetta ei voi käyttää.&lt;br&gt;Korjaa luku- ja kirjoitusoikeudet.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="814"/>
+<source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
+<translation>Tietokoneellasi ei ole tarpeeksi tilaa.&lt;br&gt;Lataus on peruutettu.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="818"/>
+<source>System error.</source>
+<translation>Järjestelmävirhe.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="825"/>
+<source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Kohde on jo olemassa toisella puolella.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="840"/>
+<source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+<translation>Tekninen virhe on tapahtunut.&lt;br&gt;Tyhjennä historia ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1082"/>
+<source>Unable to open folder path %1.</source>
+<translation>Kansion polkua %1 ei voi avata.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1096"/>
+<source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
+<translation>Siirto valmis!&lt;br&gt;Viittaa tunnukseen &lt;b&gt;%1&lt;/b&gt; virheraporteissa.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1097"/>
+<source>Transmission failed!
+Please, use the following link to send the logs to the support: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</source>
+<translation>Siirto epäonnistui!
+Käytä seuraavaa linkkiä lähettääksesi lokit tuelle: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1118"/>
+<source>No kDrive configured!</source>
+<translation>kDrivea ei ole määritetty!</translation>
+</message>
 </context>
 <context>
-    <name>KDC::PreferencesBlocWidget</name>
-    <message>
-        <location filename="../src/gui/preferencesblocwidget.cpp" line="187"/>
-        <source>This synchronization is being deleted.</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::PreferencesBlocWidget</name>
+<message>
+<location filename="../src/gui/preferencesblocwidget.cpp" line="187"/>
+<source>This synchronization is being deleted.</source>
+<translation>Tätä synkronointia poistetaan.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::PreferencesMenuBarWidget</name>
-    <message>
-        <location filename="../src/gui/preferencesmenubarwidget.cpp" line="63"/>
-        <source>Back to drive list</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferencesmenubarwidget.cpp" line="64"/>
-        <source>Preferences</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::PreferencesMenuBarWidget</name>
+<message>
+<location filename="../src/gui/preferencesmenubarwidget.cpp" line="63"/>
+<source>Back to drive list</source>
+<translation>Takaisin asemaluetteloon</translation>
+</message>
+<message>
+<location filename="../src/gui/preferencesmenubarwidget.cpp" line="64"/>
+<source>Preferences</source>
+<translation>Asetukset</translation>
+</message>
 </context>
 <context>
-    <name>KDC::PreferencesWidget</name>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="466"/>
-        <source>Unable to open folder %1.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="478"/>
-        <source>Unable to open link %1.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="483"/>
-        <source>Invalid link %1.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="490"/>
-        <source>Some process failed to run.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="491"/>
-        <source>General</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="493"/>
-        <source>Activate dark theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="495"/>
-        <source>Activate monochrome icons</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="496"/>
-        <source>Launch kDrive at startup</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="497"/>
-        <source>Language</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="498"/>
-        <source>Move deleted files to my computer&apos;s trash</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="499"/>
-        <source>Some files or folders may not be moved to the computer&apos;s trash.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="500"/>
-        <source>You can always retrieve already synced files from the kDrive web application trash.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="502"/>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="505"/>
-        <source>Default</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="506"/>
-        <source>English</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="507"/>
-        <source>French</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="508"/>
-        <source>German</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="509"/>
-        <source>Spanish</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="510"/>
-        <source>Italian</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="511"/>
-        <source>Swedish</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="512"/>
-        <source>Portuguese</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="513"/>
-        <source>Polish</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="514"/>
-        <source>Norwegian</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="515"/>
-        <source>Finnish</source>
-        <translation>Suomi</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="521"/>
-        <source>Advanced</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="522"/>
-        <source>Debugging information</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="524"/>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="525"/>
-        <source>Files to exclude</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="526"/>
-        <source>Proxy server</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="528"/>
-        <source>Lite Sync</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::PreferencesWidget</name>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="466"/>
+<source>Unable to open folder %1.</source>
+<translation>Kansiota %1 ei voi avata.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="478"/>
+<source>Unable to open link %1.</source>
+<translation>Linkkiä %1 ei voi avata.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="483"/>
+<source>Invalid link %1.</source>
+<translation>Virheellinen linkki %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="490"/>
+<source>Some process failed to run.</source>
+<translation>Joidenkin prosessien käynnistyminen epäonnistui.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="491"/>
+<source>General</source>
+<translation>Yleiset</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="493"/>
+<source>Activate dark theme</source>
+<translation>Ota tumma teema käyttöön</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="495"/>
+<source>Activate monochrome icons</source>
+<translation>Ota yksivärisiä kuvakkeita käyttöön</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="496"/>
+<source>Launch kDrive at startup</source>
+<translation>Käynnistä kDrive automaattisesti</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="497"/>
+<source>Language</source>
+<translation>Kieli</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="498"/>
+<source>Move deleted files to my computer's trash</source>
+<translation>Siirrä poistetut tiedostot tietokoneen roskakoriin</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="499"/>
+<source>Some files or folders may not be moved to the computer's trash.</source>
+<translation>Joitakin tiedostoja tai kansioita ei ehkä voi siirtää tietokoneen roskakoriin.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="500"/>
+<source>You can always retrieve already synced files from the kDrive web application trash.</source>
+<translation>Voit aina palauttaa jo synkronoidut tiedostot kDriven verkkosovelluksen roskakorista.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="502"/>
+<source>&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;Lue lisää&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="505"/>
+<source>Default</source>
+<translation>Oletus</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="506"/>
+<source>English</source>
+<translation>Englanti</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="507"/>
+<source>French</source>
+<translation>Ranska</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="508"/>
+<source>German</source>
+<translation>Saksa</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="509"/>
+<source>Spanish</source>
+<translation>Espanja</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="510"/>
+<source>Italian</source>
+<translation>Italia</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="511"/>
+<source>Swedish</source>
+<translation>Ruotsi</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="512"/>
+<source>Portuguese</source>
+<translation>Portugali</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="513"/>
+<source>Polish</source>
+<translation>Puola</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="514"/>
+<source>Norwegian</source>
+<translation>Norja</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="515"/>
+<source>Finnish</source>
+<translation>Suomi</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="521"/>
+<source>Advanced</source>
+<translation>Lisäasetukset</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="522"/>
+<source>Debugging information</source>
+<translation>Virheenkorjaustiedot</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="524"/>
+<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;Avaa virheenkorjauskansio&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="525"/>
+<source>Files to exclude</source>
+<translation>Suljettavat tiedostot</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="526"/>
+<source>Proxy server</source>
+<translation>Välityspalvelin</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="528"/>
+<source>Lite Sync</source>
+<translation>Lite Sync</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ProgressBarWidget</name>
-    <message>
-        <location filename="../src/gui/progressbarwidget.cpp" line="70"/>
-        <source>%1 in use</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::ProgressBarWidget</name>
+<message>
+<location filename="../src/gui/progressbarwidget.cpp" line="70"/>
+<source>%1 in use</source>
+<translation>%1 käytössä</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ProxyServerDialog</name>
-    <message>
-        <location filename="../src/gui/proxyserverdialog.cpp" line="50"/>
-        <source>HTTP(S) Proxy</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/proxyserverdialog.cpp" line="73"/>
-        <source>Proxy server</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/proxyserverdialog.cpp" line="85"/>
-        <source>No proxy server</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/proxyserverdialog.cpp" line="90"/>
-        <source>Use system parameters</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/proxyserverdialog.cpp" line="95"/>
-        <source>Indicate a proxy manually</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/proxyserverdialog.cpp" line="131"/>
-        <source>Port</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/proxyserverdialog.cpp" line="144"/>
-        <source>Address of the proxy server</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/proxyserverdialog.cpp" line="150"/>
-        <source>Authentication needed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/proxyserverdialog.cpp" line="165"/>
-        <source>User</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/proxyserverdialog.cpp" line="171"/>
-        <source>Password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/proxyserverdialog.cpp" line="185"/>
-        <source>SAVE</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/proxyserverdialog.cpp" line="192"/>
-        <source>CANCEL</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/proxyserverdialog.cpp" line="286"/>
-        <source>Do you want to save your modifications?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/proxyserverdialog.cpp" line="295"/>
-        <source>Unable to save, all mandatory fields are not completed!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/proxyserverdialog.cpp" line="316"/>
-        <source>Proxy not found, save anyway?</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::ProxyServerDialog</name>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="50"/>
+<source>HTTP(S) Proxy</source>
+<translation>HTTP(S)-välityspalvelin</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="73"/>
+<source>Proxy server</source>
+<translation>Välityspalvelin</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="85"/>
+<source>No proxy server</source>
+<translation>Ei välityspalvelinta</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="90"/>
+<source>Use system parameters</source>
+<translation>Käytä järjestelmäasetuksia</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="95"/>
+<source>Indicate a proxy manually</source>
+<translation>Määritä välityspalvelin manuaalisesti</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="131"/>
+<source>Port</source>
+<translation>Portti</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="144"/>
+<source>Address of the proxy server</source>
+<translation>Välityspalvelimen osoite</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="150"/>
+<source>Authentication needed</source>
+<translation>Todennus vaaditaan</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="165"/>
+<source>User</source>
+<translation>Käyttäjä</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="171"/>
+<source>Password</source>
+<translation>Salasana</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="185"/>
+<source>SAVE</source>
+<translation>TALLENNA</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="192"/>
+<source>CANCEL</source>
+<translation>PERUUTA</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="286"/>
+<source>Do you want to save your modifications?</source>
+<translation>Haluatko tallentaa muutokset?</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="295"/>
+<source>Unable to save, all mandatory fields are not completed!</source>
+<translation>Tallennus epäonnistui, kaikki pakolliset kentät eivät ole täytetty!</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="316"/>
+<source>Proxy not found, save anyway?</source>
+<translation>Välityspalvelinta ei löydy, tallennetaanko silti?</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ResourcesManagerDialog</name>
-    <message>
-        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="55"/>
-        <source>Resources Manager</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="65"/>
-        <source>Maximum CPU usage allowed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="96"/>
-        <source>SAVE</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="103"/>
-        <source>CANCEL</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="122"/>
-        <source>Do you want to save your modifications?</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::ResourcesManagerDialog</name>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="55"/>
+<source>Resources Manager</source>
+<translation>Resurssien hallinta</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="65"/>
+<source>Maximum CPU usage allowed</source>
+<translation>Suurin sallittu suorittimen käyttö</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="96"/>
+<source>SAVE</source>
+<translation>TALLENNA</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="103"/>
+<source>CANCEL</source>
+<translation>PERUUTA</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="122"/>
+<source>Do you want to save your modifications?</source>
+<translation>Haluatko tallentaa muutokset?</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ServerBaseFolderDialog</name>
-    <message>
-        <location filename="../src/gui/serverbasefolderdialog.cpp" line="81"/>
-        <source>Select a folder on your kDrive</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/serverbasefolderdialog.cpp" line="90"/>
-        <source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/serverbasefolderdialog.cpp" line="134"/>
-        <source>CONTINUE</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/serverbasefolderdialog.cpp" line="150"/>
-        <source>Space available on your computer for the current folder : %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/serverbasefolderdialog.cpp" line="190"/>
-        <source>This folder is already being synced.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/serverbasefolderdialog.cpp" line="204"/>
-        <source>CONFIRM</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/serverbasefolderdialog.cpp" line="205"/>
-        <source>CANCEL</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::ServerBaseFolderDialog</name>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="81"/>
+<source>Select a folder on your kDrive</source>
+<translation>Valitse kansio kDrivesta</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="90"/>
+<source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
+<translation>Valitun kansion sisältö synkronoidaan &lt;b&gt;%1&lt;/b&gt;-kansioon.</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="134"/>
+<source>CONTINUE</source>
+<translation>JATKA</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="150"/>
+<source>Space available on your computer for the current folder : %1</source>
+<translation>Nykyisen kansion tilaa tietokoneella: %1</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="190"/>
+<source>This folder is already being synced.</source>
+<translation>Tämä kansio on jo synkronoinnissa.</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="204"/>
+<source>CONFIRM</source>
+<translation>VAHVISTA</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="205"/>
+<source>CANCEL</source>
+<translation>PERUUTA</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ServerFoldersDialog</name>
-    <message>
-        <location filename="../src/gui/serverfoldersdialog.cpp" line="80"/>
-        <source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/serverfoldersdialog.cpp" line="110"/>
-        <source>CONTINUE</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/serverfoldersdialog.cpp" line="146"/>
-        <source>No subfolders currently on the server.</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::ServerFoldersDialog</name>
+<message>
+<location filename="../src/gui/serverfoldersdialog.cpp" line="80"/>
+<source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
+<translation>&lt;b&gt;%1&lt;/b&gt;-kansio sisältää alikansioita,&lt;br&gt; valitse synkronoitavat kansiot</translation>
+</message>
+<message>
+<location filename="../src/gui/serverfoldersdialog.cpp" line="110"/>
+<source>CONTINUE</source>
+<translation>JATKA</translation>
+</message>
+<message>
+<location filename="../src/gui/serverfoldersdialog.cpp" line="146"/>
+<source>No subfolders currently on the server.</source>
+<translation>Palvelimella ei ole alikansioita tällä hetkellä.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::StatusBarWidget</name>
-    <message>
-        <location filename="../src/gui/statusbarwidget.cpp" line="178"/>
-        <source>Resume kDrive &quot;%1&quot; synchronization</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/statusbarwidget.cpp" line="179"/>
-        <location filename="../src/gui/statusbarwidget.cpp" line="322"/>
-        <source>Resume synchronization</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/statusbarwidget.cpp" line="180"/>
-        <source>Resume all kDrives synchronization</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/statusbarwidget.cpp" line="183"/>
-        <source>Pause kDrive &quot;%1&quot; synchronization</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/statusbarwidget.cpp" line="184"/>
-        <location filename="../src/gui/statusbarwidget.cpp" line="321"/>
-        <source>Pause synchronization</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/statusbarwidget.cpp" line="185"/>
-        <source>Pause all kDrives synchronization</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::StatusBarWidget</name>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="178"/>
+<source>Resume kDrive "%1" synchronization</source>
+<translation>Jatka kDrive "%1" synkronointia</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="179"/>
+<location filename="../src/gui/statusbarwidget.cpp" line="322"/>
+<source>Resume synchronization</source>
+<translation>Jatka synkronointia</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="180"/>
+<source>Resume all kDrives synchronization</source>
+<translation>Jatka kaikkien kDrive-asemien synkronointia</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="183"/>
+<source>Pause kDrive "%1" synchronization</source>
+<translation>Keskeytä kDrive "%1" synkronointi</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="184"/>
+<location filename="../src/gui/statusbarwidget.cpp" line="321"/>
+<source>Pause synchronization</source>
+<translation>Keskeytä synkronointi</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="185"/>
+<source>Pause all kDrives synchronization</source>
+<translation>Keskeytä kaikkien kDrive-asemien synkronointi</translation>
+</message>
 </context>
 <context>
-    <name>KDC::SynchronizedItemWidget</name>
-    <message>
-        <location filename="../src/gui/synchronizeditemwidget.cpp" line="317"/>
-        <source>Open</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
-        <source>Add to favorites</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
-        <source>Copy share link</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
-        <source>Display on kdrive.infomaniak.com</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
-        <source>Show in folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
-        <source>More actions</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::SynchronizedItemWidget</name>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="317"/>
+<source>Open</source>
+<translation>Avaa</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
+<source>Add to favorites</source>
+<translation>Lisää suosikkeihin</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
+<source>Copy share link</source>
+<translation>Kopioi jakolinkki</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
+<source>Display on kdrive.infomaniak.com</source>
+<translation>Näytä kdrive.infomaniak.com-sivustolla</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
+<source>Show in folder</source>
+<translation>Näytä kansiossa</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
+<source>More actions</source>
+<translation>Lisää toimintoja</translation>
+</message>
 </context>
 <context>
-    <name>KDC::SynthesisBar</name>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="149"/>
-        <source>Unable to open folder url %1.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="219"/>
-        <source>Open in folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="257"/>
-        <source>Open %1 web version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="267"/>
-        <source>Drive parameters</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="280"/>
-        <source>Notifications disabled until %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="281"/>
-        <source>Disable Notifications</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="314"/>
-        <source>Application preferences</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="322"/>
-        <source>Need help</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="330"/>
-        <source>Send feedbacks</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="338"/>
-        <source>Quit kDrive</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="401"/>
-        <source>Unable to access web site %1.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="492"/>
-        <source>Show errors and informations</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="493"/>
-        <source>Show informations</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="494"/>
-        <source>More actions</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="495"/>
-        <location filename="../src/gui/synthesisbar.cpp" line="502"/>
-        <source>Never</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="496"/>
-        <source>During 1 hour</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="497"/>
-        <location filename="../src/gui/synthesisbar.cpp" line="504"/>
-        <source>Until tomorrow 8:00AM</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="498"/>
-        <source>During 3 days</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="499"/>
-        <source>During 1 week</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="500"/>
-        <location filename="../src/gui/synthesisbar.cpp" line="507"/>
-        <source>Always</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="503"/>
-        <source>For 1 more hour</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="505"/>
-        <source>For 3 more days</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="506"/>
-        <source>For 1 more week</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::SynthesisBar</name>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="149"/>
+<source>Unable to open folder url %1.</source>
+<translation>Kansion URL-osoitetta %1 ei voi avata.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="219"/>
+<source>Open in folder</source>
+<translation>Avaa kansiossa</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="257"/>
+<source>Open %1 web version</source>
+<translation>Avaa %1 verkkoversio</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="267"/>
+<source>Drive parameters</source>
+<translation>Aseman asetukset</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="280"/>
+<source>Notifications disabled until %1</source>
+<translation>Ilmoitukset poistettu käytöstä %1 asti</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="281"/>
+<source>Disable Notifications</source>
+<translation>Poista ilmoitukset käytöstä</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="314"/>
+<source>Application preferences</source>
+<translation>Sovelluksen asetukset</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="322"/>
+<source>Need help</source>
+<translation>Tarvitsetko apua</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="330"/>
+<source>Send feedbacks</source>
+<translation>Lähetä palautetta</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="338"/>
+<source>Quit kDrive</source>
+<translation>Lopeta kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="401"/>
+<source>Unable to access web site %1.</source>
+<translation>Verkkosivustolle %1 ei pääse.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="492"/>
+<source>Show errors and informations</source>
+<translation>Näytä virheet ja tiedotteet</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="493"/>
+<source>Show informations</source>
+<translation>Näytä tiedotteet</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="494"/>
+<source>More actions</source>
+<translation>Lisää toimintoja</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="495"/>
+<location filename="../src/gui/synthesisbar.cpp" line="502"/>
+<source>Never</source>
+<translation>Ei koskaan</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="496"/>
+<source>During 1 hour</source>
+<translation>1 tunnin ajaksi</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="497"/>
+<location filename="../src/gui/synthesisbar.cpp" line="504"/>
+<source>Until tomorrow 8:00AM</source>
+<translation>Huomiseen klo 8:00 asti</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="498"/>
+<source>During 3 days</source>
+<translation>3 päivän ajaksi</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="499"/>
+<source>During 1 week</source>
+<translation>1 viikon ajaksi</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="500"/>
+<location filename="../src/gui/synthesisbar.cpp" line="507"/>
+<source>Always</source>
+<translation>Aina</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="503"/>
+<source>For 1 more hour</source>
+<translation>1 tunti lisää</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="505"/>
+<source>For 3 more days</source>
+<translation>3 päivää lisää</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="506"/>
+<source>For 1 more week</source>
+<translation>1 viikko lisää</translation>
+</message>
 </context>
 <context>
-    <name>KDC::SynthesisPopover</name>
-    <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="446"/>
-        <source>Synchronized</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="450"/>
-        <source>Favorites</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="454"/>
-        <source>Activity</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="586"/>
-        <source>Unable to open folder url %1.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="978"/>
-        <source>Update</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="981"/>
-        <source>Update download in progress</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="984"/>
-        <source>Looking for update...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="987"/>
-        <source>Manual update</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="990"/>
-        <source>Unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1133"/>
-        <location filename="../src/gui/synthesispopover.cpp" line="1180"/>
-        <source>Not implemented!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1161"/>
-        <source>Unable to open link %1.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1173"/>
-        <source>Invalid link %1.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1181"/>
-        <source>Update kDrive App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1182"/>
-        <source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1184"/>
-        <source>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Click here to download manually&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1187"/>
-        <source>Please download the latest version on the website.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1193"/>
-        <source>No synchronized folder for this Drive!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1196"/>
-        <source>No kDrive configured!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1200"/>
-        <source>You can synchronize files &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;from your computer&lt;/a&gt; or on &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::SynthesisPopover</name>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="446"/>
+<source>Synchronized</source>
+<translation>Synkronoitu</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="450"/>
+<source>Favorites</source>
+<translation>Suosikit</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="454"/>
+<source>Activity</source>
+<translation>Toiminta</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="586"/>
+<source>Unable to open folder url %1.</source>
+<translation>Kansion URL-osoitetta %1 ei voi avata.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="978"/>
+<source>Update</source>
+<translation>Päivitä</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="981"/>
+<source>Update download in progress</source>
+<translation>Päivitystä ladataan</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="984"/>
+<source>Looking for update...</source>
+<translation>Etsitään päivitystä...</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="987"/>
+<source>Manual update</source>
+<translation>Manuaalinen päivitys</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="990"/>
+<source>Unavailable</source>
+<translation>Ei saatavilla</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1133"/>
+<location filename="../src/gui/synthesispopover.cpp" line="1180"/>
+<source>Not implemented!</source>
+<translation>Ei toteutettu!</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1161"/>
+<source>Unable to open link %1.</source>
+<translation>Linkkiä %1 ei voi avata.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1173"/>
+<source>Invalid link %1.</source>
+<translation>Virheellinen linkki %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1181"/>
+<source>Update kDrive App</source>
+<translation>Päivitä kDrive-sovellus</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1182"/>
+<source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
+<translation>Tätä kDrive-sovellusversiota ei enää tueta. Päivitä sovellus uusimpiin ominaisuuksiin pääsemiseksi.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1184"/>
+<source>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Click here to download manually&lt;/a&gt;</source>
+<translation>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Napsauta tästä ladataksesi manuaalisesti&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1187"/>
+<source>Please download the latest version on the website.</source>
+<translation>Lataa uusin versio verkkosivustolta.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1193"/>
+<source>No synchronized folder for this Drive!</source>
+<translation>Tälle asemalle ei ole synkronoitua kansiota!</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1196"/>
+<source>No kDrive configured!</source>
+<translation>kDrivea ei ole määritetty!</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1200"/>
+<source>You can synchronize files &lt;a style="%1" href="%2"&gt;from your computer&lt;/a&gt; or on &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
+<translation>Voit synkronoida tiedostoja &lt;a style="%1" href="%2"&gt;tietokoneeltasi&lt;/a&gt; tai &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;-sivustolla.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::UpdateDialog</name>
-    <message>
-        <location filename="../src/gui/updater/updatedialog.cpp" line="61"/>
-        <source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/updater/updatedialog.cpp" line="95"/>
-        <source>Skip this version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/updater/updatedialog.cpp" line="103"/>
-        <source>Remind me later</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/updater/updatedialog.cpp" line="109"/>
-        <source>Install update</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::UpdateDialog</name>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="61"/>
+<source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
+<translation>&lt;p&gt;%2-asiakkaan uusi versio &lt;b&gt;%1&lt;/b&gt; on saatavilla ja ladattu.&lt;/p&gt;&lt;p&gt;Asennettu versio on %3.&lt;/p&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="95"/>
+<source>Skip this version</source>
+<translation>Ohita tämä versio</translation>
+</message>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="103"/>
+<source>Remind me later</source>
+<translation>Muistuta myöhemmin</translation>
+</message>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="109"/>
+<source>Install update</source>
+<translation>Asenna päivitys</translation>
+</message>
 </context>
 <context>
-    <name>KDC::UpdateManager</name>
-    <message>
-        <location filename="../src/server/updater/updatemanager.cpp" line="86"/>
-        <source>New update available.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/server/updater/updatemanager.cpp" line="87"/>
-        <source>Version %1 is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::UpdateManager</name>
+<message>
+<location filename="../src/server/updater/updatemanager.cpp" line="86"/>
+<source>New update available.</source>
+<translation>Uusi päivitys saatavilla.</translation>
+</message>
+<message>
+<location filename="../src/server/updater/updatemanager.cpp" line="87"/>
+<source>Version %1 is available for download.</source>
+<translation>Versio %1 on ladattavissa.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::UserSelectionWidget</name>
-    <message>
-        <location filename="../src/gui/userselectionwidget.cpp" line="131"/>
-        <source>Add an account</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::UserSelectionWidget</name>
+<message>
+<location filename="../src/gui/userselectionwidget.cpp" line="131"/>
+<source>Add an account</source>
+<translation>Lisää tili</translation>
+</message>
 </context>
 <context>
-    <name>KDC::VersionWidget</name>
-    <message>
-        <location filename="../src/gui/versionwidget.cpp" line="169"/>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Show release note&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/versionwidget.cpp" line="172"/>
-        <source>Version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/versionwidget.cpp" line="173"/>
-        <source>UPDATE</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/versionwidget.cpp" line="197"/>
-        <source>%1 is up to date!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/versionwidget.cpp" line="201"/>
-        <source>Checking update on server...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/versionwidget.cpp" line="205"/>
-        <source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;here&lt;/a&gt;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/versionwidget.cpp" line="212"/>
-        <source>An update is available: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/versionwidget.cpp" line="218"/>
-        <source>Downloading %1. Please wait...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/versionwidget.cpp" line="223"/>
-        <source>Could not check for new updates.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/versionwidget.cpp" line="227"/>
-        <source>An error occurred during update.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/versionwidget.cpp" line="231"/>
-        <source>Could not download update.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/versionwidget.cpp" line="235"/>
-        <source>Update disabled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/versionwidget.cpp" line="251"/>
-        <source>Beta program</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/versionwidget.cpp" line="252"/>
-        <source>Get early access to new versions of the application</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/versionwidget.cpp" line="256"/>
-        <source>Join</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/versionwidget.cpp" line="259"/>
-        <source>Modify</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/versionwidget.cpp" line="259"/>
-        <source>Quit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/versionwidget.cpp" line="295"/>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>KDC::VersionWidget</name>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="169"/>
+<source>&lt;a style="%1" href="%2"&gt;Show release note&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;Näytä julkaisutiedot&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="172"/>
+<source>Version</source>
+<translation>Versio</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="173"/>
+<source>UPDATE</source>
+<translation>PÄIVITÄ</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="197"/>
+<source>%1 is up to date!</source>
+<translation>%1 on ajan tasalla!</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="201"/>
+<source>Checking update on server...</source>
+<translation>Tarkistetaan päivitystä palvelimelta...</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="205"/>
+<source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style="%2" href="%3"&gt;here&lt;/a&gt;.</source>
+<translation>Päivitys on saatavilla: %1.&lt;br&gt;Lataa se &lt;a style="%2" href="%3"&gt;täältä&lt;/a&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="212"/>
+<source>An update is available: %1</source>
+<translation>Päivitys on saatavilla: %1</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="218"/>
+<source>Downloading %1. Please wait...</source>
+<translation>Ladataan %1. Odota...</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="223"/>
+<source>Could not check for new updates.</source>
+<translation>Päivitysten tarkistus epäonnistui.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="227"/>
+<source>An error occurred during update.</source>
+<translation>Päivityksen aikana tapahtui virhe.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="231"/>
+<source>Could not download update.</source>
+<translation>Päivityksen lataaminen epäonnistui.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="235"/>
+<source>Update disabled.</source>
+<translation>Päivitys poistettu käytöstä.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="251"/>
+<source>Beta program</source>
+<translation>Beta-ohjelma</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="252"/>
+<source>Get early access to new versions of the application</source>
+<translation>Saa varhainen pääsy sovelluksen uusiin versioihin</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="256"/>
+<source>Join</source>
+<translation>Liity</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="259"/>
+<source>Modify</source>
+<translation>Muokkaa</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="259"/>
+<source>Quit</source>
+<translation>Lopeta</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="295"/>
+<source>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</translation>
+</message>
 </context>
 <context>
-    <name>QObject</name>
-    <message>
-        <location filename="../src/gui/folderitemwidget.cpp" line="42"/>
-        <source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/folderitemwidget.cpp" line="45"/>
-        <source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/folderitemwidget.cpp" line="48"/>
-        <source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/folderitemwidget.cpp" line="50"/>
-        <source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parameterscache.cpp" line="59"/>
-        <source>Unable to save parameters, please retry later.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parameterscache.cpp" line="60"/>
-        <source>Unable to save parameters!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/server/comm/extensionjob.cpp" line="1175"/>
-        <source>Make available locally</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/server/comm/extensionjob.cpp" line="1179"/>
-        <source>Free up local space</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/server/comm/extensionjob.cpp" line="1183"/>
-        <source>Cancel free up local space</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/server/comm/extensionjob.cpp" line="1187"/>
-        <source>Cancel make available locally</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/server/comm/extensionjob.cpp" line="1191"/>
-        <source>Resharing this file is not allowed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/server/comm/extensionjob.cpp" line="1192"/>
-        <source>Resharing this folder is not allowed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/server/comm/extensionjob.cpp" line="1196"/>
-        <source>Copy public share link</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/server/comm/extensionjob.cpp" line="1200"/>
-        <source>Copy private share link</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/server/comm/extensionjob.cpp" line="1204"/>
-        <source>Open in browser</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="461"/>
-        <source>The parent folder is a sync folder or contained in one</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="495"/>
-        <source>Can&apos;t find a valid path</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2108"/>
-        <source>No valid folder selected!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2119"/>
-        <source>The selected path does not exist!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2124"/>
-        <source>The selected path is not a folder!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2129"/>
-        <source>You have no permission to write to the selected folder!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2159"/>
-        <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2167"/>
-        <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2175"/>
-        <source>The local folder %1 is already synced. Please pick another one!</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>QObject</name>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="42"/>
+<source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
+<translation>Lite sync (Beta) on käytössä. kDriven tiedostot pysyvät pilvessä eivätkä käytä tietokoneen tallennustilaa.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="45"/>
+<source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
+<translation>Lite sync (Beta) ei ole käytössä. kDriven tiedostot käyttävät tietokoneen tallennustilaa.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="48"/>
+<source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
+<translation>Lite sync on käytössä. kDriven tiedostot pysyvät pilvessä eivätkä käytä tietokoneen tallennustilaa.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="50"/>
+<source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
+<translation>Lite sync ei ole käytössä. kDriven tiedostot käyttävät tietokoneen tallennustilaa.</translation>
+</message>
+<message>
+<location filename="../src/gui/parameterscache.cpp" line="59"/>
+<source>Unable to save parameters, please retry later.</source>
+<translation>Parametrien tallentaminen epäonnistui, yritä myöhemmin uudelleen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parameterscache.cpp" line="60"/>
+<source>Unable to save parameters!</source>
+<translation>Parametreja ei voi tallentaa!</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1175"/>
+<source>Make available locally</source>
+<translation>Tee saataville paikallisesti</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1179"/>
+<source>Free up local space</source>
+<translation>Vapauta paikallista tilaa</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1183"/>
+<source>Cancel free up local space</source>
+<translation>Peruuta paikallisen tilan vapautus</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1187"/>
+<source>Cancel make available locally</source>
+<translation>Peruuta paikallinen saatavillaolo</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1191"/>
+<source>Resharing this file is not allowed</source>
+<translation>Tämän tiedoston jakaminen uudelleen ei ole sallittu</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1192"/>
+<source>Resharing this folder is not allowed</source>
+<translation>Tämän kansion jakaminen uudelleen ei ole sallittu</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1196"/>
+<source>Copy public share link</source>
+<translation>Kopioi julkinen jakolinkki</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1200"/>
+<source>Copy private share link</source>
+<translation>Kopioi yksityinen jakolinkki</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1204"/>
+<source>Open in browser</source>
+<translation>Avaa selaimessa</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="461"/>
+<source>The parent folder is a sync folder or contained in one</source>
+<translation>Ylätason kansio on synkronointikansio tai sisältyy yhteen</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="495"/>
+<source>Can't find a valid path</source>
+<translation>Kelvollista polkua ei löydy</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2108"/>
+<source>No valid folder selected!</source>
+<translation>Kelvollista kansiota ei ole valittu!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2119"/>
+<source>The selected path does not exist!</source>
+<translation>Valittu polku ei ole olemassa!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2124"/>
+<source>The selected path is not a folder!</source>
+<translation>Valittu polku ei ole kansio!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2129"/>
+<source>You have no permission to write to the selected folder!</source>
+<translation>Sinulla ei ole kirjoitusoikeutta valittuun kansioon!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2159"/>
+<source>The local folder %1 contains a folder already synced. Please pick another one!</source>
+<translation>Paikallinen kansio %1 sisältää jo synkronoidun kansion. Valitse toinen!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2167"/>
+<source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
+<translation>Paikallinen kansio %1 on jo synkronoidun kansion sisällä. Valitse toinen!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2175"/>
+<source>The local folder %1 is already synced. Please pick another one!</source>
+<translation>Paikallinen kansio %1 on jo synkronoitu. Valitse toinen!</translation>
+</message>
 </context>
 <context>
-    <name>SharedTools::QtSingleApplication</name>
-    <message>
-        <location filename="../src/server/appserver.cpp" line="133"/>
-        <source>kDrive application will close due to a fatal error.</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>SharedTools::QtSingleApplication</name>
+<message>
+<location filename="../src/server/appserver.cpp" line="133"/>
+<source>kDrive application will close due to a fatal error.</source>
+<translation>kDrive-sovellus suljetaan kriittisen virheen vuoksi.</translation>
+</message>
 </context>
 <context>
-    <name>Utility</name>
-    <message numerus="yes">
-        <location filename="../src/libcommongui/utility/utility.cpp" line="41"/>
-        <source>%n year(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/libcommongui/utility/utility.cpp" line="42"/>
-        <source>%n month(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/libcommongui/utility/utility.cpp" line="43"/>
-        <source>%n day(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/libcommongui/utility/utility.cpp" line="44"/>
-        <source>%n hour(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/libcommongui/utility/utility.cpp" line="45"/>
-        <source>%n minute(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/libcommongui/utility/utility.cpp" line="46"/>
-        <source>%n second(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/libcommongui/utility/utility.cpp" line="97"/>
-        <source>%L1 GB</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/libcommongui/utility/utility.cpp" line="101"/>
-        <source>%L1 MB</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/libcommongui/utility/utility.cpp" line="105"/>
-        <source>%L1 KB</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/libcommongui/utility/utility.cpp" line="108"/>
-        <source>%L1 B</source>
-        <translation type="unfinished"></translation>
-    </message>
+<name>Utility</name>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="41"/>
+<source>%n year(s)</source>
+<translation>
+<numerusform>%n vuosi</numerusform><numerusform>%n vuotta</numerusform></translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="42"/>
+<source>%n month(s)</source>
+<translation>
+<numerusform>%n kuukausi</numerusform><numerusform>%n kuukautta</numerusform></translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="43"/>
+<source>%n day(s)</source>
+<translation>
+<numerusform>%n päivä</numerusform><numerusform>%n päivää</numerusform></translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="44"/>
+<source>%n hour(s)</source>
+<translation>
+<numerusform>%n tunti</numerusform><numerusform>%n tuntia</numerusform></translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="45"/>
+<source>%n minute(s)</source>
+<translation>
+<numerusform>%n minuutti</numerusform><numerusform>%n minuuttia</numerusform></translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="46"/>
+<source>%n second(s)</source>
+<translation>
+<numerusform>%n sekunti</numerusform><numerusform>%n sekuntia</numerusform></translation>
+</message>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="97"/>
+<source>%L1 GB</source>
+<translation>%L1 GB</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="101"/>
+<source>%L1 MB</source>
+<translation>%L1 MB</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="105"/>
+<source>%L1 KB</source>
+<translation>%L1 KB</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="108"/>
+<source>%L1 B</source>
+<translation>%L1 B</translation>
+</message>
 </context>
 <context>
-    <name>utility</name>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="84"/>
-        <source>Could not open browser</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="85"/>
-        <source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="104"/>
-        <source>Could not open email client</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="105"/>
-        <source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="324"/>
-        <source>You are not connected anymore. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Log in&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="329"/>
-        <source>No folder to synchronize
+<name>utility</name>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="84"/>
+<source>Could not open browser</source>
+<translation>Selainta ei voi avata</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="85"/>
+<source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
+<translation>Selaimen käynnistäminen URL-osoitteeseen %1 siirtymiseksi epäonnistui. Onko oletusselain määritetty?</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="104"/>
+<source>Could not open email client</source>
+<translation>Sähköpostiohjelmaa ei voi avata</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="105"/>
+<source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
+<translation>Sähköpostiohjelman käynnistäminen uuden viestin luomiseksi epäonnistui. Onko oletussähköpostiohjelma määritetty?</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="324"/>
+<source>You are not connected anymore. &lt;a style="%1" href="%2"&gt;Log in&lt;/a&gt;</source>
+<translation>Et ole enää kirjautunut. &lt;a style="%1" href="%2"&gt;Kirjaudu sisään&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="329"/>
+<source>No folder to synchronize
 You can add one from the kDrive settings.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="336"/>
-        <source>Sync in progress (%1 of %2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="340"/>
-        <source>Sync in progress (%1 of %2)
+<translation>Ei synkronoitavaa kansiota
+Voit lisätä sellaisen kDriven asetuksista.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="336"/>
+<source>Sync in progress (%1 of %2)</source>
+<translation>Synkronointi käynnissä (%1/%2)</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="340"/>
+<source>Sync in progress (%1 of %2)
 %3 left...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="347"/>
-        <source>Sync in progress (Step %1/%2).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="351"/>
-        <source>Synchronization starting</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="353"/>
-        <source>Sync in progress.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="358"/>
-        <source>You are up to date, unresolved conflicts.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="360"/>
-        <source>You are up to date!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="364"/>
-        <source>Some files couldn&apos;t be synchronized. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="370"/>
-        <source>Synchronization pausing ...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="374"/>
-        <source>Synchronization paused.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="570"/>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="576"/>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="584"/>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="595"/>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="599"/>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="651"/>
-        <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="660"/>
-        <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
-        <translation type="unfinished"></translation>
-    </message>
+<translation>Synkronointi käynnissä (%1/%2)
+%3 jäljellä...</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="347"/>
+<source>Sync in progress (Step %1/%2).</source>
+<translation>Synkronointi käynnissä (vaihe %1/%2).</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="351"/>
+<source>Synchronization starting</source>
+<translation>Synkronointi alkaa</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="353"/>
+<source>Sync in progress.</source>
+<translation>Synkronointi käynnissä.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="358"/>
+<source>You are up to date, unresolved conflicts.</source>
+<translation>Olet ajan tasalla, ratkaisemattomia ristiriitoja.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="360"/>
+<source>You are up to date!</source>
+<translation>Olet ajan tasalla!</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="364"/>
+<source>Some files couldn't be synchronized. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Joitakin tiedostoja ei voitu synkronoida. &lt;a style="%1" href="%2"&gt;Lue lisää&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="370"/>
+<source>Synchronization pausing ...</source>
+<translation>Synkronointi keskeytymässä...</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="374"/>
+<source>Synchronization paused.</source>
+<translation>Synkronointi keskeytetty.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="570"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
+<translation>Kansiota &lt;b&gt;%1&lt;/b&gt; ei voi valita, koska toinen synkronointi käyttää samaa kansiota.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="576"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+<translation>Kansiota &lt;b&gt;%1&lt;/b&gt; ei voi valita, koska se sisältää synkronoidun kansion &lt;b&gt;%2&lt;/b&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="584"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+<translation>Kansiota &lt;b&gt;%1&lt;/b&gt; ei voi valita, koska se on synkronoidun kansion &lt;b&gt;%2&lt;/b&gt; sisällä.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="595"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
+<translation>Kansiota &lt;b&gt;%1&lt;/b&gt; ei voi valita synkronointikansioksi. Valitse toinen kansio.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="599"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
+<translation>Kansiota &lt;b&gt;%1&lt;/b&gt; ei voi valita synkronointikansioksi. Valitse toinen kansio. Ehdotettu kansio: &lt;b&gt;%2&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="651"/>
+<source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
+<translation>Olet sulkenut pois enemmän kuin %1 kansiota, huomaa, että tämä vaikuttaa synkronoinnin suorituskykyyn.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="660"/>
+<source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
+<translation>Et voi sulkea pois enemmän kuin %1 kansiota. Poista ylätason kansioiden valinta.</translation>
+</message>
 </context>
 </TS>

--- a/translations/client_fi.ts
+++ b/translations/client_fi.ts
@@ -1,3020 +1,3042 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS language="fi_FI" version="2.1">
-<context>
-<name>KDC::AboutDialog</name>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="73"/>
-<source>About</source>
-<translation>Tietoja</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="112"/>
-<source>CLOSE</source>
-<translation>SULJE</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="123"/>
-<source>Version %1. For more information visit &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
-<translation>Versio %1. Lisätietoja: &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="126"/>
-<source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
-<translation>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="127"/>
-<source>Distributed by %1 and licensed under the &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
-<translation>%1 jakaa ja lisensoi &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;-lisenssin alla.&lt;br&gt;&lt;br&gt;%2 ja %2-logo ovat %1:n rekisteröityjä tavaramerkkejä.&lt;br&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="132"/>
-<source>&lt;p&gt;&lt;small&gt;Built from &lt;a style="color: #489EF3" href="%1"&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
-<translation>&lt;p&gt;&lt;small&gt;Rakennettu &lt;a style="color: #489EF3" href="%1"&gt;Git-lähteistä&lt;/a&gt; %2, %3 käyttäen Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="151"/>
-<location filename="../src/gui/aboutdialog.cpp" line="162"/>
-<location filename="../src/gui/aboutdialog.cpp" line="171"/>
-<source>Unable to open folder %1.</source>
-<translation>Kansiota %1 ei voi avata.</translation>
-</message>
-</context>
-<context>
-<name>KDC::AbstractFileItemWidget</name>
-<message>
-<location filename="../src/gui/abstractfileitemwidget.cpp" line="177"/>
-<source>Unable to open folder path %1.</source>
-<translation>Kansion polkua %1 ei voi avata.</translation>
-</message>
-</context>
-<context>
-<name>KDC::AddDriveConfirmationWidget</name>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55"/>
-<source>Synchronization will start and you will be able to add files to your %1 folder.</source>
-<translation>Synkronointi käynnistyy ja voit lisätä tiedostoja %1-kansioon.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99"/>
-<source>Your kDrive is ready!</source>
-<translation>kDrive on valmis!</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123"/>
-<source>OPEN FOLDER</source>
-<translation>AVAA KANSIO</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130"/>
-<source>PARAMETERS</source>
-<translation>ASETUKSET</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138"/>
-<source>Synchronize another drive</source>
-<translation>Synkronoi toinen asema</translation>
-</message>
-</context>
-<context>
-<name>KDC::AddDriveListWidget</name>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="170"/>
-<source>Cancel</source>
-<translation>Peruuta</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="177"/>
-<source>NEXT</source>
-<translation>SEURAAVA</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="196"/>
-<source>Select the kDrive you want to synchronize</source>
-<translation>Valitse synkronoitava kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="234"/>
-<source>Get kDrive for free</source>
-<translation>Hanki kDrive ilmaiseksi</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="244"/>
-<source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
-<translation>Tallenna kuvasi, asiakirjasi ja sähköpostisi Sveitsiin riippumattomassa yrityksessä, joka kunnioittaa yksityisyyttä. Lue lisää</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="263"/>
-<source>Test for free</source>
-<translation>Kokeile ilmaiseksi</translation>
-</message>
-</context>
-<context>
-<name>KDC::AddDriveLiteSyncWidget</name>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112"/>
-<source>Would you like to activate Lite Sync (Beta) ?</source>
-<translation>Haluatko aktivoida Lite Sync (Beta)?</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114"/>
-<source>Would you like to activate Lite Sync ?</source>
-<translation>Haluatko aktivoida Lite Sync?</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
-<source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Lite Sync synkronoi kaikki tiedostosi käyttämättä tietokoneen tallennustilaa. Voit selata kDrive-tiedostojasi ja ladata ne paikallisesti milloin tahansa. &lt;a style="%1" href="%2"&gt;Lue lisää&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147"/>
-<source>Conserve your computer space</source>
-<translation>Säästä tietokoneen tallennustilaa</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167"/>
-<source>Decide which files should be available online or locally</source>
-<translation>Päätä, mitkä tiedostot ovat saatavilla verkossa tai paikallisesti</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187"/>
-<source>LATER</source>
-<translation>MYÖHEMMIN</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193"/>
-<source>YES</source>
-<translation>KYLLÄ</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207"/>
-<source>Unable to open link %1.</source>
-<translation>Linkkiä %1 ei voi avata.</translation>
-</message>
-</context>
-<context>
-<name>KDC::AddDriveLocalFolderWidget</name>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65"/>
-<source>Location of your %1 kDrive</source>
-<translation>%1 kDrive -aseman sijainti</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155"/>
-<source>Edit folder</source>
-<translation>Muokkaa kansiota</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212"/>
-<source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
-<translation>Löydät kaikki tiedostosi tästä kansiosta konfiguroinnin jälkeen. Voit lisätä uusia tiedostoja kansioon synkronoidaksesi ne kDriveen.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
-<source>END</source>
-<translation>LOPETA</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
-<source>CONTINUE</source>
-<translation>JATKA</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
-<source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
-<translation>&lt;b&gt;%1&lt;/b&gt;-kansion sisältö synkronoidaan kDriveen</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284"/>
-<source>This folder is not compatible with Lite Sync.&lt;br&gt; 
+<TS version="2.1" language="fi_FI">
+    <context>
+        <name>KDC::AboutDialog</name>
+        <message>
+            <location filename="../src/gui/aboutdialog.cpp" line="73" />
+            <source>About</source>
+            <translation>Tietoja</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/aboutdialog.cpp" line="112" />
+            <source>CLOSE</source>
+            <translation>SULJE</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/aboutdialog.cpp" line="123" />
+            <source>Version %1. For more information visit &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
+            <translation>Versio %1. Lisätietoja: &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/aboutdialog.cpp" line="126" />
+            <source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
+            <translation>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/aboutdialog.cpp" line="127" />
+            <source>Distributed by %1 and licensed under the &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
+            <translation>%1 jakaa ja lisensoi &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;-lisenssin alla.&lt;br&gt;&lt;br&gt;%2 ja %2-logo ovat %1:n rekisteröityjä tavaramerkkejä.&lt;br&gt;&lt;br&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/aboutdialog.cpp" line="132" />
+            <source>&lt;p&gt;&lt;small&gt;Built from &lt;a style="color: #489EF3" href="%1"&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
+            <translation>&lt;p&gt;&lt;small&gt;Rakennettu &lt;a style="color: #489EF3" href="%1"&gt;Git-lähteistä&lt;/a&gt; %2, %3 käyttäen Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/aboutdialog.cpp" line="151" />
+            <location filename="../src/gui/aboutdialog.cpp" line="162" />
+            <location filename="../src/gui/aboutdialog.cpp" line="171" />
+            <source>Unable to open folder %1.</source>
+            <translation>Kansiota %1 ei voi avata.</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::AbstractFileItemWidget</name>
+        <message>
+            <location filename="../src/gui/abstractfileitemwidget.cpp" line="177" />
+            <source>Unable to open folder path %1.</source>
+            <translation>Kansion polkua %1 ei voi avata.</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::AddDriveConfirmationWidget</name>
+        <message>
+            <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55" />
+            <source>Synchronization will start and you will be able to add files to your %1 folder.</source>
+            <translation>Synkronointi käynnistyy ja voit lisätä tiedostoja %1-kansioon.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99" />
+            <source>Your kDrive is ready!</source>
+            <translation>kDrive on valmis!</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123" />
+            <source>OPEN FOLDER</source>
+            <translation>AVAA KANSIO</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130" />
+            <source>PARAMETERS</source>
+            <translation>ASETUKSET</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138" />
+            <source>Synchronize another drive</source>
+            <translation>Synkronoi toinen asema</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::AddDriveListWidget</name>
+        <message>
+            <location filename="../src/gui/adddrivelistwidget.cpp" line="170" />
+            <source>Cancel</source>
+            <translation>Peruuta</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddrivelistwidget.cpp" line="177" />
+            <source>NEXT</source>
+            <translation>SEURAAVA</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddrivelistwidget.cpp" line="196" />
+            <source>Select the kDrive you want to synchronize</source>
+            <translation>Valitse synkronoitava kDrive</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddrivelistwidget.cpp" line="234" />
+            <source>Get kDrive for free</source>
+            <translation>Hanki kDrive ilmaiseksi</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddrivelistwidget.cpp" line="244" />
+            <source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
+            <translation>Tallenna kuvasi, asiakirjasi ja sähköpostisi Sveitsiin riippumattomassa yrityksessä, joka kunnioittaa yksityisyyttä. Lue lisää</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddrivelistwidget.cpp" line="263" />
+            <source>Test for free</source>
+            <translation>Kokeile ilmaiseksi</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::AddDriveLiteSyncWidget</name>
+        <message>
+            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112" />
+            <source>Would you like to activate Lite Sync (Beta) ?</source>
+            <translation>Haluatko aktivoida Lite Sync (Beta)?</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114" />
+            <source>Would you like to activate Lite Sync ?</source>
+            <translation>Haluatko aktivoida Lite Sync?</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125" />
+            <source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+            <translation>Lite Sync synkronoi kaikki tiedostosi käyttämättä tietokoneen tallennustilaa. Voit selata kDrive-tiedostojasi ja ladata ne paikallisesti milloin tahansa. &lt;a style="%1" href="%2"&gt;Lue lisää&lt;/a&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147" />
+            <source>Conserve your computer space</source>
+            <translation>Säästä tietokoneen tallennustilaa</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167" />
+            <source>Decide which files should be available online or locally</source>
+            <translation>Päätä, mitkä tiedostot ovat saatavilla verkossa tai paikallisesti</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187" />
+            <source>LATER</source>
+            <translation>MYÖHEMMIN</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193" />
+            <source>YES</source>
+            <translation>KYLLÄ</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207" />
+            <source>Unable to open link %1.</source>
+            <translation>Linkkiä %1 ei voi avata.</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::AddDriveLocalFolderWidget</name>
+        <message>
+            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65" />
+            <source>Location of your %1 kDrive</source>
+            <translation>%1 kDrive -aseman sijainti</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155" />
+            <source>Edit folder</source>
+            <translation>Muokkaa kansiota</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212" />
+            <source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
+            <translation>Löydät kaikki tiedostosi tästä kansiosta konfiguroinnin jälkeen. Voit lisätä uusia tiedostoja kansioon synkronoidaksesi ne kDriveen.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246" />
+            <source>END</source>
+            <translation>LOPETA</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246" />
+            <source>CONTINUE</source>
+            <translation>JATKA</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264" />
+            <source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
+            <translation>&lt;b&gt;%1&lt;/b&gt;-kansion sisältö synkronoidaan kDriveen</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284" />
+            <source>This folder is not compatible with Lite Sync.&lt;br&gt; 
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt; 
 &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Tämä kansio ei ole yhteensopiva Lite Sync -toiminnon kanssa.&lt;br&gt; 
+            <translation>Tämä kansio ei ole yhteensopiva Lite Sync -toiminnon kanssa.&lt;br&gt; 
 Valitse toinen kansio. Jos jatkat, Lite Sync poistetaan käytöstä.&lt;br&gt; 
 &lt;a style="%1" href="%2"&gt;Lue lisää&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
-<source>Select folder</source>
-<translation>Valitse kansio</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377"/>
-<source>Unable to open link %1.</source>
-<translation>Linkkiä %1 ei voi avata.</translation>
-</message>
-</context>
-<context>
-<name>KDC::AddDriveLoginWidget</name>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="69"/>
-<source>Log in from your browser</source>
-<translation>Kirjaudu sisään selaimella</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="75"/>
-<source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
-<translation>Selaimesi avautuu automaattisesti yhteyden muodostamiseksi. Kun olet kirjautunut, palaat automaattisesti kDriveen.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
-<source>Open the login page</source>
-<translation>Avaa kirjautumissivu</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="119"/>
-<source>Token request failed: %1 - %2</source>
-<translation>Tunnuksen pyyntö epäonnistui: %1 - %2</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="133"/>
-<source>Login failed: %1 - %2</source>
-<translation>Kirjautuminen epäonnistui: %1 - %2</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="141"/>
-<source>Failed to open the login page in your web browser</source>
-<translation>Kirjautumissivun avaaminen selaimessa epäonnistui</translation>
-</message>
-</context>
-<context>
-<name>KDC::AddDriveServerFoldersWidget</name>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129"/>
-<source>Select kDrive folders to synchronize on your desktop</source>
-<translation>Valitse synkronoitavat kDrive-kansiot tietokoneellesi</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174"/>
-<source>CONTINUE</source>
-<translation>JATKA</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187"/>
-<source>Space available on your computer : %1</source>
-<translation>Tietokoneella vapaata tilaa: %1</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206"/>
-<source>An error occurred while loading the list of subfolders.</source>
-<translation>Alikansioiden listan lataaminen epäonnistui.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210"/>
-<source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
-<translation>Alikansioiden listaa ei voi ladata. kDrive saattaa olla huoltotilassa.&lt;br&gt;Kirjaudu &lt;a style="%1" href="%2"&gt;verkkoversiooon&lt;/a&gt; tarkistaaksesi kDriven tilan tai ota yhteyttä järjestelmänvalvojaasi.</translation>
-</message>
-</context>
-<context>
-<name>KDC::AddDriveWizard</name>
-<message>
-<location filename="../src/gui/adddrivewizard.cpp" line="222"/>
-<source>Failed to create local folder %1</source>
-<translation>Paikallisen kansion %1 luominen epäonnistui</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivewizard.cpp" line="233"/>
-<source>Failed to create new synchronization</source>
-<translation>Uuden synkronoinnin luominen epäonnistui</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivewizard.cpp" line="266"/>
-<source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
-<translation>kDrive %1 on jo synkronoitu tällä tietokoneella. Jatketaanko?</translation>
-</message>
-</context>
-<context>
-<name>KDC::AppClient</name>
-<message>
-<location filename="../src/gui/appclient.cpp" line="100"/>
-<source>kDrive client is run with bad parameters!</source>
-<translation>kDrive-asiakas käynnistettiin virheellisillä parametreillä!</translation>
-</message>
-<message>
-<location filename="../src/gui/appclient.cpp" line="109"/>
-<source>kDrive client is already running!</source>
-<translation>kDrive-asiakas on jo käynnissä!</translation>
-</message>
-<message>
-<location filename="../src/gui/appclient.cpp" line="719"/>
-<source>The user %1 is not connected. Please log in again.</source>
-<translation>Käyttäjä %1 ei ole kirjautunut. Kirjaudu uudelleen.</translation>
-</message>
-</context>
-<context>
-<name>KDC::AppServer</name>
-<message>
-<location filename="../src/server/appserver.cpp" line="1685"/>
-<source>Share link copied to clipboard</source>
-<translation>Jakolinkki kopioitu leikepöydälle</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3773"/>
-<source>%1 and %n other file(s) have been removed.</source>
-<translation>
-<numerusform>%1 ja %n muu tiedosto on poistettu.</numerusform><numerusform>%1 ja %n muuta tiedostoa on poistettu.</numerusform></translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3775"/>
-<source>%1 has been removed.</source>
-<comment>%1 names a file.</comment>
-<translation>%1 on poistettu.</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3780"/>
-<source>%1 and %n other file(s) have been added.</source>
-<translation>
-<numerusform>%1 ja %n muu tiedosto on lisätty.</numerusform><numerusform>%1 ja %n muuta tiedostoa on lisätty.</numerusform></translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3782"/>
-<source>%1 has been added.</source>
-<comment>%1 names a file.</comment>
-<translation>%1 on lisätty.</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3787"/>
-<source>%1 and %n other file(s) have been updated.</source>
-<translation>
-<numerusform>%1 ja %n muu tiedosto on päivitetty.</numerusform><numerusform>%1 ja %n muuta tiedostoa on päivitetty.</numerusform></translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3789"/>
-<source>%1 has been updated.</source>
-<comment>%1 names a file.</comment>
-<translation>%1 on päivitetty.</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3794"/>
-<source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
-<translation>
-<numerusform>%1 on siirretty kohteeseen %2 ja %n muu tiedosto on siirretty.</numerusform><numerusform>%1 on siirretty kohteeseen %2 ja %n muuta tiedostoa on siirretty.</numerusform></translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3797"/>
-<source>%1 has been moved to %2.</source>
-<translation>%1 on siirretty kohteeseen %2.</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3805"/>
-<source>Sync Activity</source>
-<translation>Synkronointiaktiviteetti</translation>
-</message>
-</context>
-<context>
-<name>KDC::BaseFolderTreeItemWidget</name>
-<message>
-<location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102"/>
-<source>No subfolders currently on the server.</source>
-<translation>Palvelimella ei ole alikansioita tällä hetkellä.</translation>
-</message>
-</context>
-<context>
-<name>KDC::BetaProgramDialog</name>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="69"/>
-<source>Quit the beta program</source>
-<translation>Poistu beta-ohjelmasta</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="69"/>
-<source>Join the beta program</source>
-<translation>Liity beta-ohjelmaan</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="77"/>
-<source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
-<translation>Saa varhainen pääsy sovelluksen uusiin versioihin ennen niiden julkaisua ja osallistu sovelluksen kehittämiseen lähettämällä kommenttisi.</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="87"/>
-<source>Benefit from application beta updates</source>
-<translation>Hyödy sovelluksen beta-päivityksistä</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="91"/>
-<source>No</source>
-<translation>Ei</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="92"/>
-<source>Public beta version</source>
-<translation>Julkinen beta-versio</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="93"/>
-<source>Internal beta version</source>
-<translation>Sisäinen beta-versio</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="141"/>
-<source>I understand</source>
-<translation>Ymmärrän</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="147"/>
-<source>Are you sure you want to leave the beta program?</source>
-<translation>Oletko varma, että haluat poistua beta-ohjelmasta?</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="161"/>
-<source>Save</source>
-<translation>Tallenna</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="167"/>
-<source>Cancel</source>
-<translation>Peruuta</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="228"/>
-<source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
-<translation>Sovelluksesi nykyinen versio saattaa olla liian uusi; valintasi astuu voimaan seuraavan päivityksen yhteydessä.</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="233"/>
-<source>Beta versions may leave unexpectedly or cause instabilities.</source>
-<translation>Beta-versiot saattavat kaatua odottamatta tai aiheuttaa epävakautta.</translation>
-</message>
-</context>
-<context>
-<name>KDC::ClientGui</name>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="116"/>
-<source>Unable to initialize kDrive client</source>
-<translation>kDrive-asiakkaan alustaminen epäonnistui</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="189"/>
-<source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
-<translation>Ristiriitojen korjaaminen kohteessa %1 synkronointikansiossa epäonnistui: %2</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="242"/>
-<source>Please sign in</source>
-<translation>Kirjaudu sisään</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="255"/>
-<source>Synchronization is paused</source>
-<translation>Synkronointi on keskeytetty</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="292"/>
-<source>Folder %1: %2</source>
-<translation>Kansio %1: %2</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="298"/>
-<source>There are no sync folders configured.</source>
-<translation>Synkronointikansioita ei ole määritetty.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="673"/>
-<source>Undefined State.</source>
-<translation>Määrittelemätön tila.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="676"/>
-<source>Waiting to start syncing.</source>
-<translation>Odotetaan synkronoinnin käynnistymistä.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="679"/>
-<source>Sync is running.</source>
-<translation>Synkronointi käynnissä.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="683"/>
-<source>Sync was successful, unresolved conflicts.</source>
-<translation>Synkronointi onnistui, ratkaisemattomia ristiriitoja.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="685"/>
-<source>Last Sync was successful.</source>
-<translation>Viimeisin synkronointi onnistui.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="692"/>
-<source>User Abort.</source>
-<translation>Käyttäjä keskeytti.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="696"/>
-<source>Sync is paused.</source>
-<translation>Synkronointi on keskeytetty.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="705"/>
-<source>%1 (Sync is paused)</source>
-<translation>%1 (Synkronointi keskeytetty)</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="849"/>
-<source>Unable to open folder path %1.</source>
-<translation>Kansion polkua %1 ei voi avata.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1257"/>
-<source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-<translation>Haluatko todella poistaa tilin &lt;i&gt;%1&lt;/i&gt; synkronoinnit?&lt;br&gt;&lt;b&gt;Huom:&lt;/b&gt; Tämä &lt;b&gt;ei&lt;/b&gt; poista tiedostoja.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1261"/>
-<source>REMOVE ALL SYNCHRONIZATIONS</source>
-<translation>POISTA KAIKKI SYNKRONOINNIT</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1262"/>
-<source>CANCEL</source>
-<translation>PERUUTA</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1422"/>
-<source>Synthesis</source>
-<translation>Yhteenveto</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1423"/>
-<source>Preferences</source>
-<translation>Asetukset</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1424"/>
-<source>Quit</source>
-<translation>Lopeta</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1590"/>
-<source>Failed to start synchronizations!</source>
-<translation>Synkronointien käynnistäminen epäonnistui!</translation>
-</message>
-</context>
-<context>
-<name>KDC::ConfirmSynchronizationDialog</name>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86"/>
-<source>Summary of your local folder synchronization</source>
-<translation>Yhteenveto paikallisen kansion synkronoinnista</translation>
-</message>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95"/>
-<source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
-<translation>Tietokoneesi kansion sisältö synkronoidaan valitun kDriven kansioon ja päinvastoin.</translation>
-</message>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184"/>
-<source>CANCEL</source>
-<translation>PERUUTA</translation>
-</message>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191"/>
-<source>SYNCHRONIZE</source>
-<translation>SYNKRONOI</translation>
-</message>
-</context>
-<context>
-<name>KDC::CustomExtensionSetupWidget</name>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="96"/>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="120"/>
-<source>Before finishing</source>
-<translation>Ennen viimeistelyä</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="107"/>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="131"/>
-<source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
-<translation>Suorita seuraavat vaiheet varmistaaksesi, että Lite Sync toimii oikein tietokoneellasi ja viimeistelläksesi kDriven konfiguroinnin.</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="208"/>
-<source>Open your Mac's &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Avaa Macin &lt;b&gt;Yleiset asetukset&lt;/b&gt; tai &lt;a style="%1" href="%2"&gt;napsauta tästä&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="212"/>
-<source>Open your Mac's &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Avaa Macin &lt;b&gt;Tietosuoja- ja turva-asetukset&lt;/b&gt; tai &lt;a style="%1" href="%2"&gt;napsauta tästä&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="216"/>
-<source>Open your Mac's &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Avaa Macin &lt;b&gt;Turvallisuus- ja tietosuoja-asetukset&lt;/b&gt; tai &lt;a style="%1" href="%2"&gt;napsauta tästä&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="246"/>
-<source>Go to &lt;b&gt;"Login Items &amp; Extensions"&lt;/b&gt; section and then to &lt;b&gt;"Endpoint Security Extensions"&lt;/b&gt;</source>
-<translation>Siirry &lt;b&gt;"Kirjautumisobjektit ja laajennukset"&lt;/b&gt;-osioon ja sitten &lt;b&gt;"Endpoint Security Extensions"&lt;/b&gt;-osioon</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="263"/>
-<source>Authorize the kDrive application</source>
-<translation>Valtuuta kDrive-sovellus</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="272"/>
-<source>Go to &lt;b&gt;"Security"&lt;/b&gt; section</source>
-<translation>Siirry &lt;b&gt;"Turvallisuus"&lt;/b&gt;-osioon</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="289"/>
-<source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
-<translation>Valtuuta kDrive-sovellus ruudussa, jossa ilmoitetaan kDriven olevan estetty</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="299"/>
-<source>Unlock the padlock &lt;img src=":/client/resources/icons/actions/lock.png"&gt; and authorize the kDrive application</source>
-<translation>Avaa lukko &lt;img src=":/client/resources/icons/actions/lock.png"&gt; ja valtuuta kDrive-sovellus</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="344"/>
-<source>Go to &lt;b&gt;"Privacy &amp; Security"&lt;/b&gt; section and click on &lt;b&gt;"Full Disk Access"&lt;/b&gt; or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Siirry &lt;b&gt;"Tietosuoja ja turvallisuus"&lt;/b&gt;-osioon ja napsauta &lt;b&gt;"Täysi levynkäyttöoikeus"&lt;/b&gt; tai &lt;a style="%1" href="%2"&gt;napsauta tästä&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="348"/>
-<source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;"Privacy"&lt;/b&gt; tab or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Turvallisuus- ja tietosuoja-asetuksissa avaa &lt;b&gt;"Tietosuoja"&lt;/b&gt;-välilehti tai &lt;a style="%1" href="%2"&gt;napsauta tästä&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="376"/>
-<source>Check the "kDrive LiteSync Extension" box then the "kDrive.app" box (if not already checked)</source>
-<translation>Valitse "kDrive LiteSync Extension" -ruutu ja sitten "kDrive.app"-ruutu (jos ei vielä valittu)</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="393"/>
-<source>A restart of the app might be proposed, in this case accept it</source>
-<translation>Sovelluksen uudelleenkäynnistystä saatetaan ehdottaa; hyväksy se siinä tapauksessa</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="399"/>
-<source>Check the "kDrive LiteSync Extension" box (and "kDrive.app" if it exists) in &lt;b&gt;"Full Disk Access"&lt;/b&gt;</source>
-<translation>Valitse "kDrive LiteSync Extension" -ruutu (ja "kDrive.app", jos se on olemassa) kohdassa &lt;b&gt;"Täysi levynkäyttöoikeus"&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
-<source>STEP 1</source>
-<translation>VAIHE 1</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="496"/>
-<source>(Done)</source>
-<translation>(Valmis)</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="496"/>
-<source>STEP 2</source>
-<translation>VAIHE 2</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="499"/>
-<source>STEPS PERFORMED</source>
-<translation>VAIHEET SUORITETTU</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="501"/>
-<source>END</source>
-<translation>LOPETA</translation>
-</message>
-</context>
-<context>
-<name>KDC::CustomMessageBox</name>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="101"/>
-<source>OK</source>
-<translation>OK</translation>
-</message>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="111"/>
-<source>CANCEL</source>
-<translation>PERUUTA</translation>
-</message>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="121"/>
-<source>YES</source>
-<translation>KYLLÄ</translation>
-</message>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="131"/>
-<source>NO</source>
-<translation>EI</translation>
-</message>
-</context>
-<context>
-<name>KDC::DebugReporter</name>
-<message>
-<location filename="../src/gui/debugreporter.cpp" line="37"/>
-<source>Sending of debugging information</source>
-<translation>Lähetetään virheenkorjaustietoja</translation>
-</message>
-<message>
-<location filename="../src/gui/debugreporter.cpp" line="37"/>
-<source>Cancel</source>
-<translation>Peruuta</translation>
-</message>
-</context>
-<context>
-<name>KDC::DebuggingDialog</name>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="45"/>
-<source>Debug</source>
-<translation>Virheenkorjaus</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="46"/>
-<source>Info</source>
-<translation>Tiedot</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="47"/>
-<source>Warning</source>
-<translation>Varoitus</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="48"/>
-<source>Error</source>
-<translation>Virhe</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="49"/>
-<source>Fatal</source>
-<translation>Kriittinen</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="74"/>
-<source>Debugging settings</source>
-<translation>Virheenkorjausasetukset</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="90"/>
-<source>Save debugging information in a folder on my computer (Recommended)</source>
-<translation>Tallenna virheenkorjaustiedot kansioon tietokoneellani (Suositeltu)</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="104"/>
-<source>This information enables IT support to determine the origin of an incident.</source>
-<translation>Nämä tiedot auttavat IT-tukea selvittämään tapauksen alkuperän.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="114"/>
-<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;Avaa virheenkorjauskansio&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="143"/>
-<source>Debug level</source>
-<translation>Virheenkorjaustaso</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="152"/>
-<source>The trace level lets you choose the extent of the debugging information recorded</source>
-<translation>Jäljitystaso antaa sinun valita tallennettavien virheenkorjaustietojen laajuuden</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="179"/>
-<source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
-<translation>Laajennettu täysloki kerää yksityiskohtaisen historian virheenkorjausta varten. Sen käyttöönotto voi hidastaa kDrive-sovellusta.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="183"/>
-<source>Extended Full Log</source>
-<translation>Laajennettu täysloki</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="207"/>
-<source>Delete logs older than %1 days</source>
-<translation>Poista lokeja, jotka ovat vanhempia kuin %1 päivää</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="226"/>
-<source>Share the debug folder with Infomaniak support.</source>
-<translation>Jaa virheenkorjauskansio Infomaniakille.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="250"/>
-<source>The last session is the periode since the last kDrive start.</source>
-<translation>Viimeinen istunto on ajanjakso viimeisimmästä kDriven käynnistyksestä.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="254"/>
-<source>Share only the last kDrive session</source>
-<translation>Jaa vain viimeisin kDrive-istunto</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="285"/>
-<source>  Loading</source>
-<translation>  Ladataan</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="294"/>
-<source>Cancel</source>
-<translation>Peruuta</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="320"/>
-<source>SAVE</source>
-<translation>TALLENNA</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="327"/>
-<source>CANCEL</source>
-<translation>PERUUTA</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="471"/>
-<source>Failed to share</source>
-<translation>Jakaminen epäonnistui</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="481"/>
-<source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
-<translation>1. Tarkista, että olet kirjautunut sisään &lt;br&gt;2. Tarkista, että olet määrittänyt vähintään yhden kDriven</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="486"/>
-<source> (Connexion interrupted)</source>
-<translation> (Yhteys katkaistu)</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="493"/>
-<source>Share the folder with SwissTransfer &lt;br&gt;</source>
-<translation>Jaa kansio SwissTransferillä &lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="494"/>
-<source> 1. We automatically compressed your log &lt;a style="%1" href="%2"&gt;here&lt;/a&gt;.&lt;br&gt;</source>
-<translation> 1. Pakkasimme lokisi automaattisesti &lt;a style="%1" href="%2"&gt;tähän&lt;/a&gt;.&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="496"/>
-<source> 2. Transfer the archive with &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
-<translation> 2. Siirrä arkisto &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;-palvelun avulla&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="498"/>
-<source> 3. Share the link with &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
-<translation> 3. Jaa linkki osoitteeseen &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="528"/>
-<source>Last upload the %1</source>
-<translation>Viimeisin lähetys %1</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="556"/>
-<source>Sharing has been cancelled</source>
-<translation>Jakaminen on peruutettu</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="597"/>
-<source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
-<translation>Laajennettu täysloki on aktivoitu KDRIVE_FORCE_EXTENDED_LOG-ympäristömuuttujalla. Aseta se arvoon 0 poistaaksesi sen käytöstä.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="611"/>
-<source>%1/%2/%3 at %4h%5m and %6s</source>
-<extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
-<translation>%1/%2/%3 klo %4:%5:%6</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="654"/>
-<source>Do you want to save your modifications?</source>
-<translation>Haluatko tallentaa muutokset?</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="709"/>
-<location filename="../src/gui/debuggingdialog.cpp" line="715"/>
-<source>Unable to open folder %1.</source>
-<translation>Kansiota %1 ei voi avata.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="722"/>
-<source>  Share</source>
-<translation>  Jaa</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="732"/>
-<source>  Sharing | step 1/2 %1%</source>
-<translation>  Jaetaan | vaihe 1/2 %1%</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="741"/>
-<source>  Sharing | step 2/2 %1%</source>
-<translation>  Jaetaan | vaihe 2/2 %1%</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="751"/>
-<source>  Canceling...</source>
-<translation>  Peruutetaan...</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.h" line="70"/>
-<source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
-<translation>Koko kansio on suuri (&gt; 100 Mt) ja jakaminen voi kestää jonkin aikaa. Jakamisajan lyhentämiseksi suosittelemme jakamaan vain viimeisimmän kDrive-istunnon.</translation>
-</message>
-</context>
-<context>
-<name>KDC::DrivePreferencesWidget</name>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
-<source>Synchronization errors and information.</source>
-<translation>Synkronointivirheet ja tiedot.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
-<source>Synchronize a local folder</source>
-<translation>Synkronoi paikallinen kansio</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
-<source>Do you really want to turn on Lite Sync?</source>
-<translation>Haluatko todella ottaa Lite Sync käyttöön?</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="356"/>
-<source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
-<translation>Tämä toiminto voi kestää muutamasta sekunnista muutamaan minuuttiin kansion koosta riippuen.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
-<source>CONFIRM</source>
-<translation>VAHVISTA</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="360"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="391"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="986"/>
-<source>CANCEL</source>
-<translation>PERUUTA</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="382"/>
-<source>Do you really want to turn off Lite Sync?</source>
-<translation>Haluatko todella poistaa Lite Sync käytöstä?</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="384"/>
-<source>You don't have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
-<translation>Sinulla ei ole tarpeeksi tilaa kaikkien kDrive-tiedostojen synkronointiin (%1 puuttuu). Jos poistat Lite Sync käytöstä, sinun on valittava synkronoitavat kansiot tietokoneellasi. Sillä välin kDriven synkronointi keskeytetään.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="388"/>
-<source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
-<translation>Jos poistat Lite Sync käytöstä, kaikki tiedostot ladataan tietokoneellesi.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="627"/>
-<source>Failed to create new synchronization</source>
-<translation>Uuden synkronoinnin luominen epäonnistui</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
-<source>New local folder synchronization failed!</source>
-<translation>Uuden paikallisen kansion synkronointi epäonnistui!</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="819"/>
-<source>Lite Sync activated.</source>
-<translation>Lite Sync aktivoitu.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
-<source>Lite Sync activation failed.</source>
-<translation>Lite Sync -aktivointi epäonnistui.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="837"/>
-<source>Lite Sync deactivated.</source>
-<translation>Lite Sync poistettu käytöstä.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
-<source>Lite Sync deactivation failed.</source>
-<translation>Lite Sync -deaktivointi epäonnistui.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="899"/>
-<source>This drive is being deleted.</source>
-<translation>Tämä asema poistetaan.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="962"/>
-<source>Impossible to open item %1</source>
-<translation>Kohteen %1 avaaminen ei onnistu</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
-<source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-<translation>Haluatko todella lopettaa kansion &lt;i&gt;%1&lt;/i&gt; synkronoinnin?&lt;br&gt;&lt;b&gt;Huom:&lt;/b&gt; Tämä &lt;b&gt;ei&lt;/b&gt; poista tiedostoja.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
-<source>REMOVE FOLDER SYNC CONNECTION</source>
-<translation>POISTA KANSION SYNKRONOINTIYHTEYS</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1007"/>
-<source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
-<translation>Kansion &lt;i&gt;%1&lt;/i&gt; synkronoinnin pysäyttäminen epäonnistui.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
-<source>An error occurred while loading the list of subfolders.</source>
-<translation>Alikansioiden listan lataaminen epäonnistui.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
-<source>Folders</source>
-<translation>Kansiot</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
-<source>Notifications</source>
-<translation>Ilmoitukset</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
-<source>Enable the notifications for this kDrive</source>
-<translation>Ota tämän kDriven ilmoitukset käyttöön</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
-<source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
-<translation>Ilmoitus näytetään heti, kun uusi kansio on synkronoitu tai muokattu</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
-<source>Connected with</source>
-<translation>Yhdistetty:</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1125"/>
-<source>Remove all synchronizations</source>
-<translation>Poista kaikki synkronoinnit</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1126"/>
-<source>Search in your kDrive</source>
-<translation>Hae kDrivesta</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1127"/>
-<source>Search</source>
-<translation>Haku</translation>
-</message>
-</context>
-<context>
-<name>KDC::DriveSelectionWidget</name>
-<message>
-<location filename="../src/gui/driveselectionwidget.cpp" line="150"/>
-<source>Add a kDrive</source>
-<translation>Lisää kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
-<source>Synchronize a kDrive</source>
-<translation>Synkronoi kDrive</translation>
-</message>
-</context>
-<context>
-<name>KDC::ErrorTabWidget</name>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="92"/>
-<location filename="../src/gui/errortabwidget.cpp" line="135"/>
-<location filename="../src/gui/errortabwidget.cpp" line="178"/>
-<location filename="../src/gui/errortabwidget.cpp" line="186"/>
-<source>Clear history</source>
-<translation>Tyhjennä historia</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="176"/>
-<source>To Resolve</source>
-<translation>Ratkaistavana</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="177"/>
-<source>problem(s) detected</source>
-<translation>havaittu ongelma(t)</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="179"/>
-<source>Resolve</source>
-<translation>Ratkaise</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="180"/>
-<source>Conflicted item(s)</source>
-<translation>Ristiriitainen kohde (kohteet)</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="181"/>
-<source>Item(s) with unsupported characters</source>
-<translation>Kohde(et), joissa on ei-tuettuja merkkejä</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="184"/>
-<source>Automatically resolved</source>
-<translation>Automaattisesti ratkaistu</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="185"/>
-<source>problem(s) solved</source>
-<translation>ratkaistut ongelma(t)</translation>
-</message>
-</context>
-<context>
-<name>KDC::ErrorsMenuBarWidget</name>
-<message>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="84"/>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="103"/>
-<source>Synchronization conflicts or errors</source>
-<translation>Synkronointiristiriidat tai -virheet</translation>
-</message>
-<message>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="86"/>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="105"/>
-<source>Errors</source>
-<translation>Virheet</translation>
-</message>
-<message>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="101"/>
-<source>Back to preferences</source>
-<translation>Takaisin asetuksiin</translation>
-</message>
-</context>
-<context>
-<name>KDC::ErrorsPopup</name>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="73"/>
-<source>Some files couldn't be synchronized on the following kDrive(s) :</source>
-<translation>Joitakin tiedostoja ei voitu synkronoida seuraavilla kDrive-asemilla:</translation>
-</message>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="95"/>
-<source> (%1 error(s))</source>
-<translation> (%1 virhe(ttä))</translation>
-</message>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="101"/>
-<source> (%1 information(s))</source>
-<translation> (%1 tiedote(tta))</translation>
-</message>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="107"/>
-<source> (%1 error(s) and %2 information(s))</source>
-<translation> (%1 virhe(ttä) ja %2 tiedote(tta))</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/gui/errorspopup.cpp" line="147"/>
-<source>Generic errors (%n warning(s) or error(s))</source>
-<comment>Number of warnings or errors</comment>
-<translation>
-<numerusform>Yleiset virheet (%n varoitus tai virhe)</numerusform><numerusform>Yleiset virheet (%n varoitusta tai virhettä)</numerusform></translation>
-</message>
-</context>
-<context>
-<name>KDC::FileExclusionDialog</name>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="78"/>
-<source>Excluded files</source>
-<translation>Poissuljetut tiedostot</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="86"/>
-<source>Add files or folders that will not be synchronized on your computer.</source>
-<translation>Lisää tiedostoja tai kansioita, joita ei synkronoida tietokoneellesi.</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="97"/>
-<source>Add</source>
-<translation>Lisää</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="109"/>
-<source>NAME</source>
-<translation>NIMI</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="114"/>
-<source>WARNING</source>
-<translation>VAROITUS</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="149"/>
-<source>SAVE</source>
-<translation>TALLENNA</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="156"/>
-<source>CANCEL</source>
-<translation>PERUUTA</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="304"/>
-<source>Do you want to save your modifications?</source>
-<translation>Haluatko tallentaa muutokset?</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="353"/>
-<source>Exclusion template already exists!</source>
-<translation>Poissulkumalli on jo olemassa!</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="374"/>
-<source>Do you really want to delete?</source>
-<translation>Haluatko todella poistaa?</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="434"/>
-<source>Cannot save changes!</source>
-<translation>Muutoksia ei voi tallentaa!</translation>
-</message>
-</context>
-<context>
-<name>KDC::FileExclusionNameDialog</name>
-<message>
-<location filename="../src/gui/fileexclusionnamedialog.cpp" line="58"/>
-<source>VALIDATE</source>
-<translation>VAHVISTA</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusionnamedialog.cpp" line="65"/>
-<source>CANCEL</source>
-<translation>PERUUTA</translation>
-</message>
-</context>
-<context>
-<name>KDC::FixConflictingFilesDialog</name>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67"/>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73"/>
-<source>Unable to open link %1.</source>
-<translation>Linkkiä %1 ei voi avata.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122"/>
-<source>Solve conflict(s)</source>
-<translation>Ratkaise ristiriita(t)</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140"/>
-<source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
-<translation>&lt;b&gt;Mitä haluat tehdä %1 ristiriitaiselle kohteelle?&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143"/>
-<source>Save my changes and replace other users' versions.</source>
-<translation>Tallenna muutokseni ja korvaa muiden käyttäjien versiot.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147"/>
-<source>Undo my changes and keep other users' versions.</source>
-<translation>Kumoa muutokseni ja säilytä muiden käyttäjien versiot.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169"/>
-<source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
-<translation>Muutoksesi voidaan poistaa pysyvästi. Niitä ei voi palauttaa kDrive-verkkosovelluksesta.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171"/>
-<source>&lt;a style=%1 href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>&lt;a style=%1 href="%2"&gt;Lue lisää&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175"/>
-<source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
-<translation>Muutoksesi poistetaan pysyvästi. Niitä ei voi palauttaa kDrive-verkkosovelluksesta.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191"/>
-<source>Show item(s)</source>
-<translation>Näytä kohde(et)</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228"/>
-<source>VALIDATE</source>
-<translation>VAHVISTA</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234"/>
-<source>CANCEL</source>
-<translation>PERUUTA</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251"/>
-<source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
-<translation>Useat käyttäjät ovat muokanneet näitä tiedostoja useissa paikoissa (kDrivessa verkossa, tietokoneella tai mobiililaitteella). Myös nämä tiedostot sisältävät kansiot on saatettu poistaa.&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253"/>
-<source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Learn more&lt;/a&gt;</source>
-<translation>Kohteesi paikallinen versio &lt;b&gt;ei ole synkronoitu&lt;/b&gt; kDriven kanssa. &lt;a style="color: #489EF3" href="%1"&gt;Lue lisää&lt;/a&gt;</translation>
-</message>
-</context>
-<context>
-<name>KDC::FolderItemWidget</name>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="188"/>
-<location filename="../src/gui/folderitemwidget.cpp" line="476"/>
-<source>Synchronized into &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</source>
-<translation>Synkronoitu kohteeseen &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="343"/>
-<source>Activate Lite Sync</source>
-<translation>Ota Lite Sync käyttöön</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="345"/>
-<source>Activate Lite Sync (Beta)</source>
-<translation>Ota Lite Sync (Beta) käyttöön</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="354"/>
-<source>Deactivate Lite Sync</source>
-<translation>Poista Lite Sync käytöstä</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="365"/>
-<source>Pause synchronization</source>
-<translation>Keskeytä synkronointi</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="375"/>
-<source>Resume synchronization</source>
-<translation>Jatka synkronointia</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="386"/>
-<source>Remove synchronization</source>
-<translation>Poista synkronointi</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="458"/>
-<source>More actions</source>
-<translation>Lisää toimintoja</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="481"/>
-<source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
-<translation>Valitsemattomat kansiot siirretään roskakoriin, jos ne sisältävät offline-kohteita. kDriveen synkronoidut kansiot pysyvät saatavilla verkossa.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="485"/>
-<source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
-<translation>Valitsemattomat kansiot siirretään roskakoriin. kDriveen synkronoidut kansiot pysyvät saatavilla verkossa.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="488"/>
-<source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
-<translation>Valitsemattomat kansiot poistetaan &lt;b&gt;pysyvästi&lt;/b&gt; tietokoneelta. kDriveen synkronoidut kansiot pysyvät saatavilla verkossa.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="493"/>
-<source>Cancel</source>
-<translation>Peruuta</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="494"/>
-<source>VALIDATE</source>
-<translation>VAHVISTA</translation>
-</message>
-</context>
-<context>
-<name>KDC::GenericErrorItemWidget</name>
-<message>
-<location filename="../src/gui/genericerroritemwidget.cpp" line="85"/>
-<source>Unable to open folder path %1.</source>
-<translation>Kansion polkua %1 ei voi avata.</translation>
-</message>
-</context>
-<context>
-<name>KDC::LiteSyncAppDialog</name>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="48"/>
-<source>Application Id</source>
-<translation>Sovelluksen tunnus</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="98"/>
-<source>Application Name</source>
-<translation>Sovelluksen nimi</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="121"/>
-<source>VALIDATE</source>
-<translation>VAHVISTA</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="128"/>
-<source>CANCEL</source>
-<translation>PERUUTA</translation>
-</message>
-</context>
-<context>
-<name>KDC::LiteSyncDialog</name>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="91"/>
-<source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are "online". Add them in the list below to avoid this behaviour.</source>
-<translation>Jotkut sovellukset (varmuuskopiointi, virustorjunta...) käyttävät tiedostojasi, mikä johtaa niiden lataamiseen, kun ne ovat "verkossa". Lisää ne alla olevaan luetteloon tämän käyttäytymisen välttämiseksi.</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="103"/>
-<source>Add</source>
-<translation>Lisää</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="115"/>
-<source>APPLICATION ID</source>
-<translation>SOVELLUKSEN TUNNUS</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="120"/>
-<source>NAME</source>
-<translation>NIMI</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="154"/>
-<source>SAVE</source>
-<translation>TALLENNA</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="161"/>
-<source>CANCEL</source>
-<translation>PERUUTA</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="295"/>
-<source>Do you want to save your modifications?</source>
-<translation>Haluatko tallentaa muutokset?</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="337"/>
-<source>Do you really want to delete?</source>
-<translation>Haluatko todella poistaa?</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="374"/>
-<source>Cannot save changes!</source>
-<translation>Muutoksia ei voi tallentaa!</translation>
-</message>
-</context>
-<context>
-<name>KDC::LocalFolderDialog</name>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="63"/>
-<source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
-<translation>Minkä tietokoneen kansion haluat&lt;br&gt;synkronoida?</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="72"/>
-<source>The content of this folder will be synchronized on the kDrive</source>
-<translation>Tämän kansion sisältö synkronoidaan kDriveen</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="91"/>
-<source>Select a folder</source>
-<translation>Valitse kansio</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="131"/>
-<source>Edit folder</source>
-<translation>Muokkaa kansiota</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="166"/>
-<source>CANCEL</source>
-<translation>PERUUTA</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="173"/>
-<source>CONTINUE</source>
-<translation>JATKA</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="210"/>
-<source>This folder is not compatible with Lite Sync.&lt;br&gt;
+        </message>
+        <message>
+            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297" />
+            <source>Select folder</source>
+            <translation>Valitse kansio</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377" />
+            <source>Unable to open link %1.</source>
+            <translation>Linkkiä %1 ei voi avata.</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::AddDriveLoginWidget</name>
+        <message>
+            <location filename="../src/gui/adddriveloginwidget.cpp" line="69" />
+            <source>Log in from your browser</source>
+            <translation>Kirjaudu sisään selaimella</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddriveloginwidget.cpp" line="75" />
+            <source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
+            <translation>Selaimesi avautuu automaattisesti yhteyden muodostamiseksi. Kun olet kirjautunut, palaat automaattisesti kDriveen.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddriveloginwidget.cpp" line="85" />
+            <source>Open the login page</source>
+            <translation>Avaa kirjautumissivu</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddriveloginwidget.cpp" line="119" />
+            <source>Token request failed: %1 - %2</source>
+            <translation>Tunnuksen pyyntö epäonnistui: %1 - %2</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddriveloginwidget.cpp" line="133" />
+            <source>Login failed: %1 - %2</source>
+            <translation>Kirjautuminen epäonnistui: %1 - %2</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddriveloginwidget.cpp" line="141" />
+            <source>Failed to open the login page in your web browser</source>
+            <translation>Kirjautumissivun avaaminen selaimessa epäonnistui</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::AddDriveServerFoldersWidget</name>
+        <message>
+            <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129" />
+            <source>Select kDrive folders to synchronize on your desktop</source>
+            <translation>Valitse synkronoitavat kDrive-kansiot tietokoneellesi</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174" />
+            <source>CONTINUE</source>
+            <translation>JATKA</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187" />
+            <source>Space available on your computer : %1</source>
+            <translation>Tietokoneella vapaata tilaa: %1</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206" />
+            <source>An error occurred while loading the list of subfolders.</source>
+            <translation>Alikansioiden listan lataaminen epäonnistui.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210" />
+            <source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
+            <translation>Alikansioiden listaa ei voi ladata. kDrive saattaa olla huoltotilassa.&lt;br&gt;Kirjaudu &lt;a style="%1" href="%2"&gt;verkkoversiooon&lt;/a&gt; tarkistaaksesi kDriven tilan tai ota yhteyttä järjestelmänvalvojaasi.</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::AddDriveWizard</name>
+        <message>
+            <location filename="../src/gui/adddrivewizard.cpp" line="222" />
+            <source>Failed to create local folder %1</source>
+            <translation>Paikallisen kansion %1 luominen epäonnistui</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddrivewizard.cpp" line="233" />
+            <source>Failed to create new synchronization</source>
+            <translation>Uuden synkronoinnin luominen epäonnistui</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/adddrivewizard.cpp" line="266" />
+            <source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
+            <translation>kDrive %1 on jo synkronoitu tällä tietokoneella. Jatketaanko?</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::AppClient</name>
+        <message>
+            <location filename="../src/gui/appclient.cpp" line="100" />
+            <source>kDrive client is run with bad parameters!</source>
+            <translation>kDrive-asiakas käynnistettiin virheellisillä parametreillä!</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/appclient.cpp" line="109" />
+            <source>kDrive client is already running!</source>
+            <translation>kDrive-asiakas on jo käynnissä!</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/appclient.cpp" line="719" />
+            <source>The user %1 is not connected. Please log in again.</source>
+            <translation>Käyttäjä %1 ei ole kirjautunut. Kirjaudu uudelleen.</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::AppServer</name>
+        <message>
+            <location filename="../src/server/appserver.cpp" line="1685" />
+            <source>Share link copied to clipboard</source>
+            <translation>Jakolinkki kopioitu leikepöydälle</translation>
+        </message>
+        <message numerus="yes">
+            <location filename="../src/server/appserver.cpp" line="3773" />
+            <source>%1 and %n other file(s) have been removed.</source>
+            <translation>
+                <numerusform>%1 ja %n muu tiedosto on poistettu.</numerusform>
+                <numerusform>%1 ja %n muuta tiedostoa on poistettu.</numerusform>
+            </translation>
+        </message>
+        <message>
+            <location filename="../src/server/appserver.cpp" line="3775" />
+            <source>%1 has been removed.</source>
+            <comment>%1 names a file.</comment>
+            <translation>%1 on poistettu.</translation>
+        </message>
+        <message numerus="yes">
+            <location filename="../src/server/appserver.cpp" line="3780" />
+            <source>%1 and %n other file(s) have been added.</source>
+            <translation>
+                <numerusform>%1 ja %n muu tiedosto on lisätty.</numerusform>
+                <numerusform>%1 ja %n muuta tiedostoa on lisätty.</numerusform>
+            </translation>
+        </message>
+        <message>
+            <location filename="../src/server/appserver.cpp" line="3782" />
+            <source>%1 has been added.</source>
+            <comment>%1 names a file.</comment>
+            <translation>%1 on lisätty.</translation>
+        </message>
+        <message numerus="yes">
+            <location filename="../src/server/appserver.cpp" line="3787" />
+            <source>%1 and %n other file(s) have been updated.</source>
+            <translation>
+                <numerusform>%1 ja %n muu tiedosto on päivitetty.</numerusform>
+                <numerusform>%1 ja %n muuta tiedostoa on päivitetty.</numerusform>
+            </translation>
+        </message>
+        <message>
+            <location filename="../src/server/appserver.cpp" line="3789" />
+            <source>%1 has been updated.</source>
+            <comment>%1 names a file.</comment>
+            <translation>%1 on päivitetty.</translation>
+        </message>
+        <message numerus="yes">
+            <location filename="../src/server/appserver.cpp" line="3794" />
+            <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
+            <translation>
+                <numerusform>%1 on siirretty kohteeseen %2 ja %n muu tiedosto on siirretty.</numerusform>
+                <numerusform>%1 on siirretty kohteeseen %2 ja %n muuta tiedostoa on siirretty.</numerusform>
+            </translation>
+        </message>
+        <message>
+            <location filename="../src/server/appserver.cpp" line="3797" />
+            <source>%1 has been moved to %2.</source>
+            <translation>%1 on siirretty kohteeseen %2.</translation>
+        </message>
+        <message>
+            <location filename="../src/server/appserver.cpp" line="3805" />
+            <source>Sync Activity</source>
+            <translation>Synkronointiaktiviteetti</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::BaseFolderTreeItemWidget</name>
+        <message>
+            <location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102" />
+            <source>No subfolders currently on the server.</source>
+            <translation>Palvelimella ei ole alikansioita tällä hetkellä.</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::BetaProgramDialog</name>
+        <message>
+            <location filename="../src/gui/betaprogramdialog.cpp" line="69" />
+            <source>Quit the beta program</source>
+            <translation>Poistu beta-ohjelmasta</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/betaprogramdialog.cpp" line="69" />
+            <source>Join the beta program</source>
+            <translation>Liity beta-ohjelmaan</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/betaprogramdialog.cpp" line="77" />
+            <source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
+            <translation>Saa varhainen pääsy sovelluksen uusiin versioihin ennen niiden julkaisua ja osallistu sovelluksen kehittämiseen lähettämällä kommenttisi.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/betaprogramdialog.cpp" line="87" />
+            <source>Benefit from application beta updates</source>
+            <translation>Hyödy sovelluksen beta-päivityksistä</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/betaprogramdialog.cpp" line="91" />
+            <source>No</source>
+            <translation>Ei</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/betaprogramdialog.cpp" line="92" />
+            <source>Public beta version</source>
+            <translation>Julkinen beta-versio</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/betaprogramdialog.cpp" line="93" />
+            <source>Internal beta version</source>
+            <translation>Sisäinen beta-versio</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/betaprogramdialog.cpp" line="141" />
+            <source>I understand</source>
+            <translation>Ymmärrän</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/betaprogramdialog.cpp" line="147" />
+            <source>Are you sure you want to leave the beta program?</source>
+            <translation>Oletko varma, että haluat poistua beta-ohjelmasta?</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/betaprogramdialog.cpp" line="161" />
+            <source>Save</source>
+            <translation>Tallenna</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/betaprogramdialog.cpp" line="167" />
+            <source>Cancel</source>
+            <translation>Peruuta</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/betaprogramdialog.cpp" line="228" />
+            <source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
+            <translation>Sovelluksesi nykyinen versio saattaa olla liian uusi; valintasi astuu voimaan seuraavan päivityksen yhteydessä.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/betaprogramdialog.cpp" line="233" />
+            <source>Beta versions may leave unexpectedly or cause instabilities.</source>
+            <translation>Beta-versiot saattavat kaatua odottamatta tai aiheuttaa epävakautta.</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::ClientGui</name>
+        <message>
+            <location filename="../src/gui/clientgui.cpp" line="116" />
+            <source>Unable to initialize kDrive client</source>
+            <translation>kDrive-asiakkaan alustaminen epäonnistui</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/clientgui.cpp" line="189" />
+            <source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
+            <translation>Ristiriitojen korjaaminen kohteessa %1 synkronointikansiossa epäonnistui: %2</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/clientgui.cpp" line="242" />
+            <source>Please sign in</source>
+            <translation>Kirjaudu sisään</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/clientgui.cpp" line="255" />
+            <source>Synchronization is paused</source>
+            <translation>Synkronointi on keskeytetty</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/clientgui.cpp" line="292" />
+            <source>Folder %1: %2</source>
+            <translation>Kansio %1: %2</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/clientgui.cpp" line="298" />
+            <source>There are no sync folders configured.</source>
+            <translation>Synkronointikansioita ei ole määritetty.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/clientgui.cpp" line="673" />
+            <source>Undefined State.</source>
+            <translation>Määrittelemätön tila.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/clientgui.cpp" line="676" />
+            <source>Waiting to start syncing.</source>
+            <translation>Odotetaan synkronoinnin käynnistymistä.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/clientgui.cpp" line="679" />
+            <source>Sync is running.</source>
+            <translation>Synkronointi käynnissä.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/clientgui.cpp" line="683" />
+            <source>Sync was successful, unresolved conflicts.</source>
+            <translation>Synkronointi onnistui, ratkaisemattomia ristiriitoja.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/clientgui.cpp" line="685" />
+            <source>Last Sync was successful.</source>
+            <translation>Viimeisin synkronointi onnistui.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/clientgui.cpp" line="692" />
+            <source>User Abort.</source>
+            <translation>Käyttäjä keskeytti.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/clientgui.cpp" line="696" />
+            <source>Sync is paused.</source>
+            <translation>Synkronointi on keskeytetty.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/clientgui.cpp" line="705" />
+            <source>%1 (Sync is paused)</source>
+            <translation>%1 (Synkronointi keskeytetty)</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/clientgui.cpp" line="849" />
+            <source>Unable to open folder path %1.</source>
+            <translation>Kansion polkua %1 ei voi avata.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/clientgui.cpp" line="1257" />
+            <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+            <translation>Haluatko todella poistaa tilin &lt;i&gt;%1&lt;/i&gt; synkronoinnit?&lt;br&gt;&lt;b&gt;Huom:&lt;/b&gt; Tämä &lt;b&gt;ei&lt;/b&gt; poista tiedostoja.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/clientgui.cpp" line="1261" />
+            <source>REMOVE ALL SYNCHRONIZATIONS</source>
+            <translation>POISTA KAIKKI SYNKRONOINNIT</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/clientgui.cpp" line="1262" />
+            <source>CANCEL</source>
+            <translation>PERUUTA</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/clientgui.cpp" line="1422" />
+            <source>Synthesis</source>
+            <translation>Yhteenveto</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/clientgui.cpp" line="1423" />
+            <source>Preferences</source>
+            <translation>Asetukset</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/clientgui.cpp" line="1424" />
+            <source>Quit</source>
+            <translation>Lopeta</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/clientgui.cpp" line="1590" />
+            <source>Failed to start synchronizations!</source>
+            <translation>Synkronointien käynnistäminen epäonnistui!</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::ConfirmSynchronizationDialog</name>
+        <message>
+            <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86" />
+            <source>Summary of your local folder synchronization</source>
+            <translation>Yhteenveto paikallisen kansion synkronoinnista</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95" />
+            <source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
+            <translation>Tietokoneesi kansion sisältö synkronoidaan valitun kDriven kansioon ja päinvastoin.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184" />
+            <source>CANCEL</source>
+            <translation>PERUUTA</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191" />
+            <source>SYNCHRONIZE</source>
+            <translation>SYNKRONOI</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::CustomExtensionSetupWidget</name>
+        <message>
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="96" />
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="120" />
+            <source>Before finishing</source>
+            <translation>Ennen viimeistelyä</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="107" />
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="131" />
+            <source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
+            <translation>Suorita seuraavat vaiheet varmistaaksesi, että Lite Sync toimii oikein tietokoneellasi ja viimeistelläksesi kDriven konfiguroinnin.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="208" />
+            <source>Open your Mac's &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+            <translation>Avaa Macin &lt;b&gt;Yleiset asetukset&lt;/b&gt; tai &lt;a style="%1" href="%2"&gt;napsauta tästä&lt;/a&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="212" />
+            <source>Open your Mac's &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+            <translation>Avaa Macin &lt;b&gt;Tietosuoja- ja turva-asetukset&lt;/b&gt; tai &lt;a style="%1" href="%2"&gt;napsauta tästä&lt;/a&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="216" />
+            <source>Open your Mac's &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+            <translation>Avaa Macin &lt;b&gt;Turvallisuus- ja tietosuoja-asetukset&lt;/b&gt; tai &lt;a style="%1" href="%2"&gt;napsauta tästä&lt;/a&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="246" />
+            <source>Go to &lt;b&gt;"Login Items &amp; Extensions"&lt;/b&gt; section and then to &lt;b&gt;"Endpoint Security Extensions"&lt;/b&gt;</source>
+            <translation>Siirry &lt;b&gt;"Kirjautumisobjektit ja laajennukset"&lt;/b&gt;-osioon ja sitten &lt;b&gt;"Endpoint Security Extensions"&lt;/b&gt;-osioon</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="263" />
+            <source>Authorize the kDrive application</source>
+            <translation>Valtuuta kDrive-sovellus</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="272" />
+            <source>Go to &lt;b&gt;"Security"&lt;/b&gt; section</source>
+            <translation>Siirry &lt;b&gt;"Turvallisuus"&lt;/b&gt;-osioon</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="289" />
+            <source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
+            <translation>Valtuuta kDrive-sovellus ruudussa, jossa ilmoitetaan kDriven olevan estetty</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="299" />
+            <source>Unlock the padlock &lt;img src=":/client/resources/icons/actions/lock.png"&gt; and authorize the kDrive application</source>
+            <translation>Avaa lukko &lt;img src=":/client/resources/icons/actions/lock.png"&gt; ja valtuuta kDrive-sovellus</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="344" />
+            <source>Go to &lt;b&gt;"Privacy &amp; Security"&lt;/b&gt; section and click on &lt;b&gt;"Full Disk Access"&lt;/b&gt; or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+            <translation>Siirry &lt;b&gt;"Tietosuoja ja turvallisuus"&lt;/b&gt;-osioon ja napsauta &lt;b&gt;"Täysi levynkäyttöoikeus"&lt;/b&gt; tai &lt;a style="%1" href="%2"&gt;napsauta tästä&lt;/a&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="348" />
+            <source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;"Privacy"&lt;/b&gt; tab or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+            <translation>Turvallisuus- ja tietosuoja-asetuksissa avaa &lt;b&gt;"Tietosuoja"&lt;/b&gt;-välilehti tai &lt;a style="%1" href="%2"&gt;napsauta tästä&lt;/a&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="376" />
+            <source>Check the "kDrive LiteSync Extension" box then the "kDrive.app" box (if not already checked)</source>
+            <translation>Valitse "kDrive LiteSync Extension" -ruutu ja sitten "kDrive.app"-ruutu (jos ei vielä valittu)</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="393" />
+            <source>A restart of the app might be proposed, in this case accept it</source>
+            <translation>Sovelluksen uudelleenkäynnistystä saatetaan ehdottaa; hyväksy se siinä tapauksessa</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="399" />
+            <source>Check the "kDrive LiteSync Extension" box (and "kDrive.app" if it exists) in &lt;b&gt;"Full Disk Access"&lt;/b&gt;</source>
+            <translation>Valitse "kDrive LiteSync Extension" -ruutu (ja "kDrive.app", jos se on olemassa) kohdassa &lt;b&gt;"Täysi levynkäyttöoikeus"&lt;/b&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="495" />
+            <source>STEP 1</source>
+            <translation>VAIHE 1</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="495" />
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="496" />
+            <source>(Done)</source>
+            <translation>(Valmis)</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="496" />
+            <source>STEP 2</source>
+            <translation>VAIHE 2</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="499" />
+            <source>STEPS PERFORMED</source>
+            <translation>VAIHEET SUORITETTU</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/customextensionsetupwidget.cpp" line="501" />
+            <source>END</source>
+            <translation>LOPETA</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::CustomMessageBox</name>
+        <message>
+            <location filename="../src/gui/custommessagebox.cpp" line="101" />
+            <source>OK</source>
+            <translation>OK</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/custommessagebox.cpp" line="111" />
+            <source>CANCEL</source>
+            <translation>PERUUTA</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/custommessagebox.cpp" line="121" />
+            <source>YES</source>
+            <translation>KYLLÄ</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/custommessagebox.cpp" line="131" />
+            <source>NO</source>
+            <translation>EI</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::DebugReporter</name>
+        <message>
+            <location filename="../src/gui/debugreporter.cpp" line="37" />
+            <source>Sending of debugging information</source>
+            <translation>Lähetetään virheenkorjaustietoja</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debugreporter.cpp" line="37" />
+            <source>Cancel</source>
+            <translation>Peruuta</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::DebuggingDialog</name>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="45" />
+            <source>Debug</source>
+            <translation>Virheenkorjaus</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="46" />
+            <source>Info</source>
+            <translation>Tiedot</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="47" />
+            <source>Warning</source>
+            <translation>Varoitus</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="48" />
+            <source>Error</source>
+            <translation>Virhe</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="49" />
+            <source>Fatal</source>
+            <translation>Kriittinen</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="74" />
+            <source>Debugging settings</source>
+            <translation>Virheenkorjausasetukset</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="90" />
+            <source>Save debugging information in a folder on my computer (Recommended)</source>
+            <translation>Tallenna virheenkorjaustiedot kansioon tietokoneellani (Suositeltu)</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="104" />
+            <source>This information enables IT support to determine the origin of an incident.</source>
+            <translation>Nämä tiedot auttavat IT-tukea selvittämään tapauksen alkuperän.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="114" />
+            <source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
+            <translation>&lt;a style="%1" href="%2"&gt;Avaa virheenkorjauskansio&lt;/a&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="143" />
+            <source>Debug level</source>
+            <translation>Virheenkorjaustaso</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="152" />
+            <source>The trace level lets you choose the extent of the debugging information recorded</source>
+            <translation>Jäljitystaso antaa sinun valita tallennettavien virheenkorjaustietojen laajuuden</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="179" />
+            <source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
+            <translation>Laajennettu täysloki kerää yksityiskohtaisen historian virheenkorjausta varten. Sen käyttöönotto voi hidastaa kDrive-sovellusta.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="183" />
+            <source>Extended Full Log</source>
+            <translation>Laajennettu täysloki</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="207" />
+            <source>Delete logs older than %1 days</source>
+            <translation>Poista lokeja, jotka ovat vanhempia kuin %1 päivää</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="226" />
+            <source>Share the debug folder with Infomaniak support.</source>
+            <translation>Jaa virheenkorjauskansio Infomaniakille.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="250" />
+            <source>The last session is the periode since the last kDrive start.</source>
+            <translation>Viimeinen istunto on ajanjakso viimeisimmästä kDriven käynnistyksestä.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="254" />
+            <source>Share only the last kDrive session</source>
+            <translation>Jaa vain viimeisin kDrive-istunto</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="285" />
+            <source>  Loading</source>
+            <translation>  Ladataan</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="294" />
+            <source>Cancel</source>
+            <translation>Peruuta</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="320" />
+            <source>SAVE</source>
+            <translation>TALLENNA</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="327" />
+            <source>CANCEL</source>
+            <translation>PERUUTA</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="471" />
+            <source>Failed to share</source>
+            <translation>Jakaminen epäonnistui</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="481" />
+            <source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
+            <translation>1. Tarkista, että olet kirjautunut sisään &lt;br&gt;2. Tarkista, että olet määrittänyt vähintään yhden kDriven</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="486" />
+            <source> (Connexion interrupted)</source>
+            <translation> (Yhteys katkaistu)</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="493" />
+            <source>Share the folder with SwissTransfer &lt;br&gt;</source>
+            <translation>Jaa kansio SwissTransferillä &lt;br&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="494" />
+            <source> 1. We automatically compressed your log &lt;a style="%1" href="%2"&gt;here&lt;/a&gt;.&lt;br&gt;</source>
+            <translation> 1. Pakkasimme lokisi automaattisesti &lt;a style="%1" href="%2"&gt;tähän&lt;/a&gt;.&lt;br&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="496" />
+            <source> 2. Transfer the archive with &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
+            <translation> 2. Siirrä arkisto &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;-palvelun avulla&lt;br&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="498" />
+            <source> 3. Share the link with &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
+            <translation> 3. Jaa linkki osoitteeseen &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="528" />
+            <source>Last upload the %1</source>
+            <translation>Viimeisin lähetys %1</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="556" />
+            <source>Sharing has been cancelled</source>
+            <translation>Jakaminen on peruutettu</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="597" />
+            <source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
+            <translation>Laajennettu täysloki on aktivoitu KDRIVE_FORCE_EXTENDED_LOG-ympäristömuuttujalla. Aseta se arvoon 0 poistaaksesi sen käytöstä.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="611" />
+            <source>%1/%2/%3 at %4h%5m and %6s</source>
+            <extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
+            <translation>%1/%2/%3 klo %4:%5:%6</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="654" />
+            <source>Do you want to save your modifications?</source>
+            <translation>Haluatko tallentaa muutokset?</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="709" />
+            <location filename="../src/gui/debuggingdialog.cpp" line="715" />
+            <source>Unable to open folder %1.</source>
+            <translation>Kansiota %1 ei voi avata.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="722" />
+            <source>  Share</source>
+            <translation>  Jaa</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="732" />
+            <source>  Sharing | step 1/2 %1%</source>
+            <translation>  Jaetaan | vaihe 1/2 %1%</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="741" />
+            <source>  Sharing | step 2/2 %1%</source>
+            <translation>  Jaetaan | vaihe 2/2 %1%</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.cpp" line="751" />
+            <source>  Canceling...</source>
+            <translation>  Peruutetaan...</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/debuggingdialog.h" line="70" />
+            <source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
+            <translation>Koko kansio on suuri (&gt; 100 Mt) ja jakaminen voi kestää jonkin aikaa. Jakamisajan lyhentämiseksi suosittelemme jakamaan vain viimeisimmän kDrive-istunnon.</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::DrivePreferencesWidget</name>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="120" />
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1117" />
+            <source>Synchronization errors and information.</source>
+            <translation>Synkronointivirheet ja tiedot.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="144" />
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1119" />
+            <source>Synchronize a local folder</source>
+            <translation>Synkronoi paikallinen kansio</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="355" />
+            <source>Do you really want to turn on Lite Sync?</source>
+            <translation>Haluatko todella ottaa Lite Sync käyttöön?</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="356" />
+            <source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
+            <translation>Tämä toiminto voi kestää muutamasta sekunnista muutamaan minuuttiin kansion koosta riippuen.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="359" />
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="390" />
+            <source>CONFIRM</source>
+            <translation>VAHVISTA</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="360" />
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="391" />
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="986" />
+            <source>CANCEL</source>
+            <translation>PERUUTA</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="382" />
+            <source>Do you really want to turn off Lite Sync?</source>
+            <translation>Haluatko todella poistaa Lite Sync käytöstä?</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="384" />
+            <source>You don't have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
+            <translation>Sinulla ei ole tarpeeksi tilaa kaikkien kDrive-tiedostojen synkronointiin (%1 puuttuu). Jos poistat Lite Sync käytöstä, sinun on valittava synkronoitavat kansiot tietokoneellasi. Sillä välin kDriven synkronointi keskeytetään.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="388" />
+            <source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
+            <translation>Jos poistat Lite Sync käytöstä, kaikki tiedostot ladataan tietokoneellesi.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="627" />
+            <source>Failed to create new synchronization</source>
+            <translation>Uuden synkronoinnin luominen epäonnistui</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="645" />
+            <source>New local folder synchronization failed!</source>
+            <translation>Uuden paikallisen kansion synkronointi epäonnistui!</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="819" />
+            <source>Lite Sync activated.</source>
+            <translation>Lite Sync aktivoitu.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="823" />
+            <source>Lite Sync activation failed.</source>
+            <translation>Lite Sync -aktivointi epäonnistui.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="837" />
+            <source>Lite Sync deactivated.</source>
+            <translation>Lite Sync poistettu käytöstä.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="841" />
+            <source>Lite Sync deactivation failed.</source>
+            <translation>Lite Sync -deaktivointi epäonnistui.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="899" />
+            <source>This drive is being deleted.</source>
+            <translation>Tämä asema poistetaan.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="962" />
+            <source>Impossible to open item %1</source>
+            <translation>Kohteen %1 avaaminen ei onnistu</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="981" />
+            <source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+            <translation>Haluatko todella lopettaa kansion &lt;i&gt;%1&lt;/i&gt; synkronoinnin?&lt;br&gt;&lt;b&gt;Huom:&lt;/b&gt; Tämä &lt;b&gt;ei&lt;/b&gt; poista tiedostoja.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="985" />
+            <source>REMOVE FOLDER SYNC CONNECTION</source>
+            <translation>POISTA KANSION SYNKRONOINTIYHTEYS</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1007" />
+            <source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
+            <translation>Kansion &lt;i&gt;%1&lt;/i&gt; synkronoinnin pysäyttäminen epäonnistui.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1048" />
+            <source>An error occurred while loading the list of subfolders.</source>
+            <translation>Alikansioiden listan lataaminen epäonnistui.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1118" />
+            <source>Folders</source>
+            <translation>Kansiot</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1120" />
+            <source>Notifications</source>
+            <translation>Ilmoitukset</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1121" />
+            <source>Enable the notifications for this kDrive</source>
+            <translation>Ota tämän kDriven ilmoitukset käyttöön</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1123" />
+            <source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
+            <translation>Ilmoitus näytetään heti, kun uusi kansio on synkronoitu tai muokattu</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1124" />
+            <source>Connected with</source>
+            <translation>Yhdistetty:</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1125" />
+            <source>Remove all synchronizations</source>
+            <translation>Poista kaikki synkronoinnit</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1126" />
+            <source>Search in your kDrive</source>
+            <translation>Hae kDrivesta</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1127" />
+            <source>Search</source>
+            <translation>Haku</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::DriveSelectionWidget</name>
+        <message>
+            <location filename="../src/gui/driveselectionwidget.cpp" line="150" />
+            <source>Add a kDrive</source>
+            <translation>Lisää kDrive</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/driveselectionwidget.cpp" line="216" />
+            <source>Synchronize a kDrive</source>
+            <translation>Synkronoi kDrive</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::ErrorTabWidget</name>
+        <message>
+            <location filename="../src/gui/errortabwidget.cpp" line="92" />
+            <location filename="../src/gui/errortabwidget.cpp" line="135" />
+            <location filename="../src/gui/errortabwidget.cpp" line="178" />
+            <location filename="../src/gui/errortabwidget.cpp" line="186" />
+            <source>Clear history</source>
+            <translation>Tyhjennä historia</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/errortabwidget.cpp" line="176" />
+            <source>To Resolve</source>
+            <translation>Ratkaistavana</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/errortabwidget.cpp" line="177" />
+            <source>problem(s) detected</source>
+            <translation>havaittu ongelma(t)</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/errortabwidget.cpp" line="179" />
+            <source>Resolve</source>
+            <translation>Ratkaise</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/errortabwidget.cpp" line="180" />
+            <source>Conflicted item(s)</source>
+            <translation>Ristiriitainen kohde (kohteet)</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/errortabwidget.cpp" line="181" />
+            <source>Item(s) with unsupported characters</source>
+            <translation>Kohde(et), joissa on ei-tuettuja merkkejä</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/errortabwidget.cpp" line="184" />
+            <source>Automatically resolved</source>
+            <translation>Automaattisesti ratkaistu</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/errortabwidget.cpp" line="185" />
+            <source>problem(s) solved</source>
+            <translation>ratkaistut ongelma(t)</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::ErrorsMenuBarWidget</name>
+        <message>
+            <location filename="../src/gui/errorsmenubarwidget.cpp" line="84" />
+            <location filename="../src/gui/errorsmenubarwidget.cpp" line="103" />
+            <source>Synchronization conflicts or errors</source>
+            <translation>Synkronointiristiriidat tai -virheet</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/errorsmenubarwidget.cpp" line="86" />
+            <location filename="../src/gui/errorsmenubarwidget.cpp" line="105" />
+            <source>Errors</source>
+            <translation>Virheet</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/errorsmenubarwidget.cpp" line="101" />
+            <source>Back to preferences</source>
+            <translation>Takaisin asetuksiin</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::ErrorsPopup</name>
+        <message>
+            <location filename="../src/gui/errorspopup.cpp" line="73" />
+            <source>Some files couldn't be synchronized on the following kDrive(s) :</source>
+            <translation>Joitakin tiedostoja ei voitu synkronoida seuraavilla kDrive-asemilla:</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/errorspopup.cpp" line="95" />
+            <source> (%1 error(s))</source>
+            <translation> (%1 virhe(ttä))</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/errorspopup.cpp" line="101" />
+            <source> (%1 information(s))</source>
+            <translation> (%1 tiedote(tta))</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/errorspopup.cpp" line="107" />
+            <source> (%1 error(s) and %2 information(s))</source>
+            <translation> (%1 virhe(ttä) ja %2 tiedote(tta))</translation>
+        </message>
+        <message numerus="yes">
+            <location filename="../src/gui/errorspopup.cpp" line="147" />
+            <source>Generic errors (%n warning(s) or error(s))</source>
+            <comment>Number of warnings or errors</comment>
+            <translation>
+                <numerusform>Yleiset virheet (%n varoitus tai virhe)</numerusform>
+                <numerusform>Yleiset virheet (%n varoitusta tai virhettä)</numerusform>
+            </translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::FileExclusionDialog</name>
+        <message>
+            <location filename="../src/gui/fileexclusiondialog.cpp" line="78" />
+            <source>Excluded files</source>
+            <translation>Poissuljetut tiedostot</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fileexclusiondialog.cpp" line="86" />
+            <source>Add files or folders that will not be synchronized on your computer.</source>
+            <translation>Lisää tiedostoja tai kansioita, joita ei synkronoida tietokoneellesi.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fileexclusiondialog.cpp" line="97" />
+            <source>Add</source>
+            <translation>Lisää</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fileexclusiondialog.cpp" line="109" />
+            <source>NAME</source>
+            <translation>NIMI</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fileexclusiondialog.cpp" line="114" />
+            <source>WARNING</source>
+            <translation>VAROITUS</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fileexclusiondialog.cpp" line="149" />
+            <source>SAVE</source>
+            <translation>TALLENNA</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fileexclusiondialog.cpp" line="156" />
+            <source>CANCEL</source>
+            <translation>PERUUTA</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fileexclusiondialog.cpp" line="304" />
+            <source>Do you want to save your modifications?</source>
+            <translation>Haluatko tallentaa muutokset?</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fileexclusiondialog.cpp" line="353" />
+            <source>Exclusion template already exists!</source>
+            <translation>Poissulkumalli on jo olemassa!</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fileexclusiondialog.cpp" line="374" />
+            <source>Do you really want to delete?</source>
+            <translation>Haluatko todella poistaa?</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fileexclusiondialog.cpp" line="434" />
+            <source>Cannot save changes!</source>
+            <translation>Muutoksia ei voi tallentaa!</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::FileExclusionNameDialog</name>
+        <message>
+            <location filename="../src/gui/fileexclusionnamedialog.cpp" line="58" />
+            <source>VALIDATE</source>
+            <translation>VAHVISTA</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fileexclusionnamedialog.cpp" line="65" />
+            <source>CANCEL</source>
+            <translation>PERUUTA</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::FixConflictingFilesDialog</name>
+        <message>
+            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67" />
+            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73" />
+            <source>Unable to open link %1.</source>
+            <translation>Linkkiä %1 ei voi avata.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122" />
+            <source>Solve conflict(s)</source>
+            <translation>Ratkaise ristiriita(t)</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140" />
+            <source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
+            <translation>&lt;b&gt;Mitä haluat tehdä %1 ristiriitaiselle kohteelle?&lt;/b&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143" />
+            <source>Save my changes and replace other users' versions.</source>
+            <translation>Tallenna muutokseni ja korvaa muiden käyttäjien versiot.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147" />
+            <source>Undo my changes and keep other users' versions.</source>
+            <translation>Kumoa muutokseni ja säilytä muiden käyttäjien versiot.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169" />
+            <source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
+            <translation>Muutoksesi voidaan poistaa pysyvästi. Niitä ei voi palauttaa kDrive-verkkosovelluksesta.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171" />
+            <source>&lt;a style=%1 href="%2"&gt;Learn more&lt;/a&gt;</source>
+            <translation>&lt;a style=%1 href="%2"&gt;Lue lisää&lt;/a&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175" />
+            <source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
+            <translation>Muutoksesi poistetaan pysyvästi. Niitä ei voi palauttaa kDrive-verkkosovelluksesta.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191" />
+            <source>Show item(s)</source>
+            <translation>Näytä kohde(et)</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228" />
+            <source>VALIDATE</source>
+            <translation>VAHVISTA</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234" />
+            <source>CANCEL</source>
+            <translation>PERUUTA</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251" />
+            <source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
+            <translation>Useat käyttäjät ovat muokanneet näitä tiedostoja useissa paikoissa (kDrivessa verkossa, tietokoneella tai mobiililaitteella). Myös nämä tiedostot sisältävät kansiot on saatettu poistaa.&lt;br&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253" />
+            <source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Learn more&lt;/a&gt;</source>
+            <translation>Kohteesi paikallinen versio &lt;b&gt;ei ole synkronoitu&lt;/b&gt; kDriven kanssa. &lt;a style="color: #489EF3" href="%1"&gt;Lue lisää&lt;/a&gt;</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::FolderItemWidget</name>
+        <message>
+            <location filename="../src/gui/folderitemwidget.cpp" line="188" />
+            <location filename="../src/gui/folderitemwidget.cpp" line="476" />
+            <source>Synchronized into &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</source>
+            <translation>Synkronoitu kohteeseen &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/folderitemwidget.cpp" line="343" />
+            <source>Activate Lite Sync</source>
+            <translation>Ota Lite Sync käyttöön</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/folderitemwidget.cpp" line="345" />
+            <source>Activate Lite Sync (Beta)</source>
+            <translation>Ota Lite Sync (Beta) käyttöön</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/folderitemwidget.cpp" line="354" />
+            <source>Deactivate Lite Sync</source>
+            <translation>Poista Lite Sync käytöstä</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/folderitemwidget.cpp" line="365" />
+            <source>Pause synchronization</source>
+            <translation>Keskeytä synkronointi</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/folderitemwidget.cpp" line="375" />
+            <source>Resume synchronization</source>
+            <translation>Jatka synkronointia</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/folderitemwidget.cpp" line="386" />
+            <source>Remove synchronization</source>
+            <translation>Poista synkronointi</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/folderitemwidget.cpp" line="458" />
+            <source>More actions</source>
+            <translation>Lisää toimintoja</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/folderitemwidget.cpp" line="481" />
+            <source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
+            <translation>Valitsemattomat kansiot siirretään roskakoriin, jos ne sisältävät offline-kohteita. kDriveen synkronoidut kansiot pysyvät saatavilla verkossa.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/folderitemwidget.cpp" line="485" />
+            <source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
+            <translation>Valitsemattomat kansiot siirretään roskakoriin. kDriveen synkronoidut kansiot pysyvät saatavilla verkossa.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/folderitemwidget.cpp" line="488" />
+            <source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
+            <translation>Valitsemattomat kansiot poistetaan &lt;b&gt;pysyvästi&lt;/b&gt; tietokoneelta. kDriveen synkronoidut kansiot pysyvät saatavilla verkossa.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/folderitemwidget.cpp" line="493" />
+            <source>Cancel</source>
+            <translation>Peruuta</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/folderitemwidget.cpp" line="494" />
+            <source>VALIDATE</source>
+            <translation>VAHVISTA</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::GenericErrorItemWidget</name>
+        <message>
+            <location filename="../src/gui/genericerroritemwidget.cpp" line="85" />
+            <source>Unable to open folder path %1.</source>
+            <translation>Kansion polkua %1 ei voi avata.</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::LiteSyncAppDialog</name>
+        <message>
+            <location filename="../src/gui/litesyncappdialog.cpp" line="48" />
+            <source>Application Id</source>
+            <translation>Sovelluksen tunnus</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/litesyncappdialog.cpp" line="98" />
+            <source>Application Name</source>
+            <translation>Sovelluksen nimi</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/litesyncappdialog.cpp" line="121" />
+            <source>VALIDATE</source>
+            <translation>VAHVISTA</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/litesyncappdialog.cpp" line="128" />
+            <source>CANCEL</source>
+            <translation>PERUUTA</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::LiteSyncDialog</name>
+        <message>
+            <location filename="../src/gui/litesyncdialog.cpp" line="91" />
+            <source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are "online". Add them in the list below to avoid this behaviour.</source>
+            <translation>Jotkut sovellukset (varmuuskopiointi, virustorjunta...) käyttävät tiedostojasi, mikä johtaa niiden lataamiseen, kun ne ovat "verkossa". Lisää ne alla olevaan luetteloon tämän käyttäytymisen välttämiseksi.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/litesyncdialog.cpp" line="103" />
+            <source>Add</source>
+            <translation>Lisää</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/litesyncdialog.cpp" line="115" />
+            <source>APPLICATION ID</source>
+            <translation>SOVELLUKSEN TUNNUS</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/litesyncdialog.cpp" line="120" />
+            <source>NAME</source>
+            <translation>NIMI</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/litesyncdialog.cpp" line="154" />
+            <source>SAVE</source>
+            <translation>TALLENNA</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/litesyncdialog.cpp" line="161" />
+            <source>CANCEL</source>
+            <translation>PERUUTA</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/litesyncdialog.cpp" line="295" />
+            <source>Do you want to save your modifications?</source>
+            <translation>Haluatko tallentaa muutokset?</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/litesyncdialog.cpp" line="337" />
+            <source>Do you really want to delete?</source>
+            <translation>Haluatko todella poistaa?</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/litesyncdialog.cpp" line="374" />
+            <source>Cannot save changes!</source>
+            <translation>Muutoksia ei voi tallentaa!</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::LocalFolderDialog</name>
+        <message>
+            <location filename="../src/gui/localfolderdialog.cpp" line="63" />
+            <source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
+            <translation>Minkä tietokoneen kansion haluat&lt;br&gt;synkronoida?</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/localfolderdialog.cpp" line="72" />
+            <source>The content of this folder will be synchronized on the kDrive</source>
+            <translation>Tämän kansion sisältö synkronoidaan kDriveen</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/localfolderdialog.cpp" line="91" />
+            <source>Select a folder</source>
+            <translation>Valitse kansio</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/localfolderdialog.cpp" line="131" />
+            <source>Edit folder</source>
+            <translation>Muokkaa kansiota</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/localfolderdialog.cpp" line="166" />
+            <source>CANCEL</source>
+            <translation>PERUUTA</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/localfolderdialog.cpp" line="173" />
+            <source>CONTINUE</source>
+            <translation>JATKA</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/localfolderdialog.cpp" line="210" />
+            <source>This folder is not compatible with Lite Sync.&lt;br&gt;
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt;
 &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Tämä kansio ei ole yhteensopiva Lite Sync -toiminnon kanssa.&lt;br&gt;
+            <translation>Tämä kansio ei ole yhteensopiva Lite Sync -toiminnon kanssa.&lt;br&gt;
 Valitse toinen kansio. Jos jatkat, Lite Sync poistetaan käytöstä.&lt;br&gt;
 &lt;a style="%1" href="%2"&gt;Lue lisää&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="233"/>
-<source>Select folder</source>
-<translation>Valitse kansio</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="292"/>
-<source>Unable to open link %1.</source>
-<translation>Linkkiä %1 ei voi avata.</translation>
-</message>
-</context>
-<context>
-<name>KDC::Logger</name>
-<message>
-<location filename="../src/libcommongui/logger.cpp" line="189"/>
-<source>Error</source>
-<translation>Virhe</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/logger.cpp" line="189"/>
-<source>&lt;nobr&gt;File '%1'&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
-<translation>&lt;nobr&gt;Tiedostoa '%1'&lt;br/&gt;ei voi avata kirjoittamista varten.&lt;br/&gt;&lt;br/&gt;Lokia &lt;b&gt;ei&lt;/b&gt; voi tallentaa!&lt;/nobr&gt;</translation>
-</message>
-</context>
-<context>
-<name>KDC::MainMenuBarWidget</name>
-<message>
-<location filename="../src/gui/mainmenubarwidget.cpp" line="115"/>
-<source>Preferences</source>
-<translation>Asetukset</translation>
-</message>
-<message>
-<location filename="../src/gui/mainmenubarwidget.cpp" line="116"/>
-<source>Help</source>
-<translation>Ohje</translation>
-</message>
-</context>
-<context>
-<name>KDC::ParametersDialog</name>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="320"/>
-<source>kDrive needs to have write access to your computer's temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
-<translation>kDrivella on oltava kirjoitusoikeus tietokoneesi väliaikaiseen hakemistoon.&lt;br&gt;Käynnistä kDrive-sovellus uudelleen ratkaistaksesi tämän ongelman.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="330"/>
-<location filename="../src/gui/parametersdialog.cpp" line="487"/>
-<source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-<translation>Tekninen virhe on tapahtunut.&lt;br&gt;Synkronointi jatkuu mahdollisimman pian. Ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="337"/>
-<location filename="../src/gui/parametersdialog.cpp" line="440"/>
-<location filename="../src/gui/parametersdialog.cpp" line="506"/>
-<location filename="../src/gui/parametersdialog.cpp" line="546"/>
-<location filename="../src/gui/parametersdialog.cpp" line="560"/>
-<source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-<translation>Tekninen virhe on tapahtunut (virhe %1).&lt;br&gt;Tyhjennä historia ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="342"/>
-<source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
-<translation>Verkkoyhteyden aikakatkaisuarvo näyttää olevan liian pieni sovelluksen oikeaa toimintaa varten (virhe %1).&lt;br&gt;Tarkista verkkoasetuksesi.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="347"/>
-<location filename="../src/gui/parametersdialog.cpp" line="516"/>
-<source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
-<translation>kDrive-palvelimeen ei saada yhteyttä (virhe %1).&lt;br&gt;Yritetään yhdistää uudelleen. Tarkista Internet-yhteys ja palomuuri.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="352"/>
-<source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
-<translation>Kirjautumisvirhe (virhe %1).&lt;br&gt;Kirjaudu uudelleen ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="356"/>
-<source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
-<translation>Sovelluksesta on saatavilla uusi versio.&lt;br&gt;Päivitä sovellus jatkaaksesi sen käyttöä.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="360"/>
-<source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
-<translation>Lokin lähetys epäonnistui (virhe %1).&lt;br&gt;Yritä myöhemmin uudelleen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="385"/>
-<source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
-<translation>Synkronointikansio ei ole enää käytettävissä (virhe %1).&lt;br&gt;Synkronointi jatkuu heti, kun kansio on taas käytettävissä.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="389"/>
-<source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
-<translation>Synkronointikansion sisältävä asema ei ole enää yhteydessä (virhe %1).&lt;br&gt;Yhdistä se uudelleen jatkaaksesi synkronointia.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="393"/>
-<source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
-<translation>Tietokoneellasi ei ole tarpeeksi tilaa.&lt;br&gt;Synkronointi on pysäytetty.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="397"/>
-<source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
-<translation>Tietokoneellasi ei ole tarpeeksi muistia.&lt;br&gt;Synkronointi on pysäytetty.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="401"/>
-<source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing '/etc/sysctl.conf'.</source>
-<translation>Inotify-tarkkailijamäärä on riittämätön (virhe %1).&lt;br&gt;Voit kasvattaa tätä lukua muokkaamalla '/etc/sysctl.conf'-tiedostoa.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="406"/>
-<source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
-<translation>Synkronointia ei voi käynnistää (virhe %1).&lt;br&gt;Sinun on sallittava:&lt;br&gt;- kDrive kohdassa Järjestelmäasetukset &gt;&gt; Yleiset &gt;&gt; Kirjautumisobjektit ja laajennukset &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension kohdassa Järjestelmäasetukset &gt;&gt; Tietosuoja ja turvallisuus &gt;&gt; Täysi levynkäyttöoikeus.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="413"/>
-<source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
-<translation>Synkronointia ei voi käynnistää (virhe %1).&lt;br&gt;LiteSyncExt-prosessi ei ole käynnissä. Synkronointi jatkuu heti, kun se käynnistyy.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="419"/>
-<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-<translation>Lite Sync -laajennusta ei voi käynnistää (virhe %1).&lt;br&gt;Tarkista, että Lite Sync -laajennus on asennettu ja Windowsin hakupalvelu on käytössä.&lt;br&gt;Tyhjennä historia, käynnistä uudelleen ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="424"/>
-<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-<translation>Lite Sync -laajennusta ei voi käynnistää (virhe %1).&lt;br&gt;Tarkista, että Lite Sync -laajennuksella on oikeat käyttöoikeudet ja se on käynnissä.&lt;br&gt;Tyhjennä historia, käynnistä uudelleen ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="429"/>
-<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-<translation>Lite Sync -laajennusta ei voi käynnistää (virhe %1).&lt;br&gt;Tyhjennä historia, käynnistä uudelleen ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="435"/>
-<source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
-<translation>Synkronointikansiossa oleva tiedosto tai kansio näyttää vioittuneelta.&lt;br&gt;Synkronointi on pysäytetty.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="449"/>
-<source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-<translation>kDrive on huoltotilassa.&lt;br&gt;Synkronointi alkaa uudelleen mahdollisimman pian. Ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="455"/>
-<source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-<translation>kDrive on estetty.&lt;br&gt;Uudista kDrive. Jos toimenpiteitä ei tehdä, tiedot poistetaan pysyvästi eikä niitä voi palauttaa.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="460"/>
-<source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-<translation>kDrive on estetty.&lt;br&gt;Ota yhteyttä järjestelmänvalvojaan kDriven uudistamiseksi. Jos toimenpiteitä ei tehdä, tiedot poistetaan pysyvästi eikä niitä voi palauttaa.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="466"/>
-<source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-<translation>kDrive herää.&lt;br&gt;Synkronointi alkaa uudelleen mahdollisimman pian. Ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="475"/>
-<source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
-<translation>kDrive on lepotilassa.&lt;br&gt;Kirjaudu &lt;a style="%1" href="%2"&gt;verkkoversiooon&lt;/a&gt; tarkistaaksesi kDriven tilan tai ota yhteyttä järjestelmänvalvojaasi.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="479"/>
-<source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive's status, or contact your administrator.</source>
-<translation>kDrive on lepotilassa.&lt;br&gt;Kirjaudu verkkoversiooon tarkistaaksesi kDriven tilan tai ota yhteyttä järjestelmänvalvojaasi.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="483"/>
-<source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
-<translation>Sinulla ei ole oikeutta käyttää tätä kDrivea.&lt;br&gt;Synkronointi on keskeytetty. Ota yhteyttä järjestelmänvalvojaan.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="493"/>
-<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-<translation>Tekninen virhe on tapahtunut (virhe %1).&lt;br&gt;Synkronointi jatkuu mahdollisimman pian. Ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="512"/>
-<source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-<translation>Käyttöjärjestelmän ydin katkaisi verkkoyhteydet (virhe %1).&lt;br&gt;Tyhjennä historia ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="522"/>
-<source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
-<translation>Vanhaa konfiguraatiota ei valitettavasti voitu siirtää.&lt;br&gt;Sovellus käyttää tyhjää konfiguraatiota.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="526"/>
-<source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
-<translation>Vanhaa välityspalvelinasetusten konfiguraatiota ei valitettavasti voitu siirtää, SOCKS5-välityspalvelimia ei tueta tällä hetkellä.&lt;br&gt;Sovellus käyttää järjestelmän välityspalvelinasetuksia.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="532"/>
-<source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
-<translation>Synkronointikansio on korvattu tai siirretty tavalla, joka estää synkronoinnin (virhe %1).&lt;br&gt;Tämä voi tapahtua kansion kopioinnin, siirtämisen tai palauttamisen jälkeen.&lt;br&gt;Korjataksesi tämän, luo uusi synkronointi uuteen kansioon.&lt;br&gt;Huom: jos vanhassa kansiossa on synkronoimattomia muutoksia, ne täytyy kopioida manuaalisesti uuteen kansioon.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="539"/>
-<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
-<translation>Tekninen virhe on tapahtunut (virhe %1).&lt;br&gt;Synkronointi on käynnistetty uudelleen. Tyhjennä historia ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="550"/>
-<source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
-<translation>Synkronointitietokannan käyttämisessä tapahtui virhe (virhe %1).&lt;br&gt;Synkronointi on pysäytetty.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="564"/>
-<source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
-<translation>Kirjautumisvirhe (virhe %1).&lt;br&gt;Tunnus on virheellinen tai peruutettu.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="569"/>
-<source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
-<translation>Sisäkkäiset synkronoinnit ovat kiellettyjä (virhe %1).&lt;br&gt;Säilytä vain synkronoinnit, joiden kansiot eivät ole sisäkkäisiä.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="573"/>
-<source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
-<translation>kDriven etäpalvelimella oleva synkronointikansio ei ole enää olemassa tai käytettävissä (virhe %1).&lt;br&gt;Sinun on palautettava se tai annettava sille takaisin käyttöoikeudet tai poistettava/luotava synkronointi uudelleen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="580"/>
-<source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
-<translation>Tiedostonimen jäsennysvirhe (virhe %1).&lt;br&gt;Erikoismerkit kuten lainausmerkit, kenoviivat tai rivinvaihdot voivat aiheuttaa jäsennysvirheitä.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="609"/>
-<source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
-<translation>Tämä elementti on siirretty muualle.&lt;br&gt;Paikallinen toiminto on peruutettu.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="614"/>
-<source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
-<translation>Samanlaisella nimellä oleva elementti on jo olemassa tässä sijainnissa.&lt;br&gt;Paikallinen toiminto on peruutettu.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="618"/>
-<source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
-<translation>Samanlaisella nimellä oleva elementti on jo olemassa tässä sijainnissa.&lt;br&gt;Paikallinen elementti on nimetty uudelleen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="622"/>
-<source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
-<translation>Toinen käyttäjä muokkasi tiedostoa samanaikaisesti.&lt;br&gt;Muutoksesi on tallennettu kopioon.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="626"/>
-<source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
-<translation>Toinen käyttäjä on siirtänyt kohteen ylätason kansion.&lt;br&gt;Paikallinen toiminto on peruutettu.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="649"/>
-<source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Olemassa olevalla kohteella on sama nimi samoilla kirjainkoolla.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="656"/>
-<source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Kohteen nimi sisältää ei-tuetun merkin.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="662"/>
-<source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Kohteen nimi päättyy välilyöntiin, mikä on kiellettyä käyttöjärjestelmässäsi.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="668"/>
-<source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Tämä nimi on varattu käyttöjärjestelmässäsi.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="674"/>
-<source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Kohteen nimi on liian pitkä.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="680"/>
-<source>The item path is too long.&lt;br&gt;It has been ignored.</source>
-<translation>Kohteen polku on liian pitkä.&lt;br&gt;Se on ohitettu.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="686"/>
-<source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
-<translation>Kohteen nimi sisältää uuden Unicode-merkin, jota tiedostojärjestelmäsi ei vielä tue.&lt;br&gt;Se on suljettu pois synkronoinnista.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="692"/>
-<source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Kohteen nimi sisältää vain välilyöntejä.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="703"/>
-<source>Either you are not allowed to create an item, or another item already exists with the same name.&lt;br&gt;The item has been excluded from synchronization.</source>
-<translation>Sinulla ei ole oikeutta luoda kohdetta tai samalla nimellä on jo olemassa oleva kohde.&lt;br&gt;Kohde on suljettu pois synkronoinnista.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="708"/>
-<source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
-<translation>Sinulla ei ole oikeutta muokata kohdetta.&lt;br&gt;Muutoksesi sisältävä tiedosto on nimetty uudelleen ja suljettu pois synkronoinnista.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="716"/>
-<source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
-<translation>Sinulla ei ole oikeutta nimetä kohdetta uudelleen.&lt;br&gt;Se palautetaan alkuperäisellä nimellään.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="722"/>
-<source>You are not allowed to move item to "%1".&lt;br&gt;It will be restored into its original parent folder.</source>
-<translation>Sinulla ei ole oikeutta siirtää kohdetta kohteeseen "%1".&lt;br&gt;Se palautetaan alkuperäiseen yläkansioonsa.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="727"/>
-<source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
-<translation>Sinulla ei ole oikeutta poistaa kohdetta.&lt;br&gt;Se palautetaan alkuperäiseen sijaintiinsa.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="732"/>
-<source>Failed to move this item to trash, it has been blacklisted.</source>
-<translation>Kohteen siirtäminen roskakoriin epäonnistui, se on lisätty estolistalle.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="735"/>
-<source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
-<translation>Kohteen synkronointi epäonnistui. Se on lisätty väliaikaisesti estolistalle.&lt;br&gt;Synkronointia yritetään uudelleen tunnin kuluttua tai seuraavalla sovelluksen käynnistyksellä.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="740"/>
-<source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
-<translation>Tämä kohde on suljettu synkronoinnista mukautetun mallin avulla.&lt;br&gt;Voit poistaa tämän tyyppiset ilmoitukset käytöstä Asetuksissa</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="745"/>
-<source>This item has been excluded from sync because it is a hard link.</source>
-<translation>Tämä kohde on suljettu synkronoinnista, koska se on kova linkki.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="748"/>
-<source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
-<translation>Tiedostoa on muokattu paikallisesti, kun se on poistettu etä-kDrivesta.&lt;br&gt;Paikallinen kopio on tallennettu pelastuskansioon.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="765"/>
-<source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
-<translation>Kohteelle suoritettu toiminto on kielletty.&lt;br&gt;Kohde on lisätty väliaikaisesti estolistalle.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="771"/>
-<source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
-<translation>Kohteelle suoritettu toiminto epäonnistui.&lt;br&gt;Kohde on lisätty väliaikaisesti estolistalle.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="776"/>
-<source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
-<translation>Tiedosto on liian suuri ladattavaksi. Se on lisätty väliaikaisesti estolistalle.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="779"/>
-<source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
-<translation>Olet ylittänyt kiintiösi. Kasvata tallennustilaasi ottaaksesi tiedostojen lataamisen uudelleen käyttöön.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="782"/>
-<source>Impossible to download the file.</source>
-<translation>Tiedostoa ei voi ladata.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="785"/>
-<source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
-<translation>Toinen käyttäjä on tällä hetkellä lukinnut tämän kohteen verkossa.&lt;br&gt;Yritämme ladata muutoksesi myöhemmin uudelleen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="790"/>
-<location filename="../src/gui/parametersdialog.cpp" line="834"/>
-<source>Synchronization error.</source>
-<translation>Synkronointivirhe.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="810"/>
-<source>Can't access item.&lt;br&gt;Please fix the read and write permissions.</source>
-<translation>Kohdetta ei voi käyttää.&lt;br&gt;Korjaa luku- ja kirjoitusoikeudet.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="814"/>
-<source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
-<translation>Tietokoneellasi ei ole tarpeeksi tilaa.&lt;br&gt;Lataus on peruutettu.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="818"/>
-<source>System error.</source>
-<translation>Järjestelmävirhe.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="825"/>
-<source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Kohde on jo olemassa toisella puolella.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="840"/>
-<source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-<translation>Tekninen virhe on tapahtunut.&lt;br&gt;Tyhjennä historia ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1082"/>
-<source>Unable to open folder path %1.</source>
-<translation>Kansion polkua %1 ei voi avata.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1096"/>
-<source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
-<translation>Siirto valmis!&lt;br&gt;Viittaa tunnukseen &lt;b&gt;%1&lt;/b&gt; virheraporteissa.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1097"/>
-<source>Transmission failed!
+        </message>
+        <message>
+            <location filename="../src/gui/localfolderdialog.cpp" line="233" />
+            <source>Select folder</source>
+            <translation>Valitse kansio</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/localfolderdialog.cpp" line="292" />
+            <source>Unable to open link %1.</source>
+            <translation>Linkkiä %1 ei voi avata.</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::Logger</name>
+        <message>
+            <location filename="../src/libcommongui/logger.cpp" line="189" />
+            <source>Error</source>
+            <translation>Virhe</translation>
+        </message>
+        <message>
+            <location filename="../src/libcommongui/logger.cpp" line="189" />
+            <source>&lt;nobr&gt;File '%1'&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
+            <translation>&lt;nobr&gt;Tiedostoa '%1'&lt;br/&gt;ei voi avata kirjoittamista varten.&lt;br/&gt;&lt;br/&gt;Lokia &lt;b&gt;ei&lt;/b&gt; voi tallentaa!&lt;/nobr&gt;</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::MainMenuBarWidget</name>
+        <message>
+            <location filename="../src/gui/mainmenubarwidget.cpp" line="115" />
+            <source>Preferences</source>
+            <translation>Asetukset</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/mainmenubarwidget.cpp" line="116" />
+            <source>Help</source>
+            <translation>Ohje</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::ParametersDialog</name>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="320" />
+            <source>kDrive needs to have write access to your computer's temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
+            <translation>kDrivella on oltava kirjoitusoikeus tietokoneesi väliaikaiseen hakemistoon.&lt;br&gt;Käynnistä kDrive-sovellus uudelleen ratkaistaksesi tämän ongelman.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="330" />
+            <location filename="../src/gui/parametersdialog.cpp" line="487" />
+            <source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+            <translation>Tekninen virhe on tapahtunut.&lt;br&gt;Synkronointi jatkuu mahdollisimman pian. Ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="337" />
+            <location filename="../src/gui/parametersdialog.cpp" line="440" />
+            <location filename="../src/gui/parametersdialog.cpp" line="506" />
+            <location filename="../src/gui/parametersdialog.cpp" line="546" />
+            <location filename="../src/gui/parametersdialog.cpp" line="560" />
+            <source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+            <translation>Tekninen virhe on tapahtunut (virhe %1).&lt;br&gt;Tyhjennä historia ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="342" />
+            <source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
+            <translation>Verkkoyhteyden aikakatkaisuarvo näyttää olevan liian pieni sovelluksen oikeaa toimintaa varten (virhe %1).&lt;br&gt;Tarkista verkkoasetuksesi.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="347" />
+            <location filename="../src/gui/parametersdialog.cpp" line="516" />
+            <source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
+            <translation>kDrive-palvelimeen ei saada yhteyttä (virhe %1).&lt;br&gt;Yritetään yhdistää uudelleen. Tarkista Internet-yhteys ja palomuuri.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="352" />
+            <source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
+            <translation>Kirjautumisvirhe (virhe %1).&lt;br&gt;Kirjaudu uudelleen ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="356" />
+            <source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
+            <translation>Sovelluksesta on saatavilla uusi versio.&lt;br&gt;Päivitä sovellus jatkaaksesi sen käyttöä.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="360" />
+            <source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
+            <translation>Lokin lähetys epäonnistui (virhe %1).&lt;br&gt;Yritä myöhemmin uudelleen.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="385" />
+            <source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
+            <translation>Synkronointikansio ei ole enää käytettävissä (virhe %1).&lt;br&gt;Synkronointi jatkuu heti, kun kansio on taas käytettävissä.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="389" />
+            <source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
+            <translation>Synkronointikansion sisältävä asema ei ole enää yhteydessä (virhe %1).&lt;br&gt;Yhdistä se uudelleen jatkaaksesi synkronointia.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="393" />
+            <source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
+            <translation>Tietokoneellasi ei ole tarpeeksi tilaa.&lt;br&gt;Synkronointi on pysäytetty.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="397" />
+            <source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
+            <translation>Tietokoneellasi ei ole tarpeeksi muistia.&lt;br&gt;Synkronointi on pysäytetty.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="401" />
+            <source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing '/etc/sysctl.conf'.</source>
+            <translation>Inotify-tarkkailijamäärä on riittämätön (virhe %1).&lt;br&gt;Voit kasvattaa tätä lukua muokkaamalla '/etc/sysctl.conf'-tiedostoa.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="406" />
+            <source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
+            <translation>Synkronointia ei voi käynnistää (virhe %1).&lt;br&gt;Sinun on sallittava:&lt;br&gt;- kDrive kohdassa Järjestelmäasetukset &gt;&gt; Yleiset &gt;&gt; Kirjautumisobjektit ja laajennukset &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension kohdassa Järjestelmäasetukset &gt;&gt; Tietosuoja ja turvallisuus &gt;&gt; Täysi levynkäyttöoikeus.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="413" />
+            <source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
+            <translation>Synkronointia ei voi käynnistää (virhe %1).&lt;br&gt;LiteSyncExt-prosessi ei ole käynnissä. Synkronointi jatkuu heti, kun se käynnistyy.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="419" />
+            <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+            <translation>Lite Sync -laajennusta ei voi käynnistää (virhe %1).&lt;br&gt;Tarkista, että Lite Sync -laajennus on asennettu ja Windowsin hakupalvelu on käytössä.&lt;br&gt;Tyhjennä historia, käynnistä uudelleen ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="424" />
+            <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+            <translation>Lite Sync -laajennusta ei voi käynnistää (virhe %1).&lt;br&gt;Tarkista, että Lite Sync -laajennuksella on oikeat käyttöoikeudet ja se on käynnissä.&lt;br&gt;Tyhjennä historia, käynnistä uudelleen ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="429" />
+            <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+            <translation>Lite Sync -laajennusta ei voi käynnistää (virhe %1).&lt;br&gt;Tyhjennä historia, käynnistä uudelleen ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="435" />
+            <source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
+            <translation>Synkronointikansiossa oleva tiedosto tai kansio näyttää vioittuneelta.&lt;br&gt;Synkronointi on pysäytetty.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="449" />
+            <source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+            <translation>kDrive on huoltotilassa.&lt;br&gt;Synkronointi alkaa uudelleen mahdollisimman pian. Ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="455" />
+            <source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+            <translation>kDrive on estetty.&lt;br&gt;Uudista kDrive. Jos toimenpiteitä ei tehdä, tiedot poistetaan pysyvästi eikä niitä voi palauttaa.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="460" />
+            <source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+            <translation>kDrive on estetty.&lt;br&gt;Ota yhteyttä järjestelmänvalvojaan kDriven uudistamiseksi. Jos toimenpiteitä ei tehdä, tiedot poistetaan pysyvästi eikä niitä voi palauttaa.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="466" />
+            <source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+            <translation>kDrive herää.&lt;br&gt;Synkronointi alkaa uudelleen mahdollisimman pian. Ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="475" />
+            <source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
+            <translation>kDrive on lepotilassa.&lt;br&gt;Kirjaudu &lt;a style="%1" href="%2"&gt;verkkoversiooon&lt;/a&gt; tarkistaaksesi kDriven tilan tai ota yhteyttä järjestelmänvalvojaasi.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="479" />
+            <source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive's status, or contact your administrator.</source>
+            <translation>kDrive on lepotilassa.&lt;br&gt;Kirjaudu verkkoversiooon tarkistaaksesi kDriven tilan tai ota yhteyttä järjestelmänvalvojaasi.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="483" />
+            <source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
+            <translation>Sinulla ei ole oikeutta käyttää tätä kDrivea.&lt;br&gt;Synkronointi on keskeytetty. Ota yhteyttä järjestelmänvalvojaan.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="493" />
+            <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+            <translation>Tekninen virhe on tapahtunut (virhe %1).&lt;br&gt;Synkronointi jatkuu mahdollisimman pian. Ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="512" />
+            <source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+            <translation>Käyttöjärjestelmän ydin katkaisi verkkoyhteydet (virhe %1).&lt;br&gt;Tyhjennä historia ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="522" />
+            <source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
+            <translation>Vanhaa konfiguraatiota ei valitettavasti voitu siirtää.&lt;br&gt;Sovellus käyttää tyhjää konfiguraatiota.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="526" />
+            <source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
+            <translation>Vanhaa välityspalvelinasetusten konfiguraatiota ei valitettavasti voitu siirtää, SOCKS5-välityspalvelimia ei tueta tällä hetkellä.&lt;br&gt;Sovellus käyttää järjestelmän välityspalvelinasetuksia.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="532" />
+            <source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
+            <translation>Synkronointikansio on korvattu tai siirretty tavalla, joka estää synkronoinnin (virhe %1).&lt;br&gt;Tämä voi tapahtua kansion kopioinnin, siirtämisen tai palauttamisen jälkeen.&lt;br&gt;Korjataksesi tämän, luo uusi synkronointi uuteen kansioon.&lt;br&gt;Huom: jos vanhassa kansiossa on synkronoimattomia muutoksia, ne täytyy kopioida manuaalisesti uuteen kansioon.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="539" />
+            <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
+            <translation>Tekninen virhe on tapahtunut (virhe %1).&lt;br&gt;Synkronointi on käynnistetty uudelleen. Tyhjennä historia ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="550" />
+            <source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
+            <translation>Synkronointitietokannan käyttämisessä tapahtui virhe (virhe %1).&lt;br&gt;Synkronointi on pysäytetty.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="564" />
+            <source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
+            <translation>Kirjautumisvirhe (virhe %1).&lt;br&gt;Tunnus on virheellinen tai peruutettu.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="569" />
+            <source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
+            <translation>Sisäkkäiset synkronoinnit ovat kiellettyjä (virhe %1).&lt;br&gt;Säilytä vain synkronoinnit, joiden kansiot eivät ole sisäkkäisiä.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="573" />
+            <source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
+            <translation>kDriven etäpalvelimella oleva synkronointikansio ei ole enää olemassa tai käytettävissä (virhe %1).&lt;br&gt;Sinun on palautettava se tai annettava sille takaisin käyttöoikeudet tai poistettava/luotava synkronointi uudelleen.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="580" />
+            <source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
+            <translation>Tiedostonimen jäsennysvirhe (virhe %1).&lt;br&gt;Erikoismerkit kuten lainausmerkit, kenoviivat tai rivinvaihdot voivat aiheuttaa jäsennysvirheitä.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="609" />
+            <source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
+            <translation>Tämä elementti on siirretty muualle.&lt;br&gt;Paikallinen toiminto on peruutettu.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="614" />
+            <source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
+            <translation>Samanlaisella nimellä oleva elementti on jo olemassa tässä sijainnissa.&lt;br&gt;Paikallinen toiminto on peruutettu.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="618" />
+            <source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
+            <translation>Samanlaisella nimellä oleva elementti on jo olemassa tässä sijainnissa.&lt;br&gt;Paikallinen elementti on nimetty uudelleen.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="622" />
+            <source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
+            <translation>Toinen käyttäjä muokkasi tiedostoa samanaikaisesti.&lt;br&gt;Muutoksesi on tallennettu kopioon.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="626" />
+            <source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
+            <translation>Toinen käyttäjä on siirtänyt kohteen ylätason kansion.&lt;br&gt;Paikallinen toiminto on peruutettu.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="649" />
+            <source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
+            <translation>Olemassa olevalla kohteella on sama nimi samoilla kirjainkoolla.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="656" />
+            <source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
+            <translation>Kohteen nimi sisältää ei-tuetun merkin.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="662" />
+            <source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+            <translation>Kohteen nimi päättyy välilyöntiin, mikä on kiellettyä käyttöjärjestelmässäsi.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="668" />
+            <source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+            <translation>Tämä nimi on varattu käyttöjärjestelmässäsi.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="674" />
+            <source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
+            <translation>Kohteen nimi on liian pitkä.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="680" />
+            <source>The item path is too long.&lt;br&gt;It has been ignored.</source>
+            <translation>Kohteen polku on liian pitkä.&lt;br&gt;Se on ohitettu.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="686" />
+            <source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+            <translation>Kohteen nimi sisältää uuden Unicode-merkin, jota tiedostojärjestelmäsi ei vielä tue.&lt;br&gt;Se on suljettu pois synkronoinnista.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="692" />
+            <source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
+            <translation>Kohteen nimi sisältää vain välilyöntejä.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="703" />
+            <source>Either you are not allowed to create an item, or another item already exists with the same name.&lt;br&gt;The item has been excluded from synchronization.</source>
+            <translation>Sinulla ei ole oikeutta luoda kohdetta tai samalla nimellä on jo olemassa oleva kohde.&lt;br&gt;Kohde on suljettu pois synkronoinnista.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="708" />
+            <source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
+            <translation>Sinulla ei ole oikeutta muokata kohdetta.&lt;br&gt;Muutoksesi sisältävä tiedosto on nimetty uudelleen ja suljettu pois synkronoinnista.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="716" />
+            <source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
+            <translation>Sinulla ei ole oikeutta nimetä kohdetta uudelleen.&lt;br&gt;Se palautetaan alkuperäisellä nimellään.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="722" />
+            <source>You are not allowed to move item to "%1".&lt;br&gt;It will be restored into its original parent folder.</source>
+            <translation>Sinulla ei ole oikeutta siirtää kohdetta kohteeseen "%1".&lt;br&gt;Se palautetaan alkuperäiseen yläkansioonsa.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="727" />
+            <source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
+            <translation>Sinulla ei ole oikeutta poistaa kohdetta.&lt;br&gt;Se palautetaan alkuperäiseen sijaintiinsa.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="732" />
+            <source>Failed to move this item to trash, it has been blacklisted.</source>
+            <translation>Kohteen siirtäminen roskakoriin epäonnistui, se on lisätty estolistalle.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="735" />
+            <source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
+            <translation>Kohteen synkronointi epäonnistui. Se on lisätty väliaikaisesti estolistalle.&lt;br&gt;Synkronointia yritetään uudelleen tunnin kuluttua tai seuraavalla sovelluksen käynnistyksellä.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="740" />
+            <source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
+            <translation>Tämä kohde on suljettu synkronoinnista mukautetun mallin avulla.&lt;br&gt;Voit poistaa tämän tyyppiset ilmoitukset käytöstä Asetuksissa</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="745" />
+            <source>This item has been excluded from sync because it is a hard link.</source>
+            <translation>Tämä kohde on suljettu synkronoinnista, koska se on kova linkki.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="748" />
+            <source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
+            <translation>Tiedostoa on muokattu paikallisesti, kun se on poistettu etä-kDrivesta.&lt;br&gt;Paikallinen kopio on tallennettu pelastuskansioon.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="765" />
+            <source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
+            <translation>Kohteelle suoritettu toiminto on kielletty.&lt;br&gt;Kohde on lisätty väliaikaisesti estolistalle.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="771" />
+            <source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
+            <translation>Kohteelle suoritettu toiminto epäonnistui.&lt;br&gt;Kohde on lisätty väliaikaisesti estolistalle.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="776" />
+            <source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
+            <translation>Tiedosto on liian suuri ladattavaksi. Se on lisätty väliaikaisesti estolistalle.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="779" />
+            <source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
+            <translation>Olet ylittänyt kiintiösi. Kasvata tallennustilaasi ottaaksesi tiedostojen lataamisen uudelleen käyttöön.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="782" />
+            <source>Impossible to download the file.</source>
+            <translation>Tiedostoa ei voi ladata.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="785" />
+            <source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
+            <translation>Toinen käyttäjä on tällä hetkellä lukinnut tämän kohteen verkossa.&lt;br&gt;Yritämme ladata muutoksesi myöhemmin uudelleen.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="790" />
+            <location filename="../src/gui/parametersdialog.cpp" line="834" />
+            <source>Synchronization error.</source>
+            <translation>Synkronointivirhe.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="810" />
+            <source>Can't access item.&lt;br&gt;Please fix the read and write permissions.</source>
+            <translation>Kohdetta ei voi käyttää.&lt;br&gt;Korjaa luku- ja kirjoitusoikeudet.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="814" />
+            <source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
+            <translation>Tietokoneellasi ei ole tarpeeksi tilaa.&lt;br&gt;Lataus on peruutettu.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="818" />
+            <source>System error.</source>
+            <translation>Järjestelmävirhe.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="825" />
+            <source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
+            <translation>Kohde on jo olemassa toisella puolella.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="840" />
+            <source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+            <translation>Tekninen virhe on tapahtunut.&lt;br&gt;Tyhjennä historia ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="1082" />
+            <source>Unable to open folder path %1.</source>
+            <translation>Kansion polkua %1 ei voi avata.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="1096" />
+            <source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
+            <translation>Siirto valmis!&lt;br&gt;Viittaa tunnukseen &lt;b&gt;%1&lt;/b&gt; virheraporteissa.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="1097" />
+            <source>Transmission failed!
 Please, use the following link to send the logs to the support: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</source>
-<translation>Siirto epäonnistui!
+            <translation>Siirto epäonnistui!
 Käytä seuraavaa linkkiä lähettääksesi lokit tuelle: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1118"/>
-<source>No kDrive configured!</source>
-<translation>kDrivea ei ole määritetty!</translation>
-</message>
-</context>
-<context>
-<name>KDC::PreferencesBlocWidget</name>
-<message>
-<location filename="../src/gui/preferencesblocwidget.cpp" line="187"/>
-<source>This synchronization is being deleted.</source>
-<translation>Tätä synkronointia poistetaan.</translation>
-</message>
-</context>
-<context>
-<name>KDC::PreferencesMenuBarWidget</name>
-<message>
-<location filename="../src/gui/preferencesmenubarwidget.cpp" line="63"/>
-<source>Back to drive list</source>
-<translation>Takaisin asemaluetteloon</translation>
-</message>
-<message>
-<location filename="../src/gui/preferencesmenubarwidget.cpp" line="64"/>
-<source>Preferences</source>
-<translation>Asetukset</translation>
-</message>
-</context>
-<context>
-<name>KDC::PreferencesWidget</name>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="466"/>
-<source>Unable to open folder %1.</source>
-<translation>Kansiota %1 ei voi avata.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="478"/>
-<source>Unable to open link %1.</source>
-<translation>Linkkiä %1 ei voi avata.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="483"/>
-<source>Invalid link %1.</source>
-<translation>Virheellinen linkki %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="490"/>
-<source>Some process failed to run.</source>
-<translation>Joidenkin prosessien käynnistyminen epäonnistui.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="491"/>
-<source>General</source>
-<translation>Yleiset</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="493"/>
-<source>Activate dark theme</source>
-<translation>Ota tumma teema käyttöön</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="495"/>
-<source>Activate monochrome icons</source>
-<translation>Ota yksivärisiä kuvakkeita käyttöön</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="496"/>
-<source>Launch kDrive at startup</source>
-<translation>Käynnistä kDrive automaattisesti</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="497"/>
-<source>Language</source>
-<translation>Kieli</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="498"/>
-<source>Move deleted files to my computer's trash</source>
-<translation>Siirrä poistetut tiedostot tietokoneen roskakoriin</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="499"/>
-<source>Some files or folders may not be moved to the computer's trash.</source>
-<translation>Joitakin tiedostoja tai kansioita ei ehkä voi siirtää tietokoneen roskakoriin.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="500"/>
-<source>You can always retrieve already synced files from the kDrive web application trash.</source>
-<translation>Voit aina palauttaa jo synkronoidut tiedostot kDriven verkkosovelluksen roskakorista.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="502"/>
-<source>&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;Lue lisää&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="505"/>
-<source>Default</source>
-<translation>Oletus</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="506"/>
-<source>English</source>
-<translation>Englanti</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="507"/>
-<source>French</source>
-<translation>Ranska</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="508"/>
-<source>German</source>
-<translation>Saksa</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="509"/>
-<source>Spanish</source>
-<translation>Espanja</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="510"/>
-<source>Italian</source>
-<translation>Italia</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="511"/>
-<source>Swedish</source>
-<translation>Ruotsi</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="512"/>
-<source>Portuguese</source>
-<translation>Portugali</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="513"/>
-<source>Polish</source>
-<translation>Puola</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="514"/>
-<source>Norwegian</source>
-<translation>Norja</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="515"/>
-<source>Finnish</source>
-<translation>Suomi</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="521"/>
-<source>Advanced</source>
-<translation>Lisäasetukset</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="522"/>
-<source>Debugging information</source>
-<translation>Virheenkorjaustiedot</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="524"/>
-<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;Avaa virheenkorjauskansio&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="525"/>
-<source>Files to exclude</source>
-<translation>Suljettavat tiedostot</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="526"/>
-<source>Proxy server</source>
-<translation>Välityspalvelin</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="528"/>
-<source>Lite Sync</source>
-<translation>Lite Sync</translation>
-</message>
-</context>
-<context>
-<name>KDC::ProgressBarWidget</name>
-<message>
-<location filename="../src/gui/progressbarwidget.cpp" line="70"/>
-<source>%1 in use</source>
-<translation>%1 käytössä</translation>
-</message>
-</context>
-<context>
-<name>KDC::ProxyServerDialog</name>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="50"/>
-<source>HTTP(S) Proxy</source>
-<translation>HTTP(S)-välityspalvelin</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="73"/>
-<source>Proxy server</source>
-<translation>Välityspalvelin</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="85"/>
-<source>No proxy server</source>
-<translation>Ei välityspalvelinta</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="90"/>
-<source>Use system parameters</source>
-<translation>Käytä järjestelmäasetuksia</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="95"/>
-<source>Indicate a proxy manually</source>
-<translation>Määritä välityspalvelin manuaalisesti</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="131"/>
-<source>Port</source>
-<translation>Portti</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="144"/>
-<source>Address of the proxy server</source>
-<translation>Välityspalvelimen osoite</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="150"/>
-<source>Authentication needed</source>
-<translation>Todennus vaaditaan</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="165"/>
-<source>User</source>
-<translation>Käyttäjä</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="171"/>
-<source>Password</source>
-<translation>Salasana</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="185"/>
-<source>SAVE</source>
-<translation>TALLENNA</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="192"/>
-<source>CANCEL</source>
-<translation>PERUUTA</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="286"/>
-<source>Do you want to save your modifications?</source>
-<translation>Haluatko tallentaa muutokset?</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="295"/>
-<source>Unable to save, all mandatory fields are not completed!</source>
-<translation>Tallennus epäonnistui, kaikki pakolliset kentät eivät ole täytetty!</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="316"/>
-<source>Proxy not found, save anyway?</source>
-<translation>Välityspalvelinta ei löydy, tallennetaanko silti?</translation>
-</message>
-</context>
-<context>
-<name>KDC::ResourcesManagerDialog</name>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="55"/>
-<source>Resources Manager</source>
-<translation>Resurssien hallinta</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="65"/>
-<source>Maximum CPU usage allowed</source>
-<translation>Suurin sallittu suorittimen käyttö</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="96"/>
-<source>SAVE</source>
-<translation>TALLENNA</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="103"/>
-<source>CANCEL</source>
-<translation>PERUUTA</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="122"/>
-<source>Do you want to save your modifications?</source>
-<translation>Haluatko tallentaa muutokset?</translation>
-</message>
-</context>
-<context>
-<name>KDC::ServerBaseFolderDialog</name>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="81"/>
-<source>Select a folder on your kDrive</source>
-<translation>Valitse kansio kDrivesta</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="90"/>
-<source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
-<translation>Valitun kansion sisältö synkronoidaan &lt;b&gt;%1&lt;/b&gt;-kansioon.</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="134"/>
-<source>CONTINUE</source>
-<translation>JATKA</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="150"/>
-<source>Space available on your computer for the current folder : %1</source>
-<translation>Nykyisen kansion tilaa tietokoneella: %1</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="190"/>
-<source>This folder is already being synced.</source>
-<translation>Tämä kansio on jo synkronoinnissa.</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="204"/>
-<source>CONFIRM</source>
-<translation>VAHVISTA</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="205"/>
-<source>CANCEL</source>
-<translation>PERUUTA</translation>
-</message>
-</context>
-<context>
-<name>KDC::ServerFoldersDialog</name>
-<message>
-<location filename="../src/gui/serverfoldersdialog.cpp" line="80"/>
-<source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
-<translation>&lt;b&gt;%1&lt;/b&gt;-kansio sisältää alikansioita,&lt;br&gt; valitse synkronoitavat kansiot</translation>
-</message>
-<message>
-<location filename="../src/gui/serverfoldersdialog.cpp" line="110"/>
-<source>CONTINUE</source>
-<translation>JATKA</translation>
-</message>
-<message>
-<location filename="../src/gui/serverfoldersdialog.cpp" line="146"/>
-<source>No subfolders currently on the server.</source>
-<translation>Palvelimella ei ole alikansioita tällä hetkellä.</translation>
-</message>
-</context>
-<context>
-<name>KDC::StatusBarWidget</name>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="178"/>
-<source>Resume kDrive "%1" synchronization</source>
-<translation>Jatka kDrive "%1" synkronointia</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="179"/>
-<location filename="../src/gui/statusbarwidget.cpp" line="322"/>
-<source>Resume synchronization</source>
-<translation>Jatka synkronointia</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="180"/>
-<source>Resume all kDrives synchronization</source>
-<translation>Jatka kaikkien kDrive-asemien synkronointia</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="183"/>
-<source>Pause kDrive "%1" synchronization</source>
-<translation>Keskeytä kDrive "%1" synkronointi</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="184"/>
-<location filename="../src/gui/statusbarwidget.cpp" line="321"/>
-<source>Pause synchronization</source>
-<translation>Keskeytä synkronointi</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="185"/>
-<source>Pause all kDrives synchronization</source>
-<translation>Keskeytä kaikkien kDrive-asemien synkronointi</translation>
-</message>
-</context>
-<context>
-<name>KDC::SynchronizedItemWidget</name>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="317"/>
-<source>Open</source>
-<translation>Avaa</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
-<source>Add to favorites</source>
-<translation>Lisää suosikkeihin</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
-<source>Copy share link</source>
-<translation>Kopioi jakolinkki</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
-<source>Display on kdrive.infomaniak.com</source>
-<translation>Näytä kdrive.infomaniak.com-sivustolla</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
-<source>Show in folder</source>
-<translation>Näytä kansiossa</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
-<source>More actions</source>
-<translation>Lisää toimintoja</translation>
-</message>
-</context>
-<context>
-<name>KDC::SynthesisBar</name>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="149"/>
-<source>Unable to open folder url %1.</source>
-<translation>Kansion URL-osoitetta %1 ei voi avata.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="219"/>
-<source>Open in folder</source>
-<translation>Avaa kansiossa</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="257"/>
-<source>Open %1 web version</source>
-<translation>Avaa %1 verkkoversio</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="267"/>
-<source>Drive parameters</source>
-<translation>Aseman asetukset</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="280"/>
-<source>Notifications disabled until %1</source>
-<translation>Ilmoitukset poistettu käytöstä %1 asti</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="281"/>
-<source>Disable Notifications</source>
-<translation>Poista ilmoitukset käytöstä</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="314"/>
-<source>Application preferences</source>
-<translation>Sovelluksen asetukset</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="322"/>
-<source>Need help</source>
-<translation>Tarvitsetko apua</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="330"/>
-<source>Send feedbacks</source>
-<translation>Lähetä palautetta</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="338"/>
-<source>Quit kDrive</source>
-<translation>Lopeta kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="401"/>
-<source>Unable to access web site %1.</source>
-<translation>Verkkosivustolle %1 ei pääse.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="492"/>
-<source>Show errors and informations</source>
-<translation>Näytä virheet ja tiedotteet</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="493"/>
-<source>Show informations</source>
-<translation>Näytä tiedotteet</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="494"/>
-<source>More actions</source>
-<translation>Lisää toimintoja</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="495"/>
-<location filename="../src/gui/synthesisbar.cpp" line="502"/>
-<source>Never</source>
-<translation>Ei koskaan</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="496"/>
-<source>During 1 hour</source>
-<translation>1 tunnin ajaksi</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="497"/>
-<location filename="../src/gui/synthesisbar.cpp" line="504"/>
-<source>Until tomorrow 8:00AM</source>
-<translation>Huomiseen klo 8:00 asti</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="498"/>
-<source>During 3 days</source>
-<translation>3 päivän ajaksi</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="499"/>
-<source>During 1 week</source>
-<translation>1 viikon ajaksi</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="500"/>
-<location filename="../src/gui/synthesisbar.cpp" line="507"/>
-<source>Always</source>
-<translation>Aina</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="503"/>
-<source>For 1 more hour</source>
-<translation>1 tunti lisää</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="505"/>
-<source>For 3 more days</source>
-<translation>3 päivää lisää</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="506"/>
-<source>For 1 more week</source>
-<translation>1 viikko lisää</translation>
-</message>
-</context>
-<context>
-<name>KDC::SynthesisPopover</name>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="446"/>
-<source>Synchronized</source>
-<translation>Synkronoitu</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="450"/>
-<source>Favorites</source>
-<translation>Suosikit</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="454"/>
-<source>Activity</source>
-<translation>Toiminta</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="586"/>
-<source>Unable to open folder url %1.</source>
-<translation>Kansion URL-osoitetta %1 ei voi avata.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="978"/>
-<source>Update</source>
-<translation>Päivitä</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="981"/>
-<source>Update download in progress</source>
-<translation>Päivitystä ladataan</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="984"/>
-<source>Looking for update...</source>
-<translation>Etsitään päivitystä...</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="987"/>
-<source>Manual update</source>
-<translation>Manuaalinen päivitys</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="990"/>
-<source>Unavailable</source>
-<translation>Ei saatavilla</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1133"/>
-<location filename="../src/gui/synthesispopover.cpp" line="1180"/>
-<source>Not implemented!</source>
-<translation>Ei toteutettu!</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1161"/>
-<source>Unable to open link %1.</source>
-<translation>Linkkiä %1 ei voi avata.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1173"/>
-<source>Invalid link %1.</source>
-<translation>Virheellinen linkki %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1181"/>
-<source>Update kDrive App</source>
-<translation>Päivitä kDrive-sovellus</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1182"/>
-<source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
-<translation>Tätä kDrive-sovellusversiota ei enää tueta. Päivitä sovellus uusimpiin ominaisuuksiin pääsemiseksi.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1184"/>
-<source>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Click here to download manually&lt;/a&gt;</source>
-<translation>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Napsauta tästä ladataksesi manuaalisesti&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1187"/>
-<source>Please download the latest version on the website.</source>
-<translation>Lataa uusin versio verkkosivustolta.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1193"/>
-<source>No synchronized folder for this Drive!</source>
-<translation>Tälle asemalle ei ole synkronoitua kansiota!</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1196"/>
-<source>No kDrive configured!</source>
-<translation>kDrivea ei ole määritetty!</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1200"/>
-<source>You can synchronize files &lt;a style="%1" href="%2"&gt;from your computer&lt;/a&gt; or on &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
-<translation>Voit synkronoida tiedostoja &lt;a style="%1" href="%2"&gt;tietokoneeltasi&lt;/a&gt; tai &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;-sivustolla.</translation>
-</message>
-</context>
-<context>
-<name>KDC::UpdateDialog</name>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="61"/>
-<source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
-<translation>&lt;p&gt;%2-asiakkaan uusi versio &lt;b&gt;%1&lt;/b&gt; on saatavilla ja ladattu.&lt;/p&gt;&lt;p&gt;Asennettu versio on %3.&lt;/p&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="95"/>
-<source>Skip this version</source>
-<translation>Ohita tämä versio</translation>
-</message>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="103"/>
-<source>Remind me later</source>
-<translation>Muistuta myöhemmin</translation>
-</message>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="109"/>
-<source>Install update</source>
-<translation>Asenna päivitys</translation>
-</message>
-</context>
-<context>
-<name>KDC::UpdateManager</name>
-<message>
-<location filename="../src/server/updater/updatemanager.cpp" line="86"/>
-<source>New update available.</source>
-<translation>Uusi päivitys saatavilla.</translation>
-</message>
-<message>
-<location filename="../src/server/updater/updatemanager.cpp" line="87"/>
-<source>Version %1 is available for download.</source>
-<translation>Versio %1 on ladattavissa.</translation>
-</message>
-</context>
-<context>
-<name>KDC::UserSelectionWidget</name>
-<message>
-<location filename="../src/gui/userselectionwidget.cpp" line="131"/>
-<source>Add an account</source>
-<translation>Lisää tili</translation>
-</message>
-</context>
-<context>
-<name>KDC::VersionWidget</name>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="169"/>
-<source>&lt;a style="%1" href="%2"&gt;Show release note&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;Näytä julkaisutiedot&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="172"/>
-<source>Version</source>
-<translation>Versio</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="173"/>
-<source>UPDATE</source>
-<translation>PÄIVITÄ</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="197"/>
-<source>%1 is up to date!</source>
-<translation>%1 on ajan tasalla!</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="201"/>
-<source>Checking update on server...</source>
-<translation>Tarkistetaan päivitystä palvelimelta...</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="205"/>
-<source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style="%2" href="%3"&gt;here&lt;/a&gt;.</source>
-<translation>Päivitys on saatavilla: %1.&lt;br&gt;Lataa se &lt;a style="%2" href="%3"&gt;täältä&lt;/a&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="212"/>
-<source>An update is available: %1</source>
-<translation>Päivitys on saatavilla: %1</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="218"/>
-<source>Downloading %1. Please wait...</source>
-<translation>Ladataan %1. Odota...</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="223"/>
-<source>Could not check for new updates.</source>
-<translation>Päivitysten tarkistus epäonnistui.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="227"/>
-<source>An error occurred during update.</source>
-<translation>Päivityksen aikana tapahtui virhe.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="231"/>
-<source>Could not download update.</source>
-<translation>Päivityksen lataaminen epäonnistui.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="235"/>
-<source>Update disabled.</source>
-<translation>Päivitys poistettu käytöstä.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="251"/>
-<source>Beta program</source>
-<translation>Beta-ohjelma</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="252"/>
-<source>Get early access to new versions of the application</source>
-<translation>Saa varhainen pääsy sovelluksen uusiin versioihin</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="256"/>
-<source>Join</source>
-<translation>Liity</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="259"/>
-<source>Modify</source>
-<translation>Muokkaa</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="259"/>
-<source>Quit</source>
-<translation>Lopeta</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="295"/>
-<source>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</translation>
-</message>
-</context>
-<context>
-<name>QObject</name>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="42"/>
-<source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
-<translation>Lite sync (Beta) on käytössä. kDriven tiedostot pysyvät pilvessä eivätkä käytä tietokoneen tallennustilaa.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="45"/>
-<source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
-<translation>Lite sync (Beta) ei ole käytössä. kDriven tiedostot käyttävät tietokoneen tallennustilaa.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="48"/>
-<source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
-<translation>Lite sync on käytössä. kDriven tiedostot pysyvät pilvessä eivätkä käytä tietokoneen tallennustilaa.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="50"/>
-<source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
-<translation>Lite sync ei ole käytössä. kDriven tiedostot käyttävät tietokoneen tallennustilaa.</translation>
-</message>
-<message>
-<location filename="../src/gui/parameterscache.cpp" line="59"/>
-<source>Unable to save parameters, please retry later.</source>
-<translation>Parametrien tallentaminen epäonnistui, yritä myöhemmin uudelleen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parameterscache.cpp" line="60"/>
-<source>Unable to save parameters!</source>
-<translation>Parametreja ei voi tallentaa!</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1175"/>
-<source>Make available locally</source>
-<translation>Tee saataville paikallisesti</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1179"/>
-<source>Free up local space</source>
-<translation>Vapauta paikallista tilaa</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1183"/>
-<source>Cancel free up local space</source>
-<translation>Peruuta paikallisen tilan vapautus</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1187"/>
-<source>Cancel make available locally</source>
-<translation>Peruuta paikallinen saatavillaolo</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1191"/>
-<source>Resharing this file is not allowed</source>
-<translation>Tämän tiedoston jakaminen uudelleen ei ole sallittu</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1192"/>
-<source>Resharing this folder is not allowed</source>
-<translation>Tämän kansion jakaminen uudelleen ei ole sallittu</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1196"/>
-<source>Copy public share link</source>
-<translation>Kopioi julkinen jakolinkki</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1200"/>
-<source>Copy private share link</source>
-<translation>Kopioi yksityinen jakolinkki</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1204"/>
-<source>Open in browser</source>
-<translation>Avaa selaimessa</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="461"/>
-<source>The parent folder is a sync folder or contained in one</source>
-<translation>Ylätason kansio on synkronointikansio tai sisältyy yhteen</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="495"/>
-<source>Can't find a valid path</source>
-<translation>Kelvollista polkua ei löydy</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2108"/>
-<source>No valid folder selected!</source>
-<translation>Kelvollista kansiota ei ole valittu!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2119"/>
-<source>The selected path does not exist!</source>
-<translation>Valittu polku ei ole olemassa!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2124"/>
-<source>The selected path is not a folder!</source>
-<translation>Valittu polku ei ole kansio!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2129"/>
-<source>You have no permission to write to the selected folder!</source>
-<translation>Sinulla ei ole kirjoitusoikeutta valittuun kansioon!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2159"/>
-<source>The local folder %1 contains a folder already synced. Please pick another one!</source>
-<translation>Paikallinen kansio %1 sisältää jo synkronoidun kansion. Valitse toinen!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2167"/>
-<source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
-<translation>Paikallinen kansio %1 on jo synkronoidun kansion sisällä. Valitse toinen!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2175"/>
-<source>The local folder %1 is already synced. Please pick another one!</source>
-<translation>Paikallinen kansio %1 on jo synkronoitu. Valitse toinen!</translation>
-</message>
-</context>
-<context>
-<name>SharedTools::QtSingleApplication</name>
-<message>
-<location filename="../src/server/appserver.cpp" line="133"/>
-<source>kDrive application will close due to a fatal error.</source>
-<translation>kDrive-sovellus suljetaan kriittisen virheen vuoksi.</translation>
-</message>
-</context>
-<context>
-<name>Utility</name>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="41"/>
-<source>%n year(s)</source>
-<translation>
-<numerusform>%n vuosi</numerusform><numerusform>%n vuotta</numerusform></translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="42"/>
-<source>%n month(s)</source>
-<translation>
-<numerusform>%n kuukausi</numerusform><numerusform>%n kuukautta</numerusform></translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="43"/>
-<source>%n day(s)</source>
-<translation>
-<numerusform>%n päivä</numerusform><numerusform>%n päivää</numerusform></translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="44"/>
-<source>%n hour(s)</source>
-<translation>
-<numerusform>%n tunti</numerusform><numerusform>%n tuntia</numerusform></translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="45"/>
-<source>%n minute(s)</source>
-<translation>
-<numerusform>%n minuutti</numerusform><numerusform>%n minuuttia</numerusform></translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="46"/>
-<source>%n second(s)</source>
-<translation>
-<numerusform>%n sekunti</numerusform><numerusform>%n sekuntia</numerusform></translation>
-</message>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="97"/>
-<source>%L1 GB</source>
-<translation>%L1 GB</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="101"/>
-<source>%L1 MB</source>
-<translation>%L1 MB</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="105"/>
-<source>%L1 KB</source>
-<translation>%L1 KB</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="108"/>
-<source>%L1 B</source>
-<translation>%L1 B</translation>
-</message>
-</context>
-<context>
-<name>utility</name>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="84"/>
-<source>Could not open browser</source>
-<translation>Selainta ei voi avata</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="85"/>
-<source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
-<translation>Selaimen käynnistäminen URL-osoitteeseen %1 siirtymiseksi epäonnistui. Onko oletusselain määritetty?</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="104"/>
-<source>Could not open email client</source>
-<translation>Sähköpostiohjelmaa ei voi avata</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="105"/>
-<source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
-<translation>Sähköpostiohjelman käynnistäminen uuden viestin luomiseksi epäonnistui. Onko oletussähköpostiohjelma määritetty?</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="324"/>
-<source>You are not connected anymore. &lt;a style="%1" href="%2"&gt;Log in&lt;/a&gt;</source>
-<translation>Et ole enää kirjautunut. &lt;a style="%1" href="%2"&gt;Kirjaudu sisään&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="329"/>
-<source>No folder to synchronize
+        </message>
+        <message>
+            <location filename="../src/gui/parametersdialog.cpp" line="1118" />
+            <source>No kDrive configured!</source>
+            <translation>kDrivea ei ole määritetty!</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::PreferencesBlocWidget</name>
+        <message>
+            <location filename="../src/gui/preferencesblocwidget.cpp" line="187" />
+            <source>This synchronization is being deleted.</source>
+            <translation>Tätä synkronointia poistetaan.</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::PreferencesMenuBarWidget</name>
+        <message>
+            <location filename="../src/gui/preferencesmenubarwidget.cpp" line="63" />
+            <source>Back to drive list</source>
+            <translation>Takaisin asemaluetteloon</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferencesmenubarwidget.cpp" line="64" />
+            <source>Preferences</source>
+            <translation>Asetukset</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::PreferencesWidget</name>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="466" />
+            <source>Unable to open folder %1.</source>
+            <translation>Kansiota %1 ei voi avata.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="478" />
+            <source>Unable to open link %1.</source>
+            <translation>Linkkiä %1 ei voi avata.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="483" />
+            <source>Invalid link %1.</source>
+            <translation>Virheellinen linkki %1.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="490" />
+            <source>Some process failed to run.</source>
+            <translation>Joidenkin prosessien käynnistyminen epäonnistui.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="491" />
+            <source>General</source>
+            <translation>Yleiset</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="493" />
+            <source>Activate dark theme</source>
+            <translation>Ota tumma teema käyttöön</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="495" />
+            <source>Activate monochrome icons</source>
+            <translation>Ota yksivärisiä kuvakkeita käyttöön</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="496" />
+            <source>Launch kDrive at startup</source>
+            <translation>Käynnistä kDrive automaattisesti</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="497" />
+            <source>Language</source>
+            <translation>Kieli</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="498" />
+            <source>Move deleted files to my computer's trash</source>
+            <translation>Siirrä poistetut tiedostot tietokoneen roskakoriin</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="499" />
+            <source>Some files or folders may not be moved to the computer's trash.</source>
+            <translation>Joitakin tiedostoja tai kansioita ei ehkä voi siirtää tietokoneen roskakoriin.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="500" />
+            <source>You can always retrieve already synced files from the kDrive web application trash.</source>
+            <translation>Voit aina palauttaa jo synkronoidut tiedostot kDriven verkkosovelluksen roskakorista.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="502" />
+            <source>&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+            <translation>&lt;a style="%1" href="%2"&gt;Lue lisää&lt;/a&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="505" />
+            <source>Default</source>
+            <translation>Oletus</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="506" />
+            <source>English</source>
+            <translation>Englanti</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="507" />
+            <source>French</source>
+            <translation>Ranska</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="508" />
+            <source>German</source>
+            <translation>Saksa</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="509" />
+            <source>Spanish</source>
+            <translation>Espanja</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="510" />
+            <source>Italian</source>
+            <translation>Italia</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="511" />
+            <source>Swedish</source>
+            <translation>Ruotsi</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="512" />
+            <source>Portuguese</source>
+            <translation>Portugali</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="513" />
+            <source>Polish</source>
+            <translation>Puola</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="514" />
+            <source>Norwegian</source>
+            <translation>Norja</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="515" />
+            <source>Finnish</source>
+            <translation>Suomi</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="521" />
+            <source>Advanced</source>
+            <translation>Lisäasetukset</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="522" />
+            <source>Debugging information</source>
+            <translation>Virheenkorjaustiedot</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="524" />
+            <source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
+            <translation>&lt;a style="%1" href="%2"&gt;Avaa virheenkorjauskansio&lt;/a&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="525" />
+            <source>Files to exclude</source>
+            <translation>Suljettavat tiedostot</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="526" />
+            <source>Proxy server</source>
+            <translation>Välityspalvelin</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/preferenceswidget.cpp" line="528" />
+            <source>Lite Sync</source>
+            <translation>Lite Sync</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::ProgressBarWidget</name>
+        <message>
+            <location filename="../src/gui/progressbarwidget.cpp" line="70" />
+            <source>%1 in use</source>
+            <translation>%1 käytössä</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::ProxyServerDialog</name>
+        <message>
+            <location filename="../src/gui/proxyserverdialog.cpp" line="50" />
+            <source>HTTP(S) Proxy</source>
+            <translation>HTTP(S)-välityspalvelin</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/proxyserverdialog.cpp" line="73" />
+            <source>Proxy server</source>
+            <translation>Välityspalvelin</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/proxyserverdialog.cpp" line="85" />
+            <source>No proxy server</source>
+            <translation>Ei välityspalvelinta</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/proxyserverdialog.cpp" line="90" />
+            <source>Use system parameters</source>
+            <translation>Käytä järjestelmäasetuksia</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/proxyserverdialog.cpp" line="95" />
+            <source>Indicate a proxy manually</source>
+            <translation>Määritä välityspalvelin manuaalisesti</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/proxyserverdialog.cpp" line="131" />
+            <source>Port</source>
+            <translation>Portti</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/proxyserverdialog.cpp" line="144" />
+            <source>Address of the proxy server</source>
+            <translation>Välityspalvelimen osoite</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/proxyserverdialog.cpp" line="150" />
+            <source>Authentication needed</source>
+            <translation>Todennus vaaditaan</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/proxyserverdialog.cpp" line="165" />
+            <source>User</source>
+            <translation>Käyttäjä</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/proxyserverdialog.cpp" line="171" />
+            <source>Password</source>
+            <translation>Salasana</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/proxyserverdialog.cpp" line="185" />
+            <source>SAVE</source>
+            <translation>TALLENNA</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/proxyserverdialog.cpp" line="192" />
+            <source>CANCEL</source>
+            <translation>PERUUTA</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/proxyserverdialog.cpp" line="286" />
+            <source>Do you want to save your modifications?</source>
+            <translation>Haluatko tallentaa muutokset?</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/proxyserverdialog.cpp" line="295" />
+            <source>Unable to save, all mandatory fields are not completed!</source>
+            <translation>Tallennus epäonnistui, kaikki pakolliset kentät eivät ole täytetty!</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/proxyserverdialog.cpp" line="316" />
+            <source>Proxy not found, save anyway?</source>
+            <translation>Välityspalvelinta ei löydy, tallennetaanko silti?</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::ResourcesManagerDialog</name>
+        <message>
+            <location filename="../src/gui/resourcesmanagerdialog.cpp" line="55" />
+            <source>Resources Manager</source>
+            <translation>Resurssien hallinta</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/resourcesmanagerdialog.cpp" line="65" />
+            <source>Maximum CPU usage allowed</source>
+            <translation>Suurin sallittu suorittimen käyttö</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/resourcesmanagerdialog.cpp" line="96" />
+            <source>SAVE</source>
+            <translation>TALLENNA</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/resourcesmanagerdialog.cpp" line="103" />
+            <source>CANCEL</source>
+            <translation>PERUUTA</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/resourcesmanagerdialog.cpp" line="122" />
+            <source>Do you want to save your modifications?</source>
+            <translation>Haluatko tallentaa muutokset?</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::ServerBaseFolderDialog</name>
+        <message>
+            <location filename="../src/gui/serverbasefolderdialog.cpp" line="81" />
+            <source>Select a folder on your kDrive</source>
+            <translation>Valitse kansio kDrivesta</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/serverbasefolderdialog.cpp" line="90" />
+            <source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
+            <translation>Valitun kansion sisältö synkronoidaan &lt;b&gt;%1&lt;/b&gt;-kansioon.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/serverbasefolderdialog.cpp" line="134" />
+            <source>CONTINUE</source>
+            <translation>JATKA</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/serverbasefolderdialog.cpp" line="150" />
+            <source>Space available on your computer for the current folder : %1</source>
+            <translation>Nykyisen kansion tilaa tietokoneella: %1</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/serverbasefolderdialog.cpp" line="190" />
+            <source>This folder is already being synced.</source>
+            <translation>Tämä kansio on jo synkronoinnissa.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/serverbasefolderdialog.cpp" line="204" />
+            <source>CONFIRM</source>
+            <translation>VAHVISTA</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/serverbasefolderdialog.cpp" line="205" />
+            <source>CANCEL</source>
+            <translation>PERUUTA</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::ServerFoldersDialog</name>
+        <message>
+            <location filename="../src/gui/serverfoldersdialog.cpp" line="80" />
+            <source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
+            <translation>&lt;b&gt;%1&lt;/b&gt;-kansio sisältää alikansioita,&lt;br&gt; valitse synkronoitavat kansiot</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/serverfoldersdialog.cpp" line="110" />
+            <source>CONTINUE</source>
+            <translation>JATKA</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/serverfoldersdialog.cpp" line="146" />
+            <source>No subfolders currently on the server.</source>
+            <translation>Palvelimella ei ole alikansioita tällä hetkellä.</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::StatusBarWidget</name>
+        <message>
+            <location filename="../src/gui/statusbarwidget.cpp" line="178" />
+            <source>Resume kDrive "%1" synchronization</source>
+            <translation>Jatka kDrive "%1" synkronointia</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/statusbarwidget.cpp" line="179" />
+            <location filename="../src/gui/statusbarwidget.cpp" line="322" />
+            <source>Resume synchronization</source>
+            <translation>Jatka synkronointia</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/statusbarwidget.cpp" line="180" />
+            <source>Resume all kDrives synchronization</source>
+            <translation>Jatka kaikkien kDrive-asemien synkronointia</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/statusbarwidget.cpp" line="183" />
+            <source>Pause kDrive "%1" synchronization</source>
+            <translation>Keskeytä kDrive "%1" synkronointi</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/statusbarwidget.cpp" line="184" />
+            <location filename="../src/gui/statusbarwidget.cpp" line="321" />
+            <source>Pause synchronization</source>
+            <translation>Keskeytä synkronointi</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/statusbarwidget.cpp" line="185" />
+            <source>Pause all kDrives synchronization</source>
+            <translation>Keskeytä kaikkien kDrive-asemien synkronointi</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::SynchronizedItemWidget</name>
+        <message>
+            <location filename="../src/gui/synchronizeditemwidget.cpp" line="317" />
+            <source>Open</source>
+            <translation>Avaa</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synchronizeditemwidget.cpp" line="325" />
+            <source>Add to favorites</source>
+            <translation>Lisää suosikkeihin</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synchronizeditemwidget.cpp" line="333" />
+            <source>Copy share link</source>
+            <translation>Kopioi jakolinkki</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synchronizeditemwidget.cpp" line="342" />
+            <source>Display on kdrive.infomaniak.com</source>
+            <translation>Näytä kdrive.infomaniak.com-sivustolla</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synchronizeditemwidget.cpp" line="387" />
+            <source>Show in folder</source>
+            <translation>Näytä kansiossa</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synchronizeditemwidget.cpp" line="388" />
+            <source>More actions</source>
+            <translation>Lisää toimintoja</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::SynthesisBar</name>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="149" />
+            <source>Unable to open folder url %1.</source>
+            <translation>Kansion URL-osoitetta %1 ei voi avata.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="219" />
+            <source>Open in folder</source>
+            <translation>Avaa kansiossa</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="257" />
+            <source>Open %1 web version</source>
+            <translation>Avaa %1 verkkoversio</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="267" />
+            <source>Drive parameters</source>
+            <translation>Aseman asetukset</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="280" />
+            <source>Notifications disabled until %1</source>
+            <translation>Ilmoitukset poistettu käytöstä %1 asti</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="281" />
+            <source>Disable Notifications</source>
+            <translation>Poista ilmoitukset käytöstä</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="314" />
+            <source>Application preferences</source>
+            <translation>Sovelluksen asetukset</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="322" />
+            <source>Need help</source>
+            <translation>Tarvitsetko apua</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="330" />
+            <source>Send feedbacks</source>
+            <translation>Lähetä palautetta</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="338" />
+            <source>Quit kDrive</source>
+            <translation>Lopeta kDrive</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="401" />
+            <source>Unable to access web site %1.</source>
+            <translation>Verkkosivustolle %1 ei pääse.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="492" />
+            <source>Show errors and informations</source>
+            <translation>Näytä virheet ja tiedotteet</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="493" />
+            <source>Show informations</source>
+            <translation>Näytä tiedotteet</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="494" />
+            <source>More actions</source>
+            <translation>Lisää toimintoja</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="495" />
+            <location filename="../src/gui/synthesisbar.cpp" line="502" />
+            <source>Never</source>
+            <translation>Ei koskaan</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="496" />
+            <source>During 1 hour</source>
+            <translation>1 tunnin ajaksi</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="497" />
+            <location filename="../src/gui/synthesisbar.cpp" line="504" />
+            <source>Until tomorrow 8:00AM</source>
+            <translation>Huomiseen klo 8:00 asti</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="498" />
+            <source>During 3 days</source>
+            <translation>3 päivän ajaksi</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="499" />
+            <source>During 1 week</source>
+            <translation>1 viikon ajaksi</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="500" />
+            <location filename="../src/gui/synthesisbar.cpp" line="507" />
+            <source>Always</source>
+            <translation>Aina</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="503" />
+            <source>For 1 more hour</source>
+            <translation>1 tunti lisää</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="505" />
+            <source>For 3 more days</source>
+            <translation>3 päivää lisää</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesisbar.cpp" line="506" />
+            <source>For 1 more week</source>
+            <translation>1 viikko lisää</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::SynthesisPopover</name>
+        <message>
+            <location filename="../src/gui/synthesispopover.cpp" line="446" />
+            <source>Synchronized</source>
+            <translation>Synkronoitu</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesispopover.cpp" line="450" />
+            <source>Favorites</source>
+            <translation>Suosikit</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesispopover.cpp" line="454" />
+            <source>Activity</source>
+            <translation>Toiminta</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesispopover.cpp" line="586" />
+            <source>Unable to open folder url %1.</source>
+            <translation>Kansion URL-osoitetta %1 ei voi avata.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesispopover.cpp" line="978" />
+            <source>Update</source>
+            <translation>Päivitä</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesispopover.cpp" line="981" />
+            <source>Update download in progress</source>
+            <translation>Päivitystä ladataan</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesispopover.cpp" line="984" />
+            <source>Looking for update...</source>
+            <translation>Etsitään päivitystä...</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesispopover.cpp" line="987" />
+            <source>Manual update</source>
+            <translation>Manuaalinen päivitys</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesispopover.cpp" line="990" />
+            <source>Unavailable</source>
+            <translation>Ei saatavilla</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesispopover.cpp" line="1133" />
+            <location filename="../src/gui/synthesispopover.cpp" line="1180" />
+            <source>Not implemented!</source>
+            <translation>Ei toteutettu!</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesispopover.cpp" line="1161" />
+            <source>Unable to open link %1.</source>
+            <translation>Linkkiä %1 ei voi avata.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesispopover.cpp" line="1173" />
+            <source>Invalid link %1.</source>
+            <translation>Virheellinen linkki %1.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesispopover.cpp" line="1181" />
+            <source>Update kDrive App</source>
+            <translation>Päivitä kDrive-sovellus</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesispopover.cpp" line="1182" />
+            <source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
+            <translation>Tätä kDrive-sovellusversiota ei enää tueta. Päivitä sovellus uusimpiin ominaisuuksiin pääsemiseksi.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesispopover.cpp" line="1184" />
+            <source>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Click here to download manually&lt;/a&gt;</source>
+            <translation>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Napsauta tästä ladataksesi manuaalisesti&lt;/a&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesispopover.cpp" line="1187" />
+            <source>Please download the latest version on the website.</source>
+            <translation>Lataa uusin versio verkkosivustolta.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesispopover.cpp" line="1193" />
+            <source>No synchronized folder for this Drive!</source>
+            <translation>Tälle asemalle ei ole synkronoitua kansiota!</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesispopover.cpp" line="1196" />
+            <source>No kDrive configured!</source>
+            <translation>kDrivea ei ole määritetty!</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/synthesispopover.cpp" line="1200" />
+            <source>You can synchronize files &lt;a style="%1" href="%2"&gt;from your computer&lt;/a&gt; or on &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
+            <translation>Voit synkronoida tiedostoja &lt;a style="%1" href="%2"&gt;tietokoneeltasi&lt;/a&gt; tai &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;-sivustolla.</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::UpdateDialog</name>
+        <message>
+            <location filename="../src/gui/updater/updatedialog.cpp" line="61" />
+            <source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
+            <translation>&lt;p&gt;%2-asiakkaan uusi versio &lt;b&gt;%1&lt;/b&gt; on saatavilla ja ladattu.&lt;/p&gt;&lt;p&gt;Asennettu versio on %3.&lt;/p&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/updater/updatedialog.cpp" line="95" />
+            <source>Skip this version</source>
+            <translation>Ohita tämä versio</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/updater/updatedialog.cpp" line="103" />
+            <source>Remind me later</source>
+            <translation>Muistuta myöhemmin</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/updater/updatedialog.cpp" line="109" />
+            <source>Install update</source>
+            <translation>Asenna päivitys</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::UpdateManager</name>
+        <message>
+            <location filename="../src/server/updater/updatemanager.cpp" line="86" />
+            <source>New update available.</source>
+            <translation>Uusi päivitys saatavilla.</translation>
+        </message>
+        <message>
+            <location filename="../src/server/updater/updatemanager.cpp" line="87" />
+            <source>Version %1 is available for download.</source>
+            <translation>Versio %1 on ladattavissa.</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::UserSelectionWidget</name>
+        <message>
+            <location filename="../src/gui/userselectionwidget.cpp" line="131" />
+            <source>Add an account</source>
+            <translation>Lisää tili</translation>
+        </message>
+    </context>
+    <context>
+        <name>KDC::VersionWidget</name>
+        <message>
+            <location filename="../src/gui/versionwidget.cpp" line="169" />
+            <source>&lt;a style="%1" href="%2"&gt;Show release note&lt;/a&gt;</source>
+            <translation>&lt;a style="%1" href="%2"&gt;Näytä julkaisutiedot&lt;/a&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/versionwidget.cpp" line="172" />
+            <source>Version</source>
+            <translation>Versio</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/versionwidget.cpp" line="173" />
+            <source>UPDATE</source>
+            <translation>PÄIVITÄ</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/versionwidget.cpp" line="197" />
+            <source>%1 is up to date!</source>
+            <translation>%1 on ajan tasalla!</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/versionwidget.cpp" line="201" />
+            <source>Checking update on server...</source>
+            <translation>Tarkistetaan päivitystä palvelimelta...</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/versionwidget.cpp" line="205" />
+            <source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style="%2" href="%3"&gt;here&lt;/a&gt;.</source>
+            <translation>Päivitys on saatavilla: %1.&lt;br&gt;Lataa se &lt;a style="%2" href="%3"&gt;täältä&lt;/a&gt;.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/versionwidget.cpp" line="212" />
+            <source>An update is available: %1</source>
+            <translation>Päivitys on saatavilla: %1</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/versionwidget.cpp" line="218" />
+            <source>Downloading %1. Please wait...</source>
+            <translation>Ladataan %1. Odota...</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/versionwidget.cpp" line="223" />
+            <source>Could not check for new updates.</source>
+            <translation>Päivitysten tarkistus epäonnistui.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/versionwidget.cpp" line="227" />
+            <source>An error occurred during update.</source>
+            <translation>Päivityksen aikana tapahtui virhe.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/versionwidget.cpp" line="231" />
+            <source>Could not download update.</source>
+            <translation>Päivityksen lataaminen epäonnistui.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/versionwidget.cpp" line="235" />
+            <source>Update disabled.</source>
+            <translation>Päivitys poistettu käytöstä.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/versionwidget.cpp" line="251" />
+            <source>Beta program</source>
+            <translation>Beta-ohjelma</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/versionwidget.cpp" line="252" />
+            <source>Get early access to new versions of the application</source>
+            <translation>Saa varhainen pääsy sovelluksen uusiin versioihin</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/versionwidget.cpp" line="256" />
+            <source>Join</source>
+            <translation>Liity</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/versionwidget.cpp" line="259" />
+            <source>Modify</source>
+            <translation>Muokkaa</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/versionwidget.cpp" line="259" />
+            <source>Quit</source>
+            <translation>Lopeta</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/versionwidget.cpp" line="295" />
+            <source>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</source>
+            <translation>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</translation>
+        </message>
+    </context>
+    <context>
+        <name>QObject</name>
+        <message>
+            <location filename="../src/gui/folderitemwidget.cpp" line="42" />
+            <source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
+            <translation>Lite sync (Beta) on käytössä. kDriven tiedostot pysyvät pilvessä eivätkä käytä tietokoneen tallennustilaa.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/folderitemwidget.cpp" line="45" />
+            <source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
+            <translation>Lite sync (Beta) ei ole käytössä. kDriven tiedostot käyttävät tietokoneen tallennustilaa.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/folderitemwidget.cpp" line="48" />
+            <source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
+            <translation>Lite sync on käytössä. kDriven tiedostot pysyvät pilvessä eivätkä käytä tietokoneen tallennustilaa.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/folderitemwidget.cpp" line="50" />
+            <source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
+            <translation>Lite sync ei ole käytössä. kDriven tiedostot käyttävät tietokoneen tallennustilaa.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parameterscache.cpp" line="59" />
+            <source>Unable to save parameters, please retry later.</source>
+            <translation>Parametrien tallentaminen epäonnistui, yritä myöhemmin uudelleen.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/parameterscache.cpp" line="60" />
+            <source>Unable to save parameters!</source>
+            <translation>Parametreja ei voi tallentaa!</translation>
+        </message>
+        <message>
+            <location filename="../src/server/comm/extensionjob.cpp" line="1175" />
+            <source>Make available locally</source>
+            <translation>Tee saataville paikallisesti</translation>
+        </message>
+        <message>
+            <location filename="../src/server/comm/extensionjob.cpp" line="1179" />
+            <source>Free up local space</source>
+            <translation>Vapauta paikallista tilaa</translation>
+        </message>
+        <message>
+            <location filename="../src/server/comm/extensionjob.cpp" line="1183" />
+            <source>Cancel free up local space</source>
+            <translation>Peruuta paikallisen tilan vapautus</translation>
+        </message>
+        <message>
+            <location filename="../src/server/comm/extensionjob.cpp" line="1187" />
+            <source>Cancel make available locally</source>
+            <translation>Peruuta paikallinen saatavillaolo</translation>
+        </message>
+        <message>
+            <location filename="../src/server/comm/extensionjob.cpp" line="1191" />
+            <source>Resharing this file is not allowed</source>
+            <translation>Tämän tiedoston jakaminen uudelleen ei ole sallittu</translation>
+        </message>
+        <message>
+            <location filename="../src/server/comm/extensionjob.cpp" line="1192" />
+            <source>Resharing this folder is not allowed</source>
+            <translation>Tämän kansion jakaminen uudelleen ei ole sallittu</translation>
+        </message>
+        <message>
+            <location filename="../src/server/comm/extensionjob.cpp" line="1196" />
+            <source>Copy public share link</source>
+            <translation>Kopioi julkinen jakolinkki</translation>
+        </message>
+        <message>
+            <location filename="../src/server/comm/extensionjob.cpp" line="1200" />
+            <source>Copy private share link</source>
+            <translation>Kopioi yksityinen jakolinkki</translation>
+        </message>
+        <message>
+            <location filename="../src/server/comm/extensionjob.cpp" line="1204" />
+            <source>Open in browser</source>
+            <translation>Avaa selaimessa</translation>
+        </message>
+        <message>
+            <location filename="../src/server/requests/serverrequests.cpp" line="461" />
+            <source>The parent folder is a sync folder or contained in one</source>
+            <translation>Ylätason kansio on synkronointikansio tai sisältyy yhteen</translation>
+        </message>
+        <message>
+            <location filename="../src/server/requests/serverrequests.cpp" line="495" />
+            <source>Can't find a valid path</source>
+            <translation>Kelvollista polkua ei löydy</translation>
+        </message>
+        <message>
+            <location filename="../src/server/requests/serverrequests.cpp" line="2108" />
+            <source>No valid folder selected!</source>
+            <translation>Kelvollista kansiota ei ole valittu!</translation>
+        </message>
+        <message>
+            <location filename="../src/server/requests/serverrequests.cpp" line="2119" />
+            <source>The selected path does not exist!</source>
+            <translation>Valittu polku ei ole olemassa!</translation>
+        </message>
+        <message>
+            <location filename="../src/server/requests/serverrequests.cpp" line="2124" />
+            <source>The selected path is not a folder!</source>
+            <translation>Valittu polku ei ole kansio!</translation>
+        </message>
+        <message>
+            <location filename="../src/server/requests/serverrequests.cpp" line="2129" />
+            <source>You have no permission to write to the selected folder!</source>
+            <translation>Sinulla ei ole kirjoitusoikeutta valittuun kansioon!</translation>
+        </message>
+        <message>
+            <location filename="../src/server/requests/serverrequests.cpp" line="2159" />
+            <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
+            <translation>Paikallinen kansio %1 sisältää jo synkronoidun kansion. Valitse toinen!</translation>
+        </message>
+        <message>
+            <location filename="../src/server/requests/serverrequests.cpp" line="2167" />
+            <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
+            <translation>Paikallinen kansio %1 on jo synkronoidun kansion sisällä. Valitse toinen!</translation>
+        </message>
+        <message>
+            <location filename="../src/server/requests/serverrequests.cpp" line="2175" />
+            <source>The local folder %1 is already synced. Please pick another one!</source>
+            <translation>Paikallinen kansio %1 on jo synkronoitu. Valitse toinen!</translation>
+        </message>
+    </context>
+    <context>
+        <name>SharedTools::QtSingleApplication</name>
+        <message>
+            <location filename="../src/server/appserver.cpp" line="133" />
+            <source>kDrive application will close due to a fatal error.</source>
+            <translation>kDrive-sovellus suljetaan kriittisen virheen vuoksi.</translation>
+        </message>
+    </context>
+    <context>
+        <name>Utility</name>
+        <message numerus="yes">
+            <location filename="../src/libcommongui/utility/utility.cpp" line="41" />
+            <source>%n year(s)</source>
+            <translation>
+                <numerusform>%n vuosi</numerusform>
+                <numerusform>%n vuotta</numerusform>
+            </translation>
+        </message>
+        <message numerus="yes">
+            <location filename="../src/libcommongui/utility/utility.cpp" line="42" />
+            <source>%n month(s)</source>
+            <translation>
+                <numerusform>%n kuukausi</numerusform>
+                <numerusform>%n kuukautta</numerusform>
+            </translation>
+        </message>
+        <message numerus="yes">
+            <location filename="../src/libcommongui/utility/utility.cpp" line="43" />
+            <source>%n day(s)</source>
+            <translation>
+                <numerusform>%n päivä</numerusform>
+                <numerusform>%n päivää</numerusform>
+            </translation>
+        </message>
+        <message numerus="yes">
+            <location filename="../src/libcommongui/utility/utility.cpp" line="44" />
+            <source>%n hour(s)</source>
+            <translation>
+                <numerusform>%n tunti</numerusform>
+                <numerusform>%n tuntia</numerusform>
+            </translation>
+        </message>
+        <message numerus="yes">
+            <location filename="../src/libcommongui/utility/utility.cpp" line="45" />
+            <source>%n minute(s)</source>
+            <translation>
+                <numerusform>%n minuutti</numerusform>
+                <numerusform>%n minuuttia</numerusform>
+            </translation>
+        </message>
+        <message numerus="yes">
+            <location filename="../src/libcommongui/utility/utility.cpp" line="46" />
+            <source>%n second(s)</source>
+            <translation>
+                <numerusform>%n sekunti</numerusform>
+                <numerusform>%n sekuntia</numerusform>
+            </translation>
+        </message>
+        <message>
+            <location filename="../src/libcommongui/utility/utility.cpp" line="97" />
+            <source>%L1 GB</source>
+            <translation>%L1 GB</translation>
+        </message>
+        <message>
+            <location filename="../src/libcommongui/utility/utility.cpp" line="101" />
+            <source>%L1 MB</source>
+            <translation>%L1 MB</translation>
+        </message>
+        <message>
+            <location filename="../src/libcommongui/utility/utility.cpp" line="105" />
+            <source>%L1 KB</source>
+            <translation>%L1 KB</translation>
+        </message>
+        <message>
+            <location filename="../src/libcommongui/utility/utility.cpp" line="108" />
+            <source>%L1 B</source>
+            <translation>%L1 B</translation>
+        </message>
+    </context>
+    <context>
+        <name>utility</name>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="84" />
+            <source>Could not open browser</source>
+            <translation>Selainta ei voi avata</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="85" />
+            <source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
+            <translation>Selaimen käynnistäminen URL-osoitteeseen %1 siirtymiseksi epäonnistui. Onko oletusselain määritetty?</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="104" />
+            <source>Could not open email client</source>
+            <translation>Sähköpostiohjelmaa ei voi avata</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="105" />
+            <source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
+            <translation>Sähköpostiohjelman käynnistäminen uuden viestin luomiseksi epäonnistui. Onko oletussähköpostiohjelma määritetty?</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="324" />
+            <source>You are not connected anymore. &lt;a style="%1" href="%2"&gt;Log in&lt;/a&gt;</source>
+            <translation>Et ole enää kirjautunut. &lt;a style="%1" href="%2"&gt;Kirjaudu sisään&lt;/a&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="329" />
+            <source>No folder to synchronize
 You can add one from the kDrive settings.</source>
-<translation>Ei synkronoitavaa kansiota
+            <translation>Ei synkronoitavaa kansiota
 Voit lisätä sellaisen kDriven asetuksista.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="336"/>
-<source>Sync in progress (%1 of %2)</source>
-<translation>Synkronointi käynnissä (%1/%2)</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="340"/>
-<source>Sync in progress (%1 of %2)
+        </message>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="336" />
+            <source>Sync in progress (%1 of %2)</source>
+            <translation>Synkronointi käynnissä (%1/%2)</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="340" />
+            <source>Sync in progress (%1 of %2)
 %3 left...</source>
-<translation>Synkronointi käynnissä (%1/%2)
+            <translation>Synkronointi käynnissä (%1/%2)
 %3 jäljellä...</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="347"/>
-<source>Sync in progress (Step %1/%2).</source>
-<translation>Synkronointi käynnissä (vaihe %1/%2).</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="351"/>
-<source>Synchronization starting</source>
-<translation>Synkronointi alkaa</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="353"/>
-<source>Sync in progress.</source>
-<translation>Synkronointi käynnissä.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="358"/>
-<source>You are up to date, unresolved conflicts.</source>
-<translation>Olet ajan tasalla, ratkaisemattomia ristiriitoja.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="360"/>
-<source>You are up to date!</source>
-<translation>Olet ajan tasalla!</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="364"/>
-<source>Some files couldn't be synchronized. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Joitakin tiedostoja ei voitu synkronoida. &lt;a style="%1" href="%2"&gt;Lue lisää&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="370"/>
-<source>Synchronization pausing ...</source>
-<translation>Synkronointi keskeytymässä...</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="374"/>
-<source>Synchronization paused.</source>
-<translation>Synkronointi keskeytetty.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="570"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
-<translation>Kansiota &lt;b&gt;%1&lt;/b&gt; ei voi valita, koska toinen synkronointi käyttää samaa kansiota.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="576"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-<translation>Kansiota &lt;b&gt;%1&lt;/b&gt; ei voi valita, koska se sisältää synkronoidun kansion &lt;b&gt;%2&lt;/b&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="584"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-<translation>Kansiota &lt;b&gt;%1&lt;/b&gt; ei voi valita, koska se on synkronoidun kansion &lt;b&gt;%2&lt;/b&gt; sisällä.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="595"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
-<translation>Kansiota &lt;b&gt;%1&lt;/b&gt; ei voi valita synkronointikansioksi. Valitse toinen kansio.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="599"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
-<translation>Kansiota &lt;b&gt;%1&lt;/b&gt; ei voi valita synkronointikansioksi. Valitse toinen kansio. Ehdotettu kansio: &lt;b&gt;%2&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="651"/>
-<source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
-<translation>Olet sulkenut pois enemmän kuin %1 kansiota, huomaa, että tämä vaikuttaa synkronoinnin suorituskykyyn.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="660"/>
-<source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
-<translation>Et voi sulkea pois enemmän kuin %1 kansiota. Poista ylätason kansioiden valinta.</translation>
-</message>
-</context>
+        </message>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="347" />
+            <source>Sync in progress (Step %1/%2).</source>
+            <translation>Synkronointi käynnissä (vaihe %1/%2).</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="351" />
+            <source>Synchronization starting</source>
+            <translation>Synkronointi alkaa</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="353" />
+            <source>Sync in progress.</source>
+            <translation>Synkronointi käynnissä.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="358" />
+            <source>You are up to date, unresolved conflicts.</source>
+            <translation>Olet ajan tasalla, ratkaisemattomia ristiriitoja.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="360" />
+            <source>You are up to date!</source>
+            <translation>Olet ajan tasalla!</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="364" />
+            <source>Some files couldn't be synchronized. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+            <translation>Joitakin tiedostoja ei voitu synkronoida. &lt;a style="%1" href="%2"&gt;Lue lisää&lt;/a&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="370" />
+            <source>Synchronization pausing ...</source>
+            <translation>Synkronointi keskeytymässä...</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="374" />
+            <source>Synchronization paused.</source>
+            <translation>Synkronointi keskeytetty.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="570" />
+            <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
+            <translation>Kansiota &lt;b&gt;%1&lt;/b&gt; ei voi valita, koska toinen synkronointi käyttää samaa kansiota.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="576" />
+            <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+            <translation>Kansiota &lt;b&gt;%1&lt;/b&gt; ei voi valita, koska se sisältää synkronoidun kansion &lt;b&gt;%2&lt;/b&gt;.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="584" />
+            <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+            <translation>Kansiota &lt;b&gt;%1&lt;/b&gt; ei voi valita, koska se on synkronoidun kansion &lt;b&gt;%2&lt;/b&gt; sisällä.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="595" />
+            <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
+            <translation>Kansiota &lt;b&gt;%1&lt;/b&gt; ei voi valita synkronointikansioksi. Valitse toinen kansio.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="599" />
+            <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
+            <translation>Kansiota &lt;b&gt;%1&lt;/b&gt; ei voi valita synkronointikansioksi. Valitse toinen kansio. Ehdotettu kansio: &lt;b&gt;%2&lt;/b&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="651" />
+            <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
+            <translation>Olet sulkenut pois enemmän kuin %1 kansiota, huomaa, että tämä vaikuttaa synkronoinnin suorituskykyyn.</translation>
+        </message>
+        <message>
+            <location filename="../src/gui/guiutility.cpp" line="660" />
+            <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
+            <translation>Et voi sulkea pois enemmän kuin %1 kansiota. Poista ylätason kansioiden valinta.</translation>
+        </message>
+    </context>
 </TS>

--- a/translations/client_fi.ts
+++ b/translations/client_fi.ts
@@ -263,7 +263,7 @@ Valitse toinen kansio. Jos jatkat, Lite Sync poistetaan käytöstä.&lt;br&gt;
         <message>
             <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210" />
             <source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
-            <translation>Alikansioiden listaa ei voi ladata. kDrive saattaa olla huoltotilassa.&lt;br&gt;Kirjaudu &lt;a style="%1" href="%2"&gt;verkkoversiooon&lt;/a&gt; tarkistaaksesi kDriven tilan tai ota yhteyttä järjestelmänvalvojaasi.</translation>
+            <translation>Alikansioiden listaa ei voi ladata. kDrive saattaa olla huoltotilassa.&lt;br&gt;Kirjaudu &lt;a style="%1" href="%2"&gt;verkkoversioon&lt;/a&gt; tarkistaaksesi kDriven tilan tai ota yhteyttä järjestelmänvalvojaasi.</translation>
         </message>
     </context>
     <context>
@@ -1680,12 +1680,12 @@ Valitse toinen kansio. Jos jatkat, Lite Sync poistetaan käytöstä.&lt;br&gt;
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="475" />
             <source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
-            <translation>kDrive on lepotilassa.&lt;br&gt;Kirjaudu &lt;a style="%1" href="%2"&gt;verkkoversiooon&lt;/a&gt; tarkistaaksesi kDriven tilan tai ota yhteyttä järjestelmänvalvojaasi.</translation>
+            <translation>kDrive on lepotilassa.&lt;br&gt;Kirjaudu &lt;a style="%1" href="%2"&gt;verkkoversioon&lt;/a&gt; tarkistaaksesi kDriven tilan tai ota yhteyttä järjestelmänvalvojaasi.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="479" />
             <source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive's status, or contact your administrator.</source>
-            <translation>kDrive on lepotilassa.&lt;br&gt;Kirjaudu verkkoversiooon tarkistaaksesi kDriven tilan tai ota yhteyttä järjestelmänvalvojaasi.</translation>
+            <translation>kDrive on lepotilassa.&lt;br&gt;Kirjaudu verkkoversioon tarkistaaksesi kDriven tilan tai ota yhteyttä järjestelmänvalvojaasi.</translation>
         </message>
         <message>
             <location filename="../src/gui/parametersdialog.cpp" line="483" />

--- a/translations/client_fi.ts
+++ b/translations/client_fi.ts
@@ -1,44 +1,44 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="sv_SE">
+<TS version="2.1" language="fi_FI">
 <context>
     <name>KDC::AboutDialog</name>
     <message>
         <location filename="../src/gui/aboutdialog.cpp" line="73"/>
         <source>About</source>
-        <translation>Om</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/aboutdialog.cpp" line="112"/>
         <source>CLOSE</source>
-        <translation>STÄNG</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/aboutdialog.cpp" line="123"/>
         <source>Version %1. For more information visit &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
-        <translation>Version %1. För mer information, besök &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/aboutdialog.cpp" line="126"/>
         <source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
-        <translation>Copyright 2019–%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/aboutdialog.cpp" line="127"/>
         <source>Distributed by %1 and licensed under the &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
-        <translation>Distribueras av %1 och licensieras enligt &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 och %2-logotypen är registrerade varumärken som tillhör %1.&lt;br&gt;&lt;br&gt;</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="132"/>
+        <source>&lt;p&gt;&lt;small&gt;Built from &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/aboutdialog.cpp" line="151"/>
         <location filename="../src/gui/aboutdialog.cpp" line="162"/>
         <location filename="../src/gui/aboutdialog.cpp" line="171"/>
         <source>Unable to open folder %1.</source>
-        <translation>Det går inte att öppna mappen %1.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/aboutdialog.cpp" line="132"/>
-        <source>&lt;p&gt;&lt;small&gt;Built from &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
-        <translation>&lt;p&gt;&lt;small&gt;Kompilerad från &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git-källkod&lt;/a&gt; den %2, %3 med Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -46,7 +46,7 @@
     <message>
         <location filename="../src/gui/abstractfileitemwidget.cpp" line="177"/>
         <source>Unable to open folder path %1.</source>
-        <translation>Det går inte att öppna mappsökvägen %1.</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -54,27 +54,27 @@
     <message>
         <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55"/>
         <source>Synchronization will start and you will be able to add files to your %1 folder.</source>
-        <translation>Synkroniseringen startar och du kan lägga till filer i mappen %1.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99"/>
         <source>Your kDrive is ready!</source>
-        <translation>Din kDrive är klar!</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123"/>
         <source>OPEN FOLDER</source>
-        <translation>ÖPPNA MAPP</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130"/>
         <source>PARAMETERS</source>
-        <translation>INSTÄLLNINGAR</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138"/>
         <source>Synchronize another drive</source>
-        <translation>Synkronisera en annan enhet</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -82,75 +82,75 @@
     <message>
         <location filename="../src/gui/adddrivelistwidget.cpp" line="170"/>
         <source>Cancel</source>
-        <translation>Avbryt</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/adddrivelistwidget.cpp" line="177"/>
         <source>NEXT</source>
-        <translation>NÄSTA</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/adddrivelistwidget.cpp" line="196"/>
         <source>Select the kDrive you want to synchronize</source>
-        <translation>Välj den kDrive du vill synkronisera</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/adddrivelistwidget.cpp" line="234"/>
         <source>Get kDrive for free</source>
-        <translation>Skaffa kDrive gratis</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/adddrivelistwidget.cpp" line="244"/>
         <source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
-        <translation>Spara dina bilder, dokument och e-postmeddelanden i Schweiz hos ett oberoende företag som respekterar din integritet. Läs mer</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/adddrivelistwidget.cpp" line="263"/>
         <source>Test for free</source>
-        <translation>Testa gratis</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>KDC::AddDriveLiteSyncWidget</name>
     <message>
-        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147"/>
-        <source>Conserve your computer space</source>
-        <translation>Spara utrymme på datorn</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167"/>
-        <source>Decide which files should be available online or locally</source>
-        <translation>Bestäm vilka filer som ska vara tillgängliga online eller lokalt</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187"/>
-        <source>LATER</source>
-        <translation>SENARE</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193"/>
-        <source>YES</source>
-        <translation>JA</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
-        <source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation>Lite Sync synkroniserar alla dina filer utan att ta upp utrymme på din dator. Du kan bläddra bland filerna i ditt kDrive och ladda ner dem lokalt när du vill. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Läs mer&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207"/>
-        <source>Unable to open link %1.</source>
-        <translation>Det går inte att öppna länken %1.</translation>
-    </message>
-    <message>
         <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112"/>
         <source>Would you like to activate Lite Sync (Beta) ?</source>
-        <translation>Vill du aktivera Lite Sync (Beta)?</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114"/>
         <source>Would you like to activate Lite Sync ?</source>
-        <translation>Vill du aktivera Lite Sync?</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
+        <source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147"/>
+        <source>Conserve your computer space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167"/>
+        <source>Decide which files should be available online or locally</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187"/>
+        <source>LATER</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193"/>
+        <source>YES</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207"/>
+        <source>Unable to open link %1.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -158,51 +158,49 @@
     <message>
         <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65"/>
         <source>Location of your %1 kDrive</source>
-        <translation>Plats för din %1 kDrive</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155"/>
         <source>Edit folder</source>
-        <translation>Ändra mapp</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
-        <source>END</source>
-        <translation>SLUTFÖR</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
-        <source>Select folder</source>
-        <translation>Välj mapp</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
-        <source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
-        <translation>Innehållet i mappen &lt;b&gt;%1&lt;/b&gt; kommer att synkroniseras i din kDrive</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212"/>
         <source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
-        <translation>När konfigurationen är klar hittar du alla dina filer i den här mappen. Du kan lägga in nya filer där för att synkronisera dem till din kDrive.</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+        <source>END</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+        <source>CONTINUE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
+        <source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284"/>
         <source>This folder is not compatible with Lite Sync.&lt;br&gt; 
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt; 
 &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation>Den här mappen är inte kompatibel med Lite Sync.&lt;br&gt; 
-Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&gt; 
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Läs mer&lt;/a&gt;</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
+        <source>Select folder</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377"/>
         <source>Unable to open link %1.</source>
-        <translation>Det går inte att öppna länken %1.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
-        <source>CONTINUE</source>
-        <translation>FORTSÄTT</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -210,32 +208,32 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
     <message>
         <location filename="../src/gui/adddriveloginwidget.cpp" line="69"/>
         <source>Log in from your browser</source>
-        <translation>Logga in från din webbläsare</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/adddriveloginwidget.cpp" line="75"/>
         <source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
-        <translation>Din webbläsare bör öppnas automatiskt för att slutföra anslutningen. När anslutningen är upprättad återgår du automatiskt till kDrive.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
         <source>Open the login page</source>
-        <translation>Öppna inloggningssidan</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/adddriveloginwidget.cpp" line="119"/>
         <source>Token request failed: %1 - %2</source>
-        <translation>Begäran om token misslyckades: %1 - %2</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/adddriveloginwidget.cpp" line="133"/>
         <source>Login failed: %1 - %2</source>
-        <translation>Inloggningen misslyckades: %1 - %2</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/adddriveloginwidget.cpp" line="141"/>
         <source>Failed to open the login page in your web browser</source>
-        <translation>Det gick inte att öppna inloggningssidan i din webbläsare</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -243,27 +241,27 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
     <message>
         <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129"/>
         <source>Select kDrive folders to synchronize on your desktop</source>
-        <translation>Välj vilka kDrive-mappar som ska synkroniseras på din dator</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174"/>
         <source>CONTINUE</source>
-        <translation>FORTSÄTT</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187"/>
         <source>Space available on your computer : %1</source>
-        <translation>Ledigt utrymme på din dator: %1</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206"/>
         <source>An error occurred while loading the list of subfolders.</source>
-        <translation>Ett fel uppstod vid inläsningen av listan över undermappar.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210"/>
         <source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
-        <translation>Det går inte att ladda listan över undermappar&lt;br&gt;. Din kDrive kan vara under underhåll. Logga in på &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;webbversionen&lt;/a&gt; för att kontrollera statusen för din kDrive, eller kontakta din administratör.</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -271,17 +269,17 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
     <message>
         <location filename="../src/gui/adddrivewizard.cpp" line="222"/>
         <source>Failed to create local folder %1</source>
-        <translation>Det gick inte att skapa den lokala mappen %1</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/adddrivewizard.cpp" line="233"/>
         <source>Failed to create new synchronization</source>
-        <translation>Det gick inte att skapa en ny synkronisering</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/adddrivewizard.cpp" line="266"/>
         <source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
-        <translation>kDrive %1 är redan synkroniserat på den här datorn. Vill du fortsätta ändå?</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -289,17 +287,17 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
     <message>
         <location filename="../src/gui/appclient.cpp" line="100"/>
         <source>kDrive client is run with bad parameters!</source>
-        <translation>kDrive-klienten körs med felaktiga parametrar!</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/appclient.cpp" line="109"/>
         <source>kDrive client is already running!</source>
-        <translation>kDrive-klienten är redan igång!</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/appclient.cpp" line="719"/>
         <source>The user %1 is not connected. Please log in again.</source>
-        <translation>Användaren %1 är inte inloggad. Logga in igen.</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -307,67 +305,67 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
     <message>
         <location filename="../src/server/appserver.cpp" line="1685"/>
         <source>Share link copied to clipboard</source>
-        <translation>Delningslänken har kopierats till urklipp</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
         <location filename="../src/server/appserver.cpp" line="3773"/>
         <source>%1 and %n other file(s) have been removed.</source>
-        <translation>
-            <numerusform>%1 och %n annan fil har tagits bort.</numerusform>
-            <numerusform>%1 och %n andra filer har tagits bort.</numerusform>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message>
         <location filename="../src/server/appserver.cpp" line="3775"/>
         <source>%1 has been removed.</source>
         <comment>%1 names a file.</comment>
-        <translation>%1 har tagits bort.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
         <location filename="../src/server/appserver.cpp" line="3780"/>
         <source>%1 and %n other file(s) have been added.</source>
-        <translation>
-            <numerusform>%1 och %n annan fil har lagts till.</numerusform>
-            <numerusform>%1 och %n andra filer har lagts till.</numerusform>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message>
         <location filename="../src/server/appserver.cpp" line="3782"/>
         <source>%1 has been added.</source>
         <comment>%1 names a file.</comment>
-        <translation>%1 har lagts till.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
         <location filename="../src/server/appserver.cpp" line="3787"/>
         <source>%1 and %n other file(s) have been updated.</source>
-        <translation>
-            <numerusform>%1 och %n annan fil har uppdaterats.</numerusform>
-            <numerusform>%1 och %n andra filer har uppdaterats.</numerusform>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message>
         <location filename="../src/server/appserver.cpp" line="3789"/>
         <source>%1 has been updated.</source>
         <comment>%1 names a file.</comment>
-        <translation>%1 har uppdaterats.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
         <location filename="../src/server/appserver.cpp" line="3794"/>
         <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
-        <translation>
-            <numerusform>%1 har flyttats till %2 och %n annan fil har flyttats.</numerusform>
-            <numerusform>%1 har flyttats till %2 och %n andra filer har flyttats.</numerusform>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message>
         <location filename="../src/server/appserver.cpp" line="3797"/>
         <source>%1 has been moved to %2.</source>
-        <translation>%1 har flyttats till %2.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/server/appserver.cpp" line="3805"/>
         <source>Sync Activity</source>
-        <translation>Synkroniseringsaktivitet</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -375,7 +373,7 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
     <message>
         <location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102"/>
         <source>No subfolders currently on the server.</source>
-        <translation>Det finns för närvarande inga undermappar på servern.</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -383,181 +381,180 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
     <message>
         <location filename="../src/gui/betaprogramdialog.cpp" line="69"/>
         <source>Quit the beta program</source>
-        <translation>Avsluta betaprogrammet</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/betaprogramdialog.cpp" line="69"/>
         <source>Join the beta program</source>
-        <translation>Anmäl dig till betaprogrammet</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/betaprogramdialog.cpp" line="77"/>
         <source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
-        <translation>Få tillgång till nya versioner av applikationen innan de släpps till allmänheten och bidra till att förbättra applikationen genom att skicka oss dina synpunkter.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/betaprogramdialog.cpp" line="87"/>
         <source>Benefit from application beta updates</source>
-        <translation>Dra nytta av uppdateringar av betaversionen av appen</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/betaprogramdialog.cpp" line="91"/>
         <source>No</source>
-        <translation>Nej</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/betaprogramdialog.cpp" line="92"/>
         <source>Public beta version</source>
-        <translation>Offentlig betaversion</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/betaprogramdialog.cpp" line="93"/>
         <source>Internal beta version</source>
-        <translation>Intern betaversion</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/betaprogramdialog.cpp" line="141"/>
         <source>I understand</source>
-        <translation>Jag förstår</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/betaprogramdialog.cpp" line="147"/>
         <source>Are you sure you want to leave the beta program?</source>
-        <translation>Är du säker på att du vill lämna betaprogrammet?</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/betaprogramdialog.cpp" line="161"/>
         <source>Save</source>
-        <translation>Spara</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/betaprogramdialog.cpp" line="167"/>
         <source>Cancel</source>
-        <translation>Avbryt</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/betaprogramdialog.cpp" line="228"/>
         <source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
-        <translation>Din nuvarande version av appen kan vara för ny; ditt val träder i kraft när nästa uppdatering blir tillgänglig.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/betaprogramdialog.cpp" line="233"/>
         <source>Beta versions may leave unexpectedly or cause instabilities.</source>
-        <translation>Betaversioner kan stängas ner utan förvarning eller orsaka instabilitet.</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>KDC::ClientGui</name>
     <message>
+        <location filename="../src/gui/clientgui.cpp" line="116"/>
+        <source>Unable to initialize kDrive client</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/gui/clientgui.cpp" line="189"/>
         <source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
-        <translation>Det gick inte att lösa konflikterna för %1 objekt i synkroniseringsmappen: %2</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/clientgui.cpp" line="242"/>
         <source>Please sign in</source>
-        <translation>Logga in</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="292"/>
-        <source>Folder %1: %2</source>
-        <translation>Mappen %1: %2</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="298"/>
-        <source>There are no sync folders configured.</source>
-        <translation>Det finns inga synkroniseringsmappar konfigurerade.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="1422"/>
-        <source>Synthesis</source>
-        <translation>Sammanfattning</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="1423"/>
-        <source>Preferences</source>
-        <translatorcomment>Préférences</translatorcomment>
-        <translation>Inställningar</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="1424"/>
-        <source>Quit</source>
-        <translation>Avsluta</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="673"/>
-        <source>Undefined State.</source>
-        <translation>Odefinierat tillstånd.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="676"/>
-        <source>Waiting to start syncing.</source>
-        <translation>Väntar på att synkroniseringen ska starta.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="679"/>
-        <source>Sync is running.</source>
-        <translation>Synkroniseringen pågår.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="683"/>
-        <source>Sync was successful, unresolved conflicts.</source>
-        <translation>Synkroniseringen lyckades, men det finns olösta konflikter.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="685"/>
-        <source>Last Sync was successful.</source>
-        <translation>Den senaste synkroniseringen genomfördes utan problem.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="692"/>
-        <source>User Abort.</source>
-        <translation>Användaren avbryter.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="696"/>
-        <source>Sync is paused.</source>
-        <translation>Synkroniseringen är pausad.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="705"/>
-        <source>%1 (Sync is paused)</source>
-        <translation>%1 (Synkroniseringen är pausad)</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="1257"/>
-        <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-        <translation>Vill du verkligen ta bort synkroniseringarna för kontot &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Obs!&lt;/b&gt; Detta raderar inga filer.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="1261"/>
-        <source>REMOVE ALL SYNCHRONIZATIONS</source>
-        <translation>TA BORT ALLA SYNKRONISERINGAR</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="1262"/>
-        <source>CANCEL</source>
-        <translation>AVBRYT</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="1590"/>
-        <source>Failed to start synchronizations!</source>
-        <translation>Det gick inte att starta synkroniseringarna!</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="849"/>
-        <source>Unable to open folder path %1.</source>
-        <translation>Det går inte att öppna mappsökvägen %1.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="116"/>
-        <source>Unable to initialize kDrive client</source>
-        <translation>Det går inte att starta kDrive-klienten</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/clientgui.cpp" line="255"/>
         <source>Synchronization is paused</source>
-        <translation>Synkroniseringen är pausad</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="292"/>
+        <source>Folder %1: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="298"/>
+        <source>There are no sync folders configured.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="673"/>
+        <source>Undefined State.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="676"/>
+        <source>Waiting to start syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="679"/>
+        <source>Sync is running.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="683"/>
+        <source>Sync was successful, unresolved conflicts.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="685"/>
+        <source>Last Sync was successful.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="692"/>
+        <source>User Abort.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="696"/>
+        <source>Sync is paused.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="705"/>
+        <source>%1 (Sync is paused)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="849"/>
+        <source>Unable to open folder path %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1257"/>
+        <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1261"/>
+        <source>REMOVE ALL SYNCHRONIZATIONS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1262"/>
+        <source>CANCEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1422"/>
+        <source>Synthesis</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1423"/>
+        <source>Preferences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1424"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1590"/>
+        <source>Failed to start synchronizations!</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -565,22 +562,22 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
     <message>
         <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86"/>
         <source>Summary of your local folder synchronization</source>
-        <translation>Sammanfattning av synkroniseringen av din lokala mapp</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95"/>
         <source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
-        <translation>Innehållet i mappen på din dator kommer att synkroniseras med mappen på den valda kDrive-enheten och vice versa.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184"/>
         <source>CANCEL</source>
-        <translation>AVBRYT</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191"/>
         <source>SYNCHRONIZE</source>
-        <translation>SYNKRONISERA</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -589,104 +586,104 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="96"/>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="120"/>
         <source>Before finishing</source>
-        <translation>Innan du avslutar</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="107"/>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="131"/>
         <source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
-        <translation>Följ dessa steg för att säkerställa att Lite Sync fungerar korrekt på din dator och för att slutföra konfigurationen av kDrive.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="208"/>
         <source>Open your Mac&apos;s &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation>Öppna &lt;b&gt;inställningarna under ”Allmänt”&lt;/b&gt; på din Mac eller  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klicka här&lt;/a&gt;</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="212"/>
         <source>Open your Mac&apos;s &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation>Öppna &lt;b&gt;inställningarna för sekretess och säkerhet&lt;/b&gt; på din Mac eller  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klicka här&lt;/a&gt;</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="216"/>
         <source>Open your Mac&apos;s &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation>Öppna &lt;b&gt;inställningarna&lt;/b&gt; för &lt;b&gt;Säkerhet och integritet&lt;/b&gt; på din Mac eller  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klicka här&lt;/a&gt;</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="246"/>
         <source>Go to &lt;b&gt;&quot;Login Items &amp; Extensions&quot;&lt;/b&gt; section and then to &lt;b&gt;&quot;Endpoint Security Extensions&quot;&lt;/b&gt;</source>
-        <translation>Gå till avsnittet &lt;b&gt;”Inloggningsobjekt och tillägg”&lt;/b&gt; och sedan till &lt;b&gt;”Endpoint Security-tillägg”&lt;/b&gt;</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="263"/>
         <source>Authorize the kDrive application</source>
-        <translation>Godkänn appen kDrive</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="272"/>
         <source>Go to &lt;b&gt;&quot;Security&quot;&lt;/b&gt; section</source>
-        <translation>Gå till avsnittet &lt;b&gt;”Säkerhet”&lt;/b&gt;</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="289"/>
         <source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
-        <translation>Godkänn kDrive-appen i rutan där det står att kDrive har blockerats</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="299"/>
         <source>Unlock the padlock &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; and authorize the kDrive application</source>
-        <translation>Lås upp hänglåset &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; och godkänn kDrive-appen</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="344"/>
         <source>Go to &lt;b&gt;&quot;Privacy &amp; Security&quot;&lt;/b&gt; section and click on &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt; or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation>Gå till avsnittet &lt;b&gt;”Sekretess och säkerhet”&lt;/b&gt; och klicka på &lt;b&gt;”Fullständig disktillgång”&lt;/b&gt; eller &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klicka här&lt;/a&gt;</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="348"/>
         <source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;&quot;Privacy&quot;&lt;/b&gt; tab or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation>Öppna fliken &lt;b&gt;”Sekretess”&lt;/b&gt; i inställningarna för säkerhet och sekretess, eller &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klicka här&lt;/a&gt;</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="376"/>
         <source>Check the &quot;kDrive LiteSync Extension&quot; box then the &quot;kDrive.app&quot; box (if not already checked)</source>
-        <translation>Markera rutan ”kDrive LiteSync Extension” och sedan rutan ”kDrive.app” (om den inte redan är markerad)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="393"/>
         <source>A restart of the app might be proposed, in this case accept it</source>
-        <translation>Det kan hända att appen föreslår en omstart; i så fall godkänner du den</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="399"/>
         <source>Check the &quot;kDrive LiteSync Extension&quot; box (and &quot;kDrive.app&quot; if it exists) in &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt;</source>
-        <translation>Markera rutan ”kDrive LiteSync Extension” (och ”kDrive.app” om den finns) under &lt;b&gt;”Fullständig diskåtkomst”&lt;/b&gt;</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
         <source>STEP 1</source>
-        <translation>STEG 1</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="496"/>
         <source>(Done)</source>
-        <translation>(Klart)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="496"/>
         <source>STEP 2</source>
-        <translation>STEG 2</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="499"/>
         <source>STEPS PERFORMED</source>
-        <translation>UTFÖRDA STEG</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="501"/>
         <source>END</source>
-        <translation>SLUTFÖR</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -694,22 +691,22 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
     <message>
         <location filename="../src/gui/custommessagebox.cpp" line="101"/>
         <source>OK</source>
-        <translation>OKEJ</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/custommessagebox.cpp" line="111"/>
         <source>CANCEL</source>
-        <translation>AVBRYT</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/custommessagebox.cpp" line="121"/>
         <source>YES</source>
-        <translation>JA</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/custommessagebox.cpp" line="131"/>
         <source>NO</source>
-        <translation>NEJ</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -717,165 +714,165 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
     <message>
         <location filename="../src/gui/debugreporter.cpp" line="37"/>
         <source>Sending of debugging information</source>
-        <translation>Översändning av felsökningsinformation</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/debugreporter.cpp" line="37"/>
         <source>Cancel</source>
-        <translation>Avbryt</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>KDC::DebuggingDialog</name>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="46"/>
-        <source>Info</source>
-        <translation>Info</translation>
-    </message>
-    <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="45"/>
         <source>Debug</source>
-        <translation>Felsökning</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="46"/>
+        <source>Info</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="47"/>
         <source>Warning</source>
-        <translation>Varning</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="48"/>
         <source>Error</source>
-        <translation>Fel</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="49"/>
         <source>Fatal</source>
-        <translation>Dödlig</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="74"/>
         <source>Debugging settings</source>
-        <translation>Felsökningsinställningar</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="90"/>
         <source>Save debugging information in a folder on my computer (Recommended)</source>
-        <translation>Spara felsökningsinformation i en mapp på min dator (rekommenderas)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="104"/>
         <source>This information enables IT support to determine the origin of an incident.</source>
-        <translation>Med hjälp av denna information kan IT-supporten fastställa var ett fel har sitt ursprung.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="114"/>
         <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
-        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Öppna felsökningsmappen&lt;/a&gt;</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="143"/>
         <source>Debug level</source>
-        <translation>Felsökningsnivå</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="152"/>
         <source>The trace level lets you choose the extent of the debugging information recorded</source>
-        <translation>Med spårningsnivån kan du välja hur mycket felsökningsinformation som ska registreras</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="179"/>
         <source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
-        <translation>Den utökade fullständiga loggen samlar in en detaljerad historik som kan användas för felsökning. Om du aktiverar den kan det göra att kDrive-programmet går långsammare.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="183"/>
         <source>Extended Full Log</source>
-        <translation>Utökad fullständig logg</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="207"/>
         <source>Delete logs older than %1 days</source>
-        <translation>Ta bort loggar som är äldre än %1 dagar</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="226"/>
         <source>Share the debug folder with Infomaniak support.</source>
-        <translation>Skicka debug-mappen till Infomaniaks support.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="250"/>
         <source>The last session is the periode since the last kDrive start.</source>
-        <translation>Den sista sessionen är tidsperioden sedan kDrive senast startades.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="254"/>
         <source>Share only the last kDrive session</source>
-        <translation>Dela endast den senaste kDrive-sessionen</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="285"/>
         <source>  Loading</source>
-        <translation>  Laddar</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="294"/>
         <source>Cancel</source>
-        <translation>Avbryt</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="320"/>
         <source>SAVE</source>
-        <translation>SPARA</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="327"/>
         <source>CANCEL</source>
-        <translation>AVBRYT</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="471"/>
         <source>Failed to share</source>
-        <translation>Det gick inte att dela</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="481"/>
         <source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
-        <translation>1. Kontrollera att du är inloggad &lt;br&gt;2. Kontrollera att du har konfigurerat minst en kDrive</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="486"/>
         <source> (Connexion interrupted)</source>
-        <translation> (Anslutningen avbröts)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="493"/>
         <source>Share the folder with SwissTransfer &lt;br&gt;</source>
-        <translation>Dela mappen med SwissTransfer &lt;br&gt;</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="494"/>
         <source> 1. We automatically compressed your log &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;here&lt;/a&gt;.&lt;br&gt;</source>
-        <translation> 1. Vi har automatiskt komprimerat din logg &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;här&lt;/a&gt;.&lt;br&gt;</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="496"/>
         <source> 2. Transfer the archive with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
-        <translation> 2. Skicka arkivet via &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="498"/>
         <source> 3. Share the link with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
-        <translation> 3. Dela länken med &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="528"/>
         <source>Last upload the %1</source>
-        <translation>Senaste uppladdning: %1</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="556"/>
         <source>Sharing has been cancelled</source>
-        <translation>Delningen har avbrutits</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="597"/>
@@ -883,258 +880,258 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.h" line="70"/>
-        <source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
-        <translation>Hela mappen är stor (&gt; 100 MB) och det kan ta en stund att dela den. För att minska delningstiden rekommenderar vi att du endast delar den senaste kDrive-sessionen.</translation>
-    </message>
-    <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="611"/>
         <source>%1/%2/%3 at %4h%5m and %6s</source>
         <extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
-        <translation>%1/%2/%3 kl. %4:%5 och %6 sekunder</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="654"/>
         <source>Do you want to save your modifications?</source>
-        <translation>Vill du spara dina ändringar?</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="709"/>
         <location filename="../src/gui/debuggingdialog.cpp" line="715"/>
         <source>Unable to open folder %1.</source>
-        <translation>Det går inte att öppna mappen %1.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="722"/>
         <source>  Share</source>
-        <translation>  Dela</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="732"/>
         <source>  Sharing | step 1/2 %1%</source>
-        <translation>  Dela | steg 1/2 %1%</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="741"/>
         <source>  Sharing | step 2/2 %1%</source>
-        <translation>  Dela | steg 2/2 %1%</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="751"/>
         <source>  Canceling...</source>
-        <translation>  Avbryter...</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.h" line="70"/>
+        <source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>KDC::DrivePreferencesWidget</name>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
-        <source>Folders</source>
-        <translation>Mappar</translation>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
+        <source>Synchronization errors and information.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
-        <source>Notifications</source>
-        <translation>Meddelanden</translation>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
+        <source>Synchronize a local folder</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
-        <source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
-        <translation>Ett meddelande visas så snart en ny mapp har synkroniserats eller ändrats</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
-        <source>Connected with</source>
-        <translation>I samband med</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
-        <source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-        <translation>Vill du verkligen sluta synkronisera mappen &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Obs!&lt;/b&gt; Detta kommer &lt;b&gt;inte&lt;/b&gt; att radera några filer.</translation>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
+        <source>Do you really want to turn on Lite Sync?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/drivepreferenceswidget.cpp" line="356"/>
         <source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
-        <translation>Denna åtgärd kan ta allt från några sekunder till några minuter, beroende på mappens storlek.</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
+        <source>CONFIRM</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/drivepreferenceswidget.cpp" line="360"/>
         <location filename="../src/gui/drivepreferenceswidget.cpp" line="391"/>
         <location filename="../src/gui/drivepreferenceswidget.cpp" line="986"/>
         <source>CANCEL</source>
-        <translation>AVBRYT</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
-        <source>New local folder synchronization failed!</source>
-        <translation>Synkroniseringen av den nya lokala mappen misslyckades!</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
-        <source>Lite Sync activation failed.</source>
-        <translation>Aktiveringen av Lite Sync misslyckades.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
-        <source>Lite Sync deactivation failed.</source>
-        <translation>Det gick inte att inaktivera Lite Sync.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
-        <source>REMOVE FOLDER SYNC CONNECTION</source>
-        <translation>TA BORT SYNKRONISERINGSFÖRBINDELSEN FÖR MAPPEN</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
-        <source>An error occurred while loading the list of subfolders.</source>
-        <translation>Ett fel uppstod vid inläsningen av listan över undermappar.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
-        <source>Enable the notifications for this kDrive</source>
-        <translation>Aktivera aviseringar för denna kDrive</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
-        <source>CONFIRM</source>
-        <translation>BEKRÄFTA</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
-        <source>Synchronization errors and information.</source>
-        <translation>Synkroniseringsfel och information.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
-        <source>Synchronize a local folder</source>
-        <translation>Synkronisera en lokal mapp</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
-        <source>Do you really want to turn on Lite Sync?</source>
-        <translation>Vill du verkligen aktivera Lite Sync?</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/drivepreferenceswidget.cpp" line="382"/>
         <source>Do you really want to turn off Lite Sync?</source>
-        <translation>Vill du verkligen stänga av Lite Sync?</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/drivepreferenceswidget.cpp" line="384"/>
         <source>You don&apos;t have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
-        <translation>Du har inte tillräckligt med utrymme för att synkronisera alla filer på din kDrive (%1 saknas). Om du inaktiverar Lite Sync måste du välja vilka mappar som ska synkroniseras på din dator. Under tiden kommer synkroniseringen av din kDrive att pausas.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/drivepreferenceswidget.cpp" line="388"/>
         <source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
-        <translation>Om du stänger av Lite Sync kommer alla filer att laddas ner till din dator.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/drivepreferenceswidget.cpp" line="627"/>
         <source>Failed to create new synchronization</source>
-        <translation>Det gick inte att skapa en ny synkronisering</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
+        <source>New local folder synchronization failed!</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/drivepreferenceswidget.cpp" line="819"/>
         <source>Lite Sync activated.</source>
-        <translation>Lite Sync är aktiverat.</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
+        <source>Lite Sync activation failed.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/drivepreferenceswidget.cpp" line="837"/>
         <source>Lite Sync deactivated.</source>
-        <translation>Lite Sync är inaktiverat.</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
+        <source>Lite Sync deactivation failed.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/drivepreferenceswidget.cpp" line="899"/>
         <source>This drive is being deleted.</source>
-        <translation>Den här enheten raderas.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/drivepreferenceswidget.cpp" line="962"/>
         <source>Impossible to open item %1</source>
-        <translation>Det går inte att öppna objekt %1</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
+        <source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
+        <source>REMOVE FOLDER SYNC CONNECTION</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/drivepreferenceswidget.cpp" line="1007"/>
         <source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
-        <translation>Det gick inte att avbryta synkroniseringen av mappen &lt;i&gt;%1&lt;/i&gt;.</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
+        <source>An error occurred while loading the list of subfolders.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
+        <source>Folders</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
+        <source>Notifications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
+        <source>Enable the notifications for this kDrive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
+        <source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
+        <source>Connected with</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/drivepreferenceswidget.cpp" line="1125"/>
         <source>Remove all synchronizations</source>
-        <translation>Ta bort alla synkroniseringar</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/drivepreferenceswidget.cpp" line="1126"/>
         <source>Search in your kDrive</source>
-        <translation>Sök i din kDrive</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/drivepreferenceswidget.cpp" line="1127"/>
         <source>Search</source>
-        <translation>Sök</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>KDC::DriveSelectionWidget</name>
     <message>
-        <location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
-        <source>Synchronize a kDrive</source>
-        <translation>Synkronisera en kDrive</translation>
-    </message>
-    <message>
         <location filename="../src/gui/driveselectionwidget.cpp" line="150"/>
         <source>Add a kDrive</source>
-        <translation>Lägg till en kDrive</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
+        <source>Synchronize a kDrive</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>KDC::ErrorTabWidget</name>
-    <message>
-        <location filename="../src/gui/errortabwidget.cpp" line="179"/>
-        <source>Resolve</source>
-        <translation>Lösa</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/errortabwidget.cpp" line="180"/>
-        <source>Conflicted item(s)</source>
-        <translation>Konflikterande objekt</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/errortabwidget.cpp" line="181"/>
-        <source>Item(s) with unsupported characters</source>
-        <translation>Objekt med tecken som inte stöds</translation>
-    </message>
     <message>
         <location filename="../src/gui/errortabwidget.cpp" line="92"/>
         <location filename="../src/gui/errortabwidget.cpp" line="135"/>
         <location filename="../src/gui/errortabwidget.cpp" line="178"/>
         <location filename="../src/gui/errortabwidget.cpp" line="186"/>
         <source>Clear history</source>
-        <translation>Rensa historiken</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/errortabwidget.cpp" line="176"/>
         <source>To Resolve</source>
-        <translation>Att lösa</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/errortabwidget.cpp" line="184"/>
-        <source>Automatically resolved</source>
-        <translation>Löst automatiskt</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/errortabwidget.cpp" line="185"/>
-        <source>problem(s) solved</source>
-        <translation>problem löst</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/errortabwidget.cpp" line="177"/>
         <source>problem(s) detected</source>
-        <translation>problem har upptäckts</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="179"/>
+        <source>Resolve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="180"/>
+        <source>Conflicted item(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="181"/>
+        <source>Item(s) with unsupported characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="184"/>
+        <source>Automatically resolved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="185"/>
+        <source>problem(s) solved</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1143,18 +1140,18 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <location filename="../src/gui/errorsmenubarwidget.cpp" line="84"/>
         <location filename="../src/gui/errorsmenubarwidget.cpp" line="103"/>
         <source>Synchronization conflicts or errors</source>
-        <translation>Synkroniseringskonflikter eller fel</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/errorsmenubarwidget.cpp" line="86"/>
         <location filename="../src/gui/errorsmenubarwidget.cpp" line="105"/>
         <source>Errors</source>
-        <translation>Fel</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/errorsmenubarwidget.cpp" line="101"/>
         <source>Back to preferences</source>
-        <translation>Tillbaka till inställningar</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1162,30 +1159,30 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
     <message>
         <location filename="../src/gui/errorspopup.cpp" line="73"/>
         <source>Some files couldn&apos;t be synchronized on the following kDrive(s) :</source>
-        <translation>Vissa filer kunde inte synkroniseras på följande kDrive-enheter:</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/errorspopup.cpp" line="95"/>
         <source> (%1 error(s))</source>
-        <translation> (%1 fel)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/errorspopup.cpp" line="101"/>
         <source> (%1 information(s))</source>
-        <translation> (%1 uppgift(er))</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/errorspopup.cpp" line="107"/>
         <source> (%1 error(s) and %2 information(s))</source>
-        <translation> (%1 fel och %2 uppgifter)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
         <location filename="../src/gui/errorspopup.cpp" line="147"/>
         <source>Generic errors (%n warning(s) or error(s))</source>
         <comment>Number of warnings or errors</comment>
-        <translation>
-            <numerusform>Allmänna fel (%n varning eller fel)</numerusform>
-            <numerusform>Allmänna fel (%n varningar eller fel)</numerusform>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
 </context>
@@ -1194,57 +1191,57 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
     <message>
         <location filename="../src/gui/fileexclusiondialog.cpp" line="78"/>
         <source>Excluded files</source>
-        <translation>Undantagna filer</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/fileexclusiondialog.cpp" line="86"/>
         <source>Add files or folders that will not be synchronized on your computer.</source>
-        <translation>Lägg till filer eller mappar som inte ska synkroniseras på din dator.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/fileexclusiondialog.cpp" line="97"/>
         <source>Add</source>
-        <translation>Lägg till</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/fileexclusiondialog.cpp" line="109"/>
         <source>NAME</source>
-        <translation>NAMN</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/fileexclusiondialog.cpp" line="114"/>
         <source>WARNING</source>
-        <translation>VARNING</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/fileexclusiondialog.cpp" line="149"/>
         <source>SAVE</source>
-        <translation>SPARA</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/fileexclusiondialog.cpp" line="156"/>
         <source>CANCEL</source>
-        <translation>AVBRYT</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/fileexclusiondialog.cpp" line="304"/>
         <source>Do you want to save your modifications?</source>
-        <translation>Vill du spara dina ändringar?</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/fileexclusiondialog.cpp" line="353"/>
         <source>Exclusion template already exists!</source>
-        <translation>Mallen för uteslutning finns redan!</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/fileexclusiondialog.cpp" line="374"/>
         <source>Do you really want to delete?</source>
-        <translation>Vill du verkligen ta bort det?</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/fileexclusiondialog.cpp" line="434"/>
         <source>Cannot save changes!</source>
-        <translation>Det går inte att spara ändringarna!</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1252,12 +1249,12 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
     <message>
         <location filename="../src/gui/fileexclusionnamedialog.cpp" line="58"/>
         <source>VALIDATE</source>
-        <translation>BEKRÄFTA</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/fileexclusionnamedialog.cpp" line="65"/>
         <source>CANCEL</source>
-        <translation>AVBRYT</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1266,136 +1263,136 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67"/>
         <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73"/>
         <source>Unable to open link %1.</source>
-        <translation>Det går inte att öppna länken %1.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122"/>
         <source>Solve conflict(s)</source>
-        <translation>Lösa konflikter</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140"/>
         <source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
-        <translation>&lt;b&gt;Vad vill du göra med den/de %1 objektet/objekten som är i konflikt?&lt;/b&gt;</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143"/>
         <source>Save my changes and replace other users&apos; versions.</source>
-        <translation>Spara mina ändringar och ersätt andra användares versioner.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147"/>
         <source>Undo my changes and keep other users&apos; versions.</source>
-        <translation>Ångra mina ändringar och behåll andra användares versioner.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169"/>
         <source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
-        <translation>Dina ändringar kan raderas permanent. De går inte att återställa via kDrive-webbappen.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171"/>
         <source>&lt;a style=%1 href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation>&lt;a style=%1 href=&quot;%2&quot;&gt;Läs mer&lt;/a&gt;</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175"/>
         <source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
-        <translation>Dina ändringar kommer att raderas permanent. De kan inte återställas via kDrive-webbappen.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191"/>
         <source>Show item(s)</source>
-        <translation>Visa objekt</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228"/>
         <source>VALIDATE</source>
-        <translation>BEKRÄFTA</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234"/>
         <source>CANCEL</source>
-        <translation>AVBRYT</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251"/>
         <source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
-        <translation>Flera användare har gjort ändringar i dessa filer på olika ställen (online på kDrive, på en dator eller i en mobil). Mappar som innehåller dessa filer kan också ha raderats.&lt;br&gt;</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253"/>
         <source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation>Den lokala versionen av din artikel &lt;b&gt;är inte synkroniserad&lt;/b&gt; med kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Läs mer&lt;/a&gt;</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>KDC::FolderItemWidget</name>
     <message>
-        <location filename="../src/gui/folderitemwidget.cpp" line="458"/>
-        <source>More actions</source>
-        <translation>Fler åtgärder</translation>
-    </message>
-    <message>
         <location filename="../src/gui/folderitemwidget.cpp" line="188"/>
         <location filename="../src/gui/folderitemwidget.cpp" line="476"/>
         <source>Synchronized into &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</source>
-        <translation>Synkroniserad till &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/folderitemwidget.cpp" line="343"/>
         <source>Activate Lite Sync</source>
-        <translation>Aktivera Lite Sync</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/folderitemwidget.cpp" line="345"/>
         <source>Activate Lite Sync (Beta)</source>
-        <translation>Aktivera Lite Sync (Beta)</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/folderitemwidget.cpp" line="481"/>
-        <source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
-        <translation>Mappar som inte är markerade flyttas till papperskorgen om de innehåller objekt som är offline. Mappar som synkroniserats till kDrive förblir tillgängliga online.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/folderitemwidget.cpp" line="485"/>
-        <source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
-        <translation>Mappar som inte är markerade kommer att flyttas till papperskorgen. Mappar som synkroniserats till kDrive kommer att förbli tillgängliga online.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/folderitemwidget.cpp" line="488"/>
-        <source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
-        <translation>Mappar som inte är markerade kommer att raderas &lt;b&gt;permanent&lt;/b&gt; från datorn. Mappar som synkroniserats till kDrive kommer att finnas kvar online.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/folderitemwidget.cpp" line="493"/>
-        <source>Cancel</source>
-        <translation>Avbryt</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/folderitemwidget.cpp" line="494"/>
-        <source>VALIDATE</source>
-        <translation>BEKRÄFTA</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/folderitemwidget.cpp" line="365"/>
-        <source>Pause synchronization</source>
-        <translation>Pausa synkroniseringen</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/folderitemwidget.cpp" line="354"/>
         <source>Deactivate Lite Sync</source>
-        <translation>Inaktivera Lite Sync</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="365"/>
+        <source>Pause synchronization</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/folderitemwidget.cpp" line="375"/>
         <source>Resume synchronization</source>
-        <translation>Fortsätt synkroniseringen</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/folderitemwidget.cpp" line="386"/>
         <source>Remove synchronization</source>
-        <translation>Avaktivera synkronisering</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="458"/>
+        <source>More actions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="481"/>
+        <source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="485"/>
+        <source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="488"/>
+        <source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="493"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="494"/>
+        <source>VALIDATE</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1403,7 +1400,7 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
     <message>
         <location filename="../src/gui/genericerroritemwidget.cpp" line="85"/>
         <source>Unable to open folder path %1.</source>
-        <translation>Det går inte att öppna mappsökvägen %1.</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1411,22 +1408,22 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
     <message>
         <location filename="../src/gui/litesyncappdialog.cpp" line="48"/>
         <source>Application Id</source>
-        <translation>Applikations-ID</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/litesyncappdialog.cpp" line="98"/>
         <source>Application Name</source>
-        <translation>Programnamn</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/litesyncappdialog.cpp" line="121"/>
         <source>VALIDATE</source>
-        <translation>BEKRÄFTA</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/litesyncappdialog.cpp" line="128"/>
         <source>CANCEL</source>
-        <translation>AVBRYT</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1434,47 +1431,47 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
     <message>
         <location filename="../src/gui/litesyncdialog.cpp" line="91"/>
         <source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are &quot;online&quot;. Add them in the list below to avoid this behaviour.</source>
-        <translation>Vissa appar (säkerhetskopieringsappar, antivirusprogram...) får åtkomst till dina filer, vilket gör att de laddas ner när de är ”uppkopplade”. Lägg till dem i listan nedan för att undvika detta.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/litesyncdialog.cpp" line="103"/>
         <source>Add</source>
-        <translation>Lägg till</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/litesyncdialog.cpp" line="115"/>
         <source>APPLICATION ID</source>
-        <translation>APPLIKATIONS-ID</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/litesyncdialog.cpp" line="120"/>
         <source>NAME</source>
-        <translation>NAMN</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/litesyncdialog.cpp" line="154"/>
         <source>SAVE</source>
-        <translation>SPARA</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/litesyncdialog.cpp" line="161"/>
         <source>CANCEL</source>
-        <translation>AVBRYT</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/litesyncdialog.cpp" line="295"/>
         <source>Do you want to save your modifications?</source>
-        <translation>Vill du spara dina ändringar?</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/litesyncdialog.cpp" line="337"/>
         <source>Do you really want to delete?</source>
-        <translation>Vill du verkligen ta bort det?</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/litesyncdialog.cpp" line="374"/>
         <source>Cannot save changes!</source>
-        <translation>Det går inte att spara ändringarna!</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1482,52 +1479,49 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
     <message>
         <location filename="../src/gui/localfolderdialog.cpp" line="63"/>
         <source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
-        <translation>Vilken mapp på din dator vill du&lt;br&gt;synkronisera?</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/localfolderdialog.cpp" line="72"/>
         <source>The content of this folder will be synchronized on the kDrive</source>
-        <translation>Innehållet i den här mappen kommer att synkroniseras på kDrive</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/localfolderdialog.cpp" line="91"/>
         <source>Select a folder</source>
-        <translation>Välj en mapp</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/localfolderdialog.cpp" line="131"/>
         <source>Edit folder</source>
-        <translation>Ändra mapp</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/localfolderdialog.cpp" line="166"/>
         <source>CANCEL</source>
-        <translation>AVBRYT</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/localfolderdialog.cpp" line="173"/>
         <source>CONTINUE</source>
-        <translation>FORTSÄTT</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/localfolderdialog.cpp" line="210"/>
         <source>This folder is not compatible with Lite Sync.&lt;br&gt;
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt;
 &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation>Den här mappen är inte kompatibel med Lite Sync.&lt;br&gt;
-Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&gt;
-
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Läs mer&lt;/a&gt;</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/localfolderdialog.cpp" line="233"/>
         <source>Select folder</source>
-        <translation>Välj mapp</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/localfolderdialog.cpp" line="292"/>
         <source>Unable to open link %1.</source>
-        <translation>Det går inte att öppna länken %1.</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1535,12 +1529,12 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
     <message>
         <location filename="../src/libcommongui/logger.cpp" line="189"/>
         <source>Error</source>
-        <translation>Fel</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/libcommongui/logger.cpp" line="189"/>
         <source>&lt;nobr&gt;File &apos;%1&apos;&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
-        <translation>&lt;nobr&gt;Filen &amp;#x27;%1&amp;#x27;&lt;br/&gt;kan inte öppnas för skrivning.&lt;br/&gt;&lt;br/&gt;Logginformationen kan &lt;b&gt;inte&lt;/b&gt; sparas!&lt;/nobr&gt;</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1548,37 +1542,26 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
     <message>
         <location filename="../src/gui/mainmenubarwidget.cpp" line="115"/>
         <source>Preferences</source>
-        <translation>Inställningar</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/mainmenubarwidget.cpp" line="116"/>
         <source>Help</source>
-        <translation>Hjälp</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>KDC::ParametersDialog</name>
     <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1082"/>
-        <source>Unable to open folder path %1.</source>
-        <translation>Det går inte att öppna mappsökvägen %1.</translation>
+        <location filename="../src/gui/parametersdialog.cpp" line="320"/>
+        <source>kDrive needs to have write access to your computer&apos;s temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1096"/>
-        <source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
-        <translation>Överföringen är klar!&lt;br&gt;Ange referensnummer &lt;b&gt;%1&lt;/b&gt; i felrapporter.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1118"/>
-        <source>No kDrive configured!</source>
-        <translation>kDrive är inte konfigurerat!</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1097"/>
-        <source>Transmission failed!
-Please, use the following link to send the logs to the support: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</source>
-        <translation>Överföringen misslyckades!
-Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</translation>
+        <location filename="../src/gui/parametersdialog.cpp" line="330"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="487"/>
+        <source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="337"/>
@@ -1587,365 +1570,375 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <location filename="../src/gui/parametersdialog.cpp" line="546"/>
         <location filename="../src/gui/parametersdialog.cpp" line="560"/>
         <source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-        <translation>Ett tekniskt fel har uppstått (fel %1).&lt;br&gt;Rensa historiken och kontakta vår support om felet kvarstår.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="342"/>
         <source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
-        <translation>Det verkar som om tidsgränsen för din nätverksanslutning är inställd på ett för lågt värde för att programmet ska fungera korrekt (fel %1).&lt;br&gt;Kontrollera din nätverkskonfiguration.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="347"/>
         <location filename="../src/gui/parametersdialog.cpp" line="516"/>
         <source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
-        <translation>Det går inte att ansluta till kDrive-servern (fel %1).&lt;br&gt;Försöker ansluta igen. Kontrollera din internetanslutning och din brandvägg.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="352"/>
         <source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
-        <translation>Ett inloggningsproblem har uppstått (fel %1).&lt;br&gt;Logga in igen. Om felet kvarstår, kontakta vår support.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="356"/>
         <source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
-        <translation>En ny version av appen finns tillgänglig. Uppdatera&lt;br&gt;appen för att kunna fortsätta använda den.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="360"/>
         <source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
-        <translation>Uppladdningen av loggen misslyckades (fel %1).&lt;br&gt;Försök igen senare.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="385"/>
         <source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
-        <translation>Synkroniseringsmappen är inte längre tillgänglig (fel %1).&lt;br&gt;Synkroniseringen återupptas så snart mappen blir tillgänglig.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="532"/>
-        <source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
-        <translation>Synkroniseringsmappen har ersatts eller flyttats på ett sätt som förhindrar synkronisering (fel %1).&lt;br&gt;Detta kan inträffa efter att mappen har kopierats, flyttats eller återställts.&lt;br&gt;För att åtgärda detta, skapa en ny synkronisering med en ny mapp.&lt;br&gt;Obs! Om det finns osynkroniserade ändringar i den gamla mappen måste du kopiera dem manuellt till den nya.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="397"/>
-        <source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
-        <translation>Det finns inte tillräckligt med minne kvar på din dator.&lt;br&gt;Synkroniseringen har avbrutits.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="320"/>
-        <source>kDrive needs to have write access to your computer&apos;s temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
-        <translation>kDrive måste ha skrivbehörighet till datorns temporära katalog.&lt;br&gt;Starta om kDrive-appen för att lösa problemet.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="330"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="487"/>
-        <source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>Ett tekniskt fel har uppstått.&lt;br&gt;Synkroniseringen återupptas så snart som möjligt. Kontakta vår support om felet kvarstår.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="401"/>
-        <source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing &apos;/etc/sysctl.conf&apos;.</source>
-        <translation>Antalet inotify-övervakningar är otillräckligt (fel %1).&lt;br&gt;Du kan öka detta antal genom att redigera filen &amp;#x27;/etc/sysctl.conf&amp;#x27;.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="406"/>
-        <source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
-        <translation>Det går inte att starta synkroniseringen (fel %1).&lt;br&gt;Du måste ge behörighet till:&lt;br&gt;– kDrive i Systeminställningar &gt;&gt; Allmänt &gt;&gt; Inloggningsobjekt och tillägg &gt;&gt; Tillägg för&lt;br&gt;Endpoint Security– kDrive LiteSync-tillägget i Systeminställningar &gt;&gt; Sekretess och säkerhet &gt;&gt; Fullständig disktillgång.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="419"/>
-        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-        <translation>Det går inte att starta tillägget Lite Sync (fel %1).&lt;br&gt;Kontrollera att tillägget Lite Sync är installerat och att tjänsten Windows Search är aktiverad.&lt;br&gt;Rensa historiken, starta om datorn och kontakta vår support om felet kvarstår.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="424"/>
-        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-        <translation>Det går inte att starta tillägget Lite Sync (fel %1).&lt;br&gt;Kontrollera att tillägget Lite Sync har rätt behörigheter och är igång.&lt;br&gt;Rensa historiken, starta om och kontakta vår support om felet kvarstår.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="429"/>
-        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-        <translation>Det går inte att starta Lite Sync-tillägget (fel %1).&lt;br&gt;Rensa historiken, starta om och kontakta vår support om felet kvarstår.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="435"/>
-        <source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
-        <translation>En fil eller mapp i din synkroniseringsmapp verkar vara skadad.&lt;br&gt;Synkroniseringen har avbrutits.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="449"/>
-        <source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>kDrive är i underhållsläge.&lt;br&gt;Synkroniseringen kommer att återupptas så snart som möjligt. Kontakta vår support om felet kvarstår.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="455"/>
-        <source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-        <translation>kDrive är blockerat.&lt;br&gt;Förnya kDrive. Om inga åtgärder vidtas kommer uppgifterna att raderas permanent och det går inte att återställa dem.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="460"/>
-        <source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-        <translation>kDrive är spärrat.&lt;br&gt;Kontakta en administratör för att återställa kDrive. Om inga åtgärder vidtas kommer uppgifterna att raderas permanent och det går inte att återställa dem.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="466"/>
-        <source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>kDrive startar upp.&lt;br&gt;Synkroniseringen kommer att återupptas så snart som möjligt. Kontakta vår support om felet kvarstår.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="475"/>
-        <source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
-        <translation>kDrive är inaktivt.&lt;br&gt;Logga in på &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web&lt;/a&gt;versionen för att kontrollera statusen för ditt kDrive, eller kontakta din administratör.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="479"/>
-        <source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive&apos;s status, or contact your administrator.</source>
-        <translation>kDrive är inaktivt.&lt;br&gt;Logga in på webbversionen för att kontrollera statusen för ditt kDrive, eller kontakta din administratör.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="483"/>
-        <source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
-        <translation>Du har inte behörighet att komma åt denna kDrive.&lt;br&gt;Synkroniseringen har pausats. Kontakta en administratör.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="493"/>
-        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>Ett tekniskt fel har uppstått (fel %1).&lt;br&gt;Synkroniseringen återupptas så snart som möjligt. Kontakta vår support om felet kvarstår.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="512"/>
-        <source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-        <translation>Nätverksanslutningarna har avbrutits av kärnan (fel %1).&lt;br&gt;Rensa historiken och kontakta vår support om felet kvarstår.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="522"/>
-        <source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
-        <translation>Tyvärr gick det inte att överföra din gamla konfiguration.&lt;br&gt;Programmet kommer att använda en tom konfiguration.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="526"/>
-        <source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
-        <translation>Tyvärr gick det inte att överföra din gamla proxykonfiguration, eftersom SOCKS5-proxyservrar inte stöds för närvarande.&lt;br&gt;Programmet kommer istället att använda systemets proxyinställningar.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="539"/>
-        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
-        <translation>Ett tekniskt fel har uppstått (fel %1).&lt;br&gt;Synkroniseringen har startats om. Rensa historiken och kontakta vår support om felet kvarstår.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="550"/>
-        <source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
-        <translation>Ett fel har uppstått vid åtkomst till synkroniseringsdatabasen (fel %1).&lt;br&gt;Synkroniseringen har avbrutits.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="564"/>
-        <source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
-        <translation>Ett inloggningsproblem har uppstått (fel %1).&lt;br&gt;Tokenet är ogiltigt eller har återkallats.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="569"/>
-        <source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
-        <translation>Nästlade synkroniseringar är inte tillåtna (fel %1).&lt;br&gt;Du bör endast behålla synkroniseringar där mapparna inte är nästlade.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="573"/>
-        <source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
-        <translation>Synkroniseringsmappen på den fjärranslutna kDrive-enheten finns inte längre eller är inte längre tillgänglig (fel %1).&lt;br&gt;Du måste återställa den, återställa åtkomsträttigheterna eller ta bort och skapa synkroniseringen på nytt.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="580"/>
-        <source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
-        <translation>Fel vid tolkning av filnamn (fel %1).&lt;br&gt;Specialtecken som dubbla citattecken, bakstreck eller radbrytningar kan orsaka fel vid tolkningen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="722"/>
-        <source>You are not allowed to move item to &quot;%1&quot;.&lt;br&gt;It will be restored into its original parent folder.</source>
-        <translation>Du får inte flytta objektet till &amp;quot;%1&amp;quot;.&lt;br&gt;Det kommer att återställas till sin ursprungliga överordnade mapp.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="814"/>
-        <source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
-        <translation>Det finns inte tillräckligt med utrymme kvar på din dator.&lt;br&gt;Nedladdningen har avbrutits.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="609"/>
-        <source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
-        <translation>Denna komponent har flyttats till en annan plats.&lt;br&gt;Den lokala åtgärden har avbrutits.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="618"/>
-        <source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
-        <translation>Det finns redan ett element med samma namn på den här platsen.&lt;br&gt;Det lokala elementet har bytt namn.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="614"/>
-        <source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
-        <translation>Det finns redan ett element med samma namn på den här platsen.&lt;br&gt;Den lokala åtgärden har avbrutits.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="393"/>
-        <source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
-        <translation>Det finns inte tillräckligt med utrymme kvar på din dator.&lt;br&gt;Synkroniseringen har avbrutits.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="622"/>
-        <source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
-        <translation>Filen redigerades samtidigt av en annan användare.&lt;br&gt;Dina ändringar har sparats i en kopia.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="626"/>
-        <source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
-        <translation>En annan användare har flyttat en överordnad mapp till målplatsen.&lt;br&gt;Den lokala åtgärden har avbrutits.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="692"/>
-        <source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Artikelnamnet innehåller endast mellanslag.&lt;br&gt;Det har tillfälligt lagts till på svartlistan.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="703"/>
-        <source>Either you are not allowed to create an item, or another item already exists with the same name.&lt;br&gt;The item has been excluded from synchronization.</source>
-        <translation>Antingen har du inte behörighet att skapa ett objekt, eller så finns det redan ett objekt med samma namn.&lt;br&gt;Objektet har undantagits från synkroniseringen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="708"/>
-        <source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
-        <translation>Du har inte behörighet att redigera objektet.&lt;br&gt;Filen med dina ändringar har bytt namn och har undantagits från synkroniseringen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="716"/>
-        <source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
-        <translation>Du får inte byta namn på objektet.&lt;br&gt;Det återställs till sitt ursprungliga namn.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="727"/>
-        <source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
-        <translation>Du får inte ta bort objektet.&lt;br&gt;Det återställs till sin ursprungliga plats.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="732"/>
-        <source>Failed to move this item to trash, it has been blacklisted.</source>
-        <translation>Det gick inte att flytta objektet till papperskorgen; det har lagts till i svartlistan.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="748"/>
-        <source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
-        <translation>Filen har ändrats lokalt samtidigt som den har raderats på den fjärranslutna kDrive-enheten. En&lt;br&gt;lokal kopia har sparats i räddningsmappen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="765"/>
-        <source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
-        <translation>Den åtgärd som utförts på objektet är inte tillåten.&lt;br&gt;Objektet har tillfälligt lagts till i svartlistan.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="771"/>
-        <source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
-        <translation>Åtgärden som utfördes på detta objekt misslyckades.&lt;br&gt;Objektet har tillfälligt lagts till i svartlistan.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="776"/>
-        <source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
-        <translation>Filen är för stor för att laddas upp. Den har tillfälligt blockerats.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="782"/>
-        <source>Impossible to download the file.</source>
-        <translation>Det går inte att ladda ner filen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="779"/>
-        <source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
-        <translation>Du har överskridit din kvot. Öka din lagringskvot för att återaktivera filuppladdning.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="389"/>
         <source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
-        <translation>Enheten som innehåller din synkroniseringsmapp är inte längre ansluten (fel %1).&lt;br&gt;Anslut den igen för att återuppta synkroniseringen.</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="393"/>
+        <source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="397"/>
+        <source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="401"/>
+        <source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing &apos;/etc/sysctl.conf&apos;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="406"/>
+        <source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="413"/>
         <source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
-        <translation>Det går inte att starta synkroniseringen (fel %1).&lt;br&gt;Processen LiteSyncExt körs inte just nu. Synkroniseringen återupptas så snart processen har startats.</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="419"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="424"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="429"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="435"/>
+        <source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="449"/>
+        <source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="455"/>
+        <source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="460"/>
+        <source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="466"/>
+        <source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="475"/>
+        <source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="479"/>
+        <source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="483"/>
+        <source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="493"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="512"/>
+        <source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="522"/>
+        <source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="526"/>
+        <source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="532"/>
+        <source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="539"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="550"/>
+        <source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="564"/>
+        <source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="569"/>
+        <source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="573"/>
+        <source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="580"/>
+        <source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="609"/>
+        <source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="614"/>
+        <source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="618"/>
+        <source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="622"/>
+        <source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="626"/>
+        <source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="649"/>
         <source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Ett befintligt objekt har ett identiskt namn med samma versaler och gemener.&lt;br&gt;Det har tillfälligt blockerats.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="656"/>
         <source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Produktnamnet innehåller ett tecken som inte stöds.&lt;br&gt;Det har tillfälligt blockerats.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="662"/>
         <source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Objektnamnet slutar med ett mellanslag, vilket inte är tillåtet i ditt operativsystem.&lt;br&gt;Det har tillfälligt lagts till i svartlistan.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="668"/>
         <source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Det här objektnamnet är reserverat av ditt operativsystem.&lt;br&gt;Det har tillfälligt lagts till i svartlistan.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="674"/>
         <source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Artikelnamnet är för långt.&lt;br&gt;Det har tillfälligt blockerats.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="680"/>
         <source>The item path is too long.&lt;br&gt;It has been ignored.</source>
-        <translation>Sökvägen är för lång.&lt;br&gt;Den har ignorerats.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="686"/>
         <source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
-        <translation>Objektnamnet innehåller ett nytt Unicode-tecken som ännu inte stöds av ditt filsystem.&lt;br&gt;Det har uteslutits från synkroniseringen.</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="692"/>
+        <source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="703"/>
+        <source>Either you are not allowed to create an item, or another item already exists with the same name.&lt;br&gt;The item has been excluded from synchronization.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="708"/>
+        <source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="716"/>
+        <source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="722"/>
+        <source>You are not allowed to move item to &quot;%1&quot;.&lt;br&gt;It will be restored into its original parent folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="727"/>
+        <source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="732"/>
+        <source>Failed to move this item to trash, it has been blacklisted.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="735"/>
         <source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
-        <translation>Det gick inte att synkronisera det här objektet. Det har tillfälligt lagts till i svartlistan.&lt;br&gt;Ett nytt försök att synkronisera det kommer att göras om en timme eller nästa gång programmet startas.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="740"/>
         <source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
-        <translation>Denna post har undantagits från synkroniseringen genom en anpassad mall.&lt;br&gt;Du kan inaktivera denna typ av avisering under Inställningar</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="745"/>
         <source>This item has been excluded from sync because it is a hard link.</source>
-        <translation>Den här posten har uteslutits från synkroniseringen eftersom det är en hård länk.</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="748"/>
+        <source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="765"/>
+        <source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="771"/>
+        <source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="776"/>
+        <source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="779"/>
+        <source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="782"/>
+        <source>Impossible to download the file.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="785"/>
         <source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
-        <translation>Den här artikeln är för närvarande upptagen av en annan användare som är inloggad.&lt;br&gt;Vi försöker ladda upp dina ändringar igen senare.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="790"/>
         <location filename="../src/gui/parametersdialog.cpp" line="834"/>
         <source>Synchronization error.</source>
-        <translation>Synkroniseringsfel.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="810"/>
         <source>Can&apos;t access item.&lt;br&gt;Please fix the read and write permissions.</source>
-        <translation>Det går inte att komma åt objektet.&lt;br&gt;Kontrollera läs- och skrivbehörigheterna.</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="814"/>
+        <source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="818"/>
         <source>System error.</source>
-        <translation>Systemfel.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="825"/>
         <source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Objektet finns redan på den andra sidan.&lt;br&gt;Det har tillfälligt blockerats.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="840"/>
         <source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-        <translation>Ett tekniskt fel har uppstått.&lt;br&gt;Rensa historiken och kontakta vår support om felet kvarstår.</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1082"/>
+        <source>Unable to open folder path %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1096"/>
+        <source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1097"/>
+        <source>Transmission failed!
+Please, use the following link to send the logs to the support: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1118"/>
+        <source>No kDrive configured!</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1953,7 +1946,7 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
     <message>
         <location filename="../src/gui/preferencesblocwidget.cpp" line="187"/>
         <source>This synchronization is being deleted.</source>
-        <translation>Denna synkronisering raderas.</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1961,165 +1954,165 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
     <message>
         <location filename="../src/gui/preferencesmenubarwidget.cpp" line="63"/>
         <source>Back to drive list</source>
-        <translation>Tillbaka till listan över körningar</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/preferencesmenubarwidget.cpp" line="64"/>
         <source>Preferences</source>
-        <translation>Inställningar</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>KDC::PreferencesWidget</name>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="491"/>
-        <source>General</source>
-        <translation>Allmänt</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="493"/>
-        <source>Activate dark theme</source>
-        <translation>Aktivera mörkt tema</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="495"/>
-        <source>Activate monochrome icons</source>
-        <translation>Aktivera monokroma ikoner</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="496"/>
-        <source>Launch kDrive at startup</source>
-        <translation>Starta kDrive vid uppstart</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="515"/>
-        <source>Finnish</source>
-        <translation>Finska</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="521"/>
-        <source>Advanced</source>
-        <translation>Avancerat</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="522"/>
-        <source>Debugging information</source>
-        <translation>Felsökningsinformation</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="524"/>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
-        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Öppna felsökningsmappen&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="525"/>
-        <source>Files to exclude</source>
-        <translation>Filer att exkludera</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="526"/>
-        <source>Proxy server</source>
-        <translation>Proxyserver</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="511"/>
-        <source>Swedish</source>
-        <translation>Svenska</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="512"/>
-        <source>Portuguese</source>
-        <translation>Portugisiska</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="513"/>
-        <source>Polish</source>
-        <translation>Polska</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="514"/>
-        <source>Norwegian</source>
-        <translation>Norska</translation>
-    </message>
-    <message>
         <location filename="../src/gui/preferenceswidget.cpp" line="466"/>
         <source>Unable to open folder %1.</source>
-        <translation>Det går inte att öppna mappen %1.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/preferenceswidget.cpp" line="478"/>
         <source>Unable to open link %1.</source>
-        <translation>Det går inte att öppna länken %1.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/preferenceswidget.cpp" line="483"/>
         <source>Invalid link %1.</source>
-        <translation>Ogiltig länk %1.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="528"/>
-        <source>Lite Sync</source>
-        <translation>Lite Sync</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="497"/>
-        <source>Language</source>
-        <translation>Språk</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/preferenceswidget.cpp" line="490"/>
         <source>Some process failed to run.</source>
-        <translation>Någon process kunde inte köras.</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="491"/>
+        <source>General</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="493"/>
+        <source>Activate dark theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="495"/>
+        <source>Activate monochrome icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="496"/>
+        <source>Launch kDrive at startup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="497"/>
+        <source>Language</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/preferenceswidget.cpp" line="498"/>
         <source>Move deleted files to my computer&apos;s trash</source>
-        <translation>Flytta borttagna filer till datorns papperskorg</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/preferenceswidget.cpp" line="499"/>
         <source>Some files or folders may not be moved to the computer&apos;s trash.</source>
-        <translation>Vissa filer eller mappar kanske inte kan flyttas till datorns papperskorg.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/preferenceswidget.cpp" line="500"/>
         <source>You can always retrieve already synced files from the kDrive web application trash.</source>
-        <translation>Du kan alltid återställa redan synkroniserade filer från papperskorgen i kDrives webbapp.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/preferenceswidget.cpp" line="502"/>
         <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Läs mer&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="506"/>
-        <source>English</source>
-        <translation>Engelska</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="507"/>
-        <source>French</source>
-        <translation>Franska</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="508"/>
-        <source>German</source>
-        <translation>Tyska</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="509"/>
-        <source>Spanish</source>
-        <translation>Spanska</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="510"/>
-        <source>Italian</source>
-        <translation>Italienska</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/preferenceswidget.cpp" line="505"/>
         <source>Default</source>
-        <translation>Standard</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="506"/>
+        <source>English</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="507"/>
+        <source>French</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="508"/>
+        <source>German</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="509"/>
+        <source>Spanish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="510"/>
+        <source>Italian</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="511"/>
+        <source>Swedish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="512"/>
+        <source>Portuguese</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="513"/>
+        <source>Polish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="514"/>
+        <source>Norwegian</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="515"/>
+        <source>Finnish</source>
+        <translation>Suomi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="521"/>
+        <source>Advanced</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="522"/>
+        <source>Debugging information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="524"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="525"/>
+        <source>Files to exclude</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="526"/>
+        <source>Proxy server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="528"/>
+        <source>Lite Sync</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2127,7 +2120,7 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
     <message>
         <location filename="../src/gui/progressbarwidget.cpp" line="70"/>
         <source>%1 in use</source>
-        <translation>%1 används</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2135,77 +2128,77 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
     <message>
         <location filename="../src/gui/proxyserverdialog.cpp" line="50"/>
         <source>HTTP(S) Proxy</source>
-        <translation>HTTP(S)-proxy</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/proxyserverdialog.cpp" line="73"/>
         <source>Proxy server</source>
-        <translation>Proxyserver</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/proxyserverdialog.cpp" line="85"/>
         <source>No proxy server</source>
-        <translation>Ingen proxyserver</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/proxyserverdialog.cpp" line="90"/>
         <source>Use system parameters</source>
-        <translation>Använd systemparametrar</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/proxyserverdialog.cpp" line="95"/>
         <source>Indicate a proxy manually</source>
-        <translation>Ange en fullmaktsinnehavare manuellt</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/proxyserverdialog.cpp" line="131"/>
         <source>Port</source>
-        <translation>Hamn</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/proxyserverdialog.cpp" line="144"/>
         <source>Address of the proxy server</source>
-        <translation>Proxyserverns adress</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/proxyserverdialog.cpp" line="150"/>
         <source>Authentication needed</source>
-        <translation>Inloggning krävs</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/proxyserverdialog.cpp" line="165"/>
         <source>User</source>
-        <translation>Användare</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/proxyserverdialog.cpp" line="171"/>
         <source>Password</source>
-        <translation>Lösenord</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/proxyserverdialog.cpp" line="185"/>
         <source>SAVE</source>
-        <translation>SPARA</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/proxyserverdialog.cpp" line="192"/>
         <source>CANCEL</source>
-        <translation>AVBRYT</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/proxyserverdialog.cpp" line="286"/>
         <source>Do you want to save your modifications?</source>
-        <translation>Vill du spara dina ändringar?</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/proxyserverdialog.cpp" line="295"/>
         <source>Unable to save, all mandatory fields are not completed!</source>
-        <translation>Det går inte att spara, eftersom alla obligatoriska fält inte är ifyllda!</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/proxyserverdialog.cpp" line="316"/>
         <source>Proxy not found, save anyway?</source>
-        <translation>Proxy hittades inte, vill du spara ändå?</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2213,27 +2206,27 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
     <message>
         <location filename="../src/gui/resourcesmanagerdialog.cpp" line="55"/>
         <source>Resources Manager</source>
-        <translation>Resursansvarig</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/resourcesmanagerdialog.cpp" line="65"/>
         <source>Maximum CPU usage allowed</source>
-        <translation>Högsta tillåtna CPU-användning</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/resourcesmanagerdialog.cpp" line="96"/>
         <source>SAVE</source>
-        <translation>SPARA</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/resourcesmanagerdialog.cpp" line="103"/>
         <source>CANCEL</source>
-        <translation>AVBRYT</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/resourcesmanagerdialog.cpp" line="122"/>
         <source>Do you want to save your modifications?</source>
-        <translation>Vill du spara dina ändringar?</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2241,37 +2234,37 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
     <message>
         <location filename="../src/gui/serverbasefolderdialog.cpp" line="81"/>
         <source>Select a folder on your kDrive</source>
-        <translation>Välj en mapp på din kDrive</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/serverbasefolderdialog.cpp" line="90"/>
         <source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
-        <translation>Innehållet i den valda mappen kommer att synkroniseras till mappen &lt;b&gt;%1&lt;/b&gt;.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/serverbasefolderdialog.cpp" line="134"/>
         <source>CONTINUE</source>
-        <translation>FORTSÄTT</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/serverbasefolderdialog.cpp" line="150"/>
         <source>Space available on your computer for the current folder : %1</source>
-        <translation>Ledig utrymme på din dator för den aktuella mappen: %1</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/serverbasefolderdialog.cpp" line="190"/>
         <source>This folder is already being synced.</source>
-        <translation>Den här mappen synkroniseras redan.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/serverbasefolderdialog.cpp" line="204"/>
         <source>CONFIRM</source>
-        <translation>BEKRÄFTA</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/serverbasefolderdialog.cpp" line="205"/>
         <source>CANCEL</source>
-        <translation>AVBRYT</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2279,17 +2272,17 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
     <message>
         <location filename="../src/gui/serverfoldersdialog.cpp" line="80"/>
         <source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
-        <translation>Mappen &lt;b&gt;%1&lt;/b&gt; innehåller undermappar.&lt;br&gt; Välj de som du vill synkronisera</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/serverfoldersdialog.cpp" line="110"/>
         <source>CONTINUE</source>
-        <translation>FORTSÄTT</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/serverfoldersdialog.cpp" line="146"/>
         <source>No subfolders currently on the server.</source>
-        <translation>Det finns för närvarande inga undermappar på servern.</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2297,287 +2290,287 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
     <message>
         <location filename="../src/gui/statusbarwidget.cpp" line="178"/>
         <source>Resume kDrive &quot;%1&quot; synchronization</source>
-        <translation>Återuppta synkroniseringen av kDrive &amp;quot;%1&amp;quot;</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/statusbarwidget.cpp" line="180"/>
-        <source>Resume all kDrives synchronization</source>
-        <translation>Återuppta all synkronisering av kDrives</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/statusbarwidget.cpp" line="183"/>
-        <source>Pause kDrive &quot;%1&quot; synchronization</source>
-        <translation>Avbryt synkroniseringen av kDrive &amp;quot;%1&amp;quot;</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/statusbarwidget.cpp" line="184"/>
-        <location filename="../src/gui/statusbarwidget.cpp" line="321"/>
-        <source>Pause synchronization</source>
-        <translation>Pausa synkroniseringen</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/statusbarwidget.cpp" line="185"/>
-        <source>Pause all kDrives synchronization</source>
-        <translation>Pausa all synkronisering av kDrives</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/statusbarwidget.cpp" line="179"/>
         <location filename="../src/gui/statusbarwidget.cpp" line="322"/>
         <source>Resume synchronization</source>
-        <translation>Fortsätt synkroniseringen</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="180"/>
+        <source>Resume all kDrives synchronization</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="183"/>
+        <source>Pause kDrive &quot;%1&quot; synchronization</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="184"/>
+        <location filename="../src/gui/statusbarwidget.cpp" line="321"/>
+        <source>Pause synchronization</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="185"/>
+        <source>Pause all kDrives synchronization</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>KDC::SynchronizedItemWidget</name>
     <message>
-        <location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
-        <source>Copy share link</source>
-        <translation>Kopiera delningslänken</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
-        <source>Display on kdrive.infomaniak.com</source>
-        <translation>Visas på kdrive.infomaniak.com</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
-        <source>Show in folder</source>
-        <translation>Visa i mappen</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
-        <source>More actions</source>
-        <translation>Fler åtgärder</translation>
-    </message>
-    <message>
         <location filename="../src/gui/synchronizeditemwidget.cpp" line="317"/>
         <source>Open</source>
-        <translation>Öppna</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
         <source>Add to favorites</source>
-        <translation>Lägg till i favoriter</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
+        <source>Copy share link</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
+        <source>Display on kdrive.infomaniak.com</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
+        <source>Show in folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
+        <source>More actions</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>KDC::SynthesisBar</name>
     <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="149"/>
+        <source>Unable to open folder url %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="219"/>
+        <source>Open in folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="257"/>
+        <source>Open %1 web version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="267"/>
+        <source>Drive parameters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="280"/>
+        <source>Notifications disabled until %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="281"/>
+        <source>Disable Notifications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="314"/>
+        <source>Application preferences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="322"/>
+        <source>Need help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="330"/>
+        <source>Send feedbacks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="338"/>
+        <source>Quit kDrive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="401"/>
+        <source>Unable to access web site %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="492"/>
+        <source>Show errors and informations</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="493"/>
+        <source>Show informations</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="494"/>
+        <source>More actions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/gui/synthesisbar.cpp" line="495"/>
         <location filename="../src/gui/synthesisbar.cpp" line="502"/>
         <source>Never</source>
-        <translation>Aldrig</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/synthesisbar.cpp" line="496"/>
         <source>During 1 hour</source>
-        <translation>Under 1 timme</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/synthesisbar.cpp" line="497"/>
         <location filename="../src/gui/synthesisbar.cpp" line="504"/>
         <source>Until tomorrow 8:00AM</source>
-        <translation>Fram till imorgon kl. 08.00</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/synthesisbar.cpp" line="498"/>
         <source>During 3 days</source>
-        <translation>Under tre dagar</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/synthesisbar.cpp" line="499"/>
         <source>During 1 week</source>
-        <translation>Under en vecka</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/synthesisbar.cpp" line="500"/>
         <location filename="../src/gui/synthesisbar.cpp" line="507"/>
         <source>Always</source>
-        <translation>Alltid</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/synthesisbar.cpp" line="503"/>
         <source>For 1 more hour</source>
-        <translation>I ytterligare 1 timme</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/synthesisbar.cpp" line="505"/>
         <source>For 3 more days</source>
-        <translation>I ytterligare 3 dagar</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/synthesisbar.cpp" line="506"/>
         <source>For 1 more week</source>
-        <translation>Ytterligare en vecka</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="149"/>
-        <source>Unable to open folder url %1.</source>
-        <translation>Det går inte att öppna mappen med adressen %1.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="219"/>
-        <source>Open in folder</source>
-        <translation>Öppna i mappen</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="257"/>
-        <source>Open %1 web version</source>
-        <translation>Öppna webbversionen av %1</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="267"/>
-        <source>Drive parameters</source>
-        <translation>Drivparametrar</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="280"/>
-        <source>Notifications disabled until %1</source>
-        <translation>Meddelanden är inaktiverade fram till %1</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="281"/>
-        <source>Disable Notifications</source>
-        <translation>Inaktivera aviseringar</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="314"/>
-        <source>Application preferences</source>
-        <translation>Inställningar för applikationen</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="322"/>
-        <source>Need help</source>
-        <translation>Behöver du hjälp?</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="330"/>
-        <source>Send feedbacks</source>
-        <translation>Skicka synpunkter</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="338"/>
-        <source>Quit kDrive</source>
-        <translation>Avsluta kDrive</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="401"/>
-        <source>Unable to access web site %1.</source>
-        <translation>Det går inte att komma åt webbplatsen %1.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="492"/>
-        <source>Show errors and informations</source>
-        <translation>Visa fel och information</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="493"/>
-        <source>Show informations</source>
-        <translation>Visa information</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="494"/>
-        <source>More actions</source>
-        <translation>Fler åtgärder</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>KDC::SynthesisPopover</name>
     <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1181"/>
-        <source>Update kDrive App</source>
-        <translation>Uppdatera kDrive-appen</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1182"/>
-        <source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
-        <translation>Denna version av kDrive-appen stöds inte längre. Uppdatera appen för att få tillgång till de senaste funktionerna och förbättringarna.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="978"/>
-        <source>Update</source>
-        <translation>Uppdatering</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1187"/>
-        <source>Please download the latest version on the website.</source>
-        <translation>Ladda gärna ner den senaste versionen från webbplatsen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="981"/>
-        <source>Update download in progress</source>
-        <translation>Uppdateringen hämtas just nu</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="984"/>
-        <source>Looking for update...</source>
-        <translation>Väntar på uppdatering...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="987"/>
-        <source>Manual update</source>
-        <translation>Manuell uppdatering</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="990"/>
-        <source>Unavailable</source>
-        <translation>Ej tillgängligt</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1200"/>
-        <source>You can synchronize files &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;from your computer&lt;/a&gt; or on &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
-        <translation>Du kan synkronisera filer &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;från din dator&lt;/a&gt; eller från &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
-    </message>
-    <message>
         <location filename="../src/gui/synthesispopover.cpp" line="446"/>
         <source>Synchronized</source>
-        <translation>Synkroniserad</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/synthesispopover.cpp" line="450"/>
         <source>Favorites</source>
-        <translation>Favoriter</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/synthesispopover.cpp" line="454"/>
         <source>Activity</source>
-        <translation>Aktivitet</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="586"/>
+        <source>Unable to open folder url %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="978"/>
+        <source>Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="981"/>
+        <source>Update download in progress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="984"/>
+        <source>Looking for update...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="987"/>
+        <source>Manual update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="990"/>
+        <source>Unavailable</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/synthesispopover.cpp" line="1133"/>
         <location filename="../src/gui/synthesispopover.cpp" line="1180"/>
         <source>Not implemented!</source>
-        <translation>Har inte implementerats!</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1184"/>
-        <source>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Click here to download manually&lt;/a&gt;</source>
-        <translation>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Klicka här för att ladda ner manuellt&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1193"/>
-        <source>No synchronized folder for this Drive!</source>
-        <translation>Det finns ingen synkroniserad mapp för den här Drive-kontot!</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1196"/>
-        <source>No kDrive configured!</source>
-        <translation>kDrive är inte konfigurerat!</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/synthesispopover.cpp" line="1161"/>
         <source>Unable to open link %1.</source>
-        <translation>Det går inte att öppna länken %1.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/synthesispopover.cpp" line="1173"/>
         <source>Invalid link %1.</source>
-        <translation>Ogiltig länk %1.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="586"/>
-        <source>Unable to open folder url %1.</source>
-        <translation>Det går inte att öppna mappen med adressen %1.</translation>
+        <location filename="../src/gui/synthesispopover.cpp" line="1181"/>
+        <source>Update kDrive App</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1182"/>
+        <source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1184"/>
+        <source>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Click here to download manually&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1187"/>
+        <source>Please download the latest version on the website.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1193"/>
+        <source>No synchronized folder for this Drive!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1196"/>
+        <source>No kDrive configured!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1200"/>
+        <source>You can synchronize files &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;from your computer&lt;/a&gt; or on &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2585,22 +2578,22 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
     <message>
         <location filename="../src/gui/updater/updatedialog.cpp" line="61"/>
         <source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
-        <translation>&lt;p&gt;Den nya versionen &lt;b&gt;%1&lt;/b&gt; av %2-klienten är tillgänglig och har hämtats.&lt;/p&gt;&lt;p&gt;Den installerade versionen är %3.&lt;/p&gt;</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/updater/updatedialog.cpp" line="95"/>
         <source>Skip this version</source>
-        <translation>Hoppa över den här versionen</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/updater/updatedialog.cpp" line="103"/>
         <source>Remind me later</source>
-        <translation>Påminn mig senare</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/updater/updatedialog.cpp" line="109"/>
         <source>Install update</source>
-        <translation>Installera uppdatering</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2608,12 +2601,12 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
     <message>
         <location filename="../src/server/updater/updatemanager.cpp" line="86"/>
         <source>New update available.</source>
-        <translation>En ny uppdatering finns tillgänglig.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/server/updater/updatemanager.cpp" line="87"/>
         <source>Version %1 is available for download.</source>
-        <translation>Version %1 finns tillgänglig för nedladdning.</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2621,223 +2614,223 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
     <message>
         <location filename="../src/gui/userselectionwidget.cpp" line="131"/>
         <source>Add an account</source>
-        <translation>Lägg till ett konto</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>KDC::VersionWidget</name>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="295"/>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</source>
-        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</translation>
-    </message>
-    <message>
         <location filename="../src/gui/versionwidget.cpp" line="169"/>
         <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Show release note&lt;/a&gt;</source>
-        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Visa informationsnot&lt;/a&gt;</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/versionwidget.cpp" line="172"/>
         <source>Version</source>
-        <translation>Version</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/versionwidget.cpp" line="173"/>
         <source>UPDATE</source>
-        <translation>UPPDATERING</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/versionwidget.cpp" line="197"/>
         <source>%1 is up to date!</source>
-        <translation>%1 är uppdaterad!</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/versionwidget.cpp" line="201"/>
         <source>Checking update on server...</source>
-        <translation>Kontrollerar uppdateringar på servern...</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/versionwidget.cpp" line="205"/>
         <source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;here&lt;/a&gt;.</source>
-        <translation>En uppdatering finns tillgänglig: %1.&lt;br&gt;Ladda ner den &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;här&lt;/a&gt;.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/versionwidget.cpp" line="212"/>
         <source>An update is available: %1</source>
-        <translation>En uppdatering finns tillgänglig: %1</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/versionwidget.cpp" line="218"/>
         <source>Downloading %1. Please wait...</source>
-        <translation>Hämtar %1. Vänta...</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/versionwidget.cpp" line="223"/>
         <source>Could not check for new updates.</source>
-        <translation>Det gick inte att söka efter nya uppdateringar.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/versionwidget.cpp" line="227"/>
         <source>An error occurred during update.</source>
-        <translation>Ett fel uppstod under uppdateringen.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/versionwidget.cpp" line="231"/>
         <source>Could not download update.</source>
-        <translation>Det gick inte att ladda ner uppdateringen.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/versionwidget.cpp" line="235"/>
         <source>Update disabled.</source>
-        <translation>Uppdateringen är inaktiverad.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/versionwidget.cpp" line="251"/>
         <source>Beta program</source>
-        <translation>Betaprogram</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/versionwidget.cpp" line="252"/>
         <source>Get early access to new versions of the application</source>
-        <translation>Få tidig tillgång till nya versioner av applikationen</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/versionwidget.cpp" line="256"/>
         <source>Join</source>
-        <translation>Gå med</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/versionwidget.cpp" line="259"/>
         <source>Modify</source>
-        <translation>Ändra</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/versionwidget.cpp" line="259"/>
         <source>Quit</source>
-        <translation>Avsluta</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="295"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/gui/parameterscache.cpp" line="59"/>
-        <source>Unable to save parameters, please retry later.</source>
-        <translation>Det gick inte att spara parametrarna. Försök igen senare.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parameterscache.cpp" line="60"/>
-        <source>Unable to save parameters!</source>
-        <translation>Det går inte att spara parametrarna!</translation>
-    </message>
-    <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="461"/>
-        <source>The parent folder is a sync folder or contained in one</source>
-        <translation>Överordnad mapp är en synkroniseringsmapp eller ingår i en sådan</translation>
-    </message>
-    <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="495"/>
-        <source>Can&apos;t find a valid path</source>
-        <translation>Det går inte att hitta en giltig sökväg</translation>
-    </message>
-    <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2108"/>
-        <source>No valid folder selected!</source>
-        <translation>Ingen giltig mapp har valts!</translation>
-    </message>
-    <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2119"/>
-        <source>The selected path does not exist!</source>
-        <translation>Den valda sökvägen finns inte!</translation>
-    </message>
-    <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2124"/>
-        <source>The selected path is not a folder!</source>
-        <translation>Den valda sökvägen är ingen mapp!</translation>
-    </message>
-    <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2129"/>
-        <source>You have no permission to write to the selected folder!</source>
-        <translation>Du har inte behörighet att skriva till den valda mappen!</translation>
-    </message>
-    <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2159"/>
-        <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
-        <translation>Den lokala mappen %1 innehåller en mapp som redan är synkroniserad. Välj en annan!</translation>
-    </message>
-    <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2167"/>
-        <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
-        <translation>Den lokala mappen %1 finns i en mapp som redan är synkroniserad. Välj en annan mapp!</translation>
-    </message>
-    <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2175"/>
-        <source>The local folder %1 is already synced. Please pick another one!</source>
-        <translation>Den lokala mappen %1 är redan synkroniserad. Välj en annan!</translation>
-    </message>
-    <message>
         <location filename="../src/gui/folderitemwidget.cpp" line="42"/>
         <source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
-        <translation>Lite sync (Beta) är aktiverat. Filerna från kDrive sparas i molnet och tar inte upp lagringsutrymme på din dator.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/folderitemwidget.cpp" line="45"/>
         <source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
-        <translation>Lite sync (Beta) är inaktiverat. kDrive-filerna använder lagringsutrymmet på din dator.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/folderitemwidget.cpp" line="48"/>
         <source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
-        <translation>Lite-synkronisering är aktiverad. Filerna från kDrive sparas i molnet och tar inte upp lagringsutrymme på din dator.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/folderitemwidget.cpp" line="50"/>
         <source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
-        <translation>Lite sync är inaktiverat. kDrive-filerna använder lagringsutrymmet på din dator.</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parameterscache.cpp" line="59"/>
+        <source>Unable to save parameters, please retry later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parameterscache.cpp" line="60"/>
+        <source>Unable to save parameters!</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/server/comm/extensionjob.cpp" line="1175"/>
         <source>Make available locally</source>
-        <translation>Gör tillgängligt lokalt</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/server/comm/extensionjob.cpp" line="1179"/>
         <source>Free up local space</source>
-        <translation>Frigör lokalt lagringsutrymme</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/server/comm/extensionjob.cpp" line="1183"/>
         <source>Cancel free up local space</source>
-        <translation>Avbryt för att frigöra lokalt utrymme</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/server/comm/extensionjob.cpp" line="1187"/>
         <source>Cancel make available locally</source>
-        <translation>Avbryt lokal tillgängliggöring</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/server/comm/extensionjob.cpp" line="1191"/>
         <source>Resharing this file is not allowed</source>
-        <translation>Det är inte tillåtet att vidarebefordra den här filen</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/server/comm/extensionjob.cpp" line="1192"/>
         <source>Resharing this folder is not allowed</source>
-        <translation>Det är inte tillåtet att dela den här mappen vidare</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/server/comm/extensionjob.cpp" line="1196"/>
         <source>Copy public share link</source>
-        <translation>Kopiera länken till den offentliga delningen</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/server/comm/extensionjob.cpp" line="1200"/>
         <source>Copy private share link</source>
-        <translation>Kopiera länken till den privata delningen</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/server/comm/extensionjob.cpp" line="1204"/>
         <source>Open in browser</source>
-        <translation>Öppna i webbläsaren</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="461"/>
+        <source>The parent folder is a sync folder or contained in one</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="495"/>
+        <source>Can&apos;t find a valid path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2108"/>
+        <source>No valid folder selected!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2119"/>
+        <source>The selected path does not exist!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2124"/>
+        <source>The selected path is not a folder!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2129"/>
+        <source>You have no permission to write to the selected folder!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2159"/>
+        <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2167"/>
+        <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2175"/>
+        <source>The local folder %1 is already synced. Please pick another one!</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2845,78 +2838,78 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
     <message>
         <location filename="../src/server/appserver.cpp" line="133"/>
         <source>kDrive application will close due to a fatal error.</source>
-        <translation>kDrive-programmet kommer att stängas på grund av ett allvarligt fel.</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Utility</name>
-    <message>
-        <location filename="../src/libcommongui/utility/utility.cpp" line="97"/>
-        <source>%L1 GB</source>
-        <translation>%L1 GB</translation>
-    </message>
-    <message>
-        <location filename="../src/libcommongui/utility/utility.cpp" line="101"/>
-        <source>%L1 MB</source>
-        <translation>%L1 MB</translation>
-    </message>
-    <message>
-        <location filename="../src/libcommongui/utility/utility.cpp" line="105"/>
-        <source>%L1 KB</source>
-        <translation>%L1 KB</translation>
-    </message>
-    <message>
-        <location filename="../src/libcommongui/utility/utility.cpp" line="108"/>
-        <source>%L1 B</source>
-        <translation>%L1 B</translation>
-    </message>
     <message numerus="yes">
         <location filename="../src/libcommongui/utility/utility.cpp" line="41"/>
         <source>%n year(s)</source>
-        <translation>
-            <numerusform>%n år</numerusform>
-            <numerusform>%n år</numerusform>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/libcommongui/utility/utility.cpp" line="42"/>
         <source>%n month(s)</source>
-        <translation>
-            <numerusform>%n månad</numerusform>
-            <numerusform>%n månader</numerusform>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/libcommongui/utility/utility.cpp" line="43"/>
         <source>%n day(s)</source>
-        <translation>
-            <numerusform>%n dag</numerusform>
-            <numerusform>%n dagar</numerusform>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/libcommongui/utility/utility.cpp" line="44"/>
         <source>%n hour(s)</source>
-        <translation>
-            <numerusform>%n timme</numerusform>
-            <numerusform>%n timmar</numerusform>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/libcommongui/utility/utility.cpp" line="45"/>
         <source>%n minute(s)</source>
-        <translation>
-            <numerusform>%n minut</numerusform>
-            <numerusform>%n minuter</numerusform>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/libcommongui/utility/utility.cpp" line="46"/>
         <source>%n second(s)</source>
-        <translation>
-            <numerusform>%n sekund</numerusform>
-            <numerusform>%n sekunder</numerusform>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="97"/>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="101"/>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="105"/>
+        <source>%L1 KB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="108"/>
+        <source>%L1 B</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2924,121 +2917,119 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
     <message>
         <location filename="../src/gui/guiutility.cpp" line="84"/>
         <source>Could not open browser</source>
-        <translation>Det gick inte att öppna webbläsaren</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/guiutility.cpp" line="85"/>
         <source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
-        <translation>Det uppstod ett fel när webbläsaren startades för att öppna webbadressen %1. Kanske har ingen standardwebbläsare angetts?</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/guiutility.cpp" line="104"/>
         <source>Could not open email client</source>
-        <translation>Det gick inte att öppna e-postprogrammet</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/guiutility.cpp" line="105"/>
         <source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
-        <translation>Det uppstod ett fel när e-postprogrammet startades för att skapa ett nytt meddelande. Kanske har inget standardprogram för e-post konfigurerats?</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/guiutility.cpp" line="324"/>
         <source>You are not connected anymore. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Log in&lt;/a&gt;</source>
-        <translation>Du är inte inloggad längre. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Logga in&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="347"/>
-        <source>Sync in progress (Step %1/%2).</source>
-        <translation>Synkronisering pågår (Steg %1/%2).</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="353"/>
-        <source>Sync in progress.</source>
-        <translation>Synkronisering pågår.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="364"/>
-        <source>Some files couldn&apos;t be synchronized. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation>Vissa filer kunde inte synkroniseras. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Läs mer&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="370"/>
-        <source>Synchronization pausing ...</source>
-        <translation>Synkroniseringen pausas ...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="570"/>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
-        <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan inte väljas eftersom en annan synkronisering använder samma mapp.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="576"/>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-        <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan inte väljas eftersom den innehåller den synkroniserade mappen &lt;b&gt;%2&lt;/b&gt;.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="584"/>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-        <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan inte väljas eftersom den ingår i den synkroniserade mappen &lt;b&gt;%2&lt;/b&gt;.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="595"/>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
-        <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan inte väljas som synkroniseringsmapp. Välj en annan mapp.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="599"/>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
-        <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan inte väljas som synkroniseringsmapp. Välj en annan mapp. Föreslagen mapp: &lt;b&gt;%2&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="651"/>
-        <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
-        <translation>Du har uteslutit mer än %1 mappar. Observera att detta kommer att påverka synkroniseringsprestandan.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="660"/>
-        <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
-        <translation>Du kan inte utesluta fler än %1 mappar. Avmarkera mapparna på högre nivå.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="351"/>
-        <source>Synchronization starting</source>
-        <translation>Synkroniseringen påbörjas</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="374"/>
-        <source>Synchronization paused.</source>
-        <translation>Synkroniseringen har pausats.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="336"/>
-        <source>Sync in progress (%1 of %2)</source>
-        <translation>Synkronisering pågår (%1 av %2)</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="340"/>
-        <source>Sync in progress (%1 of %2)
-%3 left...</source>
-        <translation>Synkronisering pågår (%1 av %2)
-%3 kvar...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="358"/>
-        <source>You are up to date, unresolved conflicts.</source>
-        <translation>Du har aktuella, olösta konflikter.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="360"/>
-        <source>You are up to date!</source>
-        <translation>Nu är du uppdaterad!</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/guiutility.cpp" line="329"/>
         <source>No folder to synchronize
 You can add one from the kDrive settings.</source>
-        <translation>Ingen mapp att synkronisera
-Du kan lägga till en i kDrive-inställningarna.</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="336"/>
+        <source>Sync in progress (%1 of %2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="340"/>
+        <source>Sync in progress (%1 of %2)
+%3 left...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="347"/>
+        <source>Sync in progress (Step %1/%2).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="351"/>
+        <source>Synchronization starting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="353"/>
+        <source>Sync in progress.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="358"/>
+        <source>You are up to date, unresolved conflicts.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="360"/>
+        <source>You are up to date!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="364"/>
+        <source>Some files couldn&apos;t be synchronized. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="370"/>
+        <source>Synchronization pausing ...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="374"/>
+        <source>Synchronization paused.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="570"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="576"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="584"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="595"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="599"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="651"/>
+        <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="660"/>
+        <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/client_fr.ts
+++ b/translations/client_fr.ts
@@ -305,12 +305,12 @@ Veuillez sélectionner un autre dossier. Si vous continuez, Lite Sync sera désa
 <context>
     <name>KDC::AppServer</name>
     <message>
-        <location filename="../src/server/appserver.cpp" line="1679"/>
+        <location filename="../src/server/appserver.cpp" line="1685"/>
         <source>Share link copied to clipboard</source>
         <translation>Lien de partage copié dans le presse-papiers</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/server/appserver.cpp" line="3759"/>
+        <location filename="../src/server/appserver.cpp" line="3773"/>
         <source>%1 and %n other file(s) have been removed.</source>
         <translation>
             <numerusform>%1 a été supprimé.</numerusform>
@@ -318,13 +318,13 @@ Veuillez sélectionner un autre dossier. Si vous continuez, Lite Sync sera désa
         </translation>
     </message>
     <message>
-        <location filename="../src/server/appserver.cpp" line="3761"/>
+        <location filename="../src/server/appserver.cpp" line="3775"/>
         <source>%1 has been removed.</source>
         <comment>%1 names a file.</comment>
         <translation>%1 a été supprimé.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/server/appserver.cpp" line="3766"/>
+        <location filename="../src/server/appserver.cpp" line="3780"/>
         <source>%1 and %n other file(s) have been added.</source>
         <translation>
             <numerusform>%1 et %n autre(s) fichier(s) ont été ajouté(s).</numerusform>
@@ -332,13 +332,13 @@ Veuillez sélectionner un autre dossier. Si vous continuez, Lite Sync sera désa
         </translation>
     </message>
     <message>
-        <location filename="../src/server/appserver.cpp" line="3768"/>
+        <location filename="../src/server/appserver.cpp" line="3782"/>
         <source>%1 has been added.</source>
         <comment>%1 names a file.</comment>
         <translation>%1 a été ajouté.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/server/appserver.cpp" line="3773"/>
+        <location filename="../src/server/appserver.cpp" line="3787"/>
         <source>%1 and %n other file(s) have been updated.</source>
         <translation>
             <numerusform>%1 a été mis à jour.</numerusform>
@@ -346,13 +346,13 @@ Veuillez sélectionner un autre dossier. Si vous continuez, Lite Sync sera désa
         </translation>
     </message>
     <message>
-        <location filename="../src/server/appserver.cpp" line="3775"/>
+        <location filename="../src/server/appserver.cpp" line="3789"/>
         <source>%1 has been updated.</source>
         <comment>%1 names a file.</comment>
         <translation>%1 a été mis à jour.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/server/appserver.cpp" line="3780"/>
+        <location filename="../src/server/appserver.cpp" line="3794"/>
         <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
         <translation>
             <numerusform>%1 a été déplacé vers %2.</numerusform>
@@ -360,12 +360,12 @@ Veuillez sélectionner un autre dossier. Si vous continuez, Lite Sync sera désa
         </translation>
     </message>
     <message>
-        <location filename="../src/server/appserver.cpp" line="3783"/>
+        <location filename="../src/server/appserver.cpp" line="3797"/>
         <source>%1 has been moved to %2.</source>
         <translation>%1 a été déplacé vers %2.</translation>
     </message>
     <message>
-        <location filename="../src/server/appserver.cpp" line="3791"/>
+        <location filename="../src/server/appserver.cpp" line="3805"/>
         <source>Sync Activity</source>
         <translation>Activité de synchronisation</translation>
     </message>
@@ -469,18 +469,18 @@ Veuillez sélectionner un autre dossier. Si vous continuez, Lite Sync sera désa
         <translation>Aucun dossier à synchroniser n&apos;est configuré.</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1426"/>
+        <location filename="../src/gui/clientgui.cpp" line="1422"/>
         <source>Synthesis</source>
         <translation>Synthèse</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1427"/>
+        <location filename="../src/gui/clientgui.cpp" line="1423"/>
         <source>Preferences</source>
         <translatorcomment>Préférences</translatorcomment>
         <translation>Préférences</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1428"/>
+        <location filename="../src/gui/clientgui.cpp" line="1424"/>
         <source>Quit</source>
         <translation>Quitter</translation>
     </message>
@@ -525,22 +525,22 @@ Veuillez sélectionner un autre dossier. Si vous continuez, Lite Sync sera désa
         <translation>%1 (Synchronisation en pause)</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1261"/>
+        <location filename="../src/gui/clientgui.cpp" line="1257"/>
         <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
         <translation>Voulez-vous vraiment supprimer les synchronisations du compte &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Remarque&#xa0;:&lt;/b&gt; Cela &lt;b&gt;ne&lt;/b&gt; supprimera aucun fichier.</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1265"/>
+        <location filename="../src/gui/clientgui.cpp" line="1261"/>
         <source>REMOVE ALL SYNCHRONIZATIONS</source>
         <translation>SUPPRIMER TOUTES LES SYNC</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1266"/>
+        <location filename="../src/gui/clientgui.cpp" line="1262"/>
         <source>CANCEL</source>
         <translation>ANNULER</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1594"/>
+        <location filename="../src/gui/clientgui.cpp" line="1590"/>
         <source>Failed to start synchronizations!</source>
         <translation>Échec du démarrage des synchronisations&#xa0;!</translation>
     </message>
@@ -793,89 +793,94 @@ Veuillez sélectionner un autre dossier. Si vous continuez, Lite Sync sera désa
         <translation>Journal complet étendu</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="206"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="207"/>
         <source>Delete logs older than %1 days</source>
         <translation>Supprimer les journaux datant de plus de %1 jours</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="225"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="226"/>
         <source>Share the debug folder with Infomaniak support.</source>
         <translation>Partagez le dossier debug avec le support Infomaniak.</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="249"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="250"/>
         <source>The last session is the periode since the last kDrive start.</source>
         <translation>La dernière session est la période depuis le dernier démarrage de kDrive.</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="253"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="254"/>
         <source>Share only the last kDrive session</source>
         <translation>Partager uniquement la dernière session kDrive</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="284"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="285"/>
         <source>  Loading</source>
         <translation>  Chargement</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="293"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="294"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="319"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="320"/>
         <source>SAVE</source>
         <translation>ENREGISTRER</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="326"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="327"/>
         <source>CANCEL</source>
         <translation>ANNULER</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="470"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="471"/>
         <source>Failed to share</source>
         <translation>Échec du partage</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="480"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="481"/>
         <source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
         <translation>1. Vérifiez que vous êtes connecté &lt;br&gt;2. Vérifiez que vous avez configuré au moins un kDrive</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="485"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="486"/>
         <source> (Connexion interrupted)</source>
         <translation> (Connexion interrompue)</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="492"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="493"/>
         <source>Share the folder with SwissTransfer &lt;br&gt;</source>
         <translation>Partager le dossier avec SwissTransfer &lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="493"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="494"/>
         <source> 1. We automatically compressed your log &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;here&lt;/a&gt;.&lt;br&gt;</source>
         <translation> 1. Nous avons automatiquement compressé votre journal &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;ici&lt;/a&gt;.&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="495"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="496"/>
         <source> 2. Transfer the archive with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
         <translation> 2. Transférez l&apos;archive avec &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="497"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="498"/>
         <source> 3. Share the link with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
         <translation> 3. Partagez le lien avec &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="527"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="528"/>
         <source>Last upload the %1</source>
         <translation>Dernier envoi le %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="555"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="556"/>
         <source>Sharing has been cancelled</source>
         <translation>Le partage a été annulé</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="597"/>
+        <source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.h" line="70"/>
@@ -883,39 +888,39 @@ Veuillez sélectionner un autre dossier. Si vous continuez, Lite Sync sera désa
         <translation>Le dossier entier est volumineux (&gt; 100 Mo) et son partage peut prendre un certain temps. Pour réduire le temps de partage, nous vous recommandons de ne partager que la dernière session kDrive.</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="600"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="611"/>
         <source>%1/%2/%3 at %4h%5m and %6s</source>
         <extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
         <translation>%2/%1/%3 à %4h%5 et %6s</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="643"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="654"/>
         <source>Do you want to save your modifications?</source>
         <translation>Voulez-vous enregistrer vos modifications ?</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="698"/>
-        <location filename="../src/gui/debuggingdialog.cpp" line="704"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="709"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="715"/>
         <source>Unable to open folder %1.</source>
         <translation>Impossible d&apos;ouvrir le dossier %1.</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="711"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="722"/>
         <source>  Share</source>
         <translation>  Partager</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="721"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="732"/>
         <source>  Sharing | step 1/2 %1%</source>
         <translation>  Partage | étape 1/2 %1%</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="730"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="741"/>
         <source>  Sharing | step 2/2 %1%</source>
         <translation>  Partage | étape 2/2 %1%</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="740"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="751"/>
         <source>  Canceling...</source>
         <translation>  Annulation...</translation>
     </message>
@@ -1986,27 +1991,32 @@ Veuillez utiliser le lien suivant pour envoyer les logs au support: &lt;a style=
         <translation>Lancer kDrive au démarrage</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="516"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="515"/>
+        <source>Finnish</source>
+        <translation>Finnois</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="521"/>
         <source>Advanced</source>
         <translation>Avancé</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="517"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="522"/>
         <source>Debugging information</source>
         <translation>Informations de débogage</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="519"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="524"/>
         <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
         <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Ouvrir le dossier de débogage&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="520"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="525"/>
         <source>Files to exclude</source>
         <translation>Fichiers à exclure</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="521"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="526"/>
         <source>Proxy server</source>
         <translation>Serveur proxy</translation>
     </message>
@@ -2046,7 +2056,7 @@ Veuillez utiliser le lien suivant pour envoyer les logs au support: &lt;a style=
         <translation>Lien %1 invalide.</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="523"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="528"/>
         <source>Lite Sync</source>
         <translation>Lite Sync</translation>
     </message>
@@ -2729,37 +2739,37 @@ Veuillez utiliser le lien suivant pour envoyer les logs au support: &lt;a style=
         <translation>Impossible de trouver un chemin valide</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2109"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2108"/>
         <source>No valid folder selected!</source>
         <translation>Aucun dossier valable sélectionné!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2120"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2119"/>
         <source>The selected path does not exist!</source>
         <translation>Le chemin sélectionné n’existe pas!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2125"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2124"/>
         <source>The selected path is not a folder!</source>
         <translation>Le chemin sélectionné n&apos;est pas un dossier!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2130"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2129"/>
         <source>You have no permission to write to the selected folder!</source>
         <translation>Vous n&apos;avez pas la permission d&apos;écrire dans le dossier sélectionné!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2160"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2159"/>
         <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
         <translation>Le dossier local %1 contient un dossier déjà synchronisé. Veuillez en choisir un autre&#xa0;!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2168"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2167"/>
         <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
         <translation>Le dossier local %1 est contenu dans un dossier déjà synchronisé. Veuillez en choisir un autre&#xa0;!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2176"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2175"/>
         <source>The local folder %1 is already synced. Please pick another one!</source>
         <translation>Le dossier local %1 est déjà synchronisé. Veuillez en choisir un autre&#xa0;!</translation>
     </message>
@@ -2909,19 +2919,6 @@ Veuillez utiliser le lien suivant pour envoyer les logs au support: &lt;a style=
     </message>
 </context>
 <context>
-    <name>main.cpp</name>
-    <message>
-        <location filename="../src/gui/mainclient.cpp" line="49"/>
-        <source>System Tray not available</source>
-        <translation>Zone de notification indisponible</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/mainclient.cpp" line="48"/>
-        <source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as &apos;trayer&apos; and try again.</source>
-        <translation>%1 nécessite une zone de notification (system tray) fonctionnelle. Si vous utilisez XFCE, veuillez suivre &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;ces instructions&lt;/a&gt;. Sinon, veuillez installer une application de zone de notification telle que « trayer » et réessayer.</translation>
-    </message>
-</context>
-<context>
     <name>utility</name>
     <message>
         <location filename="../src/gui/guiutility.cpp" line="84"/>
@@ -2994,12 +2991,12 @@ Veuillez utiliser le lien suivant pour envoyer les logs au support: &lt;a style=
         <translation>Le dossier &lt;b&gt;%1&lt;/b&gt; ne peut pas être sélectionné comme dossier de synchronisation. Veuillez sélectionner un autre dossier. Dossier suggéré : &lt;b&gt;%2&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/guiutility.cpp" line="641"/>
+        <location filename="../src/gui/guiutility.cpp" line="651"/>
         <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
         <translation>Vous avez exclu plus de %1 dossiers. Veuillez noter que cela affectera les performances de synchronisation.</translation>
     </message>
     <message>
-        <location filename="../src/gui/guiutility.cpp" line="650"/>
+        <location filename="../src/gui/guiutility.cpp" line="660"/>
         <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
         <translation>Vous ne pouvez pas exclure plus de %1 dossiers. Veuillez décocher les dossiers de niveau supérieur.</translation>
     </message>

--- a/translations/client_fr.ts
+++ b/translations/client_fr.ts
@@ -880,7 +880,7 @@ Veuillez sélectionner un autre dossier. Si vous continuez, Lite Sync sera désa
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="597"/>
         <source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
-        <translation type="unfinished"></translation>
+        <translation>Le journal complet étendu est activé via la variable d&apos;environnement KDRIVE_FORCE_EXTENDED_LOG. Définissez-la à 0 pour la désactiver.</translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.h" line="70"/>
@@ -2916,6 +2916,19 @@ Veuillez utiliser le lien suivant pour envoyer les logs au support: &lt;a style=
             <numerusform>%n seconde</numerusform>
             <numerusform>%n secondes</numerusform>
         </translation>
+    </message>
+</context>
+<context>
+    <name>main.cpp</name>
+    <message>
+        <location filename="../src/gui/mainclient.cpp" line="49"/>
+        <source>System Tray not available</source>
+        <translation>Zone de notification indisponible</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/mainclient.cpp" line="48"/>
+        <source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as &apos;trayer&apos; and try again.</source>
+        <translation>%1 nécessite une zone de notification (system tray) fonctionnelle. Si vous utilisez XFCE, veuillez suivre &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;ces instructions&lt;/a&gt;. Sinon, veuillez installer une application de zone de notification telle que « trayer » et réessayer.</translation>
     </message>
 </context>
 <context>

--- a/translations/client_it.ts
+++ b/translations/client_it.ts
@@ -305,12 +305,12 @@ Seleziona un&apos;altra cartella. Se continui, Lite Sync verrà disabilitato.&lt
 <context>
     <name>KDC::AppServer</name>
     <message>
-        <location filename="../src/server/appserver.cpp" line="1679"/>
+        <location filename="../src/server/appserver.cpp" line="1685"/>
         <source>Share link copied to clipboard</source>
         <translation>Link di condivisione copiato negli appunti</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/server/appserver.cpp" line="3759"/>
+        <location filename="../src/server/appserver.cpp" line="3773"/>
         <source>%1 and %n other file(s) have been removed.</source>
         <translation>
             <numerusform>%1 e %n altri file sono stati rimossi.</numerusform>
@@ -318,13 +318,13 @@ Seleziona un&apos;altra cartella. Se continui, Lite Sync verrà disabilitato.&lt
         </translation>
     </message>
     <message>
-        <location filename="../src/server/appserver.cpp" line="3761"/>
+        <location filename="../src/server/appserver.cpp" line="3775"/>
         <source>%1 has been removed.</source>
         <comment>%1 names a file.</comment>
         <translation>%1 è stato rimosso.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/server/appserver.cpp" line="3766"/>
+        <location filename="../src/server/appserver.cpp" line="3780"/>
         <source>%1 and %n other file(s) have been added.</source>
         <translation>
             <numerusform>%1 e %n altri file sono stati aggiunti.</numerusform>
@@ -332,13 +332,13 @@ Seleziona un&apos;altra cartella. Se continui, Lite Sync verrà disabilitato.&lt
         </translation>
     </message>
     <message>
-        <location filename="../src/server/appserver.cpp" line="3768"/>
+        <location filename="../src/server/appserver.cpp" line="3782"/>
         <source>%1 has been added.</source>
         <comment>%1 names a file.</comment>
         <translation>%1 è stato aggiunto.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/server/appserver.cpp" line="3773"/>
+        <location filename="../src/server/appserver.cpp" line="3787"/>
         <source>%1 and %n other file(s) have been updated.</source>
         <translation>
             <numerusform>%1 e %n altri file sono stati aggiornati.</numerusform>
@@ -346,13 +346,13 @@ Seleziona un&apos;altra cartella. Se continui, Lite Sync verrà disabilitato.&lt
         </translation>
     </message>
     <message>
-        <location filename="../src/server/appserver.cpp" line="3775"/>
+        <location filename="../src/server/appserver.cpp" line="3789"/>
         <source>%1 has been updated.</source>
         <comment>%1 names a file.</comment>
         <translation>%1 è stato aggiornato.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/server/appserver.cpp" line="3780"/>
+        <location filename="../src/server/appserver.cpp" line="3794"/>
         <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
         <translation>
             <numerusform>%1 è stato spostato in %2 e %n altri file sono stati spostati.</numerusform>
@@ -360,12 +360,12 @@ Seleziona un&apos;altra cartella. Se continui, Lite Sync verrà disabilitato.&lt
         </translation>
     </message>
     <message>
-        <location filename="../src/server/appserver.cpp" line="3783"/>
+        <location filename="../src/server/appserver.cpp" line="3797"/>
         <source>%1 has been moved to %2.</source>
         <translation>%1 è stato spostato in %2.</translation>
     </message>
     <message>
-        <location filename="../src/server/appserver.cpp" line="3791"/>
+        <location filename="../src/server/appserver.cpp" line="3805"/>
         <source>Sync Activity</source>
         <translation>Sincronizza attività</translation>
     </message>
@@ -464,17 +464,17 @@ Seleziona un&apos;altra cartella. Se continui, Lite Sync verrà disabilitato.&lt
         <translation>Non è stata configurata alcuna cartella per la sincronizzazione.</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1426"/>
+        <location filename="../src/gui/clientgui.cpp" line="1422"/>
         <source>Synthesis</source>
         <translation>Sintesi</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1427"/>
+        <location filename="../src/gui/clientgui.cpp" line="1423"/>
         <source>Preferences</source>
         <translation>Preferenze</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1428"/>
+        <location filename="../src/gui/clientgui.cpp" line="1424"/>
         <source>Quit</source>
         <translation>Esci</translation>
     </message>
@@ -519,22 +519,22 @@ Seleziona un&apos;altra cartella. Se continui, Lite Sync verrà disabilitato.&lt
         <translation>%1 (Sincronizzazione sospesa)</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1261"/>
+        <location filename="../src/gui/clientgui.cpp" line="1257"/>
         <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
         <translation>Vuoi davvero rimuovere le sincronizzazioni dell&apos;account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Nota:&lt;/b&gt; questo &lt;b&gt;non&lt;/b&gt; eliminerà alcun file.</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1265"/>
+        <location filename="../src/gui/clientgui.cpp" line="1261"/>
         <source>REMOVE ALL SYNCHRONIZATIONS</source>
         <translation>RIMUOVERE TUTTE LE SINC</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1266"/>
+        <location filename="../src/gui/clientgui.cpp" line="1262"/>
         <source>CANCEL</source>
         <translation>ANNULLA</translation>
     </message>
     <message>
-        <location filename="../src/gui/clientgui.cpp" line="1594"/>
+        <location filename="../src/gui/clientgui.cpp" line="1590"/>
         <source>Failed to start synchronizations!</source>
         <translation>Impossibile avviare la sincronizzazione!</translation>
     </message>
@@ -792,89 +792,94 @@ Seleziona un&apos;altra cartella. Se continui, Lite Sync verrà disabilitato.&lt
         <translation>Log completo esteso</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="206"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="207"/>
         <source>Delete logs older than %1 days</source>
         <translation>Elimina i registri più vecchi di %1 giorni</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="225"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="226"/>
         <source>Share the debug folder with Infomaniak support.</source>
         <translation>Condividi la cartella debug con il supporto di Infomaniak.</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="249"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="250"/>
         <source>The last session is the periode since the last kDrive start.</source>
         <translation>L&apos;ultima sessione è il periodo trascorso dall&apos;ultimo avvio di kDrive.</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="253"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="254"/>
         <source>Share only the last kDrive session</source>
         <translation>Condividi solo l&apos;ultima sessione di kDrive</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="284"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="285"/>
         <source>  Loading</source>
         <translation>  Caricamento</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="293"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="294"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="319"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="320"/>
         <source>SAVE</source>
         <translation>SALVA</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="326"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="327"/>
         <source>CANCEL</source>
         <translation>ANNULLA</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="470"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="471"/>
         <source>Failed to share</source>
         <translation>Impossibile condividere</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="480"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="481"/>
         <source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
         <translation>1. Verifica di aver effettuato l&apos;accesso&lt;br&gt;2. Verifica di aver configurato almeno un kDrive</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="485"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="486"/>
         <source> (Connexion interrupted)</source>
         <translation> (Connessione interrotta)</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="492"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="493"/>
         <source>Share the folder with SwissTransfer &lt;br&gt;</source>
         <translation>Condividi la cartella con SwissTransfer &lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="493"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="494"/>
         <source> 1. We automatically compressed your log &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;here&lt;/a&gt;.&lt;br&gt;</source>
         <translation> 1. Abbiamo compresso automaticamente il tuo registro &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;qui&lt;/a&gt;.&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="495"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="496"/>
         <source> 2. Transfer the archive with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
         <translation> 2. Trasferisci l&apos;archivio con &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="497"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="498"/>
         <source> 3. Share the link with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
         <translation> 3. Condividi il link con &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="527"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="528"/>
         <source>Last upload the %1</source>
         <translation>Ultimo caricamento il %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="555"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="556"/>
         <source>Sharing has been cancelled</source>
         <translation>La condivisione è stata annullata</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="597"/>
+        <source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.h" line="70"/>
@@ -882,39 +887,39 @@ Seleziona un&apos;altra cartella. Se continui, Lite Sync verrà disabilitato.&lt
         <translation>L&apos;intera cartella è di grandi dimensioni (&gt; 100 MB) e potrebbe richiedere del tempo per essere condivisa. Per ridurre il tempo di condivisione, si consiglia di condividere solo l&apos;ultima sessione di kDrive.</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="600"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="611"/>
         <source>%1/%2/%3 at %4h%5m and %6s</source>
         <extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
         <translation>%2/%1/%3 alle %4:%5:%6</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="643"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="654"/>
         <source>Do you want to save your modifications?</source>
         <translation>Salvare le modifiche?</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="698"/>
-        <location filename="../src/gui/debuggingdialog.cpp" line="704"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="709"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="715"/>
         <source>Unable to open folder %1.</source>
         <translation>Impossibile aprire la cartella %1.</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="711"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="722"/>
         <source>  Share</source>
         <translation>  Condividere</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="721"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="732"/>
         <source>  Sharing | step 1/2 %1%</source>
         <translation>  Condivisione | passaggio 1/2 %1%</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="730"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="741"/>
         <source>  Sharing | step 2/2 %1%</source>
         <translation>  Condivisione | passaggio 2/2 %1%</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="740"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="751"/>
         <source>  Canceling...</source>
         <translation>  Annullamento...</translation>
     </message>
@@ -1986,27 +1991,32 @@ Accedi alla versione web per verificare lo stato del tuo kDrive oppure contatta 
         <translation>Lancia kDrive all&apos;avvio del sistema</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="516"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="515"/>
+        <source>Finnish</source>
+        <translation>Finlandese</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="521"/>
         <source>Advanced</source>
         <translation>Avanzate</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="517"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="522"/>
         <source>Debugging information</source>
         <translation>Informazioni di debug</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="519"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="524"/>
         <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
         <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Apri cartella di debug&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="520"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="525"/>
         <source>Files to exclude</source>
         <translation>File da escludere</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="521"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="526"/>
         <source>Proxy server</source>
         <translation>Server proxy</translation>
     </message>
@@ -2046,7 +2056,7 @@ Accedi alla versione web per verificare lo stato del tuo kDrive oppure contatta 
         <translation>Link %1 non valido.</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="523"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="528"/>
         <source>Lite Sync</source>
         <translation>Lite Sync</translation>
     </message>
@@ -2729,37 +2739,37 @@ Accedi alla versione web per verificare lo stato del tuo kDrive oppure contatta 
         <translation>Impossibile trovare un percorso valido</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2109"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2108"/>
         <source>No valid folder selected!</source>
         <translation>Nessuna cartella valida selezionata!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2120"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2119"/>
         <source>The selected path does not exist!</source>
         <translation>Il percorso selezionato non esiste!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2125"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2124"/>
         <source>The selected path is not a folder!</source>
         <translation>Il percorso selezionato non è una cartella!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2130"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2129"/>
         <source>You have no permission to write to the selected folder!</source>
         <translation>Non disponi dell&apos;autorizzazione di scrittura per la cartella selezionata!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2160"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2159"/>
         <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
         <translation>La cartella locale %1 contiene una cartella già sincronizzata. Scegline un&apos;altra!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2168"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2167"/>
         <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
         <translation>La cartella locale %1 è contenuta in una cartella già sincronizzata. Scegline un&apos;altra!</translation>
     </message>
     <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2176"/>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2175"/>
         <source>The local folder %1 is already synced. Please pick another one!</source>
         <translation>La cartella locale %1 è già sincronizzata. Scegline un&apos;altra!</translation>
     </message>
@@ -2910,19 +2920,6 @@ Accedi alla versione web per verificare lo stato del tuo kDrive oppure contatta 
     </message>
 </context>
 <context>
-    <name>main.cpp</name>
-    <message>
-        <location filename="../src/gui/mainclient.cpp" line="49"/>
-        <source>System Tray not available</source>
-        <translation>Area di notifica non disponibile</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/mainclient.cpp" line="48"/>
-        <source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as &apos;trayer&apos; and try again.</source>
-        <translation>%1 richiede un’area di notifica (system tray) funzionante. Se utilizzi XFCE, segui &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;queste istruzioni&lt;/a&gt;. In caso contrario, installa un’applicazione per l’area di notifica come “trayer” e riprova.</translation>
-    </message>
-</context>
-<context>
     <name>utility</name>
     <message>
         <location filename="../src/gui/guiutility.cpp" line="84"/>
@@ -3009,12 +3006,12 @@ Puoi aggiungerne uno dalle impostazioni di kDrive.</translation>
         <translation>La cartella &lt;b&gt;%1&lt;/b&gt; non può essere selezionata come cartella di sincronizzazione. Selezionare un&apos;altra cartella. Cartella suggerita: &lt;b&gt;%2&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/guiutility.cpp" line="641"/>
+        <location filename="../src/gui/guiutility.cpp" line="651"/>
         <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
         <translation>Hai escluso più di %1 cartelle. Tieni presente che ciò influirà sulle prestazioni di sincronizzazione.</translation>
     </message>
     <message>
-        <location filename="../src/gui/guiutility.cpp" line="650"/>
+        <location filename="../src/gui/guiutility.cpp" line="660"/>
         <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
         <translation>Non puoi escludere più di %1 cartelle. Deseleziona le cartelle di livello superiore.</translation>
     </message>

--- a/translations/client_it.ts
+++ b/translations/client_it.ts
@@ -879,7 +879,7 @@ Seleziona un&apos;altra cartella. Se continui, Lite Sync verrà disabilitato.&lt
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="597"/>
         <source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
-        <translation type="unfinished"></translation>
+        <translation>Il log completo esteso è attivato tramite la variabile d&apos;ambiente KDRIVE_FORCE_EXTENDED_LOG. Impostala a 0 per disattivarlo.</translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.h" line="70"/>
@@ -2917,6 +2917,19 @@ Accedi alla versione web per verificare lo stato del tuo kDrive oppure contatta 
             <numerusform>%n secondo/i</numerusform>
             <numerusform>%n secondo/i</numerusform>
         </translation>
+    </message>
+</context>
+<context>
+    <name>main.cpp</name>
+    <message>
+        <location filename="../src/gui/mainclient.cpp" line="49"/>
+        <source>System Tray not available</source>
+        <translation>Area di notifica non disponibile</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/mainclient.cpp" line="48"/>
+        <source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as &apos;trayer&apos; and try again.</source>
+        <translation>%1 richiede un&apos;area di notifica (system tray) funzionante. Se utilizzi XFCE, segui &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;queste istruzioni&lt;/a&gt;. In caso contrario, installa un&apos;applicazione per l&apos;area di notifica come &quot;trayer&quot; e riprova.</translation>
     </message>
 </context>
 <context>

--- a/translations/client_nb.ts
+++ b/translations/client_nb.ts
@@ -1,3047 +1,3044 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="nb_NO">
-    <context>
-        <name>KDC::AboutDialog</name>
-        <message>
-            <location filename="../src/gui/aboutdialog.cpp" line="73" />
-            <source>About</source>
-            <translation>Om</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/aboutdialog.cpp" line="112" />
-            <source>CLOSE</source>
-            <translation>LUKK</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/aboutdialog.cpp" line="123" />
-            <source>Version %1. For more information visit &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
-            <translation>Versjon %1. For mer informasjon, gå til &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/aboutdialog.cpp" line="126" />
-            <source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
-            <translation>Opphavsrett 2019–%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/aboutdialog.cpp" line="127" />
-            <source>Distributed by %1 and licensed under the &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
-            <translation>Distribuert av %1 og lisensiert under &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 og %2-logoen er registrerte varemerker tilhørende %1.&lt;br&gt;&lt;br&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/aboutdialog.cpp" line="151" />
-            <location filename="../src/gui/aboutdialog.cpp" line="162" />
-            <location filename="../src/gui/aboutdialog.cpp" line="171" />
-            <source>Unable to open folder %1.</source>
-            <translation>Kan ikke apne mappen %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/aboutdialog.cpp" line="132" />
-            <source>&lt;p&gt;&lt;small&gt;Built from &lt;a style="color: #489EF3" href="%1"&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
-            <translation>&lt;p&gt;&lt;small&gt;Kompilert fra &lt;a style="color: #489EF3" href="%1"&gt;Git-kildekoden&lt;/a&gt; den %2, %3 ved hjelp av Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::AbstractFileItemWidget</name>
-        <message>
-            <location filename="../src/gui/abstractfileitemwidget.cpp" line="177" />
-            <source>Unable to open folder path %1.</source>
-            <translation>Kan ikke apne mappestien %1.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::AddDriveConfirmationWidget</name>
-        <message>
-            <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55" />
-            <source>Synchronization will start and you will be able to add files to your %1 folder.</source>
-            <translation>Synkroniseringen starter, og du vil kunne legge til filer i mappen %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99" />
-            <source>Your kDrive is ready!</source>
-            <translation>kDrive-enheten din er klar!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123" />
-            <source>OPEN FOLDER</source>
-            <translation>APNE MAPPE</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130" />
-            <source>PARAMETERS</source>
-            <translation>INNSTILLINGER</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138" />
-            <source>Synchronize another drive</source>
-            <translation>Synkroniser en annen stasjon</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::AddDriveListWidget</name>
-        <message>
-            <location filename="../src/gui/adddrivelistwidget.cpp" line="170" />
-            <source>Cancel</source>
-            <translation>Avbryt</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelistwidget.cpp" line="177" />
-            <source>NEXT</source>
-            <translation>NESTE</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelistwidget.cpp" line="196" />
-            <source>Select the kDrive you want to synchronize</source>
-            <translation>Velg kDrive-enheten du vil synkronisere</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelistwidget.cpp" line="234" />
-            <source>Get kDrive for free</source>
-            <translation>Fa kDrive gratis</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelistwidget.cpp" line="244" />
-            <source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
-            <translation>Lagre bilder, dokumenter og e-poster i Sveits hos et uavhengig selskap som respekterer personvernet. Les mer</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelistwidget.cpp" line="263" />
-            <source>Test for free</source>
-            <translation>Test gratis</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::AddDriveLiteSyncWidget</name>
-        <message>
-            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147" />
-            <source>Conserve your computer space</source>
-            <translation>Spar plass pa datamaskinen</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167" />
-            <source>Decide which files should be available online or locally</source>
-            <translation>Bestem hvilke filer som skal vaere tilgjengelige pa nettet eller lokalt</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187" />
-            <source>LATER</source>
-            <translation>SENERE</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193" />
-            <source>YES</source>
-            <translation>JA</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125" />
-            <source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-            <translation>Lite Sync synkroniserer alle filene dine uten å ta opp plass på datamaskinen din. Du kan bla gjennom filene i kDrive og laste dem ned lokalt når du vil. &lt;a style="%1" href="%2"&gt;Les mer&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207" />
-            <source>Unable to open link %1.</source>
-            <translation>Kan ikke apne lenken %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112" />
-            <source>Would you like to activate Lite Sync (Beta) ?</source>
-            <translation>Vil du aktivere Lite Sync (Beta)?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114" />
-            <source>Would you like to activate Lite Sync ?</source>
-            <translation>Vil du aktivere Lite Sync?</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::AddDriveLocalFolderWidget</name>
-        <message>
-            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65" />
-            <source>Location of your %1 kDrive</source>
-            <translation>Plassering av din %1 kDrive</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155" />
-            <source>Edit folder</source>
-            <translation>Rediger mappe</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246" />
-            <source>END</source>
-            <translation>FULLFOR</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297" />
-            <source>Select folder</source>
-            <translation>Velg mappe</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264" />
-            <source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
-            <translation>Innholdet i mappen &lt;b&gt;%1&lt;/b&gt; vil bli synkronisert i kDrive</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212" />
-            <source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
-            <translation>Når konfigurasjonen er fullført, finner du alle filene dine i denne mappen. Du kan legge nye filer der for å synkronisere dem til kDrive.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284" />
-            <source>This folder is not compatible with Lite Sync.&lt;br&gt; 
+<context>
+    <name>KDC::AboutDialog</name>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="73"/>
+        <source>About</source>
+        <translation>Om</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="112"/>
+        <source>CLOSE</source>
+        <translation>LUKK</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="123"/>
+        <source>Version %1. For more information visit &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
+        <translation>Versjon %1. For mer informasjon, gå til &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="126"/>
+        <source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
+        <translation>Opphavsrett 2019–%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="127"/>
+        <source>Distributed by %1 and licensed under the &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
+        <translation>Distribuert av %1 og lisensiert under &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 og %2-logoen er registrerte varemerker tilhørende %1.&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="151"/>
+        <location filename="../src/gui/aboutdialog.cpp" line="162"/>
+        <location filename="../src/gui/aboutdialog.cpp" line="171"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Kan ikke apne mappen %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="132"/>
+        <source>&lt;p&gt;&lt;small&gt;Built from &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
+        <translation>&lt;p&gt;&lt;small&gt;Kompilert fra &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git-kildekoden&lt;/a&gt; den %2, %3 ved hjelp av Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AbstractFileItemWidget</name>
+    <message>
+        <location filename="../src/gui/abstractfileitemwidget.cpp" line="177"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Kan ikke apne mappestien %1.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AddDriveConfirmationWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55"/>
+        <source>Synchronization will start and you will be able to add files to your %1 folder.</source>
+        <translation>Synkroniseringen starter, og du vil kunne legge til filer i mappen %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99"/>
+        <source>Your kDrive is ready!</source>
+        <translation>kDrive-enheten din er klar!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123"/>
+        <source>OPEN FOLDER</source>
+        <translation>APNE MAPPE</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130"/>
+        <source>PARAMETERS</source>
+        <translation>INNSTILLINGER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138"/>
+        <source>Synchronize another drive</source>
+        <translation>Synkroniser en annen stasjon</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AddDriveListWidget</name>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="170"/>
+        <source>Cancel</source>
+        <translation>Avbryt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="177"/>
+        <source>NEXT</source>
+        <translation>NESTE</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="196"/>
+        <source>Select the kDrive you want to synchronize</source>
+        <translation>Velg kDrive-enheten du vil synkronisere</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="234"/>
+        <source>Get kDrive for free</source>
+        <translation>Fa kDrive gratis</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="244"/>
+        <source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
+        <translation>Lagre bilder, dokumenter og e-poster i Sveits hos et uavhengig selskap som respekterer personvernet. Les mer</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="263"/>
+        <source>Test for free</source>
+        <translation>Test gratis</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AddDriveLiteSyncWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147"/>
+        <source>Conserve your computer space</source>
+        <translation>Spar plass pa datamaskinen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167"/>
+        <source>Decide which files should be available online or locally</source>
+        <translation>Bestem hvilke filer som skal vaere tilgjengelige pa nettet eller lokalt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187"/>
+        <source>LATER</source>
+        <translation>SENERE</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193"/>
+        <source>YES</source>
+        <translation>JA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
+        <source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Lite Sync synkroniserer alle filene dine uten å ta opp plass på datamaskinen din. Du kan bla gjennom filene i kDrive og laste dem ned lokalt når du vil. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Les mer&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207"/>
+        <source>Unable to open link %1.</source>
+        <translation>Kan ikke apne lenken %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112"/>
+        <source>Would you like to activate Lite Sync (Beta) ?</source>
+        <translation>Vil du aktivere Lite Sync (Beta)?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114"/>
+        <source>Would you like to activate Lite Sync ?</source>
+        <translation>Vil du aktivere Lite Sync?</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AddDriveLocalFolderWidget</name>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65"/>
+        <source>Location of your %1 kDrive</source>
+        <translation>Plassering av din %1 kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155"/>
+        <source>Edit folder</source>
+        <translation>Rediger mappe</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+        <source>END</source>
+        <translation>FULLFOR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
+        <source>Select folder</source>
+        <translation>Velg mappe</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
+        <source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
+        <translation>Innholdet i mappen &lt;b&gt;%1&lt;/b&gt; vil bli synkronisert i kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212"/>
+        <source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
+        <translation>Når konfigurasjonen er fullført, finner du alle filene dine i denne mappen. Du kan legge nye filer der for å synkronisere dem til kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284"/>
+        <source>This folder is not compatible with Lite Sync.&lt;br&gt; 
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt; 
-&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-            <translation>Denne mappen er ikke kompatibel med Lite Sync.&lt;br&gt; 
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Denne mappen er ikke kompatibel med Lite Sync.&lt;br&gt; 
 Velg en annen mappe. Hvis du fortsetter, vil Lite Sync bli deaktivert.&lt;br&gt; 
-&lt;a style="%1" href="%2"&gt;Les mer&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377" />
-            <source>Unable to open link %1.</source>
-            <translation>Kan ikke apne lenken %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246" />
-            <source>CONTINUE</source>
-            <translation>FORTSETT</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::AddDriveLoginWidget</name>
-        <message>
-            <location filename="../src/gui/adddriveloginwidget.cpp" line="69" />
-            <source>Log in from your browser</source>
-            <translation>Logg inn fra nettleseren din</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveloginwidget.cpp" line="75" />
-            <source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
-            <translation>Nettleseren din bør åpne seg automatisk for å fullføre tilkoblingen. Når du er tilkoblet, kommer du automatisk tilbake til kDrive.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveloginwidget.cpp" line="85" />
-            <source>Open the login page</source>
-            <translation>Åpne påloggingssiden</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveloginwidget.cpp" line="119" />
-            <source>Token request failed: %1 - %2</source>
-            <translation>Forespørsel om token mislyktes: %1 - %2</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveloginwidget.cpp" line="133" />
-            <source>Login failed: %1 - %2</source>
-            <translation>Innlogging mislyktes: %1 - %2</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveloginwidget.cpp" line="141" />
-            <source>Failed to open the login page in your web browser</source>
-            <translation>Det gikk ikke an å åpne påloggingssiden i nettleseren din</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::AddDriveServerFoldersWidget</name>
-        <message>
-            <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129" />
-            <source>Select kDrive folders to synchronize on your desktop</source>
-            <translation>Velg kDrive-mapper som skal synkroniseres på skrivebordet</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174" />
-            <source>CONTINUE</source>
-            <translation>FORTSETT</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187" />
-            <source>Space available on your computer : %1</source>
-            <translation>Ledig plass på datamaskinen din: %1</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206" />
-            <source>An error occurred while loading the list of subfolders.</source>
-            <translation>Det oppstod en feil under lasting av listen over undermapper.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210" />
-            <source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
-            <translation>Det er ikke mulig å laste inn listen over undermapper. Det kan hende at kDrive er under vedlikehold.&lt;br&gt;Logg inn på nettversjonen for å sjekke statusen til kDrive, eller kontakt administratoren din.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::AddDriveWizard</name>
-        <message>
-            <location filename="../src/gui/adddrivewizard.cpp" line="222" />
-            <source>Failed to create local folder %1</source>
-            <translation>Det gikk ikke å opprette den lokale mappen %1</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivewizard.cpp" line="233" />
-            <source>Failed to create new synchronization</source>
-            <translation>Det gikk ikke å opprette ny synkronisering</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivewizard.cpp" line="266" />
-            <source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
-            <translation>kDrive %1 er allerede synkronisert på denne datamaskinen. Vil du fortsette likevel?</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::AppClient</name>
-        <message>
-            <location filename="../src/gui/appclient.cpp" line="100" />
-            <source>kDrive client is run with bad parameters!</source>
-            <translation>kDrive-klienten kjøres med feil parametere!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/appclient.cpp" line="109" />
-            <source>kDrive client is already running!</source>
-            <translation>kDrive-klienten kjører allerede!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/appclient.cpp" line="719" />
-            <source>The user %1 is not connected. Please log in again.</source>
-            <translation>Brukeren %1 er ikke pålogget. Vennligst logg inn på nytt.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::AppServer</name>
-        <message>
-            <location filename="../src/server/appserver.cpp" line="1679" />
-            <source>Share link copied to clipboard</source>
-            <translation>Del-lenken er kopiert til utklippstavlen</translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/server/appserver.cpp" line="3759" />
-            <source>%1 and %n other file(s) have been removed.</source>
-            <translation>
-                <numerusform>%1 og %n annen fil har blitt fjernet.</numerusform>
-                <numerusform>%1 og %n andre filer har blitt fjernet.</numerusform>
-            </translation>
-        </message>
-        <message>
-            <location filename="../src/server/appserver.cpp" line="3761" />
-            <source>%1 has been removed.</source>
-            <comment>%1 names a file.</comment>
-            <translation>%1 er fjernet.</translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/server/appserver.cpp" line="3766" />
-            <source>%1 and %n other file(s) have been added.</source>
-            <translation>
-                <numerusform>%1 og %n annen fil har blitt lagt til.</numerusform>
-                <numerusform>%1 og %n andre filer har blitt lagt til.</numerusform>
-            </translation>
-        </message>
-        <message>
-            <location filename="../src/server/appserver.cpp" line="3768" />
-            <source>%1 has been added.</source>
-            <comment>%1 names a file.</comment>
-            <translation>%1 er lagt til.</translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/server/appserver.cpp" line="3773" />
-            <source>%1 and %n other file(s) have been updated.</source>
-            <translation>
-                <numerusform>%1 og %n annen fil har blitt oppdatert.</numerusform>
-                <numerusform>%1 og %n andre filer har blitt oppdatert.</numerusform>
-            </translation>
-        </message>
-        <message>
-            <location filename="../src/server/appserver.cpp" line="3775" />
-            <source>%1 has been updated.</source>
-            <comment>%1 names a file.</comment>
-            <translation>%1 er oppdatert.</translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/server/appserver.cpp" line="3780" />
-            <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
-            <translation>
-                <numerusform>%1 har blitt flyttet til %2, og %n annen fil har blitt flyttet.</numerusform>
-                <numerusform>%1 har blitt flyttet til %2, og %n andre filer har blitt flyttet.</numerusform>
-            </translation>
-        </message>
-        <message>
-            <location filename="../src/server/appserver.cpp" line="3783" />
-            <source>%1 has been moved to %2.</source>
-            <translation>%1 er flyttet til %2.</translation>
-        </message>
-        <message>
-            <location filename="../src/server/appserver.cpp" line="3791" />
-            <source>Sync Activity</source>
-            <translation>Synkroniseringsaktivitet</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::BaseFolderTreeItemWidget</name>
-        <message>
-            <location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102" />
-            <source>No subfolders currently on the server.</source>
-            <translation>Det finnes for øyeblikket ingen undermapper på serveren.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::BetaProgramDialog</name>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="69" />
-            <source>Quit the beta program</source>
-            <translation>Avslutt betaprogrammet</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="69" />
-            <source>Join the beta program</source>
-            <translation>Bli med i betaprogrammet</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="77" />
-            <source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
-            <translation>Få tidlig tilgang til nye versjoner av applikasjonen før de blir gjort tilgjengelig for allmennheten, og bidra til å forbedre applikasjonen ved å sende oss dine kommentarer.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="87" />
-            <source>Benefit from application beta updates</source>
-            <translation>Dra nytte av oppdateringer til betaversjonen av appen</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="91" />
-            <source>No</source>
-            <translation>Nei</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="92" />
-            <source>Public beta version</source>
-            <translation>Offentlig betaversjon</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="93" />
-            <source>Internal beta version</source>
-            <translation>Intern betaversjon</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="141" />
-            <source>I understand</source>
-            <translation>Jeg forstår</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="147" />
-            <source>Are you sure you want to leave the beta program?</source>
-            <translation>Er du sikker på at du vil melde deg ut av betaprogrammet?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="161" />
-            <source>Save</source>
-            <translation>Lagre</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="167" />
-            <source>Cancel</source>
-            <translation>Avbryt</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="228" />
-            <source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
-            <translation>Den nåværende versjonen av applikasjonen er kanskje for ny; valget ditt trer i kraft når neste oppdatering blir tilgjengelig.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="233" />
-            <source>Beta versions may leave unexpectedly or cause instabilities.</source>
-            <translation>Betaversjoner kan avsluttes uventet eller føre til ustabilitet.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::ClientGui</name>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="189" />
-            <source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
-            <translation>Det lyktes ikke å løse konflikter på %1 element(er) i synkroniseringsmappen: %2</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="242" />
-            <source>Please sign in</source>
-            <translation>Vennligst logg inn</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="292" />
-            <source>Folder %1: %2</source>
-            <translation>Mappe %1: %2</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="298" />
-            <source>There are no sync folders configured.</source>
-            <translation>Det er ikke konfigurert noen synkroniseringsmapper.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="1426" />
-            <source>Synthesis</source>
-            <translation>Sammendrag</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="1427" />
-            <source>Preferences</source>
-            <translatorcomment>Préférences</translatorcomment>
-            <translation>Innstillinger</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="1428" />
-            <source>Quit</source>
-            <translation>Avslutt</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="673" />
-            <source>Undefined State.</source>
-            <translation>Udefinert tilstand.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="676" />
-            <source>Waiting to start syncing.</source>
-            <translation>Venter på å starte synkroniseringen.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="679" />
-            <source>Sync is running.</source>
-            <translation>Synkroniseringen pågår.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="683" />
-            <source>Sync was successful, unresolved conflicts.</source>
-            <translation>Synkroniseringen ble fullført, men det er noen uløste konflikter.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="685" />
-            <source>Last Sync was successful.</source>
-            <translation>Den siste synkroniseringen ble gjennomført.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="692" />
-            <source>User Abort.</source>
-            <translation>Brukeravbrudd.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="696" />
-            <source>Sync is paused.</source>
-            <translation>Synkroniseringen er satt på pause.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="705" />
-            <source>%1 (Sync is paused)</source>
-            <translation>%1 (Synkroniseringen er satt på pause)</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="1261" />
-            <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-            <translation>Vil du virkelig fjerne synkroniseringene for kontoen &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Merk:&lt;/b&gt; Dette vil &lt;b&gt;ikke&lt;/b&gt; slette noen filer.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="1265" />
-            <source>REMOVE ALL SYNCHRONIZATIONS</source>
-            <translation>FJERN ALLE SYNKRONISERINGER</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="1266" />
-            <source>CANCEL</source>
-            <translation>AVBRYT</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="1594" />
-            <source>Failed to start synchronizations!</source>
-            <translation>Det gikk ikke å starte synkroniseringen!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="849" />
-            <source>Unable to open folder path %1.</source>
-            <translation>Kan ikke apne mappestien %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="116" />
-            <source>Unable to initialize kDrive client</source>
-            <translation>Kan ikke starte kDrive-klienten</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="255" />
-            <source>Synchronization is paused</source>
-            <translation>Synkroniseringen er satt på pause</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::ConfirmSynchronizationDialog</name>
-        <message>
-            <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86" />
-            <source>Summary of your local folder synchronization</source>
-            <translation>Oversikt over synkroniseringen av den lokale mappen din</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95" />
-            <source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
-            <translation>Innholdet i mappen på datamaskinen din vil bli synkronisert med mappen på den valgte kDrive-enheten, og omvendt.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184" />
-            <source>CANCEL</source>
-            <translation>AVBRYT</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191" />
-            <source>SYNCHRONIZE</source>
-            <translation>SYNKRONISER</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::CustomExtensionSetupWidget</name>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="96" />
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="120" />
-            <source>Before finishing</source>
-            <translation>Før du avslutter</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="107" />
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="131" />
-            <source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
-            <translation>Følg disse trinnene for å sikre at Lite Sync fungerer som det skal på datamaskinen din og for å fullføre konfigurasjonen av kDrive.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="208" />
-            <source>Open your Mac's &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-            <translation>Åpne &lt;b&gt;innstillingene under «Generelt»&lt;/b&gt; på Mac-en din, eller  &lt;a style="%1" href="%2"&gt;klikk her&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="212" />
-            <source>Open your Mac's &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-            <translation>Åpne &lt;b&gt;innstillingene for personvern og sikkerhet&lt;/b&gt; på Mac-en din, eller  &lt;a style="%1" href="%2"&gt;klikk her&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="216" />
-            <source>Open your Mac's &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-            <translation>Åpne &lt;b&gt;innstillingene for Sikkerhet og personvern&lt;/b&gt; på Mac-en din, eller  &lt;a style="%1" href="%2"&gt;klikk her&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="246" />
-            <source>Go to &lt;b&gt;"Login Items &amp; Extensions"&lt;/b&gt; section and then to &lt;b&gt;"Endpoint Security Extensions"&lt;/b&gt;</source>
-            <translation>Gå til delen &lt;b&gt;«Påloggingselementer og utvidelser»&lt;/b&gt; og deretter til &lt;b&gt;«Utvidelser for endepunktsikkerhet»&lt;/b&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="263" />
-            <source>Authorize the kDrive application</source>
-            <translation>Godkjenn kDrive-appen</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="272" />
-            <source>Go to &lt;b&gt;"Security"&lt;/b&gt; section</source>
-            <translation>Gå til avsnittet &lt;b&gt;«Sikkerhet»&lt;/b&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="289" />
-            <source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
-            <translation>Godkjenn kDrive-appen i boksen der det står at kDrive er blokkert</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="299" />
-            <source>Unlock the padlock &lt;img src=":/client/resources/icons/actions/lock.png"&gt; and authorize the kDrive application</source>
-            <translation>Lås opp hengelåsen &lt;img src=":/client/resources/icons/actions/lock.png"&gt; og godkjenn kDrive-appen</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="344" />
-            <source>Go to &lt;b&gt;"Privacy &amp; Security"&lt;/b&gt; section and click on &lt;b&gt;"Full Disk Access"&lt;/b&gt; or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-            <translation>Gå til delen &lt;b&gt;«Personvern og sikkerhet»&lt;/b&gt; og klikk på &lt;b&gt;«Full disktilgang»,&lt;/b&gt; eller &lt;a style="%1" href="%2"&gt;klikk her&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="348" />
-            <source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;"Privacy"&lt;/b&gt; tab or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-            <translation>Mens du fortsatt er i innstillingene for Sikkerhet og personvern, åpner du fanen &lt;b&gt;«Personvern»&lt;/b&gt; eller &lt;a style="%1" href="%2"&gt;klikker her&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="376" />
-            <source>Check the "kDrive LiteSync Extension" box then the "kDrive.app" box (if not already checked)</source>
-            <translation>Merk av i boksen «kDrive LiteSync Extension» og deretter i boksen «kDrive.app» (hvis den ikke allerede er merket av)</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="393" />
-            <source>A restart of the app might be proposed, in this case accept it</source>
-            <translation>Det kan bli foreslått å starte appen på nytt; i så fall må du godta dette</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="399" />
-            <source>Check the "kDrive LiteSync Extension" box (and "kDrive.app" if it exists) in &lt;b&gt;"Full Disk Access"&lt;/b&gt;</source>
-            <translation>Merk av for «kDrive LiteSync Extension» (og «kDrive.app» hvis den finnes) under &lt;b&gt;«Full diskadgang»&lt;/b&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="495" />
-            <source>STEP 1</source>
-            <translation>TRINN 1</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="495" />
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="496" />
-            <source>(Done)</source>
-            <translation>(Ferdig)</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="496" />
-            <source>STEP 2</source>
-            <translation>TRINN 2</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="499" />
-            <source>STEPS PERFORMED</source>
-            <translation>UTFØRTE TRINN</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="501" />
-            <source>END</source>
-            <translation>FULLFOR</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::CustomMessageBox</name>
-        <message>
-            <location filename="../src/gui/custommessagebox.cpp" line="101" />
-            <source>OK</source>
-            <translation>OK</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/custommessagebox.cpp" line="111" />
-            <source>CANCEL</source>
-            <translation>AVBRYT</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/custommessagebox.cpp" line="121" />
-            <source>YES</source>
-            <translation>JA</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/custommessagebox.cpp" line="131" />
-            <source>NO</source>
-            <translation>NEI</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::DebugReporter</name>
-        <message>
-            <location filename="../src/gui/debugreporter.cpp" line="37" />
-            <source>Sending of debugging information</source>
-            <translation>Overføring av feilsøkingsinformasjon</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debugreporter.cpp" line="37" />
-            <source>Cancel</source>
-            <translation>Avbryt</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::DebuggingDialog</name>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="46" />
-            <source>Info</source>
-            <translation>Informasjon</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="45" />
-            <source>Debug</source>
-            <translation>Feilsøking</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="47" />
-            <source>Warning</source>
-            <translation>Advarsel</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="48" />
-            <source>Error</source>
-            <translation>Feil</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="49" />
-            <source>Fatal</source>
-            <translation>Dødelig</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="74" />
-            <source>Debugging settings</source>
-            <translation>Feilsøkingsinnstillinger</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="90" />
-            <source>Save debugging information in a folder on my computer (Recommended)</source>
-            <translation>Lagre feilsøkingsinformasjon i en mappe på datamaskinen min (anbefalt)</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="104" />
-            <source>This information enables IT support to determine the origin of an incident.</source>
-            <translation>Denne informasjonen gjør det mulig for IT-supporten å fastslå årsaken til en hendelse.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="114" />
-            <source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
-            <translation>&lt;a style="%1" href="%2"&gt;Åpne feilsøkingsmappen&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="143" />
-            <source>Debug level</source>
-            <translation>Feilsøkingsnivå</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="152" />
-            <source>The trace level lets you choose the extent of the debugging information recorded</source>
-            <translation>Med sporingsnivået kan du velge omfanget av feilsøkingsinformasjonen som skal loggføres</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="179" />
-            <source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
-            <translation>Den utvidede fullstendige loggen samler inn en detaljert historikk som kan brukes til feilsøking. Hvis du aktiverer den, kan det føre til at kDrive-programmet går tregere.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="183" />
-            <source>Extended Full Log</source>
-            <translation>Utvidet fullstendig logg</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="206" />
-            <source>Delete logs older than %1 days</source>
-            <translation>Slett logger som er eldre enn %1 dager</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="225" />
-            <source>Share the debug folder with Infomaniak support.</source>
-            <translation>Del feilsøkingsmappen med Infomaniaks kundestøtte.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="249" />
-            <source>The last session is the periode since the last kDrive start.</source>
-            <translation>Den siste økten er tidsperioden siden kDrive sist ble startet.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="253" />
-            <source>Share only the last kDrive session</source>
-            <translation>Del kun den siste kDrive-økten</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="284" />
-            <source>  Loading</source>
-            <translation>  Laster</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="293" />
-            <source>Cancel</source>
-            <translation>Avbryt</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="319" />
-            <source>SAVE</source>
-            <translation>LAGRE</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="326" />
-            <source>CANCEL</source>
-            <translation>AVBRYT</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="470" />
-            <source>Failed to share</source>
-            <translation>Det gikk ikke å dele</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="480" />
-            <source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
-            <translation>1. Sjekk at du er logget inn &lt;br&gt;2. Sjekk at du har konfigurert minst én kDrive</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="485" />
-            <source> (Connexion interrupted)</source>
-            <translation> (Forbindelsen ble brutt)</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="492" />
-            <source>Share the folder with SwissTransfer &lt;br&gt;</source>
-            <translation>Del mappen med SwissTransfer &lt;br&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="493" />
-            <source> 1. We automatically compressed your log &lt;a style="%1" href="%2"&gt;here&lt;/a&gt;.&lt;br&gt;</source>
-            <translation> 1. Vi har automatisk komprimert loggen din &lt;a style="%1" href="%2"&gt;her&lt;/a&gt;.&lt;br&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="495" />
-            <source> 2. Transfer the archive with &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
-            <translation> 2. Overfør arkivet med &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="497" />
-            <source> 3. Share the link with &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
-            <translation> 3. Del lenken med&lt;a style="%1" href="%2"&gt;support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="527" />
-            <source>Last upload the %1</source>
-            <translation>Siste opplasting av %1</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="555" />
-            <source>Sharing has been cancelled</source>
-            <translation>Delingen er avbrutt</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.h" line="70" />
-            <source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
-            <translation>Hele mappen er stor (&amp;gt; 100 MB) og det kan ta litt tid å dele den. For å redusere delingstiden anbefaler vi at du bare deler den siste kDrive-økten.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="600" />
-            <source>%1/%2/%3 at %4h%5m and %6s</source>
-            <extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
-            <translation>%1/%2/%3 kl. %4:%5 og %6 sek.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="643" />
-            <source>Do you want to save your modifications?</source>
-            <translation>Vil du lagre endringene dine?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="698" />
-            <location filename="../src/gui/debuggingdialog.cpp" line="704" />
-            <source>Unable to open folder %1.</source>
-            <translation>Kan ikke apne mappen %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="711" />
-            <source>  Share</source>
-            <translation>  Del</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="721" />
-            <source>  Sharing | step 1/2 %1%</source>
-            <translation>  Deling | trinn 1/2 %1%</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="730" />
-            <source>  Sharing | step 2/2 %1%</source>
-            <translation>  Deling | trinn 2/2 %1%</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="740" />
-            <source>  Canceling...</source>
-            <translation>  Avbryter...</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::DrivePreferencesWidget</name>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1118" />
-            <source>Folders</source>
-            <translation>Mapper</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1120" />
-            <source>Notifications</source>
-            <translation>Varsler</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1123" />
-            <source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
-            <translation>Det vises en melding så snart en ny mappe er synkronisert eller endret</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1124" />
-            <source>Connected with</source>
-            <translation>I forbindelse med</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="981" />
-            <source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-            <translation>Vil du virkelig slutte å synkronisere mappen &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Merk:&lt;/b&gt; Dette vil &lt;b&gt;ikke&lt;/b&gt; slette noen filer.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="356" />
-            <source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
-            <translation>Denne operasjonen kan ta alt fra noen sekunder til noen minutter, avhengig av mappens størrelse.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="360" />
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="391" />
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="986" />
-            <source>CANCEL</source>
-            <translation>AVBRYT</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="645" />
-            <source>New local folder synchronization failed!</source>
-            <translation>Synkroniseringen av den nye lokale mappen mislyktes!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="823" />
-            <source>Lite Sync activation failed.</source>
-            <translation>Aktivering av Lite Sync mislyktes.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="841" />
-            <source>Lite Sync deactivation failed.</source>
-            <translation>Deaktivering av Lite Sync mislyktes.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="985" />
-            <source>REMOVE FOLDER SYNC CONNECTION</source>
-            <translation>FJERN SYNKRONISERINGSTILKOBLING FOR MAPPEN</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1048" />
-            <source>An error occurred while loading the list of subfolders.</source>
-            <translation>Det oppstod en feil under lasting av listen over undermapper.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1121" />
-            <source>Enable the notifications for this kDrive</source>
-            <translation>Slå på varslinger for denne kDrive</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="359" />
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="390" />
-            <source>CONFIRM</source>
-            <translation>BEKREFT</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="120" />
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1117" />
-            <source>Synchronization errors and information.</source>
-            <translation>Synkroniseringsfeil og informasjon.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="144" />
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1119" />
-            <source>Synchronize a local folder</source>
-            <translation>Synkroniser en lokal mappe</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="355" />
-            <source>Do you really want to turn on Lite Sync?</source>
-            <translation>Vil du virkelig slå på Lite Sync?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="382" />
-            <source>Do you really want to turn off Lite Sync?</source>
-            <translation>Vil du virkelig slå av Lite Sync?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="384" />
-            <source>You don't have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
-            <translation>Du har ikke nok plass til å synkronisere alle filene på kDrive (%1 mangler). Hvis du deaktiverer Lite Sync, må du velge hvilke mapper som skal synkroniseres på datamaskinen din. I mellomtiden vil synkroniseringen av kDrive bli satt på pause.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="388" />
-            <source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
-            <translation>Hvis du deaktiverer Lite Sync, vil alle filene lastes ned til datamaskinen din.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="627" />
-            <source>Failed to create new synchronization</source>
-            <translation>Det gikk ikke å opprette ny synkronisering</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="819" />
-            <source>Lite Sync activated.</source>
-            <translation>Lite Sync er aktivert.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="837" />
-            <source>Lite Sync deactivated.</source>
-            <translation>Lite Sync er deaktivert.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="899" />
-            <source>This drive is being deleted.</source>
-            <translation>Denne stasjonen blir slettet.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="962" />
-            <source>Impossible to open item %1</source>
-            <translation>Det er umulig å åpne elementet %1</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1007" />
-            <source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
-            <translation>Det gikk ikke å stoppe synkroniseringen av mappen &lt;i&gt;%1&lt;/i&gt;.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1125" />
-            <source>Remove all synchronizations</source>
-            <translation>Fjern alle synkroniseringer</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1126" />
-            <source>Search in your kDrive</source>
-            <translation>Søk i kDrive</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1127" />
-            <source>Search</source>
-            <translation>Søk</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::DriveSelectionWidget</name>
-        <message>
-            <location filename="../src/gui/driveselectionwidget.cpp" line="216" />
-            <source>Synchronize a kDrive</source>
-            <translation>Synkroniser en kDrive</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/driveselectionwidget.cpp" line="150" />
-            <source>Add a kDrive</source>
-            <translation>Legg til en kDrive</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::ErrorTabWidget</name>
-        <message>
-            <location filename="../src/gui/errortabwidget.cpp" line="179" />
-            <source>Resolve</source>
-            <translation>Løsning</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errortabwidget.cpp" line="180" />
-            <source>Conflicted item(s)</source>
-            <translation>Elementer med konflikt</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errortabwidget.cpp" line="181" />
-            <source>Item(s) with unsupported characters</source>
-            <translation>Element(er) med tegn som ikke støttes</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errortabwidget.cpp" line="92" />
-            <location filename="../src/gui/errortabwidget.cpp" line="135" />
-            <location filename="../src/gui/errortabwidget.cpp" line="178" />
-            <location filename="../src/gui/errortabwidget.cpp" line="186" />
-            <source>Clear history</source>
-            <translation>Slett historikk</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errortabwidget.cpp" line="176" />
-            <source>To Resolve</source>
-            <translation>Å løse</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errortabwidget.cpp" line="184" />
-            <source>Automatically resolved</source>
-            <translation>Løst automatisk</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errortabwidget.cpp" line="185" />
-            <source>problem(s) solved</source>
-            <translation>problemer løst</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errortabwidget.cpp" line="177" />
-            <source>problem(s) detected</source>
-            <translation>det er oppdaget et eller flere problemer</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::ErrorsMenuBarWidget</name>
-        <message>
-            <location filename="../src/gui/errorsmenubarwidget.cpp" line="84" />
-            <location filename="../src/gui/errorsmenubarwidget.cpp" line="103" />
-            <source>Synchronization conflicts or errors</source>
-            <translation>Synkroniseringskonflikter eller feil</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errorsmenubarwidget.cpp" line="86" />
-            <location filename="../src/gui/errorsmenubarwidget.cpp" line="105" />
-            <source>Errors</source>
-            <translation>Feil</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errorsmenubarwidget.cpp" line="101" />
-            <source>Back to preferences</source>
-            <translation>Tilbake til innstillinger</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::ErrorsPopup</name>
-        <message>
-            <location filename="../src/gui/errorspopup.cpp" line="73" />
-            <source>Some files couldn't be synchronized on the following kDrive(s) :</source>
-            <translation>Noen filer kunne ikke synkroniseres på følgende kDrive(r):</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errorspopup.cpp" line="95" />
-            <source> (%1 error(s))</source>
-            <translation> (%1 feil)</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errorspopup.cpp" line="101" />
-            <source> (%1 information(s))</source>
-            <translation> (%1 opplysning(er))</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errorspopup.cpp" line="107" />
-            <source> (%1 error(s) and %2 information(s))</source>
-            <translation> (%1 feil og %2 opplysninger)</translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/gui/errorspopup.cpp" line="147" />
-            <source>Generic errors (%n warning(s) or error(s))</source>
-            <comment>Number of warnings or errors</comment>
-            <translation>
-                <numerusform>Generelle feil (%n advarsel eller feil)</numerusform>
-                <numerusform>Generelle feil (%n advarsler eller feil)</numerusform>
-            </translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::FileExclusionDialog</name>
-        <message>
-            <location filename="../src/gui/fileexclusiondialog.cpp" line="78" />
-            <source>Excluded files</source>
-            <translation>Ekskluderte filer</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fileexclusiondialog.cpp" line="86" />
-            <source>Add files or folders that will not be synchronized on your computer.</source>
-            <translation>Legg til filer eller mapper som ikke skal synkroniseres på datamaskinen din.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fileexclusiondialog.cpp" line="97" />
-            <source>Add</source>
-            <translation>Legg til</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fileexclusiondialog.cpp" line="109" />
-            <source>NAME</source>
-            <translation>NAVN</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fileexclusiondialog.cpp" line="114" />
-            <source>WARNING</source>
-            <translation>ADVARSEL</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fileexclusiondialog.cpp" line="149" />
-            <source>SAVE</source>
-            <translation>LAGRE</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fileexclusiondialog.cpp" line="156" />
-            <source>CANCEL</source>
-            <translation>AVBRYT</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fileexclusiondialog.cpp" line="304" />
-            <source>Do you want to save your modifications?</source>
-            <translation>Vil du lagre endringene dine?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fileexclusiondialog.cpp" line="353" />
-            <source>Exclusion template already exists!</source>
-            <translation>Utelukkelsesmalen finnes allerede!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fileexclusiondialog.cpp" line="374" />
-            <source>Do you really want to delete?</source>
-            <translation>Vil du virkelig slette?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fileexclusiondialog.cpp" line="434" />
-            <source>Cannot save changes!</source>
-            <translation>Kan ikke lagre endringene!</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::FileExclusionNameDialog</name>
-        <message>
-            <location filename="../src/gui/fileexclusionnamedialog.cpp" line="58" />
-            <source>VALIDATE</source>
-            <translation>BEKREFT</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fileexclusionnamedialog.cpp" line="65" />
-            <source>CANCEL</source>
-            <translation>AVBRYT</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::FixConflictingFilesDialog</name>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67" />
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73" />
-            <source>Unable to open link %1.</source>
-            <translation>Kan ikke apne lenken %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122" />
-            <source>Solve conflict(s)</source>
-            <translation>Løse konflikter</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140" />
-            <source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
-            <translation>&lt;b&gt;Hva vil du gjøre med det/de %1 elementet/elementene som er i konflikt?&lt;/b&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143" />
-            <source>Save my changes and replace other users' versions.</source>
-            <translation>Lagre endringene mine og erstatt andre brukeres versjoner.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147" />
-            <source>Undo my changes and keep other users' versions.</source>
-            <translation>Angre mine endringer og behold andre brukeres versjoner.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169" />
-            <source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
-            <translation>Endringene dine kan bli slettet permanent. De kan ikke gjenopprettes fra kDrive-nettapplikasjonen.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171" />
-            <source>&lt;a style=%1 href="%2"&gt;Learn more&lt;/a&gt;</source>
-            <translation>&lt;a style=%1 href="%2"&gt;Les mer&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175" />
-            <source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
-            <translation>Endringene dine vil bli slettet permanent. De kan ikke gjenopprettes fra kDrive-nettapplikasjonen.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191" />
-            <source>Show item(s)</source>
-            <translation>Vis element(er)</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228" />
-            <source>VALIDATE</source>
-            <translation>BEKREFT</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234" />
-            <source>CANCEL</source>
-            <translation>AVBRYT</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251" />
-            <source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
-            <translation>Flere brukere har gjort endringer i disse filene på flere steder (på nettet via kDrive, på en datamaskin eller på en mobil). Mapper som inneholder disse filene kan også ha blitt slettet.&lt;br&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253" />
-            <source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Learn more&lt;/a&gt;</source>
-            <translation>Den lokale versjonen av elementet ditt &lt;b&gt;er ikke synkronisert&lt;/b&gt; med kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Les mer&lt;/a&gt;</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::FolderItemWidget</name>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="458" />
-            <source>More actions</source>
-            <translation>Flere handlinger</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="188" />
-            <location filename="../src/gui/folderitemwidget.cpp" line="476" />
-            <source>Synchronized into &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</source>
-            <translation>Synkronisert til &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="343" />
-            <source>Activate Lite Sync</source>
-            <translation>Aktiver Lite Sync</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="345" />
-            <source>Activate Lite Sync (Beta)</source>
-            <translation>Aktiver Lite Sync (Beta)</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="481" />
-            <source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
-            <translation>Mapper som ikke er valgt, flyttes til papirkurven dersom de inneholder elementer som er tilgjengelige uten nettilgang. Mapper som er synkronisert med kDrive, vil fortsatt være tilgjengelige på nettet.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="485" />
-            <source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
-            <translation>Mapper som ikke er valgt, flyttes til papirkurven. Mapper som er synkronisert med kDrive, vil fortsatt være tilgjengelige på nettet.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="488" />
-            <source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
-            <translation>Mapper som ikke er valgt, vil bli slettet &lt;b&gt;permanent&lt;/b&gt; fra datamaskinen. Mapper som er synkronisert med kDrive, vil fortsatt være tilgjengelige på nettet.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="493" />
-            <source>Cancel</source>
-            <translation>Avbryt</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="494" />
-            <source>VALIDATE</source>
-            <translation>BEKREFT</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="365" />
-            <source>Pause synchronization</source>
-            <translation>Stopp synkroniseringen</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="354" />
-            <source>Deactivate Lite Sync</source>
-            <translation>Deaktiver Lite Sync</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="375" />
-            <source>Resume synchronization</source>
-            <translation>Fortsett synkroniseringen</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="386" />
-            <source>Remove synchronization</source>
-            <translation>Fjern synkronisering</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::GenericErrorItemWidget</name>
-        <message>
-            <location filename="../src/gui/genericerroritemwidget.cpp" line="85" />
-            <source>Unable to open folder path %1.</source>
-            <translation>Kan ikke apne mappestien %1.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::LiteSyncAppDialog</name>
-        <message>
-            <location filename="../src/gui/litesyncappdialog.cpp" line="48" />
-            <source>Application Id</source>
-            <translation>Applikasjons-ID</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/litesyncappdialog.cpp" line="98" />
-            <source>Application Name</source>
-            <translation>Programnavn</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/litesyncappdialog.cpp" line="121" />
-            <source>VALIDATE</source>
-            <translation>BEKREFT</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/litesyncappdialog.cpp" line="128" />
-            <source>CANCEL</source>
-            <translation>AVBRYT</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::LiteSyncDialog</name>
-        <message>
-            <location filename="../src/gui/litesyncdialog.cpp" line="91" />
-            <source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are "online". Add them in the list below to avoid this behaviour.</source>
-            <translation>Noen apper (sikkerhetskopiering, antivirusprogrammer osv.) får tilgang til filene dine, noe som fører til at de lastes ned når de er «online». Legg dem til i listen nedenfor for å unngå dette.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/litesyncdialog.cpp" line="103" />
-            <source>Add</source>
-            <translation>Legg til</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/litesyncdialog.cpp" line="115" />
-            <source>APPLICATION ID</source>
-            <translation>SØKNADS-ID</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/litesyncdialog.cpp" line="120" />
-            <source>NAME</source>
-            <translation>NAVN</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/litesyncdialog.cpp" line="154" />
-            <source>SAVE</source>
-            <translation>LAGRE</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/litesyncdialog.cpp" line="161" />
-            <source>CANCEL</source>
-            <translation>AVBRYT</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/litesyncdialog.cpp" line="295" />
-            <source>Do you want to save your modifications?</source>
-            <translation>Vil du lagre endringene dine?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/litesyncdialog.cpp" line="337" />
-            <source>Do you really want to delete?</source>
-            <translation>Vil du virkelig slette?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/litesyncdialog.cpp" line="374" />
-            <source>Cannot save changes!</source>
-            <translation>Kan ikke lagre endringene!</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::LocalFolderDialog</name>
-        <message>
-            <location filename="../src/gui/localfolderdialog.cpp" line="63" />
-            <source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
-            <translation>Hvilken mappe på datamaskinen din ønsker du å&lt;br&gt;synkronisere?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/localfolderdialog.cpp" line="72" />
-            <source>The content of this folder will be synchronized on the kDrive</source>
-            <translation>Innholdet i denne mappen vil bli synkronisert på kDrive</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/localfolderdialog.cpp" line="91" />
-            <source>Select a folder</source>
-            <translation>Velg en mappe</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/localfolderdialog.cpp" line="131" />
-            <source>Edit folder</source>
-            <translation>Rediger mappe</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/localfolderdialog.cpp" line="166" />
-            <source>CANCEL</source>
-            <translation>AVBRYT</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/localfolderdialog.cpp" line="173" />
-            <source>CONTINUE</source>
-            <translation>FORTSETT</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/localfolderdialog.cpp" line="210" />
-            <source>This folder is not compatible with Lite Sync.&lt;br&gt;
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Les mer&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377"/>
+        <source>Unable to open link %1.</source>
+        <translation>Kan ikke apne lenken %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+        <source>CONTINUE</source>
+        <translation>FORTSETT</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AddDriveLoginWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="69"/>
+        <source>Log in from your browser</source>
+        <translation>Logg inn fra nettleseren din</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="75"/>
+        <source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
+        <translation>Nettleseren din bør åpne seg automatisk for å fullføre tilkoblingen. Når du er tilkoblet, kommer du automatisk tilbake til kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
+        <source>Open the login page</source>
+        <translation>Åpne påloggingssiden</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="119"/>
+        <source>Token request failed: %1 - %2</source>
+        <translation>Forespørsel om token mislyktes: %1 - %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="133"/>
+        <source>Login failed: %1 - %2</source>
+        <translation>Innlogging mislyktes: %1 - %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="141"/>
+        <source>Failed to open the login page in your web browser</source>
+        <translation>Det gikk ikke an å åpne påloggingssiden i nettleseren din</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AddDriveServerFoldersWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129"/>
+        <source>Select kDrive folders to synchronize on your desktop</source>
+        <translation>Velg kDrive-mapper som skal synkroniseres på skrivebordet</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174"/>
+        <source>CONTINUE</source>
+        <translation>FORTSETT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187"/>
+        <source>Space available on your computer : %1</source>
+        <translation>Ledig plass på datamaskinen din: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206"/>
+        <source>An error occurred while loading the list of subfolders.</source>
+        <translation>Det oppstod en feil under lasting av listen over undermapper.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210"/>
+        <source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>Det er ikke mulig å laste inn listen over undermapper. Det kan hende at kDrive er under vedlikehold.&lt;br&gt;Logg inn på nettversjonen for å sjekke statusen til kDrive, eller kontakt administratoren din.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AddDriveWizard</name>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="222"/>
+        <source>Failed to create local folder %1</source>
+        <translation>Det gikk ikke å opprette den lokale mappen %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="233"/>
+        <source>Failed to create new synchronization</source>
+        <translation>Det gikk ikke å opprette ny synkronisering</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="266"/>
+        <source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
+        <translation>kDrive %1 er allerede synkronisert på denne datamaskinen. Vil du fortsette likevel?</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AppClient</name>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="100"/>
+        <source>kDrive client is run with bad parameters!</source>
+        <translation>kDrive-klienten kjøres med feil parametere!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="109"/>
+        <source>kDrive client is already running!</source>
+        <translation>kDrive-klienten kjører allerede!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="719"/>
+        <source>The user %1 is not connected. Please log in again.</source>
+        <translation>Brukeren %1 er ikke pålogget. Vennligst logg inn på nytt.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AppServer</name>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="1685"/>
+        <source>Share link copied to clipboard</source>
+        <translation>Del-lenken er kopiert til utklippstavlen</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3773"/>
+        <source>%1 and %n other file(s) have been removed.</source>
+        <translation>
+            <numerusform>%1 og %n annen fil har blitt fjernet.</numerusform>
+            <numerusform>%1 og %n andre filer har blitt fjernet.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3775"/>
+        <source>%1 has been removed.</source>
+        <comment>%1 names a file.</comment>
+        <translation>%1 er fjernet.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3780"/>
+        <source>%1 and %n other file(s) have been added.</source>
+        <translation>
+            <numerusform>%1 og %n annen fil har blitt lagt til.</numerusform>
+            <numerusform>%1 og %n andre filer har blitt lagt til.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3782"/>
+        <source>%1 has been added.</source>
+        <comment>%1 names a file.</comment>
+        <translation>%1 er lagt til.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3787"/>
+        <source>%1 and %n other file(s) have been updated.</source>
+        <translation>
+            <numerusform>%1 og %n annen fil har blitt oppdatert.</numerusform>
+            <numerusform>%1 og %n andre filer har blitt oppdatert.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3789"/>
+        <source>%1 has been updated.</source>
+        <comment>%1 names a file.</comment>
+        <translation>%1 er oppdatert.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3794"/>
+        <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
+        <translation>
+            <numerusform>%1 har blitt flyttet til %2, og %n annen fil har blitt flyttet.</numerusform>
+            <numerusform>%1 har blitt flyttet til %2, og %n andre filer har blitt flyttet.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3797"/>
+        <source>%1 has been moved to %2.</source>
+        <translation>%1 er flyttet til %2.</translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3805"/>
+        <source>Sync Activity</source>
+        <translation>Synkroniseringsaktivitet</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::BaseFolderTreeItemWidget</name>
+    <message>
+        <location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102"/>
+        <source>No subfolders currently on the server.</source>
+        <translation>Det finnes for øyeblikket ingen undermapper på serveren.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::BetaProgramDialog</name>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="69"/>
+        <source>Quit the beta program</source>
+        <translation>Avslutt betaprogrammet</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="69"/>
+        <source>Join the beta program</source>
+        <translation>Bli med i betaprogrammet</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="77"/>
+        <source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
+        <translation>Få tidlig tilgang til nye versjoner av applikasjonen før de blir gjort tilgjengelig for allmennheten, og bidra til å forbedre applikasjonen ved å sende oss dine kommentarer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="87"/>
+        <source>Benefit from application beta updates</source>
+        <translation>Dra nytte av oppdateringer til betaversjonen av appen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="91"/>
+        <source>No</source>
+        <translation>Nei</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="92"/>
+        <source>Public beta version</source>
+        <translation>Offentlig betaversjon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="93"/>
+        <source>Internal beta version</source>
+        <translation>Intern betaversjon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="141"/>
+        <source>I understand</source>
+        <translation>Jeg forstår</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="147"/>
+        <source>Are you sure you want to leave the beta program?</source>
+        <translation>Er du sikker på at du vil melde deg ut av betaprogrammet?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="161"/>
+        <source>Save</source>
+        <translation>Lagre</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="167"/>
+        <source>Cancel</source>
+        <translation>Avbryt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="228"/>
+        <source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
+        <translation>Den nåværende versjonen av applikasjonen er kanskje for ny; valget ditt trer i kraft når neste oppdatering blir tilgjengelig.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="233"/>
+        <source>Beta versions may leave unexpectedly or cause instabilities.</source>
+        <translation>Betaversjoner kan avsluttes uventet eller føre til ustabilitet.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ClientGui</name>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="189"/>
+        <source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
+        <translation>Det lyktes ikke å løse konflikter på %1 element(er) i synkroniseringsmappen: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="242"/>
+        <source>Please sign in</source>
+        <translation>Vennligst logg inn</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="292"/>
+        <source>Folder %1: %2</source>
+        <translation>Mappe %1: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="298"/>
+        <source>There are no sync folders configured.</source>
+        <translation>Det er ikke konfigurert noen synkroniseringsmapper.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1422"/>
+        <source>Synthesis</source>
+        <translation>Sammendrag</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1423"/>
+        <source>Preferences</source>
+        <translatorcomment>Préférences</translatorcomment>
+        <translation>Innstillinger</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1424"/>
+        <source>Quit</source>
+        <translation>Avslutt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="673"/>
+        <source>Undefined State.</source>
+        <translation>Udefinert tilstand.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="676"/>
+        <source>Waiting to start syncing.</source>
+        <translation>Venter på å starte synkroniseringen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="679"/>
+        <source>Sync is running.</source>
+        <translation>Synkroniseringen pågår.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="683"/>
+        <source>Sync was successful, unresolved conflicts.</source>
+        <translation>Synkroniseringen ble fullført, men det er noen uløste konflikter.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="685"/>
+        <source>Last Sync was successful.</source>
+        <translation>Den siste synkroniseringen ble gjennomført.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="692"/>
+        <source>User Abort.</source>
+        <translation>Brukeravbrudd.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="696"/>
+        <source>Sync is paused.</source>
+        <translation>Synkroniseringen er satt på pause.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="705"/>
+        <source>%1 (Sync is paused)</source>
+        <translation>%1 (Synkroniseringen er satt på pause)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1257"/>
+        <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+        <translation>Vil du virkelig fjerne synkroniseringene for kontoen &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Merk:&lt;/b&gt; Dette vil &lt;b&gt;ikke&lt;/b&gt; slette noen filer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1261"/>
+        <source>REMOVE ALL SYNCHRONIZATIONS</source>
+        <translation>FJERN ALLE SYNKRONISERINGER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1262"/>
+        <source>CANCEL</source>
+        <translation>AVBRYT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1590"/>
+        <source>Failed to start synchronizations!</source>
+        <translation>Det gikk ikke å starte synkroniseringen!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="849"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Kan ikke apne mappestien %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="116"/>
+        <source>Unable to initialize kDrive client</source>
+        <translation>Kan ikke starte kDrive-klienten</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="255"/>
+        <source>Synchronization is paused</source>
+        <translation>Synkroniseringen er satt på pause</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ConfirmSynchronizationDialog</name>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86"/>
+        <source>Summary of your local folder synchronization</source>
+        <translation>Oversikt over synkroniseringen av den lokale mappen din</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95"/>
+        <source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
+        <translation>Innholdet i mappen på datamaskinen din vil bli synkronisert med mappen på den valgte kDrive-enheten, og omvendt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184"/>
+        <source>CANCEL</source>
+        <translation>AVBRYT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191"/>
+        <source>SYNCHRONIZE</source>
+        <translation>SYNKRONISER</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::CustomExtensionSetupWidget</name>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="96"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="120"/>
+        <source>Before finishing</source>
+        <translation>Før du avslutter</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="107"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="131"/>
+        <source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
+        <translation>Følg disse trinnene for å sikre at Lite Sync fungerer som det skal på datamaskinen din og for å fullføre konfigurasjonen av kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="208"/>
+        <source>Open your Mac&apos;s &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Åpne &lt;b&gt;innstillingene under «Generelt»&lt;/b&gt; på Mac-en din, eller  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klikk her&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="212"/>
+        <source>Open your Mac&apos;s &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Åpne &lt;b&gt;innstillingene for personvern og sikkerhet&lt;/b&gt; på Mac-en din, eller  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klikk her&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="216"/>
+        <source>Open your Mac&apos;s &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Åpne &lt;b&gt;innstillingene for Sikkerhet og personvern&lt;/b&gt; på Mac-en din, eller  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klikk her&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="246"/>
+        <source>Go to &lt;b&gt;&quot;Login Items &amp; Extensions&quot;&lt;/b&gt; section and then to &lt;b&gt;&quot;Endpoint Security Extensions&quot;&lt;/b&gt;</source>
+        <translation>Gå til delen &lt;b&gt;«Påloggingselementer og utvidelser»&lt;/b&gt; og deretter til &lt;b&gt;«Utvidelser for endepunktsikkerhet»&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="263"/>
+        <source>Authorize the kDrive application</source>
+        <translation>Godkjenn kDrive-appen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="272"/>
+        <source>Go to &lt;b&gt;&quot;Security&quot;&lt;/b&gt; section</source>
+        <translation>Gå til avsnittet &lt;b&gt;«Sikkerhet»&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="289"/>
+        <source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
+        <translation>Godkjenn kDrive-appen i boksen der det står at kDrive er blokkert</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="299"/>
+        <source>Unlock the padlock &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; and authorize the kDrive application</source>
+        <translation>Lås opp hengelåsen &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; og godkjenn kDrive-appen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="344"/>
+        <source>Go to &lt;b&gt;&quot;Privacy &amp; Security&quot;&lt;/b&gt; section and click on &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt; or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Gå til delen &lt;b&gt;«Personvern og sikkerhet»&lt;/b&gt; og klikk på &lt;b&gt;«Full disktilgang»,&lt;/b&gt; eller &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klikk her&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="348"/>
+        <source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;&quot;Privacy&quot;&lt;/b&gt; tab or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Mens du fortsatt er i innstillingene for Sikkerhet og personvern, åpner du fanen &lt;b&gt;«Personvern»&lt;/b&gt; eller &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klikker her&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="376"/>
+        <source>Check the &quot;kDrive LiteSync Extension&quot; box then the &quot;kDrive.app&quot; box (if not already checked)</source>
+        <translation>Merk av i boksen «kDrive LiteSync Extension» og deretter i boksen «kDrive.app» (hvis den ikke allerede er merket av)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="393"/>
+        <source>A restart of the app might be proposed, in this case accept it</source>
+        <translation>Det kan bli foreslått å starte appen på nytt; i så fall må du godta dette</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="399"/>
+        <source>Check the &quot;kDrive LiteSync Extension&quot; box (and &quot;kDrive.app&quot; if it exists) in &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt;</source>
+        <translation>Merk av for «kDrive LiteSync Extension» (og «kDrive.app» hvis den finnes) under &lt;b&gt;«Full diskadgang»&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
+        <source>STEP 1</source>
+        <translation>TRINN 1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="496"/>
+        <source>(Done)</source>
+        <translation>(Ferdig)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="496"/>
+        <source>STEP 2</source>
+        <translation>TRINN 2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="499"/>
+        <source>STEPS PERFORMED</source>
+        <translation>UTFØRTE TRINN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="501"/>
+        <source>END</source>
+        <translation>FULLFOR</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::CustomMessageBox</name>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="101"/>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="111"/>
+        <source>CANCEL</source>
+        <translation>AVBRYT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="121"/>
+        <source>YES</source>
+        <translation>JA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="131"/>
+        <source>NO</source>
+        <translation>NEI</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::DebugReporter</name>
+    <message>
+        <location filename="../src/gui/debugreporter.cpp" line="37"/>
+        <source>Sending of debugging information</source>
+        <translation>Overføring av feilsøkingsinformasjon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debugreporter.cpp" line="37"/>
+        <source>Cancel</source>
+        <translation>Avbryt</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::DebuggingDialog</name>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="46"/>
+        <source>Info</source>
+        <translation>Informasjon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="45"/>
+        <source>Debug</source>
+        <translation>Feilsøking</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="47"/>
+        <source>Warning</source>
+        <translation>Advarsel</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="48"/>
+        <source>Error</source>
+        <translation>Feil</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="49"/>
+        <source>Fatal</source>
+        <translation>Dødelig</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="74"/>
+        <source>Debugging settings</source>
+        <translation>Feilsøkingsinnstillinger</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="90"/>
+        <source>Save debugging information in a folder on my computer (Recommended)</source>
+        <translation>Lagre feilsøkingsinformasjon i en mappe på datamaskinen min (anbefalt)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="104"/>
+        <source>This information enables IT support to determine the origin of an incident.</source>
+        <translation>Denne informasjonen gjør det mulig for IT-supporten å fastslå årsaken til en hendelse.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="114"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Åpne feilsøkingsmappen&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="143"/>
+        <source>Debug level</source>
+        <translation>Feilsøkingsnivå</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="152"/>
+        <source>The trace level lets you choose the extent of the debugging information recorded</source>
+        <translation>Med sporingsnivået kan du velge omfanget av feilsøkingsinformasjonen som skal loggføres</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="179"/>
+        <source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
+        <translation>Den utvidede fullstendige loggen samler inn en detaljert historikk som kan brukes til feilsøking. Hvis du aktiverer den, kan det føre til at kDrive-programmet går tregere.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="183"/>
+        <source>Extended Full Log</source>
+        <translation>Utvidet fullstendig logg</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="207"/>
+        <source>Delete logs older than %1 days</source>
+        <translation>Slett logger som er eldre enn %1 dager</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="226"/>
+        <source>Share the debug folder with Infomaniak support.</source>
+        <translation>Del feilsøkingsmappen med Infomaniaks kundestøtte.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="250"/>
+        <source>The last session is the periode since the last kDrive start.</source>
+        <translation>Den siste økten er tidsperioden siden kDrive sist ble startet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="254"/>
+        <source>Share only the last kDrive session</source>
+        <translation>Del kun den siste kDrive-økten</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="285"/>
+        <source>  Loading</source>
+        <translation>  Laster</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="294"/>
+        <source>Cancel</source>
+        <translation>Avbryt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="320"/>
+        <source>SAVE</source>
+        <translation>LAGRE</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="327"/>
+        <source>CANCEL</source>
+        <translation>AVBRYT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="471"/>
+        <source>Failed to share</source>
+        <translation>Det gikk ikke å dele</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="481"/>
+        <source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
+        <translation>1. Sjekk at du er logget inn &lt;br&gt;2. Sjekk at du har konfigurert minst én kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="486"/>
+        <source> (Connexion interrupted)</source>
+        <translation> (Forbindelsen ble brutt)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="493"/>
+        <source>Share the folder with SwissTransfer &lt;br&gt;</source>
+        <translation>Del mappen med SwissTransfer &lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="494"/>
+        <source> 1. We automatically compressed your log &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;here&lt;/a&gt;.&lt;br&gt;</source>
+        <translation> 1. Vi har automatisk komprimert loggen din &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;her&lt;/a&gt;.&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="496"/>
+        <source> 2. Transfer the archive with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
+        <translation> 2. Overfør arkivet med &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="498"/>
+        <source> 3. Share the link with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
+        <translation> 3. Del lenken med&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="528"/>
+        <source>Last upload the %1</source>
+        <translation>Siste opplasting av %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="556"/>
+        <source>Sharing has been cancelled</source>
+        <translation>Delingen er avbrutt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="597"/>
+        <source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.h" line="70"/>
+        <source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
+        <translation>Hele mappen er stor (&amp;gt; 100 MB) og det kan ta litt tid å dele den. For å redusere delingstiden anbefaler vi at du bare deler den siste kDrive-økten.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="611"/>
+        <source>%1/%2/%3 at %4h%5m and %6s</source>
+        <extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
+        <translation>%1/%2/%3 kl. %4:%5 og %6 sek.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="654"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Vil du lagre endringene dine?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="709"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="715"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Kan ikke apne mappen %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="722"/>
+        <source>  Share</source>
+        <translation>  Del</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="732"/>
+        <source>  Sharing | step 1/2 %1%</source>
+        <translation>  Deling | trinn 1/2 %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="741"/>
+        <source>  Sharing | step 2/2 %1%</source>
+        <translation>  Deling | trinn 2/2 %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="751"/>
+        <source>  Canceling...</source>
+        <translation>  Avbryter...</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::DrivePreferencesWidget</name>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
+        <source>Folders</source>
+        <translation>Mapper</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
+        <source>Notifications</source>
+        <translation>Varsler</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
+        <source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
+        <translation>Det vises en melding så snart en ny mappe er synkronisert eller endret</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
+        <source>Connected with</source>
+        <translation>I forbindelse med</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
+        <source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+        <translation>Vil du virkelig slutte å synkronisere mappen &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Merk:&lt;/b&gt; Dette vil &lt;b&gt;ikke&lt;/b&gt; slette noen filer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="356"/>
+        <source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
+        <translation>Denne operasjonen kan ta alt fra noen sekunder til noen minutter, avhengig av mappens størrelse.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="360"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="391"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="986"/>
+        <source>CANCEL</source>
+        <translation>AVBRYT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
+        <source>New local folder synchronization failed!</source>
+        <translation>Synkroniseringen av den nye lokale mappen mislyktes!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
+        <source>Lite Sync activation failed.</source>
+        <translation>Aktivering av Lite Sync mislyktes.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
+        <source>Lite Sync deactivation failed.</source>
+        <translation>Deaktivering av Lite Sync mislyktes.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
+        <source>REMOVE FOLDER SYNC CONNECTION</source>
+        <translation>FJERN SYNKRONISERINGSTILKOBLING FOR MAPPEN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
+        <source>An error occurred while loading the list of subfolders.</source>
+        <translation>Det oppstod en feil under lasting av listen over undermapper.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
+        <source>Enable the notifications for this kDrive</source>
+        <translation>Slå på varslinger for denne kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
+        <source>CONFIRM</source>
+        <translation>BEKREFT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
+        <source>Synchronization errors and information.</source>
+        <translation>Synkroniseringsfeil og informasjon.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
+        <source>Synchronize a local folder</source>
+        <translation>Synkroniser en lokal mappe</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
+        <source>Do you really want to turn on Lite Sync?</source>
+        <translation>Vil du virkelig slå på Lite Sync?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="382"/>
+        <source>Do you really want to turn off Lite Sync?</source>
+        <translation>Vil du virkelig slå av Lite Sync?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="384"/>
+        <source>You don&apos;t have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
+        <translation>Du har ikke nok plass til å synkronisere alle filene på kDrive (%1 mangler). Hvis du deaktiverer Lite Sync, må du velge hvilke mapper som skal synkroniseres på datamaskinen din. I mellomtiden vil synkroniseringen av kDrive bli satt på pause.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="388"/>
+        <source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
+        <translation>Hvis du deaktiverer Lite Sync, vil alle filene lastes ned til datamaskinen din.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="627"/>
+        <source>Failed to create new synchronization</source>
+        <translation>Det gikk ikke å opprette ny synkronisering</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="819"/>
+        <source>Lite Sync activated.</source>
+        <translation>Lite Sync er aktivert.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="837"/>
+        <source>Lite Sync deactivated.</source>
+        <translation>Lite Sync er deaktivert.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="899"/>
+        <source>This drive is being deleted.</source>
+        <translation>Denne stasjonen blir slettet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="962"/>
+        <source>Impossible to open item %1</source>
+        <translation>Det er umulig å åpne elementet %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1007"/>
+        <source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
+        <translation>Det gikk ikke å stoppe synkroniseringen av mappen &lt;i&gt;%1&lt;/i&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1125"/>
+        <source>Remove all synchronizations</source>
+        <translation>Fjern alle synkroniseringer</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1126"/>
+        <source>Search in your kDrive</source>
+        <translation>Søk i kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1127"/>
+        <source>Search</source>
+        <translation>Søk</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::DriveSelectionWidget</name>
+    <message>
+        <location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
+        <source>Synchronize a kDrive</source>
+        <translation>Synkroniser en kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/driveselectionwidget.cpp" line="150"/>
+        <source>Add a kDrive</source>
+        <translation>Legg til en kDrive</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ErrorTabWidget</name>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="179"/>
+        <source>Resolve</source>
+        <translation>Løsning</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="180"/>
+        <source>Conflicted item(s)</source>
+        <translation>Elementer med konflikt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="181"/>
+        <source>Item(s) with unsupported characters</source>
+        <translation>Element(er) med tegn som ikke støttes</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="92"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="135"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="178"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="186"/>
+        <source>Clear history</source>
+        <translation>Slett historikk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="176"/>
+        <source>To Resolve</source>
+        <translation>Å løse</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="184"/>
+        <source>Automatically resolved</source>
+        <translation>Løst automatisk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="185"/>
+        <source>problem(s) solved</source>
+        <translation>problemer løst</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="177"/>
+        <source>problem(s) detected</source>
+        <translation>det er oppdaget et eller flere problemer</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ErrorsMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="84"/>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="103"/>
+        <source>Synchronization conflicts or errors</source>
+        <translation>Synkroniseringskonflikter eller feil</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="86"/>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="105"/>
+        <source>Errors</source>
+        <translation>Feil</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="101"/>
+        <source>Back to preferences</source>
+        <translation>Tilbake til innstillinger</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ErrorsPopup</name>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="73"/>
+        <source>Some files couldn&apos;t be synchronized on the following kDrive(s) :</source>
+        <translation>Noen filer kunne ikke synkroniseres på følgende kDrive(r):</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="95"/>
+        <source> (%1 error(s))</source>
+        <translation> (%1 feil)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="101"/>
+        <source> (%1 information(s))</source>
+        <translation> (%1 opplysning(er))</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="107"/>
+        <source> (%1 error(s) and %2 information(s))</source>
+        <translation> (%1 feil og %2 opplysninger)</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/errorspopup.cpp" line="147"/>
+        <source>Generic errors (%n warning(s) or error(s))</source>
+        <comment>Number of warnings or errors</comment>
+        <translation>
+            <numerusform>Generelle feil (%n advarsel eller feil)</numerusform>
+            <numerusform>Generelle feil (%n advarsler eller feil)</numerusform>
+        </translation>
+    </message>
+</context>
+<context>
+    <name>KDC::FileExclusionDialog</name>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="78"/>
+        <source>Excluded files</source>
+        <translation>Ekskluderte filer</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="86"/>
+        <source>Add files or folders that will not be synchronized on your computer.</source>
+        <translation>Legg til filer eller mapper som ikke skal synkroniseres på datamaskinen din.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="97"/>
+        <source>Add</source>
+        <translation>Legg til</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="109"/>
+        <source>NAME</source>
+        <translation>NAVN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="114"/>
+        <source>WARNING</source>
+        <translation>ADVARSEL</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="149"/>
+        <source>SAVE</source>
+        <translation>LAGRE</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="156"/>
+        <source>CANCEL</source>
+        <translation>AVBRYT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="304"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Vil du lagre endringene dine?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="353"/>
+        <source>Exclusion template already exists!</source>
+        <translation>Utelukkelsesmalen finnes allerede!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="374"/>
+        <source>Do you really want to delete?</source>
+        <translation>Vil du virkelig slette?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="434"/>
+        <source>Cannot save changes!</source>
+        <translation>Kan ikke lagre endringene!</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::FileExclusionNameDialog</name>
+    <message>
+        <location filename="../src/gui/fileexclusionnamedialog.cpp" line="58"/>
+        <source>VALIDATE</source>
+        <translation>BEKREFT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusionnamedialog.cpp" line="65"/>
+        <source>CANCEL</source>
+        <translation>AVBRYT</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::FixConflictingFilesDialog</name>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67"/>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73"/>
+        <source>Unable to open link %1.</source>
+        <translation>Kan ikke apne lenken %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122"/>
+        <source>Solve conflict(s)</source>
+        <translation>Løse konflikter</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140"/>
+        <source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
+        <translation>&lt;b&gt;Hva vil du gjøre med det/de %1 elementet/elementene som er i konflikt?&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143"/>
+        <source>Save my changes and replace other users&apos; versions.</source>
+        <translation>Lagre endringene mine og erstatt andre brukeres versjoner.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147"/>
+        <source>Undo my changes and keep other users&apos; versions.</source>
+        <translation>Angre mine endringer og behold andre brukeres versjoner.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169"/>
+        <source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
+        <translation>Endringene dine kan bli slettet permanent. De kan ikke gjenopprettes fra kDrive-nettapplikasjonen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171"/>
+        <source>&lt;a style=%1 href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a style=%1 href=&quot;%2&quot;&gt;Les mer&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175"/>
+        <source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
+        <translation>Endringene dine vil bli slettet permanent. De kan ikke gjenopprettes fra kDrive-nettapplikasjonen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191"/>
+        <source>Show item(s)</source>
+        <translation>Vis element(er)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228"/>
+        <source>VALIDATE</source>
+        <translation>BEKREFT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234"/>
+        <source>CANCEL</source>
+        <translation>AVBRYT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251"/>
+        <source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
+        <translation>Flere brukere har gjort endringer i disse filene på flere steder (på nettet via kDrive, på en datamaskin eller på en mobil). Mapper som inneholder disse filene kan også ha blitt slettet.&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253"/>
+        <source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Den lokale versjonen av elementet ditt &lt;b&gt;er ikke synkronisert&lt;/b&gt; med kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Les mer&lt;/a&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::FolderItemWidget</name>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="458"/>
+        <source>More actions</source>
+        <translation>Flere handlinger</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="188"/>
+        <location filename="../src/gui/folderitemwidget.cpp" line="476"/>
+        <source>Synchronized into &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</source>
+        <translation>Synkronisert til &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="343"/>
+        <source>Activate Lite Sync</source>
+        <translation>Aktiver Lite Sync</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="345"/>
+        <source>Activate Lite Sync (Beta)</source>
+        <translation>Aktiver Lite Sync (Beta)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="481"/>
+        <source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
+        <translation>Mapper som ikke er valgt, flyttes til papirkurven dersom de inneholder elementer som er tilgjengelige uten nettilgang. Mapper som er synkronisert med kDrive, vil fortsatt være tilgjengelige på nettet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="485"/>
+        <source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
+        <translation>Mapper som ikke er valgt, flyttes til papirkurven. Mapper som er synkronisert med kDrive, vil fortsatt være tilgjengelige på nettet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="488"/>
+        <source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
+        <translation>Mapper som ikke er valgt, vil bli slettet &lt;b&gt;permanent&lt;/b&gt; fra datamaskinen. Mapper som er synkronisert med kDrive, vil fortsatt være tilgjengelige på nettet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="493"/>
+        <source>Cancel</source>
+        <translation>Avbryt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="494"/>
+        <source>VALIDATE</source>
+        <translation>BEKREFT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="365"/>
+        <source>Pause synchronization</source>
+        <translation>Stopp synkroniseringen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="354"/>
+        <source>Deactivate Lite Sync</source>
+        <translation>Deaktiver Lite Sync</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="375"/>
+        <source>Resume synchronization</source>
+        <translation>Fortsett synkroniseringen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="386"/>
+        <source>Remove synchronization</source>
+        <translation>Fjern synkronisering</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::GenericErrorItemWidget</name>
+    <message>
+        <location filename="../src/gui/genericerroritemwidget.cpp" line="85"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Kan ikke apne mappestien %1.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::LiteSyncAppDialog</name>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="48"/>
+        <source>Application Id</source>
+        <translation>Applikasjons-ID</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="98"/>
+        <source>Application Name</source>
+        <translation>Programnavn</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="121"/>
+        <source>VALIDATE</source>
+        <translation>BEKREFT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="128"/>
+        <source>CANCEL</source>
+        <translation>AVBRYT</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::LiteSyncDialog</name>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="91"/>
+        <source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are &quot;online&quot;. Add them in the list below to avoid this behaviour.</source>
+        <translation>Noen apper (sikkerhetskopiering, antivirusprogrammer osv.) får tilgang til filene dine, noe som fører til at de lastes ned når de er «online». Legg dem til i listen nedenfor for å unngå dette.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="103"/>
+        <source>Add</source>
+        <translation>Legg til</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="115"/>
+        <source>APPLICATION ID</source>
+        <translation>SØKNADS-ID</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="120"/>
+        <source>NAME</source>
+        <translation>NAVN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="154"/>
+        <source>SAVE</source>
+        <translation>LAGRE</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="161"/>
+        <source>CANCEL</source>
+        <translation>AVBRYT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="295"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Vil du lagre endringene dine?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="337"/>
+        <source>Do you really want to delete?</source>
+        <translation>Vil du virkelig slette?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="374"/>
+        <source>Cannot save changes!</source>
+        <translation>Kan ikke lagre endringene!</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::LocalFolderDialog</name>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="63"/>
+        <source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
+        <translation>Hvilken mappe på datamaskinen din ønsker du å&lt;br&gt;synkronisere?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="72"/>
+        <source>The content of this folder will be synchronized on the kDrive</source>
+        <translation>Innholdet i denne mappen vil bli synkronisert på kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="91"/>
+        <source>Select a folder</source>
+        <translation>Velg en mappe</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="131"/>
+        <source>Edit folder</source>
+        <translation>Rediger mappe</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="166"/>
+        <source>CANCEL</source>
+        <translation>AVBRYT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="173"/>
+        <source>CONTINUE</source>
+        <translation>FORTSETT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="210"/>
+        <source>This folder is not compatible with Lite Sync.&lt;br&gt;
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt;
-&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-            <translation>Denne mappen er ikke kompatibel med Lite Sync.&lt;br&gt;
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Denne mappen er ikke kompatibel med Lite Sync.&lt;br&gt;
 Velg en annen mappe. Hvis du fortsetter, vil Lite Sync bli deaktivert.&lt;br&gt;
 
-&lt;a style="%1" href="%2"&gt;Les mer&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/localfolderdialog.cpp" line="233" />
-            <source>Select folder</source>
-            <translation>Velg mappe</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/localfolderdialog.cpp" line="292" />
-            <source>Unable to open link %1.</source>
-            <translation>Kan ikke apne lenken %1.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::Logger</name>
-        <message>
-            <location filename="../src/libcommongui/logger.cpp" line="189" />
-            <source>Error</source>
-            <translation>Feil</translation>
-        </message>
-        <message>
-            <location filename="../src/libcommongui/logger.cpp" line="189" />
-            <source>&lt;nobr&gt;File '%1'&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
-            <translation>&lt;nobr&gt;Filen «%1»&lt;br/&gt;kan ikke åpnes for skriving.&lt;br/&gt;&lt;br/&gt;Loggutskriften kan &lt;b&gt;ikke&lt;/b&gt; lagres!&lt;/nobr&gt;</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::MainMenuBarWidget</name>
-        <message>
-            <location filename="../src/gui/mainmenubarwidget.cpp" line="115" />
-            <source>Preferences</source>
-            <translation>Innstillinger</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/mainmenubarwidget.cpp" line="116" />
-            <source>Help</source>
-            <translation>Hjelp</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::ParametersDialog</name>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="1082" />
-            <source>Unable to open folder path %1.</source>
-            <translation>Kan ikke apne mappestien %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="1096" />
-            <source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
-            <translation>Overføringen er fullført!&lt;br&gt;Vennligst oppgi identifikatoren &lt;b&gt;%1&lt;/b&gt; i feilmeldinger.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="1118" />
-            <source>No kDrive configured!</source>
-            <translation>kDrive er ikke konfigurert!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="1097" />
-            <source>Transmission failed!
-Please, use the following link to send the logs to the support: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</source>
-            <translation>Overføringen mislyktes!
-Bruk følgende lenke for å sende loggfilene til kundestøtte: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="337" />
-            <location filename="../src/gui/parametersdialog.cpp" line="440" />
-            <location filename="../src/gui/parametersdialog.cpp" line="506" />
-            <location filename="../src/gui/parametersdialog.cpp" line="546" />
-            <location filename="../src/gui/parametersdialog.cpp" line="560" />
-            <source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-            <translation>Det har oppstått en teknisk feil (feil %1).&lt;br&gt;Tøm historikken, og ta kontakt med kundestøtten vår hvis feilen vedvarer.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="342" />
-            <source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
-            <translation>Det ser ut til at tidsavbruddet i nettverkstilkoblingen din er satt for lavt til at programmet skal fungere som det skal (feil %1).&lt;br&gt;Vennligst sjekk nettverksinnstillingene dine.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="347" />
-            <location filename="../src/gui/parametersdialog.cpp" line="516" />
-            <source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
-            <translation>Kan ikke koble til kDrive-serveren (feil %1).&lt;br&gt;Forsøker å koble til på nytt. Kontroller internettforbindelsen og brannmuren din.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="352" />
-            <source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
-            <translation>Det har oppstått et innloggingsproblem (feil %1).&lt;br&gt;Vennligst logg inn på nytt, og kontakt vår kundestøtte dersom feilen vedvarer.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="356" />
-            <source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
-            <translation>Det er en ny versjon av appen tilgjengelig.&lt;br&gt;Oppdater appen for å kunne fortsette å bruke den.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="360" />
-            <source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
-            <translation>Opplastingen av loggen mislyktes (feil %1).&lt;br&gt;Prøv igjen senere.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="385" />
-            <source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
-            <translation>Synkroniseringsmappen er ikke lenger tilgjengelig (feil %1).&lt;br&gt;Synkroniseringen fortsetter så snart mappen er tilgjengelig.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="532" />
-            <source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
-            <translation>Synkroniseringsmappen er erstattet eller flyttet på en måte som forhindrer synkronisering (feil %1).&lt;br&gt;Dette kan skje etter at mappen er kopiert, flyttet eller gjenopprettet.&lt;br&gt;For å løse dette må du opprette en ny synkronisering med en ny mappe.&lt;br&gt;Merk: Hvis du har endringer i den gamle mappen som ikke er synkronisert, må du kopiere dem manuelt over til den nye mappen.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="397" />
-            <source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
-            <translation>Det er ikke nok ledig minne på datamaskinen din.&lt;br&gt;Synkroniseringen er avbrutt.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="320" />
-            <source>kDrive needs to have write access to your computer's temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
-            <translation>kDrive må ha skrivetilgang til datamaskinens midlertidige mappe. Start kDrive-appen&lt;br&gt;på nytt for å løse dette problemet.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="330" />
-            <location filename="../src/gui/parametersdialog.cpp" line="487" />
-            <source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-            <translation>Det har oppstått en teknisk feil.&lt;br&gt;Synkroniseringen vil gjenopptas så snart som mulig. Ta kontakt med kundestøtten vår hvis feilen vedvarer.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="401" />
-            <source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing '/etc/sysctl.conf'.</source>
-            <translation>Antallet inotify-overvåkninger er for lavt (feil %1).&lt;br&gt;Du kan øke dette antallet ved å redigere «/etc/sysctl.conf».</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="406" />
-            <source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
-            <translation>Det går ikke an å starte synkroniseringen (feil %1).&lt;br&gt;Du må gi tillatelse til&lt;br&gt;:– kDrive i Systeminnstillinger &amp;gt;&amp;gt; Generelt &amp;gt;&amp;gt; Påloggingselementer og utvidelser &amp;gt;&amp;gt;&lt;br&gt;Utvidelser for endepunktsikkerhet– kDrive LiteSync-utvidelsen i Systeminnstillinger &amp;gt;&amp;gt; Personvern og sikkerhet &amp;gt;&amp;gt; Full disktilgang.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="419" />
-            <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-            <translation>Det går ikke an å starte Lite Sync-tillegget (feil %1).&lt;br&gt;Kontroller at Lite Sync-utvidelsen er installert og at Windows Search-tjenesten er aktivert.&lt;br&gt;Tøm historikken, start på nytt, og hvis feilen vedvarer, kan du kontakte vår kundestøtte.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="424" />
-            <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-            <translation>Det går ikke an å starte Lite Sync-tillegget (feil %1).&lt;br&gt;Sjekk at Lite Sync-utvidelsen har riktige tillatelser og at den kjører.&lt;br&gt;Tøm historikken, start på nytt, og hvis feilen vedvarer, kan du kontakte vår kundestøtte.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="429" />
-            <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-            <translation>Det går ikke an å starte Lite Sync-pluginen (feil %1).&lt;br&gt;Tøm historikken, start på nytt, og kontakt kundestøtten vår hvis feilen vedvarer.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="435" />
-            <source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
-            <translation>En fil eller mappe i synkroniseringsmappen din ser ut til å være ødelagt.&lt;br&gt;Synkroniseringen er stoppet.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="449" />
-            <source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-            <translation>kDrive er i vedlikeholdsmodus.&lt;br&gt;Synkroniseringen vil starte igjen så snart som mulig. Ta kontakt med vår kundestøtte hvis feilen vedvarer.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="455" />
-            <source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-            <translation>kDrive er blokkert.&lt;br&gt;Vennligst oppdater kDrive. Hvis du ikke gjør noe, vil dataene bli slettet permanent, og det vil være umulig å gjenopprette dem.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="460" />
-            <source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-            <translation>kDrive er sperret.&lt;br&gt;Ta kontakt med en administrator for å fornye kDrive. Hvis du ikke gjør noe, vil dataene bli slettet permanent, og det vil være umulig å gjenopprette dem.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="466" />
-            <source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-            <translation>kDrive er i ferd med å starte opp.&lt;br&gt;Synkroniseringen vil gjenopptas så snart som mulig. Ta kontakt med kundestøtten vår hvis feilen vedvarer.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="475" />
-            <source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
-            <translation>kDrive er inaktiv.&lt;br&gt;Vennligst logg inn på nettversjonen for å sjekke statusen til kDrive, eller kontakt administratoren din.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="479" />
-            <source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive's status, or contact your administrator.</source>
-            <translation>kDrive er inaktiv.&lt;br&gt;Vennligst logg inn på nettversjonen for å sjekke statusen til kDrive, eller kontakt administratoren din.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="483" />
-            <source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
-            <translation>Du har ikke tilgang til denne kDrive-kontoen.&lt;br&gt;Synkroniseringen er satt på pause. Ta kontakt med en administrator.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="493" />
-            <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-            <translation>Det har oppstått en teknisk feil (feil %1).&lt;br&gt;Synkroniseringen vil gjenopptas så snart som mulig. Ta kontakt med vår kundestøtte hvis feilen vedvarer.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="512" />
-            <source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-            <translation>Nettverkstilkoblingene er blitt avbrutt av kjernen (feil %1).&lt;br&gt;Tøm historikken, og ta kontakt med vår kundestøtte hvis feilen vedvarer.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="522" />
-            <source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
-            <translation>Dessverre kunne ikke den gamle konfigurasjonen overføres.&lt;br&gt;Programmet vil bruke en tom konfigurasjon.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="526" />
-            <source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
-            <translation>Dessverre kunne ikke den gamle proxykonfigurasjonen din overføres, da SOCKS5-proxyer foreløpig ikke støttes.&lt;br&gt;Programmet vil i stedet bruke systemets proxyinnstillinger.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="539" />
-            <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
-            <translation>Det har oppstått en teknisk feil (feil %1).&lt;br&gt;Synkroniseringen har blitt startet på nytt. Tøm historikken, og ta kontakt med kundestøtten vår hvis feilen vedvarer.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="550" />
-            <source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
-            <translation>Det har oppstått en feil ved tilgang til synkroniseringsdatabasen (feil %1).&lt;br&gt;Synkroniseringen er stoppet.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="564" />
-            <source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
-            <translation>Det har oppstått et innloggingsproblem (feil %1).&lt;br&gt;Tokenet er ugyldig eller tilbakekalt.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="569" />
-            <source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
-            <translation>Innebygde synkroniseringer er ikke tillatt (feil %1).&lt;br&gt;Du bør kun beholde synkroniseringer der mappene ikke er innebygde.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="573" />
-            <source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
-            <translation>Synkroniseringsmappen på den eksterne kDrive-enheten finnes ikke lenger eller er ikke lenger tilgjengelig (feil %1).&lt;br&gt;Du må gjenopprette den, gi den tilgang igjen eller slette og opprette synkroniseringen på nytt.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="580" />
-            <source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
-            <translation>Feil ved tolkning av filnavn (feil %1).&lt;br&gt;Spesialtegn som doble anførselstegn, tilbakeslag eller linjeskift kan føre til feil ved tolkningen.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="722" />
-            <source>You are not allowed to move item to "%1".&lt;br&gt;It will be restored into its original parent folder.</source>
-            <translation>Du har ikke tillatelse til å flytte elementet til «%1».&lt;br&gt;Det vil bli gjenopprettet i den opprinnelige overordnede mappen.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="814" />
-            <source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
-            <translation>Det er ikke nok ledig plass på datamaskinen din.&lt;br&gt;Nedlastingen er avbrutt.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="609" />
-            <source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
-            <translation>Dette elementet er flyttet til et annet sted.&lt;br&gt;Den lokale operasjonen er avbrutt.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="618" />
-            <source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
-            <translation>Det finnes allerede et element med samme navn på dette stedet.&lt;br&gt;Det lokale elementet har fått nytt navn.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="614" />
-            <source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
-            <translation>Det finnes allerede et element med samme navn på dette stedet.&lt;br&gt;Den lokale operasjonen er avbrutt.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="393" />
-            <source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
-            <translation>Det er ikke nok ledig plass på datamaskinen din.&lt;br&gt;Synkroniseringen er avbrutt.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="622" />
-            <source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
-            <translation>Filen ble redigert samtidig av en annen bruker.&lt;br&gt;Endringene dine er lagret i en kopi.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="626" />
-            <source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
-            <translation>En annen bruker har flyttet en overordnet mappe for målmappen.&lt;br&gt;Den lokale operasjonen er avbrutt.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="692" />
-            <source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
-            <translation>Varenavnet inneholder kun mellomrom.&lt;br&gt;Det er midlertidig satt på svartelisten.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="703" />
-            <source>Either you are not allowed to create an item, or another item already exists with the same name.&lt;br&gt;The item has been excluded from synchronization.</source>
-            <translation>Enten har du ikke tillatelse til å opprette et element, eller så finnes det allerede et element med samme navn.&lt;br&gt;Elementet er ekskludert fra synkroniseringen.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="708" />
-            <source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
-            <translation>Du har ikke rett til å redigere elementet.&lt;br&gt;Filen som inneholder endringene dine, har blitt omdøpt og ekskludert fra synkroniseringen.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="716" />
-            <source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
-            <translation>Du har ikke lov til å endre navnet på elementet.&lt;br&gt;Det vil bli gjenopprettet med sitt opprinnelige navn.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="727" />
-            <source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
-            <translation>Du har ikke tillatelse til å slette elementet.&lt;br&gt;Det vil bli gjenopprettet til sin opprinnelige plassering.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="732" />
-            <source>Failed to move this item to trash, it has been blacklisted.</source>
-            <translation>Det gikk ikke å flytte dette elementet til papirkurven; det er blitt svartelistet.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="748" />
-            <source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
-            <translation>Filen er endret lokalt, mens den er slettet på den eksterne kDrive-enheten. Den&lt;br&gt;lokale kopien er lagret i redningsmappen.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="765" />
-            <source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
-            <translation>Handlingen som ble utført på elementet, er forbudt.&lt;br&gt;Elementet er midlertidig satt på svartelisten.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="771" />
-            <source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
-            <translation>Operasjonen som ble utført på dette elementet mislyktes.&lt;br&gt;Elementet er midlertidig satt på svartelisten.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="776" />
-            <source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
-            <translation>Filen er for stor til å kunne lastes opp. Den er midlertidig satt på svartelisten.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="782" />
-            <source>Impossible to download the file.</source>
-            <translation>Det er umulig å laste ned filen.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="779" />
-            <source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
-            <translation>Du har overskredet kvoten din. Øk lagringsplasskvoten din for å aktivere filopplasting igjen.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="389" />
-            <source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
-            <translation>Stasjonen som inneholder synkroniseringsmappen din, er ikke lenger tilkoblet (feil %1).&lt;br&gt;Koble den til igjen for å fortsette synkroniseringen.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="413" />
-            <source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
-            <translation>Det er ikke mulig å starte synkroniseringen (feil %1).&lt;br&gt;LiteSyncExt-prosessen kjører ikke for øyeblikket. Synkroniseringen vil fortsette så snart prosessen er startet.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="649" />
-            <source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
-            <translation>Et eksisterende element har et identisk navn med samme bruk av store og små bokstaver.&lt;br&gt;Det er midlertidig satt på svartelisten.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="656" />
-            <source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
-            <translation>Varenavnet inneholder et tegn som ikke støttes.&lt;br&gt;Det er midlertidig satt på svartelisten.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="662" />
-            <source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-            <translation>Navnet på elementet slutter med et mellomrom, noe som er forbudt i operativsystemet ditt.&lt;br&gt;Det er midlertidig satt på svartelisten.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="668" />
-            <source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-            <translation>Dette elementnavnet er reservert av operativsystemet ditt.&lt;br&gt;Det er midlertidig satt på svartelisten.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="674" />
-            <source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
-            <translation>Varenavnet er for langt.&lt;br&gt;Det er midlertidig satt på svartelisten.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="680" />
-            <source>The item path is too long.&lt;br&gt;It has been ignored.</source>
-            <translation>Elementstien er for lang.&lt;br&gt;Den er blitt ignorert.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="686" />
-            <source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
-            <translation>Navnet på elementet inneholder et nytt Unicode-tegn som filsystemet ditt ennå ikke støtter.&lt;br&gt;Det er utelatt fra synkroniseringen.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="735" />
-            <source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
-            <translation>Det gikk ikke å synkronisere dette elementet. Det er midlertidig satt på svartelisten. Det vil bli&lt;br&gt;gjort et nytt forsøk på å synkronisere det om en time eller ved neste oppstart av applikasjonen.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="740" />
-            <source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
-            <translation>Dette elementet er ekskludert fra synkroniseringen av en tilpasset mal.&lt;br&gt;Du kan deaktivere denne typen varsler under Innstillinger</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="745" />
-            <source>This item has been excluded from sync because it is a hard link.</source>
-            <translation>Dette elementet er utelatt fra synkroniseringen fordi det er en hardlenke.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="785" />
-            <source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
-            <translation>Denne varen er for øyeblikket låst av en annen bruker som er online.&lt;br&gt;Vi prøver å laste opp endringene dine senere.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="790" />
-            <location filename="../src/gui/parametersdialog.cpp" line="834" />
-            <source>Synchronization error.</source>
-            <translation>Synkroniseringsfeil.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="810" />
-            <source>Can't access item.&lt;br&gt;Please fix the read and write permissions.</source>
-            <translation>Kan ikke få tilgang til elementet.&lt;br&gt;Vennligst korriger lese- og skrivetillatelsene.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="818" />
-            <source>System error.</source>
-            <translation>Systemfeil.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="825" />
-            <source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
-            <translation>Elementet finnes allerede på den andre siden.&lt;br&gt;Det er midlertidig satt på svartelisten.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="840" />
-            <source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-            <translation>Det har oppstått en teknisk feil. Tøm&lt;br&gt;historikken, og ta kontakt med kundestøtten vår hvis feilen vedvarer.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::PreferencesBlocWidget</name>
-        <message>
-            <location filename="../src/gui/preferencesblocwidget.cpp" line="187" />
-            <source>This synchronization is being deleted.</source>
-            <translation>Denne synkroniseringen blir slettet.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::PreferencesMenuBarWidget</name>
-        <message>
-            <location filename="../src/gui/preferencesmenubarwidget.cpp" line="63" />
-            <source>Back to drive list</source>
-            <translation>Tilbake til listen over stasjoner</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferencesmenubarwidget.cpp" line="64" />
-            <source>Preferences</source>
-            <translation>Innstillinger</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::PreferencesWidget</name>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="491" />
-            <source>General</source>
-            <translation>Generelt</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="493" />
-            <source>Activate dark theme</source>
-            <translation>Aktiver morkt tema</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="495" />
-            <source>Activate monochrome icons</source>
-            <translation>Aktiver monokrome ikoner</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="496" />
-            <source>Launch kDrive at startup</source>
-            <translation>Start kDrive ved oppstart</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="516" />
-            <source>Advanced</source>
-            <translation>Avansert</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="517" />
-            <source>Debugging information</source>
-            <translation>Feilsokingsinformasjon</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="519" />
-            <source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
-            <translation>&lt;a style="%1" href="%2"&gt;Åpne feilsøkingsmappen&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="520" />
-            <source>Files to exclude</source>
-            <translation>Filer som skal utelukkes</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="521" />
-            <source>Proxy server</source>
-            <translation>Proxyserver</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="511" />
-            <source>Swedish</source>
-            <translation>Svensk</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="512" />
-            <source>Portuguese</source>
-            <translation>Portugisisk</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="513" />
-            <source>Polish</source>
-            <translation>Polsk</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="514" />
-            <source>Norwegian</source>
-            <translation>Norsk</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="466" />
-            <source>Unable to open folder %1.</source>
-            <translation>Kan ikke apne mappen %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="478" />
-            <source>Unable to open link %1.</source>
-            <translation>Kan ikke apne lenken %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="483" />
-            <source>Invalid link %1.</source>
-            <translation>Ugyldig lenke %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="523" />
-            <source>Lite Sync</source>
-            <translation>Lite Sync</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="497" />
-            <source>Language</source>
-            <translation>Sprak</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="490" />
-            <source>Some process failed to run.</source>
-            <translation>En eller annen prosess kunne ikke kjøres.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="498" />
-            <source>Move deleted files to my computer's trash</source>
-            <translation>Flytt slettede filer til papirkurven pa datamaskinen</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="499" />
-            <source>Some files or folders may not be moved to the computer's trash.</source>
-            <translation>Noen filer eller mapper kan ikke flyttes til datamaskinens papirkurv.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="500" />
-            <source>You can always retrieve already synced files from the kDrive web application trash.</source>
-            <translation>Du kan alltid gjenopprette allerede synkroniserte filer fra papirkurven i kDrive-nettappen.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="502" />
-            <source>&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-            <translation>&lt;a style="%1" href="%2"&gt;Les mer&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="506" />
-            <source>English</source>
-            <translation>Engelsk</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="507" />
-            <source>French</source>
-            <translation>Fransk</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="508" />
-            <source>German</source>
-            <translation>Tysk</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="509" />
-            <source>Spanish</source>
-            <translation>Spansk</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="510" />
-            <source>Italian</source>
-            <translation>Italiensk</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="505" />
-            <source>Default</source>
-            <translation>Standard</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::ProgressBarWidget</name>
-        <message>
-            <location filename="../src/gui/progressbarwidget.cpp" line="70" />
-            <source>%1 in use</source>
-            <translation>%1 i bruk</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::ProxyServerDialog</name>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="50" />
-            <source>HTTP(S) Proxy</source>
-            <translation>HTTP(S)-proxy</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="73" />
-            <source>Proxy server</source>
-            <translation>Proxyserver</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="85" />
-            <source>No proxy server</source>
-            <translation>Ingen proxy-server</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="90" />
-            <source>Use system parameters</source>
-            <translation>Bruk systemparametere</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="95" />
-            <source>Indicate a proxy manually</source>
-            <translation>Angi en fullmektig manuelt</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="131" />
-            <source>Port</source>
-            <translation>Havn</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="144" />
-            <source>Address of the proxy server</source>
-            <translation>Adressen til proxy-serveren</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="150" />
-            <source>Authentication needed</source>
-            <translation>Pålogging kreves</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="165" />
-            <source>User</source>
-            <translation>Bruker</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="171" />
-            <source>Password</source>
-            <translation>Passord</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="185" />
-            <source>SAVE</source>
-            <translation>LAGRE</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="192" />
-            <source>CANCEL</source>
-            <translation>AVBRYT</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="286" />
-            <source>Do you want to save your modifications?</source>
-            <translation>Vil du lagre endringene dine?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="295" />
-            <source>Unable to save, all mandatory fields are not completed!</source>
-            <translation>Det er ikke mulig å lagre, da alle obligatoriske felt ikke er fylt ut!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="316" />
-            <source>Proxy not found, save anyway?</source>
-            <translation>Proxy funnet, vil du lagre likevel?</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::ResourcesManagerDialog</name>
-        <message>
-            <location filename="../src/gui/resourcesmanagerdialog.cpp" line="55" />
-            <source>Resources Manager</source>
-            <translation>Ressursansvarlig</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/resourcesmanagerdialog.cpp" line="65" />
-            <source>Maximum CPU usage allowed</source>
-            <translation>Maksimal tillatt CPU-bruk</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/resourcesmanagerdialog.cpp" line="96" />
-            <source>SAVE</source>
-            <translation>LAGRE</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/resourcesmanagerdialog.cpp" line="103" />
-            <source>CANCEL</source>
-            <translation>AVBRYT</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/resourcesmanagerdialog.cpp" line="122" />
-            <source>Do you want to save your modifications?</source>
-            <translation>Vil du lagre endringene dine?</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::ServerBaseFolderDialog</name>
-        <message>
-            <location filename="../src/gui/serverbasefolderdialog.cpp" line="81" />
-            <source>Select a folder on your kDrive</source>
-            <translation>Velg en mappe på kDrive</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/serverbasefolderdialog.cpp" line="90" />
-            <source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
-            <translation>Innholdet i den valgte mappen vil bli synkronisert til mappen &lt;b&gt;%1&lt;/b&gt;.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/serverbasefolderdialog.cpp" line="134" />
-            <source>CONTINUE</source>
-            <translation>FORTSETT</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/serverbasefolderdialog.cpp" line="150" />
-            <source>Space available on your computer for the current folder : %1</source>
-            <translation>Ledig plass på datamaskinen din for den aktuelle mappen: %1</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/serverbasefolderdialog.cpp" line="190" />
-            <source>This folder is already being synced.</source>
-            <translation>Denne mappen synkroniseres allerede.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/serverbasefolderdialog.cpp" line="204" />
-            <source>CONFIRM</source>
-            <translation>BEKREFT</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/serverbasefolderdialog.cpp" line="205" />
-            <source>CANCEL</source>
-            <translation>AVBRYT</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::ServerFoldersDialog</name>
-        <message>
-            <location filename="../src/gui/serverfoldersdialog.cpp" line="80" />
-            <source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
-            <translation>Mappen &lt;b&gt;%1&lt;/b&gt; inneholder undermapper.&lt;br&gt; Velg de du ønsker å synkronisere</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/serverfoldersdialog.cpp" line="110" />
-            <source>CONTINUE</source>
-            <translation>FORTSETT</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/serverfoldersdialog.cpp" line="146" />
-            <source>No subfolders currently on the server.</source>
-            <translation>Det finnes for øyeblikket ingen undermapper på serveren.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::StatusBarWidget</name>
-        <message>
-            <location filename="../src/gui/statusbarwidget.cpp" line="178" />
-            <source>Resume kDrive "%1" synchronization</source>
-            <translation>Gjenoppta synkroniseringen av kDrive «%1»</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/statusbarwidget.cpp" line="180" />
-            <source>Resume all kDrives synchronization</source>
-            <translation>Gjenoppta all synkronisering av kDrives</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/statusbarwidget.cpp" line="183" />
-            <source>Pause kDrive "%1" synchronization</source>
-            <translation>Stopp synkroniseringen av kDrive «%1»</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/statusbarwidget.cpp" line="184" />
-            <location filename="../src/gui/statusbarwidget.cpp" line="321" />
-            <source>Pause synchronization</source>
-            <translation>Stopp synkroniseringen</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/statusbarwidget.cpp" line="185" />
-            <source>Pause all kDrives synchronization</source>
-            <translation>Stopp all synkronisering av kDrives</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/statusbarwidget.cpp" line="179" />
-            <location filename="../src/gui/statusbarwidget.cpp" line="322" />
-            <source>Resume synchronization</source>
-            <translation>Fortsett synkroniseringen</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::SynchronizedItemWidget</name>
-        <message>
-            <location filename="../src/gui/synchronizeditemwidget.cpp" line="333" />
-            <source>Copy share link</source>
-            <translation>Kopier delingslenken</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synchronizeditemwidget.cpp" line="342" />
-            <source>Display on kdrive.infomaniak.com</source>
-            <translation>Vis på kdrive.infomaniak.com</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synchronizeditemwidget.cpp" line="387" />
-            <source>Show in folder</source>
-            <translation>Vis i mappe</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synchronizeditemwidget.cpp" line="388" />
-            <source>More actions</source>
-            <translation>Flere handlinger</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synchronizeditemwidget.cpp" line="317" />
-            <source>Open</source>
-            <translation>Åpne</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synchronizeditemwidget.cpp" line="325" />
-            <source>Add to favorites</source>
-            <translation>Legg til i favoritter</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::SynthesisBar</name>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="495" />
-            <location filename="../src/gui/synthesisbar.cpp" line="502" />
-            <source>Never</source>
-            <translation>Aldri</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="496" />
-            <source>During 1 hour</source>
-            <translation>I løpet av 1 time</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="497" />
-            <location filename="../src/gui/synthesisbar.cpp" line="504" />
-            <source>Until tomorrow 8:00AM</source>
-            <translation>Frem til i morgen kl. 08.00</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="498" />
-            <source>During 3 days</source>
-            <translation>I løpet av 3 dager</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="499" />
-            <source>During 1 week</source>
-            <translation>I løpet av 1 uke</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="500" />
-            <location filename="../src/gui/synthesisbar.cpp" line="507" />
-            <source>Always</source>
-            <translation>Alltid</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="503" />
-            <source>For 1 more hour</source>
-            <translation>I én time til</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="505" />
-            <source>For 3 more days</source>
-            <translation>I ytterligere 3 dager</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="506" />
-            <source>For 1 more week</source>
-            <translation>I én uke til</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="149" />
-            <source>Unable to open folder url %1.</source>
-            <translation>Det går ikke an å åpne mappen %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="219" />
-            <source>Open in folder</source>
-            <translation>Åpne i mappe</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="257" />
-            <source>Open %1 web version</source>
-            <translation>Åpne %1-nettversjonen</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="267" />
-            <source>Drive parameters</source>
-            <translation>Drivparametere</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="280" />
-            <source>Notifications disabled until %1</source>
-            <translation>Varsler er deaktivert frem til %1</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="281" />
-            <source>Disable Notifications</source>
-            <translation>Deaktiver varsler</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="314" />
-            <source>Application preferences</source>
-            <translation>Innstillinger for applikasjonen</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="322" />
-            <source>Need help</source>
-            <translation>Trenger du hjelp?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="330" />
-            <source>Send feedbacks</source>
-            <translation>Send tilbakemeldinger</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="338" />
-            <source>Quit kDrive</source>
-            <translation>Avslutt kDrive</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="401" />
-            <source>Unable to access web site %1.</source>
-            <translation>Det er ikke mulig å få tilgang til nettstedet %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="492" />
-            <source>Show errors and informations</source>
-            <translation>Vis feil og informasjon</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="493" />
-            <source>Show informations</source>
-            <translation>Vis informasjon</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="494" />
-            <source>More actions</source>
-            <translation>Flere handlinger</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::SynthesisPopover</name>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="1181" />
-            <source>Update kDrive App</source>
-            <translation>Oppdater kDrive-appen</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="1182" />
-            <source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
-            <translation>Denne versjonen av kDrive-appen støttes ikke lenger. Oppdater appen for å få tilgang til de nyeste funksjonene og forbedringene.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="978" />
-            <source>Update</source>
-            <translation>Oppdatering</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="1187" />
-            <source>Please download the latest version on the website.</source>
-            <translation>Last ned den nyeste versjonen fra nettstedet.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="981" />
-            <source>Update download in progress</source>
-            <translation>Oppdateringen lastes ned</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="984" />
-            <source>Looking for update...</source>
-            <translation>Leter etter oppdatering...</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="987" />
-            <source>Manual update</source>
-            <translation>Manuell oppdatering</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="990" />
-            <source>Unavailable</source>
-            <translation>Ikke tilgjengelig</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="1200" />
-            <source>You can synchronize files &lt;a style="%1" href="%2"&gt;from your computer&lt;/a&gt; or on &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
-            <translation>Du kan synkronisere filer &lt;a style="%1" href="%2"&gt;fra datamaskinen din&lt;/a&gt; eller fra &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="446" />
-            <source>Synchronized</source>
-            <translation>Synkronisert</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="450" />
-            <source>Favorites</source>
-            <translation>Favoritter</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="454" />
-            <source>Activity</source>
-            <translation>Aktivitet</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="1133" />
-            <location filename="../src/gui/synthesispopover.cpp" line="1180" />
-            <source>Not implemented!</source>
-            <translation>Ikke implementert!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="1184" />
-            <source>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Click here to download manually&lt;/a&gt;</source>
-            <translation>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Klikk her for å laste ned manuelt&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="1193" />
-            <source>No synchronized folder for this Drive!</source>
-            <translation>Det finnes ingen synkronisert mappe for denne Drive-kontoen!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="1196" />
-            <source>No kDrive configured!</source>
-            <translation>kDrive er ikke konfigurert!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="1161" />
-            <source>Unable to open link %1.</source>
-            <translation>Kan ikke apne lenken %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="1173" />
-            <source>Invalid link %1.</source>
-            <translation>Ugyldig lenke %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="586" />
-            <source>Unable to open folder url %1.</source>
-            <translation>Det går ikke an å åpne mappen %1.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::UpdateDialog</name>
-        <message>
-            <location filename="../src/gui/updater/updatedialog.cpp" line="61" />
-            <source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
-            <translation>&lt;p&gt;Den nye versjonen &lt;b&gt;%1&lt;/b&gt; av %2-klienten er tilgjengelig og er lastet ned.&lt;/p&gt;&lt;p&gt;Den installerte versjonen er %3.&lt;/p&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/updater/updatedialog.cpp" line="95" />
-            <source>Skip this version</source>
-            <translation>Hopp over denne versjonen</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/updater/updatedialog.cpp" line="103" />
-            <source>Remind me later</source>
-            <translation>Minn meg på det senere</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/updater/updatedialog.cpp" line="109" />
-            <source>Install update</source>
-            <translation>Installer oppdatering</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::UpdateManager</name>
-        <message>
-            <location filename="../src/server/updater/updatemanager.cpp" line="86" />
-            <source>New update available.</source>
-            <translation>Ny oppdatering tilgjengelig.</translation>
-        </message>
-        <message>
-            <location filename="../src/server/updater/updatemanager.cpp" line="87" />
-            <source>Version %1 is available for download.</source>
-            <translation>Versjon %1 er tilgjengelig for nedlasting.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::UserSelectionWidget</name>
-        <message>
-            <location filename="../src/gui/userselectionwidget.cpp" line="131" />
-            <source>Add an account</source>
-            <translation>Legg til en konto</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::VersionWidget</name>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="295" />
-            <source>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</source>
-            <translation>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="169" />
-            <source>&lt;a style="%1" href="%2"&gt;Show release note&lt;/a&gt;</source>
-            <translation>&lt;a style="%1" href="%2"&gt;Vis utgivelsesnotat&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="172" />
-            <source>Version</source>
-            <translation>Versjon</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="173" />
-            <source>UPDATE</source>
-            <translation>OPPDATERING</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="197" />
-            <source>%1 is up to date!</source>
-            <translation>%1 er oppdatert!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="201" />
-            <source>Checking update on server...</source>
-            <translation>Sjekker oppdateringer på serveren...</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="205" />
-            <source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style="%2" href="%3"&gt;here&lt;/a&gt;.</source>
-            <translation>Det er en oppdatering tilgjengelig: %1. Last&lt;br&gt;den ned &lt;a style="%2" href="%3"&gt;her&lt;/a&gt;.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="212" />
-            <source>An update is available: %1</source>
-            <translation>Det er en oppdatering tilgjengelig: %1</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="218" />
-            <source>Downloading %1. Please wait...</source>
-            <translation>Laster ned %1. Vennligst vent...</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="223" />
-            <source>Could not check for new updates.</source>
-            <translation>Det var ikke mulig å sjekke om det var nye oppdateringer.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="227" />
-            <source>An error occurred during update.</source>
-            <translation>Det oppstod en feil under oppdateringen.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="231" />
-            <source>Could not download update.</source>
-            <translation>Det gikk ikke an å laste ned oppdateringen.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="235" />
-            <source>Update disabled.</source>
-            <translation>Oppdatering deaktivert.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="251" />
-            <source>Beta program</source>
-            <translation>Betaprogram</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="252" />
-            <source>Get early access to new versions of the application</source>
-            <translation>Få tidlig tilgang til nye versjoner av applikasjonen</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="256" />
-            <source>Join</source>
-            <translation>Bli med</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="259" />
-            <source>Modify</source>
-            <translation>Endre</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="259" />
-            <source>Quit</source>
-            <translation>Avslutt</translation>
-        </message>
-    </context>
-    <context>
-        <name>QObject</name>
-        <message>
-            <location filename="../src/gui/parameterscache.cpp" line="59" />
-            <source>Unable to save parameters, please retry later.</source>
-            <translation>Det gikk ikke an å lagre parametrene. Prøv igjen senere.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parameterscache.cpp" line="60" />
-            <source>Unable to save parameters!</source>
-            <translation>Kan ikke lagre parametrene!</translation>
-        </message>
-        <message>
-            <location filename="../src/server/requests/serverrequests.cpp" line="461" />
-            <source>The parent folder is a sync folder or contained in one</source>
-            <translation>Overordnet mappe er en synkroniseringsmappe eller ligger i en slik</translation>
-        </message>
-        <message>
-            <location filename="../src/server/requests/serverrequests.cpp" line="495" />
-            <source>Can't find a valid path</source>
-            <translation>Finner ikke en gyldig sti</translation>
-        </message>
-        <message>
-            <location filename="../src/server/requests/serverrequests.cpp" line="2109" />
-            <source>No valid folder selected!</source>
-            <translation>Det er ikke valgt noen gyldig mappe!</translation>
-        </message>
-        <message>
-            <location filename="../src/server/requests/serverrequests.cpp" line="2120" />
-            <source>The selected path does not exist!</source>
-            <translation>Den valgte banen finnes ikke!</translation>
-        </message>
-        <message>
-            <location filename="../src/server/requests/serverrequests.cpp" line="2125" />
-            <source>The selected path is not a folder!</source>
-            <translation>Den valgte banen er ikke en mappe!</translation>
-        </message>
-        <message>
-            <location filename="../src/server/requests/serverrequests.cpp" line="2130" />
-            <source>You have no permission to write to the selected folder!</source>
-            <translation>Du har ikke tilgang til å skrive til den valgte mappen!</translation>
-        </message>
-        <message>
-            <location filename="../src/server/requests/serverrequests.cpp" line="2160" />
-            <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
-            <translation>Den lokale mappen %1 inneholder en mappe som allerede er synkronisert. Vennligst velg en annen!</translation>
-        </message>
-        <message>
-            <location filename="../src/server/requests/serverrequests.cpp" line="2168" />
-            <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
-            <translation>Den lokale mappen %1 ligger i en mappe som allerede er synkronisert. Vennligst velg en annen!</translation>
-        </message>
-        <message>
-            <location filename="../src/server/requests/serverrequests.cpp" line="2176" />
-            <source>The local folder %1 is already synced. Please pick another one!</source>
-            <translation>Den lokale mappen %1 er allerede synkronisert. Velg en annen!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="42" />
-            <source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
-            <translation>Lite sync (Beta) er aktivert. Filer fra kDrive forblir i skyen og bruker ikke lagringsplassen på datamaskinen din.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="45" />
-            <source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
-            <translation>Lite sync (Beta) er deaktivert. kDrive-filene bruker lagringsplassen på datamaskinen din.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="48" />
-            <source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
-            <translation>Lite-synkronisering er aktivert. Filer fra kDrive forblir i skyen og opptar ikke lagringsplass på datamaskinen din.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="50" />
-            <source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
-            <translation>Lite sync er deaktivert. kDrive-filene bruker lagringsplassen på datamaskinen din.</translation>
-        </message>
-        <message>
-            <location filename="../src/server/comm/extensionjob.cpp" line="1175" />
-            <source>Make available locally</source>
-            <translation>Gjør tilgjengelig lokalt</translation>
-        </message>
-        <message>
-            <location filename="../src/server/comm/extensionjob.cpp" line="1179" />
-            <source>Free up local space</source>
-            <translation>Frigjør lokal lagringsplass</translation>
-        </message>
-        <message>
-            <location filename="../src/server/comm/extensionjob.cpp" line="1183" />
-            <source>Cancel free up local space</source>
-            <translation>Avbryt for å frigjøre lokal lagringsplass</translation>
-        </message>
-        <message>
-            <location filename="../src/server/comm/extensionjob.cpp" line="1187" />
-            <source>Cancel make available locally</source>
-            <translation>Avbryt lokal tilgjengeliggjøring</translation>
-        </message>
-        <message>
-            <location filename="../src/server/comm/extensionjob.cpp" line="1191" />
-            <source>Resharing this file is not allowed</source>
-            <translation>Det er ikke tillatt å dele denne filen videre</translation>
-        </message>
-        <message>
-            <location filename="../src/server/comm/extensionjob.cpp" line="1192" />
-            <source>Resharing this folder is not allowed</source>
-            <translation>Det er ikke tillatt å dele denne mappen videre</translation>
-        </message>
-        <message>
-            <location filename="../src/server/comm/extensionjob.cpp" line="1196" />
-            <source>Copy public share link</source>
-            <translation>Kopier lenken til den offentlige delingen</translation>
-        </message>
-        <message>
-            <location filename="../src/server/comm/extensionjob.cpp" line="1200" />
-            <source>Copy private share link</source>
-            <translation>Kopier lenken til privat deling</translation>
-        </message>
-        <message>
-            <location filename="../src/server/comm/extensionjob.cpp" line="1204" />
-            <source>Open in browser</source>
-            <translation>Åpne i nettleseren</translation>
-        </message>
-    </context>
-    <context>
-        <name>SharedTools::QtSingleApplication</name>
-        <message>
-            <location filename="../src/server/appserver.cpp" line="133" />
-            <source>kDrive application will close due to a fatal error.</source>
-            <translation>kDrive-programmet vil lukkes på grunn av en alvorlig feil.</translation>
-        </message>
-    </context>
-    <context>
-        <name>Utility</name>
-        <message>
-            <location filename="../src/libcommongui/utility/utility.cpp" line="97" />
-            <source>%L1 GB</source>
-            <translation>%L1 GB</translation>
-        </message>
-        <message>
-            <location filename="../src/libcommongui/utility/utility.cpp" line="101" />
-            <source>%L1 MB</source>
-            <translation>%L1 MB</translation>
-        </message>
-        <message>
-            <location filename="../src/libcommongui/utility/utility.cpp" line="105" />
-            <source>%L1 KB</source>
-            <translation>%L1 KB</translation>
-        </message>
-        <message>
-            <location filename="../src/libcommongui/utility/utility.cpp" line="108" />
-            <source>%L1 B</source>
-            <translation>%L1 B</translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/libcommongui/utility/utility.cpp" line="41" />
-            <source>%n year(s)</source>
-            <translation>
-                <numerusform>%n ar</numerusform>
-                <numerusform>%n ar</numerusform>
-            </translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/libcommongui/utility/utility.cpp" line="42" />
-            <source>%n month(s)</source>
-            <translation>
-                <numerusform>%n maned</numerusform>
-                <numerusform>%n maneder</numerusform>
-            </translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/libcommongui/utility/utility.cpp" line="43" />
-            <source>%n day(s)</source>
-            <translation>
-                <numerusform>%n dag</numerusform>
-                <numerusform>%n dager</numerusform>
-            </translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/libcommongui/utility/utility.cpp" line="44" />
-            <source>%n hour(s)</source>
-            <translation>
-                <numerusform>%n time</numerusform>
-                <numerusform>%n timer</numerusform>
-            </translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/libcommongui/utility/utility.cpp" line="45" />
-            <source>%n minute(s)</source>
-            <translation>
-                <numerusform>%n minutt</numerusform>
-                <numerusform>%n minutter</numerusform>
-            </translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/libcommongui/utility/utility.cpp" line="46" />
-            <source>%n second(s)</source>
-            <translation>
-                <numerusform>%n sekund</numerusform>
-                <numerusform>%n sekunder</numerusform>
-            </translation>
-        </message>
-    </context>
-    <context>
-        <name>main.cpp</name>
-        <message>
-            <location filename="../src/gui/mainclient.cpp" line="49" />
-            <source>System Tray not available</source>
-            <translation>Systemstatusfeltet er ikke tilgjengelig</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/mainclient.cpp" line="48" />
-            <source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as 'trayer' and try again.</source>
-            <translation>%1 krever et fungerende systemfelt. Hvis du bruker XFCE, må du følge &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;disse instruksjonene&lt;/a&gt;. Ellers må du installere et program for systemfeltet, for eksempel «trayer», og prøve på nytt.</translation>
-        </message>
-    </context>
-    <context>
-        <name>utility</name>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="84" />
-            <source>Could not open browser</source>
-            <translation>Kunne ikke åpne nettleseren</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="85" />
-            <source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
-            <translation>Det oppstod en feil da nettleseren ble startet for å gå til URL-adressen %1. Kanskje er det ikke konfigurert noen standard nettleser?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="104" />
-            <source>Could not open email client</source>
-            <translation>Kunne ikke åpne e-postprogrammet</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="105" />
-            <source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
-            <translation>Det oppstod en feil da e-postklienten ble startet for å opprette en ny melding. Kanskje er det ikke konfigurert noen standard e-postklient?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="324" />
-            <source>You are not connected anymore. &lt;a style="%1" href="%2"&gt;Log in&lt;/a&gt;</source>
-            <translation>Du er ikke lenger pålogget. &lt;a style="%1" href="%2"&gt;Logg inn&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="347" />
-            <source>Sync in progress (Step %1/%2).</source>
-            <translation>Synkronisering pågår (Trinn %1/%2).</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="353" />
-            <source>Sync in progress.</source>
-            <translation>Synkronisering pågår.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="364" />
-            <source>Some files couldn't be synchronized. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-            <translation>Noen filer kunne ikke synkroniseres. &lt;a style="%1" href="%2"&gt;Les mer&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="370" />
-            <source>Synchronization pausing ...</source>
-            <translation>Synkronisering på pause ...</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="570" />
-            <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
-            <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke velges fordi en annen synkronisering bruker den samme mappen.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="576" />
-            <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-            <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke velges fordi den inneholder den synkroniserte mappen &lt;b&gt;%2&lt;/b&gt;.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="584" />
-            <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-            <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke velges fordi den ligger i den synkroniserte mappen &lt;b&gt;%2&lt;/b&gt;.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="595" />
-            <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
-            <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke velges som synkroniseringsmappe. Vennligst velg en annen mappe.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="599" />
-            <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
-            <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke velges som synkroniseringsmappe. Vennligst velg en annen mappe. Forslag til mappe: &lt;b&gt;%2&lt;/b&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="641" />
-            <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
-            <translation>Du har ekskludert mer enn %1 mapper. Vær oppmerksom på at dette vil påvirke synkroniseringsytelsen.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="650" />
-            <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
-            <translation>Du kan ikke ekskludere mer enn 1 % av mappene. Fjern merket for mapper på høyere nivå.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="351" />
-            <source>Synchronization starting</source>
-            <translation>Synkronisering starter</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="374" />
-            <source>Synchronization paused.</source>
-            <translation>Synkroniseringen er satt på pause.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="336" />
-            <source>Sync in progress (%1 of %2)</source>
-            <translation>Synkronisering pågår (1 % av 2 %)</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="340" />
-            <source>Sync in progress (%1 of %2)
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Les mer&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="233"/>
+        <source>Select folder</source>
+        <translation>Velg mappe</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="292"/>
+        <source>Unable to open link %1.</source>
+        <translation>Kan ikke apne lenken %1.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::Logger</name>
+    <message>
+        <location filename="../src/libcommongui/logger.cpp" line="189"/>
+        <source>Error</source>
+        <translation>Feil</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/logger.cpp" line="189"/>
+        <source>&lt;nobr&gt;File &apos;%1&apos;&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
+        <translation>&lt;nobr&gt;Filen «%1»&lt;br/&gt;kan ikke åpnes for skriving.&lt;br/&gt;&lt;br/&gt;Loggutskriften kan &lt;b&gt;ikke&lt;/b&gt; lagres!&lt;/nobr&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::MainMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/mainmenubarwidget.cpp" line="115"/>
+        <source>Preferences</source>
+        <translation>Innstillinger</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/mainmenubarwidget.cpp" line="116"/>
+        <source>Help</source>
+        <translation>Hjelp</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ParametersDialog</name>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1082"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Kan ikke apne mappestien %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1096"/>
+        <source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
+        <translation>Overføringen er fullført!&lt;br&gt;Vennligst oppgi identifikatoren &lt;b&gt;%1&lt;/b&gt; i feilmeldinger.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1118"/>
+        <source>No kDrive configured!</source>
+        <translation>kDrive er ikke konfigurert!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1097"/>
+        <source>Transmission failed!
+Please, use the following link to send the logs to the support: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</source>
+        <translation>Overføringen mislyktes!
+Bruk følgende lenke for å sende loggfilene til kundestøtte: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="337"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="440"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="506"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="546"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="560"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>Det har oppstått en teknisk feil (feil %1).&lt;br&gt;Tøm historikken, og ta kontakt med kundestøtten vår hvis feilen vedvarer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="342"/>
+        <source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
+        <translation>Det ser ut til at tidsavbruddet i nettverkstilkoblingen din er satt for lavt til at programmet skal fungere som det skal (feil %1).&lt;br&gt;Vennligst sjekk nettverksinnstillingene dine.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="347"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="516"/>
+        <source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
+        <translation>Kan ikke koble til kDrive-serveren (feil %1).&lt;br&gt;Forsøker å koble til på nytt. Kontroller internettforbindelsen og brannmuren din.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="352"/>
+        <source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
+        <translation>Det har oppstått et innloggingsproblem (feil %1).&lt;br&gt;Vennligst logg inn på nytt, og kontakt vår kundestøtte dersom feilen vedvarer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="356"/>
+        <source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
+        <translation>Det er en ny versjon av appen tilgjengelig.&lt;br&gt;Oppdater appen for å kunne fortsette å bruke den.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="360"/>
+        <source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
+        <translation>Opplastingen av loggen mislyktes (feil %1).&lt;br&gt;Prøv igjen senere.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="385"/>
+        <source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
+        <translation>Synkroniseringsmappen er ikke lenger tilgjengelig (feil %1).&lt;br&gt;Synkroniseringen fortsetter så snart mappen er tilgjengelig.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="532"/>
+        <source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
+        <translation>Synkroniseringsmappen er erstattet eller flyttet på en måte som forhindrer synkronisering (feil %1).&lt;br&gt;Dette kan skje etter at mappen er kopiert, flyttet eller gjenopprettet.&lt;br&gt;For å løse dette må du opprette en ny synkronisering med en ny mappe.&lt;br&gt;Merk: Hvis du har endringer i den gamle mappen som ikke er synkronisert, må du kopiere dem manuelt over til den nye mappen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="397"/>
+        <source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>Det er ikke nok ledig minne på datamaskinen din.&lt;br&gt;Synkroniseringen er avbrutt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="320"/>
+        <source>kDrive needs to have write access to your computer&apos;s temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
+        <translation>kDrive må ha skrivetilgang til datamaskinens midlertidige mappe. Start kDrive-appen&lt;br&gt;på nytt for å løse dette problemet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="330"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="487"/>
+        <source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>Det har oppstått en teknisk feil.&lt;br&gt;Synkroniseringen vil gjenopptas så snart som mulig. Ta kontakt med kundestøtten vår hvis feilen vedvarer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="401"/>
+        <source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing &apos;/etc/sysctl.conf&apos;.</source>
+        <translation>Antallet inotify-overvåkninger er for lavt (feil %1).&lt;br&gt;Du kan øke dette antallet ved å redigere «/etc/sysctl.conf».</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="406"/>
+        <source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
+        <translation>Det går ikke an å starte synkroniseringen (feil %1).&lt;br&gt;Du må gi tillatelse til&lt;br&gt;:– kDrive i Systeminnstillinger &amp;gt;&amp;gt; Generelt &amp;gt;&amp;gt; Påloggingselementer og utvidelser &amp;gt;&amp;gt;&lt;br&gt;Utvidelser for endepunktsikkerhet– kDrive LiteSync-utvidelsen i Systeminnstillinger &amp;gt;&amp;gt; Personvern og sikkerhet &amp;gt;&amp;gt; Full disktilgang.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="419"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Det går ikke an å starte Lite Sync-tillegget (feil %1).&lt;br&gt;Kontroller at Lite Sync-utvidelsen er installert og at Windows Search-tjenesten er aktivert.&lt;br&gt;Tøm historikken, start på nytt, og hvis feilen vedvarer, kan du kontakte vår kundestøtte.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="424"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Det går ikke an å starte Lite Sync-tillegget (feil %1).&lt;br&gt;Sjekk at Lite Sync-utvidelsen har riktige tillatelser og at den kjører.&lt;br&gt;Tøm historikken, start på nytt, og hvis feilen vedvarer, kan du kontakte vår kundestøtte.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="429"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Det går ikke an å starte Lite Sync-pluginen (feil %1).&lt;br&gt;Tøm historikken, start på nytt, og kontakt kundestøtten vår hvis feilen vedvarer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="435"/>
+        <source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>En fil eller mappe i synkroniseringsmappen din ser ut til å være ødelagt.&lt;br&gt;Synkroniseringen er stoppet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="449"/>
+        <source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>kDrive er i vedlikeholdsmodus.&lt;br&gt;Synkroniseringen vil starte igjen så snart som mulig. Ta kontakt med vår kundestøtte hvis feilen vedvarer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="455"/>
+        <source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+        <translation>kDrive er blokkert.&lt;br&gt;Vennligst oppdater kDrive. Hvis du ikke gjør noe, vil dataene bli slettet permanent, og det vil være umulig å gjenopprette dem.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="460"/>
+        <source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+        <translation>kDrive er sperret.&lt;br&gt;Ta kontakt med en administrator for å fornye kDrive. Hvis du ikke gjør noe, vil dataene bli slettet permanent, og det vil være umulig å gjenopprette dem.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="466"/>
+        <source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>kDrive er i ferd med å starte opp.&lt;br&gt;Synkroniseringen vil gjenopptas så snart som mulig. Ta kontakt med kundestøtten vår hvis feilen vedvarer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="475"/>
+        <source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>kDrive er inaktiv.&lt;br&gt;Vennligst logg inn på nettversjonen for å sjekke statusen til kDrive, eller kontakt administratoren din.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="479"/>
+        <source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>kDrive er inaktiv.&lt;br&gt;Vennligst logg inn på nettversjonen for å sjekke statusen til kDrive, eller kontakt administratoren din.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="483"/>
+        <source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
+        <translation>Du har ikke tilgang til denne kDrive-kontoen.&lt;br&gt;Synkroniseringen er satt på pause. Ta kontakt med en administrator.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="493"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>Det har oppstått en teknisk feil (feil %1).&lt;br&gt;Synkroniseringen vil gjenopptas så snart som mulig. Ta kontakt med vår kundestøtte hvis feilen vedvarer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="512"/>
+        <source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>Nettverkstilkoblingene er blitt avbrutt av kjernen (feil %1).&lt;br&gt;Tøm historikken, og ta kontakt med vår kundestøtte hvis feilen vedvarer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="522"/>
+        <source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
+        <translation>Dessverre kunne ikke den gamle konfigurasjonen overføres.&lt;br&gt;Programmet vil bruke en tom konfigurasjon.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="526"/>
+        <source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
+        <translation>Dessverre kunne ikke den gamle proxykonfigurasjonen din overføres, da SOCKS5-proxyer foreløpig ikke støttes.&lt;br&gt;Programmet vil i stedet bruke systemets proxyinnstillinger.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="539"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
+        <translation>Det har oppstått en teknisk feil (feil %1).&lt;br&gt;Synkroniseringen har blitt startet på nytt. Tøm historikken, og ta kontakt med kundestøtten vår hvis feilen vedvarer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="550"/>
+        <source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
+        <translation>Det har oppstått en feil ved tilgang til synkroniseringsdatabasen (feil %1).&lt;br&gt;Synkroniseringen er stoppet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="564"/>
+        <source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
+        <translation>Det har oppstått et innloggingsproblem (feil %1).&lt;br&gt;Tokenet er ugyldig eller tilbakekalt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="569"/>
+        <source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
+        <translation>Innebygde synkroniseringer er ikke tillatt (feil %1).&lt;br&gt;Du bør kun beholde synkroniseringer der mappene ikke er innebygde.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="573"/>
+        <source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
+        <translation>Synkroniseringsmappen på den eksterne kDrive-enheten finnes ikke lenger eller er ikke lenger tilgjengelig (feil %1).&lt;br&gt;Du må gjenopprette den, gi den tilgang igjen eller slette og opprette synkroniseringen på nytt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="580"/>
+        <source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
+        <translation>Feil ved tolkning av filnavn (feil %1).&lt;br&gt;Spesialtegn som doble anførselstegn, tilbakeslag eller linjeskift kan føre til feil ved tolkningen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="722"/>
+        <source>You are not allowed to move item to &quot;%1&quot;.&lt;br&gt;It will be restored into its original parent folder.</source>
+        <translation>Du har ikke tillatelse til å flytte elementet til «%1».&lt;br&gt;Det vil bli gjenopprettet i den opprinnelige overordnede mappen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="814"/>
+        <source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
+        <translation>Det er ikke nok ledig plass på datamaskinen din.&lt;br&gt;Nedlastingen er avbrutt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="609"/>
+        <source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>Dette elementet er flyttet til et annet sted.&lt;br&gt;Den lokale operasjonen er avbrutt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="618"/>
+        <source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
+        <translation>Det finnes allerede et element med samme navn på dette stedet.&lt;br&gt;Det lokale elementet har fått nytt navn.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="614"/>
+        <source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>Det finnes allerede et element med samme navn på dette stedet.&lt;br&gt;Den lokale operasjonen er avbrutt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="393"/>
+        <source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>Det er ikke nok ledig plass på datamaskinen din.&lt;br&gt;Synkroniseringen er avbrutt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="622"/>
+        <source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
+        <translation>Filen ble redigert samtidig av en annen bruker.&lt;br&gt;Endringene dine er lagret i en kopi.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="626"/>
+        <source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>En annen bruker har flyttet en overordnet mappe for målmappen.&lt;br&gt;Den lokale operasjonen er avbrutt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="692"/>
+        <source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Varenavnet inneholder kun mellomrom.&lt;br&gt;Det er midlertidig satt på svartelisten.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="703"/>
+        <source>Either you are not allowed to create an item, or another item already exists with the same name.&lt;br&gt;The item has been excluded from synchronization.</source>
+        <translation>Enten har du ikke tillatelse til å opprette et element, eller så finnes det allerede et element med samme navn.&lt;br&gt;Elementet er ekskludert fra synkroniseringen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="708"/>
+        <source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
+        <translation>Du har ikke rett til å redigere elementet.&lt;br&gt;Filen som inneholder endringene dine, har blitt omdøpt og ekskludert fra synkroniseringen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="716"/>
+        <source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
+        <translation>Du har ikke lov til å endre navnet på elementet.&lt;br&gt;Det vil bli gjenopprettet med sitt opprinnelige navn.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="727"/>
+        <source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
+        <translation>Du har ikke tillatelse til å slette elementet.&lt;br&gt;Det vil bli gjenopprettet til sin opprinnelige plassering.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="732"/>
+        <source>Failed to move this item to trash, it has been blacklisted.</source>
+        <translation>Det gikk ikke å flytte dette elementet til papirkurven; det er blitt svartelistet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="748"/>
+        <source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
+        <translation>Filen er endret lokalt, mens den er slettet på den eksterne kDrive-enheten. Den&lt;br&gt;lokale kopien er lagret i redningsmappen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="765"/>
+        <source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
+        <translation>Handlingen som ble utført på elementet, er forbudt.&lt;br&gt;Elementet er midlertidig satt på svartelisten.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="771"/>
+        <source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
+        <translation>Operasjonen som ble utført på dette elementet mislyktes.&lt;br&gt;Elementet er midlertidig satt på svartelisten.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="776"/>
+        <source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
+        <translation>Filen er for stor til å kunne lastes opp. Den er midlertidig satt på svartelisten.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="782"/>
+        <source>Impossible to download the file.</source>
+        <translation>Det er umulig å laste ned filen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="779"/>
+        <source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
+        <translation>Du har overskredet kvoten din. Øk lagringsplasskvoten din for å aktivere filopplasting igjen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="389"/>
+        <source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
+        <translation>Stasjonen som inneholder synkroniseringsmappen din, er ikke lenger tilkoblet (feil %1).&lt;br&gt;Koble den til igjen for å fortsette synkroniseringen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="413"/>
+        <source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
+        <translation>Det er ikke mulig å starte synkroniseringen (feil %1).&lt;br&gt;LiteSyncExt-prosessen kjører ikke for øyeblikket. Synkroniseringen vil fortsette så snart prosessen er startet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="649"/>
+        <source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Et eksisterende element har et identisk navn med samme bruk av store og små bokstaver.&lt;br&gt;Det er midlertidig satt på svartelisten.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="656"/>
+        <source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Varenavnet inneholder et tegn som ikke støttes.&lt;br&gt;Det er midlertidig satt på svartelisten.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="662"/>
+        <source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Navnet på elementet slutter med et mellomrom, noe som er forbudt i operativsystemet ditt.&lt;br&gt;Det er midlertidig satt på svartelisten.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="668"/>
+        <source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Dette elementnavnet er reservert av operativsystemet ditt.&lt;br&gt;Det er midlertidig satt på svartelisten.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="674"/>
+        <source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Varenavnet er for langt.&lt;br&gt;Det er midlertidig satt på svartelisten.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="680"/>
+        <source>The item path is too long.&lt;br&gt;It has been ignored.</source>
+        <translation>Elementstien er for lang.&lt;br&gt;Den er blitt ignorert.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="686"/>
+        <source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+        <translation>Navnet på elementet inneholder et nytt Unicode-tegn som filsystemet ditt ennå ikke støtter.&lt;br&gt;Det er utelatt fra synkroniseringen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="735"/>
+        <source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
+        <translation>Det gikk ikke å synkronisere dette elementet. Det er midlertidig satt på svartelisten. Det vil bli&lt;br&gt;gjort et nytt forsøk på å synkronisere det om en time eller ved neste oppstart av applikasjonen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="740"/>
+        <source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
+        <translation>Dette elementet er ekskludert fra synkroniseringen av en tilpasset mal.&lt;br&gt;Du kan deaktivere denne typen varsler under Innstillinger</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="745"/>
+        <source>This item has been excluded from sync because it is a hard link.</source>
+        <translation>Dette elementet er utelatt fra synkroniseringen fordi det er en hardlenke.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="785"/>
+        <source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
+        <translation>Denne varen er for øyeblikket låst av en annen bruker som er online.&lt;br&gt;Vi prøver å laste opp endringene dine senere.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="790"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="834"/>
+        <source>Synchronization error.</source>
+        <translation>Synkroniseringsfeil.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="810"/>
+        <source>Can&apos;t access item.&lt;br&gt;Please fix the read and write permissions.</source>
+        <translation>Kan ikke få tilgang til elementet.&lt;br&gt;Vennligst korriger lese- og skrivetillatelsene.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="818"/>
+        <source>System error.</source>
+        <translation>Systemfeil.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="825"/>
+        <source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Elementet finnes allerede på den andre siden.&lt;br&gt;Det er midlertidig satt på svartelisten.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="840"/>
+        <source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>Det har oppstått en teknisk feil. Tøm&lt;br&gt;historikken, og ta kontakt med kundestøtten vår hvis feilen vedvarer.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::PreferencesBlocWidget</name>
+    <message>
+        <location filename="../src/gui/preferencesblocwidget.cpp" line="187"/>
+        <source>This synchronization is being deleted.</source>
+        <translation>Denne synkroniseringen blir slettet.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::PreferencesMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/preferencesmenubarwidget.cpp" line="63"/>
+        <source>Back to drive list</source>
+        <translation>Tilbake til listen over stasjoner</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferencesmenubarwidget.cpp" line="64"/>
+        <source>Preferences</source>
+        <translation>Innstillinger</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::PreferencesWidget</name>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="491"/>
+        <source>General</source>
+        <translation>Generelt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="493"/>
+        <source>Activate dark theme</source>
+        <translation>Aktiver morkt tema</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="495"/>
+        <source>Activate monochrome icons</source>
+        <translation>Aktiver monokrome ikoner</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="496"/>
+        <source>Launch kDrive at startup</source>
+        <translation>Start kDrive ved oppstart</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="515"/>
+        <source>Finnish</source>
+        <translation>Finsk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="521"/>
+        <source>Advanced</source>
+        <translation>Avansert</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="522"/>
+        <source>Debugging information</source>
+        <translation>Feilsokingsinformasjon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="524"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Åpne feilsøkingsmappen&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="525"/>
+        <source>Files to exclude</source>
+        <translation>Filer som skal utelukkes</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="526"/>
+        <source>Proxy server</source>
+        <translation>Proxyserver</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="511"/>
+        <source>Swedish</source>
+        <translation>Svensk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="512"/>
+        <source>Portuguese</source>
+        <translation>Portugisisk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="513"/>
+        <source>Polish</source>
+        <translation>Polsk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="514"/>
+        <source>Norwegian</source>
+        <translation>Norsk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="466"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Kan ikke apne mappen %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="478"/>
+        <source>Unable to open link %1.</source>
+        <translation>Kan ikke apne lenken %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="483"/>
+        <source>Invalid link %1.</source>
+        <translation>Ugyldig lenke %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="528"/>
+        <source>Lite Sync</source>
+        <translation>Lite Sync</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="497"/>
+        <source>Language</source>
+        <translation>Sprak</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="490"/>
+        <source>Some process failed to run.</source>
+        <translation>En eller annen prosess kunne ikke kjøres.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="498"/>
+        <source>Move deleted files to my computer&apos;s trash</source>
+        <translation>Flytt slettede filer til papirkurven pa datamaskinen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="499"/>
+        <source>Some files or folders may not be moved to the computer&apos;s trash.</source>
+        <translation>Noen filer eller mapper kan ikke flyttes til datamaskinens papirkurv.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="500"/>
+        <source>You can always retrieve already synced files from the kDrive web application trash.</source>
+        <translation>Du kan alltid gjenopprette allerede synkroniserte filer fra papirkurven i kDrive-nettappen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="502"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Les mer&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="506"/>
+        <source>English</source>
+        <translation>Engelsk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="507"/>
+        <source>French</source>
+        <translation>Fransk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="508"/>
+        <source>German</source>
+        <translation>Tysk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="509"/>
+        <source>Spanish</source>
+        <translation>Spansk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="510"/>
+        <source>Italian</source>
+        <translation>Italiensk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="505"/>
+        <source>Default</source>
+        <translation>Standard</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ProgressBarWidget</name>
+    <message>
+        <location filename="../src/gui/progressbarwidget.cpp" line="70"/>
+        <source>%1 in use</source>
+        <translation>%1 i bruk</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ProxyServerDialog</name>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="50"/>
+        <source>HTTP(S) Proxy</source>
+        <translation>HTTP(S)-proxy</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="73"/>
+        <source>Proxy server</source>
+        <translation>Proxyserver</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="85"/>
+        <source>No proxy server</source>
+        <translation>Ingen proxy-server</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="90"/>
+        <source>Use system parameters</source>
+        <translation>Bruk systemparametere</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="95"/>
+        <source>Indicate a proxy manually</source>
+        <translation>Angi en fullmektig manuelt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="131"/>
+        <source>Port</source>
+        <translation>Havn</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="144"/>
+        <source>Address of the proxy server</source>
+        <translation>Adressen til proxy-serveren</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="150"/>
+        <source>Authentication needed</source>
+        <translation>Pålogging kreves</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="165"/>
+        <source>User</source>
+        <translation>Bruker</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="171"/>
+        <source>Password</source>
+        <translation>Passord</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="185"/>
+        <source>SAVE</source>
+        <translation>LAGRE</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="192"/>
+        <source>CANCEL</source>
+        <translation>AVBRYT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="286"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Vil du lagre endringene dine?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="295"/>
+        <source>Unable to save, all mandatory fields are not completed!</source>
+        <translation>Det er ikke mulig å lagre, da alle obligatoriske felt ikke er fylt ut!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="316"/>
+        <source>Proxy not found, save anyway?</source>
+        <translation>Proxy funnet, vil du lagre likevel?</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ResourcesManagerDialog</name>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="55"/>
+        <source>Resources Manager</source>
+        <translation>Ressursansvarlig</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="65"/>
+        <source>Maximum CPU usage allowed</source>
+        <translation>Maksimal tillatt CPU-bruk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="96"/>
+        <source>SAVE</source>
+        <translation>LAGRE</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="103"/>
+        <source>CANCEL</source>
+        <translation>AVBRYT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="122"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Vil du lagre endringene dine?</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ServerBaseFolderDialog</name>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="81"/>
+        <source>Select a folder on your kDrive</source>
+        <translation>Velg en mappe på kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="90"/>
+        <source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
+        <translation>Innholdet i den valgte mappen vil bli synkronisert til mappen &lt;b&gt;%1&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="134"/>
+        <source>CONTINUE</source>
+        <translation>FORTSETT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="150"/>
+        <source>Space available on your computer for the current folder : %1</source>
+        <translation>Ledig plass på datamaskinen din for den aktuelle mappen: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="190"/>
+        <source>This folder is already being synced.</source>
+        <translation>Denne mappen synkroniseres allerede.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="204"/>
+        <source>CONFIRM</source>
+        <translation>BEKREFT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="205"/>
+        <source>CANCEL</source>
+        <translation>AVBRYT</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ServerFoldersDialog</name>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="80"/>
+        <source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
+        <translation>Mappen &lt;b&gt;%1&lt;/b&gt; inneholder undermapper.&lt;br&gt; Velg de du ønsker å synkronisere</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="110"/>
+        <source>CONTINUE</source>
+        <translation>FORTSETT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="146"/>
+        <source>No subfolders currently on the server.</source>
+        <translation>Det finnes for øyeblikket ingen undermapper på serveren.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::StatusBarWidget</name>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="178"/>
+        <source>Resume kDrive &quot;%1&quot; synchronization</source>
+        <translation>Gjenoppta synkroniseringen av kDrive «%1»</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="180"/>
+        <source>Resume all kDrives synchronization</source>
+        <translation>Gjenoppta all synkronisering av kDrives</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="183"/>
+        <source>Pause kDrive &quot;%1&quot; synchronization</source>
+        <translation>Stopp synkroniseringen av kDrive «%1»</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="184"/>
+        <location filename="../src/gui/statusbarwidget.cpp" line="321"/>
+        <source>Pause synchronization</source>
+        <translation>Stopp synkroniseringen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="185"/>
+        <source>Pause all kDrives synchronization</source>
+        <translation>Stopp all synkronisering av kDrives</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="179"/>
+        <location filename="../src/gui/statusbarwidget.cpp" line="322"/>
+        <source>Resume synchronization</source>
+        <translation>Fortsett synkroniseringen</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::SynchronizedItemWidget</name>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
+        <source>Copy share link</source>
+        <translation>Kopier delingslenken</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
+        <source>Display on kdrive.infomaniak.com</source>
+        <translation>Vis på kdrive.infomaniak.com</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
+        <source>Show in folder</source>
+        <translation>Vis i mappe</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
+        <source>More actions</source>
+        <translation>Flere handlinger</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="317"/>
+        <source>Open</source>
+        <translation>Åpne</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
+        <source>Add to favorites</source>
+        <translation>Legg til i favoritter</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::SynthesisBar</name>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="495"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="502"/>
+        <source>Never</source>
+        <translation>Aldri</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="496"/>
+        <source>During 1 hour</source>
+        <translation>I løpet av 1 time</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="497"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="504"/>
+        <source>Until tomorrow 8:00AM</source>
+        <translation>Frem til i morgen kl. 08.00</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="498"/>
+        <source>During 3 days</source>
+        <translation>I løpet av 3 dager</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="499"/>
+        <source>During 1 week</source>
+        <translation>I løpet av 1 uke</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="500"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="507"/>
+        <source>Always</source>
+        <translation>Alltid</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="503"/>
+        <source>For 1 more hour</source>
+        <translation>I én time til</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="505"/>
+        <source>For 3 more days</source>
+        <translation>I ytterligere 3 dager</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="506"/>
+        <source>For 1 more week</source>
+        <translation>I én uke til</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="149"/>
+        <source>Unable to open folder url %1.</source>
+        <translation>Det går ikke an å åpne mappen %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="219"/>
+        <source>Open in folder</source>
+        <translation>Åpne i mappe</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="257"/>
+        <source>Open %1 web version</source>
+        <translation>Åpne %1-nettversjonen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="267"/>
+        <source>Drive parameters</source>
+        <translation>Drivparametere</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="280"/>
+        <source>Notifications disabled until %1</source>
+        <translation>Varsler er deaktivert frem til %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="281"/>
+        <source>Disable Notifications</source>
+        <translation>Deaktiver varsler</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="314"/>
+        <source>Application preferences</source>
+        <translation>Innstillinger for applikasjonen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="322"/>
+        <source>Need help</source>
+        <translation>Trenger du hjelp?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="330"/>
+        <source>Send feedbacks</source>
+        <translation>Send tilbakemeldinger</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="338"/>
+        <source>Quit kDrive</source>
+        <translation>Avslutt kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="401"/>
+        <source>Unable to access web site %1.</source>
+        <translation>Det er ikke mulig å få tilgang til nettstedet %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="492"/>
+        <source>Show errors and informations</source>
+        <translation>Vis feil og informasjon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="493"/>
+        <source>Show informations</source>
+        <translation>Vis informasjon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="494"/>
+        <source>More actions</source>
+        <translation>Flere handlinger</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::SynthesisPopover</name>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1181"/>
+        <source>Update kDrive App</source>
+        <translation>Oppdater kDrive-appen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1182"/>
+        <source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
+        <translation>Denne versjonen av kDrive-appen støttes ikke lenger. Oppdater appen for å få tilgang til de nyeste funksjonene og forbedringene.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="978"/>
+        <source>Update</source>
+        <translation>Oppdatering</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1187"/>
+        <source>Please download the latest version on the website.</source>
+        <translation>Last ned den nyeste versjonen fra nettstedet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="981"/>
+        <source>Update download in progress</source>
+        <translation>Oppdateringen lastes ned</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="984"/>
+        <source>Looking for update...</source>
+        <translation>Leter etter oppdatering...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="987"/>
+        <source>Manual update</source>
+        <translation>Manuell oppdatering</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="990"/>
+        <source>Unavailable</source>
+        <translation>Ikke tilgjengelig</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1200"/>
+        <source>You can synchronize files &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;from your computer&lt;/a&gt; or on &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
+        <translation>Du kan synkronisere filer &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;fra datamaskinen din&lt;/a&gt; eller fra &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="446"/>
+        <source>Synchronized</source>
+        <translation>Synkronisert</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="450"/>
+        <source>Favorites</source>
+        <translation>Favoritter</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="454"/>
+        <source>Activity</source>
+        <translation>Aktivitet</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1133"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1180"/>
+        <source>Not implemented!</source>
+        <translation>Ikke implementert!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1184"/>
+        <source>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Click here to download manually&lt;/a&gt;</source>
+        <translation>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Klikk her for å laste ned manuelt&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1193"/>
+        <source>No synchronized folder for this Drive!</source>
+        <translation>Det finnes ingen synkronisert mappe for denne Drive-kontoen!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1196"/>
+        <source>No kDrive configured!</source>
+        <translation>kDrive er ikke konfigurert!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1161"/>
+        <source>Unable to open link %1.</source>
+        <translation>Kan ikke apne lenken %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1173"/>
+        <source>Invalid link %1.</source>
+        <translation>Ugyldig lenke %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="586"/>
+        <source>Unable to open folder url %1.</source>
+        <translation>Det går ikke an å åpne mappen %1.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::UpdateDialog</name>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="61"/>
+        <source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Den nye versjonen &lt;b&gt;%1&lt;/b&gt; av %2-klienten er tilgjengelig og er lastet ned.&lt;/p&gt;&lt;p&gt;Den installerte versjonen er %3.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="95"/>
+        <source>Skip this version</source>
+        <translation>Hopp over denne versjonen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="103"/>
+        <source>Remind me later</source>
+        <translation>Minn meg på det senere</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="109"/>
+        <source>Install update</source>
+        <translation>Installer oppdatering</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::UpdateManager</name>
+    <message>
+        <location filename="../src/server/updater/updatemanager.cpp" line="86"/>
+        <source>New update available.</source>
+        <translation>Ny oppdatering tilgjengelig.</translation>
+    </message>
+    <message>
+        <location filename="../src/server/updater/updatemanager.cpp" line="87"/>
+        <source>Version %1 is available for download.</source>
+        <translation>Versjon %1 er tilgjengelig for nedlasting.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::UserSelectionWidget</name>
+    <message>
+        <location filename="../src/gui/userselectionwidget.cpp" line="131"/>
+        <source>Add an account</source>
+        <translation>Legg til en konto</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::VersionWidget</name>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="295"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="169"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Show release note&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Vis utgivelsesnotat&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="172"/>
+        <source>Version</source>
+        <translation>Versjon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="173"/>
+        <source>UPDATE</source>
+        <translation>OPPDATERING</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="197"/>
+        <source>%1 is up to date!</source>
+        <translation>%1 er oppdatert!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="201"/>
+        <source>Checking update on server...</source>
+        <translation>Sjekker oppdateringer på serveren...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="205"/>
+        <source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;here&lt;/a&gt;.</source>
+        <translation>Det er en oppdatering tilgjengelig: %1. Last&lt;br&gt;den ned &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;her&lt;/a&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="212"/>
+        <source>An update is available: %1</source>
+        <translation>Det er en oppdatering tilgjengelig: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="218"/>
+        <source>Downloading %1. Please wait...</source>
+        <translation>Laster ned %1. Vennligst vent...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="223"/>
+        <source>Could not check for new updates.</source>
+        <translation>Det var ikke mulig å sjekke om det var nye oppdateringer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="227"/>
+        <source>An error occurred during update.</source>
+        <translation>Det oppstod en feil under oppdateringen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="231"/>
+        <source>Could not download update.</source>
+        <translation>Det gikk ikke an å laste ned oppdateringen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="235"/>
+        <source>Update disabled.</source>
+        <translation>Oppdatering deaktivert.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="251"/>
+        <source>Beta program</source>
+        <translation>Betaprogram</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="252"/>
+        <source>Get early access to new versions of the application</source>
+        <translation>Få tidlig tilgang til nye versjoner av applikasjonen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="256"/>
+        <source>Join</source>
+        <translation>Bli med</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="259"/>
+        <source>Modify</source>
+        <translation>Endre</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="259"/>
+        <source>Quit</source>
+        <translation>Avslutt</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/gui/parameterscache.cpp" line="59"/>
+        <source>Unable to save parameters, please retry later.</source>
+        <translation>Det gikk ikke an å lagre parametrene. Prøv igjen senere.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parameterscache.cpp" line="60"/>
+        <source>Unable to save parameters!</source>
+        <translation>Kan ikke lagre parametrene!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="461"/>
+        <source>The parent folder is a sync folder or contained in one</source>
+        <translation>Overordnet mappe er en synkroniseringsmappe eller ligger i en slik</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="495"/>
+        <source>Can&apos;t find a valid path</source>
+        <translation>Finner ikke en gyldig sti</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2108"/>
+        <source>No valid folder selected!</source>
+        <translation>Det er ikke valgt noen gyldig mappe!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2119"/>
+        <source>The selected path does not exist!</source>
+        <translation>Den valgte banen finnes ikke!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2124"/>
+        <source>The selected path is not a folder!</source>
+        <translation>Den valgte banen er ikke en mappe!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2129"/>
+        <source>You have no permission to write to the selected folder!</source>
+        <translation>Du har ikke tilgang til å skrive til den valgte mappen!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2159"/>
+        <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
+        <translation>Den lokale mappen %1 inneholder en mappe som allerede er synkronisert. Vennligst velg en annen!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2167"/>
+        <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
+        <translation>Den lokale mappen %1 ligger i en mappe som allerede er synkronisert. Vennligst velg en annen!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2175"/>
+        <source>The local folder %1 is already synced. Please pick another one!</source>
+        <translation>Den lokale mappen %1 er allerede synkronisert. Velg en annen!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="42"/>
+        <source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
+        <translation>Lite sync (Beta) er aktivert. Filer fra kDrive forblir i skyen og bruker ikke lagringsplassen på datamaskinen din.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="45"/>
+        <source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
+        <translation>Lite sync (Beta) er deaktivert. kDrive-filene bruker lagringsplassen på datamaskinen din.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="48"/>
+        <source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
+        <translation>Lite-synkronisering er aktivert. Filer fra kDrive forblir i skyen og opptar ikke lagringsplass på datamaskinen din.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="50"/>
+        <source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
+        <translation>Lite sync er deaktivert. kDrive-filene bruker lagringsplassen på datamaskinen din.</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1175"/>
+        <source>Make available locally</source>
+        <translation>Gjør tilgjengelig lokalt</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1179"/>
+        <source>Free up local space</source>
+        <translation>Frigjør lokal lagringsplass</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1183"/>
+        <source>Cancel free up local space</source>
+        <translation>Avbryt for å frigjøre lokal lagringsplass</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1187"/>
+        <source>Cancel make available locally</source>
+        <translation>Avbryt lokal tilgjengeliggjøring</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1191"/>
+        <source>Resharing this file is not allowed</source>
+        <translation>Det er ikke tillatt å dele denne filen videre</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1192"/>
+        <source>Resharing this folder is not allowed</source>
+        <translation>Det er ikke tillatt å dele denne mappen videre</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1196"/>
+        <source>Copy public share link</source>
+        <translation>Kopier lenken til den offentlige delingen</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1200"/>
+        <source>Copy private share link</source>
+        <translation>Kopier lenken til privat deling</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1204"/>
+        <source>Open in browser</source>
+        <translation>Åpne i nettleseren</translation>
+    </message>
+</context>
+<context>
+    <name>SharedTools::QtSingleApplication</name>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="133"/>
+        <source>kDrive application will close due to a fatal error.</source>
+        <translation>kDrive-programmet vil lukkes på grunn av en alvorlig feil.</translation>
+    </message>
+</context>
+<context>
+    <name>Utility</name>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="97"/>
+        <source>%L1 GB</source>
+        <translation>%L1 GB</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="101"/>
+        <source>%L1 MB</source>
+        <translation>%L1 MB</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="105"/>
+        <source>%L1 KB</source>
+        <translation>%L1 KB</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="108"/>
+        <source>%L1 B</source>
+        <translation>%L1 B</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="41"/>
+        <source>%n year(s)</source>
+        <translation>
+            <numerusform>%n ar</numerusform>
+            <numerusform>%n ar</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="42"/>
+        <source>%n month(s)</source>
+        <translation>
+            <numerusform>%n maned</numerusform>
+            <numerusform>%n maneder</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="43"/>
+        <source>%n day(s)</source>
+        <translation>
+            <numerusform>%n dag</numerusform>
+            <numerusform>%n dager</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="44"/>
+        <source>%n hour(s)</source>
+        <translation>
+            <numerusform>%n time</numerusform>
+            <numerusform>%n timer</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="45"/>
+        <source>%n minute(s)</source>
+        <translation>
+            <numerusform>%n minutt</numerusform>
+            <numerusform>%n minutter</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="46"/>
+        <source>%n second(s)</source>
+        <translation>
+            <numerusform>%n sekund</numerusform>
+            <numerusform>%n sekunder</numerusform>
+        </translation>
+    </message>
+</context>
+<context>
+    <name>utility</name>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="84"/>
+        <source>Could not open browser</source>
+        <translation>Kunne ikke åpne nettleseren</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="85"/>
+        <source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
+        <translation>Det oppstod en feil da nettleseren ble startet for å gå til URL-adressen %1. Kanskje er det ikke konfigurert noen standard nettleser?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="104"/>
+        <source>Could not open email client</source>
+        <translation>Kunne ikke åpne e-postprogrammet</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="105"/>
+        <source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
+        <translation>Det oppstod en feil da e-postklienten ble startet for å opprette en ny melding. Kanskje er det ikke konfigurert noen standard e-postklient?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="324"/>
+        <source>You are not connected anymore. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Log in&lt;/a&gt;</source>
+        <translation>Du er ikke lenger pålogget. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Logg inn&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="347"/>
+        <source>Sync in progress (Step %1/%2).</source>
+        <translation>Synkronisering pågår (Trinn %1/%2).</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="353"/>
+        <source>Sync in progress.</source>
+        <translation>Synkronisering pågår.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="364"/>
+        <source>Some files couldn&apos;t be synchronized. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Noen filer kunne ikke synkroniseres. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Les mer&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="370"/>
+        <source>Synchronization pausing ...</source>
+        <translation>Synkronisering på pause ...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="570"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
+        <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke velges fordi en annen synkronisering bruker den samme mappen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="576"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+        <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke velges fordi den inneholder den synkroniserte mappen &lt;b&gt;%2&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="584"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+        <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke velges fordi den ligger i den synkroniserte mappen &lt;b&gt;%2&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="595"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
+        <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke velges som synkroniseringsmappe. Vennligst velg en annen mappe.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="599"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
+        <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke velges som synkroniseringsmappe. Vennligst velg en annen mappe. Forslag til mappe: &lt;b&gt;%2&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="651"/>
+        <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
+        <translation>Du har ekskludert mer enn %1 mapper. Vær oppmerksom på at dette vil påvirke synkroniseringsytelsen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="660"/>
+        <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
+        <translation>Du kan ikke ekskludere mer enn 1 % av mappene. Fjern merket for mapper på høyere nivå.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="351"/>
+        <source>Synchronization starting</source>
+        <translation>Synkronisering starter</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="374"/>
+        <source>Synchronization paused.</source>
+        <translation>Synkroniseringen er satt på pause.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="336"/>
+        <source>Sync in progress (%1 of %2)</source>
+        <translation>Synkronisering pågår (1 % av 2 %)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="340"/>
+        <source>Sync in progress (%1 of %2)
 %3 left...</source>
-            <translation>Synkronisering pågår (%1 av %2)
+        <translation>Synkronisering pågår (%1 av %2)
 %3 igjen...</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="358" />
-            <source>You are up to date, unresolved conflicts.</source>
-            <translation>Du har uavklarte konflikter.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="360" />
-            <source>You are up to date!</source>
-            <translation>Du er oppdatert!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="329" />
-            <source>No folder to synchronize
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="358"/>
+        <source>You are up to date, unresolved conflicts.</source>
+        <translation>Du har uavklarte konflikter.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="360"/>
+        <source>You are up to date!</source>
+        <translation>Du er oppdatert!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="329"/>
+        <source>No folder to synchronize
 You can add one from the kDrive settings.</source>
-            <translation>Ingen mappe å synkronisere
+        <translation>Ingen mappe å synkronisere
 Du kan legge til en i kDrive-innstillingene.</translation>
-        </message>
-    </context>
+    </message>
+</context>
 </TS>

--- a/translations/client_pl.ts
+++ b/translations/client_pl.ts
@@ -1,3047 +1,3055 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="pl_PL">
-    <context>
-        <name>KDC::AboutDialog</name>
-        <message>
-            <location filename="../src/gui/aboutdialog.cpp" line="73" />
-            <source>About</source>
-            <translation>Informacje</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/aboutdialog.cpp" line="112" />
-            <source>CLOSE</source>
-            <translation>ZAMKNIJ</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/aboutdialog.cpp" line="123" />
-            <source>Version %1. For more information visit &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
-            <translation>Wersja %1. Więcej informacji można znaleźć na stronie &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/aboutdialog.cpp" line="126" />
-            <source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
-            <translation>Prawa autorskie 2019–%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/aboutdialog.cpp" line="127" />
-            <source>Distributed by %1 and licensed under the &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
-            <translation>Dystrybucja: %1; na licencji &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 oraz logo %2 są zastrzeżonymi znakami towarowymi firmy %1.&lt;br&gt;&lt;br&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/aboutdialog.cpp" line="151" />
-            <location filename="../src/gui/aboutdialog.cpp" line="162" />
-            <location filename="../src/gui/aboutdialog.cpp" line="171" />
-            <source>Unable to open folder %1.</source>
-            <translation>Nie można otworzyć folderu %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/aboutdialog.cpp" line="132" />
-            <source>&lt;p&gt;&lt;small&gt;Built from &lt;a style="color: #489EF3" href="%1"&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
-            <translation>&lt;p&gt;&lt;small&gt;Skompilowano ze &lt;a style="color: #489EF3" href="%1"&gt;źródeł Git&lt;/a&gt; w dniu %2, %3 przy użyciu Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::AbstractFileItemWidget</name>
-        <message>
-            <location filename="../src/gui/abstractfileitemwidget.cpp" line="177" />
-            <source>Unable to open folder path %1.</source>
-            <translation>Nie można otworzyć ścieżki folderu %1.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::AddDriveConfirmationWidget</name>
-        <message>
-            <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55" />
-            <source>Synchronization will start and you will be able to add files to your %1 folder.</source>
-            <translation>Rozpocznie się synchronizacja i będzie można dodawać pliki do folderu %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99" />
-            <source>Your kDrive is ready!</source>
-            <translation>Twój kDrive jest gotowy!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123" />
-            <source>OPEN FOLDER</source>
-            <translation>OTWÓRZ FOLDER</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130" />
-            <source>PARAMETERS</source>
-            <translation>USTAWIENIA</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138" />
-            <source>Synchronize another drive</source>
-            <translation>Zsynchronizuj inny dysk</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::AddDriveListWidget</name>
-        <message>
-            <location filename="../src/gui/adddrivelistwidget.cpp" line="170" />
-            <source>Cancel</source>
-            <translation>Anuluj</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelistwidget.cpp" line="177" />
-            <source>NEXT</source>
-            <translation>DALEJ</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelistwidget.cpp" line="196" />
-            <source>Select the kDrive you want to synchronize</source>
-            <translation>Wybierz urządzenie kDrive, które chcesz zsynchronizować</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelistwidget.cpp" line="234" />
-            <source>Get kDrive for free</source>
-            <translation>Pobierz kDrive za darmo</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelistwidget.cpp" line="244" />
-            <source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
-            <translation>Przechowuj swoje zdjęcia, dokumenty i wiadomości e-mail w Szwajcarii, korzystając z usług niezależnej firmy, która szanuje prywatność. Dowiedz się więcej</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelistwidget.cpp" line="263" />
-            <source>Test for free</source>
-            <translation>Wypróbuj za darmo</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::AddDriveLiteSyncWidget</name>
-        <message>
-            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147" />
-            <source>Conserve your computer space</source>
-            <translation>Oszczędzaj miejsce na komputerze</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167" />
-            <source>Decide which files should be available online or locally</source>
-            <translation>Zdecyduj, które pliki mają być dostępne online lub lokalnie</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187" />
-            <source>LATER</source>
-            <translation>PÓŹNIEJ</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193" />
-            <source>YES</source>
-            <translation>TAK</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125" />
-            <source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-            <translation>Lite Sync synchronizuje wszystkie Twoje pliki bez zajmowania miejsca na komputerze. Możesz przeglądać pliki w kDrive i pobierać je lokalnie w dowolnym momencie. &lt;a style="%1" href="%2"&gt;Dowiedz się więcej&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207" />
-            <source>Unable to open link %1.</source>
-            <translation>Nie można otworzyć linku %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112" />
-            <source>Would you like to activate Lite Sync (Beta) ?</source>
-            <translation>Czy chcesz włączyć funkcję Lite Sync (wersja beta)?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114" />
-            <source>Would you like to activate Lite Sync ?</source>
-            <translation>Czy chcesz włączyć funkcję Lite Sync?</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::AddDriveLocalFolderWidget</name>
-        <message>
-            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65" />
-            <source>Location of your %1 kDrive</source>
-            <translation>Lokalizacja dysku %1 kDrive</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155" />
-            <source>Edit folder</source>
-            <translation>Edytuj folder</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246" />
-            <source>END</source>
-            <translation>ZAKOŃCZ</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297" />
-            <source>Select folder</source>
-            <translation>Wybierz folder</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264" />
-            <source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
-            <translation>Zawartość folderu &lt;b&gt;%1&lt;/b&gt; zostanie zsynchronizowana w Twoim kDrive</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212" />
-            <source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
-            <translation>Po zakończeniu konfiguracji wszystkie pliki znajdziesz w tym folderze. Możesz wrzucić tam nowe pliki, aby zsynchronizować je z usługą kDrive.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284" />
-            <source>This folder is not compatible with Lite Sync.&lt;br&gt; 
+<context>
+    <name>KDC::AboutDialog</name>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="73"/>
+        <source>About</source>
+        <translation>Informacje</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="112"/>
+        <source>CLOSE</source>
+        <translation>ZAMKNIJ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="123"/>
+        <source>Version %1. For more information visit &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
+        <translation>Wersja %1. Więcej informacji można znaleźć na stronie &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="126"/>
+        <source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
+        <translation>Prawa autorskie 2019–%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="127"/>
+        <source>Distributed by %1 and licensed under the &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
+        <translation>Dystrybucja: %1; na licencji &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 oraz logo %2 są zastrzeżonymi znakami towarowymi firmy %1.&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="151"/>
+        <location filename="../src/gui/aboutdialog.cpp" line="162"/>
+        <location filename="../src/gui/aboutdialog.cpp" line="171"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Nie można otworzyć folderu %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="132"/>
+        <source>&lt;p&gt;&lt;small&gt;Built from &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
+        <translation>&lt;p&gt;&lt;small&gt;Skompilowano ze &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;źródeł Git&lt;/a&gt; w dniu %2, %3 przy użyciu Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AbstractFileItemWidget</name>
+    <message>
+        <location filename="../src/gui/abstractfileitemwidget.cpp" line="177"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Nie można otworzyć ścieżki folderu %1.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AddDriveConfirmationWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55"/>
+        <source>Synchronization will start and you will be able to add files to your %1 folder.</source>
+        <translation>Rozpocznie się synchronizacja i będzie można dodawać pliki do folderu %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99"/>
+        <source>Your kDrive is ready!</source>
+        <translation>Twój kDrive jest gotowy!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123"/>
+        <source>OPEN FOLDER</source>
+        <translation>OTWÓRZ FOLDER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130"/>
+        <source>PARAMETERS</source>
+        <translation>USTAWIENIA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138"/>
+        <source>Synchronize another drive</source>
+        <translation>Zsynchronizuj inny dysk</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AddDriveListWidget</name>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="170"/>
+        <source>Cancel</source>
+        <translation>Anuluj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="177"/>
+        <source>NEXT</source>
+        <translation>DALEJ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="196"/>
+        <source>Select the kDrive you want to synchronize</source>
+        <translation>Wybierz urządzenie kDrive, które chcesz zsynchronizować</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="234"/>
+        <source>Get kDrive for free</source>
+        <translation>Pobierz kDrive za darmo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="244"/>
+        <source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
+        <translation>Przechowuj swoje zdjęcia, dokumenty i wiadomości e-mail w Szwajcarii, korzystając z usług niezależnej firmy, która szanuje prywatność. Dowiedz się więcej</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="263"/>
+        <source>Test for free</source>
+        <translation>Wypróbuj za darmo</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AddDriveLiteSyncWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147"/>
+        <source>Conserve your computer space</source>
+        <translation>Oszczędzaj miejsce na komputerze</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167"/>
+        <source>Decide which files should be available online or locally</source>
+        <translation>Zdecyduj, które pliki mają być dostępne online lub lokalnie</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187"/>
+        <source>LATER</source>
+        <translation>PÓŹNIEJ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193"/>
+        <source>YES</source>
+        <translation>TAK</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
+        <source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Lite Sync synchronizuje wszystkie Twoje pliki bez zajmowania miejsca na komputerze. Możesz przeglądać pliki w kDrive i pobierać je lokalnie w dowolnym momencie. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Dowiedz się więcej&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207"/>
+        <source>Unable to open link %1.</source>
+        <translation>Nie można otworzyć linku %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112"/>
+        <source>Would you like to activate Lite Sync (Beta) ?</source>
+        <translation>Czy chcesz włączyć funkcję Lite Sync (wersja beta)?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114"/>
+        <source>Would you like to activate Lite Sync ?</source>
+        <translation>Czy chcesz włączyć funkcję Lite Sync?</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AddDriveLocalFolderWidget</name>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65"/>
+        <source>Location of your %1 kDrive</source>
+        <translation>Lokalizacja dysku %1 kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155"/>
+        <source>Edit folder</source>
+        <translation>Edytuj folder</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+        <source>END</source>
+        <translation>ZAKOŃCZ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
+        <source>Select folder</source>
+        <translation>Wybierz folder</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
+        <source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
+        <translation>Zawartość folderu &lt;b&gt;%1&lt;/b&gt; zostanie zsynchronizowana w Twoim kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212"/>
+        <source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
+        <translation>Po zakończeniu konfiguracji wszystkie pliki znajdziesz w tym folderze. Możesz wrzucić tam nowe pliki, aby zsynchronizować je z usługą kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284"/>
+        <source>This folder is not compatible with Lite Sync.&lt;br&gt; 
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt; 
-&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-            <translation>Ten folder nie jest zgodny z Lite Sync.&lt;br&gt; 
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Ten folder nie jest zgodny z Lite Sync.&lt;br&gt; 
 Wybierz inny folder. Jeśli kontynuujesz, funkcja Lite Sync zostanie wyłączona.&lt;br&gt; 
-&lt;a style="%1" href="%2"&gt;Dowiedz się więcej&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377" />
-            <source>Unable to open link %1.</source>
-            <translation>Nie można otworzyć linku %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246" />
-            <source>CONTINUE</source>
-            <translation>KONTYNUUJ</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::AddDriveLoginWidget</name>
-        <message>
-            <location filename="../src/gui/adddriveloginwidget.cpp" line="69" />
-            <source>Log in from your browser</source>
-            <translation>Zaloguj się w przeglądarce</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveloginwidget.cpp" line="75" />
-            <source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
-            <translation>Przeglądarka powinna otworzyć się automatycznie, aby nawiązać połączenie. Po nawiązaniu połączenia nastąpi automatyczny powrót do serwisu kDrive.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveloginwidget.cpp" line="85" />
-            <source>Open the login page</source>
-            <translation>Otwórz stronę logowania</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveloginwidget.cpp" line="119" />
-            <source>Token request failed: %1 - %2</source>
-            <translation>Wystąpił błąd podczas żądania tokenu: %1 - %2</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveloginwidget.cpp" line="133" />
-            <source>Login failed: %1 - %2</source>
-            <translation>Nie udało się zalogować: %1 - %2</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveloginwidget.cpp" line="141" />
-            <source>Failed to open the login page in your web browser</source>
-            <translation>Nie udało się otworzyć strony logowania w przeglądarce internetowej</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::AddDriveServerFoldersWidget</name>
-        <message>
-            <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129" />
-            <source>Select kDrive folders to synchronize on your desktop</source>
-            <translation>Wybierz foldery kDrive, które chcesz zsynchronizować na pulpicie</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174" />
-            <source>CONTINUE</source>
-            <translation>KONTYNUUJ</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187" />
-            <source>Space available on your computer : %1</source>
-            <translation>Wolne miejsce na komputerze: %1</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206" />
-            <source>An error occurred while loading the list of subfolders.</source>
-            <translation>Wystąpił błąd podczas ładowania listy podfolderów.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210" />
-            <source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
-            <translation>Nie można załadować listy podfolderów. Być może Twoje konto kDrive jest obecnie w trakcie konserwacji.&lt;br&gt;Zaloguj się do &lt;a style="%1" href="%2"&gt;wersji&lt;/a&gt; &lt;a style="%1" href="%2"&gt;internetowej&lt;/a&gt;, aby sprawdzić stan swojego konta kDrive, lub skontaktuj się z administratorem.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::AddDriveWizard</name>
-        <message>
-            <location filename="../src/gui/adddrivewizard.cpp" line="222" />
-            <source>Failed to create local folder %1</source>
-            <translation>Nie udało się utworzyć folderu lokalnego %1</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivewizard.cpp" line="233" />
-            <source>Failed to create new synchronization</source>
-            <translation>Nie udało się utworzyć nowej synchronizacji</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivewizard.cpp" line="266" />
-            <source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
-            <translation>Aplikacja kDrive %1 jest już zsynchronizowana na tym komputerze. Czy mimo to chcesz kontynuować?</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::AppClient</name>
-        <message>
-            <location filename="../src/gui/appclient.cpp" line="100" />
-            <source>kDrive client is run with bad parameters!</source>
-            <translation>Program kDrive został uruchomiony z nieprawidłowymi parametrami!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/appclient.cpp" line="109" />
-            <source>kDrive client is already running!</source>
-            <translation>Klient kDrive już działa!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/appclient.cpp" line="719" />
-            <source>The user %1 is not connected. Please log in again.</source>
-            <translation>Użytkownik %1 nie jest zalogowany. Zaloguj się ponownie.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::AppServer</name>
-        <message>
-            <location filename="../src/server/appserver.cpp" line="1679" />
-            <source>Share link copied to clipboard</source>
-            <translation>Link do udostępnienia skopiowano do schowka</translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/server/appserver.cpp" line="3759" />
-            <source>%1 and %n other file(s) have been removed.</source>
-            <translation>
-                <numerusform>%1 oraz %n inny plik zostały usunięte.</numerusform>
-                <numerusform>%1 oraz %n innych plików zostało usuniętych.</numerusform>
-            </translation>
-        </message>
-        <message>
-            <location filename="../src/server/appserver.cpp" line="3761" />
-            <source>%1 has been removed.</source>
-            <comment>%1 names a file.</comment>
-            <translation>%1 został usunięty.</translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/server/appserver.cpp" line="3766" />
-            <source>%1 and %n other file(s) have been added.</source>
-            <translation>
-                <numerusform>%1 oraz %n inny plik zostały dodane.</numerusform>
-                <numerusform>%1 oraz %n innych plików zostało dodanych.</numerusform>
-            </translation>
-        </message>
-        <message>
-            <location filename="../src/server/appserver.cpp" line="3768" />
-            <source>%1 has been added.</source>
-            <comment>%1 names a file.</comment>
-            <translation>Dodano %1.</translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/server/appserver.cpp" line="3773" />
-            <source>%1 and %n other file(s) have been updated.</source>
-            <translation>
-                <numerusform>%1 oraz %n inny plik zostały zaktualizowane.</numerusform>
-                <numerusform>%1 oraz %n innych plików zostało zaktualizowanych.</numerusform>
-            </translation>
-        </message>
-        <message>
-            <location filename="../src/server/appserver.cpp" line="3775" />
-            <source>%1 has been updated.</source>
-            <comment>%1 names a file.</comment>
-            <translation>%1 zostało zaktualizowane.</translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/server/appserver.cpp" line="3780" />
-            <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
-            <translation>
-                <numerusform>%1 został przeniesiony do %2, a %n inny plik został przeniesiony.</numerusform>
-                <numerusform>%1 został przeniesiony do %2, a %n innych plików zostało przeniesionych.</numerusform>
-            </translation>
-        </message>
-        <message>
-            <location filename="../src/server/appserver.cpp" line="3783" />
-            <source>%1 has been moved to %2.</source>
-            <translation>%1 zostało przeniesione do %2.</translation>
-        </message>
-        <message>
-            <location filename="../src/server/appserver.cpp" line="3791" />
-            <source>Sync Activity</source>
-            <translation>Synchronizacja działań</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::BaseFolderTreeItemWidget</name>
-        <message>
-            <location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102" />
-            <source>No subfolders currently on the server.</source>
-            <translation>Obecnie na serwerze nie ma żadnych podfolderów.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::BetaProgramDialog</name>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="69" />
-            <source>Quit the beta program</source>
-            <translation>Wyjdź z programu beta</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="69" />
-            <source>Join the beta program</source>
-            <translation>Dołącz do programu beta</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="77" />
-            <source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
-            <translation>Zyskaj wczesny dostęp do nowych wersji aplikacji, zanim zostaną one udostępnione szerokiej publiczności, i pomóż nam ulepszać aplikację, przesyłając nam swoje uwagi.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="87" />
-            <source>Benefit from application beta updates</source>
-            <translation>Skorzystaj z aktualizacji wersji beta aplikacji</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="91" />
-            <source>No</source>
-            <translation>Nie</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="92" />
-            <source>Public beta version</source>
-            <translation>Publiczna wersja beta</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="93" />
-            <source>Internal beta version</source>
-            <translation>Wewnętrzna wersja beta</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="141" />
-            <source>I understand</source>
-            <translation>Rozumiem</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="147" />
-            <source>Are you sure you want to leave the beta program?</source>
-            <translation>Czy na pewno chcesz opuścić program beta?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="161" />
-            <source>Save</source>
-            <translation>Zapisz</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="167" />
-            <source>Cancel</source>
-            <translation>Anuluj</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="228" />
-            <source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
-            <translation>Obecna wersja aplikacji może być zbyt nowa; wybrane ustawienia zaczną obowiązywać po udostępnieniu kolejnej aktualizacji.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="233" />
-            <source>Beta versions may leave unexpectedly or cause instabilities.</source>
-            <translation>Wersje beta mogą się niespodziewanie zamknąć lub powodować niestabilność działania.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::ClientGui</name>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="189" />
-            <source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
-            <translation>Nie udało się rozwiązać konfliktu(-ów) dotyczących %1 elementu(-ów) w folderze synchronizacji: %2</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="242" />
-            <source>Please sign in</source>
-            <translation>Zaloguj się</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="292" />
-            <source>Folder %1: %2</source>
-            <translation>Folder %1: %2</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="298" />
-            <source>There are no sync folders configured.</source>
-            <translation>Nie skonfigurowano żadnych folderów synchronizacji.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="1426" />
-            <source>Synthesis</source>
-            <translation>Podsumowanie</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="1427" />
-            <source>Preferences</source>
-            <translatorcomment>Préférences</translatorcomment>
-            <translation>Preferencje</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="1428" />
-            <source>Quit</source>
-            <translation>Zakończ</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="673" />
-            <source>Undefined State.</source>
-            <translation>Stan nieokreślony.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="676" />
-            <source>Waiting to start syncing.</source>
-            <translation>Oczekiwanie na rozpoczęcie synchronizacji.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="679" />
-            <source>Sync is running.</source>
-            <translation>Synchronizacja trwa.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="683" />
-            <source>Sync was successful, unresolved conflicts.</source>
-            <translation>Synchronizacja przebiegła pomyślnie, pozostały nierozwiązane konflikty.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="685" />
-            <source>Last Sync was successful.</source>
-            <translation>Ostatnia synchronizacja zakończyła się powodzeniem.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="692" />
-            <source>User Abort.</source>
-            <translation>Anulowanie przez użytkownika.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="696" />
-            <source>Sync is paused.</source>
-            <translation>Synchronizacja została wstrzymana.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="705" />
-            <source>%1 (Sync is paused)</source>
-            <translation>%1 (Synchronizacja została wstrzymana)</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="1261" />
-            <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-            <translation>Czy na pewno chcesz usunąć synchronizacje konta &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Uwaga: Nie&lt;/b&gt; spowoduje to usunięcia żadnych plików.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="1265" />
-            <source>REMOVE ALL SYNCHRONIZATIONS</source>
-            <translation>USUŃ WSZYSTKIE SYNCHRONIZACJE</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="1266" />
-            <source>CANCEL</source>
-            <translation>ANULUJ</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="1594" />
-            <source>Failed to start synchronizations!</source>
-            <translation>Nie udało się uruchomić synchronizacji!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="849" />
-            <source>Unable to open folder path %1.</source>
-            <translation>Nie można otworzyć ścieżki folderu %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="116" />
-            <source>Unable to initialize kDrive client</source>
-            <translation>Nie można zainicjować klienta kDrive</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="255" />
-            <source>Synchronization is paused</source>
-            <translation>Synchronizacja została wstrzymana</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::ConfirmSynchronizationDialog</name>
-        <message>
-            <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86" />
-            <source>Summary of your local folder synchronization</source>
-            <translation>Podsumowanie synchronizacji folderów lokalnych</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95" />
-            <source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
-            <translation>Zawartość folderu na Twoim komputerze zostanie zsynchronizowana z folderem na wybranym serwerze kDrive i odwrotnie.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184" />
-            <source>CANCEL</source>
-            <translation>ANULUJ</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191" />
-            <source>SYNCHRONIZE</source>
-            <translation>SYNCHRONIZUJ</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::CustomExtensionSetupWidget</name>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="96" />
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="120" />
-            <source>Before finishing</source>
-            <translation>Zanim skończymy</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="107" />
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="131" />
-            <source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
-            <translation>Wykonaj poniższe czynności, aby upewnić się, że program Lite Sync działa poprawnie na Twoim komputerze, oraz aby zakończyć konfigurację serwisu kDrive.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="208" />
-            <source>Open your Mac's &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-            <translation>Otwórz &lt;b&gt;ustawienia ogólne&lt;/b&gt; komputera Mac lub &lt;a style="%1" href="%2"&gt;kliknij tutaj&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="212" />
-            <source>Open your Mac's &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-            <translation>Otwórz &lt;b&gt;ustawienia prywatności i bezpieczeństwa&lt;/b&gt; na komputerze Mac lub &lt;a style="%1" href="%2"&gt;kliknij tutaj&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="216" />
-            <source>Open your Mac's &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-            <translation>Otwórz &lt;b&gt;ustawienia „Bezpieczeństwo i prywatność”&lt;/b&gt; na komputerze Mac lub &lt;a style="%1" href="%2"&gt;kliknij tutaj&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="246" />
-            <source>Go to &lt;b&gt;"Login Items &amp; Extensions"&lt;/b&gt; section and then to &lt;b&gt;"Endpoint Security Extensions"&lt;/b&gt;</source>
-            <translation>Przejdź do sekcji &lt;b&gt;„Elementy logowania i rozszerzenia”,&lt;/b&gt; a następnie do &lt;b&gt;„Rozszerzenia Endpoint Security”&lt;/b&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="263" />
-            <source>Authorize the kDrive application</source>
-            <translation>Zezwól aplikacji kDrive</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="272" />
-            <source>Go to &lt;b&gt;"Security"&lt;/b&gt; section</source>
-            <translation>Przejdź do sekcji &lt;b&gt;„Bezpieczeństwo”&lt;/b&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="289" />
-            <source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
-            <translation>Zezwól aplikacji kDrive w oknie informującym, że kDrive zostało zablokowane</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="299" />
-            <source>Unlock the padlock &lt;img src=":/client/resources/icons/actions/lock.png"&gt; and authorize the kDrive application</source>
-            <translation>Odblokuj kłódkę &lt;img src=":/client/resources/icons/actions/lock.png"&gt; i autoryzuj aplikację kDrive</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="344" />
-            <source>Go to &lt;b&gt;"Privacy &amp; Security"&lt;/b&gt; section and click on &lt;b&gt;"Full Disk Access"&lt;/b&gt; or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-            <translation>Przejdź do sekcji &lt;b&gt;„Prywatność i bezpieczeństwo”&lt;/b&gt; i kliknij opcję &lt;b&gt;„Pełny dostęp do dysku”&lt;/b&gt; lub &lt;a style="%1" href="%2"&gt;kliknij tutaj&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="348" />
-            <source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;"Privacy"&lt;/b&gt; tab or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-            <translation>Wciąż w ustawieniach „Bezpieczeństwo i prywatność” otwórz zakładkę &lt;b&gt;„Prywatność”&lt;/b&gt; lub &lt;a style="%1" href="%2"&gt;kliknij tutaj&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="376" />
-            <source>Check the "kDrive LiteSync Extension" box then the "kDrive.app" box (if not already checked)</source>
-            <translation>Zaznacz pole „kDrive LiteSync Extension”, a następnie pole „kDrive.app” (jeśli nie jest jeszcze zaznaczone)</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="393" />
-            <source>A restart of the app might be proposed, in this case accept it</source>
-            <translation>Może pojawić się propozycja ponownego uruchomienia aplikacji; w takim przypadku należy ją zaakceptować</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="399" />
-            <source>Check the "kDrive LiteSync Extension" box (and "kDrive.app" if it exists) in &lt;b&gt;"Full Disk Access"&lt;/b&gt;</source>
-            <translation>Zaznacz pole „kDrive LiteSync Extension” (oraz „kDrive.app”, jeśli istnieje) w &lt;b&gt;sekcji „Pełny dostęp do dysku”&lt;/b&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="495" />
-            <source>STEP 1</source>
-            <translation>KROK 1</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="495" />
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="496" />
-            <source>(Done)</source>
-            <translation>(Gotowe)</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="496" />
-            <source>STEP 2</source>
-            <translation>KROK 2</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="499" />
-            <source>STEPS PERFORMED</source>
-            <translation>WYKONANE CZYNNOŚCI</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="501" />
-            <source>END</source>
-            <translation>ZAKOŃCZ</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::CustomMessageBox</name>
-        <message>
-            <location filename="../src/gui/custommessagebox.cpp" line="101" />
-            <source>OK</source>
-            <translation>OK</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/custommessagebox.cpp" line="111" />
-            <source>CANCEL</source>
-            <translation>ANULUJ</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/custommessagebox.cpp" line="121" />
-            <source>YES</source>
-            <translation>TAK</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/custommessagebox.cpp" line="131" />
-            <source>NO</source>
-            <translation>NIE</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::DebugReporter</name>
-        <message>
-            <location filename="../src/gui/debugreporter.cpp" line="37" />
-            <source>Sending of debugging information</source>
-            <translation>Wysyłanie informacji dotyczących debugowania</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debugreporter.cpp" line="37" />
-            <source>Cancel</source>
-            <translation>Anuluj</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::DebuggingDialog</name>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="46" />
-            <source>Info</source>
-            <translation>Informacje</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="45" />
-            <source>Debug</source>
-            <translation>Debugowanie</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="47" />
-            <source>Warning</source>
-            <translation>Ostrzeżenie</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="48" />
-            <source>Error</source>
-            <translation>Błąd</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="49" />
-            <source>Fatal</source>
-            <translation>Śmiertelny</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="74" />
-            <source>Debugging settings</source>
-            <translation>Ustawienia debugowania</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="90" />
-            <source>Save debugging information in a folder on my computer (Recommended)</source>
-            <translation>Zapisz informacje dotyczące debugowania w folderze na moim komputerze (zalecane)</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="104" />
-            <source>This information enables IT support to determine the origin of an incident.</source>
-            <translation>Informacje te pozwalają działowi wsparcia IT ustalić przyczynę incydentu.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="114" />
-            <source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
-            <translation>&lt;a style="%1" href="%2"&gt;Otwórz folder debugowania&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="143" />
-            <source>Debug level</source>
-            <translation>Poziom debugowania</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="152" />
-            <source>The trace level lets you choose the extent of the debugging information recorded</source>
-            <translation>Poziom śledzenia pozwala wybrać zakres rejestrowanych informacji dotyczących debugowania</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="179" />
-            <source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
-            <translation>Rozszerzony dziennik pełny gromadzi szczegółową historię, którą można wykorzystać do debugowania. Jego włączenie może spowolnić działanie aplikacji kDrive.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="183" />
-            <source>Extended Full Log</source>
-            <translation>Rozszerzony pełny dziennik</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="206" />
-            <source>Delete logs older than %1 days</source>
-            <translation>Usuń logi starsze niż %1 dni</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="225" />
-            <source>Share the debug folder with Infomaniak support.</source>
-            <translation>Prześlij folder debugowania do działu pomocy technicznej Infomaniak.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="249" />
-            <source>The last session is the periode since the last kDrive start.</source>
-            <translation>Ostatnia sesja to okres od ostatniego uruchomienia programu kDrive.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="253" />
-            <source>Share only the last kDrive session</source>
-            <translation>Udostępnij tylko ostatnią sesję kDrive</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="284" />
-            <source>  Loading</source>
-            <translation>  Ładowanie</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="293" />
-            <source>Cancel</source>
-            <translation>Anuluj</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="319" />
-            <source>SAVE</source>
-            <translation>ZAPISZ</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="326" />
-            <source>CANCEL</source>
-            <translation>ANULUJ</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="470" />
-            <source>Failed to share</source>
-            <translation>Nie udało się udostępnić</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="480" />
-            <source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
-            <translation>1. Sprawdź, czy jesteś zalogowany &lt;br&gt;2. Sprawdź, czy skonfigurowałeś co najmniej jeden serwer kDrive</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="485" />
-            <source> (Connexion interrupted)</source>
-            <translation> (Przerwano połączenie)</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="492" />
-            <source>Share the folder with SwissTransfer &lt;br&gt;</source>
-            <translation>Udostępnij folder za pomocą SwissTransfer &lt;br&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="493" />
-            <source> 1. We automatically compressed your log &lt;a style="%1" href="%2"&gt;here&lt;/a&gt;.&lt;br&gt;</source>
-            <translation> 1. Automatycznie skompresowaliśmy &lt;a style="%1" href="%2"&gt;tutaj&lt;/a&gt; Twój plik dziennika.&lt;br&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="495" />
-            <source> 2. Transfer the archive with &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
-            <translation> 2. Prześlij archiwum za pomocą serwisu &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="497" />
-            <source> 3. Share the link with &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
-            <translation> 3. Prześlij link na adres&lt;a style="%1" href="%2"&gt;support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="527" />
-            <source>Last upload the %1</source>
-            <translation>Ostatnie przesłanie: %1</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="555" />
-            <source>Sharing has been cancelled</source>
-            <translation>Udostępnianie zostało anulowane</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.h" line="70" />
-            <source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
-            <translation>Cały folder jest duży (&gt; 100 MB) i udostępnienie go może zająć trochę czasu. Aby skrócić czas udostępniania, zalecamy udostępnienie tylko ostatniej sesji kDrive.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="600" />
-            <source>%1/%2/%3 at %4h%5m and %6s</source>
-            <extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
-            <translation>%1/%2/%3 o godz. %4:%5 i %6 s</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="643" />
-            <source>Do you want to save your modifications?</source>
-            <translation>Czy chcesz zapisać wprowadzone zmiany?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="698" />
-            <location filename="../src/gui/debuggingdialog.cpp" line="704" />
-            <source>Unable to open folder %1.</source>
-            <translation>Nie można otworzyć folderu %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="711" />
-            <source>  Share</source>
-            <translation>  Udostępnij</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="721" />
-            <source>  Sharing | step 1/2 %1%</source>
-            <translation>  Udostępnianie | krok 1/2 %1%</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="730" />
-            <source>  Sharing | step 2/2 %1%</source>
-            <translation>  Udostępnianie | krok 2/2 %1%</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="740" />
-            <source>  Canceling...</source>
-            <translation>  Anulowanie...</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::DrivePreferencesWidget</name>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1118" />
-            <source>Folders</source>
-            <translation>Foldery</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1120" />
-            <source>Notifications</source>
-            <translation>Powiadomienia</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1123" />
-            <source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
-            <translation>Gdy tylko nowy folder zostanie zsynchronizowany lub zmodyfikowany, pojawi się powiadomienie</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1124" />
-            <source>Connected with</source>
-            <translation>Związane z</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="981" />
-            <source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-            <translation>Czy na pewno chcesz przerwać synchronizację folderu &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Uwaga: Nie&lt;/b&gt; spowoduje to usunięcia żadnych plików.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="356" />
-            <source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
-            <translation>Operacja ta może potrwać od kilku sekund do kilku minut, w zależności od rozmiaru folderu.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="360" />
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="391" />
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="986" />
-            <source>CANCEL</source>
-            <translation>ANULUJ</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="645" />
-            <source>New local folder synchronization failed!</source>
-            <translation>Nie udało się zsynchronizować nowego folderu lokalnego!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="823" />
-            <source>Lite Sync activation failed.</source>
-            <translation>Aktywacja funkcji Lite Sync nie powiodła się.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="841" />
-            <source>Lite Sync deactivation failed.</source>
-            <translation>Nie udało się wyłączyć funkcji Lite Sync.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="985" />
-            <source>REMOVE FOLDER SYNC CONNECTION</source>
-            <translation>USUŃ POŁĄCZENIE SYNCHRONIZACJI FOLDERÓW</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1048" />
-            <source>An error occurred while loading the list of subfolders.</source>
-            <translation>Wystąpił błąd podczas ładowania listy podfolderów.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1121" />
-            <source>Enable the notifications for this kDrive</source>
-            <translation>Włącz powiadomienia dla tego kDrive</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="359" />
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="390" />
-            <source>CONFIRM</source>
-            <translation>POTWIERDŹ</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="120" />
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1117" />
-            <source>Synchronization errors and information.</source>
-            <translation>Błędy synchronizacji i informacje.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="144" />
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1119" />
-            <source>Synchronize a local folder</source>
-            <translation>Zsynchronizuj folder lokalny</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="355" />
-            <source>Do you really want to turn on Lite Sync?</source>
-            <translation>Czy na pewno chcesz włączyć funkcję Lite Sync?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="382" />
-            <source>Do you really want to turn off Lite Sync?</source>
-            <translation>Czy na pewno chcesz wyłączyć funkcję Lite Sync?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="384" />
-            <source>You don't have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
-            <translation>Nie masz wystarczającej ilości miejsca, aby zsynchronizować wszystkie pliki z kDrive (brakuje %1). Jeśli wyłączysz funkcję Lite Sync, musisz wybrać foldery, które chcesz zsynchronizować na swoim komputerze. W międzyczasie synchronizacja kDrive zostanie wstrzymana.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="388" />
-            <source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
-            <translation>Jeśli wyłączysz funkcję Lite Sync, wszystkie pliki zostaną pobrane na Twój komputer.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="627" />
-            <source>Failed to create new synchronization</source>
-            <translation>Nie udało się utworzyć nowej synchronizacji</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="819" />
-            <source>Lite Sync activated.</source>
-            <translation>Włączono funkcję Lite Sync.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="837" />
-            <source>Lite Sync deactivated.</source>
-            <translation>Funkcja Lite Sync została wyłączona.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="899" />
-            <source>This drive is being deleted.</source>
-            <translation>Ten dysk jest właśnie usuwany.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="962" />
-            <source>Impossible to open item %1</source>
-            <translation>Nie można otworzyć elementu %1</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1007" />
-            <source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
-            <translation>Nie udało się zatrzymać synchronizacji folderu &lt;i&gt;%1&lt;/i&gt;.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1125" />
-            <source>Remove all synchronizations</source>
-            <translation>Usuń wszystkie synchronizacje</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1126" />
-            <source>Search in your kDrive</source>
-            <translation>Wyszukaj w swoim kDrive</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1127" />
-            <source>Search</source>
-            <translation>Wyszukaj</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::DriveSelectionWidget</name>
-        <message>
-            <location filename="../src/gui/driveselectionwidget.cpp" line="216" />
-            <source>Synchronize a kDrive</source>
-            <translation>Zsynchronizuj kDrive</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/driveselectionwidget.cpp" line="150" />
-            <source>Add a kDrive</source>
-            <translation>Dodaj kDrive</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::ErrorTabWidget</name>
-        <message>
-            <location filename="../src/gui/errortabwidget.cpp" line="179" />
-            <source>Resolve</source>
-            <translation>Rozwiązać</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errortabwidget.cpp" line="180" />
-            <source>Conflicted item(s)</source>
-            <translation>Elementy powodujące konflikt</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errortabwidget.cpp" line="181" />
-            <source>Item(s) with unsupported characters</source>
-            <translation>Elementy zawierające znaki nieobsługiwane</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errortabwidget.cpp" line="92" />
-            <location filename="../src/gui/errortabwidget.cpp" line="135" />
-            <location filename="../src/gui/errortabwidget.cpp" line="178" />
-            <location filename="../src/gui/errortabwidget.cpp" line="186" />
-            <source>Clear history</source>
-            <translation>Wyczyść historię</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errortabwidget.cpp" line="176" />
-            <source>To Resolve</source>
-            <translation>Aby rozwiązać</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errortabwidget.cpp" line="184" />
-            <source>Automatically resolved</source>
-            <translation>Rozwiązano automatycznie</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errortabwidget.cpp" line="185" />
-            <source>problem(s) solved</source>
-            <translation>rozwiązane problemy</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errortabwidget.cpp" line="177" />
-            <source>problem(s) detected</source>
-            <translation>wykryto problem(y)</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::ErrorsMenuBarWidget</name>
-        <message>
-            <location filename="../src/gui/errorsmenubarwidget.cpp" line="84" />
-            <location filename="../src/gui/errorsmenubarwidget.cpp" line="103" />
-            <source>Synchronization conflicts or errors</source>
-            <translation>Konflikty lub błędy synchronizacji</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errorsmenubarwidget.cpp" line="86" />
-            <location filename="../src/gui/errorsmenubarwidget.cpp" line="105" />
-            <source>Errors</source>
-            <translation>Błędy</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errorsmenubarwidget.cpp" line="101" />
-            <source>Back to preferences</source>
-            <translation>Powrót do ustawień</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::ErrorsPopup</name>
-        <message>
-            <location filename="../src/gui/errorspopup.cpp" line="73" />
-            <source>Some files couldn't be synchronized on the following kDrive(s) :</source>
-            <translation>Nie udało się zsynchronizować niektórych plików na następujących urządzeniach kDrive:</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errorspopup.cpp" line="95" />
-            <source> (%1 error(s))</source>
-            <translation> (%1 błąd(ów))</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errorspopup.cpp" line="101" />
-            <source> (%1 information(s))</source>
-            <translation> (%1 informacja(i))</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errorspopup.cpp" line="107" />
-            <source> (%1 error(s) and %2 information(s))</source>
-            <translation> (%1 błąd(ów) i %2 informacja(i))</translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/gui/errorspopup.cpp" line="147" />
-            <source>Generic errors (%n warning(s) or error(s))</source>
-            <comment>Number of warnings or errors</comment>
-            <translation>
-                <numerusform>Błędy ogólne (%n ostrzeżenie lub błąd)</numerusform>
-                <numerusform>Błędy ogólne (%n ostrzeżenia lub błędy)</numerusform>
-            </translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::FileExclusionDialog</name>
-        <message>
-            <location filename="../src/gui/fileexclusiondialog.cpp" line="78" />
-            <source>Excluded files</source>
-            <translation>Pliki wykluczone</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fileexclusiondialog.cpp" line="86" />
-            <source>Add files or folders that will not be synchronized on your computer.</source>
-            <translation>Dodaj pliki lub foldery, które nie będą synchronizowane na Twoim komputerze.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fileexclusiondialog.cpp" line="97" />
-            <source>Add</source>
-            <translation>Dodaj</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fileexclusiondialog.cpp" line="109" />
-            <source>NAME</source>
-            <translation>IMIĘ</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fileexclusiondialog.cpp" line="114" />
-            <source>WARNING</source>
-            <translation>OSTRZEŻENIE</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fileexclusiondialog.cpp" line="149" />
-            <source>SAVE</source>
-            <translation>ZAPISZ</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fileexclusiondialog.cpp" line="156" />
-            <source>CANCEL</source>
-            <translation>ANULUJ</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fileexclusiondialog.cpp" line="304" />
-            <source>Do you want to save your modifications?</source>
-            <translation>Czy chcesz zapisać wprowadzone zmiany?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fileexclusiondialog.cpp" line="353" />
-            <source>Exclusion template already exists!</source>
-            <translation>Szablon wykluczenia już istnieje!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fileexclusiondialog.cpp" line="374" />
-            <source>Do you really want to delete?</source>
-            <translation>Czy na pewno chcesz usunąć?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fileexclusiondialog.cpp" line="434" />
-            <source>Cannot save changes!</source>
-            <translation>Nie można zapisać zmian!</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::FileExclusionNameDialog</name>
-        <message>
-            <location filename="../src/gui/fileexclusionnamedialog.cpp" line="58" />
-            <source>VALIDATE</source>
-            <translation>ZATWIERDŹ</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fileexclusionnamedialog.cpp" line="65" />
-            <source>CANCEL</source>
-            <translation>ANULUJ</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::FixConflictingFilesDialog</name>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67" />
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73" />
-            <source>Unable to open link %1.</source>
-            <translation>Nie można otworzyć linku %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122" />
-            <source>Solve conflict(s)</source>
-            <translation>Rozwiązywanie konfliktów</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140" />
-            <source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
-            <translation>&lt;b&gt;Co chcesz zrobić z %1 elementem (elementami) powodującym konflikt?&lt;/b&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143" />
-            <source>Save my changes and replace other users' versions.</source>
-            <translation>Zapisz moje zmiany i zastąp wersje innych użytkowników.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147" />
-            <source>Undo my changes and keep other users' versions.</source>
-            <translation>Cofnij moje zmiany i zachowaj wersje innych użytkowników.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169" />
-            <source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
-            <translation>Twoje zmiany mogą zostać trwale usunięte. Nie da się ich przywrócić za pomocą aplikacji internetowej kDrive.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171" />
-            <source>&lt;a style=%1 href="%2"&gt;Learn more&lt;/a&gt;</source>
-            <translation>&lt;a style=%1 href="%2"&gt;Dowiedz się więcej&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175" />
-            <source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
-            <translation>Twoje zmiany zostaną trwale usunięte. Nie będzie można ich przywrócić za pomocą aplikacji internetowej kDrive.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191" />
-            <source>Show item(s)</source>
-            <translation>Pokaż produkty</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228" />
-            <source>VALIDATE</source>
-            <translation>ZATWIERDŹ</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234" />
-            <source>CANCEL</source>
-            <translation>ANULUJ</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251" />
-            <source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
-            <translation>Pliki te zostały zmodyfikowane przez kilku użytkowników w różnych miejscach (online w serwisie kDrive, na komputerze lub urządzeniu mobilnym). Foldery zawierające te pliki mogły również zostać usunięte.&lt;br&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253" />
-            <source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Learn more&lt;/a&gt;</source>
-            <translation>Lokalna wersja Twojego elementu &lt;b&gt;nie jest zsynchronizowana&lt;/b&gt; z kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Dowiedz się więcej&lt;/a&gt;</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::FolderItemWidget</name>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="458" />
-            <source>More actions</source>
-            <translation>Więcej działań</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="188" />
-            <location filename="../src/gui/folderitemwidget.cpp" line="476" />
-            <source>Synchronized into &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</source>
-            <translation>Zsynchronizowano do &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="343" />
-            <source>Activate Lite Sync</source>
-            <translation>Włącz Lite Sync</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="345" />
-            <source>Activate Lite Sync (Beta)</source>
-            <translation>Włącz Lite Sync (wersja beta)</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="481" />
-            <source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
-            <translation>Foldery, które nie zostały zaznaczone, zostaną przeniesione do kosza, o ile zawierają elementy dostępne w trybie offline. Foldery zsynchronizowane z kDrive pozostaną dostępne online.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="485" />
-            <source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
-            <translation>Foldery, które nie zostały zaznaczone, zostaną przeniesione do kosza. Foldery zsynchronizowane z kDrive pozostaną dostępne online.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="488" />
-            <source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
-            <translation>Foldery, które nie zostały zaznaczone, zostaną &lt;b&gt;trwale&lt;/b&gt; usunięte z komputera. Foldery zsynchronizowane z kDrive pozostaną dostępne online.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="493" />
-            <source>Cancel</source>
-            <translation>Anuluj</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="494" />
-            <source>VALIDATE</source>
-            <translation>ZATWIERDŹ</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="365" />
-            <source>Pause synchronization</source>
-            <translation>Wstrzymaj synchronizację</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="354" />
-            <source>Deactivate Lite Sync</source>
-            <translation>Wyłącz Lite Sync</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="375" />
-            <source>Resume synchronization</source>
-            <translation>Wznowienie synchronizacji</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="386" />
-            <source>Remove synchronization</source>
-            <translation>Wyłącz synchronizację</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::GenericErrorItemWidget</name>
-        <message>
-            <location filename="../src/gui/genericerroritemwidget.cpp" line="85" />
-            <source>Unable to open folder path %1.</source>
-            <translation>Nie można otworzyć ścieżki folderu %1.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::LiteSyncAppDialog</name>
-        <message>
-            <location filename="../src/gui/litesyncappdialog.cpp" line="48" />
-            <source>Application Id</source>
-            <translation>Identyfikator aplikacji</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/litesyncappdialog.cpp" line="98" />
-            <source>Application Name</source>
-            <translation>Nazwa aplikacji</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/litesyncappdialog.cpp" line="121" />
-            <source>VALIDATE</source>
-            <translation>ZATWIERDŹ</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/litesyncappdialog.cpp" line="128" />
-            <source>CANCEL</source>
-            <translation>ANULUJ</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::LiteSyncDialog</name>
-        <message>
-            <location filename="../src/gui/litesyncdialog.cpp" line="91" />
-            <source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are "online". Add them in the list below to avoid this behaviour.</source>
-            <translation>Niektóre aplikacje (do tworzenia kopii zapasowych, antywirusowe...) uzyskują dostęp do Twoich plików, co powoduje ich pobieranie, gdy są one „online”. Dodaj je do poniższej listy, aby uniknąć tego zjawiska.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/litesyncdialog.cpp" line="103" />
-            <source>Add</source>
-            <translation>Dodaj</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/litesyncdialog.cpp" line="115" />
-            <source>APPLICATION ID</source>
-            <translation>ID WNIOSKU</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/litesyncdialog.cpp" line="120" />
-            <source>NAME</source>
-            <translation>IMIĘ</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/litesyncdialog.cpp" line="154" />
-            <source>SAVE</source>
-            <translation>ZAPISZ</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/litesyncdialog.cpp" line="161" />
-            <source>CANCEL</source>
-            <translation>ANULUJ</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/litesyncdialog.cpp" line="295" />
-            <source>Do you want to save your modifications?</source>
-            <translation>Czy chcesz zapisać wprowadzone zmiany?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/litesyncdialog.cpp" line="337" />
-            <source>Do you really want to delete?</source>
-            <translation>Czy na pewno chcesz usunąć?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/litesyncdialog.cpp" line="374" />
-            <source>Cannot save changes!</source>
-            <translation>Nie można zapisać zmian!</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::LocalFolderDialog</name>
-        <message>
-            <location filename="../src/gui/localfolderdialog.cpp" line="63" />
-            <source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
-            <translation>Który folder na komputerze chcesz&lt;br&gt;zsynchronizować?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/localfolderdialog.cpp" line="72" />
-            <source>The content of this folder will be synchronized on the kDrive</source>
-            <translation>Zawartość tego folderu zostanie zsynchronizowana w usłudze kDrive</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/localfolderdialog.cpp" line="91" />
-            <source>Select a folder</source>
-            <translation>Wybierz folder</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/localfolderdialog.cpp" line="131" />
-            <source>Edit folder</source>
-            <translation>Edytuj folder</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/localfolderdialog.cpp" line="166" />
-            <source>CANCEL</source>
-            <translation>ANULUJ</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/localfolderdialog.cpp" line="173" />
-            <source>CONTINUE</source>
-            <translation>KONTYNUUJ</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/localfolderdialog.cpp" line="210" />
-            <source>This folder is not compatible with Lite Sync.&lt;br&gt;
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Dowiedz się więcej&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377"/>
+        <source>Unable to open link %1.</source>
+        <translation>Nie można otworzyć linku %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+        <source>CONTINUE</source>
+        <translation>KONTYNUUJ</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AddDriveLoginWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="69"/>
+        <source>Log in from your browser</source>
+        <translation>Zaloguj się w przeglądarce</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="75"/>
+        <source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
+        <translation>Przeglądarka powinna otworzyć się automatycznie, aby nawiązać połączenie. Po nawiązaniu połączenia nastąpi automatyczny powrót do serwisu kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
+        <source>Open the login page</source>
+        <translation>Otwórz stronę logowania</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="119"/>
+        <source>Token request failed: %1 - %2</source>
+        <translation>Wystąpił błąd podczas żądania tokenu: %1 - %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="133"/>
+        <source>Login failed: %1 - %2</source>
+        <translation>Nie udało się zalogować: %1 - %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="141"/>
+        <source>Failed to open the login page in your web browser</source>
+        <translation>Nie udało się otworzyć strony logowania w przeglądarce internetowej</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AddDriveServerFoldersWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129"/>
+        <source>Select kDrive folders to synchronize on your desktop</source>
+        <translation>Wybierz foldery kDrive, które chcesz zsynchronizować na pulpicie</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174"/>
+        <source>CONTINUE</source>
+        <translation>KONTYNUUJ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187"/>
+        <source>Space available on your computer : %1</source>
+        <translation>Wolne miejsce na komputerze: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206"/>
+        <source>An error occurred while loading the list of subfolders.</source>
+        <translation>Wystąpił błąd podczas ładowania listy podfolderów.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210"/>
+        <source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>Nie można załadować listy podfolderów. Być może Twoje konto kDrive jest obecnie w trakcie konserwacji.&lt;br&gt;Zaloguj się do &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;wersji&lt;/a&gt; &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;internetowej&lt;/a&gt;, aby sprawdzić stan swojego konta kDrive, lub skontaktuj się z administratorem.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AddDriveWizard</name>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="222"/>
+        <source>Failed to create local folder %1</source>
+        <translation>Nie udało się utworzyć folderu lokalnego %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="233"/>
+        <source>Failed to create new synchronization</source>
+        <translation>Nie udało się utworzyć nowej synchronizacji</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="266"/>
+        <source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
+        <translation>Aplikacja kDrive %1 jest już zsynchronizowana na tym komputerze. Czy mimo to chcesz kontynuować?</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AppClient</name>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="100"/>
+        <source>kDrive client is run with bad parameters!</source>
+        <translation>Program kDrive został uruchomiony z nieprawidłowymi parametrami!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="109"/>
+        <source>kDrive client is already running!</source>
+        <translation>Klient kDrive już działa!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="719"/>
+        <source>The user %1 is not connected. Please log in again.</source>
+        <translation>Użytkownik %1 nie jest zalogowany. Zaloguj się ponownie.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AppServer</name>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="1685"/>
+        <source>Share link copied to clipboard</source>
+        <translation>Link do udostępnienia skopiowano do schowka</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3773"/>
+        <source>%1 and %n other file(s) have been removed.</source>
+        <translation>
+            <numerusform>%1 oraz %n inny plik zostały usunięte.</numerusform>
+            <numerusform>%1 oraz %n innych plików zostało usuniętych.</numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3775"/>
+        <source>%1 has been removed.</source>
+        <comment>%1 names a file.</comment>
+        <translation>%1 został usunięty.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3780"/>
+        <source>%1 and %n other file(s) have been added.</source>
+        <translation>
+            <numerusform>%1 oraz %n inny plik zostały dodane.</numerusform>
+            <numerusform>%1 oraz %n innych plików zostało dodanych.</numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3782"/>
+        <source>%1 has been added.</source>
+        <comment>%1 names a file.</comment>
+        <translation>Dodano %1.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3787"/>
+        <source>%1 and %n other file(s) have been updated.</source>
+        <translation>
+            <numerusform>%1 oraz %n inny plik zostały zaktualizowane.</numerusform>
+            <numerusform>%1 oraz %n innych plików zostało zaktualizowanych.</numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3789"/>
+        <source>%1 has been updated.</source>
+        <comment>%1 names a file.</comment>
+        <translation>%1 zostało zaktualizowane.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3794"/>
+        <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
+        <translation>
+            <numerusform>%1 został przeniesiony do %2, a %n inny plik został przeniesiony.</numerusform>
+            <numerusform>%1 został przeniesiony do %2, a %n innych plików zostało przeniesionych.</numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3797"/>
+        <source>%1 has been moved to %2.</source>
+        <translation>%1 zostało przeniesione do %2.</translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3805"/>
+        <source>Sync Activity</source>
+        <translation>Synchronizacja działań</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::BaseFolderTreeItemWidget</name>
+    <message>
+        <location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102"/>
+        <source>No subfolders currently on the server.</source>
+        <translation>Obecnie na serwerze nie ma żadnych podfolderów.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::BetaProgramDialog</name>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="69"/>
+        <source>Quit the beta program</source>
+        <translation>Wyjdź z programu beta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="69"/>
+        <source>Join the beta program</source>
+        <translation>Dołącz do programu beta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="77"/>
+        <source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
+        <translation>Zyskaj wczesny dostęp do nowych wersji aplikacji, zanim zostaną one udostępnione szerokiej publiczności, i pomóż nam ulepszać aplikację, przesyłając nam swoje uwagi.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="87"/>
+        <source>Benefit from application beta updates</source>
+        <translation>Skorzystaj z aktualizacji wersji beta aplikacji</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="91"/>
+        <source>No</source>
+        <translation>Nie</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="92"/>
+        <source>Public beta version</source>
+        <translation>Publiczna wersja beta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="93"/>
+        <source>Internal beta version</source>
+        <translation>Wewnętrzna wersja beta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="141"/>
+        <source>I understand</source>
+        <translation>Rozumiem</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="147"/>
+        <source>Are you sure you want to leave the beta program?</source>
+        <translation>Czy na pewno chcesz opuścić program beta?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="161"/>
+        <source>Save</source>
+        <translation>Zapisz</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="167"/>
+        <source>Cancel</source>
+        <translation>Anuluj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="228"/>
+        <source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
+        <translation>Obecna wersja aplikacji może być zbyt nowa; wybrane ustawienia zaczną obowiązywać po udostępnieniu kolejnej aktualizacji.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="233"/>
+        <source>Beta versions may leave unexpectedly or cause instabilities.</source>
+        <translation>Wersje beta mogą się niespodziewanie zamknąć lub powodować niestabilność działania.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ClientGui</name>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="189"/>
+        <source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
+        <translation>Nie udało się rozwiązać konfliktu(-ów) dotyczących %1 elementu(-ów) w folderze synchronizacji: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="242"/>
+        <source>Please sign in</source>
+        <translation>Zaloguj się</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="292"/>
+        <source>Folder %1: %2</source>
+        <translation>Folder %1: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="298"/>
+        <source>There are no sync folders configured.</source>
+        <translation>Nie skonfigurowano żadnych folderów synchronizacji.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1422"/>
+        <source>Synthesis</source>
+        <translation>Podsumowanie</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1423"/>
+        <source>Preferences</source>
+        <translatorcomment>Préférences</translatorcomment>
+        <translation>Preferencje</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1424"/>
+        <source>Quit</source>
+        <translation>Zakończ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="673"/>
+        <source>Undefined State.</source>
+        <translation>Stan nieokreślony.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="676"/>
+        <source>Waiting to start syncing.</source>
+        <translation>Oczekiwanie na rozpoczęcie synchronizacji.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="679"/>
+        <source>Sync is running.</source>
+        <translation>Synchronizacja trwa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="683"/>
+        <source>Sync was successful, unresolved conflicts.</source>
+        <translation>Synchronizacja przebiegła pomyślnie, pozostały nierozwiązane konflikty.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="685"/>
+        <source>Last Sync was successful.</source>
+        <translation>Ostatnia synchronizacja zakończyła się powodzeniem.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="692"/>
+        <source>User Abort.</source>
+        <translation>Anulowanie przez użytkownika.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="696"/>
+        <source>Sync is paused.</source>
+        <translation>Synchronizacja została wstrzymana.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="705"/>
+        <source>%1 (Sync is paused)</source>
+        <translation>%1 (Synchronizacja została wstrzymana)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1257"/>
+        <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+        <translation>Czy na pewno chcesz usunąć synchronizacje konta &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Uwaga: Nie&lt;/b&gt; spowoduje to usunięcia żadnych plików.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1261"/>
+        <source>REMOVE ALL SYNCHRONIZATIONS</source>
+        <translation>USUŃ WSZYSTKIE SYNCHRONIZACJE</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1262"/>
+        <source>CANCEL</source>
+        <translation>ANULUJ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1590"/>
+        <source>Failed to start synchronizations!</source>
+        <translation>Nie udało się uruchomić synchronizacji!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="849"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Nie można otworzyć ścieżki folderu %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="116"/>
+        <source>Unable to initialize kDrive client</source>
+        <translation>Nie można zainicjować klienta kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="255"/>
+        <source>Synchronization is paused</source>
+        <translation>Synchronizacja została wstrzymana</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ConfirmSynchronizationDialog</name>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86"/>
+        <source>Summary of your local folder synchronization</source>
+        <translation>Podsumowanie synchronizacji folderów lokalnych</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95"/>
+        <source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
+        <translation>Zawartość folderu na Twoim komputerze zostanie zsynchronizowana z folderem na wybranym serwerze kDrive i odwrotnie.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184"/>
+        <source>CANCEL</source>
+        <translation>ANULUJ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191"/>
+        <source>SYNCHRONIZE</source>
+        <translation>SYNCHRONIZUJ</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::CustomExtensionSetupWidget</name>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="96"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="120"/>
+        <source>Before finishing</source>
+        <translation>Zanim skończymy</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="107"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="131"/>
+        <source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
+        <translation>Wykonaj poniższe czynności, aby upewnić się, że program Lite Sync działa poprawnie na Twoim komputerze, oraz aby zakończyć konfigurację serwisu kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="208"/>
+        <source>Open your Mac&apos;s &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Otwórz &lt;b&gt;ustawienia ogólne&lt;/b&gt; komputera Mac lub &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;kliknij tutaj&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="212"/>
+        <source>Open your Mac&apos;s &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Otwórz &lt;b&gt;ustawienia prywatności i bezpieczeństwa&lt;/b&gt; na komputerze Mac lub &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;kliknij tutaj&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="216"/>
+        <source>Open your Mac&apos;s &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Otwórz &lt;b&gt;ustawienia „Bezpieczeństwo i prywatność”&lt;/b&gt; na komputerze Mac lub &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;kliknij tutaj&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="246"/>
+        <source>Go to &lt;b&gt;&quot;Login Items &amp; Extensions&quot;&lt;/b&gt; section and then to &lt;b&gt;&quot;Endpoint Security Extensions&quot;&lt;/b&gt;</source>
+        <translation>Przejdź do sekcji &lt;b&gt;„Elementy logowania i rozszerzenia”,&lt;/b&gt; a następnie do &lt;b&gt;„Rozszerzenia Endpoint Security”&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="263"/>
+        <source>Authorize the kDrive application</source>
+        <translation>Zezwól aplikacji kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="272"/>
+        <source>Go to &lt;b&gt;&quot;Security&quot;&lt;/b&gt; section</source>
+        <translation>Przejdź do sekcji &lt;b&gt;„Bezpieczeństwo”&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="289"/>
+        <source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
+        <translation>Zezwól aplikacji kDrive w oknie informującym, że kDrive zostało zablokowane</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="299"/>
+        <source>Unlock the padlock &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; and authorize the kDrive application</source>
+        <translation>Odblokuj kłódkę &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; i autoryzuj aplikację kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="344"/>
+        <source>Go to &lt;b&gt;&quot;Privacy &amp; Security&quot;&lt;/b&gt; section and click on &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt; or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Przejdź do sekcji &lt;b&gt;„Prywatność i bezpieczeństwo”&lt;/b&gt; i kliknij opcję &lt;b&gt;„Pełny dostęp do dysku”&lt;/b&gt; lub &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;kliknij tutaj&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="348"/>
+        <source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;&quot;Privacy&quot;&lt;/b&gt; tab or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Wciąż w ustawieniach „Bezpieczeństwo i prywatność” otwórz zakładkę &lt;b&gt;„Prywatność”&lt;/b&gt; lub &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;kliknij tutaj&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="376"/>
+        <source>Check the &quot;kDrive LiteSync Extension&quot; box then the &quot;kDrive.app&quot; box (if not already checked)</source>
+        <translation>Zaznacz pole „kDrive LiteSync Extension”, a następnie pole „kDrive.app” (jeśli nie jest jeszcze zaznaczone)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="393"/>
+        <source>A restart of the app might be proposed, in this case accept it</source>
+        <translation>Może pojawić się propozycja ponownego uruchomienia aplikacji; w takim przypadku należy ją zaakceptować</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="399"/>
+        <source>Check the &quot;kDrive LiteSync Extension&quot; box (and &quot;kDrive.app&quot; if it exists) in &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt;</source>
+        <translation>Zaznacz pole „kDrive LiteSync Extension” (oraz „kDrive.app”, jeśli istnieje) w &lt;b&gt;sekcji „Pełny dostęp do dysku”&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
+        <source>STEP 1</source>
+        <translation>KROK 1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="496"/>
+        <source>(Done)</source>
+        <translation>(Gotowe)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="496"/>
+        <source>STEP 2</source>
+        <translation>KROK 2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="499"/>
+        <source>STEPS PERFORMED</source>
+        <translation>WYKONANE CZYNNOŚCI</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="501"/>
+        <source>END</source>
+        <translation>ZAKOŃCZ</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::CustomMessageBox</name>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="101"/>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="111"/>
+        <source>CANCEL</source>
+        <translation>ANULUJ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="121"/>
+        <source>YES</source>
+        <translation>TAK</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="131"/>
+        <source>NO</source>
+        <translation>NIE</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::DebugReporter</name>
+    <message>
+        <location filename="../src/gui/debugreporter.cpp" line="37"/>
+        <source>Sending of debugging information</source>
+        <translation>Wysyłanie informacji dotyczących debugowania</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debugreporter.cpp" line="37"/>
+        <source>Cancel</source>
+        <translation>Anuluj</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::DebuggingDialog</name>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="46"/>
+        <source>Info</source>
+        <translation>Informacje</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="45"/>
+        <source>Debug</source>
+        <translation>Debugowanie</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="47"/>
+        <source>Warning</source>
+        <translation>Ostrzeżenie</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="48"/>
+        <source>Error</source>
+        <translation>Błąd</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="49"/>
+        <source>Fatal</source>
+        <translation>Śmiertelny</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="74"/>
+        <source>Debugging settings</source>
+        <translation>Ustawienia debugowania</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="90"/>
+        <source>Save debugging information in a folder on my computer (Recommended)</source>
+        <translation>Zapisz informacje dotyczące debugowania w folderze na moim komputerze (zalecane)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="104"/>
+        <source>This information enables IT support to determine the origin of an incident.</source>
+        <translation>Informacje te pozwalają działowi wsparcia IT ustalić przyczynę incydentu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="114"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Otwórz folder debugowania&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="143"/>
+        <source>Debug level</source>
+        <translation>Poziom debugowania</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="152"/>
+        <source>The trace level lets you choose the extent of the debugging information recorded</source>
+        <translation>Poziom śledzenia pozwala wybrać zakres rejestrowanych informacji dotyczących debugowania</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="179"/>
+        <source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
+        <translation>Rozszerzony dziennik pełny gromadzi szczegółową historię, którą można wykorzystać do debugowania. Jego włączenie może spowolnić działanie aplikacji kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="183"/>
+        <source>Extended Full Log</source>
+        <translation>Rozszerzony pełny dziennik</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="207"/>
+        <source>Delete logs older than %1 days</source>
+        <translation>Usuń logi starsze niż %1 dni</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="226"/>
+        <source>Share the debug folder with Infomaniak support.</source>
+        <translation>Prześlij folder debugowania do działu pomocy technicznej Infomaniak.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="250"/>
+        <source>The last session is the periode since the last kDrive start.</source>
+        <translation>Ostatnia sesja to okres od ostatniego uruchomienia programu kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="254"/>
+        <source>Share only the last kDrive session</source>
+        <translation>Udostępnij tylko ostatnią sesję kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="285"/>
+        <source>  Loading</source>
+        <translation>  Ładowanie</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="294"/>
+        <source>Cancel</source>
+        <translation>Anuluj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="320"/>
+        <source>SAVE</source>
+        <translation>ZAPISZ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="327"/>
+        <source>CANCEL</source>
+        <translation>ANULUJ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="471"/>
+        <source>Failed to share</source>
+        <translation>Nie udało się udostępnić</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="481"/>
+        <source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
+        <translation>1. Sprawdź, czy jesteś zalogowany &lt;br&gt;2. Sprawdź, czy skonfigurowałeś co najmniej jeden serwer kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="486"/>
+        <source> (Connexion interrupted)</source>
+        <translation> (Przerwano połączenie)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="493"/>
+        <source>Share the folder with SwissTransfer &lt;br&gt;</source>
+        <translation>Udostępnij folder za pomocą SwissTransfer &lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="494"/>
+        <source> 1. We automatically compressed your log &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;here&lt;/a&gt;.&lt;br&gt;</source>
+        <translation> 1. Automatycznie skompresowaliśmy &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;tutaj&lt;/a&gt; Twój plik dziennika.&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="496"/>
+        <source> 2. Transfer the archive with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
+        <translation> 2. Prześlij archiwum za pomocą serwisu &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="498"/>
+        <source> 3. Share the link with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
+        <translation> 3. Prześlij link na adres&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="528"/>
+        <source>Last upload the %1</source>
+        <translation>Ostatnie przesłanie: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="556"/>
+        <source>Sharing has been cancelled</source>
+        <translation>Udostępnianie zostało anulowane</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="597"/>
+        <source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.h" line="70"/>
+        <source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
+        <translation>Cały folder jest duży (&gt; 100 MB) i udostępnienie go może zająć trochę czasu. Aby skrócić czas udostępniania, zalecamy udostępnienie tylko ostatniej sesji kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="611"/>
+        <source>%1/%2/%3 at %4h%5m and %6s</source>
+        <extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
+        <translation>%1/%2/%3 o godz. %4:%5 i %6 s</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="654"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Czy chcesz zapisać wprowadzone zmiany?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="709"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="715"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Nie można otworzyć folderu %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="722"/>
+        <source>  Share</source>
+        <translation>  Udostępnij</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="732"/>
+        <source>  Sharing | step 1/2 %1%</source>
+        <translation>  Udostępnianie | krok 1/2 %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="741"/>
+        <source>  Sharing | step 2/2 %1%</source>
+        <translation>  Udostępnianie | krok 2/2 %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="751"/>
+        <source>  Canceling...</source>
+        <translation>  Anulowanie...</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::DrivePreferencesWidget</name>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
+        <source>Folders</source>
+        <translation>Foldery</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
+        <source>Notifications</source>
+        <translation>Powiadomienia</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
+        <source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
+        <translation>Gdy tylko nowy folder zostanie zsynchronizowany lub zmodyfikowany, pojawi się powiadomienie</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
+        <source>Connected with</source>
+        <translation>Związane z</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
+        <source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+        <translation>Czy na pewno chcesz przerwać synchronizację folderu &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Uwaga: Nie&lt;/b&gt; spowoduje to usunięcia żadnych plików.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="356"/>
+        <source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
+        <translation>Operacja ta może potrwać od kilku sekund do kilku minut, w zależności od rozmiaru folderu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="360"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="391"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="986"/>
+        <source>CANCEL</source>
+        <translation>ANULUJ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
+        <source>New local folder synchronization failed!</source>
+        <translation>Nie udało się zsynchronizować nowego folderu lokalnego!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
+        <source>Lite Sync activation failed.</source>
+        <translation>Aktywacja funkcji Lite Sync nie powiodła się.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
+        <source>Lite Sync deactivation failed.</source>
+        <translation>Nie udało się wyłączyć funkcji Lite Sync.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
+        <source>REMOVE FOLDER SYNC CONNECTION</source>
+        <translation>USUŃ POŁĄCZENIE SYNCHRONIZACJI FOLDERÓW</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
+        <source>An error occurred while loading the list of subfolders.</source>
+        <translation>Wystąpił błąd podczas ładowania listy podfolderów.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
+        <source>Enable the notifications for this kDrive</source>
+        <translation>Włącz powiadomienia dla tego kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
+        <source>CONFIRM</source>
+        <translation>POTWIERDŹ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
+        <source>Synchronization errors and information.</source>
+        <translation>Błędy synchronizacji i informacje.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
+        <source>Synchronize a local folder</source>
+        <translation>Zsynchronizuj folder lokalny</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
+        <source>Do you really want to turn on Lite Sync?</source>
+        <translation>Czy na pewno chcesz włączyć funkcję Lite Sync?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="382"/>
+        <source>Do you really want to turn off Lite Sync?</source>
+        <translation>Czy na pewno chcesz wyłączyć funkcję Lite Sync?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="384"/>
+        <source>You don&apos;t have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
+        <translation>Nie masz wystarczającej ilości miejsca, aby zsynchronizować wszystkie pliki z kDrive (brakuje %1). Jeśli wyłączysz funkcję Lite Sync, musisz wybrać foldery, które chcesz zsynchronizować na swoim komputerze. W międzyczasie synchronizacja kDrive zostanie wstrzymana.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="388"/>
+        <source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
+        <translation>Jeśli wyłączysz funkcję Lite Sync, wszystkie pliki zostaną pobrane na Twój komputer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="627"/>
+        <source>Failed to create new synchronization</source>
+        <translation>Nie udało się utworzyć nowej synchronizacji</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="819"/>
+        <source>Lite Sync activated.</source>
+        <translation>Włączono funkcję Lite Sync.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="837"/>
+        <source>Lite Sync deactivated.</source>
+        <translation>Funkcja Lite Sync została wyłączona.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="899"/>
+        <source>This drive is being deleted.</source>
+        <translation>Ten dysk jest właśnie usuwany.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="962"/>
+        <source>Impossible to open item %1</source>
+        <translation>Nie można otworzyć elementu %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1007"/>
+        <source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
+        <translation>Nie udało się zatrzymać synchronizacji folderu &lt;i&gt;%1&lt;/i&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1125"/>
+        <source>Remove all synchronizations</source>
+        <translation>Usuń wszystkie synchronizacje</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1126"/>
+        <source>Search in your kDrive</source>
+        <translation>Wyszukaj w swoim kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1127"/>
+        <source>Search</source>
+        <translation>Wyszukaj</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::DriveSelectionWidget</name>
+    <message>
+        <location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
+        <source>Synchronize a kDrive</source>
+        <translation>Zsynchronizuj kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/driveselectionwidget.cpp" line="150"/>
+        <source>Add a kDrive</source>
+        <translation>Dodaj kDrive</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ErrorTabWidget</name>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="179"/>
+        <source>Resolve</source>
+        <translation>Rozwiązać</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="180"/>
+        <source>Conflicted item(s)</source>
+        <translation>Elementy powodujące konflikt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="181"/>
+        <source>Item(s) with unsupported characters</source>
+        <translation>Elementy zawierające znaki nieobsługiwane</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="92"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="135"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="178"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="186"/>
+        <source>Clear history</source>
+        <translation>Wyczyść historię</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="176"/>
+        <source>To Resolve</source>
+        <translation>Aby rozwiązać</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="184"/>
+        <source>Automatically resolved</source>
+        <translation>Rozwiązano automatycznie</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="185"/>
+        <source>problem(s) solved</source>
+        <translation>rozwiązane problemy</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="177"/>
+        <source>problem(s) detected</source>
+        <translation>wykryto problem(y)</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ErrorsMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="84"/>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="103"/>
+        <source>Synchronization conflicts or errors</source>
+        <translation>Konflikty lub błędy synchronizacji</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="86"/>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="105"/>
+        <source>Errors</source>
+        <translation>Błędy</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="101"/>
+        <source>Back to preferences</source>
+        <translation>Powrót do ustawień</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ErrorsPopup</name>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="73"/>
+        <source>Some files couldn&apos;t be synchronized on the following kDrive(s) :</source>
+        <translation>Nie udało się zsynchronizować niektórych plików na następujących urządzeniach kDrive:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="95"/>
+        <source> (%1 error(s))</source>
+        <translation> (%1 błąd(ów))</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="101"/>
+        <source> (%1 information(s))</source>
+        <translation> (%1 informacja(i))</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="107"/>
+        <source> (%1 error(s) and %2 information(s))</source>
+        <translation> (%1 błąd(ów) i %2 informacja(i))</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/errorspopup.cpp" line="147"/>
+        <source>Generic errors (%n warning(s) or error(s))</source>
+        <comment>Number of warnings or errors</comment>
+        <translation>
+            <numerusform>Błędy ogólne (%n ostrzeżenie lub błąd)</numerusform>
+            <numerusform>Błędy ogólne (%n ostrzeżenia lub błędy)</numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+</context>
+<context>
+    <name>KDC::FileExclusionDialog</name>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="78"/>
+        <source>Excluded files</source>
+        <translation>Pliki wykluczone</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="86"/>
+        <source>Add files or folders that will not be synchronized on your computer.</source>
+        <translation>Dodaj pliki lub foldery, które nie będą synchronizowane na Twoim komputerze.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="97"/>
+        <source>Add</source>
+        <translation>Dodaj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="109"/>
+        <source>NAME</source>
+        <translation>IMIĘ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="114"/>
+        <source>WARNING</source>
+        <translation>OSTRZEŻENIE</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="149"/>
+        <source>SAVE</source>
+        <translation>ZAPISZ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="156"/>
+        <source>CANCEL</source>
+        <translation>ANULUJ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="304"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Czy chcesz zapisać wprowadzone zmiany?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="353"/>
+        <source>Exclusion template already exists!</source>
+        <translation>Szablon wykluczenia już istnieje!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="374"/>
+        <source>Do you really want to delete?</source>
+        <translation>Czy na pewno chcesz usunąć?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="434"/>
+        <source>Cannot save changes!</source>
+        <translation>Nie można zapisać zmian!</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::FileExclusionNameDialog</name>
+    <message>
+        <location filename="../src/gui/fileexclusionnamedialog.cpp" line="58"/>
+        <source>VALIDATE</source>
+        <translation>ZATWIERDŹ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusionnamedialog.cpp" line="65"/>
+        <source>CANCEL</source>
+        <translation>ANULUJ</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::FixConflictingFilesDialog</name>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67"/>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73"/>
+        <source>Unable to open link %1.</source>
+        <translation>Nie można otworzyć linku %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122"/>
+        <source>Solve conflict(s)</source>
+        <translation>Rozwiązywanie konfliktów</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140"/>
+        <source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
+        <translation>&lt;b&gt;Co chcesz zrobić z %1 elementem (elementami) powodującym konflikt?&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143"/>
+        <source>Save my changes and replace other users&apos; versions.</source>
+        <translation>Zapisz moje zmiany i zastąp wersje innych użytkowników.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147"/>
+        <source>Undo my changes and keep other users&apos; versions.</source>
+        <translation>Cofnij moje zmiany i zachowaj wersje innych użytkowników.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169"/>
+        <source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
+        <translation>Twoje zmiany mogą zostać trwale usunięte. Nie da się ich przywrócić za pomocą aplikacji internetowej kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171"/>
+        <source>&lt;a style=%1 href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a style=%1 href=&quot;%2&quot;&gt;Dowiedz się więcej&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175"/>
+        <source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
+        <translation>Twoje zmiany zostaną trwale usunięte. Nie będzie można ich przywrócić za pomocą aplikacji internetowej kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191"/>
+        <source>Show item(s)</source>
+        <translation>Pokaż produkty</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228"/>
+        <source>VALIDATE</source>
+        <translation>ZATWIERDŹ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234"/>
+        <source>CANCEL</source>
+        <translation>ANULUJ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251"/>
+        <source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
+        <translation>Pliki te zostały zmodyfikowane przez kilku użytkowników w różnych miejscach (online w serwisie kDrive, na komputerze lub urządzeniu mobilnym). Foldery zawierające te pliki mogły również zostać usunięte.&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253"/>
+        <source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Lokalna wersja Twojego elementu &lt;b&gt;nie jest zsynchronizowana&lt;/b&gt; z kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Dowiedz się więcej&lt;/a&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::FolderItemWidget</name>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="458"/>
+        <source>More actions</source>
+        <translation>Więcej działań</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="188"/>
+        <location filename="../src/gui/folderitemwidget.cpp" line="476"/>
+        <source>Synchronized into &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</source>
+        <translation>Zsynchronizowano do &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="343"/>
+        <source>Activate Lite Sync</source>
+        <translation>Włącz Lite Sync</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="345"/>
+        <source>Activate Lite Sync (Beta)</source>
+        <translation>Włącz Lite Sync (wersja beta)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="481"/>
+        <source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
+        <translation>Foldery, które nie zostały zaznaczone, zostaną przeniesione do kosza, o ile zawierają elementy dostępne w trybie offline. Foldery zsynchronizowane z kDrive pozostaną dostępne online.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="485"/>
+        <source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
+        <translation>Foldery, które nie zostały zaznaczone, zostaną przeniesione do kosza. Foldery zsynchronizowane z kDrive pozostaną dostępne online.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="488"/>
+        <source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
+        <translation>Foldery, które nie zostały zaznaczone, zostaną &lt;b&gt;trwale&lt;/b&gt; usunięte z komputera. Foldery zsynchronizowane z kDrive pozostaną dostępne online.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="493"/>
+        <source>Cancel</source>
+        <translation>Anuluj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="494"/>
+        <source>VALIDATE</source>
+        <translation>ZATWIERDŹ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="365"/>
+        <source>Pause synchronization</source>
+        <translation>Wstrzymaj synchronizację</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="354"/>
+        <source>Deactivate Lite Sync</source>
+        <translation>Wyłącz Lite Sync</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="375"/>
+        <source>Resume synchronization</source>
+        <translation>Wznowienie synchronizacji</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="386"/>
+        <source>Remove synchronization</source>
+        <translation>Wyłącz synchronizację</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::GenericErrorItemWidget</name>
+    <message>
+        <location filename="../src/gui/genericerroritemwidget.cpp" line="85"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Nie można otworzyć ścieżki folderu %1.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::LiteSyncAppDialog</name>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="48"/>
+        <source>Application Id</source>
+        <translation>Identyfikator aplikacji</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="98"/>
+        <source>Application Name</source>
+        <translation>Nazwa aplikacji</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="121"/>
+        <source>VALIDATE</source>
+        <translation>ZATWIERDŹ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="128"/>
+        <source>CANCEL</source>
+        <translation>ANULUJ</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::LiteSyncDialog</name>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="91"/>
+        <source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are &quot;online&quot;. Add them in the list below to avoid this behaviour.</source>
+        <translation>Niektóre aplikacje (do tworzenia kopii zapasowych, antywirusowe...) uzyskują dostęp do Twoich plików, co powoduje ich pobieranie, gdy są one „online”. Dodaj je do poniższej listy, aby uniknąć tego zjawiska.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="103"/>
+        <source>Add</source>
+        <translation>Dodaj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="115"/>
+        <source>APPLICATION ID</source>
+        <translation>ID WNIOSKU</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="120"/>
+        <source>NAME</source>
+        <translation>IMIĘ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="154"/>
+        <source>SAVE</source>
+        <translation>ZAPISZ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="161"/>
+        <source>CANCEL</source>
+        <translation>ANULUJ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="295"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Czy chcesz zapisać wprowadzone zmiany?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="337"/>
+        <source>Do you really want to delete?</source>
+        <translation>Czy na pewno chcesz usunąć?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="374"/>
+        <source>Cannot save changes!</source>
+        <translation>Nie można zapisać zmian!</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::LocalFolderDialog</name>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="63"/>
+        <source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
+        <translation>Który folder na komputerze chcesz&lt;br&gt;zsynchronizować?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="72"/>
+        <source>The content of this folder will be synchronized on the kDrive</source>
+        <translation>Zawartość tego folderu zostanie zsynchronizowana w usłudze kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="91"/>
+        <source>Select a folder</source>
+        <translation>Wybierz folder</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="131"/>
+        <source>Edit folder</source>
+        <translation>Edytuj folder</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="166"/>
+        <source>CANCEL</source>
+        <translation>ANULUJ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="173"/>
+        <source>CONTINUE</source>
+        <translation>KONTYNUUJ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="210"/>
+        <source>This folder is not compatible with Lite Sync.&lt;br&gt;
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt;
-&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-            <translation>Ten folder nie jest zgodny z aplikacją Lite Sync.&lt;br&gt;
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Ten folder nie jest zgodny z aplikacją Lite Sync.&lt;br&gt;
 Wybierz inny folder. Jeśli kontynuujesz, aplikacja Lite Sync zostanie wyłączona.&lt;br&gt;
 
-&lt;a style="%1" href="%2"&gt;Dowiedz się więcej&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/localfolderdialog.cpp" line="233" />
-            <source>Select folder</source>
-            <translation>Wybierz folder</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/localfolderdialog.cpp" line="292" />
-            <source>Unable to open link %1.</source>
-            <translation>Nie można otworzyć linku %1.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::Logger</name>
-        <message>
-            <location filename="../src/libcommongui/logger.cpp" line="189" />
-            <source>Error</source>
-            <translation>Błąd</translation>
-        </message>
-        <message>
-            <location filename="../src/libcommongui/logger.cpp" line="189" />
-            <source>&lt;nobr&gt;File '%1'&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
-            <translation>&lt;nobr&gt;Nie można otworzyć&lt;br/&gt;pliku „%1” w trybie zapisu. &lt;b&gt;Nie&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;można zapisać danych dziennika!&lt;/nobr&gt;</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::MainMenuBarWidget</name>
-        <message>
-            <location filename="../src/gui/mainmenubarwidget.cpp" line="115" />
-            <source>Preferences</source>
-            <translation>Preferencje</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/mainmenubarwidget.cpp" line="116" />
-            <source>Help</source>
-            <translation>Pomoc</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::ParametersDialog</name>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="1082" />
-            <source>Unable to open folder path %1.</source>
-            <translation>Nie można otworzyć ścieżki folderu %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="1096" />
-            <source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
-            <translation>Przesłanie zakończone! W&lt;br&gt;zgłoszeniach błędów proszę podać identyfikator &lt;b&gt;%1&lt;/b&gt;.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="1118" />
-            <source>No kDrive configured!</source>
-            <translation>Nie skonfigurowano programu kDrive!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="1097" />
-            <source>Transmission failed!
-Please, use the following link to send the logs to the support: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</source>
-            <translation>Przesyłanie nie powiodło się!
-Proszę skorzystać z poniższego linku, aby przesłać logi do działu pomocy technicznej: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="337" />
-            <location filename="../src/gui/parametersdialog.cpp" line="440" />
-            <location filename="../src/gui/parametersdialog.cpp" line="506" />
-            <location filename="../src/gui/parametersdialog.cpp" line="546" />
-            <location filename="../src/gui/parametersdialog.cpp" line="560" />
-            <source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-            <translation>Wystąpił błąd techniczny (błąd %1).&lt;br&gt;Proszę wyczyścić historię, a jeśli błąd nadal występuje, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="342" />
-            <source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
-            <translation>Wygląda na to, że limit czasu połączenia sieciowego jest ustawiony na zbyt niską wartość, co uniemożliwia prawidłowe działanie aplikacji (błąd %1).&lt;br&gt;Sprawdź ustawienia sieciowe.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="347" />
-            <location filename="../src/gui/parametersdialog.cpp" line="516" />
-            <source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
-            <translation>Nie można połączyć się z serwerem kDrive (błąd %1).&lt;br&gt;Próbuję ponownie nawiązać połączenie. Sprawdź połączenie internetowe i ustawienia zapory sieciowej.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="352" />
-            <source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
-            <translation>Wystąpił problem z logowaniem (błąd %1).&lt;br&gt;Zaloguj się ponownie, a jeśli błąd nadal występuje, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="356" />
-            <source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
-            <translation>Dostępna jest nowa wersja aplikacji. Aby móc nadal z&lt;br&gt;niej korzystać, należy ją zaktualizować.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="360" />
-            <source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
-            <translation>Przesyłanie dziennika nie powiodło się (błąd %1).&lt;br&gt;Spróbuj ponownie później.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="385" />
-            <source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
-            <translation>Nie ma już dostępu do folderu synchronizacji (błąd %1).&lt;br&gt;Synchronizacja zostanie wznowiona, gdy tylko folder będzie ponownie dostępny.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="532" />
-            <source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
-            <translation>Folder synchronizacji został zastąpiony lub przeniesiony w sposób uniemożliwiający synchronizację (błąd %1). Może&lt;br&gt;się to zdarzyć po skopiowaniu, przeniesieniu lub przywróceniu folderu.&lt;br&gt;Aby to naprawić, należy utworzyć nową synchronizację z nowym folderem.&lt;br&gt;Uwaga: jeśli w starym folderze znajdują się niezsynchronizowane zmiany, należy je ręcznie skopiować do nowego folderu.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="397" />
-            <source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
-            <translation>Na komputerze zabrakło pamięci.&lt;br&gt;Synchronizacja została zatrzymana.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="320" />
-            <source>kDrive needs to have write access to your computer's temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
-            <translation>Aplikacja kDrive musi mieć uprawnienia do zapisu w katalogu tymczasowym komputera.&lt;br&gt;Aby rozwiązać ten problem, uruchom ponownie aplikację kDrive.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="330" />
-            <location filename="../src/gui/parametersdialog.cpp" line="487" />
-            <source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-            <translation>Wystąpił błąd techniczny.&lt;br&gt;Synchronizacja zostanie wznowiona tak szybko, jak to możliwe. Jeśli błąd nie ustąpi, prosimy o kontakt z naszym zespołem pomocy technicznej.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="401" />
-            <source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing '/etc/sysctl.conf'.</source>
-            <translation>Liczba obserwacji inotify jest niewystarczająca (błąd %1).&lt;br&gt;Można zwiększyć tę liczbę, edytując plik „/etc/sysctl.conf”.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="406" />
-            <source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
-            <translation>Nie można rozpocząć synchronizacji (błąd %1).&lt;br&gt;Należy zezwolić na&lt;br&gt;:- kDrive w Ustawieniach systemu &gt;&gt; Ogólne &gt;&gt; Elementy logowania i rozszerzenia &gt;&gt; Rozszerzenia zabezpieczeń punktów&lt;br&gt;końcowych - Rozszerzenie kDrive LiteSync w Ustawieniach systemu &gt;&gt; Prywatność i bezpieczeństwo &gt;&gt; Pełny dostęp do dysku.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="419" />
-            <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-            <translation>Nie można uruchomić wtyczki Lite Sync (błąd %1).&lt;br&gt;Sprawdź, czy rozszerzenie Lite Sync jest zainstalowane, a usługa Windows Search włączona.&lt;br&gt;Wyczyść historię, uruchom ponownie przeglądarkę, a jeśli błąd nadal występuje, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="424" />
-            <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-            <translation>Nie można uruchomić wtyczki Lite Sync (błąd %1).&lt;br&gt;Sprawdź, czy rozszerzenie Lite Sync ma odpowiednie uprawnienia i czy jest uruchomione.&lt;br&gt;Wyczyść historię, uruchom ponownie przeglądarkę, a jeśli błąd nadal występuje, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="429" />
-            <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-            <translation>Nie można uruchomić wtyczki Lite Sync (błąd %1).&lt;br&gt;Proszę wyczyścić historię, ponownie uruchomić program, a jeśli błąd nadal występuje, skontaktować się z naszym zespołem pomocy technicznej.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="435" />
-            <source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
-            <translation>Wygląda na to, że plik lub folder w folderze synchronizacji jest uszkodzony.&lt;br&gt;Synchronizacja została zatrzymana.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="449" />
-            <source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-            <translation>Serwer kDrive znajduje się w trybie konserwacji.&lt;br&gt;Synchronizacja zostanie wznowiona tak szybko, jak to możliwe. Jeśli błąd nadal występuje, prosimy o kontakt z naszym zespołem pomocy technicznej.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="455" />
-            <source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-            <translation>Usługa kDrive została zablokowana.&lt;br&gt;Proszę odnowić subskrypcję kDrive. Jeśli nie podejmiesz żadnych działań, dane zostaną trwale usunięte i nie będzie możliwości ich odzyskania.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="460" />
-            <source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-            <translation>Konto kDrive zostało zablokowane.&lt;br&gt;Skontaktuj się z administratorem w celu odblokowania konta kDrive. Jeśli nie podejmiesz żadnych działań, dane zostaną trwale usunięte i nie będzie możliwości ich odzyskania.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="466" />
-            <source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-            <translation>Usługa kDrive się uruchamia.&lt;br&gt;Synchronizacja zostanie wznowiona tak szybko, jak to możliwe. Jeśli błąd nadal występuje, prosimy o kontakt z naszym zespołem pomocy technicznej.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="475" />
-            <source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
-            <translation>Usługa kDrive jest wyłączona.&lt;br&gt;Zaloguj się do &lt;a style="%1" href="%2"&gt;wersji&lt;/a&gt; &lt;a style="%1" href="%2"&gt;internetowej&lt;/a&gt;, aby sprawdzić stan usługi kDrive, lub skontaktuj się z administratorem.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="479" />
-            <source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive's status, or contact your administrator.</source>
-            <translation>Usługa kDrive jest wyłączona.&lt;br&gt;Zaloguj się do wersji internetowej, aby sprawdzić stan usługi kDrive, lub skontaktuj się z administratorem.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="483" />
-            <source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
-            <translation>Nie masz uprawnień dostępu do tego konta kDrive.&lt;br&gt;Synchronizacja została wstrzymana. Skontaktuj się z administratorem.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="493" />
-            <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-            <translation>Wystąpił błąd techniczny (błąd %1).&lt;br&gt;Synchronizacja zostanie wznowiona tak szybko, jak to możliwe. Jeśli błąd nie ustąpi, prosimy o kontakt z naszym zespołem pomocy technicznej.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="512" />
-            <source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-            <translation>Jądro systemu przerwało połączenia sieciowe (błąd %1).&lt;br&gt;Proszę wyczyścić historię, a jeśli błąd nadal występuje, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="522" />
-            <source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
-            <translation>Niestety nie udało się przenieść starej konfiguracji.&lt;br&gt;Aplikacja będzie korzystać z pustej konfiguracji.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="526" />
-            <source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
-            <translation>Niestety nie udało się przenieść Twojej poprzedniej konfiguracji proxy; serwery proxy SOCKS5 nie są obecnie obsługiwane.&lt;br&gt;Aplikacja będzie korzystać z ustawień proxy systemu.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="539" />
-            <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
-            <translation>Wystąpił błąd techniczny (błąd %1).&lt;br&gt;Synchronizacja została wznowiona. Proszę wyczyścić historię, a jeśli błąd nadal występuje, prosimy o kontakt z naszym zespołem pomocy technicznej.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="550" />
-            <source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
-            <translation>Wystąpił błąd podczas uzyskiwania dostępu do bazy danych synchronizacji (błąd %1).&lt;br&gt;Synchronizacja została zatrzymana.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="564" />
-            <source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
-            <translation>Wystąpił problem z logowaniem (błąd %1).&lt;br&gt;Token jest nieprawidłowy lub został unieważniony.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="569" />
-            <source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
-            <translation>Zabronione jest zagnieżdżanie synchronizacji (błąd %1).&lt;br&gt;Należy zachować wyłącznie te synchronizacje, których foldery nie są zagnieżdżone.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="573" />
-            <source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
-            <translation>Folder synchronizacji na zdalnym serwerze kDrive nie istnieje już lub nie ma do niego dostępu (błąd %1).&lt;br&gt;Należy go przywrócić, przywrócić do niego uprawnienia dostępu lub usunąć i utworzyć synchronizację od nowa.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="580" />
-            <source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
-            <translation>Błąd analizy nazwy pliku (błąd %1). Znaki&lt;br&gt;specjalne, takie jak cudzysłowy, ukośniki odwrotne lub znaki końca linii, mogą powodować błędy analizy.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="722" />
-            <source>You are not allowed to move item to "%1".&lt;br&gt;It will be restored into its original parent folder.</source>
-            <translation>Nie można przenieść elementu do folderu „%1”. Zostanie&lt;br&gt;on przywrócony do pierwotnego folderu nadrzędnego.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="814" />
-            <source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
-            <translation>Na komputerze zabrakło miejsca.&lt;br&gt;Pobieranie zostało przerwane.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="609" />
-            <source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
-            <translation>Ten element został przeniesiony w inne miejsce.&lt;br&gt;Operacja lokalna została anulowana.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="618" />
-            <source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
-            <translation>W tej lokalizacji istnieje już element o tej samej nazwie.&lt;br&gt;Nazwa lokalnego elementu została zmieniona.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="614" />
-            <source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
-            <translation>W tej lokalizacji istnieje już element o tej samej nazwie.&lt;br&gt;Operacja lokalna została anulowana.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="393" />
-            <source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
-            <translation>Na komputerze zabrakło miejsca.&lt;br&gt;Synchronizacja została zatrzymana.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="622" />
-            <source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
-            <translation>Plik został zmieniony w tym samym czasie przez innego użytkownika.&lt;br&gt;Twoje zmiany zostały zapisane w kopii.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="626" />
-            <source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
-            <translation>Inny użytkownik przeniósł folder nadrzędny miejsca docelowego.&lt;br&gt;Operacja lokalna została anulowana.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="692" />
-            <source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
-            <translation>Nazwa pozycji zawiera wyłącznie spacje.&lt;br&gt;Została ona tymczasowo umieszczona na czarnej liście.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="703" />
-            <source>Either you are not allowed to create an item, or another item already exists with the same name.&lt;br&gt;The item has been excluded from synchronization.</source>
-            <translation>Albo nie masz uprawnień do utworzenia elementu, albo istnieje już inny element o tej samej nazwie.&lt;br&gt;Element został wykluczony z synchronizacji.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="708" />
-            <source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
-            <translation>Nie masz uprawnień do edycji tego elementu.&lt;br&gt;Plik zawierający wprowadzone zmiany został przemianowany i wykluczony z synchronizacji.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="716" />
-            <source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
-            <translation>Nie można zmienić nazwy tego elementu. Zostanie&lt;br&gt;on przywrócony pod pierwotną nazwą.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="727" />
-            <source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
-            <translation>Nie można usunąć tego elementu. Zostanie&lt;br&gt;on przywrócony do pierwotnej lokalizacji.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="732" />
-            <source>Failed to move this item to trash, it has been blacklisted.</source>
-            <translation>Nie udało się przenieść tego elementu do kosza; został on dodany do czarnej listy.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="748" />
-            <source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
-            <translation>Plik został zmodyfikowany lokalnie, podczas gdy na zdalnym serwerze kDrive został usunięty.&lt;br&gt;Lokalna kopia została zapisana w folderze awaryjnym.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="765" />
-            <source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
-            <translation>Wykonanie tej operacji na tym elemencie jest zabronione.&lt;br&gt;Element został tymczasowo umieszczony na czarnej liście.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="771" />
-            <source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
-            <translation>Operacja wykonana na tym elemencie nie powiodła się.&lt;br&gt;Element został tymczasowo umieszczony na czarnej liście.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="776" />
-            <source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
-            <translation>Plik jest zbyt duży, aby można go było przesłać. Został tymczasowo zablokowany.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="782" />
-            <source>Impossible to download the file.</source>
-            <translation>Nie można pobrać pliku.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="779" />
-            <source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
-            <translation>Przekroczyłeś limit miejsca. Zwiększ limit miejsca, aby ponownie umożliwić przesyłanie plików.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="389" />
-            <source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
-            <translation>Dysk zawierający folder synchronizacji nie jest już podłączony (błąd %1).&lt;br&gt;Podłącz go ponownie, aby wznowić synchronizację.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="413" />
-            <source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
-            <translation>Nie można rozpocząć synchronizacji (błąd %1).&lt;br&gt;Proces LiteSyncExt nie jest obecnie uruchomiony. Synchronizacja zostanie wznowiona zaraz po jego uruchomieniu.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="649" />
-            <source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
-            <translation>Istniejący element ma identyczną nazwę z zachowaniem tej samej wielkości liter (wszystkie litery są wielkie lub małe).&lt;br&gt;Został on tymczasowo umieszczony na czarnej liście.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="656" />
-            <source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
-            <translation>Nazwa pozycji zawiera znak, który nie jest obsługiwany.&lt;br&gt;Została ona tymczasowo umieszczona na czarnej liście.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="662" />
-            <source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-            <translation>Nazwa elementu kończy się spacją, co jest niedozwolone w Twoim systemie operacyjnym.&lt;br&gt;Została ona tymczasowo umieszczona na czarnej liście.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="668" />
-            <source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-            <translation>Ta nazwa elementu jest zarezerwowana przez system operacyjny.&lt;br&gt;Została tymczasowo umieszczona na czarnej liście.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="674" />
-            <source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
-            <translation>Nazwa produktu jest zbyt długa.&lt;br&gt;Została tymczasowo umieszczona na czarnej liście.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="680" />
-            <source>The item path is too long.&lt;br&gt;It has been ignored.</source>
-            <translation>Ścieżka do elementu jest zbyt długa.&lt;br&gt;Została pominięta.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="686" />
-            <source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
-            <translation>Nazwa elementu zawiera znak Unicode, który nie jest jeszcze obsługiwany przez system plików.&lt;br&gt;Została ona wykluczona z synchronizacji.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="735" />
-            <source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
-            <translation>Nie udało się zsynchronizować tego elementu. Został on tymczasowo umieszczony na czarnej liście.&lt;br&gt;Kolejna próba synchronizacji zostanie podjęta za godzinę lub przy następnym uruchomieniu aplikacji.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="740" />
-            <source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
-            <translation>Ten element został wykluczony z synchronizacji przez szablon niestandardowy.&lt;br&gt;Możesz wyłączyć tego typu powiadomienia w ustawieniach</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="745" />
-            <source>This item has been excluded from sync because it is a hard link.</source>
-            <translation>Ten element został wykluczony z synchronizacji, ponieważ jest to dowiązanie twarde.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="785" />
-            <source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
-            <translation>Ten element jest obecnie zablokowany przez innego użytkownika online.&lt;br&gt;Spróbujemy ponownie przesłać Twoje zmiany później.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="790" />
-            <location filename="../src/gui/parametersdialog.cpp" line="834" />
-            <source>Synchronization error.</source>
-            <translation>Błąd synchronizacji.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="810" />
-            <source>Can't access item.&lt;br&gt;Please fix the read and write permissions.</source>
-            <translation>Nie można uzyskać dostępu do elementu.&lt;br&gt;Proszę poprawić uprawnienia do odczytu i zapisu.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="818" />
-            <source>System error.</source>
-            <translation>Błąd systemu.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="825" />
-            <source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
-            <translation>Ten element istnieje już po drugiej stronie.&lt;br&gt;Został tymczasowo umieszczony na czarnej liście.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="840" />
-            <source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-            <translation>Wystąpił błąd techniczny.&lt;br&gt;Proszę wyczyścić historię, a jeśli błąd nadal występuje, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::PreferencesBlocWidget</name>
-        <message>
-            <location filename="../src/gui/preferencesblocwidget.cpp" line="187" />
-            <source>This synchronization is being deleted.</source>
-            <translation>Ta synchronizacja zostanie usunięta.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::PreferencesMenuBarWidget</name>
-        <message>
-            <location filename="../src/gui/preferencesmenubarwidget.cpp" line="63" />
-            <source>Back to drive list</source>
-            <translation>Powrót do listy dysków</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferencesmenubarwidget.cpp" line="64" />
-            <source>Preferences</source>
-            <translation>Preferencje</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::PreferencesWidget</name>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="491" />
-            <source>General</source>
-            <translation>Ogólne</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="493" />
-            <source>Activate dark theme</source>
-            <translation>Włącz ciemny motyw</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="495" />
-            <source>Activate monochrome icons</source>
-            <translation>Włącz monochromatyczne ikony</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="496" />
-            <source>Launch kDrive at startup</source>
-            <translation>Uruchamiaj kDrive przy starcie systemu</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="516" />
-            <source>Advanced</source>
-            <translation>Zaawansowane</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="517" />
-            <source>Debugging information</source>
-            <translation>Informacje debugowania</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="519" />
-            <source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
-            <translation>&lt;a style="%1" href="%2"&gt;Otwórz folder debugowania&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="520" />
-            <source>Files to exclude</source>
-            <translation>Pliki do wykluczenia</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="521" />
-            <source>Proxy server</source>
-            <translation>Serwer proxy</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="511" />
-            <source>Swedish</source>
-            <translation>Szwedzki</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="512" />
-            <source>Portuguese</source>
-            <translation>Portugalski</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="513" />
-            <source>Polish</source>
-            <translation>Polski</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="514" />
-            <source>Norwegian</source>
-            <translation>Norweski</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="466" />
-            <source>Unable to open folder %1.</source>
-            <translation>Nie można otworzyć folderu %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="478" />
-            <source>Unable to open link %1.</source>
-            <translation>Nie można otworzyć linku %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="483" />
-            <source>Invalid link %1.</source>
-            <translation>Nieprawidłowy link %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="523" />
-            <source>Lite Sync</source>
-            <translation>Lite Sync</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="497" />
-            <source>Language</source>
-            <translation>Język</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="490" />
-            <source>Some process failed to run.</source>
-            <translation>Nie udało się uruchomić jakiegoś procesu.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="498" />
-            <source>Move deleted files to my computer's trash</source>
-            <translation>Przenoś usunięte pliki do kosza na komputerze</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="499" />
-            <source>Some files or folders may not be moved to the computer's trash.</source>
-            <translation>Niektórych plików lub folderów nie da się przenieść do kosza komputera.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="500" />
-            <source>You can always retrieve already synced files from the kDrive web application trash.</source>
-            <translation>Zawsze możesz odzyskać wcześniej zsynchronizowane pliki z kosza aplikacji webowej kDrive.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="502" />
-            <source>&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-            <translation>&lt;a style="%1" href="%2"&gt;Dowiedz się więcej&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="506" />
-            <source>English</source>
-            <translation>Angielski</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="507" />
-            <source>French</source>
-            <translation>Francuski</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="508" />
-            <source>German</source>
-            <translation>Niemiecki</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="509" />
-            <source>Spanish</source>
-            <translation>Hiszpański</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="510" />
-            <source>Italian</source>
-            <translation>Włoski</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="505" />
-            <source>Default</source>
-            <translation>Domyślny</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::ProgressBarWidget</name>
-        <message>
-            <location filename="../src/gui/progressbarwidget.cpp" line="70" />
-            <source>%1 in use</source>
-            <translation>%1 w użyciu</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::ProxyServerDialog</name>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="50" />
-            <source>HTTP(S) Proxy</source>
-            <translation>Serwer proxy HTTP(S)</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="73" />
-            <source>Proxy server</source>
-            <translation>Serwer proxy</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="85" />
-            <source>No proxy server</source>
-            <translation>Brak serwera proxy</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="90" />
-            <source>Use system parameters</source>
-            <translation>Użyj parametrów systemowych</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="95" />
-            <source>Indicate a proxy manually</source>
-            <translation>Wprowadź pełnomocnika ręcznie</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="131" />
-            <source>Port</source>
-            <translation>Port</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="144" />
-            <source>Address of the proxy server</source>
-            <translation>Adres serwera proxy</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="150" />
-            <source>Authentication needed</source>
-            <translation>Wymagane uwierzytelnienie</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="165" />
-            <source>User</source>
-            <translation>Użytkownik</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="171" />
-            <source>Password</source>
-            <translation>Hasło</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="185" />
-            <source>SAVE</source>
-            <translation>ZAPISZ</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="192" />
-            <source>CANCEL</source>
-            <translation>ANULUJ</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="286" />
-            <source>Do you want to save your modifications?</source>
-            <translation>Czy chcesz zapisać wprowadzone zmiany?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="295" />
-            <source>Unable to save, all mandatory fields are not completed!</source>
-            <translation>Nie można zapisać danych, ponieważ nie wszystkie pola obowiązkowe zostały wypełnione!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="316" />
-            <source>Proxy not found, save anyway?</source>
-            <translation>Nie znaleziono serwera proxy. Czy chcesz zapisać mimo to?</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::ResourcesManagerDialog</name>
-        <message>
-            <location filename="../src/gui/resourcesmanagerdialog.cpp" line="55" />
-            <source>Resources Manager</source>
-            <translation>Kierownik ds. zasobów</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/resourcesmanagerdialog.cpp" line="65" />
-            <source>Maximum CPU usage allowed</source>
-            <translation>Maksymalne dopuszczalne obciążenie procesora</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/resourcesmanagerdialog.cpp" line="96" />
-            <source>SAVE</source>
-            <translation>ZAPISZ</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/resourcesmanagerdialog.cpp" line="103" />
-            <source>CANCEL</source>
-            <translation>ANULUJ</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/resourcesmanagerdialog.cpp" line="122" />
-            <source>Do you want to save your modifications?</source>
-            <translation>Czy chcesz zapisać wprowadzone zmiany?</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::ServerBaseFolderDialog</name>
-        <message>
-            <location filename="../src/gui/serverbasefolderdialog.cpp" line="81" />
-            <source>Select a folder on your kDrive</source>
-            <translation>Wybierz folder na swoim kDrive</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/serverbasefolderdialog.cpp" line="90" />
-            <source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
-            <translation>Zawartość wybranego folderu zostanie zsynchronizowana z folderem &lt;b&gt;%1&lt;/b&gt;.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/serverbasefolderdialog.cpp" line="134" />
-            <source>CONTINUE</source>
-            <translation>KONTYNUUJ</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/serverbasefolderdialog.cpp" line="150" />
-            <source>Space available on your computer for the current folder : %1</source>
-            <translation>Miejsce dostępne na komputerze dla bieżącego folderu: %1</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/serverbasefolderdialog.cpp" line="190" />
-            <source>This folder is already being synced.</source>
-            <translation>Ten folder jest już synchronizowany.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/serverbasefolderdialog.cpp" line="204" />
-            <source>CONFIRM</source>
-            <translation>POTWIERDŹ</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/serverbasefolderdialog.cpp" line="205" />
-            <source>CANCEL</source>
-            <translation>ANULUJ</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::ServerFoldersDialog</name>
-        <message>
-            <location filename="../src/gui/serverfoldersdialog.cpp" line="80" />
-            <source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
-            <translation>Folder &lt;b&gt;%1&lt;/b&gt; zawiera podfoldery;&lt;br&gt; wybierz te, które chcesz zsynchronizować</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/serverfoldersdialog.cpp" line="110" />
-            <source>CONTINUE</source>
-            <translation>KONTYNUUJ</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/serverfoldersdialog.cpp" line="146" />
-            <source>No subfolders currently on the server.</source>
-            <translation>Obecnie na serwerze nie ma żadnych podfolderów.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::StatusBarWidget</name>
-        <message>
-            <location filename="../src/gui/statusbarwidget.cpp" line="178" />
-            <source>Resume kDrive "%1" synchronization</source>
-            <translation>Wznowić synchronizację kDrive „%1”</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/statusbarwidget.cpp" line="180" />
-            <source>Resume all kDrives synchronization</source>
-            <translation>Wznowić synchronizację wszystkich dysków kDrive</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/statusbarwidget.cpp" line="183" />
-            <source>Pause kDrive "%1" synchronization</source>
-            <translation>Wstrzymaj synchronizację kDrive „%1”</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/statusbarwidget.cpp" line="184" />
-            <location filename="../src/gui/statusbarwidget.cpp" line="321" />
-            <source>Pause synchronization</source>
-            <translation>Wstrzymaj synchronizację</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/statusbarwidget.cpp" line="185" />
-            <source>Pause all kDrives synchronization</source>
-            <translation>Wstrzymaj synchronizację wszystkich kDrives</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/statusbarwidget.cpp" line="179" />
-            <location filename="../src/gui/statusbarwidget.cpp" line="322" />
-            <source>Resume synchronization</source>
-            <translation>Wznowienie synchronizacji</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::SynchronizedItemWidget</name>
-        <message>
-            <location filename="../src/gui/synchronizeditemwidget.cpp" line="333" />
-            <source>Copy share link</source>
-            <translation>Skopiuj link do udostępnienia</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synchronizeditemwidget.cpp" line="342" />
-            <source>Display on kdrive.infomaniak.com</source>
-            <translation>Wyświetl na stronie kdrive.infomaniak.com</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synchronizeditemwidget.cpp" line="387" />
-            <source>Show in folder</source>
-            <translation>Pokaż w folderze</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synchronizeditemwidget.cpp" line="388" />
-            <source>More actions</source>
-            <translation>Więcej działań</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synchronizeditemwidget.cpp" line="317" />
-            <source>Open</source>
-            <translation>Otwórz</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synchronizeditemwidget.cpp" line="325" />
-            <source>Add to favorites</source>
-            <translation>Dodaj do ulubionych</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::SynthesisBar</name>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="495" />
-            <location filename="../src/gui/synthesisbar.cpp" line="502" />
-            <source>Never</source>
-            <translation>Nigdy</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="496" />
-            <source>During 1 hour</source>
-            <translation>W ciągu godziny</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="497" />
-            <location filename="../src/gui/synthesisbar.cpp" line="504" />
-            <source>Until tomorrow 8:00AM</source>
-            <translation>Do jutra do godziny 8:00 rano</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="498" />
-            <source>During 3 days</source>
-            <translation>Przez 3 dni</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="499" />
-            <source>During 1 week</source>
-            <translation>W ciągu tygodnia</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="500" />
-            <location filename="../src/gui/synthesisbar.cpp" line="507" />
-            <source>Always</source>
-            <translation>Zawsze</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="503" />
-            <source>For 1 more hour</source>
-            <translation>Jeszcze przez 1 godzinę</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="505" />
-            <source>For 3 more days</source>
-            <translation>Jeszcze przez 3 dni</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="506" />
-            <source>For 1 more week</source>
-            <translation>Jeszcze przez 1 tydzień</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="149" />
-            <source>Unable to open folder url %1.</source>
-            <translation>Nie można otworzyć folderu o adresie URL %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="219" />
-            <source>Open in folder</source>
-            <translation>Otwórz w folderze</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="257" />
-            <source>Open %1 web version</source>
-            <translation>Otwórz wersję internetową %1</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="267" />
-            <source>Drive parameters</source>
-            <translation>Parametry napędu</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="280" />
-            <source>Notifications disabled until %1</source>
-            <translation>Powiadomienia wyłączone do %1</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="281" />
-            <source>Disable Notifications</source>
-            <translation>Wyłącz powiadomienia</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="314" />
-            <source>Application preferences</source>
-            <translation>Ustawienia aplikacji</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="322" />
-            <source>Need help</source>
-            <translation>Potrzebujesz pomocy?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="330" />
-            <source>Send feedbacks</source>
-            <translation>Prześlij opinię</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="338" />
-            <source>Quit kDrive</source>
-            <translation>Zamknij kDrive</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="401" />
-            <source>Unable to access web site %1.</source>
-            <translation>Nie można uzyskać dostępu do strony internetowej %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="492" />
-            <source>Show errors and informations</source>
-            <translation>Pokaż błędy i informacje</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="493" />
-            <source>Show informations</source>
-            <translation>Pokaż informacje</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="494" />
-            <source>More actions</source>
-            <translation>Więcej działań</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::SynthesisPopover</name>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="1181" />
-            <source>Update kDrive App</source>
-            <translation>Zaktualizuj aplikację kDrive</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="1182" />
-            <source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
-            <translation>Ta wersja aplikacji kDrive nie jest już obsługiwana. Aby uzyskać dostęp do najnowszych funkcji i ulepszeń, zaktualizuj aplikację.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="978" />
-            <source>Update</source>
-            <translation>Aktualizacja</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="1187" />
-            <source>Please download the latest version on the website.</source>
-            <translation>Proszę pobrać najnowszą wersję ze strony internetowej.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="981" />
-            <source>Update download in progress</source>
-            <translation>Trwa pobieranie aktualizacji</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="984" />
-            <source>Looking for update...</source>
-            <translation>Czekam na aktualizację...</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="987" />
-            <source>Manual update</source>
-            <translation>Ręczna aktualizacja</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="990" />
-            <source>Unavailable</source>
-            <translation>Niedostępne</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="1200" />
-            <source>You can synchronize files &lt;a style="%1" href="%2"&gt;from your computer&lt;/a&gt; or on &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
-            <translation>Możesz zsynchronizować pliki &lt;a style="%1" href="%2"&gt;z komputera&lt;/a&gt; lub ze strony &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="446" />
-            <source>Synchronized</source>
-            <translation>Zsynchronizowane</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="450" />
-            <source>Favorites</source>
-            <translation>Ulubione</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="454" />
-            <source>Activity</source>
-            <translation>Zajęcia</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="1133" />
-            <location filename="../src/gui/synthesispopover.cpp" line="1180" />
-            <source>Not implemented!</source>
-            <translation>Nie zaimplementowano!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="1184" />
-            <source>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Click here to download manually&lt;/a&gt;</source>
-            <translation>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Kliknij tutaj, aby pobrać plik ręcznie&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="1193" />
-            <source>No synchronized folder for this Drive!</source>
-            <translation>Brak zsynchronizowanego folderu dla tego dysku!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="1196" />
-            <source>No kDrive configured!</source>
-            <translation>Nie skonfigurowano programu kDrive!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="1161" />
-            <source>Unable to open link %1.</source>
-            <translation>Nie można otworzyć linku %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="1173" />
-            <source>Invalid link %1.</source>
-            <translation>Nieprawidłowy link %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="586" />
-            <source>Unable to open folder url %1.</source>
-            <translation>Nie można otworzyć folderu o adresie URL %1.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::UpdateDialog</name>
-        <message>
-            <location filename="../src/gui/updater/updatedialog.cpp" line="61" />
-            <source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
-            <translation>&lt;p&gt;Nowa wersja &lt;b&gt;%1&lt;/b&gt; klienta %2 jest już dostępna i została pobrana.&lt;/p&gt;&lt;p&gt;Zainstalowana wersja to %3.&lt;/p&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/updater/updatedialog.cpp" line="95" />
-            <source>Skip this version</source>
-            <translation>Pomiń tę wersję</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/updater/updatedialog.cpp" line="103" />
-            <source>Remind me later</source>
-            <translation>Przypomnij mi później</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/updater/updatedialog.cpp" line="109" />
-            <source>Install update</source>
-            <translation>Zainstaluj aktualizację</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::UpdateManager</name>
-        <message>
-            <location filename="../src/server/updater/updatemanager.cpp" line="86" />
-            <source>New update available.</source>
-            <translation>Dostępna jest nowa aktualizacja.</translation>
-        </message>
-        <message>
-            <location filename="../src/server/updater/updatemanager.cpp" line="87" />
-            <source>Version %1 is available for download.</source>
-            <translation>Wersja %1 jest dostępna do pobrania.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::UserSelectionWidget</name>
-        <message>
-            <location filename="../src/gui/userselectionwidget.cpp" line="131" />
-            <source>Add an account</source>
-            <translation>Dodaj konto</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::VersionWidget</name>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="295" />
-            <source>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</source>
-            <translation>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="169" />
-            <source>&lt;a style="%1" href="%2"&gt;Show release note&lt;/a&gt;</source>
-            <translation>&lt;a style="%1" href="%2"&gt;Pokaż informacje o aktualizacji&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="172" />
-            <source>Version</source>
-            <translation>Wersja</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="173" />
-            <source>UPDATE</source>
-            <translation>AKTUALIZACJA</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="197" />
-            <source>%1 is up to date!</source>
-            <translation>%1 jest aktualne!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="201" />
-            <source>Checking update on server...</source>
-            <translation>Sprawdzam aktualizacje na serwerze...</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="205" />
-            <source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style="%2" href="%3"&gt;here&lt;/a&gt;.</source>
-            <translation>Dostępna jest aktualizacja: %1.&lt;br&gt;Pobierz ją stąd.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="212" />
-            <source>An update is available: %1</source>
-            <translation>Dostępna jest aktualizacja: %1</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="218" />
-            <source>Downloading %1. Please wait...</source>
-            <translation>Pobieranie %1. Proszę czekać...</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="223" />
-            <source>Could not check for new updates.</source>
-            <translation>Nie udało się sprawdzić dostępności nowych aktualizacji.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="227" />
-            <source>An error occurred during update.</source>
-            <translation>Podczas aktualizacji wystąpił błąd.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="231" />
-            <source>Could not download update.</source>
-            <translation>Nie udało się pobrać aktualizacji.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="235" />
-            <source>Update disabled.</source>
-            <translation>Funkcja aktualizacji została wyłączona.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="251" />
-            <source>Beta program</source>
-            <translation>Program beta</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="252" />
-            <source>Get early access to new versions of the application</source>
-            <translation>Zyskaj wczesny dostęp do nowych wersji aplikacji</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="256" />
-            <source>Join</source>
-            <translation>Dołącz</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="259" />
-            <source>Modify</source>
-            <translation>Zmodyfikuj</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="259" />
-            <source>Quit</source>
-            <translation>Zakończ</translation>
-        </message>
-    </context>
-    <context>
-        <name>QObject</name>
-        <message>
-            <location filename="../src/gui/parameterscache.cpp" line="59" />
-            <source>Unable to save parameters, please retry later.</source>
-            <translation>Nie można zapisać parametrów. Spróbuj ponownie później.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parameterscache.cpp" line="60" />
-            <source>Unable to save parameters!</source>
-            <translation>Nie można zapisać parametrów!</translation>
-        </message>
-        <message>
-            <location filename="../src/server/requests/serverrequests.cpp" line="461" />
-            <source>The parent folder is a sync folder or contained in one</source>
-            <translation>Folder nadrzędny jest folderem synchronizacji lub znajduje się w takim folderze</translation>
-        </message>
-        <message>
-            <location filename="../src/server/requests/serverrequests.cpp" line="495" />
-            <source>Can't find a valid path</source>
-            <translation>Nie można znaleźć prawidłowej ścieżki</translation>
-        </message>
-        <message>
-            <location filename="../src/server/requests/serverrequests.cpp" line="2109" />
-            <source>No valid folder selected!</source>
-            <translation>Nie wybrano żadnego prawidłowego folderu!</translation>
-        </message>
-        <message>
-            <location filename="../src/server/requests/serverrequests.cpp" line="2120" />
-            <source>The selected path does not exist!</source>
-            <translation>Wybrana ścieżka nie istnieje!</translation>
-        </message>
-        <message>
-            <location filename="../src/server/requests/serverrequests.cpp" line="2125" />
-            <source>The selected path is not a folder!</source>
-            <translation>Wybrana ścieżka nie jest folderem!</translation>
-        </message>
-        <message>
-            <location filename="../src/server/requests/serverrequests.cpp" line="2130" />
-            <source>You have no permission to write to the selected folder!</source>
-            <translation>Nie masz uprawnień do zapisu w wybranym folderze!</translation>
-        </message>
-        <message>
-            <location filename="../src/server/requests/serverrequests.cpp" line="2160" />
-            <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
-            <translation>Folder lokalny %1 zawiera folder, który został już zsynchronizowany. Wybierz inny!</translation>
-        </message>
-        <message>
-            <location filename="../src/server/requests/serverrequests.cpp" line="2168" />
-            <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
-            <translation>Folder lokalny %1 znajduje się w folderze, który został już zsynchronizowany. Wybierz inny!</translation>
-        </message>
-        <message>
-            <location filename="../src/server/requests/serverrequests.cpp" line="2176" />
-            <source>The local folder %1 is already synced. Please pick another one!</source>
-            <translation>Lokalny folder %1 został już zsynchronizowany. Wybierz inny!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="42" />
-            <source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
-            <translation>Włączono funkcję Lite sync (wersja beta). Pliki z serwisu kDrive pozostają w chmurze i nie zajmują miejsca na dysku komputera.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="45" />
-            <source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
-            <translation>Funkcja Lite sync (wersja beta) jest wyłączona. Pliki kDrive zajmują miejsce na dysku komputera.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="48" />
-            <source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
-            <translation>Włączono funkcję Lite Sync. Pliki z serwisu kDrive pozostają w chmurze i nie zajmują miejsca na dysku komputera.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="50" />
-            <source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
-            <translation>Funkcja Lite Sync jest wyłączona. Pliki kDrive zajmują miejsce na dysku komputera.</translation>
-        </message>
-        <message>
-            <location filename="../src/server/comm/extensionjob.cpp" line="1175" />
-            <source>Make available locally</source>
-            <translation>Udostępnij lokalnie</translation>
-        </message>
-        <message>
-            <location filename="../src/server/comm/extensionjob.cpp" line="1179" />
-            <source>Free up local space</source>
-            <translation>Zwolnij miejsce na dysku lokalnym</translation>
-        </message>
-        <message>
-            <location filename="../src/server/comm/extensionjob.cpp" line="1183" />
-            <source>Cancel free up local space</source>
-            <translation>Anuluj, aby zwolnić miejsce na dysku</translation>
-        </message>
-        <message>
-            <location filename="../src/server/comm/extensionjob.cpp" line="1187" />
-            <source>Cancel make available locally</source>
-            <translation>Anuluj udostępnianie lokalne</translation>
-        </message>
-        <message>
-            <location filename="../src/server/comm/extensionjob.cpp" line="1191" />
-            <source>Resharing this file is not allowed</source>
-            <translation>Ponowne udostępnianie tego pliku jest zabronione</translation>
-        </message>
-        <message>
-            <location filename="../src/server/comm/extensionjob.cpp" line="1192" />
-            <source>Resharing this folder is not allowed</source>
-            <translation>Ponowne udostępnianie tego folderu jest zabronione</translation>
-        </message>
-        <message>
-            <location filename="../src/server/comm/extensionjob.cpp" line="1196" />
-            <source>Copy public share link</source>
-            <translation>Skopiuj link do publicznego udostępnienia</translation>
-        </message>
-        <message>
-            <location filename="../src/server/comm/extensionjob.cpp" line="1200" />
-            <source>Copy private share link</source>
-            <translation>Skopiuj prywatny link do udostępnienia</translation>
-        </message>
-        <message>
-            <location filename="../src/server/comm/extensionjob.cpp" line="1204" />
-            <source>Open in browser</source>
-            <translation>Otwórz w przeglądarce</translation>
-        </message>
-    </context>
-    <context>
-        <name>SharedTools::QtSingleApplication</name>
-        <message>
-            <location filename="../src/server/appserver.cpp" line="133" />
-            <source>kDrive application will close due to a fatal error.</source>
-            <translation>Aplikacja kDrive zostanie zamknięta z powodu poważnego błędu.</translation>
-        </message>
-    </context>
-    <context>
-        <name>Utility</name>
-        <message>
-            <location filename="../src/libcommongui/utility/utility.cpp" line="97" />
-            <source>%L1 GB</source>
-            <translation>%L1 GB</translation>
-        </message>
-        <message>
-            <location filename="../src/libcommongui/utility/utility.cpp" line="101" />
-            <source>%L1 MB</source>
-            <translation>%L1 MB</translation>
-        </message>
-        <message>
-            <location filename="../src/libcommongui/utility/utility.cpp" line="105" />
-            <source>%L1 KB</source>
-            <translation>%L1 KB</translation>
-        </message>
-        <message>
-            <location filename="../src/libcommongui/utility/utility.cpp" line="108" />
-            <source>%L1 B</source>
-            <translation>%L1 B</translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/libcommongui/utility/utility.cpp" line="41" />
-            <source>%n year(s)</source>
-            <translation>
-                <numerusform>%n rok</numerusform>
-                <numerusform>%n lat</numerusform>
-            </translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/libcommongui/utility/utility.cpp" line="42" />
-            <source>%n month(s)</source>
-            <translation>
-                <numerusform>%n miesiąc</numerusform>
-                <numerusform>%n miesięcy</numerusform>
-            </translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/libcommongui/utility/utility.cpp" line="43" />
-            <source>%n day(s)</source>
-            <translation>
-                <numerusform>%n dzień</numerusform>
-                <numerusform>%n dni</numerusform>
-            </translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/libcommongui/utility/utility.cpp" line="44" />
-            <source>%n hour(s)</source>
-            <translation>
-                <numerusform>%n godzina</numerusform>
-                <numerusform>%n godzin</numerusform>
-            </translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/libcommongui/utility/utility.cpp" line="45" />
-            <source>%n minute(s)</source>
-            <translation>
-                <numerusform>%n minuta</numerusform>
-                <numerusform>%n minut</numerusform>
-            </translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/libcommongui/utility/utility.cpp" line="46" />
-            <source>%n second(s)</source>
-            <translation>
-                <numerusform>%n sekunda</numerusform>
-                <numerusform>%n sekund</numerusform>
-            </translation>
-        </message>
-    </context>
-    <context>
-        <name>main.cpp</name>
-        <message>
-            <location filename="../src/gui/mainclient.cpp" line="49" />
-            <source>System Tray not available</source>
-            <translation>Pasek zadań nie jest dostępny</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/mainclient.cpp" line="48" />
-            <source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as 'trayer' and try again.</source>
-            <translation>%1 wymaga działającego paska zadań. Jeśli korzystasz z środowiska XFCE, postępuj zgodnie z &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;poniższymi instrukcjami&lt;/a&gt;. W przeciwnym razie zainstaluj aplikację do obsługi paska zadań, np. „trayer”, i spróbuj ponownie.</translation>
-        </message>
-    </context>
-    <context>
-        <name>utility</name>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="84" />
-            <source>Could not open browser</source>
-            <translation>Nie udało się otworzyć przeglądarki</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="85" />
-            <source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
-            <translation>Wystąpił błąd podczas uruchamiania przeglądarki w celu przejścia do adresu URL %1. Być może nie skonfigurowano domyślnej przeglądarki?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="104" />
-            <source>Could not open email client</source>
-            <translation>Nie udało się uruchomić klienta poczty elektronicznej</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="105" />
-            <source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
-            <translation>Wystąpił błąd podczas uruchamiania klienta poczty e-mail w celu utworzenia nowej wiadomości. Być może nie skonfigurowano domyślnego klienta poczty e-mail?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="324" />
-            <source>You are not connected anymore. &lt;a style="%1" href="%2"&gt;Log in&lt;/a&gt;</source>
-            <translation>Nie masz już połączenia. &lt;a style="%1" href="%2"&gt;Zaloguj się&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="347" />
-            <source>Sync in progress (Step %1/%2).</source>
-            <translation>Trwa synchronizacja (Krok %1/%2).</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="353" />
-            <source>Sync in progress.</source>
-            <translation>Trwa synchronizacja.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="364" />
-            <source>Some files couldn't be synchronized. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-            <translation>Niektórych plików nie udało się zsynchronizować. &lt;a style="%1" href="%2"&gt;Dowiedz się więcej&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="370" />
-            <source>Synchronization pausing ...</source>
-            <translation>Wstrzymywanie synchronizacji...</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="570" />
-            <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
-            <translation>Nie można wybrać folderu &lt;b&gt;%1,&lt;/b&gt; ponieważ inna synchronizacja korzysta z tego samego folderu.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="576" />
-            <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-            <translation>Nie można zaznaczyć folderu &lt;b&gt;%1,&lt;/b&gt; ponieważ zawiera on zsynchronizowany folder &lt;b&gt;%2&lt;/b&gt;.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="584" />
-            <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-            <translation>Nie można zaznaczyć folderu &lt;b&gt;%1,&lt;/b&gt; ponieważ znajduje się on w folderze synchronizowanym &lt;b&gt;%2&lt;/b&gt;.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="595" />
-            <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
-            <translation>Folderu &lt;b&gt;%1&lt;/b&gt; nie można wybrać jako folderu do synchronizacji. Wybierz inny folder.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="599" />
-            <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
-            <translation>Folder &lt;b&gt;%1&lt;/b&gt; nie może zostać wybrany jako folder synchronizacji. Wybierz inny folder. Sugerowany folder: &lt;b&gt;%2&lt;/b&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="641" />
-            <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
-            <translation>Wykluczyłeś ponad %1 folderów. Pamiętaj, że wpłynie to na wydajność synchronizacji.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="650" />
-            <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
-            <translation>Nie można wykluczyć więcej niż %1 folderów. Proszę odznaczyć foldery wyższego poziomu.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="351" />
-            <source>Synchronization starting</source>
-            <translation>Rozpoczyna się synchronizacja</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="374" />
-            <source>Synchronization paused.</source>
-            <translation>Synchronizacja została wstrzymana.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="336" />
-            <source>Sync in progress (%1 of %2)</source>
-            <translation>Trwa synchronizacja (%1 z %2)</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="340" />
-            <source>Sync in progress (%1 of %2)
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Dowiedz się więcej&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="233"/>
+        <source>Select folder</source>
+        <translation>Wybierz folder</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="292"/>
+        <source>Unable to open link %1.</source>
+        <translation>Nie można otworzyć linku %1.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::Logger</name>
+    <message>
+        <location filename="../src/libcommongui/logger.cpp" line="189"/>
+        <source>Error</source>
+        <translation>Błąd</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/logger.cpp" line="189"/>
+        <source>&lt;nobr&gt;File &apos;%1&apos;&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
+        <translation>&lt;nobr&gt;Nie można otworzyć&lt;br/&gt;pliku „%1” w trybie zapisu. &lt;b&gt;Nie&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;można zapisać danych dziennika!&lt;/nobr&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::MainMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/mainmenubarwidget.cpp" line="115"/>
+        <source>Preferences</source>
+        <translation>Preferencje</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/mainmenubarwidget.cpp" line="116"/>
+        <source>Help</source>
+        <translation>Pomoc</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ParametersDialog</name>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1082"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Nie można otworzyć ścieżki folderu %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1096"/>
+        <source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
+        <translation>Przesłanie zakończone! W&lt;br&gt;zgłoszeniach błędów proszę podać identyfikator &lt;b&gt;%1&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1118"/>
+        <source>No kDrive configured!</source>
+        <translation>Nie skonfigurowano programu kDrive!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1097"/>
+        <source>Transmission failed!
+Please, use the following link to send the logs to the support: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</source>
+        <translation>Przesyłanie nie powiodło się!
+Proszę skorzystać z poniższego linku, aby przesłać logi do działu pomocy technicznej: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="337"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="440"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="506"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="546"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="560"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>Wystąpił błąd techniczny (błąd %1).&lt;br&gt;Proszę wyczyścić historię, a jeśli błąd nadal występuje, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="342"/>
+        <source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
+        <translation>Wygląda na to, że limit czasu połączenia sieciowego jest ustawiony na zbyt niską wartość, co uniemożliwia prawidłowe działanie aplikacji (błąd %1).&lt;br&gt;Sprawdź ustawienia sieciowe.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="347"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="516"/>
+        <source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
+        <translation>Nie można połączyć się z serwerem kDrive (błąd %1).&lt;br&gt;Próbuję ponownie nawiązać połączenie. Sprawdź połączenie internetowe i ustawienia zapory sieciowej.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="352"/>
+        <source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
+        <translation>Wystąpił problem z logowaniem (błąd %1).&lt;br&gt;Zaloguj się ponownie, a jeśli błąd nadal występuje, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="356"/>
+        <source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
+        <translation>Dostępna jest nowa wersja aplikacji. Aby móc nadal z&lt;br&gt;niej korzystać, należy ją zaktualizować.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="360"/>
+        <source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
+        <translation>Przesyłanie dziennika nie powiodło się (błąd %1).&lt;br&gt;Spróbuj ponownie później.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="385"/>
+        <source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
+        <translation>Nie ma już dostępu do folderu synchronizacji (błąd %1).&lt;br&gt;Synchronizacja zostanie wznowiona, gdy tylko folder będzie ponownie dostępny.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="532"/>
+        <source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
+        <translation>Folder synchronizacji został zastąpiony lub przeniesiony w sposób uniemożliwiający synchronizację (błąd %1). Może&lt;br&gt;się to zdarzyć po skopiowaniu, przeniesieniu lub przywróceniu folderu.&lt;br&gt;Aby to naprawić, należy utworzyć nową synchronizację z nowym folderem.&lt;br&gt;Uwaga: jeśli w starym folderze znajdują się niezsynchronizowane zmiany, należy je ręcznie skopiować do nowego folderu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="397"/>
+        <source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>Na komputerze zabrakło pamięci.&lt;br&gt;Synchronizacja została zatrzymana.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="320"/>
+        <source>kDrive needs to have write access to your computer&apos;s temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
+        <translation>Aplikacja kDrive musi mieć uprawnienia do zapisu w katalogu tymczasowym komputera.&lt;br&gt;Aby rozwiązać ten problem, uruchom ponownie aplikację kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="330"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="487"/>
+        <source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>Wystąpił błąd techniczny.&lt;br&gt;Synchronizacja zostanie wznowiona tak szybko, jak to możliwe. Jeśli błąd nie ustąpi, prosimy o kontakt z naszym zespołem pomocy technicznej.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="401"/>
+        <source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing &apos;/etc/sysctl.conf&apos;.</source>
+        <translation>Liczba obserwacji inotify jest niewystarczająca (błąd %1).&lt;br&gt;Można zwiększyć tę liczbę, edytując plik „/etc/sysctl.conf”.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="406"/>
+        <source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
+        <translation>Nie można rozpocząć synchronizacji (błąd %1).&lt;br&gt;Należy zezwolić na&lt;br&gt;:- kDrive w Ustawieniach systemu &gt;&gt; Ogólne &gt;&gt; Elementy logowania i rozszerzenia &gt;&gt; Rozszerzenia zabezpieczeń punktów&lt;br&gt;końcowych - Rozszerzenie kDrive LiteSync w Ustawieniach systemu &gt;&gt; Prywatność i bezpieczeństwo &gt;&gt; Pełny dostęp do dysku.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="419"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Nie można uruchomić wtyczki Lite Sync (błąd %1).&lt;br&gt;Sprawdź, czy rozszerzenie Lite Sync jest zainstalowane, a usługa Windows Search włączona.&lt;br&gt;Wyczyść historię, uruchom ponownie przeglądarkę, a jeśli błąd nadal występuje, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="424"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Nie można uruchomić wtyczki Lite Sync (błąd %1).&lt;br&gt;Sprawdź, czy rozszerzenie Lite Sync ma odpowiednie uprawnienia i czy jest uruchomione.&lt;br&gt;Wyczyść historię, uruchom ponownie przeglądarkę, a jeśli błąd nadal występuje, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="429"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Nie można uruchomić wtyczki Lite Sync (błąd %1).&lt;br&gt;Proszę wyczyścić historię, ponownie uruchomić program, a jeśli błąd nadal występuje, skontaktować się z naszym zespołem pomocy technicznej.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="435"/>
+        <source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>Wygląda na to, że plik lub folder w folderze synchronizacji jest uszkodzony.&lt;br&gt;Synchronizacja została zatrzymana.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="449"/>
+        <source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>Serwer kDrive znajduje się w trybie konserwacji.&lt;br&gt;Synchronizacja zostanie wznowiona tak szybko, jak to możliwe. Jeśli błąd nadal występuje, prosimy o kontakt z naszym zespołem pomocy technicznej.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="455"/>
+        <source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+        <translation>Usługa kDrive została zablokowana.&lt;br&gt;Proszę odnowić subskrypcję kDrive. Jeśli nie podejmiesz żadnych działań, dane zostaną trwale usunięte i nie będzie możliwości ich odzyskania.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="460"/>
+        <source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+        <translation>Konto kDrive zostało zablokowane.&lt;br&gt;Skontaktuj się z administratorem w celu odblokowania konta kDrive. Jeśli nie podejmiesz żadnych działań, dane zostaną trwale usunięte i nie będzie możliwości ich odzyskania.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="466"/>
+        <source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>Usługa kDrive się uruchamia.&lt;br&gt;Synchronizacja zostanie wznowiona tak szybko, jak to możliwe. Jeśli błąd nadal występuje, prosimy o kontakt z naszym zespołem pomocy technicznej.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="475"/>
+        <source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>Usługa kDrive jest wyłączona.&lt;br&gt;Zaloguj się do &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;wersji&lt;/a&gt; &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;internetowej&lt;/a&gt;, aby sprawdzić stan usługi kDrive, lub skontaktuj się z administratorem.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="479"/>
+        <source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>Usługa kDrive jest wyłączona.&lt;br&gt;Zaloguj się do wersji internetowej, aby sprawdzić stan usługi kDrive, lub skontaktuj się z administratorem.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="483"/>
+        <source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
+        <translation>Nie masz uprawnień dostępu do tego konta kDrive.&lt;br&gt;Synchronizacja została wstrzymana. Skontaktuj się z administratorem.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="493"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>Wystąpił błąd techniczny (błąd %1).&lt;br&gt;Synchronizacja zostanie wznowiona tak szybko, jak to możliwe. Jeśli błąd nie ustąpi, prosimy o kontakt z naszym zespołem pomocy technicznej.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="512"/>
+        <source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>Jądro systemu przerwało połączenia sieciowe (błąd %1).&lt;br&gt;Proszę wyczyścić historię, a jeśli błąd nadal występuje, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="522"/>
+        <source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
+        <translation>Niestety nie udało się przenieść starej konfiguracji.&lt;br&gt;Aplikacja będzie korzystać z pustej konfiguracji.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="526"/>
+        <source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
+        <translation>Niestety nie udało się przenieść Twojej poprzedniej konfiguracji proxy; serwery proxy SOCKS5 nie są obecnie obsługiwane.&lt;br&gt;Aplikacja będzie korzystać z ustawień proxy systemu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="539"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
+        <translation>Wystąpił błąd techniczny (błąd %1).&lt;br&gt;Synchronizacja została wznowiona. Proszę wyczyścić historię, a jeśli błąd nadal występuje, prosimy o kontakt z naszym zespołem pomocy technicznej.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="550"/>
+        <source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
+        <translation>Wystąpił błąd podczas uzyskiwania dostępu do bazy danych synchronizacji (błąd %1).&lt;br&gt;Synchronizacja została zatrzymana.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="564"/>
+        <source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
+        <translation>Wystąpił problem z logowaniem (błąd %1).&lt;br&gt;Token jest nieprawidłowy lub został unieważniony.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="569"/>
+        <source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
+        <translation>Zabronione jest zagnieżdżanie synchronizacji (błąd %1).&lt;br&gt;Należy zachować wyłącznie te synchronizacje, których foldery nie są zagnieżdżone.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="573"/>
+        <source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
+        <translation>Folder synchronizacji na zdalnym serwerze kDrive nie istnieje już lub nie ma do niego dostępu (błąd %1).&lt;br&gt;Należy go przywrócić, przywrócić do niego uprawnienia dostępu lub usunąć i utworzyć synchronizację od nowa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="580"/>
+        <source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
+        <translation>Błąd analizy nazwy pliku (błąd %1). Znaki&lt;br&gt;specjalne, takie jak cudzysłowy, ukośniki odwrotne lub znaki końca linii, mogą powodować błędy analizy.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="722"/>
+        <source>You are not allowed to move item to &quot;%1&quot;.&lt;br&gt;It will be restored into its original parent folder.</source>
+        <translation>Nie można przenieść elementu do folderu „%1”. Zostanie&lt;br&gt;on przywrócony do pierwotnego folderu nadrzędnego.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="814"/>
+        <source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
+        <translation>Na komputerze zabrakło miejsca.&lt;br&gt;Pobieranie zostało przerwane.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="609"/>
+        <source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>Ten element został przeniesiony w inne miejsce.&lt;br&gt;Operacja lokalna została anulowana.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="618"/>
+        <source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
+        <translation>W tej lokalizacji istnieje już element o tej samej nazwie.&lt;br&gt;Nazwa lokalnego elementu została zmieniona.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="614"/>
+        <source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>W tej lokalizacji istnieje już element o tej samej nazwie.&lt;br&gt;Operacja lokalna została anulowana.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="393"/>
+        <source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>Na komputerze zabrakło miejsca.&lt;br&gt;Synchronizacja została zatrzymana.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="622"/>
+        <source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
+        <translation>Plik został zmieniony w tym samym czasie przez innego użytkownika.&lt;br&gt;Twoje zmiany zostały zapisane w kopii.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="626"/>
+        <source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>Inny użytkownik przeniósł folder nadrzędny miejsca docelowego.&lt;br&gt;Operacja lokalna została anulowana.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="692"/>
+        <source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Nazwa pozycji zawiera wyłącznie spacje.&lt;br&gt;Została ona tymczasowo umieszczona na czarnej liście.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="703"/>
+        <source>Either you are not allowed to create an item, or another item already exists with the same name.&lt;br&gt;The item has been excluded from synchronization.</source>
+        <translation>Albo nie masz uprawnień do utworzenia elementu, albo istnieje już inny element o tej samej nazwie.&lt;br&gt;Element został wykluczony z synchronizacji.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="708"/>
+        <source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
+        <translation>Nie masz uprawnień do edycji tego elementu.&lt;br&gt;Plik zawierający wprowadzone zmiany został przemianowany i wykluczony z synchronizacji.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="716"/>
+        <source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
+        <translation>Nie można zmienić nazwy tego elementu. Zostanie&lt;br&gt;on przywrócony pod pierwotną nazwą.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="727"/>
+        <source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
+        <translation>Nie można usunąć tego elementu. Zostanie&lt;br&gt;on przywrócony do pierwotnej lokalizacji.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="732"/>
+        <source>Failed to move this item to trash, it has been blacklisted.</source>
+        <translation>Nie udało się przenieść tego elementu do kosza; został on dodany do czarnej listy.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="748"/>
+        <source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
+        <translation>Plik został zmodyfikowany lokalnie, podczas gdy na zdalnym serwerze kDrive został usunięty.&lt;br&gt;Lokalna kopia została zapisana w folderze awaryjnym.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="765"/>
+        <source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
+        <translation>Wykonanie tej operacji na tym elemencie jest zabronione.&lt;br&gt;Element został tymczasowo umieszczony na czarnej liście.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="771"/>
+        <source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
+        <translation>Operacja wykonana na tym elemencie nie powiodła się.&lt;br&gt;Element został tymczasowo umieszczony na czarnej liście.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="776"/>
+        <source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
+        <translation>Plik jest zbyt duży, aby można go było przesłać. Został tymczasowo zablokowany.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="782"/>
+        <source>Impossible to download the file.</source>
+        <translation>Nie można pobrać pliku.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="779"/>
+        <source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
+        <translation>Przekroczyłeś limit miejsca. Zwiększ limit miejsca, aby ponownie umożliwić przesyłanie plików.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="389"/>
+        <source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
+        <translation>Dysk zawierający folder synchronizacji nie jest już podłączony (błąd %1).&lt;br&gt;Podłącz go ponownie, aby wznowić synchronizację.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="413"/>
+        <source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
+        <translation>Nie można rozpocząć synchronizacji (błąd %1).&lt;br&gt;Proces LiteSyncExt nie jest obecnie uruchomiony. Synchronizacja zostanie wznowiona zaraz po jego uruchomieniu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="649"/>
+        <source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Istniejący element ma identyczną nazwę z zachowaniem tej samej wielkości liter (wszystkie litery są wielkie lub małe).&lt;br&gt;Został on tymczasowo umieszczony na czarnej liście.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="656"/>
+        <source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Nazwa pozycji zawiera znak, który nie jest obsługiwany.&lt;br&gt;Została ona tymczasowo umieszczona na czarnej liście.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="662"/>
+        <source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Nazwa elementu kończy się spacją, co jest niedozwolone w Twoim systemie operacyjnym.&lt;br&gt;Została ona tymczasowo umieszczona na czarnej liście.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="668"/>
+        <source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Ta nazwa elementu jest zarezerwowana przez system operacyjny.&lt;br&gt;Została tymczasowo umieszczona na czarnej liście.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="674"/>
+        <source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Nazwa produktu jest zbyt długa.&lt;br&gt;Została tymczasowo umieszczona na czarnej liście.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="680"/>
+        <source>The item path is too long.&lt;br&gt;It has been ignored.</source>
+        <translation>Ścieżka do elementu jest zbyt długa.&lt;br&gt;Została pominięta.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="686"/>
+        <source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+        <translation>Nazwa elementu zawiera znak Unicode, który nie jest jeszcze obsługiwany przez system plików.&lt;br&gt;Została ona wykluczona z synchronizacji.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="735"/>
+        <source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
+        <translation>Nie udało się zsynchronizować tego elementu. Został on tymczasowo umieszczony na czarnej liście.&lt;br&gt;Kolejna próba synchronizacji zostanie podjęta za godzinę lub przy następnym uruchomieniu aplikacji.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="740"/>
+        <source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
+        <translation>Ten element został wykluczony z synchronizacji przez szablon niestandardowy.&lt;br&gt;Możesz wyłączyć tego typu powiadomienia w ustawieniach</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="745"/>
+        <source>This item has been excluded from sync because it is a hard link.</source>
+        <translation>Ten element został wykluczony z synchronizacji, ponieważ jest to dowiązanie twarde.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="785"/>
+        <source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
+        <translation>Ten element jest obecnie zablokowany przez innego użytkownika online.&lt;br&gt;Spróbujemy ponownie przesłać Twoje zmiany później.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="790"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="834"/>
+        <source>Synchronization error.</source>
+        <translation>Błąd synchronizacji.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="810"/>
+        <source>Can&apos;t access item.&lt;br&gt;Please fix the read and write permissions.</source>
+        <translation>Nie można uzyskać dostępu do elementu.&lt;br&gt;Proszę poprawić uprawnienia do odczytu i zapisu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="818"/>
+        <source>System error.</source>
+        <translation>Błąd systemu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="825"/>
+        <source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Ten element istnieje już po drugiej stronie.&lt;br&gt;Został tymczasowo umieszczony na czarnej liście.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="840"/>
+        <source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>Wystąpił błąd techniczny.&lt;br&gt;Proszę wyczyścić historię, a jeśli błąd nadal występuje, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::PreferencesBlocWidget</name>
+    <message>
+        <location filename="../src/gui/preferencesblocwidget.cpp" line="187"/>
+        <source>This synchronization is being deleted.</source>
+        <translation>Ta synchronizacja zostanie usunięta.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::PreferencesMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/preferencesmenubarwidget.cpp" line="63"/>
+        <source>Back to drive list</source>
+        <translation>Powrót do listy dysków</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferencesmenubarwidget.cpp" line="64"/>
+        <source>Preferences</source>
+        <translation>Preferencje</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::PreferencesWidget</name>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="491"/>
+        <source>General</source>
+        <translation>Ogólne</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="493"/>
+        <source>Activate dark theme</source>
+        <translation>Włącz ciemny motyw</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="495"/>
+        <source>Activate monochrome icons</source>
+        <translation>Włącz monochromatyczne ikony</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="496"/>
+        <source>Launch kDrive at startup</source>
+        <translation>Uruchamiaj kDrive przy starcie systemu</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="515"/>
+        <source>Finnish</source>
+        <translation>Fiński</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="521"/>
+        <source>Advanced</source>
+        <translation>Zaawansowane</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="522"/>
+        <source>Debugging information</source>
+        <translation>Informacje debugowania</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="524"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Otwórz folder debugowania&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="525"/>
+        <source>Files to exclude</source>
+        <translation>Pliki do wykluczenia</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="526"/>
+        <source>Proxy server</source>
+        <translation>Serwer proxy</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="511"/>
+        <source>Swedish</source>
+        <translation>Szwedzki</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="512"/>
+        <source>Portuguese</source>
+        <translation>Portugalski</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="513"/>
+        <source>Polish</source>
+        <translation>Polski</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="514"/>
+        <source>Norwegian</source>
+        <translation>Norweski</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="466"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Nie można otworzyć folderu %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="478"/>
+        <source>Unable to open link %1.</source>
+        <translation>Nie można otworzyć linku %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="483"/>
+        <source>Invalid link %1.</source>
+        <translation>Nieprawidłowy link %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="528"/>
+        <source>Lite Sync</source>
+        <translation>Lite Sync</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="497"/>
+        <source>Language</source>
+        <translation>Język</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="490"/>
+        <source>Some process failed to run.</source>
+        <translation>Nie udało się uruchomić jakiegoś procesu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="498"/>
+        <source>Move deleted files to my computer&apos;s trash</source>
+        <translation>Przenoś usunięte pliki do kosza na komputerze</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="499"/>
+        <source>Some files or folders may not be moved to the computer&apos;s trash.</source>
+        <translation>Niektórych plików lub folderów nie da się przenieść do kosza komputera.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="500"/>
+        <source>You can always retrieve already synced files from the kDrive web application trash.</source>
+        <translation>Zawsze możesz odzyskać wcześniej zsynchronizowane pliki z kosza aplikacji webowej kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="502"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Dowiedz się więcej&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="506"/>
+        <source>English</source>
+        <translation>Angielski</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="507"/>
+        <source>French</source>
+        <translation>Francuski</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="508"/>
+        <source>German</source>
+        <translation>Niemiecki</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="509"/>
+        <source>Spanish</source>
+        <translation>Hiszpański</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="510"/>
+        <source>Italian</source>
+        <translation>Włoski</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="505"/>
+        <source>Default</source>
+        <translation>Domyślny</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ProgressBarWidget</name>
+    <message>
+        <location filename="../src/gui/progressbarwidget.cpp" line="70"/>
+        <source>%1 in use</source>
+        <translation>%1 w użyciu</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ProxyServerDialog</name>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="50"/>
+        <source>HTTP(S) Proxy</source>
+        <translation>Serwer proxy HTTP(S)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="73"/>
+        <source>Proxy server</source>
+        <translation>Serwer proxy</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="85"/>
+        <source>No proxy server</source>
+        <translation>Brak serwera proxy</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="90"/>
+        <source>Use system parameters</source>
+        <translation>Użyj parametrów systemowych</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="95"/>
+        <source>Indicate a proxy manually</source>
+        <translation>Wprowadź pełnomocnika ręcznie</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="131"/>
+        <source>Port</source>
+        <translation>Port</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="144"/>
+        <source>Address of the proxy server</source>
+        <translation>Adres serwera proxy</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="150"/>
+        <source>Authentication needed</source>
+        <translation>Wymagane uwierzytelnienie</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="165"/>
+        <source>User</source>
+        <translation>Użytkownik</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="171"/>
+        <source>Password</source>
+        <translation>Hasło</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="185"/>
+        <source>SAVE</source>
+        <translation>ZAPISZ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="192"/>
+        <source>CANCEL</source>
+        <translation>ANULUJ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="286"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Czy chcesz zapisać wprowadzone zmiany?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="295"/>
+        <source>Unable to save, all mandatory fields are not completed!</source>
+        <translation>Nie można zapisać danych, ponieważ nie wszystkie pola obowiązkowe zostały wypełnione!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="316"/>
+        <source>Proxy not found, save anyway?</source>
+        <translation>Nie znaleziono serwera proxy. Czy chcesz zapisać mimo to?</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ResourcesManagerDialog</name>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="55"/>
+        <source>Resources Manager</source>
+        <translation>Kierownik ds. zasobów</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="65"/>
+        <source>Maximum CPU usage allowed</source>
+        <translation>Maksymalne dopuszczalne obciążenie procesora</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="96"/>
+        <source>SAVE</source>
+        <translation>ZAPISZ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="103"/>
+        <source>CANCEL</source>
+        <translation>ANULUJ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="122"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Czy chcesz zapisać wprowadzone zmiany?</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ServerBaseFolderDialog</name>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="81"/>
+        <source>Select a folder on your kDrive</source>
+        <translation>Wybierz folder na swoim kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="90"/>
+        <source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
+        <translation>Zawartość wybranego folderu zostanie zsynchronizowana z folderem &lt;b&gt;%1&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="134"/>
+        <source>CONTINUE</source>
+        <translation>KONTYNUUJ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="150"/>
+        <source>Space available on your computer for the current folder : %1</source>
+        <translation>Miejsce dostępne na komputerze dla bieżącego folderu: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="190"/>
+        <source>This folder is already being synced.</source>
+        <translation>Ten folder jest już synchronizowany.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="204"/>
+        <source>CONFIRM</source>
+        <translation>POTWIERDŹ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="205"/>
+        <source>CANCEL</source>
+        <translation>ANULUJ</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ServerFoldersDialog</name>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="80"/>
+        <source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
+        <translation>Folder &lt;b&gt;%1&lt;/b&gt; zawiera podfoldery;&lt;br&gt; wybierz te, które chcesz zsynchronizować</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="110"/>
+        <source>CONTINUE</source>
+        <translation>KONTYNUUJ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="146"/>
+        <source>No subfolders currently on the server.</source>
+        <translation>Obecnie na serwerze nie ma żadnych podfolderów.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::StatusBarWidget</name>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="178"/>
+        <source>Resume kDrive &quot;%1&quot; synchronization</source>
+        <translation>Wznowić synchronizację kDrive „%1”</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="180"/>
+        <source>Resume all kDrives synchronization</source>
+        <translation>Wznowić synchronizację wszystkich dysków kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="183"/>
+        <source>Pause kDrive &quot;%1&quot; synchronization</source>
+        <translation>Wstrzymaj synchronizację kDrive „%1”</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="184"/>
+        <location filename="../src/gui/statusbarwidget.cpp" line="321"/>
+        <source>Pause synchronization</source>
+        <translation>Wstrzymaj synchronizację</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="185"/>
+        <source>Pause all kDrives synchronization</source>
+        <translation>Wstrzymaj synchronizację wszystkich kDrives</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="179"/>
+        <location filename="../src/gui/statusbarwidget.cpp" line="322"/>
+        <source>Resume synchronization</source>
+        <translation>Wznowienie synchronizacji</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::SynchronizedItemWidget</name>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
+        <source>Copy share link</source>
+        <translation>Skopiuj link do udostępnienia</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
+        <source>Display on kdrive.infomaniak.com</source>
+        <translation>Wyświetl na stronie kdrive.infomaniak.com</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
+        <source>Show in folder</source>
+        <translation>Pokaż w folderze</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
+        <source>More actions</source>
+        <translation>Więcej działań</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="317"/>
+        <source>Open</source>
+        <translation>Otwórz</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
+        <source>Add to favorites</source>
+        <translation>Dodaj do ulubionych</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::SynthesisBar</name>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="495"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="502"/>
+        <source>Never</source>
+        <translation>Nigdy</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="496"/>
+        <source>During 1 hour</source>
+        <translation>W ciągu godziny</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="497"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="504"/>
+        <source>Until tomorrow 8:00AM</source>
+        <translation>Do jutra do godziny 8:00 rano</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="498"/>
+        <source>During 3 days</source>
+        <translation>Przez 3 dni</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="499"/>
+        <source>During 1 week</source>
+        <translation>W ciągu tygodnia</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="500"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="507"/>
+        <source>Always</source>
+        <translation>Zawsze</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="503"/>
+        <source>For 1 more hour</source>
+        <translation>Jeszcze przez 1 godzinę</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="505"/>
+        <source>For 3 more days</source>
+        <translation>Jeszcze przez 3 dni</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="506"/>
+        <source>For 1 more week</source>
+        <translation>Jeszcze przez 1 tydzień</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="149"/>
+        <source>Unable to open folder url %1.</source>
+        <translation>Nie można otworzyć folderu o adresie URL %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="219"/>
+        <source>Open in folder</source>
+        <translation>Otwórz w folderze</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="257"/>
+        <source>Open %1 web version</source>
+        <translation>Otwórz wersję internetową %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="267"/>
+        <source>Drive parameters</source>
+        <translation>Parametry napędu</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="280"/>
+        <source>Notifications disabled until %1</source>
+        <translation>Powiadomienia wyłączone do %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="281"/>
+        <source>Disable Notifications</source>
+        <translation>Wyłącz powiadomienia</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="314"/>
+        <source>Application preferences</source>
+        <translation>Ustawienia aplikacji</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="322"/>
+        <source>Need help</source>
+        <translation>Potrzebujesz pomocy?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="330"/>
+        <source>Send feedbacks</source>
+        <translation>Prześlij opinię</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="338"/>
+        <source>Quit kDrive</source>
+        <translation>Zamknij kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="401"/>
+        <source>Unable to access web site %1.</source>
+        <translation>Nie można uzyskać dostępu do strony internetowej %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="492"/>
+        <source>Show errors and informations</source>
+        <translation>Pokaż błędy i informacje</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="493"/>
+        <source>Show informations</source>
+        <translation>Pokaż informacje</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="494"/>
+        <source>More actions</source>
+        <translation>Więcej działań</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::SynthesisPopover</name>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1181"/>
+        <source>Update kDrive App</source>
+        <translation>Zaktualizuj aplikację kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1182"/>
+        <source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
+        <translation>Ta wersja aplikacji kDrive nie jest już obsługiwana. Aby uzyskać dostęp do najnowszych funkcji i ulepszeń, zaktualizuj aplikację.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="978"/>
+        <source>Update</source>
+        <translation>Aktualizacja</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1187"/>
+        <source>Please download the latest version on the website.</source>
+        <translation>Proszę pobrać najnowszą wersję ze strony internetowej.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="981"/>
+        <source>Update download in progress</source>
+        <translation>Trwa pobieranie aktualizacji</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="984"/>
+        <source>Looking for update...</source>
+        <translation>Czekam na aktualizację...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="987"/>
+        <source>Manual update</source>
+        <translation>Ręczna aktualizacja</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="990"/>
+        <source>Unavailable</source>
+        <translation>Niedostępne</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1200"/>
+        <source>You can synchronize files &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;from your computer&lt;/a&gt; or on &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
+        <translation>Możesz zsynchronizować pliki &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;z komputera&lt;/a&gt; lub ze strony &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="446"/>
+        <source>Synchronized</source>
+        <translation>Zsynchronizowane</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="450"/>
+        <source>Favorites</source>
+        <translation>Ulubione</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="454"/>
+        <source>Activity</source>
+        <translation>Zajęcia</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1133"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1180"/>
+        <source>Not implemented!</source>
+        <translation>Nie zaimplementowano!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1184"/>
+        <source>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Click here to download manually&lt;/a&gt;</source>
+        <translation>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Kliknij tutaj, aby pobrać plik ręcznie&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1193"/>
+        <source>No synchronized folder for this Drive!</source>
+        <translation>Brak zsynchronizowanego folderu dla tego dysku!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1196"/>
+        <source>No kDrive configured!</source>
+        <translation>Nie skonfigurowano programu kDrive!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1161"/>
+        <source>Unable to open link %1.</source>
+        <translation>Nie można otworzyć linku %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1173"/>
+        <source>Invalid link %1.</source>
+        <translation>Nieprawidłowy link %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="586"/>
+        <source>Unable to open folder url %1.</source>
+        <translation>Nie można otworzyć folderu o adresie URL %1.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::UpdateDialog</name>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="61"/>
+        <source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Nowa wersja &lt;b&gt;%1&lt;/b&gt; klienta %2 jest już dostępna i została pobrana.&lt;/p&gt;&lt;p&gt;Zainstalowana wersja to %3.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="95"/>
+        <source>Skip this version</source>
+        <translation>Pomiń tę wersję</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="103"/>
+        <source>Remind me later</source>
+        <translation>Przypomnij mi później</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="109"/>
+        <source>Install update</source>
+        <translation>Zainstaluj aktualizację</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::UpdateManager</name>
+    <message>
+        <location filename="../src/server/updater/updatemanager.cpp" line="86"/>
+        <source>New update available.</source>
+        <translation>Dostępna jest nowa aktualizacja.</translation>
+    </message>
+    <message>
+        <location filename="../src/server/updater/updatemanager.cpp" line="87"/>
+        <source>Version %1 is available for download.</source>
+        <translation>Wersja %1 jest dostępna do pobrania.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::UserSelectionWidget</name>
+    <message>
+        <location filename="../src/gui/userselectionwidget.cpp" line="131"/>
+        <source>Add an account</source>
+        <translation>Dodaj konto</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::VersionWidget</name>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="295"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="169"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Show release note&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Pokaż informacje o aktualizacji&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="172"/>
+        <source>Version</source>
+        <translation>Wersja</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="173"/>
+        <source>UPDATE</source>
+        <translation>AKTUALIZACJA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="197"/>
+        <source>%1 is up to date!</source>
+        <translation>%1 jest aktualne!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="201"/>
+        <source>Checking update on server...</source>
+        <translation>Sprawdzam aktualizacje na serwerze...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="205"/>
+        <source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;here&lt;/a&gt;.</source>
+        <translation>Dostępna jest aktualizacja: %1.&lt;br&gt;Pobierz ją stąd.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="212"/>
+        <source>An update is available: %1</source>
+        <translation>Dostępna jest aktualizacja: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="218"/>
+        <source>Downloading %1. Please wait...</source>
+        <translation>Pobieranie %1. Proszę czekać...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="223"/>
+        <source>Could not check for new updates.</source>
+        <translation>Nie udało się sprawdzić dostępności nowych aktualizacji.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="227"/>
+        <source>An error occurred during update.</source>
+        <translation>Podczas aktualizacji wystąpił błąd.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="231"/>
+        <source>Could not download update.</source>
+        <translation>Nie udało się pobrać aktualizacji.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="235"/>
+        <source>Update disabled.</source>
+        <translation>Funkcja aktualizacji została wyłączona.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="251"/>
+        <source>Beta program</source>
+        <translation>Program beta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="252"/>
+        <source>Get early access to new versions of the application</source>
+        <translation>Zyskaj wczesny dostęp do nowych wersji aplikacji</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="256"/>
+        <source>Join</source>
+        <translation>Dołącz</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="259"/>
+        <source>Modify</source>
+        <translation>Zmodyfikuj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="259"/>
+        <source>Quit</source>
+        <translation>Zakończ</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/gui/parameterscache.cpp" line="59"/>
+        <source>Unable to save parameters, please retry later.</source>
+        <translation>Nie można zapisać parametrów. Spróbuj ponownie później.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parameterscache.cpp" line="60"/>
+        <source>Unable to save parameters!</source>
+        <translation>Nie można zapisać parametrów!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="461"/>
+        <source>The parent folder is a sync folder or contained in one</source>
+        <translation>Folder nadrzędny jest folderem synchronizacji lub znajduje się w takim folderze</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="495"/>
+        <source>Can&apos;t find a valid path</source>
+        <translation>Nie można znaleźć prawidłowej ścieżki</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2108"/>
+        <source>No valid folder selected!</source>
+        <translation>Nie wybrano żadnego prawidłowego folderu!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2119"/>
+        <source>The selected path does not exist!</source>
+        <translation>Wybrana ścieżka nie istnieje!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2124"/>
+        <source>The selected path is not a folder!</source>
+        <translation>Wybrana ścieżka nie jest folderem!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2129"/>
+        <source>You have no permission to write to the selected folder!</source>
+        <translation>Nie masz uprawnień do zapisu w wybranym folderze!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2159"/>
+        <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
+        <translation>Folder lokalny %1 zawiera folder, który został już zsynchronizowany. Wybierz inny!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2167"/>
+        <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
+        <translation>Folder lokalny %1 znajduje się w folderze, który został już zsynchronizowany. Wybierz inny!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2175"/>
+        <source>The local folder %1 is already synced. Please pick another one!</source>
+        <translation>Lokalny folder %1 został już zsynchronizowany. Wybierz inny!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="42"/>
+        <source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
+        <translation>Włączono funkcję Lite sync (wersja beta). Pliki z serwisu kDrive pozostają w chmurze i nie zajmują miejsca na dysku komputera.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="45"/>
+        <source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
+        <translation>Funkcja Lite sync (wersja beta) jest wyłączona. Pliki kDrive zajmują miejsce na dysku komputera.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="48"/>
+        <source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
+        <translation>Włączono funkcję Lite Sync. Pliki z serwisu kDrive pozostają w chmurze i nie zajmują miejsca na dysku komputera.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="50"/>
+        <source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
+        <translation>Funkcja Lite Sync jest wyłączona. Pliki kDrive zajmują miejsce na dysku komputera.</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1175"/>
+        <source>Make available locally</source>
+        <translation>Udostępnij lokalnie</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1179"/>
+        <source>Free up local space</source>
+        <translation>Zwolnij miejsce na dysku lokalnym</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1183"/>
+        <source>Cancel free up local space</source>
+        <translation>Anuluj, aby zwolnić miejsce na dysku</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1187"/>
+        <source>Cancel make available locally</source>
+        <translation>Anuluj udostępnianie lokalne</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1191"/>
+        <source>Resharing this file is not allowed</source>
+        <translation>Ponowne udostępnianie tego pliku jest zabronione</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1192"/>
+        <source>Resharing this folder is not allowed</source>
+        <translation>Ponowne udostępnianie tego folderu jest zabronione</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1196"/>
+        <source>Copy public share link</source>
+        <translation>Skopiuj link do publicznego udostępnienia</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1200"/>
+        <source>Copy private share link</source>
+        <translation>Skopiuj prywatny link do udostępnienia</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1204"/>
+        <source>Open in browser</source>
+        <translation>Otwórz w przeglądarce</translation>
+    </message>
+</context>
+<context>
+    <name>SharedTools::QtSingleApplication</name>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="133"/>
+        <source>kDrive application will close due to a fatal error.</source>
+        <translation>Aplikacja kDrive zostanie zamknięta z powodu poważnego błędu.</translation>
+    </message>
+</context>
+<context>
+    <name>Utility</name>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="97"/>
+        <source>%L1 GB</source>
+        <translation>%L1 GB</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="101"/>
+        <source>%L1 MB</source>
+        <translation>%L1 MB</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="105"/>
+        <source>%L1 KB</source>
+        <translation>%L1 KB</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="108"/>
+        <source>%L1 B</source>
+        <translation>%L1 B</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="41"/>
+        <source>%n year(s)</source>
+        <translation>
+            <numerusform>%n rok</numerusform>
+            <numerusform>%n lat</numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="42"/>
+        <source>%n month(s)</source>
+        <translation>
+            <numerusform>%n miesiąc</numerusform>
+            <numerusform>%n miesięcy</numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="43"/>
+        <source>%n day(s)</source>
+        <translation>
+            <numerusform>%n dzień</numerusform>
+            <numerusform>%n dni</numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="44"/>
+        <source>%n hour(s)</source>
+        <translation>
+            <numerusform>%n godzina</numerusform>
+            <numerusform>%n godzin</numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="45"/>
+        <source>%n minute(s)</source>
+        <translation>
+            <numerusform>%n minuta</numerusform>
+            <numerusform>%n minut</numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="46"/>
+        <source>%n second(s)</source>
+        <translation>
+            <numerusform>%n sekunda</numerusform>
+            <numerusform>%n sekund</numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+</context>
+<context>
+    <name>utility</name>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="84"/>
+        <source>Could not open browser</source>
+        <translation>Nie udało się otworzyć przeglądarki</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="85"/>
+        <source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
+        <translation>Wystąpił błąd podczas uruchamiania przeglądarki w celu przejścia do adresu URL %1. Być może nie skonfigurowano domyślnej przeglądarki?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="104"/>
+        <source>Could not open email client</source>
+        <translation>Nie udało się uruchomić klienta poczty elektronicznej</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="105"/>
+        <source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
+        <translation>Wystąpił błąd podczas uruchamiania klienta poczty e-mail w celu utworzenia nowej wiadomości. Być może nie skonfigurowano domyślnego klienta poczty e-mail?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="324"/>
+        <source>You are not connected anymore. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Log in&lt;/a&gt;</source>
+        <translation>Nie masz już połączenia. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Zaloguj się&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="347"/>
+        <source>Sync in progress (Step %1/%2).</source>
+        <translation>Trwa synchronizacja (Krok %1/%2).</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="353"/>
+        <source>Sync in progress.</source>
+        <translation>Trwa synchronizacja.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="364"/>
+        <source>Some files couldn&apos;t be synchronized. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Niektórych plików nie udało się zsynchronizować. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Dowiedz się więcej&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="370"/>
+        <source>Synchronization pausing ...</source>
+        <translation>Wstrzymywanie synchronizacji...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="570"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
+        <translation>Nie można wybrać folderu &lt;b&gt;%1,&lt;/b&gt; ponieważ inna synchronizacja korzysta z tego samego folderu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="576"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+        <translation>Nie można zaznaczyć folderu &lt;b&gt;%1,&lt;/b&gt; ponieważ zawiera on zsynchronizowany folder &lt;b&gt;%2&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="584"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+        <translation>Nie można zaznaczyć folderu &lt;b&gt;%1,&lt;/b&gt; ponieważ znajduje się on w folderze synchronizowanym &lt;b&gt;%2&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="595"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
+        <translation>Folderu &lt;b&gt;%1&lt;/b&gt; nie można wybrać jako folderu do synchronizacji. Wybierz inny folder.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="599"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
+        <translation>Folder &lt;b&gt;%1&lt;/b&gt; nie może zostać wybrany jako folder synchronizacji. Wybierz inny folder. Sugerowany folder: &lt;b&gt;%2&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="651"/>
+        <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
+        <translation>Wykluczyłeś ponad %1 folderów. Pamiętaj, że wpłynie to na wydajność synchronizacji.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="660"/>
+        <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
+        <translation>Nie można wykluczyć więcej niż %1 folderów. Proszę odznaczyć foldery wyższego poziomu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="351"/>
+        <source>Synchronization starting</source>
+        <translation>Rozpoczyna się synchronizacja</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="374"/>
+        <source>Synchronization paused.</source>
+        <translation>Synchronizacja została wstrzymana.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="336"/>
+        <source>Sync in progress (%1 of %2)</source>
+        <translation>Trwa synchronizacja (%1 z %2)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="340"/>
+        <source>Sync in progress (%1 of %2)
 %3 left...</source>
-            <translation>Trwa synchronizacja (%1 z %2)
+        <translation>Trwa synchronizacja (%1 z %2)
 Zostało %3...</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="358" />
-            <source>You are up to date, unresolved conflicts.</source>
-            <translation>Masz zaległości w postaci nierozwiązanych konfliktów.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="360" />
-            <source>You are up to date!</source>
-            <translation>Jesteś na bieżąco!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="329" />
-            <source>No folder to synchronize
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="358"/>
+        <source>You are up to date, unresolved conflicts.</source>
+        <translation>Masz zaległości w postaci nierozwiązanych konfliktów.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="360"/>
+        <source>You are up to date!</source>
+        <translation>Jesteś na bieżąco!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="329"/>
+        <source>No folder to synchronize
 You can add one from the kDrive settings.</source>
-            <translation>Brak folderu do synchronizacji
+        <translation>Brak folderu do synchronizacji
 Możesz dodać folder w ustawieniach kDrive.</translation>
-        </message>
-    </context>
+    </message>
+</context>
 </TS>

--- a/translations/client_pt.ts
+++ b/translations/client_pt.ts
@@ -1,3047 +1,3044 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="pt_PT">
-    <context>
-        <name>KDC::AboutDialog</name>
-        <message>
-            <location filename="../src/gui/aboutdialog.cpp" line="73" />
-            <source>About</source>
-            <translation>Sobre</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/aboutdialog.cpp" line="112" />
-            <source>CLOSE</source>
-            <translation>FECHAR</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/aboutdialog.cpp" line="123" />
-            <source>Version %1. For more information visit &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
-            <translation>Versão %1. Para mais informações, visite &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/aboutdialog.cpp" line="126" />
-            <source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
-            <translation>Direitos de autor 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/aboutdialog.cpp" line="127" />
-            <source>Distributed by %1 and licensed under the &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
-            <translation>Distribuído por %1 e licenciado ao abrigo da &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 e o logótipo %2 são marcas registadas da %1.&lt;br&gt;&lt;br&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/aboutdialog.cpp" line="151" />
-            <location filename="../src/gui/aboutdialog.cpp" line="162" />
-            <location filename="../src/gui/aboutdialog.cpp" line="171" />
-            <source>Unable to open folder %1.</source>
-            <translation>Não foi possível abrir a pasta %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/aboutdialog.cpp" line="132" />
-            <source>&lt;p&gt;&lt;small&gt;Built from &lt;a style="color: #489EF3" href="%1"&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
-            <translation>&lt;p&gt;&lt;small&gt;Compilado a partir &lt;a style="color: #489EF3" href="%1"&gt;das fontes do Git&lt;/a&gt; em %2, %3 utilizando o Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::AbstractFileItemWidget</name>
-        <message>
-            <location filename="../src/gui/abstractfileitemwidget.cpp" line="177" />
-            <source>Unable to open folder path %1.</source>
-            <translation>Não foi possível abrir o caminho da pasta %1.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::AddDriveConfirmationWidget</name>
-        <message>
-            <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55" />
-            <source>Synchronization will start and you will be able to add files to your %1 folder.</source>
-            <translation>A sincronização irá iniciar e poderá adicionar ficheiros à sua pasta %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99" />
-            <source>Your kDrive is ready!</source>
-            <translation>O seu kDrive está pronto!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123" />
-            <source>OPEN FOLDER</source>
-            <translation>ABRIR PASTA</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130" />
-            <source>PARAMETERS</source>
-            <translation>PARÂMETROS</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138" />
-            <source>Synchronize another drive</source>
-            <translation>Sincronizar outra unidade</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::AddDriveListWidget</name>
-        <message>
-            <location filename="../src/gui/adddrivelistwidget.cpp" line="170" />
-            <source>Cancel</source>
-            <translation>Cancelar</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelistwidget.cpp" line="177" />
-            <source>NEXT</source>
-            <translation>SEGUINTE</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelistwidget.cpp" line="196" />
-            <source>Select the kDrive you want to synchronize</source>
-            <translation>Selecione o kDrive que pretende sincronizar</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelistwidget.cpp" line="234" />
-            <source>Get kDrive for free</source>
-            <translation>Obter o kDrive gratuitamente</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelistwidget.cpp" line="244" />
-            <source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
-            <translation>Guarde as suas fotografias, documentos e e-mails na Suíça, através de uma empresa independente que respeita a privacidade. Saiba mais</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelistwidget.cpp" line="263" />
-            <source>Test for free</source>
-            <translation>Experimentar gratuitamente</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::AddDriveLiteSyncWidget</name>
-        <message>
-            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147" />
-            <source>Conserve your computer space</source>
-            <translation>Poupe espaco no seu computador</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167" />
-            <source>Decide which files should be available online or locally</source>
-            <translation>Decida que ficheiros devem estar disponiveis online ou localmente</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187" />
-            <source>LATER</source>
-            <translation>MAIS TARDE</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193" />
-            <source>YES</source>
-            <translation>SIM</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125" />
-            <source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-            <translation>O Lite Sync sincroniza todos os seus ficheiros sem ocupar espaço no seu computador. Pode navegar pelos ficheiros no seu kDrive e descarregá-los para o seu computador sempre que quiser. &lt;a style="%1" href="%2"&gt;Saiba mais&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207" />
-            <source>Unable to open link %1.</source>
-            <translation>Não foi possível abrir a ligação %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112" />
-            <source>Would you like to activate Lite Sync (Beta) ?</source>
-            <translation>Gostaria de ativar o Lite Sync (Beta)?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114" />
-            <source>Would you like to activate Lite Sync ?</source>
-            <translation>Gostaria de ativar o Lite Sync?</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::AddDriveLocalFolderWidget</name>
-        <message>
-            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65" />
-            <source>Location of your %1 kDrive</source>
-            <translation>Localização do seu %1 kDrive</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155" />
-            <source>Edit folder</source>
-            <translation>Editar pasta</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246" />
-            <source>END</source>
-            <translation>CONCLUIR</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297" />
-            <source>Select folder</source>
-            <translation>Selecionar pasta</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264" />
-            <source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
-            <translation>O conteúdo da pasta &lt;b&gt;%1&lt;/b&gt; será sincronizado no seu kDrive</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212" />
-            <source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
-            <translation>Encontrará todos os seus ficheiros nesta pasta quando a configuração estiver concluída. Pode colocar novos ficheiros nessa pasta para os sincronizar com o seu kDrive.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284" />
-            <source>This folder is not compatible with Lite Sync.&lt;br&gt; 
+<context>
+    <name>KDC::AboutDialog</name>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="73"/>
+        <source>About</source>
+        <translation>Sobre</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="112"/>
+        <source>CLOSE</source>
+        <translation>FECHAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="123"/>
+        <source>Version %1. For more information visit &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
+        <translation>Versão %1. Para mais informações, visite &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="126"/>
+        <source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
+        <translation>Direitos de autor 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="127"/>
+        <source>Distributed by %1 and licensed under the &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
+        <translation>Distribuído por %1 e licenciado ao abrigo da &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 e o logótipo %2 são marcas registadas da %1.&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="151"/>
+        <location filename="../src/gui/aboutdialog.cpp" line="162"/>
+        <location filename="../src/gui/aboutdialog.cpp" line="171"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Não foi possível abrir a pasta %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="132"/>
+        <source>&lt;p&gt;&lt;small&gt;Built from &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
+        <translation>&lt;p&gt;&lt;small&gt;Compilado a partir &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;das fontes do Git&lt;/a&gt; em %2, %3 utilizando o Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AbstractFileItemWidget</name>
+    <message>
+        <location filename="../src/gui/abstractfileitemwidget.cpp" line="177"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Não foi possível abrir o caminho da pasta %1.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AddDriveConfirmationWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55"/>
+        <source>Synchronization will start and you will be able to add files to your %1 folder.</source>
+        <translation>A sincronização irá iniciar e poderá adicionar ficheiros à sua pasta %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99"/>
+        <source>Your kDrive is ready!</source>
+        <translation>O seu kDrive está pronto!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123"/>
+        <source>OPEN FOLDER</source>
+        <translation>ABRIR PASTA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130"/>
+        <source>PARAMETERS</source>
+        <translation>PARÂMETROS</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138"/>
+        <source>Synchronize another drive</source>
+        <translation>Sincronizar outra unidade</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AddDriveListWidget</name>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="170"/>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="177"/>
+        <source>NEXT</source>
+        <translation>SEGUINTE</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="196"/>
+        <source>Select the kDrive you want to synchronize</source>
+        <translation>Selecione o kDrive que pretende sincronizar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="234"/>
+        <source>Get kDrive for free</source>
+        <translation>Obter o kDrive gratuitamente</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="244"/>
+        <source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
+        <translation>Guarde as suas fotografias, documentos e e-mails na Suíça, através de uma empresa independente que respeita a privacidade. Saiba mais</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="263"/>
+        <source>Test for free</source>
+        <translation>Experimentar gratuitamente</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AddDriveLiteSyncWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147"/>
+        <source>Conserve your computer space</source>
+        <translation>Poupe espaco no seu computador</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167"/>
+        <source>Decide which files should be available online or locally</source>
+        <translation>Decida que ficheiros devem estar disponiveis online ou localmente</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187"/>
+        <source>LATER</source>
+        <translation>MAIS TARDE</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193"/>
+        <source>YES</source>
+        <translation>SIM</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
+        <source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>O Lite Sync sincroniza todos os seus ficheiros sem ocupar espaço no seu computador. Pode navegar pelos ficheiros no seu kDrive e descarregá-los para o seu computador sempre que quiser. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Saiba mais&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207"/>
+        <source>Unable to open link %1.</source>
+        <translation>Não foi possível abrir a ligação %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112"/>
+        <source>Would you like to activate Lite Sync (Beta) ?</source>
+        <translation>Gostaria de ativar o Lite Sync (Beta)?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114"/>
+        <source>Would you like to activate Lite Sync ?</source>
+        <translation>Gostaria de ativar o Lite Sync?</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AddDriveLocalFolderWidget</name>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65"/>
+        <source>Location of your %1 kDrive</source>
+        <translation>Localização do seu %1 kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155"/>
+        <source>Edit folder</source>
+        <translation>Editar pasta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+        <source>END</source>
+        <translation>CONCLUIR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
+        <source>Select folder</source>
+        <translation>Selecionar pasta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
+        <source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
+        <translation>O conteúdo da pasta &lt;b&gt;%1&lt;/b&gt; será sincronizado no seu kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212"/>
+        <source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
+        <translation>Encontrará todos os seus ficheiros nesta pasta quando a configuração estiver concluída. Pode colocar novos ficheiros nessa pasta para os sincronizar com o seu kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284"/>
+        <source>This folder is not compatible with Lite Sync.&lt;br&gt; 
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt; 
-&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-            <translation>Esta pasta não é compatível com o Lite Sync.&lt;br&gt; 
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Esta pasta não é compatível com o Lite Sync.&lt;br&gt; 
 Selecione outra pasta. Se continuar, o Lite Sync será desativado.&lt;br&gt; 
-&lt;a style="%1" href="%2"&gt;Saiba mais&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377" />
-            <source>Unable to open link %1.</source>
-            <translation>Não foi possível abrir a ligação %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246" />
-            <source>CONTINUE</source>
-            <translation>CONTINUAR</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::AddDriveLoginWidget</name>
-        <message>
-            <location filename="../src/gui/adddriveloginwidget.cpp" line="69" />
-            <source>Log in from your browser</source>
-            <translation>Inicie sessao no seu navegador</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveloginwidget.cpp" line="75" />
-            <source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
-            <translation>O seu navegador deverá abrir automaticamente para concluir a ligação. Assim que estiver ligado, voltará automaticamente ao kDrive.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveloginwidget.cpp" line="85" />
-            <source>Open the login page</source>
-            <translation>Abrir a página de início de sessão</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveloginwidget.cpp" line="119" />
-            <source>Token request failed: %1 - %2</source>
-            <translation>Falha na solicitação do token: %1 - %2</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveloginwidget.cpp" line="133" />
-            <source>Login failed: %1 - %2</source>
-            <translation>Falha no início de sessão: %1 - %2</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveloginwidget.cpp" line="141" />
-            <source>Failed to open the login page in your web browser</source>
-            <translation>Não foi possível abrir a página de início de sessão no seu navegador</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::AddDriveServerFoldersWidget</name>
-        <message>
-            <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129" />
-            <source>Select kDrive folders to synchronize on your desktop</source>
-            <translation>Selecione as pastas do kDrive que pretende sincronizar no seu ambiente de trabalho</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174" />
-            <source>CONTINUE</source>
-            <translation>CONTINUAR</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187" />
-            <source>Space available on your computer : %1</source>
-            <translation>Espaço disponível no seu computador: %1</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206" />
-            <source>An error occurred while loading the list of subfolders.</source>
-            <translation>Ocorreu um erro ao carregar a lista de subpastas.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210" />
-            <source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
-            <translation>Não foi possível carregar a lista de subpastas. O seu kDrive poderá estar em manutenção.&lt;br&gt;Por favor, inicie sessão na &lt;a style="%1" href="%2"&gt;versão&lt;/a&gt; &lt;a style="%1" href="%2"&gt;web&lt;/a&gt; para verificar o estado do seu kDrive ou contacte o seu administrador.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::AddDriveWizard</name>
-        <message>
-            <location filename="../src/gui/adddrivewizard.cpp" line="222" />
-            <source>Failed to create local folder %1</source>
-            <translation>Não foi possível criar a pasta local %1</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivewizard.cpp" line="233" />
-            <source>Failed to create new synchronization</source>
-            <translation>Não foi possível criar uma nova sincronização</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivewizard.cpp" line="266" />
-            <source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
-            <translation>O kDrive %1 já está sincronizado neste computador. Deseja continuar na mesma?</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::AppClient</name>
-        <message>
-            <location filename="../src/gui/appclient.cpp" line="100" />
-            <source>kDrive client is run with bad parameters!</source>
-            <translation>O cliente kDrive está a ser executado com parâmetros incorretos!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/appclient.cpp" line="109" />
-            <source>kDrive client is already running!</source>
-            <translation>O cliente kDrive já está em execução!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/appclient.cpp" line="719" />
-            <source>The user %1 is not connected. Please log in again.</source>
-            <translation>O utilizador %1 não está conectado. Por favor, inicie sessão novamente.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::AppServer</name>
-        <message>
-            <location filename="../src/server/appserver.cpp" line="1679" />
-            <source>Share link copied to clipboard</source>
-            <translation>O link para partilhar foi copiado para a área de transferência</translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/server/appserver.cpp" line="3759" />
-            <source>%1 and %n other file(s) have been removed.</source>
-            <translation>
-                <numerusform>%1 e mais %n ficheiro foram removidos.</numerusform>
-                <numerusform>%1 e mais %n ficheiros foram removidos.</numerusform>
-            </translation>
-        </message>
-        <message>
-            <location filename="../src/server/appserver.cpp" line="3761" />
-            <source>%1 has been removed.</source>
-            <comment>%1 names a file.</comment>
-            <translation>O %1 foi removido.</translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/server/appserver.cpp" line="3766" />
-            <source>%1 and %n other file(s) have been added.</source>
-            <translation>
-                <numerusform>%1 e mais %n ficheiro foram adicionados.</numerusform>
-                <numerusform>%1 e mais %n ficheiros foram adicionados.</numerusform>
-            </translation>
-        </message>
-        <message>
-            <location filename="../src/server/appserver.cpp" line="3768" />
-            <source>%1 has been added.</source>
-            <comment>%1 names a file.</comment>
-            <translation>O %1 foi adicionado.</translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/server/appserver.cpp" line="3773" />
-            <source>%1 and %n other file(s) have been updated.</source>
-            <translation>
-                <numerusform>%1 e mais %n ficheiro foram atualizados.</numerusform>
-                <numerusform>%1 e mais %n ficheiros foram atualizados.</numerusform>
-            </translation>
-        </message>
-        <message>
-            <location filename="../src/server/appserver.cpp" line="3775" />
-            <source>%1 has been updated.</source>
-            <comment>%1 names a file.</comment>
-            <translation>O %1 foi atualizado.</translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/server/appserver.cpp" line="3780" />
-            <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
-            <translation>
-                <numerusform>%1 foi movido para %2 e mais %n ficheiro foi movido.</numerusform>
-                <numerusform>%1 foi movido para %2 e mais %n ficheiros foram movidos.</numerusform>
-            </translation>
-        </message>
-        <message>
-            <location filename="../src/server/appserver.cpp" line="3783" />
-            <source>%1 has been moved to %2.</source>
-            <translation>O %1 foi transferido para o %2.</translation>
-        </message>
-        <message>
-            <location filename="../src/server/appserver.cpp" line="3791" />
-            <source>Sync Activity</source>
-            <translation>Atividade de sincronização</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::BaseFolderTreeItemWidget</name>
-        <message>
-            <location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102" />
-            <source>No subfolders currently on the server.</source>
-            <translation>Não existem subpastas no servidor neste momento.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::BetaProgramDialog</name>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="69" />
-            <source>Quit the beta program</source>
-            <translation>Sair do programa beta</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="69" />
-            <source>Join the beta program</source>
-            <translation>Participe no programa beta</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="77" />
-            <source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
-            <translation>Tenha acesso antecipado às novas versões da aplicação antes do seu lançamento ao público em geral e contribua para a sua melhoria enviando-nos os seus comentários.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="87" />
-            <source>Benefit from application beta updates</source>
-            <translation>Aproveite as atualizações da versão beta da aplicação</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="91" />
-            <source>No</source>
-            <translation>Não</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="92" />
-            <source>Public beta version</source>
-            <translation>Versão beta pública</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="93" />
-            <source>Internal beta version</source>
-            <translation>Versão beta interna</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="141" />
-            <source>I understand</source>
-            <translation>Eu compreendo</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="147" />
-            <source>Are you sure you want to leave the beta program?</source>
-            <translation>Tem a certeza de que quer sair do programa beta?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="161" />
-            <source>Save</source>
-            <translation>Guardar</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="167" />
-            <source>Cancel</source>
-            <translation>Cancelar</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="228" />
-            <source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
-            <translation>A versão atual da aplicação pode ser demasiado recente; a sua escolha entrará em vigor assim que estiver disponível a próxima atualização.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="233" />
-            <source>Beta versions may leave unexpectedly or cause instabilities.</source>
-            <translation>As versões beta podem encerrar inesperadamente ou causar instabilidades.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::ClientGui</name>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="189" />
-            <source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
-            <translation>Não foi possível resolver o(s) conflito(s) em %1 item(ns) na pasta de sincronização: %2</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="242" />
-            <source>Please sign in</source>
-            <translation>Por favor, inicie sessão</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="292" />
-            <source>Folder %1: %2</source>
-            <translation>Pasta %1: %2</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="298" />
-            <source>There are no sync folders configured.</source>
-            <translation>Não há pastas de sincronização configuradas.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="1426" />
-            <source>Synthesis</source>
-            <translation>Síntese</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="1427" />
-            <source>Preferences</source>
-            <translatorcomment>Préférences</translatorcomment>
-            <translation>Preferências</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="1428" />
-            <source>Quit</source>
-            <translation>Sair</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="673" />
-            <source>Undefined State.</source>
-            <translation>Estado indefinido.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="676" />
-            <source>Waiting to start syncing.</source>
-            <translation>A aguardar o início da sincronização.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="679" />
-            <source>Sync is running.</source>
-            <translation>A sincronização está em curso.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="683" />
-            <source>Sync was successful, unresolved conflicts.</source>
-            <translation>A sincronização foi bem-sucedida, mas existem conflitos por resolver.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="685" />
-            <source>Last Sync was successful.</source>
-            <translation>A última sincronização foi bem-sucedida.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="692" />
-            <source>User Abort.</source>
-            <translation>Interrupção pelo utilizador.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="696" />
-            <source>Sync is paused.</source>
-            <translation>A sincronização está em pausa.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="705" />
-            <source>%1 (Sync is paused)</source>
-            <translation>%1 (A sincronização está em pausa)</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="1261" />
-            <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-            <translation>Quer mesmo remover as sincronizações da conta &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Nota:&lt;/b&gt; Isto &lt;b&gt;não&lt;/b&gt; irá eliminar quaisquer ficheiros.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="1265" />
-            <source>REMOVE ALL SYNCHRONIZATIONS</source>
-            <translation>REMOVER TODAS AS SINCRONIZAÇÕES</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="1266" />
-            <source>CANCEL</source>
-            <translation>CANCELAR</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="1594" />
-            <source>Failed to start synchronizations!</source>
-            <translation>Não foi possível iniciar as sincronizações!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="849" />
-            <source>Unable to open folder path %1.</source>
-            <translation>Não foi possível abrir o caminho da pasta %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="116" />
-            <source>Unable to initialize kDrive client</source>
-            <translation>Não foi possível inicializar o cliente kDrive</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="255" />
-            <source>Synchronization is paused</source>
-            <translation>A sincronização está em pausa</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::ConfirmSynchronizationDialog</name>
-        <message>
-            <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86" />
-            <source>Summary of your local folder synchronization</source>
-            <translation>Resumo da sincronização da sua pasta local</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95" />
-            <source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
-            <translation>O conteúdo da pasta no seu computador será sincronizado com a pasta do kDrive selecionado e vice-versa.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184" />
-            <source>CANCEL</source>
-            <translation>CANCELAR</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191" />
-            <source>SYNCHRONIZE</source>
-            <translation>SINCRONIZAR</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::CustomExtensionSetupWidget</name>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="96" />
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="120" />
-            <source>Before finishing</source>
-            <translation>Antes de terminar</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="107" />
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="131" />
-            <source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
-            <translation>Siga os passos abaixo para garantir que o Lite Sync funcione corretamente no seu computador e para concluir a configuração do kDrive.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="208" />
-            <source>Open your Mac's &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-            <translation>Abra &lt;b&gt;as definições gerais&lt;/b&gt; do seu Mac ou  &lt;a style="%1" href="%2"&gt;clique aqui&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="212" />
-            <source>Open your Mac's &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-            <translation>Abra &lt;b&gt;as definições de Privacidade e Segurança&lt;/b&gt; do seu Mac ou  &lt;a style="%1" href="%2"&gt;clique aqui&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="216" />
-            <source>Open your Mac's &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-            <translation>Abra &lt;b&gt;as definições de&lt;/b&gt; &lt;b&gt;Segurança e Privacidade&lt;/b&gt; do seu Mac ou &lt;a style="%1" href="%2"&gt;clique aqui&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="246" />
-            <source>Go to &lt;b&gt;"Login Items &amp; Extensions"&lt;/b&gt; section and then to &lt;b&gt;"Endpoint Security Extensions"&lt;/b&gt;</source>
-            <translation>Vá à secção &lt;b&gt;«Itens de início de sessão e extensões»&lt;/b&gt; e, em seguida, a &lt;b&gt;«Extensões de segurança de terminais»&lt;/b&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="263" />
-            <source>Authorize the kDrive application</source>
-            <translation>Autorizar a aplicação kDrive</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="272" />
-            <source>Go to &lt;b&gt;"Security"&lt;/b&gt; section</source>
-            <translation>Vá para a secção &lt;b&gt;«Segurança»&lt;/b&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="289" />
-            <source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
-            <translation>Autorize a aplicação kDrive na janela que indica que o kDrive foi bloqueado</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="299" />
-            <source>Unlock the padlock &lt;img src=":/client/resources/icons/actions/lock.png"&gt; and authorize the kDrive application</source>
-            <translation>Desbloqueie o cadeado &lt;img src=":/client/resources/icons/actions/lock.png"&gt; e autorize a aplicação kDrive</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="344" />
-            <source>Go to &lt;b&gt;"Privacy &amp; Security"&lt;/b&gt; section and click on &lt;b&gt;"Full Disk Access"&lt;/b&gt; or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-            <translation>Vá à secção &lt;b&gt;«Privacidade e Segurança»&lt;/b&gt; e clique em &lt;b&gt;«Acesso total ao disco»&lt;/b&gt; ou &lt;a style="%1" href="%2"&gt;clique aqui&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="348" />
-            <source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;"Privacy"&lt;/b&gt; tab or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-            <translation>Ainda nas definições de Segurança e Privacidade, abra o separador &lt;b&gt;«Privacidade»&lt;/b&gt; ou &lt;a style="%1" href="%2"&gt;clique aqui&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="376" />
-            <source>Check the "kDrive LiteSync Extension" box then the "kDrive.app" box (if not already checked)</source>
-            <translation>Marque a caixa «kDrive LiteSync Extension» e, em seguida, a caixa «kDrive.app» (se ainda não estiver marcada)</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="393" />
-            <source>A restart of the app might be proposed, in this case accept it</source>
-            <translation>Pode ser sugerido que reinicie a aplicação; nesse caso, aceite</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="399" />
-            <source>Check the "kDrive LiteSync Extension" box (and "kDrive.app" if it exists) in &lt;b&gt;"Full Disk Access"&lt;/b&gt;</source>
-            <translation>Marque a caixa «kDrive LiteSync Extension» (e «kDrive.app», se existir) em &lt;b&gt;«Acesso total ao disco»&lt;/b&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="495" />
-            <source>STEP 1</source>
-            <translation>PASSO 1</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="495" />
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="496" />
-            <source>(Done)</source>
-            <translation>(Concluído)</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="496" />
-            <source>STEP 2</source>
-            <translation>PASSO 2</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="499" />
-            <source>STEPS PERFORMED</source>
-            <translation>ETAPAS REALIZADAS</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="501" />
-            <source>END</source>
-            <translation>CONCLUIR</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::CustomMessageBox</name>
-        <message>
-            <location filename="../src/gui/custommessagebox.cpp" line="101" />
-            <source>OK</source>
-            <translation>OK</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/custommessagebox.cpp" line="111" />
-            <source>CANCEL</source>
-            <translation>CANCELAR</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/custommessagebox.cpp" line="121" />
-            <source>YES</source>
-            <translation>SIM</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/custommessagebox.cpp" line="131" />
-            <source>NO</source>
-            <translation>NAO</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::DebugReporter</name>
-        <message>
-            <location filename="../src/gui/debugreporter.cpp" line="37" />
-            <source>Sending of debugging information</source>
-            <translation>Envio de informações de depuração</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debugreporter.cpp" line="37" />
-            <source>Cancel</source>
-            <translation>Cancelar</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::DebuggingDialog</name>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="46" />
-            <source>Info</source>
-            <translation>Informações</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="45" />
-            <source>Debug</source>
-            <translation>Depuração</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="47" />
-            <source>Warning</source>
-            <translation>Aviso</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="48" />
-            <source>Error</source>
-            <translation>Erro</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="49" />
-            <source>Fatal</source>
-            <translation>Fatal</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="74" />
-            <source>Debugging settings</source>
-            <translation>Configurações de depuração</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="90" />
-            <source>Save debugging information in a folder on my computer (Recommended)</source>
-            <translation>Guardar as informações de depuração numa pasta no meu computador (Recomendado)</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="104" />
-            <source>This information enables IT support to determine the origin of an incident.</source>
-            <translation>Essas informações permitem que o suporte de TI determine a origem de uma incidência.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="114" />
-            <source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
-            <translation>&lt;a style="%1" href="%2"&gt;Abrir a pasta de depuração&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="143" />
-            <source>Debug level</source>
-            <translation>Nível de depuração</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="152" />
-            <source>The trace level lets you choose the extent of the debugging information recorded</source>
-            <translation>O nível de rastreio permite-lhe escolher a extensão das informações de depuração registadas</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="179" />
-            <source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
-            <translation>O registo completo alargado recolhe um histórico detalhado que pode ser utilizado para depuração. A sua ativação pode tornar a aplicação kDrive mais lenta.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="183" />
-            <source>Extended Full Log</source>
-            <translation>Registo completo alargado</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="206" />
-            <source>Delete logs older than %1 days</source>
-            <translation>Eliminar registos com mais de %1 dias</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="225" />
-            <source>Share the debug folder with Infomaniak support.</source>
-            <translation>Partilhe a pasta de depuração com o apoio técnico da Infomaniak.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="249" />
-            <source>The last session is the periode since the last kDrive start.</source>
-            <translation>A última sessão corresponde ao período decorrido desde o último arranque do kDrive.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="253" />
-            <source>Share only the last kDrive session</source>
-            <translation>Partilhar apenas a última sessão do kDrive</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="284" />
-            <source>  Loading</source>
-            <translation>  A carregar</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="293" />
-            <source>Cancel</source>
-            <translation>Cancelar</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="319" />
-            <source>SAVE</source>
-            <translation>GUARDAR</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="326" />
-            <source>CANCEL</source>
-            <translation>CANCELAR</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="470" />
-            <source>Failed to share</source>
-            <translation>Não foi possível partilhar</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="480" />
-            <source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
-            <translation>1. Verifique se está com a sessão iniciada &lt;br&gt;2. Verifique se configurou pelo menos um kDrive</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="485" />
-            <source> (Connexion interrupted)</source>
-            <translation> (Conexão interrompida)</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="492" />
-            <source>Share the folder with SwissTransfer &lt;br&gt;</source>
-            <translation>Partilhe a pasta com o SwissTransfer &lt;br&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="493" />
-            <source> 1. We automatically compressed your log &lt;a style="%1" href="%2"&gt;here&lt;/a&gt;.&lt;br&gt;</source>
-            <translation> 1. Comprimimos automaticamente o seu registo &lt;a style="%1" href="%2"&gt;aqui&lt;/a&gt;.&lt;br&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="495" />
-            <source> 2. Transfer the archive with &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
-            <translation> 2. Transfira o arquivo através do &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="497" />
-            <source> 3. Share the link with &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
-            <translation> 3. Partilhe o link com&lt;a style="%1" href="%2"&gt;support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="527" />
-            <source>Last upload the %1</source>
-            <translation>Último envio: %1</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="555" />
-            <source>Sharing has been cancelled</source>
-            <translation>A partilha foi cancelada</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.h" line="70" />
-            <source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
-            <translation>A pasta completa é grande (&gt; 100 MB) e pode demorar algum tempo a partilhar. Para reduzir o tempo de partilha, recomendamos que partilhe apenas a última sessão do kDrive.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="600" />
-            <source>%1/%2/%3 at %4h%5m and %6s</source>
-            <extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
-            <translation>%1/%2/%3 às %4h%5m e %6s</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="643" />
-            <source>Do you want to save your modifications?</source>
-            <translation>Quer guardar as suas alterações?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="698" />
-            <location filename="../src/gui/debuggingdialog.cpp" line="704" />
-            <source>Unable to open folder %1.</source>
-            <translation>Não foi possível abrir a pasta %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="711" />
-            <source>  Share</source>
-            <translation>  Partilhar</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="721" />
-            <source>  Sharing | step 1/2 %1%</source>
-            <translation>  Partilha | passo 1/2 %1%</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="730" />
-            <source>  Sharing | step 2/2 %1%</source>
-            <translation>  Partilha | passo 2/2 %1%</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="740" />
-            <source>  Canceling...</source>
-            <translation>  A cancelar...</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::DrivePreferencesWidget</name>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1118" />
-            <source>Folders</source>
-            <translation>Pastas</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1120" />
-            <source>Notifications</source>
-            <translation>Notificações</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1123" />
-            <source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
-            <translation>Será exibida uma notificação assim que uma nova pasta for sincronizada ou alterada</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1124" />
-            <source>Connected with</source>
-            <translation>Relacionado com</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="981" />
-            <source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-            <translation>Quer mesmo deixar de sincronizar a pasta &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Nota:&lt;/b&gt; Isto &lt;b&gt;não&lt;/b&gt; irá eliminar nenhum ficheiro.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="356" />
-            <source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
-            <translation>Esta operação pode demorar entre alguns segundos e alguns minutos, dependendo do tamanho da pasta.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="360" />
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="391" />
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="986" />
-            <source>CANCEL</source>
-            <translation>CANCELAR</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="645" />
-            <source>New local folder synchronization failed!</source>
-            <translation>A sincronização da nova pasta local falhou!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="823" />
-            <source>Lite Sync activation failed.</source>
-            <translation>A ativação do Lite Sync falhou.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="841" />
-            <source>Lite Sync deactivation failed.</source>
-            <translation>Falha na desativação do Lite Sync.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="985" />
-            <source>REMOVE FOLDER SYNC CONNECTION</source>
-            <translation>REMOVER A LIGAÇÃO DE SINCRONIZAÇÃO DA PASTA</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1048" />
-            <source>An error occurred while loading the list of subfolders.</source>
-            <translation>Ocorreu um erro ao carregar a lista de subpastas.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1121" />
-            <source>Enable the notifications for this kDrive</source>
-            <translation>Ativar as notificações para este kDrive</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="359" />
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="390" />
-            <source>CONFIRM</source>
-            <translation>CONFIRMAR</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="120" />
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1117" />
-            <source>Synchronization errors and information.</source>
-            <translation>Erros de sincronização e informações.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="144" />
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1119" />
-            <source>Synchronize a local folder</source>
-            <translation>Sincronizar uma pasta local</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="355" />
-            <source>Do you really want to turn on Lite Sync?</source>
-            <translation>Quer mesmo ativar o Lite Sync?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="382" />
-            <source>Do you really want to turn off Lite Sync?</source>
-            <translation>Quer mesmo desativar o Lite Sync?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="384" />
-            <source>You don't have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
-            <translation>Não tem espaço suficiente para sincronizar todos os ficheiros do seu kDrive (faltam %1). Se desativar o Lite Sync, terá de selecionar as pastas que pretende sincronizar no seu computador. Entretanto, a sincronização do seu kDrive ficará em pausa.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="388" />
-            <source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
-            <translation>Se desativar o Lite Sync, todos os ficheiros serão transferidos para o seu computador.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="627" />
-            <source>Failed to create new synchronization</source>
-            <translation>Não foi possível criar uma nova sincronização</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="819" />
-            <source>Lite Sync activated.</source>
-            <translation>Lite Sync ativado.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="837" />
-            <source>Lite Sync deactivated.</source>
-            <translation>O Lite Sync está desativado.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="899" />
-            <source>This drive is being deleted.</source>
-            <translation>Esta unidade está a ser eliminada.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="962" />
-            <source>Impossible to open item %1</source>
-            <translation>Não é possível abrir o item %1</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1007" />
-            <source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
-            <translation>Não foi possível interromper a sincronização da pasta &lt;i&gt;%1&lt;/i&gt;.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1125" />
-            <source>Remove all synchronizations</source>
-            <translation>Remover todas as sincronizações</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1126" />
-            <source>Search in your kDrive</source>
-            <translation>Pesquisar no seu kDrive</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1127" />
-            <source>Search</source>
-            <translation>Pesquisar</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::DriveSelectionWidget</name>
-        <message>
-            <location filename="../src/gui/driveselectionwidget.cpp" line="216" />
-            <source>Synchronize a kDrive</source>
-            <translation>Sincronizar um kDrive</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/driveselectionwidget.cpp" line="150" />
-            <source>Add a kDrive</source>
-            <translation>Adicionar um kDrive</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::ErrorTabWidget</name>
-        <message>
-            <location filename="../src/gui/errortabwidget.cpp" line="179" />
-            <source>Resolve</source>
-            <translation>Resolução</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errortabwidget.cpp" line="180" />
-            <source>Conflicted item(s)</source>
-            <translation>Elemento(s) em conflito</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errortabwidget.cpp" line="181" />
-            <source>Item(s) with unsupported characters</source>
-            <translation>Item(s) com caracteres não suportados</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errortabwidget.cpp" line="92" />
-            <location filename="../src/gui/errortabwidget.cpp" line="135" />
-            <location filename="../src/gui/errortabwidget.cpp" line="178" />
-            <location filename="../src/gui/errortabwidget.cpp" line="186" />
-            <source>Clear history</source>
-            <translation>Limpar histórico</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errortabwidget.cpp" line="176" />
-            <source>To Resolve</source>
-            <translation>Para resolver</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errortabwidget.cpp" line="184" />
-            <source>Automatically resolved</source>
-            <translation>Resolvido automaticamente</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errortabwidget.cpp" line="185" />
-            <source>problem(s) solved</source>
-            <translation>problema(s) resolvido(s)</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errortabwidget.cpp" line="177" />
-            <source>problem(s) detected</source>
-            <translation>foram detetados problemas</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::ErrorsMenuBarWidget</name>
-        <message>
-            <location filename="../src/gui/errorsmenubarwidget.cpp" line="84" />
-            <location filename="../src/gui/errorsmenubarwidget.cpp" line="103" />
-            <source>Synchronization conflicts or errors</source>
-            <translation>Conflitos ou erros de sincronização</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errorsmenubarwidget.cpp" line="86" />
-            <location filename="../src/gui/errorsmenubarwidget.cpp" line="105" />
-            <source>Errors</source>
-            <translation>Erros</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errorsmenubarwidget.cpp" line="101" />
-            <source>Back to preferences</source>
-            <translation>Voltar às preferências</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::ErrorsPopup</name>
-        <message>
-            <location filename="../src/gui/errorspopup.cpp" line="73" />
-            <source>Some files couldn't be synchronized on the following kDrive(s) :</source>
-            <translation>Não foi possível sincronizar alguns ficheiros nos seguintes kDrive(s):</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errorspopup.cpp" line="95" />
-            <source> (%1 error(s))</source>
-            <translation> (%1 erro(s))</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errorspopup.cpp" line="101" />
-            <source> (%1 information(s))</source>
-            <translation> (%1 informação(s))</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errorspopup.cpp" line="107" />
-            <source> (%1 error(s) and %2 information(s))</source>
-            <translation> (%1 erro(s) e %2 informação(ões))</translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/gui/errorspopup.cpp" line="147" />
-            <source>Generic errors (%n warning(s) or error(s))</source>
-            <comment>Number of warnings or errors</comment>
-            <translation>
-                <numerusform>Erros genericos (%n aviso ou erro)</numerusform>
-                <numerusform>Erros genericos (%n avisos ou erros)</numerusform>
-            </translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::FileExclusionDialog</name>
-        <message>
-            <location filename="../src/gui/fileexclusiondialog.cpp" line="78" />
-            <source>Excluded files</source>
-            <translation>Ficheiros excluídos</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fileexclusiondialog.cpp" line="86" />
-            <source>Add files or folders that will not be synchronized on your computer.</source>
-            <translation>Adicione ficheiros ou pastas que não serão sincronizados no seu computador.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fileexclusiondialog.cpp" line="97" />
-            <source>Add</source>
-            <translation>Adicionar</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fileexclusiondialog.cpp" line="109" />
-            <source>NAME</source>
-            <translation>NOME</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fileexclusiondialog.cpp" line="114" />
-            <source>WARNING</source>
-            <translation>AVISO</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fileexclusiondialog.cpp" line="149" />
-            <source>SAVE</source>
-            <translation>GUARDAR</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fileexclusiondialog.cpp" line="156" />
-            <source>CANCEL</source>
-            <translation>CANCELAR</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fileexclusiondialog.cpp" line="304" />
-            <source>Do you want to save your modifications?</source>
-            <translation>Quer guardar as suas alterações?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fileexclusiondialog.cpp" line="353" />
-            <source>Exclusion template already exists!</source>
-            <translation>O modelo de exclusão já existe!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fileexclusiondialog.cpp" line="374" />
-            <source>Do you really want to delete?</source>
-            <translation>Quer mesmo eliminar?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fileexclusiondialog.cpp" line="434" />
-            <source>Cannot save changes!</source>
-            <translation>Não é possível guardar as alterações!</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::FileExclusionNameDialog</name>
-        <message>
-            <location filename="../src/gui/fileexclusionnamedialog.cpp" line="58" />
-            <source>VALIDATE</source>
-            <translation>VALIDAR</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fileexclusionnamedialog.cpp" line="65" />
-            <source>CANCEL</source>
-            <translation>CANCELAR</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::FixConflictingFilesDialog</name>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67" />
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73" />
-            <source>Unable to open link %1.</source>
-            <translation>Não foi possível abrir a ligação %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122" />
-            <source>Solve conflict(s)</source>
-            <translation>Resolver conflitos</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140" />
-            <source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
-            <translation>&lt;b&gt;O que pretende fazer com o(s) item(ns) em conflito %1?&lt;/b&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143" />
-            <source>Save my changes and replace other users' versions.</source>
-            <translation>Guardar as minhas alterações e substituir as versões dos outros utilizadores.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147" />
-            <source>Undo my changes and keep other users' versions.</source>
-            <translation>Anular as minhas alterações e manter as versões dos outros utilizadores.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169" />
-            <source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
-            <translation>As suas alterações podem ser eliminadas definitivamente. Não é possível recuperá-las a partir da aplicação web kDrive.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171" />
-            <source>&lt;a style=%1 href="%2"&gt;Learn more&lt;/a&gt;</source>
-            <translation>&lt;a style=%1 href="%2"&gt;Saiba mais&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175" />
-            <source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
-            <translation>As suas alterações serão eliminadas definitivamente. Não é possível recuperá-las a partir da aplicação web do kDrive.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191" />
-            <source>Show item(s)</source>
-            <translation>Mostrar item(s)</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228" />
-            <source>VALIDATE</source>
-            <translation>VALIDAR</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234" />
-            <source>CANCEL</source>
-            <translation>CANCELAR</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251" />
-            <source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
-            <translation>Vários utilizadores introduziram alterações nestes ficheiros em vários locais (online no kDrive, num computador ou num dispositivo móvel). As pastas que contêm estes ficheiros também podem ter sido eliminadas.&lt;br&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253" />
-            <source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Learn more&lt;/a&gt;</source>
-            <translation>A versão local do seu item &lt;b&gt;não está sincronizada&lt;/b&gt; com o kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Saiba mais&lt;/a&gt;</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::FolderItemWidget</name>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="458" />
-            <source>More actions</source>
-            <translation>Mais ações</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="188" />
-            <location filename="../src/gui/folderitemwidget.cpp" line="476" />
-            <source>Synchronized into &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</source>
-            <translation>Sincronizado em &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="343" />
-            <source>Activate Lite Sync</source>
-            <translation>Ativar o Lite Sync</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="345" />
-            <source>Activate Lite Sync (Beta)</source>
-            <translation>Ativar o Lite Sync (Beta)</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="481" />
-            <source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
-            <translation>As pastas não selecionadas serão movidas para a lixeira, desde que contenham itens offline. As pastas sincronizadas com o kDrive permanecerão disponíveis online.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="485" />
-            <source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
-            <translation>As pastas não selecionadas serão movidas para a lixeira. As pastas sincronizadas com o kDrive permanecerão disponíveis online.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="488" />
-            <source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
-            <translation>As pastas não selecionadas serão eliminadas &lt;b&gt;definitivamente&lt;/b&gt; do computador. As pastas sincronizadas com o kDrive permanecerão disponíveis online.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="493" />
-            <source>Cancel</source>
-            <translation>Cancelar</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="494" />
-            <source>VALIDATE</source>
-            <translation>VALIDAR</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="365" />
-            <source>Pause synchronization</source>
-            <translation>Pausar a sincronização</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="354" />
-            <source>Deactivate Lite Sync</source>
-            <translation>Desativar o Lite Sync</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="375" />
-            <source>Resume synchronization</source>
-            <translation>Retomar a sincronização</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="386" />
-            <source>Remove synchronization</source>
-            <translation>Desativar a sincronização</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::GenericErrorItemWidget</name>
-        <message>
-            <location filename="../src/gui/genericerroritemwidget.cpp" line="85" />
-            <source>Unable to open folder path %1.</source>
-            <translation>Não foi possível abrir o caminho da pasta %1.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::LiteSyncAppDialog</name>
-        <message>
-            <location filename="../src/gui/litesyncappdialog.cpp" line="48" />
-            <source>Application Id</source>
-            <translation>ID da aplicação</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/litesyncappdialog.cpp" line="98" />
-            <source>Application Name</source>
-            <translation>Nome da aplicação</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/litesyncappdialog.cpp" line="121" />
-            <source>VALIDATE</source>
-            <translation>VALIDAR</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/litesyncappdialog.cpp" line="128" />
-            <source>CANCEL</source>
-            <translation>CANCELAR</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::LiteSyncDialog</name>
-        <message>
-            <location filename="../src/gui/litesyncdialog.cpp" line="91" />
-            <source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are "online". Add them in the list below to avoid this behaviour.</source>
-            <translation>Algumas aplicações (de cópia de segurança, antivírus...) acedem aos seus ficheiros, o que leva à sua transferência quando estão «online». Adicione-as à lista abaixo para evitar este comportamento.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/litesyncdialog.cpp" line="103" />
-            <source>Add</source>
-            <translation>Adicionar</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/litesyncdialog.cpp" line="115" />
-            <source>APPLICATION ID</source>
-            <translation>ID DA APLICAÇÃO</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/litesyncdialog.cpp" line="120" />
-            <source>NAME</source>
-            <translation>NOME</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/litesyncdialog.cpp" line="154" />
-            <source>SAVE</source>
-            <translation>GUARDAR</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/litesyncdialog.cpp" line="161" />
-            <source>CANCEL</source>
-            <translation>CANCELAR</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/litesyncdialog.cpp" line="295" />
-            <source>Do you want to save your modifications?</source>
-            <translation>Quer guardar as suas alterações?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/litesyncdialog.cpp" line="337" />
-            <source>Do you really want to delete?</source>
-            <translation>Quer mesmo eliminar?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/litesyncdialog.cpp" line="374" />
-            <source>Cannot save changes!</source>
-            <translation>Não é possível guardar as alterações!</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::LocalFolderDialog</name>
-        <message>
-            <location filename="../src/gui/localfolderdialog.cpp" line="63" />
-            <source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
-            <translation>Que pasta do seu computador gostaria de&lt;br&gt;sincronizar?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/localfolderdialog.cpp" line="72" />
-            <source>The content of this folder will be synchronized on the kDrive</source>
-            <translation>O conteúdo desta pasta será sincronizado no kDrive</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/localfolderdialog.cpp" line="91" />
-            <source>Select a folder</source>
-            <translation>Selecione uma pasta</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/localfolderdialog.cpp" line="131" />
-            <source>Edit folder</source>
-            <translation>Editar pasta</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/localfolderdialog.cpp" line="166" />
-            <source>CANCEL</source>
-            <translation>CANCELAR</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/localfolderdialog.cpp" line="173" />
-            <source>CONTINUE</source>
-            <translation>CONTINUAR</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/localfolderdialog.cpp" line="210" />
-            <source>This folder is not compatible with Lite Sync.&lt;br&gt;
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Saiba mais&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377"/>
+        <source>Unable to open link %1.</source>
+        <translation>Não foi possível abrir a ligação %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+        <source>CONTINUE</source>
+        <translation>CONTINUAR</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AddDriveLoginWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="69"/>
+        <source>Log in from your browser</source>
+        <translation>Inicie sessao no seu navegador</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="75"/>
+        <source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
+        <translation>O seu navegador deverá abrir automaticamente para concluir a ligação. Assim que estiver ligado, voltará automaticamente ao kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
+        <source>Open the login page</source>
+        <translation>Abrir a página de início de sessão</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="119"/>
+        <source>Token request failed: %1 - %2</source>
+        <translation>Falha na solicitação do token: %1 - %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="133"/>
+        <source>Login failed: %1 - %2</source>
+        <translation>Falha no início de sessão: %1 - %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="141"/>
+        <source>Failed to open the login page in your web browser</source>
+        <translation>Não foi possível abrir a página de início de sessão no seu navegador</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AddDriveServerFoldersWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129"/>
+        <source>Select kDrive folders to synchronize on your desktop</source>
+        <translation>Selecione as pastas do kDrive que pretende sincronizar no seu ambiente de trabalho</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174"/>
+        <source>CONTINUE</source>
+        <translation>CONTINUAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187"/>
+        <source>Space available on your computer : %1</source>
+        <translation>Espaço disponível no seu computador: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206"/>
+        <source>An error occurred while loading the list of subfolders.</source>
+        <translation>Ocorreu um erro ao carregar a lista de subpastas.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210"/>
+        <source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>Não foi possível carregar a lista de subpastas. O seu kDrive poderá estar em manutenção.&lt;br&gt;Por favor, inicie sessão na &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;versão&lt;/a&gt; &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web&lt;/a&gt; para verificar o estado do seu kDrive ou contacte o seu administrador.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AddDriveWizard</name>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="222"/>
+        <source>Failed to create local folder %1</source>
+        <translation>Não foi possível criar a pasta local %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="233"/>
+        <source>Failed to create new synchronization</source>
+        <translation>Não foi possível criar uma nova sincronização</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="266"/>
+        <source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
+        <translation>O kDrive %1 já está sincronizado neste computador. Deseja continuar na mesma?</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AppClient</name>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="100"/>
+        <source>kDrive client is run with bad parameters!</source>
+        <translation>O cliente kDrive está a ser executado com parâmetros incorretos!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="109"/>
+        <source>kDrive client is already running!</source>
+        <translation>O cliente kDrive já está em execução!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="719"/>
+        <source>The user %1 is not connected. Please log in again.</source>
+        <translation>O utilizador %1 não está conectado. Por favor, inicie sessão novamente.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AppServer</name>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="1685"/>
+        <source>Share link copied to clipboard</source>
+        <translation>O link para partilhar foi copiado para a área de transferência</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3773"/>
+        <source>%1 and %n other file(s) have been removed.</source>
+        <translation>
+            <numerusform>%1 e mais %n ficheiro foram removidos.</numerusform>
+            <numerusform>%1 e mais %n ficheiros foram removidos.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3775"/>
+        <source>%1 has been removed.</source>
+        <comment>%1 names a file.</comment>
+        <translation>O %1 foi removido.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3780"/>
+        <source>%1 and %n other file(s) have been added.</source>
+        <translation>
+            <numerusform>%1 e mais %n ficheiro foram adicionados.</numerusform>
+            <numerusform>%1 e mais %n ficheiros foram adicionados.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3782"/>
+        <source>%1 has been added.</source>
+        <comment>%1 names a file.</comment>
+        <translation>O %1 foi adicionado.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3787"/>
+        <source>%1 and %n other file(s) have been updated.</source>
+        <translation>
+            <numerusform>%1 e mais %n ficheiro foram atualizados.</numerusform>
+            <numerusform>%1 e mais %n ficheiros foram atualizados.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3789"/>
+        <source>%1 has been updated.</source>
+        <comment>%1 names a file.</comment>
+        <translation>O %1 foi atualizado.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3794"/>
+        <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
+        <translation>
+            <numerusform>%1 foi movido para %2 e mais %n ficheiro foi movido.</numerusform>
+            <numerusform>%1 foi movido para %2 e mais %n ficheiros foram movidos.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3797"/>
+        <source>%1 has been moved to %2.</source>
+        <translation>O %1 foi transferido para o %2.</translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3805"/>
+        <source>Sync Activity</source>
+        <translation>Atividade de sincronização</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::BaseFolderTreeItemWidget</name>
+    <message>
+        <location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102"/>
+        <source>No subfolders currently on the server.</source>
+        <translation>Não existem subpastas no servidor neste momento.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::BetaProgramDialog</name>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="69"/>
+        <source>Quit the beta program</source>
+        <translation>Sair do programa beta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="69"/>
+        <source>Join the beta program</source>
+        <translation>Participe no programa beta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="77"/>
+        <source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
+        <translation>Tenha acesso antecipado às novas versões da aplicação antes do seu lançamento ao público em geral e contribua para a sua melhoria enviando-nos os seus comentários.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="87"/>
+        <source>Benefit from application beta updates</source>
+        <translation>Aproveite as atualizações da versão beta da aplicação</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="91"/>
+        <source>No</source>
+        <translation>Não</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="92"/>
+        <source>Public beta version</source>
+        <translation>Versão beta pública</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="93"/>
+        <source>Internal beta version</source>
+        <translation>Versão beta interna</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="141"/>
+        <source>I understand</source>
+        <translation>Eu compreendo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="147"/>
+        <source>Are you sure you want to leave the beta program?</source>
+        <translation>Tem a certeza de que quer sair do programa beta?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="161"/>
+        <source>Save</source>
+        <translation>Guardar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="167"/>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="228"/>
+        <source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
+        <translation>A versão atual da aplicação pode ser demasiado recente; a sua escolha entrará em vigor assim que estiver disponível a próxima atualização.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="233"/>
+        <source>Beta versions may leave unexpectedly or cause instabilities.</source>
+        <translation>As versões beta podem encerrar inesperadamente ou causar instabilidades.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ClientGui</name>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="189"/>
+        <source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
+        <translation>Não foi possível resolver o(s) conflito(s) em %1 item(ns) na pasta de sincronização: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="242"/>
+        <source>Please sign in</source>
+        <translation>Por favor, inicie sessão</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="292"/>
+        <source>Folder %1: %2</source>
+        <translation>Pasta %1: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="298"/>
+        <source>There are no sync folders configured.</source>
+        <translation>Não há pastas de sincronização configuradas.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1422"/>
+        <source>Synthesis</source>
+        <translation>Síntese</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1423"/>
+        <source>Preferences</source>
+        <translatorcomment>Préférences</translatorcomment>
+        <translation>Preferências</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1424"/>
+        <source>Quit</source>
+        <translation>Sair</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="673"/>
+        <source>Undefined State.</source>
+        <translation>Estado indefinido.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="676"/>
+        <source>Waiting to start syncing.</source>
+        <translation>A aguardar o início da sincronização.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="679"/>
+        <source>Sync is running.</source>
+        <translation>A sincronização está em curso.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="683"/>
+        <source>Sync was successful, unresolved conflicts.</source>
+        <translation>A sincronização foi bem-sucedida, mas existem conflitos por resolver.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="685"/>
+        <source>Last Sync was successful.</source>
+        <translation>A última sincronização foi bem-sucedida.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="692"/>
+        <source>User Abort.</source>
+        <translation>Interrupção pelo utilizador.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="696"/>
+        <source>Sync is paused.</source>
+        <translation>A sincronização está em pausa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="705"/>
+        <source>%1 (Sync is paused)</source>
+        <translation>%1 (A sincronização está em pausa)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1257"/>
+        <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+        <translation>Quer mesmo remover as sincronizações da conta &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Nota:&lt;/b&gt; Isto &lt;b&gt;não&lt;/b&gt; irá eliminar quaisquer ficheiros.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1261"/>
+        <source>REMOVE ALL SYNCHRONIZATIONS</source>
+        <translation>REMOVER TODAS AS SINCRONIZAÇÕES</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1262"/>
+        <source>CANCEL</source>
+        <translation>CANCELAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1590"/>
+        <source>Failed to start synchronizations!</source>
+        <translation>Não foi possível iniciar as sincronizações!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="849"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Não foi possível abrir o caminho da pasta %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="116"/>
+        <source>Unable to initialize kDrive client</source>
+        <translation>Não foi possível inicializar o cliente kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="255"/>
+        <source>Synchronization is paused</source>
+        <translation>A sincronização está em pausa</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ConfirmSynchronizationDialog</name>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86"/>
+        <source>Summary of your local folder synchronization</source>
+        <translation>Resumo da sincronização da sua pasta local</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95"/>
+        <source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
+        <translation>O conteúdo da pasta no seu computador será sincronizado com a pasta do kDrive selecionado e vice-versa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184"/>
+        <source>CANCEL</source>
+        <translation>CANCELAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191"/>
+        <source>SYNCHRONIZE</source>
+        <translation>SINCRONIZAR</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::CustomExtensionSetupWidget</name>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="96"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="120"/>
+        <source>Before finishing</source>
+        <translation>Antes de terminar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="107"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="131"/>
+        <source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
+        <translation>Siga os passos abaixo para garantir que o Lite Sync funcione corretamente no seu computador e para concluir a configuração do kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="208"/>
+        <source>Open your Mac&apos;s &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Abra &lt;b&gt;as definições gerais&lt;/b&gt; do seu Mac ou  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;clique aqui&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="212"/>
+        <source>Open your Mac&apos;s &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Abra &lt;b&gt;as definições de Privacidade e Segurança&lt;/b&gt; do seu Mac ou  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;clique aqui&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="216"/>
+        <source>Open your Mac&apos;s &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Abra &lt;b&gt;as definições de&lt;/b&gt; &lt;b&gt;Segurança e Privacidade&lt;/b&gt; do seu Mac ou &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;clique aqui&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="246"/>
+        <source>Go to &lt;b&gt;&quot;Login Items &amp; Extensions&quot;&lt;/b&gt; section and then to &lt;b&gt;&quot;Endpoint Security Extensions&quot;&lt;/b&gt;</source>
+        <translation>Vá à secção &lt;b&gt;«Itens de início de sessão e extensões»&lt;/b&gt; e, em seguida, a &lt;b&gt;«Extensões de segurança de terminais»&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="263"/>
+        <source>Authorize the kDrive application</source>
+        <translation>Autorizar a aplicação kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="272"/>
+        <source>Go to &lt;b&gt;&quot;Security&quot;&lt;/b&gt; section</source>
+        <translation>Vá para a secção &lt;b&gt;«Segurança»&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="289"/>
+        <source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
+        <translation>Autorize a aplicação kDrive na janela que indica que o kDrive foi bloqueado</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="299"/>
+        <source>Unlock the padlock &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; and authorize the kDrive application</source>
+        <translation>Desbloqueie o cadeado &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; e autorize a aplicação kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="344"/>
+        <source>Go to &lt;b&gt;&quot;Privacy &amp; Security&quot;&lt;/b&gt; section and click on &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt; or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Vá à secção &lt;b&gt;«Privacidade e Segurança»&lt;/b&gt; e clique em &lt;b&gt;«Acesso total ao disco»&lt;/b&gt; ou &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;clique aqui&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="348"/>
+        <source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;&quot;Privacy&quot;&lt;/b&gt; tab or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Ainda nas definições de Segurança e Privacidade, abra o separador &lt;b&gt;«Privacidade»&lt;/b&gt; ou &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;clique aqui&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="376"/>
+        <source>Check the &quot;kDrive LiteSync Extension&quot; box then the &quot;kDrive.app&quot; box (if not already checked)</source>
+        <translation>Marque a caixa «kDrive LiteSync Extension» e, em seguida, a caixa «kDrive.app» (se ainda não estiver marcada)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="393"/>
+        <source>A restart of the app might be proposed, in this case accept it</source>
+        <translation>Pode ser sugerido que reinicie a aplicação; nesse caso, aceite</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="399"/>
+        <source>Check the &quot;kDrive LiteSync Extension&quot; box (and &quot;kDrive.app&quot; if it exists) in &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt;</source>
+        <translation>Marque a caixa «kDrive LiteSync Extension» (e «kDrive.app», se existir) em &lt;b&gt;«Acesso total ao disco»&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
+        <source>STEP 1</source>
+        <translation>PASSO 1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="496"/>
+        <source>(Done)</source>
+        <translation>(Concluído)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="496"/>
+        <source>STEP 2</source>
+        <translation>PASSO 2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="499"/>
+        <source>STEPS PERFORMED</source>
+        <translation>ETAPAS REALIZADAS</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="501"/>
+        <source>END</source>
+        <translation>CONCLUIR</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::CustomMessageBox</name>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="101"/>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="111"/>
+        <source>CANCEL</source>
+        <translation>CANCELAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="121"/>
+        <source>YES</source>
+        <translation>SIM</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="131"/>
+        <source>NO</source>
+        <translation>NAO</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::DebugReporter</name>
+    <message>
+        <location filename="../src/gui/debugreporter.cpp" line="37"/>
+        <source>Sending of debugging information</source>
+        <translation>Envio de informações de depuração</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debugreporter.cpp" line="37"/>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::DebuggingDialog</name>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="46"/>
+        <source>Info</source>
+        <translation>Informações</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="45"/>
+        <source>Debug</source>
+        <translation>Depuração</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="47"/>
+        <source>Warning</source>
+        <translation>Aviso</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="48"/>
+        <source>Error</source>
+        <translation>Erro</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="49"/>
+        <source>Fatal</source>
+        <translation>Fatal</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="74"/>
+        <source>Debugging settings</source>
+        <translation>Configurações de depuração</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="90"/>
+        <source>Save debugging information in a folder on my computer (Recommended)</source>
+        <translation>Guardar as informações de depuração numa pasta no meu computador (Recomendado)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="104"/>
+        <source>This information enables IT support to determine the origin of an incident.</source>
+        <translation>Essas informações permitem que o suporte de TI determine a origem de uma incidência.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="114"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Abrir a pasta de depuração&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="143"/>
+        <source>Debug level</source>
+        <translation>Nível de depuração</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="152"/>
+        <source>The trace level lets you choose the extent of the debugging information recorded</source>
+        <translation>O nível de rastreio permite-lhe escolher a extensão das informações de depuração registadas</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="179"/>
+        <source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
+        <translation>O registo completo alargado recolhe um histórico detalhado que pode ser utilizado para depuração. A sua ativação pode tornar a aplicação kDrive mais lenta.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="183"/>
+        <source>Extended Full Log</source>
+        <translation>Registo completo alargado</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="207"/>
+        <source>Delete logs older than %1 days</source>
+        <translation>Eliminar registos com mais de %1 dias</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="226"/>
+        <source>Share the debug folder with Infomaniak support.</source>
+        <translation>Partilhe a pasta de depuração com o apoio técnico da Infomaniak.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="250"/>
+        <source>The last session is the periode since the last kDrive start.</source>
+        <translation>A última sessão corresponde ao período decorrido desde o último arranque do kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="254"/>
+        <source>Share only the last kDrive session</source>
+        <translation>Partilhar apenas a última sessão do kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="285"/>
+        <source>  Loading</source>
+        <translation>  A carregar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="294"/>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="320"/>
+        <source>SAVE</source>
+        <translation>GUARDAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="327"/>
+        <source>CANCEL</source>
+        <translation>CANCELAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="471"/>
+        <source>Failed to share</source>
+        <translation>Não foi possível partilhar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="481"/>
+        <source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
+        <translation>1. Verifique se está com a sessão iniciada &lt;br&gt;2. Verifique se configurou pelo menos um kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="486"/>
+        <source> (Connexion interrupted)</source>
+        <translation> (Conexão interrompida)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="493"/>
+        <source>Share the folder with SwissTransfer &lt;br&gt;</source>
+        <translation>Partilhe a pasta com o SwissTransfer &lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="494"/>
+        <source> 1. We automatically compressed your log &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;here&lt;/a&gt;.&lt;br&gt;</source>
+        <translation> 1. Comprimimos automaticamente o seu registo &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;aqui&lt;/a&gt;.&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="496"/>
+        <source> 2. Transfer the archive with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
+        <translation> 2. Transfira o arquivo através do &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="498"/>
+        <source> 3. Share the link with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
+        <translation> 3. Partilhe o link com&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="528"/>
+        <source>Last upload the %1</source>
+        <translation>Último envio: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="556"/>
+        <source>Sharing has been cancelled</source>
+        <translation>A partilha foi cancelada</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="597"/>
+        <source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.h" line="70"/>
+        <source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
+        <translation>A pasta completa é grande (&gt; 100 MB) e pode demorar algum tempo a partilhar. Para reduzir o tempo de partilha, recomendamos que partilhe apenas a última sessão do kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="611"/>
+        <source>%1/%2/%3 at %4h%5m and %6s</source>
+        <extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
+        <translation>%1/%2/%3 às %4h%5m e %6s</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="654"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Quer guardar as suas alterações?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="709"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="715"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Não foi possível abrir a pasta %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="722"/>
+        <source>  Share</source>
+        <translation>  Partilhar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="732"/>
+        <source>  Sharing | step 1/2 %1%</source>
+        <translation>  Partilha | passo 1/2 %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="741"/>
+        <source>  Sharing | step 2/2 %1%</source>
+        <translation>  Partilha | passo 2/2 %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="751"/>
+        <source>  Canceling...</source>
+        <translation>  A cancelar...</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::DrivePreferencesWidget</name>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
+        <source>Folders</source>
+        <translation>Pastas</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
+        <source>Notifications</source>
+        <translation>Notificações</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
+        <source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
+        <translation>Será exibida uma notificação assim que uma nova pasta for sincronizada ou alterada</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
+        <source>Connected with</source>
+        <translation>Relacionado com</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
+        <source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+        <translation>Quer mesmo deixar de sincronizar a pasta &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Nota:&lt;/b&gt; Isto &lt;b&gt;não&lt;/b&gt; irá eliminar nenhum ficheiro.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="356"/>
+        <source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
+        <translation>Esta operação pode demorar entre alguns segundos e alguns minutos, dependendo do tamanho da pasta.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="360"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="391"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="986"/>
+        <source>CANCEL</source>
+        <translation>CANCELAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
+        <source>New local folder synchronization failed!</source>
+        <translation>A sincronização da nova pasta local falhou!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
+        <source>Lite Sync activation failed.</source>
+        <translation>A ativação do Lite Sync falhou.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
+        <source>Lite Sync deactivation failed.</source>
+        <translation>Falha na desativação do Lite Sync.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
+        <source>REMOVE FOLDER SYNC CONNECTION</source>
+        <translation>REMOVER A LIGAÇÃO DE SINCRONIZAÇÃO DA PASTA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
+        <source>An error occurred while loading the list of subfolders.</source>
+        <translation>Ocorreu um erro ao carregar a lista de subpastas.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
+        <source>Enable the notifications for this kDrive</source>
+        <translation>Ativar as notificações para este kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
+        <source>CONFIRM</source>
+        <translation>CONFIRMAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
+        <source>Synchronization errors and information.</source>
+        <translation>Erros de sincronização e informações.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
+        <source>Synchronize a local folder</source>
+        <translation>Sincronizar uma pasta local</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
+        <source>Do you really want to turn on Lite Sync?</source>
+        <translation>Quer mesmo ativar o Lite Sync?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="382"/>
+        <source>Do you really want to turn off Lite Sync?</source>
+        <translation>Quer mesmo desativar o Lite Sync?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="384"/>
+        <source>You don&apos;t have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
+        <translation>Não tem espaço suficiente para sincronizar todos os ficheiros do seu kDrive (faltam %1). Se desativar o Lite Sync, terá de selecionar as pastas que pretende sincronizar no seu computador. Entretanto, a sincronização do seu kDrive ficará em pausa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="388"/>
+        <source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
+        <translation>Se desativar o Lite Sync, todos os ficheiros serão transferidos para o seu computador.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="627"/>
+        <source>Failed to create new synchronization</source>
+        <translation>Não foi possível criar uma nova sincronização</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="819"/>
+        <source>Lite Sync activated.</source>
+        <translation>Lite Sync ativado.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="837"/>
+        <source>Lite Sync deactivated.</source>
+        <translation>O Lite Sync está desativado.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="899"/>
+        <source>This drive is being deleted.</source>
+        <translation>Esta unidade está a ser eliminada.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="962"/>
+        <source>Impossible to open item %1</source>
+        <translation>Não é possível abrir o item %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1007"/>
+        <source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
+        <translation>Não foi possível interromper a sincronização da pasta &lt;i&gt;%1&lt;/i&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1125"/>
+        <source>Remove all synchronizations</source>
+        <translation>Remover todas as sincronizações</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1126"/>
+        <source>Search in your kDrive</source>
+        <translation>Pesquisar no seu kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1127"/>
+        <source>Search</source>
+        <translation>Pesquisar</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::DriveSelectionWidget</name>
+    <message>
+        <location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
+        <source>Synchronize a kDrive</source>
+        <translation>Sincronizar um kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/driveselectionwidget.cpp" line="150"/>
+        <source>Add a kDrive</source>
+        <translation>Adicionar um kDrive</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ErrorTabWidget</name>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="179"/>
+        <source>Resolve</source>
+        <translation>Resolução</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="180"/>
+        <source>Conflicted item(s)</source>
+        <translation>Elemento(s) em conflito</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="181"/>
+        <source>Item(s) with unsupported characters</source>
+        <translation>Item(s) com caracteres não suportados</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="92"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="135"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="178"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="186"/>
+        <source>Clear history</source>
+        <translation>Limpar histórico</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="176"/>
+        <source>To Resolve</source>
+        <translation>Para resolver</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="184"/>
+        <source>Automatically resolved</source>
+        <translation>Resolvido automaticamente</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="185"/>
+        <source>problem(s) solved</source>
+        <translation>problema(s) resolvido(s)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="177"/>
+        <source>problem(s) detected</source>
+        <translation>foram detetados problemas</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ErrorsMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="84"/>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="103"/>
+        <source>Synchronization conflicts or errors</source>
+        <translation>Conflitos ou erros de sincronização</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="86"/>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="105"/>
+        <source>Errors</source>
+        <translation>Erros</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="101"/>
+        <source>Back to preferences</source>
+        <translation>Voltar às preferências</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ErrorsPopup</name>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="73"/>
+        <source>Some files couldn&apos;t be synchronized on the following kDrive(s) :</source>
+        <translation>Não foi possível sincronizar alguns ficheiros nos seguintes kDrive(s):</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="95"/>
+        <source> (%1 error(s))</source>
+        <translation> (%1 erro(s))</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="101"/>
+        <source> (%1 information(s))</source>
+        <translation> (%1 informação(s))</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="107"/>
+        <source> (%1 error(s) and %2 information(s))</source>
+        <translation> (%1 erro(s) e %2 informação(ões))</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/errorspopup.cpp" line="147"/>
+        <source>Generic errors (%n warning(s) or error(s))</source>
+        <comment>Number of warnings or errors</comment>
+        <translation>
+            <numerusform>Erros genericos (%n aviso ou erro)</numerusform>
+            <numerusform>Erros genericos (%n avisos ou erros)</numerusform>
+        </translation>
+    </message>
+</context>
+<context>
+    <name>KDC::FileExclusionDialog</name>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="78"/>
+        <source>Excluded files</source>
+        <translation>Ficheiros excluídos</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="86"/>
+        <source>Add files or folders that will not be synchronized on your computer.</source>
+        <translation>Adicione ficheiros ou pastas que não serão sincronizados no seu computador.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="97"/>
+        <source>Add</source>
+        <translation>Adicionar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="109"/>
+        <source>NAME</source>
+        <translation>NOME</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="114"/>
+        <source>WARNING</source>
+        <translation>AVISO</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="149"/>
+        <source>SAVE</source>
+        <translation>GUARDAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="156"/>
+        <source>CANCEL</source>
+        <translation>CANCELAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="304"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Quer guardar as suas alterações?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="353"/>
+        <source>Exclusion template already exists!</source>
+        <translation>O modelo de exclusão já existe!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="374"/>
+        <source>Do you really want to delete?</source>
+        <translation>Quer mesmo eliminar?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="434"/>
+        <source>Cannot save changes!</source>
+        <translation>Não é possível guardar as alterações!</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::FileExclusionNameDialog</name>
+    <message>
+        <location filename="../src/gui/fileexclusionnamedialog.cpp" line="58"/>
+        <source>VALIDATE</source>
+        <translation>VALIDAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusionnamedialog.cpp" line="65"/>
+        <source>CANCEL</source>
+        <translation>CANCELAR</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::FixConflictingFilesDialog</name>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67"/>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73"/>
+        <source>Unable to open link %1.</source>
+        <translation>Não foi possível abrir a ligação %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122"/>
+        <source>Solve conflict(s)</source>
+        <translation>Resolver conflitos</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140"/>
+        <source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
+        <translation>&lt;b&gt;O que pretende fazer com o(s) item(ns) em conflito %1?&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143"/>
+        <source>Save my changes and replace other users&apos; versions.</source>
+        <translation>Guardar as minhas alterações e substituir as versões dos outros utilizadores.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147"/>
+        <source>Undo my changes and keep other users&apos; versions.</source>
+        <translation>Anular as minhas alterações e manter as versões dos outros utilizadores.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169"/>
+        <source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
+        <translation>As suas alterações podem ser eliminadas definitivamente. Não é possível recuperá-las a partir da aplicação web kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171"/>
+        <source>&lt;a style=%1 href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a style=%1 href=&quot;%2&quot;&gt;Saiba mais&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175"/>
+        <source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
+        <translation>As suas alterações serão eliminadas definitivamente. Não é possível recuperá-las a partir da aplicação web do kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191"/>
+        <source>Show item(s)</source>
+        <translation>Mostrar item(s)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228"/>
+        <source>VALIDATE</source>
+        <translation>VALIDAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234"/>
+        <source>CANCEL</source>
+        <translation>CANCELAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251"/>
+        <source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
+        <translation>Vários utilizadores introduziram alterações nestes ficheiros em vários locais (online no kDrive, num computador ou num dispositivo móvel). As pastas que contêm estes ficheiros também podem ter sido eliminadas.&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253"/>
+        <source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>A versão local do seu item &lt;b&gt;não está sincronizada&lt;/b&gt; com o kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Saiba mais&lt;/a&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::FolderItemWidget</name>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="458"/>
+        <source>More actions</source>
+        <translation>Mais ações</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="188"/>
+        <location filename="../src/gui/folderitemwidget.cpp" line="476"/>
+        <source>Synchronized into &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</source>
+        <translation>Sincronizado em &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="343"/>
+        <source>Activate Lite Sync</source>
+        <translation>Ativar o Lite Sync</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="345"/>
+        <source>Activate Lite Sync (Beta)</source>
+        <translation>Ativar o Lite Sync (Beta)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="481"/>
+        <source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
+        <translation>As pastas não selecionadas serão movidas para a lixeira, desde que contenham itens offline. As pastas sincronizadas com o kDrive permanecerão disponíveis online.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="485"/>
+        <source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
+        <translation>As pastas não selecionadas serão movidas para a lixeira. As pastas sincronizadas com o kDrive permanecerão disponíveis online.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="488"/>
+        <source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
+        <translation>As pastas não selecionadas serão eliminadas &lt;b&gt;definitivamente&lt;/b&gt; do computador. As pastas sincronizadas com o kDrive permanecerão disponíveis online.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="493"/>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="494"/>
+        <source>VALIDATE</source>
+        <translation>VALIDAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="365"/>
+        <source>Pause synchronization</source>
+        <translation>Pausar a sincronização</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="354"/>
+        <source>Deactivate Lite Sync</source>
+        <translation>Desativar o Lite Sync</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="375"/>
+        <source>Resume synchronization</source>
+        <translation>Retomar a sincronização</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="386"/>
+        <source>Remove synchronization</source>
+        <translation>Desativar a sincronização</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::GenericErrorItemWidget</name>
+    <message>
+        <location filename="../src/gui/genericerroritemwidget.cpp" line="85"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Não foi possível abrir o caminho da pasta %1.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::LiteSyncAppDialog</name>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="48"/>
+        <source>Application Id</source>
+        <translation>ID da aplicação</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="98"/>
+        <source>Application Name</source>
+        <translation>Nome da aplicação</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="121"/>
+        <source>VALIDATE</source>
+        <translation>VALIDAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="128"/>
+        <source>CANCEL</source>
+        <translation>CANCELAR</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::LiteSyncDialog</name>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="91"/>
+        <source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are &quot;online&quot;. Add them in the list below to avoid this behaviour.</source>
+        <translation>Algumas aplicações (de cópia de segurança, antivírus...) acedem aos seus ficheiros, o que leva à sua transferência quando estão «online». Adicione-as à lista abaixo para evitar este comportamento.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="103"/>
+        <source>Add</source>
+        <translation>Adicionar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="115"/>
+        <source>APPLICATION ID</source>
+        <translation>ID DA APLICAÇÃO</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="120"/>
+        <source>NAME</source>
+        <translation>NOME</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="154"/>
+        <source>SAVE</source>
+        <translation>GUARDAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="161"/>
+        <source>CANCEL</source>
+        <translation>CANCELAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="295"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Quer guardar as suas alterações?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="337"/>
+        <source>Do you really want to delete?</source>
+        <translation>Quer mesmo eliminar?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="374"/>
+        <source>Cannot save changes!</source>
+        <translation>Não é possível guardar as alterações!</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::LocalFolderDialog</name>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="63"/>
+        <source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
+        <translation>Que pasta do seu computador gostaria de&lt;br&gt;sincronizar?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="72"/>
+        <source>The content of this folder will be synchronized on the kDrive</source>
+        <translation>O conteúdo desta pasta será sincronizado no kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="91"/>
+        <source>Select a folder</source>
+        <translation>Selecione uma pasta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="131"/>
+        <source>Edit folder</source>
+        <translation>Editar pasta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="166"/>
+        <source>CANCEL</source>
+        <translation>CANCELAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="173"/>
+        <source>CONTINUE</source>
+        <translation>CONTINUAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="210"/>
+        <source>This folder is not compatible with Lite Sync.&lt;br&gt;
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt;
-&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-            <translation>Esta pasta não é compatível com o Lite Sync.&lt;br&gt;
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Esta pasta não é compatível com o Lite Sync.&lt;br&gt;
 Selecione outra pasta. Se continuar, o Lite Sync será desativado.&lt;br&gt;
 
-&lt;a style="%1" href="%2"&gt;Saiba mais&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/localfolderdialog.cpp" line="233" />
-            <source>Select folder</source>
-            <translation>Selecionar pasta</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/localfolderdialog.cpp" line="292" />
-            <source>Unable to open link %1.</source>
-            <translation>Não foi possível abrir a ligação %1.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::Logger</name>
-        <message>
-            <location filename="../src/libcommongui/logger.cpp" line="189" />
-            <source>Error</source>
-            <translation>Erro</translation>
-        </message>
-        <message>
-            <location filename="../src/libcommongui/logger.cpp" line="189" />
-            <source>&lt;nobr&gt;File '%1'&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
-            <translation>&lt;nobr&gt;Não é possível abrir o&lt;br/&gt;ficheiro «%1» para gravação. &lt;b&gt;Não&lt;/b&gt; é&lt;br/&gt;&lt;br/&gt;possível guardar o registo!&lt;/nobr&gt;</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::MainMenuBarWidget</name>
-        <message>
-            <location filename="../src/gui/mainmenubarwidget.cpp" line="115" />
-            <source>Preferences</source>
-            <translation>Preferências</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/mainmenubarwidget.cpp" line="116" />
-            <source>Help</source>
-            <translation>Ajuda</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::ParametersDialog</name>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="1082" />
-            <source>Unable to open folder path %1.</source>
-            <translation>Não foi possível abrir o caminho da pasta %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="1096" />
-            <source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
-            <translation>Envio concluído!&lt;br&gt;Por favor, indique o identificador &lt;b&gt;%1&lt;/b&gt; nos relatórios de erros.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="1118" />
-            <source>No kDrive configured!</source>
-            <translation>O kDrive não está configurado!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="1097" />
-            <source>Transmission failed!
-Please, use the following link to send the logs to the support: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</source>
-            <translation>Falha na transmissão!
-Por favor, utilize o seguinte link para enviar os registos para o apoio técnico: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="337" />
-            <location filename="../src/gui/parametersdialog.cpp" line="440" />
-            <location filename="../src/gui/parametersdialog.cpp" line="506" />
-            <location filename="../src/gui/parametersdialog.cpp" line="546" />
-            <location filename="../src/gui/parametersdialog.cpp" line="560" />
-            <source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-            <translation>Ocorreu um erro técnico (erro %1).&lt;br&gt;Por favor, limpe o histórico e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="342" />
-            <source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
-            <translation>Parece que a sua ligação de rede está configurada com um tempo de espera demasiado curto para que a aplicação funcione corretamente (erro %1).&lt;br&gt;Verifique a sua configuração de rede.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="347" />
-            <location filename="../src/gui/parametersdialog.cpp" line="516" />
-            <source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
-            <translation>Não é possível estabelecer ligação ao servidor kDrive (erro %1).&lt;br&gt;A tentar restabelecer a ligação. Verifique a sua ligação à Internet e a sua firewall.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="352" />
-            <source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
-            <translation>Ocorreu um problema ao iniciar sessão (erro %1).&lt;br&gt;Por favor, inicie sessão novamente e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="356" />
-            <source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
-            <translation>Está disponível uma nova versão da aplicação.&lt;br&gt;Por favor, atualize a aplicação para continuar a utilizá-la.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="360" />
-            <source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
-            <translation>A publicação do registo falhou (erro %1).&lt;br&gt;Por favor, tente novamente mais tarde.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="385" />
-            <source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
-            <translation>Já não é possível aceder à pasta de sincronização (erro %1).&lt;br&gt;A sincronização será retomada assim que for possível aceder à pasta.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="532" />
-            <source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
-            <translation>A pasta de sincronização foi substituída ou movida de forma a impedir a sincronização (erro %1).&lt;br&gt;Isto pode acontecer após copiar, mover ou restaurar a pasta.&lt;br&gt;Para resolver este problema, crie uma nova sincronização com uma nova pasta.&lt;br&gt;Nota: se houver alterações não sincronizadas na pasta antiga, terá de as copiar manualmente para a nova.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="397" />
-            <source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
-            <translation>Não há memória suficiente no seu computador.&lt;br&gt;A sincronização foi interrompida.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="320" />
-            <source>kDrive needs to have write access to your computer's temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
-            <translation>O kDrive precisa de ter acesso de escrita ao diretório temporário do seu computador.&lt;br&gt;Reinicie a aplicação kDrive para resolver este problema.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="330" />
-            <location filename="../src/gui/parametersdialog.cpp" line="487" />
-            <source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-            <translation>Ocorreu um erro técnico.&lt;br&gt;A sincronização será retomada assim que possível. Se o erro persistir, contacte a nossa equipa de apoio.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="401" />
-            <source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing '/etc/sysctl.conf'.</source>
-            <translation>O número de observações inotify é insuficiente (erro %1).&lt;br&gt;Pode aumentar este número editando o ficheiro «/etc/sysctl.conf».</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="406" />
-            <source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
-            <translation>Não foi possível iniciar a sincronização (erro %1).&lt;br&gt;Deve autorizar: - o kDrive em «Definições do sistema» &gt;&gt; «Geral» &gt;&gt; «Itens de&lt;br&gt;início de sessão e extensões» &gt;&gt; «Extensões de segurança de terminais»&lt;br&gt;; - a extensão kDrive LiteSync em «Definições do sistema» &gt;&gt; «Privacidade e segurança» &gt;&gt; «Acesso total ao disco».</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="419" />
-            <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-            <translation>Não foi possível iniciar o plugin Lite Sync (erro %1).&lt;br&gt;Verifique se a extensão Lite Sync está instalada e se o serviço Windows Search está ativado.&lt;br&gt;Limpe o histórico, reinicie o computador e, se o erro persistir, contacte a nossa equipa de suporte.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="424" />
-            <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-            <translation>Não foi possível iniciar o plugin Lite Sync (erro %1).&lt;br&gt;Verifique se a extensão Lite Sync tem as permissões corretas e se está em execução.&lt;br&gt;Limpe o histórico, reinicie e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="429" />
-            <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-            <translation>Não foi possível iniciar o plugin Lite Sync (erro %1).&lt;br&gt;Limpe o histórico, reinicie e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="435" />
-            <source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
-            <translation>Parece que um ficheiro ou pasta dentro da sua pasta de sincronização está corrompido.&lt;br&gt;A sincronização foi interrompida.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="449" />
-            <source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-            <translation>O kDrive está em modo de manutenção.&lt;br&gt;A sincronização será reiniciada assim que possível. Se o erro persistir, contacte a nossa equipa de apoio.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="455" />
-            <source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-            <translation>O kDrive está bloqueado.&lt;br&gt;Por favor, atualize o kDrive. Se não forem tomadas medidas, os dados serão eliminados definitivamente e será impossível recuperá-los.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="460" />
-            <source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-            <translation>O kDrive está bloqueado.&lt;br&gt;Contacte um administrador para renovar o kDrive. Se não forem tomadas medidas, os dados serão eliminados definitivamente e será impossível recuperá-los.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="466" />
-            <source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-            <translation>O kDrive está a iniciar-se.&lt;br&gt;A sincronização será reiniciada assim que possível. Se o erro persistir, contacte a nossa equipa de apoio.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="475" />
-            <source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
-            <translation>O kDrive está inativo.&lt;br&gt;Por favor, inicie sessão na &lt;a style="%1" href="%2"&gt;versão&lt;/a&gt; &lt;a style="%1" href="%2"&gt;web&lt;/a&gt; para verificar o estado do seu kDrive ou contacte o seu administrador.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="479" />
-            <source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive's status, or contact your administrator.</source>
-            <translation>O kDrive está inativo.&lt;br&gt;Por favor, inicie sessão na versão web para verificar o estado do seu kDrive ou contacte o seu administrador.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="483" />
-            <source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
-            <translation>Não tem autorização para aceder a este kDrive.&lt;br&gt;A sincronização foi suspensa. Contacte um administrador.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="493" />
-            <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-            <translation>Ocorreu um erro técnico (erro %1).&lt;br&gt;A sincronização será retomada assim que possível. Se o erro persistir, contacte a nossa equipa de apoio.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="512" />
-            <source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-            <translation>As ligações de rede foram interrompidas pelo kernel (erro %1).&lt;br&gt;Por favor, limpe o histórico e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="522" />
-            <source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
-            <translation>Infelizmente, não foi possível migrar a sua configuração anterior.&lt;br&gt;A aplicação irá utilizar uma configuração em branco.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="526" />
-            <source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
-            <translation>Infelizmente, não foi possível migrar a sua configuração de proxy anterior; os proxies SOCKS5 não são suportados neste momento.&lt;br&gt;A aplicação utilizará, em vez disso, as definições de proxy do sistema.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="539" />
-            <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
-            <translation>Ocorreu um erro técnico (erro %1).&lt;br&gt;A sincronização foi reiniciada. Por favor, limpe o histórico e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="550" />
-            <source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
-            <translation>Ocorreu um erro ao aceder à base de dados de sincronização (erro %1).&lt;br&gt;A sincronização foi interrompida.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="564" />
-            <source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
-            <translation>Ocorreu um problema ao iniciar sessão (erro %1).&lt;br&gt;Token inválido ou revogado.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="569" />
-            <source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
-            <translation>Não são permitidas sincronizações aninhadas (erro %1).&lt;br&gt;Deve manter apenas as sincronizações cujas pastas não estejam aninhadas.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="573" />
-            <source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
-            <translation>A pasta de sincronização no kDrive remoto já não existe ou já não está acessível (erro %1).&lt;br&gt;É necessário restaurá-la, restabelecer os direitos de acesso ou eliminar/recriar a sincronização.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="580" />
-            <source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
-            <translation>Erro na análise do nome do ficheiro (erro %1).&lt;br&gt;Caracteres especiais, como aspas duplas, barras invertidas ou retornos de linha, podem causar falhas na análise.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="722" />
-            <source>You are not allowed to move item to "%1".&lt;br&gt;It will be restored into its original parent folder.</source>
-            <translation>Não é permitido mover o item para «%1».&lt;br&gt;O item será restaurado na sua pasta principal original.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="814" />
-            <source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
-            <translation>Não há espaço suficiente no seu computador.&lt;br&gt;O download foi cancelado.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="609" />
-            <source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
-            <translation>Este elemento foi movido para outro local.&lt;br&gt;A operação local foi cancelada.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="618" />
-            <source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
-            <translation>Já existe um elemento com o mesmo nome neste local.&lt;br&gt;O elemento local foi renomeado.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="614" />
-            <source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
-            <translation>Já existe um elemento com o mesmo nome neste local.&lt;br&gt;A operação local foi cancelada.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="393" />
-            <source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
-            <translation>Não há espaço suficiente no seu computador.&lt;br&gt;A sincronização foi interrompida.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="622" />
-            <source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
-            <translation>O ficheiro foi modificado ao mesmo tempo por outro utilizador.&lt;br&gt;As suas alterações foram guardadas numa cópia.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="626" />
-            <source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
-            <translation>Outro utilizador moveu uma pasta pai do destino.&lt;br&gt;A operação local foi cancelada.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="692" />
-            <source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
-            <translation>O nome do artigo contém apenas espaços.&lt;br&gt;Foi temporariamente colocado na lista negra.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="703" />
-            <source>Either you are not allowed to create an item, or another item already exists with the same name.&lt;br&gt;The item has been excluded from synchronization.</source>
-            <translation>Ou não tem permissão para criar um item, ou já existe outro item com o mesmo nome.&lt;br&gt;O item foi excluído da sincronização.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="708" />
-            <source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
-            <translation>Não tem permissão para editar este item.&lt;br&gt;O ficheiro que contém as suas alterações foi renomeado e excluído da sincronização.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="716" />
-            <source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
-            <translation>Não é permitido renomear o item.&lt;br&gt;Este será restaurado com o seu nome original.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="727" />
-            <source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
-            <translation>Não é permitido eliminar este item.&lt;br&gt;Será restaurado na sua localização original.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="732" />
-            <source>Failed to move this item to trash, it has been blacklisted.</source>
-            <translation>Não foi possível mover este item para a lixeira; foi colocado na lista negra.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="748" />
-            <source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
-            <translation>O ficheiro foi alterado localmente, embora tenha sido eliminado no kDrive remoto. A&lt;br&gt;cópia local foi guardada na pasta de recuperação.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="765" />
-            <source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
-            <translation>A operação realizada no item está proibida.&lt;br&gt;O item foi temporariamente colocado na lista negra.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="771" />
-            <source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
-            <translation>A operação realizada neste item falhou.&lt;br&gt;O item foi temporariamente colocado na lista negra.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="776" />
-            <source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
-            <translation>O ficheiro é demasiado grande para ser carregado. Foi temporariamente colocado na lista negra.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="782" />
-            <source>Impossible to download the file.</source>
-            <translation>Não é possível descarregar o ficheiro.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="779" />
-            <source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
-            <translation>Excedeste a tua quota. Aumenta a tua quota de espaço para reativar o envio de ficheiros.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="389" />
-            <source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
-            <translation>A unidade que contém a sua pasta de sincronização já não está ligada (erro %1).&lt;br&gt;Volte a ligá-la para retomar a sincronização.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="413" />
-            <source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
-            <translation>Não foi possível iniciar a sincronização (erro %1).&lt;br&gt;O processo LiteSyncExt não está a ser executado neste momento. A sincronização será retomada assim que for iniciado.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="649" />
-            <source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
-            <translation>Existe um item com um nome idêntico, com as mesmas opções de maiúsculas e minúsculas.&lt;br&gt;Esse item foi temporariamente colocado na lista negra.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="656" />
-            <source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
-            <translation>O nome do artigo contém um caractere não suportado.&lt;br&gt;Foi temporariamente colocado na lista negra.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="662" />
-            <source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-            <translation>O nome do item termina com um espaço, o que é proibido no seu sistema operativo.&lt;br&gt;Foi temporariamente colocado na lista negra.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="668" />
-            <source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-            <translation>Este nome de item está reservado pelo seu sistema operativo.&lt;br&gt;Foi temporariamente colocado na lista negra.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="674" />
-            <source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
-            <translation>O nome do artigo é demasiado longo.&lt;br&gt;Foi temporariamente colocado na lista negra.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="680" />
-            <source>The item path is too long.&lt;br&gt;It has been ignored.</source>
-            <translation>O caminho do item é demasiado longo.&lt;br&gt;Foi ignorado.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="686" />
-            <source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
-            <translation>O nome do item contém um caractere Unicode recente que ainda não é suportado pelo seu sistema de ficheiros.&lt;br&gt;Foi excluído da sincronização.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="735" />
-            <source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
-            <translation>Não foi possível sincronizar este item. Foi temporariamente colocado na lista negra. Será feita&lt;br&gt;uma nova tentativa de sincronização dentro de uma hora ou na próxima vez que a aplicação for iniciada.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="740" />
-            <source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
-            <translation>Este item foi excluído da sincronização por um modelo personalizado.&lt;br&gt;Pode desativar este tipo de notificação nas Preferências</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="745" />
-            <source>This item has been excluded from sync because it is a hard link.</source>
-            <translation>Este item foi excluído da sincronização porque é um link físico.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="785" />
-            <source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
-            <translation>Este item está atualmente bloqueado por outro utilizador online.&lt;br&gt;Voltaremos a tentar carregar as suas alterações mais tarde.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="790" />
-            <location filename="../src/gui/parametersdialog.cpp" line="834" />
-            <source>Synchronization error.</source>
-            <translation>Erro de sincronização.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="810" />
-            <source>Can't access item.&lt;br&gt;Please fix the read and write permissions.</source>
-            <translation>Não é possível aceder ao item.&lt;br&gt;Por favor, corrija as permissões de leitura e escrita.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="818" />
-            <source>System error.</source>
-            <translation>Erro do sistema.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="825" />
-            <source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
-            <translation>O item já existe no outro lado.&lt;br&gt;Foi temporariamente colocado na lista negra.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="840" />
-            <source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-            <translation>Ocorreu um erro técnico.&lt;br&gt;Limpe o histórico e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::PreferencesBlocWidget</name>
-        <message>
-            <location filename="../src/gui/preferencesblocwidget.cpp" line="187" />
-            <source>This synchronization is being deleted.</source>
-            <translation>Esta sincronização está a ser eliminada.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::PreferencesMenuBarWidget</name>
-        <message>
-            <location filename="../src/gui/preferencesmenubarwidget.cpp" line="63" />
-            <source>Back to drive list</source>
-            <translation>Voltar à lista de unidades</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferencesmenubarwidget.cpp" line="64" />
-            <source>Preferences</source>
-            <translation>Preferências</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::PreferencesWidget</name>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="491" />
-            <source>General</source>
-            <translation>Geral</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="493" />
-            <source>Activate dark theme</source>
-            <translation>Ativar tema escuro</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="495" />
-            <source>Activate monochrome icons</source>
-            <translation>Ativar icones monocromaticos</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="496" />
-            <source>Launch kDrive at startup</source>
-            <translation>Iniciar o kDrive no arranque</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="516" />
-            <source>Advanced</source>
-            <translation>Avancado</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="517" />
-            <source>Debugging information</source>
-            <translation>Informacoes de depuracao</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="519" />
-            <source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
-            <translation>&lt;a style="%1" href="%2"&gt;Abrir a pasta de depuração&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="520" />
-            <source>Files to exclude</source>
-            <translation>Ficheiros a excluir</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="521" />
-            <source>Proxy server</source>
-            <translation>Servidor proxy</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="511" />
-            <source>Swedish</source>
-            <translation>Sueco</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="512" />
-            <source>Portuguese</source>
-            <translation>Português</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="513" />
-            <source>Polish</source>
-            <translation>Polaco</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="514" />
-            <source>Norwegian</source>
-            <translation>Norueguês</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="466" />
-            <source>Unable to open folder %1.</source>
-            <translation>Não foi possível abrir a pasta %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="478" />
-            <source>Unable to open link %1.</source>
-            <translation>Não foi possível abrir a ligação %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="483" />
-            <source>Invalid link %1.</source>
-            <translation>Ligacao invalida %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="523" />
-            <source>Lite Sync</source>
-            <translation>Lite Sync</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="497" />
-            <source>Language</source>
-            <translation>Idioma</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="490" />
-            <source>Some process failed to run.</source>
-            <translation>Algum processo não foi executado.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="498" />
-            <source>Move deleted files to my computer's trash</source>
-            <translation>Mover os ficheiros eliminados para o Lixo do meu computador</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="499" />
-            <source>Some files or folders may not be moved to the computer's trash.</source>
-            <translation>Alguns ficheiros ou pastas podem nao ser movidos para o Lixo do computador.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="500" />
-            <source>You can always retrieve already synced files from the kDrive web application trash.</source>
-            <translation>Pode sempre recuperar ficheiros ja sincronizados no Lixo da aplicacao web kDrive.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="502" />
-            <source>&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-            <translation>&lt;a style="%1" href="%2"&gt;Saiba mais&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="506" />
-            <source>English</source>
-            <translation>Ingles</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="507" />
-            <source>French</source>
-            <translation>Frances</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="508" />
-            <source>German</source>
-            <translation>Alemao</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="509" />
-            <source>Spanish</source>
-            <translation>Espanhol</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="510" />
-            <source>Italian</source>
-            <translation>Italiano</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="505" />
-            <source>Default</source>
-            <translation>Predefinido</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::ProgressBarWidget</name>
-        <message>
-            <location filename="../src/gui/progressbarwidget.cpp" line="70" />
-            <source>%1 in use</source>
-            <translation>%1 em uso</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::ProxyServerDialog</name>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="50" />
-            <source>HTTP(S) Proxy</source>
-            <translation>Proxy HTTP(S)</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="73" />
-            <source>Proxy server</source>
-            <translation>Servidor proxy</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="85" />
-            <source>No proxy server</source>
-            <translation>Sem servidor proxy</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="90" />
-            <source>Use system parameters</source>
-            <translation>Utilizar parâmetros do sistema</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="95" />
-            <source>Indicate a proxy manually</source>
-            <translation>Indicar um representante manualmente</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="131" />
-            <source>Port</source>
-            <translation>Porto</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="144" />
-            <source>Address of the proxy server</source>
-            <translation>Endereço do servidor proxy</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="150" />
-            <source>Authentication needed</source>
-            <translation>É necessária autenticação</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="165" />
-            <source>User</source>
-            <translation>Utilizador</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="171" />
-            <source>Password</source>
-            <translation>Palavra-passe</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="185" />
-            <source>SAVE</source>
-            <translation>GUARDAR</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="192" />
-            <source>CANCEL</source>
-            <translation>CANCELAR</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="286" />
-            <source>Do you want to save your modifications?</source>
-            <translation>Quer guardar as suas alterações?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="295" />
-            <source>Unable to save, all mandatory fields are not completed!</source>
-            <translation>Não é possível guardar, pois nem todos os campos obrigatórios foram preenchidos!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="316" />
-            <source>Proxy not found, save anyway?</source>
-            <translation>Não foi encontrado nenhum proxy. Deseja guardar na mesma?</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::ResourcesManagerDialog</name>
-        <message>
-            <location filename="../src/gui/resourcesmanagerdialog.cpp" line="55" />
-            <source>Resources Manager</source>
-            <translation>Gestor de Recursos</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/resourcesmanagerdialog.cpp" line="65" />
-            <source>Maximum CPU usage allowed</source>
-            <translation>Utilização máxima permitida da CPU</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/resourcesmanagerdialog.cpp" line="96" />
-            <source>SAVE</source>
-            <translation>GUARDAR</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/resourcesmanagerdialog.cpp" line="103" />
-            <source>CANCEL</source>
-            <translation>CANCELAR</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/resourcesmanagerdialog.cpp" line="122" />
-            <source>Do you want to save your modifications?</source>
-            <translation>Quer guardar as suas alterações?</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::ServerBaseFolderDialog</name>
-        <message>
-            <location filename="../src/gui/serverbasefolderdialog.cpp" line="81" />
-            <source>Select a folder on your kDrive</source>
-            <translation>Selecione uma pasta no seu kDrive</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/serverbasefolderdialog.cpp" line="90" />
-            <source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
-            <translation>O conteúdo da pasta selecionada será sincronizado com a pasta &lt;b&gt;%1&lt;/b&gt;.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/serverbasefolderdialog.cpp" line="134" />
-            <source>CONTINUE</source>
-            <translation>CONTINUAR</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/serverbasefolderdialog.cpp" line="150" />
-            <source>Space available on your computer for the current folder : %1</source>
-            <translation>Espaço disponível no seu computador para a pasta atual: %1</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/serverbasefolderdialog.cpp" line="190" />
-            <source>This folder is already being synced.</source>
-            <translation>Esta pasta já está a ser sincronizada.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/serverbasefolderdialog.cpp" line="204" />
-            <source>CONFIRM</source>
-            <translation>CONFIRMAR</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/serverbasefolderdialog.cpp" line="205" />
-            <source>CANCEL</source>
-            <translation>CANCELAR</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::ServerFoldersDialog</name>
-        <message>
-            <location filename="../src/gui/serverfoldersdialog.cpp" line="80" />
-            <source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
-            <translation>A pasta &lt;b&gt;%1&lt;/b&gt; contém subpastas;&lt;br&gt; selecione as que deseja sincronizar</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/serverfoldersdialog.cpp" line="110" />
-            <source>CONTINUE</source>
-            <translation>CONTINUAR</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/serverfoldersdialog.cpp" line="146" />
-            <source>No subfolders currently on the server.</source>
-            <translation>Não existem subpastas no servidor neste momento.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::StatusBarWidget</name>
-        <message>
-            <location filename="../src/gui/statusbarwidget.cpp" line="178" />
-            <source>Resume kDrive "%1" synchronization</source>
-            <translation>Retomar a sincronização do kDrive &quot;%1&quot;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/statusbarwidget.cpp" line="180" />
-            <source>Resume all kDrives synchronization</source>
-            <translation>Retomar toda a sincronização do kDrives</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/statusbarwidget.cpp" line="183" />
-            <source>Pause kDrive "%1" synchronization</source>
-            <translation>Suspender a sincronização do kDrive &quot;%1&quot;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/statusbarwidget.cpp" line="184" />
-            <location filename="../src/gui/statusbarwidget.cpp" line="321" />
-            <source>Pause synchronization</source>
-            <translation>Pausar a sincronização</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/statusbarwidget.cpp" line="185" />
-            <source>Pause all kDrives synchronization</source>
-            <translation>Suspender toda a sincronização do kDrives</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/statusbarwidget.cpp" line="179" />
-            <location filename="../src/gui/statusbarwidget.cpp" line="322" />
-            <source>Resume synchronization</source>
-            <translation>Retomar a sincronização</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::SynchronizedItemWidget</name>
-        <message>
-            <location filename="../src/gui/synchronizeditemwidget.cpp" line="333" />
-            <source>Copy share link</source>
-            <translation>Copiar link de partilha</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synchronizeditemwidget.cpp" line="342" />
-            <source>Display on kdrive.infomaniak.com</source>
-            <translation>Exibir em kdrive.infomaniak.com</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synchronizeditemwidget.cpp" line="387" />
-            <source>Show in folder</source>
-            <translation>Mostrar na pasta</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synchronizeditemwidget.cpp" line="388" />
-            <source>More actions</source>
-            <translation>Mais ações</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synchronizeditemwidget.cpp" line="317" />
-            <source>Open</source>
-            <translation>Abrir</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synchronizeditemwidget.cpp" line="325" />
-            <source>Add to favorites</source>
-            <translation>Adicionar aos favoritos</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::SynthesisBar</name>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="495" />
-            <location filename="../src/gui/synthesisbar.cpp" line="502" />
-            <source>Never</source>
-            <translation>Nunca</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="496" />
-            <source>During 1 hour</source>
-            <translation>Durante 1 hora</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="497" />
-            <location filename="../src/gui/synthesisbar.cpp" line="504" />
-            <source>Until tomorrow 8:00AM</source>
-            <translation>Até amanhã às 8h00</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="498" />
-            <source>During 3 days</source>
-            <translation>Durante 3 dias</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="499" />
-            <source>During 1 week</source>
-            <translation>Durante uma semana</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="500" />
-            <location filename="../src/gui/synthesisbar.cpp" line="507" />
-            <source>Always</source>
-            <translation>Sempre</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="503" />
-            <source>For 1 more hour</source>
-            <translation>Por mais 1 hora</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="505" />
-            <source>For 3 more days</source>
-            <translation>Ainda por mais 3 dias</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="506" />
-            <source>For 1 more week</source>
-            <translation>Por mais uma semana</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="149" />
-            <source>Unable to open folder url %1.</source>
-            <translation>Não foi possível abrir a URL da pasta %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="219" />
-            <source>Open in folder</source>
-            <translation>Abrir na pasta</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="257" />
-            <source>Open %1 web version</source>
-            <translation>Abrir a versão web do %1</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="267" />
-            <source>Drive parameters</source>
-            <translation>Parâmetros do acionamento</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="280" />
-            <source>Notifications disabled until %1</source>
-            <translation>Notificações desativadas até %1</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="281" />
-            <source>Disable Notifications</source>
-            <translation>Desativar notificações</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="314" />
-            <source>Application preferences</source>
-            <translation>Preferências da aplicação</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="322" />
-            <source>Need help</source>
-            <translation>Precisa de ajuda</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="330" />
-            <source>Send feedbacks</source>
-            <translation>Enviar comentários</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="338" />
-            <source>Quit kDrive</source>
-            <translation>Sair do kDrive</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="401" />
-            <source>Unable to access web site %1.</source>
-            <translation>Não é possível aceder ao site %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="492" />
-            <source>Show errors and informations</source>
-            <translation>Mostrar erros e informações</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="493" />
-            <source>Show informations</source>
-            <translation>Mostrar informações</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="494" />
-            <source>More actions</source>
-            <translation>Mais ações</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::SynthesisPopover</name>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="1181" />
-            <source>Update kDrive App</source>
-            <translation>Atualizar a aplicação kDrive</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="1182" />
-            <source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
-            <translation>Esta versão da aplicação kDrive já não é suportada. Para aceder às funcionalidades e melhorias mais recentes, atualize a aplicação.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="978" />
-            <source>Update</source>
-            <translation>Atualização</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="1187" />
-            <source>Please download the latest version on the website.</source>
-            <translation>Por favor, descarregue a versão mais recente no site.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="981" />
-            <source>Update download in progress</source>
-            <translation>Download da atualização em curso</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="984" />
-            <source>Looking for update...</source>
-            <translation>À procura de atualizações...</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="987" />
-            <source>Manual update</source>
-            <translation>Atualização manual</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="990" />
-            <source>Unavailable</source>
-            <translation>Indisponível</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="1200" />
-            <source>You can synchronize files &lt;a style="%1" href="%2"&gt;from your computer&lt;/a&gt; or on &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
-            <translation>Pode sincronizar ficheiros &lt;a style="%1" href="%2"&gt;a partir do seu computador&lt;/a&gt; ou em &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="446" />
-            <source>Synchronized</source>
-            <translation>Sincronizado</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="450" />
-            <source>Favorites</source>
-            <translation>Favoritos</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="454" />
-            <source>Activity</source>
-            <translation>Atividade</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="1133" />
-            <location filename="../src/gui/synthesispopover.cpp" line="1180" />
-            <source>Not implemented!</source>
-            <translation>Não implementado!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="1184" />
-            <source>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Click here to download manually&lt;/a&gt;</source>
-            <translation>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Clique aqui para fazer o download manualmente&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="1193" />
-            <source>No synchronized folder for this Drive!</source>
-            <translation>Não existe nenhuma pasta sincronizada para este Drive!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="1196" />
-            <source>No kDrive configured!</source>
-            <translation>O kDrive não está configurado!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="1161" />
-            <source>Unable to open link %1.</source>
-            <translation>Não foi possível abrir a ligação %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="1173" />
-            <source>Invalid link %1.</source>
-            <translation>Ligacao invalida %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="586" />
-            <source>Unable to open folder url %1.</source>
-            <translation>Não foi possível abrir a URL da pasta %1.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::UpdateDialog</name>
-        <message>
-            <location filename="../src/gui/updater/updatedialog.cpp" line="61" />
-            <source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
-            <translation>&lt;p&gt;A nova versão &lt;b&gt;%1&lt;/b&gt; do Cliente %2 está disponível e já foi descarregada.&lt;/p&gt;&lt;p&gt;A versão instalada é a %3.&lt;/p&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/updater/updatedialog.cpp" line="95" />
-            <source>Skip this version</source>
-            <translation>Ignorar esta versão</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/updater/updatedialog.cpp" line="103" />
-            <source>Remind me later</source>
-            <translation>Lembra-me mais tarde</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/updater/updatedialog.cpp" line="109" />
-            <source>Install update</source>
-            <translation>Instalar atualização</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::UpdateManager</name>
-        <message>
-            <location filename="../src/server/updater/updatemanager.cpp" line="86" />
-            <source>New update available.</source>
-            <translation>Está disponível uma nova atualização.</translation>
-        </message>
-        <message>
-            <location filename="../src/server/updater/updatemanager.cpp" line="87" />
-            <source>Version %1 is available for download.</source>
-            <translation>A versão %1 está disponível para download.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::UserSelectionWidget</name>
-        <message>
-            <location filename="../src/gui/userselectionwidget.cpp" line="131" />
-            <source>Add an account</source>
-            <translation>Adicionar uma conta</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::VersionWidget</name>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="295" />
-            <source>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</source>
-            <translation>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="169" />
-            <source>&lt;a style="%1" href="%2"&gt;Show release note&lt;/a&gt;</source>
-            <translation>&lt;a style="%1" href="%2"&gt;Mostrar notas de lançamento&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="172" />
-            <source>Version</source>
-            <translation>Versão</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="173" />
-            <source>UPDATE</source>
-            <translation>ATUALIZAÇÃO</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="197" />
-            <source>%1 is up to date!</source>
-            <translation>O %1 está atualizado!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="201" />
-            <source>Checking update on server...</source>
-            <translation>A verificar se há atualizações no servidor...</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="205" />
-            <source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style="%2" href="%3"&gt;here&lt;/a&gt;.</source>
-            <translation>Está disponível uma atualização: %1.&lt;br&gt;Faça o download &lt;a style="%2" href="%3"&gt;aqui&lt;/a&gt;.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="212" />
-            <source>An update is available: %1</source>
-            <translation>Está disponível uma atualização: %1</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="218" />
-            <source>Downloading %1. Please wait...</source>
-            <translation>A descarregar %1. Por favor, aguarde...</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="223" />
-            <source>Could not check for new updates.</source>
-            <translation>Não foi possível verificar se existem novas atualizações.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="227" />
-            <source>An error occurred during update.</source>
-            <translation>Ocorreu um erro durante a atualização.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="231" />
-            <source>Could not download update.</source>
-            <translation>Não foi possível descarregar a atualização.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="235" />
-            <source>Update disabled.</source>
-            <translation>Atualização desativada.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="251" />
-            <source>Beta program</source>
-            <translation>Programa beta</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="252" />
-            <source>Get early access to new versions of the application</source>
-            <translation>Obtenha acesso antecipado às novas versões da aplicação</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="256" />
-            <source>Join</source>
-            <translation>Junte-se a nós</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="259" />
-            <source>Modify</source>
-            <translation>Modificar</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="259" />
-            <source>Quit</source>
-            <translation>Sair</translation>
-        </message>
-    </context>
-    <context>
-        <name>QObject</name>
-        <message>
-            <location filename="../src/gui/parameterscache.cpp" line="59" />
-            <source>Unable to save parameters, please retry later.</source>
-            <translation>Não foi possível guardar os parâmetros. Por favor, tente novamente mais tarde.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parameterscache.cpp" line="60" />
-            <source>Unable to save parameters!</source>
-            <translation>Não é possível guardar os parâmetros!</translation>
-        </message>
-        <message>
-            <location filename="../src/server/requests/serverrequests.cpp" line="461" />
-            <source>The parent folder is a sync folder or contained in one</source>
-            <translation>A pasta principal é uma pasta de sincronização ou está incluída numa</translation>
-        </message>
-        <message>
-            <location filename="../src/server/requests/serverrequests.cpp" line="495" />
-            <source>Can't find a valid path</source>
-            <translation>Não é possível encontrar um caminho válido</translation>
-        </message>
-        <message>
-            <location filename="../src/server/requests/serverrequests.cpp" line="2109" />
-            <source>No valid folder selected!</source>
-            <translation>Não foi selecionada nenhuma pasta válida!</translation>
-        </message>
-        <message>
-            <location filename="../src/server/requests/serverrequests.cpp" line="2120" />
-            <source>The selected path does not exist!</source>
-            <translation>O caminho selecionado não existe!</translation>
-        </message>
-        <message>
-            <location filename="../src/server/requests/serverrequests.cpp" line="2125" />
-            <source>The selected path is not a folder!</source>
-            <translation>O caminho selecionado não é uma pasta!</translation>
-        </message>
-        <message>
-            <location filename="../src/server/requests/serverrequests.cpp" line="2130" />
-            <source>You have no permission to write to the selected folder!</source>
-            <translation>Não tem permissão para gravar na pasta selecionada!</translation>
-        </message>
-        <message>
-            <location filename="../src/server/requests/serverrequests.cpp" line="2160" />
-            <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
-            <translation>A pasta local %1 contém uma pasta que já está sincronizada. Por favor, escolha outra!</translation>
-        </message>
-        <message>
-            <location filename="../src/server/requests/serverrequests.cpp" line="2168" />
-            <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
-            <translation>A pasta local %1 está incluída numa pasta já sincronizada. Por favor, escolha outra!</translation>
-        </message>
-        <message>
-            <location filename="../src/server/requests/serverrequests.cpp" line="2176" />
-            <source>The local folder %1 is already synced. Please pick another one!</source>
-            <translation>A pasta local %1 já está sincronizada. Escolha outra!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="42" />
-            <source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
-            <translation>A sincronização Lite (Beta) está ativada. Os ficheiros do kDrive permanecem na nuvem e não ocupam espaço de armazenamento no seu computador.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="45" />
-            <source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
-            <translation>O Lite sync (Beta) está desativado. Os ficheiros do kDrive ocupam espaço de armazenamento no seu computador.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="48" />
-            <source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
-            <translation>A sincronização Lite está ativada. Os ficheiros do kDrive permanecem na nuvem e não ocupam espaço de armazenamento no seu computador.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="50" />
-            <source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
-            <translation>A sincronização Lite está desativada. Os ficheiros do kDrive ocupam espaço de armazenamento no seu computador.</translation>
-        </message>
-        <message>
-            <location filename="../src/server/comm/extensionjob.cpp" line="1175" />
-            <source>Make available locally</source>
-            <translation>Disponibilizar localmente</translation>
-        </message>
-        <message>
-            <location filename="../src/server/comm/extensionjob.cpp" line="1179" />
-            <source>Free up local space</source>
-            <translation>Liberte espaço no disco local</translation>
-        </message>
-        <message>
-            <location filename="../src/server/comm/extensionjob.cpp" line="1183" />
-            <source>Cancel free up local space</source>
-            <translation>Cancelar para libertar espaço local</translation>
-        </message>
-        <message>
-            <location filename="../src/server/comm/extensionjob.cpp" line="1187" />
-            <source>Cancel make available locally</source>
-            <translation>Cancelar disponibilização local</translation>
-        </message>
-        <message>
-            <location filename="../src/server/comm/extensionjob.cpp" line="1191" />
-            <source>Resharing this file is not allowed</source>
-            <translation>Não é permitido partilhar novamente este ficheiro</translation>
-        </message>
-        <message>
-            <location filename="../src/server/comm/extensionjob.cpp" line="1192" />
-            <source>Resharing this folder is not allowed</source>
-            <translation>Não é permitido partilhar novamente esta pasta</translation>
-        </message>
-        <message>
-            <location filename="../src/server/comm/extensionjob.cpp" line="1196" />
-            <source>Copy public share link</source>
-            <translation>Copiar link de partilha pública</translation>
-        </message>
-        <message>
-            <location filename="../src/server/comm/extensionjob.cpp" line="1200" />
-            <source>Copy private share link</source>
-            <translation>Copiar link de partilha privada</translation>
-        </message>
-        <message>
-            <location filename="../src/server/comm/extensionjob.cpp" line="1204" />
-            <source>Open in browser</source>
-            <translation>Abrir no navegador</translation>
-        </message>
-    </context>
-    <context>
-        <name>SharedTools::QtSingleApplication</name>
-        <message>
-            <location filename="../src/server/appserver.cpp" line="133" />
-            <source>kDrive application will close due to a fatal error.</source>
-            <translation>A aplicação kDrive irá fechar devido a um erro grave.</translation>
-        </message>
-    </context>
-    <context>
-        <name>Utility</name>
-        <message>
-            <location filename="../src/libcommongui/utility/utility.cpp" line="97" />
-            <source>%L1 GB</source>
-            <translation>%L1 GB</translation>
-        </message>
-        <message>
-            <location filename="../src/libcommongui/utility/utility.cpp" line="101" />
-            <source>%L1 MB</source>
-            <translation>%L1 MB</translation>
-        </message>
-        <message>
-            <location filename="../src/libcommongui/utility/utility.cpp" line="105" />
-            <source>%L1 KB</source>
-            <translation>%L1 KB</translation>
-        </message>
-        <message>
-            <location filename="../src/libcommongui/utility/utility.cpp" line="108" />
-            <source>%L1 B</source>
-            <translation>%L1 B</translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/libcommongui/utility/utility.cpp" line="41" />
-            <source>%n year(s)</source>
-            <translation>
-                <numerusform>%n ano</numerusform>
-                <numerusform>%n anos</numerusform>
-            </translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/libcommongui/utility/utility.cpp" line="42" />
-            <source>%n month(s)</source>
-            <translation>
-                <numerusform>%n mes</numerusform>
-                <numerusform>%n meses</numerusform>
-            </translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/libcommongui/utility/utility.cpp" line="43" />
-            <source>%n day(s)</source>
-            <translation>
-                <numerusform>%n dia</numerusform>
-                <numerusform>%n dias</numerusform>
-            </translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/libcommongui/utility/utility.cpp" line="44" />
-            <source>%n hour(s)</source>
-            <translation>
-                <numerusform>%n hora</numerusform>
-                <numerusform>%n horas</numerusform>
-            </translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/libcommongui/utility/utility.cpp" line="45" />
-            <source>%n minute(s)</source>
-            <translation>
-                <numerusform>%n minuto</numerusform>
-                <numerusform>%n minutos</numerusform>
-            </translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/libcommongui/utility/utility.cpp" line="46" />
-            <source>%n second(s)</source>
-            <translation>
-                <numerusform>%n segundo</numerusform>
-                <numerusform>%n segundos</numerusform>
-            </translation>
-        </message>
-    </context>
-    <context>
-        <name>main.cpp</name>
-        <message>
-            <location filename="../src/gui/mainclient.cpp" line="49" />
-            <source>System Tray not available</source>
-            <translation>A bandeja do sistema não está disponível</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/mainclient.cpp" line="48" />
-            <source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as 'trayer' and try again.</source>
-            <translation>O %1 requer uma bandeja do sistema funcional. Se estiver a utilizar o XFCE, siga &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;estas instruções&lt;/a&gt;. Caso contrário, instale uma aplicação de bandeja do sistema, como o «trayer», e tente novamente.</translation>
-        </message>
-    </context>
-    <context>
-        <name>utility</name>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="84" />
-            <source>Could not open browser</source>
-            <translation>Não foi possível abrir o navegador</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="85" />
-            <source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
-            <translation>Ocorreu um erro ao iniciar o navegador para aceder ao URL %1. Será que não está configurado nenhum navegador predefinido?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="104" />
-            <source>Could not open email client</source>
-            <translation>Não foi possível abrir o cliente de e-mail</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="105" />
-            <source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
-            <translation>Ocorreu um erro ao iniciar o cliente de e-mail para criar uma nova mensagem. Será que não está configurado nenhum cliente de e-mail predefinido?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="324" />
-            <source>You are not connected anymore. &lt;a style="%1" href="%2"&gt;Log in&lt;/a&gt;</source>
-            <translation>Já não está conectado. &lt;a style="%1" href="%2"&gt;Inicie sessão&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="347" />
-            <source>Sync in progress (Step %1/%2).</source>
-            <translation>Sincronização em curso (Passo %1/%2).</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="353" />
-            <source>Sync in progress.</source>
-            <translation>Sincronização em curso.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="364" />
-            <source>Some files couldn't be synchronized. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-            <translation>Alguns ficheiros não puderam ser sincronizados. &lt;a style="%1" href="%2"&gt;Saiba mais&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="370" />
-            <source>Synchronization pausing ...</source>
-            <translation>A sincronização está em pausa...</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="570" />
-            <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
-            <translation>A pasta &lt;b&gt;%1&lt;/b&gt; não pode ser selecionada porque outra sincronização está a utilizar a mesma pasta.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="576" />
-            <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-            <translation>A pasta &lt;b&gt;%1&lt;/b&gt; não pode ser selecionada porque contém a pasta sincronizada &lt;b&gt;%2&lt;/b&gt;.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="584" />
-            <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-            <translation>A pasta &lt;b&gt;%1&lt;/b&gt; não pode ser selecionada porque está incluída na pasta sincronizada &lt;b&gt;%2&lt;/b&gt;.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="595" />
-            <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
-            <translation>A pasta &lt;b&gt;%1&lt;/b&gt; não pode ser selecionada como pasta de sincronização. Por favor, selecione outra pasta.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="599" />
-            <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
-            <translation>A pasta &lt;b&gt;%1&lt;/b&gt; não pode ser selecionada como pasta de sincronização. Por favor, selecione outra pasta. Pasta sugerida: &lt;b&gt;%2&lt;/b&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="641" />
-            <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
-            <translation>Excluiu mais de %1 pastas; tenha em atenção que isto irá afetar o desempenho da sincronização.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="650" />
-            <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
-            <translation>Não é possível excluir mais do que %1 pastas. Desmarque as pastas de nível superior.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="351" />
-            <source>Synchronization starting</source>
-            <translation>A sincronização está a começar</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="374" />
-            <source>Synchronization paused.</source>
-            <translation>A sincronização foi interrompida.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="336" />
-            <source>Sync in progress (%1 of %2)</source>
-            <translation>Sincronização em curso (%1 de %2)</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="340" />
-            <source>Sync in progress (%1 of %2)
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Saiba mais&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="233"/>
+        <source>Select folder</source>
+        <translation>Selecionar pasta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="292"/>
+        <source>Unable to open link %1.</source>
+        <translation>Não foi possível abrir a ligação %1.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::Logger</name>
+    <message>
+        <location filename="../src/libcommongui/logger.cpp" line="189"/>
+        <source>Error</source>
+        <translation>Erro</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/logger.cpp" line="189"/>
+        <source>&lt;nobr&gt;File &apos;%1&apos;&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
+        <translation>&lt;nobr&gt;Não é possível abrir o&lt;br/&gt;ficheiro «%1» para gravação. &lt;b&gt;Não&lt;/b&gt; é&lt;br/&gt;&lt;br/&gt;possível guardar o registo!&lt;/nobr&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::MainMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/mainmenubarwidget.cpp" line="115"/>
+        <source>Preferences</source>
+        <translation>Preferências</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/mainmenubarwidget.cpp" line="116"/>
+        <source>Help</source>
+        <translation>Ajuda</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ParametersDialog</name>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1082"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Não foi possível abrir o caminho da pasta %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1096"/>
+        <source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
+        <translation>Envio concluído!&lt;br&gt;Por favor, indique o identificador &lt;b&gt;%1&lt;/b&gt; nos relatórios de erros.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1118"/>
+        <source>No kDrive configured!</source>
+        <translation>O kDrive não está configurado!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1097"/>
+        <source>Transmission failed!
+Please, use the following link to send the logs to the support: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</source>
+        <translation>Falha na transmissão!
+Por favor, utilize o seguinte link para enviar os registos para o apoio técnico: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="337"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="440"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="506"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="546"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="560"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>Ocorreu um erro técnico (erro %1).&lt;br&gt;Por favor, limpe o histórico e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="342"/>
+        <source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
+        <translation>Parece que a sua ligação de rede está configurada com um tempo de espera demasiado curto para que a aplicação funcione corretamente (erro %1).&lt;br&gt;Verifique a sua configuração de rede.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="347"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="516"/>
+        <source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
+        <translation>Não é possível estabelecer ligação ao servidor kDrive (erro %1).&lt;br&gt;A tentar restabelecer a ligação. Verifique a sua ligação à Internet e a sua firewall.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="352"/>
+        <source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
+        <translation>Ocorreu um problema ao iniciar sessão (erro %1).&lt;br&gt;Por favor, inicie sessão novamente e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="356"/>
+        <source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
+        <translation>Está disponível uma nova versão da aplicação.&lt;br&gt;Por favor, atualize a aplicação para continuar a utilizá-la.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="360"/>
+        <source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
+        <translation>A publicação do registo falhou (erro %1).&lt;br&gt;Por favor, tente novamente mais tarde.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="385"/>
+        <source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
+        <translation>Já não é possível aceder à pasta de sincronização (erro %1).&lt;br&gt;A sincronização será retomada assim que for possível aceder à pasta.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="532"/>
+        <source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
+        <translation>A pasta de sincronização foi substituída ou movida de forma a impedir a sincronização (erro %1).&lt;br&gt;Isto pode acontecer após copiar, mover ou restaurar a pasta.&lt;br&gt;Para resolver este problema, crie uma nova sincronização com uma nova pasta.&lt;br&gt;Nota: se houver alterações não sincronizadas na pasta antiga, terá de as copiar manualmente para a nova.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="397"/>
+        <source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>Não há memória suficiente no seu computador.&lt;br&gt;A sincronização foi interrompida.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="320"/>
+        <source>kDrive needs to have write access to your computer&apos;s temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
+        <translation>O kDrive precisa de ter acesso de escrita ao diretório temporário do seu computador.&lt;br&gt;Reinicie a aplicação kDrive para resolver este problema.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="330"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="487"/>
+        <source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>Ocorreu um erro técnico.&lt;br&gt;A sincronização será retomada assim que possível. Se o erro persistir, contacte a nossa equipa de apoio.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="401"/>
+        <source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing &apos;/etc/sysctl.conf&apos;.</source>
+        <translation>O número de observações inotify é insuficiente (erro %1).&lt;br&gt;Pode aumentar este número editando o ficheiro «/etc/sysctl.conf».</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="406"/>
+        <source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
+        <translation>Não foi possível iniciar a sincronização (erro %1).&lt;br&gt;Deve autorizar: - o kDrive em «Definições do sistema» &gt;&gt; «Geral» &gt;&gt; «Itens de&lt;br&gt;início de sessão e extensões» &gt;&gt; «Extensões de segurança de terminais»&lt;br&gt;; - a extensão kDrive LiteSync em «Definições do sistema» &gt;&gt; «Privacidade e segurança» &gt;&gt; «Acesso total ao disco».</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="419"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Não foi possível iniciar o plugin Lite Sync (erro %1).&lt;br&gt;Verifique se a extensão Lite Sync está instalada e se o serviço Windows Search está ativado.&lt;br&gt;Limpe o histórico, reinicie o computador e, se o erro persistir, contacte a nossa equipa de suporte.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="424"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Não foi possível iniciar o plugin Lite Sync (erro %1).&lt;br&gt;Verifique se a extensão Lite Sync tem as permissões corretas e se está em execução.&lt;br&gt;Limpe o histórico, reinicie e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="429"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Não foi possível iniciar o plugin Lite Sync (erro %1).&lt;br&gt;Limpe o histórico, reinicie e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="435"/>
+        <source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>Parece que um ficheiro ou pasta dentro da sua pasta de sincronização está corrompido.&lt;br&gt;A sincronização foi interrompida.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="449"/>
+        <source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>O kDrive está em modo de manutenção.&lt;br&gt;A sincronização será reiniciada assim que possível. Se o erro persistir, contacte a nossa equipa de apoio.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="455"/>
+        <source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+        <translation>O kDrive está bloqueado.&lt;br&gt;Por favor, atualize o kDrive. Se não forem tomadas medidas, os dados serão eliminados definitivamente e será impossível recuperá-los.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="460"/>
+        <source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+        <translation>O kDrive está bloqueado.&lt;br&gt;Contacte um administrador para renovar o kDrive. Se não forem tomadas medidas, os dados serão eliminados definitivamente e será impossível recuperá-los.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="466"/>
+        <source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>O kDrive está a iniciar-se.&lt;br&gt;A sincronização será reiniciada assim que possível. Se o erro persistir, contacte a nossa equipa de apoio.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="475"/>
+        <source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>O kDrive está inativo.&lt;br&gt;Por favor, inicie sessão na &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;versão&lt;/a&gt; &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web&lt;/a&gt; para verificar o estado do seu kDrive ou contacte o seu administrador.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="479"/>
+        <source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>O kDrive está inativo.&lt;br&gt;Por favor, inicie sessão na versão web para verificar o estado do seu kDrive ou contacte o seu administrador.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="483"/>
+        <source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
+        <translation>Não tem autorização para aceder a este kDrive.&lt;br&gt;A sincronização foi suspensa. Contacte um administrador.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="493"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>Ocorreu um erro técnico (erro %1).&lt;br&gt;A sincronização será retomada assim que possível. Se o erro persistir, contacte a nossa equipa de apoio.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="512"/>
+        <source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>As ligações de rede foram interrompidas pelo kernel (erro %1).&lt;br&gt;Por favor, limpe o histórico e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="522"/>
+        <source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
+        <translation>Infelizmente, não foi possível migrar a sua configuração anterior.&lt;br&gt;A aplicação irá utilizar uma configuração em branco.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="526"/>
+        <source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
+        <translation>Infelizmente, não foi possível migrar a sua configuração de proxy anterior; os proxies SOCKS5 não são suportados neste momento.&lt;br&gt;A aplicação utilizará, em vez disso, as definições de proxy do sistema.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="539"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
+        <translation>Ocorreu um erro técnico (erro %1).&lt;br&gt;A sincronização foi reiniciada. Por favor, limpe o histórico e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="550"/>
+        <source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
+        <translation>Ocorreu um erro ao aceder à base de dados de sincronização (erro %1).&lt;br&gt;A sincronização foi interrompida.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="564"/>
+        <source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
+        <translation>Ocorreu um problema ao iniciar sessão (erro %1).&lt;br&gt;Token inválido ou revogado.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="569"/>
+        <source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
+        <translation>Não são permitidas sincronizações aninhadas (erro %1).&lt;br&gt;Deve manter apenas as sincronizações cujas pastas não estejam aninhadas.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="573"/>
+        <source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
+        <translation>A pasta de sincronização no kDrive remoto já não existe ou já não está acessível (erro %1).&lt;br&gt;É necessário restaurá-la, restabelecer os direitos de acesso ou eliminar/recriar a sincronização.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="580"/>
+        <source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
+        <translation>Erro na análise do nome do ficheiro (erro %1).&lt;br&gt;Caracteres especiais, como aspas duplas, barras invertidas ou retornos de linha, podem causar falhas na análise.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="722"/>
+        <source>You are not allowed to move item to &quot;%1&quot;.&lt;br&gt;It will be restored into its original parent folder.</source>
+        <translation>Não é permitido mover o item para «%1».&lt;br&gt;O item será restaurado na sua pasta principal original.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="814"/>
+        <source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
+        <translation>Não há espaço suficiente no seu computador.&lt;br&gt;O download foi cancelado.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="609"/>
+        <source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>Este elemento foi movido para outro local.&lt;br&gt;A operação local foi cancelada.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="618"/>
+        <source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
+        <translation>Já existe um elemento com o mesmo nome neste local.&lt;br&gt;O elemento local foi renomeado.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="614"/>
+        <source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>Já existe um elemento com o mesmo nome neste local.&lt;br&gt;A operação local foi cancelada.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="393"/>
+        <source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>Não há espaço suficiente no seu computador.&lt;br&gt;A sincronização foi interrompida.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="622"/>
+        <source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
+        <translation>O ficheiro foi modificado ao mesmo tempo por outro utilizador.&lt;br&gt;As suas alterações foram guardadas numa cópia.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="626"/>
+        <source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>Outro utilizador moveu uma pasta pai do destino.&lt;br&gt;A operação local foi cancelada.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="692"/>
+        <source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>O nome do artigo contém apenas espaços.&lt;br&gt;Foi temporariamente colocado na lista negra.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="703"/>
+        <source>Either you are not allowed to create an item, or another item already exists with the same name.&lt;br&gt;The item has been excluded from synchronization.</source>
+        <translation>Ou não tem permissão para criar um item, ou já existe outro item com o mesmo nome.&lt;br&gt;O item foi excluído da sincronização.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="708"/>
+        <source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
+        <translation>Não tem permissão para editar este item.&lt;br&gt;O ficheiro que contém as suas alterações foi renomeado e excluído da sincronização.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="716"/>
+        <source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
+        <translation>Não é permitido renomear o item.&lt;br&gt;Este será restaurado com o seu nome original.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="727"/>
+        <source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
+        <translation>Não é permitido eliminar este item.&lt;br&gt;Será restaurado na sua localização original.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="732"/>
+        <source>Failed to move this item to trash, it has been blacklisted.</source>
+        <translation>Não foi possível mover este item para a lixeira; foi colocado na lista negra.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="748"/>
+        <source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
+        <translation>O ficheiro foi alterado localmente, embora tenha sido eliminado no kDrive remoto. A&lt;br&gt;cópia local foi guardada na pasta de recuperação.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="765"/>
+        <source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
+        <translation>A operação realizada no item está proibida.&lt;br&gt;O item foi temporariamente colocado na lista negra.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="771"/>
+        <source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
+        <translation>A operação realizada neste item falhou.&lt;br&gt;O item foi temporariamente colocado na lista negra.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="776"/>
+        <source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
+        <translation>O ficheiro é demasiado grande para ser carregado. Foi temporariamente colocado na lista negra.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="782"/>
+        <source>Impossible to download the file.</source>
+        <translation>Não é possível descarregar o ficheiro.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="779"/>
+        <source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
+        <translation>Excedeste a tua quota. Aumenta a tua quota de espaço para reativar o envio de ficheiros.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="389"/>
+        <source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
+        <translation>A unidade que contém a sua pasta de sincronização já não está ligada (erro %1).&lt;br&gt;Volte a ligá-la para retomar a sincronização.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="413"/>
+        <source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
+        <translation>Não foi possível iniciar a sincronização (erro %1).&lt;br&gt;O processo LiteSyncExt não está a ser executado neste momento. A sincronização será retomada assim que for iniciado.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="649"/>
+        <source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Existe um item com um nome idêntico, com as mesmas opções de maiúsculas e minúsculas.&lt;br&gt;Esse item foi temporariamente colocado na lista negra.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="656"/>
+        <source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>O nome do artigo contém um caractere não suportado.&lt;br&gt;Foi temporariamente colocado na lista negra.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="662"/>
+        <source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>O nome do item termina com um espaço, o que é proibido no seu sistema operativo.&lt;br&gt;Foi temporariamente colocado na lista negra.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="668"/>
+        <source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Este nome de item está reservado pelo seu sistema operativo.&lt;br&gt;Foi temporariamente colocado na lista negra.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="674"/>
+        <source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>O nome do artigo é demasiado longo.&lt;br&gt;Foi temporariamente colocado na lista negra.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="680"/>
+        <source>The item path is too long.&lt;br&gt;It has been ignored.</source>
+        <translation>O caminho do item é demasiado longo.&lt;br&gt;Foi ignorado.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="686"/>
+        <source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+        <translation>O nome do item contém um caractere Unicode recente que ainda não é suportado pelo seu sistema de ficheiros.&lt;br&gt;Foi excluído da sincronização.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="735"/>
+        <source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
+        <translation>Não foi possível sincronizar este item. Foi temporariamente colocado na lista negra. Será feita&lt;br&gt;uma nova tentativa de sincronização dentro de uma hora ou na próxima vez que a aplicação for iniciada.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="740"/>
+        <source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
+        <translation>Este item foi excluído da sincronização por um modelo personalizado.&lt;br&gt;Pode desativar este tipo de notificação nas Preferências</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="745"/>
+        <source>This item has been excluded from sync because it is a hard link.</source>
+        <translation>Este item foi excluído da sincronização porque é um link físico.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="785"/>
+        <source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
+        <translation>Este item está atualmente bloqueado por outro utilizador online.&lt;br&gt;Voltaremos a tentar carregar as suas alterações mais tarde.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="790"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="834"/>
+        <source>Synchronization error.</source>
+        <translation>Erro de sincronização.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="810"/>
+        <source>Can&apos;t access item.&lt;br&gt;Please fix the read and write permissions.</source>
+        <translation>Não é possível aceder ao item.&lt;br&gt;Por favor, corrija as permissões de leitura e escrita.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="818"/>
+        <source>System error.</source>
+        <translation>Erro do sistema.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="825"/>
+        <source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>O item já existe no outro lado.&lt;br&gt;Foi temporariamente colocado na lista negra.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="840"/>
+        <source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>Ocorreu um erro técnico.&lt;br&gt;Limpe o histórico e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::PreferencesBlocWidget</name>
+    <message>
+        <location filename="../src/gui/preferencesblocwidget.cpp" line="187"/>
+        <source>This synchronization is being deleted.</source>
+        <translation>Esta sincronização está a ser eliminada.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::PreferencesMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/preferencesmenubarwidget.cpp" line="63"/>
+        <source>Back to drive list</source>
+        <translation>Voltar à lista de unidades</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferencesmenubarwidget.cpp" line="64"/>
+        <source>Preferences</source>
+        <translation>Preferências</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::PreferencesWidget</name>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="491"/>
+        <source>General</source>
+        <translation>Geral</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="493"/>
+        <source>Activate dark theme</source>
+        <translation>Ativar tema escuro</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="495"/>
+        <source>Activate monochrome icons</source>
+        <translation>Ativar icones monocromaticos</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="496"/>
+        <source>Launch kDrive at startup</source>
+        <translation>Iniciar o kDrive no arranque</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="515"/>
+        <source>Finnish</source>
+        <translation>Finlandês</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="521"/>
+        <source>Advanced</source>
+        <translation>Avancado</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="522"/>
+        <source>Debugging information</source>
+        <translation>Informacoes de depuracao</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="524"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Abrir a pasta de depuração&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="525"/>
+        <source>Files to exclude</source>
+        <translation>Ficheiros a excluir</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="526"/>
+        <source>Proxy server</source>
+        <translation>Servidor proxy</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="511"/>
+        <source>Swedish</source>
+        <translation>Sueco</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="512"/>
+        <source>Portuguese</source>
+        <translation>Português</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="513"/>
+        <source>Polish</source>
+        <translation>Polaco</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="514"/>
+        <source>Norwegian</source>
+        <translation>Norueguês</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="466"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Não foi possível abrir a pasta %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="478"/>
+        <source>Unable to open link %1.</source>
+        <translation>Não foi possível abrir a ligação %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="483"/>
+        <source>Invalid link %1.</source>
+        <translation>Ligacao invalida %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="528"/>
+        <source>Lite Sync</source>
+        <translation>Lite Sync</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="497"/>
+        <source>Language</source>
+        <translation>Idioma</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="490"/>
+        <source>Some process failed to run.</source>
+        <translation>Algum processo não foi executado.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="498"/>
+        <source>Move deleted files to my computer&apos;s trash</source>
+        <translation>Mover os ficheiros eliminados para o Lixo do meu computador</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="499"/>
+        <source>Some files or folders may not be moved to the computer&apos;s trash.</source>
+        <translation>Alguns ficheiros ou pastas podem nao ser movidos para o Lixo do computador.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="500"/>
+        <source>You can always retrieve already synced files from the kDrive web application trash.</source>
+        <translation>Pode sempre recuperar ficheiros ja sincronizados no Lixo da aplicacao web kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="502"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Saiba mais&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="506"/>
+        <source>English</source>
+        <translation>Ingles</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="507"/>
+        <source>French</source>
+        <translation>Frances</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="508"/>
+        <source>German</source>
+        <translation>Alemao</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="509"/>
+        <source>Spanish</source>
+        <translation>Espanhol</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="510"/>
+        <source>Italian</source>
+        <translation>Italiano</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="505"/>
+        <source>Default</source>
+        <translation>Predefinido</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ProgressBarWidget</name>
+    <message>
+        <location filename="../src/gui/progressbarwidget.cpp" line="70"/>
+        <source>%1 in use</source>
+        <translation>%1 em uso</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ProxyServerDialog</name>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="50"/>
+        <source>HTTP(S) Proxy</source>
+        <translation>Proxy HTTP(S)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="73"/>
+        <source>Proxy server</source>
+        <translation>Servidor proxy</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="85"/>
+        <source>No proxy server</source>
+        <translation>Sem servidor proxy</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="90"/>
+        <source>Use system parameters</source>
+        <translation>Utilizar parâmetros do sistema</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="95"/>
+        <source>Indicate a proxy manually</source>
+        <translation>Indicar um representante manualmente</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="131"/>
+        <source>Port</source>
+        <translation>Porto</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="144"/>
+        <source>Address of the proxy server</source>
+        <translation>Endereço do servidor proxy</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="150"/>
+        <source>Authentication needed</source>
+        <translation>É necessária autenticação</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="165"/>
+        <source>User</source>
+        <translation>Utilizador</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="171"/>
+        <source>Password</source>
+        <translation>Palavra-passe</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="185"/>
+        <source>SAVE</source>
+        <translation>GUARDAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="192"/>
+        <source>CANCEL</source>
+        <translation>CANCELAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="286"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Quer guardar as suas alterações?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="295"/>
+        <source>Unable to save, all mandatory fields are not completed!</source>
+        <translation>Não é possível guardar, pois nem todos os campos obrigatórios foram preenchidos!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="316"/>
+        <source>Proxy not found, save anyway?</source>
+        <translation>Não foi encontrado nenhum proxy. Deseja guardar na mesma?</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ResourcesManagerDialog</name>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="55"/>
+        <source>Resources Manager</source>
+        <translation>Gestor de Recursos</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="65"/>
+        <source>Maximum CPU usage allowed</source>
+        <translation>Utilização máxima permitida da CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="96"/>
+        <source>SAVE</source>
+        <translation>GUARDAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="103"/>
+        <source>CANCEL</source>
+        <translation>CANCELAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="122"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Quer guardar as suas alterações?</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ServerBaseFolderDialog</name>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="81"/>
+        <source>Select a folder on your kDrive</source>
+        <translation>Selecione uma pasta no seu kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="90"/>
+        <source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
+        <translation>O conteúdo da pasta selecionada será sincronizado com a pasta &lt;b&gt;%1&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="134"/>
+        <source>CONTINUE</source>
+        <translation>CONTINUAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="150"/>
+        <source>Space available on your computer for the current folder : %1</source>
+        <translation>Espaço disponível no seu computador para a pasta atual: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="190"/>
+        <source>This folder is already being synced.</source>
+        <translation>Esta pasta já está a ser sincronizada.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="204"/>
+        <source>CONFIRM</source>
+        <translation>CONFIRMAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="205"/>
+        <source>CANCEL</source>
+        <translation>CANCELAR</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ServerFoldersDialog</name>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="80"/>
+        <source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
+        <translation>A pasta &lt;b&gt;%1&lt;/b&gt; contém subpastas;&lt;br&gt; selecione as que deseja sincronizar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="110"/>
+        <source>CONTINUE</source>
+        <translation>CONTINUAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="146"/>
+        <source>No subfolders currently on the server.</source>
+        <translation>Não existem subpastas no servidor neste momento.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::StatusBarWidget</name>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="178"/>
+        <source>Resume kDrive &quot;%1&quot; synchronization</source>
+        <translation>Retomar a sincronização do kDrive &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="180"/>
+        <source>Resume all kDrives synchronization</source>
+        <translation>Retomar toda a sincronização do kDrives</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="183"/>
+        <source>Pause kDrive &quot;%1&quot; synchronization</source>
+        <translation>Suspender a sincronização do kDrive &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="184"/>
+        <location filename="../src/gui/statusbarwidget.cpp" line="321"/>
+        <source>Pause synchronization</source>
+        <translation>Pausar a sincronização</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="185"/>
+        <source>Pause all kDrives synchronization</source>
+        <translation>Suspender toda a sincronização do kDrives</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="179"/>
+        <location filename="../src/gui/statusbarwidget.cpp" line="322"/>
+        <source>Resume synchronization</source>
+        <translation>Retomar a sincronização</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::SynchronizedItemWidget</name>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
+        <source>Copy share link</source>
+        <translation>Copiar link de partilha</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
+        <source>Display on kdrive.infomaniak.com</source>
+        <translation>Exibir em kdrive.infomaniak.com</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
+        <source>Show in folder</source>
+        <translation>Mostrar na pasta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
+        <source>More actions</source>
+        <translation>Mais ações</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="317"/>
+        <source>Open</source>
+        <translation>Abrir</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
+        <source>Add to favorites</source>
+        <translation>Adicionar aos favoritos</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::SynthesisBar</name>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="495"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="502"/>
+        <source>Never</source>
+        <translation>Nunca</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="496"/>
+        <source>During 1 hour</source>
+        <translation>Durante 1 hora</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="497"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="504"/>
+        <source>Until tomorrow 8:00AM</source>
+        <translation>Até amanhã às 8h00</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="498"/>
+        <source>During 3 days</source>
+        <translation>Durante 3 dias</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="499"/>
+        <source>During 1 week</source>
+        <translation>Durante uma semana</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="500"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="507"/>
+        <source>Always</source>
+        <translation>Sempre</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="503"/>
+        <source>For 1 more hour</source>
+        <translation>Por mais 1 hora</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="505"/>
+        <source>For 3 more days</source>
+        <translation>Ainda por mais 3 dias</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="506"/>
+        <source>For 1 more week</source>
+        <translation>Por mais uma semana</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="149"/>
+        <source>Unable to open folder url %1.</source>
+        <translation>Não foi possível abrir a URL da pasta %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="219"/>
+        <source>Open in folder</source>
+        <translation>Abrir na pasta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="257"/>
+        <source>Open %1 web version</source>
+        <translation>Abrir a versão web do %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="267"/>
+        <source>Drive parameters</source>
+        <translation>Parâmetros do acionamento</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="280"/>
+        <source>Notifications disabled until %1</source>
+        <translation>Notificações desativadas até %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="281"/>
+        <source>Disable Notifications</source>
+        <translation>Desativar notificações</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="314"/>
+        <source>Application preferences</source>
+        <translation>Preferências da aplicação</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="322"/>
+        <source>Need help</source>
+        <translation>Precisa de ajuda</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="330"/>
+        <source>Send feedbacks</source>
+        <translation>Enviar comentários</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="338"/>
+        <source>Quit kDrive</source>
+        <translation>Sair do kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="401"/>
+        <source>Unable to access web site %1.</source>
+        <translation>Não é possível aceder ao site %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="492"/>
+        <source>Show errors and informations</source>
+        <translation>Mostrar erros e informações</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="493"/>
+        <source>Show informations</source>
+        <translation>Mostrar informações</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="494"/>
+        <source>More actions</source>
+        <translation>Mais ações</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::SynthesisPopover</name>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1181"/>
+        <source>Update kDrive App</source>
+        <translation>Atualizar a aplicação kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1182"/>
+        <source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
+        <translation>Esta versão da aplicação kDrive já não é suportada. Para aceder às funcionalidades e melhorias mais recentes, atualize a aplicação.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="978"/>
+        <source>Update</source>
+        <translation>Atualização</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1187"/>
+        <source>Please download the latest version on the website.</source>
+        <translation>Por favor, descarregue a versão mais recente no site.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="981"/>
+        <source>Update download in progress</source>
+        <translation>Download da atualização em curso</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="984"/>
+        <source>Looking for update...</source>
+        <translation>À procura de atualizações...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="987"/>
+        <source>Manual update</source>
+        <translation>Atualização manual</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="990"/>
+        <source>Unavailable</source>
+        <translation>Indisponível</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1200"/>
+        <source>You can synchronize files &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;from your computer&lt;/a&gt; or on &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
+        <translation>Pode sincronizar ficheiros &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;a partir do seu computador&lt;/a&gt; ou em &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="446"/>
+        <source>Synchronized</source>
+        <translation>Sincronizado</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="450"/>
+        <source>Favorites</source>
+        <translation>Favoritos</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="454"/>
+        <source>Activity</source>
+        <translation>Atividade</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1133"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1180"/>
+        <source>Not implemented!</source>
+        <translation>Não implementado!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1184"/>
+        <source>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Click here to download manually&lt;/a&gt;</source>
+        <translation>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Clique aqui para fazer o download manualmente&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1193"/>
+        <source>No synchronized folder for this Drive!</source>
+        <translation>Não existe nenhuma pasta sincronizada para este Drive!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1196"/>
+        <source>No kDrive configured!</source>
+        <translation>O kDrive não está configurado!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1161"/>
+        <source>Unable to open link %1.</source>
+        <translation>Não foi possível abrir a ligação %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1173"/>
+        <source>Invalid link %1.</source>
+        <translation>Ligacao invalida %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="586"/>
+        <source>Unable to open folder url %1.</source>
+        <translation>Não foi possível abrir a URL da pasta %1.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::UpdateDialog</name>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="61"/>
+        <source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;A nova versão &lt;b&gt;%1&lt;/b&gt; do Cliente %2 está disponível e já foi descarregada.&lt;/p&gt;&lt;p&gt;A versão instalada é a %3.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="95"/>
+        <source>Skip this version</source>
+        <translation>Ignorar esta versão</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="103"/>
+        <source>Remind me later</source>
+        <translation>Lembra-me mais tarde</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="109"/>
+        <source>Install update</source>
+        <translation>Instalar atualização</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::UpdateManager</name>
+    <message>
+        <location filename="../src/server/updater/updatemanager.cpp" line="86"/>
+        <source>New update available.</source>
+        <translation>Está disponível uma nova atualização.</translation>
+    </message>
+    <message>
+        <location filename="../src/server/updater/updatemanager.cpp" line="87"/>
+        <source>Version %1 is available for download.</source>
+        <translation>A versão %1 está disponível para download.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::UserSelectionWidget</name>
+    <message>
+        <location filename="../src/gui/userselectionwidget.cpp" line="131"/>
+        <source>Add an account</source>
+        <translation>Adicionar uma conta</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::VersionWidget</name>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="295"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="169"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Show release note&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Mostrar notas de lançamento&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="172"/>
+        <source>Version</source>
+        <translation>Versão</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="173"/>
+        <source>UPDATE</source>
+        <translation>ATUALIZAÇÃO</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="197"/>
+        <source>%1 is up to date!</source>
+        <translation>O %1 está atualizado!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="201"/>
+        <source>Checking update on server...</source>
+        <translation>A verificar se há atualizações no servidor...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="205"/>
+        <source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;here&lt;/a&gt;.</source>
+        <translation>Está disponível uma atualização: %1.&lt;br&gt;Faça o download &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;aqui&lt;/a&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="212"/>
+        <source>An update is available: %1</source>
+        <translation>Está disponível uma atualização: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="218"/>
+        <source>Downloading %1. Please wait...</source>
+        <translation>A descarregar %1. Por favor, aguarde...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="223"/>
+        <source>Could not check for new updates.</source>
+        <translation>Não foi possível verificar se existem novas atualizações.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="227"/>
+        <source>An error occurred during update.</source>
+        <translation>Ocorreu um erro durante a atualização.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="231"/>
+        <source>Could not download update.</source>
+        <translation>Não foi possível descarregar a atualização.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="235"/>
+        <source>Update disabled.</source>
+        <translation>Atualização desativada.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="251"/>
+        <source>Beta program</source>
+        <translation>Programa beta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="252"/>
+        <source>Get early access to new versions of the application</source>
+        <translation>Obtenha acesso antecipado às novas versões da aplicação</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="256"/>
+        <source>Join</source>
+        <translation>Junte-se a nós</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="259"/>
+        <source>Modify</source>
+        <translation>Modificar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="259"/>
+        <source>Quit</source>
+        <translation>Sair</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/gui/parameterscache.cpp" line="59"/>
+        <source>Unable to save parameters, please retry later.</source>
+        <translation>Não foi possível guardar os parâmetros. Por favor, tente novamente mais tarde.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parameterscache.cpp" line="60"/>
+        <source>Unable to save parameters!</source>
+        <translation>Não é possível guardar os parâmetros!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="461"/>
+        <source>The parent folder is a sync folder or contained in one</source>
+        <translation>A pasta principal é uma pasta de sincronização ou está incluída numa</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="495"/>
+        <source>Can&apos;t find a valid path</source>
+        <translation>Não é possível encontrar um caminho válido</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2108"/>
+        <source>No valid folder selected!</source>
+        <translation>Não foi selecionada nenhuma pasta válida!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2119"/>
+        <source>The selected path does not exist!</source>
+        <translation>O caminho selecionado não existe!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2124"/>
+        <source>The selected path is not a folder!</source>
+        <translation>O caminho selecionado não é uma pasta!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2129"/>
+        <source>You have no permission to write to the selected folder!</source>
+        <translation>Não tem permissão para gravar na pasta selecionada!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2159"/>
+        <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
+        <translation>A pasta local %1 contém uma pasta que já está sincronizada. Por favor, escolha outra!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2167"/>
+        <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
+        <translation>A pasta local %1 está incluída numa pasta já sincronizada. Por favor, escolha outra!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2175"/>
+        <source>The local folder %1 is already synced. Please pick another one!</source>
+        <translation>A pasta local %1 já está sincronizada. Escolha outra!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="42"/>
+        <source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
+        <translation>A sincronização Lite (Beta) está ativada. Os ficheiros do kDrive permanecem na nuvem e não ocupam espaço de armazenamento no seu computador.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="45"/>
+        <source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
+        <translation>O Lite sync (Beta) está desativado. Os ficheiros do kDrive ocupam espaço de armazenamento no seu computador.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="48"/>
+        <source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
+        <translation>A sincronização Lite está ativada. Os ficheiros do kDrive permanecem na nuvem e não ocupam espaço de armazenamento no seu computador.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="50"/>
+        <source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
+        <translation>A sincronização Lite está desativada. Os ficheiros do kDrive ocupam espaço de armazenamento no seu computador.</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1175"/>
+        <source>Make available locally</source>
+        <translation>Disponibilizar localmente</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1179"/>
+        <source>Free up local space</source>
+        <translation>Liberte espaço no disco local</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1183"/>
+        <source>Cancel free up local space</source>
+        <translation>Cancelar para libertar espaço local</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1187"/>
+        <source>Cancel make available locally</source>
+        <translation>Cancelar disponibilização local</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1191"/>
+        <source>Resharing this file is not allowed</source>
+        <translation>Não é permitido partilhar novamente este ficheiro</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1192"/>
+        <source>Resharing this folder is not allowed</source>
+        <translation>Não é permitido partilhar novamente esta pasta</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1196"/>
+        <source>Copy public share link</source>
+        <translation>Copiar link de partilha pública</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1200"/>
+        <source>Copy private share link</source>
+        <translation>Copiar link de partilha privada</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1204"/>
+        <source>Open in browser</source>
+        <translation>Abrir no navegador</translation>
+    </message>
+</context>
+<context>
+    <name>SharedTools::QtSingleApplication</name>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="133"/>
+        <source>kDrive application will close due to a fatal error.</source>
+        <translation>A aplicação kDrive irá fechar devido a um erro grave.</translation>
+    </message>
+</context>
+<context>
+    <name>Utility</name>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="97"/>
+        <source>%L1 GB</source>
+        <translation>%L1 GB</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="101"/>
+        <source>%L1 MB</source>
+        <translation>%L1 MB</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="105"/>
+        <source>%L1 KB</source>
+        <translation>%L1 KB</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="108"/>
+        <source>%L1 B</source>
+        <translation>%L1 B</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="41"/>
+        <source>%n year(s)</source>
+        <translation>
+            <numerusform>%n ano</numerusform>
+            <numerusform>%n anos</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="42"/>
+        <source>%n month(s)</source>
+        <translation>
+            <numerusform>%n mes</numerusform>
+            <numerusform>%n meses</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="43"/>
+        <source>%n day(s)</source>
+        <translation>
+            <numerusform>%n dia</numerusform>
+            <numerusform>%n dias</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="44"/>
+        <source>%n hour(s)</source>
+        <translation>
+            <numerusform>%n hora</numerusform>
+            <numerusform>%n horas</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="45"/>
+        <source>%n minute(s)</source>
+        <translation>
+            <numerusform>%n minuto</numerusform>
+            <numerusform>%n minutos</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="46"/>
+        <source>%n second(s)</source>
+        <translation>
+            <numerusform>%n segundo</numerusform>
+            <numerusform>%n segundos</numerusform>
+        </translation>
+    </message>
+</context>
+<context>
+    <name>utility</name>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="84"/>
+        <source>Could not open browser</source>
+        <translation>Não foi possível abrir o navegador</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="85"/>
+        <source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
+        <translation>Ocorreu um erro ao iniciar o navegador para aceder ao URL %1. Será que não está configurado nenhum navegador predefinido?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="104"/>
+        <source>Could not open email client</source>
+        <translation>Não foi possível abrir o cliente de e-mail</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="105"/>
+        <source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
+        <translation>Ocorreu um erro ao iniciar o cliente de e-mail para criar uma nova mensagem. Será que não está configurado nenhum cliente de e-mail predefinido?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="324"/>
+        <source>You are not connected anymore. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Log in&lt;/a&gt;</source>
+        <translation>Já não está conectado. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Inicie sessão&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="347"/>
+        <source>Sync in progress (Step %1/%2).</source>
+        <translation>Sincronização em curso (Passo %1/%2).</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="353"/>
+        <source>Sync in progress.</source>
+        <translation>Sincronização em curso.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="364"/>
+        <source>Some files couldn&apos;t be synchronized. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Alguns ficheiros não puderam ser sincronizados. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Saiba mais&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="370"/>
+        <source>Synchronization pausing ...</source>
+        <translation>A sincronização está em pausa...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="570"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
+        <translation>A pasta &lt;b&gt;%1&lt;/b&gt; não pode ser selecionada porque outra sincronização está a utilizar a mesma pasta.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="576"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+        <translation>A pasta &lt;b&gt;%1&lt;/b&gt; não pode ser selecionada porque contém a pasta sincronizada &lt;b&gt;%2&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="584"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+        <translation>A pasta &lt;b&gt;%1&lt;/b&gt; não pode ser selecionada porque está incluída na pasta sincronizada &lt;b&gt;%2&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="595"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
+        <translation>A pasta &lt;b&gt;%1&lt;/b&gt; não pode ser selecionada como pasta de sincronização. Por favor, selecione outra pasta.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="599"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
+        <translation>A pasta &lt;b&gt;%1&lt;/b&gt; não pode ser selecionada como pasta de sincronização. Por favor, selecione outra pasta. Pasta sugerida: &lt;b&gt;%2&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="651"/>
+        <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
+        <translation>Excluiu mais de %1 pastas; tenha em atenção que isto irá afetar o desempenho da sincronização.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="660"/>
+        <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
+        <translation>Não é possível excluir mais do que %1 pastas. Desmarque as pastas de nível superior.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="351"/>
+        <source>Synchronization starting</source>
+        <translation>A sincronização está a começar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="374"/>
+        <source>Synchronization paused.</source>
+        <translation>A sincronização foi interrompida.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="336"/>
+        <source>Sync in progress (%1 of %2)</source>
+        <translation>Sincronização em curso (%1 de %2)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="340"/>
+        <source>Sync in progress (%1 of %2)
 %3 left...</source>
-            <translation>Sincronização em curso (%1 de %2)
+        <translation>Sincronização em curso (%1 de %2)
 Faltam %3...</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="358" />
-            <source>You are up to date, unresolved conflicts.</source>
-            <translation>Estás em dia com os conflitos pendentes.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="360" />
-            <source>You are up to date!</source>
-            <translation>Já está tudo em dia!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="329" />
-            <source>No folder to synchronize
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="358"/>
+        <source>You are up to date, unresolved conflicts.</source>
+        <translation>Estás em dia com os conflitos pendentes.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="360"/>
+        <source>You are up to date!</source>
+        <translation>Já está tudo em dia!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="329"/>
+        <source>No folder to synchronize
 You can add one from the kDrive settings.</source>
-            <translation>Não existe nenhuma pasta para sincronizar
+        <translation>Não existe nenhuma pasta para sincronizar
 Pode adicionar uma nas definições do kDrive.</translation>
-        </message>
-    </context>
+    </message>
+</context>
 </TS>

--- a/translations/update_ui_translations.py
+++ b/translations/update_ui_translations.py
@@ -48,6 +48,7 @@ DEEPL_LANGUAGE_CODES = {
     "fr": "FR",
     "it": "IT",
     "nb": "NB",
+    "fi": "FI",
     "pl": "PL",
     "sv": "SV",
     "pt": "PT-PT",
@@ -83,7 +84,7 @@ def fill_missing_translations(git_dir_path, language):
     
     
 
-languages = ["de", "es", "fr", "it", "sv", "pt", "pl", "nb"]
+languages = ["de", "es", "fr", "it", "sv", "pt", "pl", "nb", "fi"]
 
 for language in languages:
     fill_missing_translations(args.git_dir_path, language)


### PR DESCRIPTION
## Summary

Add Finnish (`fi`) language support following the same pattern as the other recently added languages (Norwegian, Polish, Portuguese, Swedish).

## Changes

- **`Language::Finnish`** added to the `Language` enum (`cstypes.h`)
- **`toString()`**, **`languageCode()`**, **`isSupportedLanguage()`** updated with Finnish (`utility.h/.cpp`, `types.cpp`)
- **`GuiUtility::languageToQLocale()`** returns `QLocale::Finnish` (`guiutility.cpp`)
- Language selector combo box updated (`preferenceswidget.cpp`)
- Migration parsing: `"fi"` → `Language::Finnish` (`migrationparams.cpp`)
- Unit tests added for `languageCode` and `isSupportedLanguage` (`testutility.cpp`)
- `translations/client_fi.ts` created via `lupdate` (unfinished entries ready for DeepL)
- `"Finnish"` language name translated in all 8 existing TS files (de/es/fr/it/nb/pl/pt/sv)
- `update_ui_translations.py`: `"fi": "FI"` added to DeepL codes and `"fi"` to languages list
- Linux AppImage build script: `*_fi.qm` added to retained translations

## Dependencies

Depends on #1837