### PR TITLE
feat(i18n): add Danish localization support

### DIFF
--- a/infomaniak-build-tools/linux/build-release-appimage.sh
+++ b/infomaniak-build-tools/linux/build-release-appimage.sh
@@ -254,7 +254,7 @@ function clean_app_directory() {
   find . -mindepth 1 -maxdepth 1 \( -type f -o -type l \) ! -name "libqsqlite.so" -delete
   cd /app
 
-  # Clean translations - keep only de, es, fr, it, sv, pt, pl, nb, fi, en
+  # Clean translations - keep only de, es, fr, it, sv, pt, pl, nb, fi, da, en
   echo "  Cleaning translations..."
   cd ./usr/translations
 
@@ -263,9 +263,9 @@ function clean_app_directory() {
 
   # For other Qt translations, keep only supported languages
   for prefix in qt qtbase qtconnectivity qtdeclarative qtlocation qtmultimedia qtserialport qtwebsockets; do
-    # Remove all except de, es, fr, it, sv, pt, pl, nb, fi, en
+    # Remove all except de, es, fr, it, sv, pt, pl, nb, fi, da, en
     find . -mindepth 1 -maxdepth 1 \( -type f -o -type l \) -name "${prefix}_*.qm" \
-      ! -name "*_de.qm" ! -name "*_es.qm" ! -name "*_fr.qm" ! -name "*_it.qm" ! -name "*_sv.qm" ! -name "*_pt.qm" ! -name "*_pl.qm" ! -name "*_nb.qm" ! -name "*_fi.qm" ! -name "*_en.qm" -delete
+      ! -name "*_de.qm" ! -name "*_es.qm" ! -name "*_fr.qm" ! -name "*_it.qm" ! -name "*_sv.qm" ! -name "*_pt.qm" ! -name "*_pl.qm" ! -name "*_nb.qm" ! -name "*_fi.qm" ! -name "*_da.qm" ! -name "*_en.qm" -delete
   done
 
   cd /app

--- a/src/gui/guiutility.cpp
+++ b/src/gui/guiutility.cpp
@@ -634,6 +634,8 @@ QLocale GuiUtility::languageToQLocale(Language language) {
             return QLocale::NorwegianBokmal;
         case Language::Finnish:
             return QLocale::Finnish;
+        case Language::Danish:
+            return QLocale::Danish;
         default:
             return QLocale();
     }

--- a/src/gui/preferenceswidget.cpp
+++ b/src/gui/preferenceswidget.cpp
@@ -513,6 +513,7 @@ void PreferencesWidget::retranslateUi() const {
     _languageSelectorComboBox->addItem(tr("Polish"), toInt(Language::Polish));
     _languageSelectorComboBox->addItem(tr("Norwegian"), toInt(Language::Norwegian));
     _languageSelectorComboBox->addItem(tr("Finnish"), toInt(Language::Finnish));
+    _languageSelectorComboBox->addItem(tr("Danish"), toInt(Language::Danish));
     const int languageIndex =
             _languageSelectorComboBox->findData(toInt(ParametersCache::instance()->parametersInfo().language()));
     _languageSelectorComboBox->setCurrentIndex(languageIndex);

--- a/src/libcommon/utility/cstypes.h
+++ b/src/libcommon/utility/cstypes.h
@@ -191,6 +191,7 @@ enum class Language {
     Polish,
     Norwegian,
     Finnish,
+    Danish,
     EnumEnd
 };
 

--- a/src/libcommon/utility/types.cpp
+++ b/src/libcommon/utility/types.cpp
@@ -547,6 +547,8 @@ std::string toString(const Language e) {
             return "Norwegian";
         case Language::Finnish:
             return "Finnish";
+        case Language::Danish:
+            return "Danish";
         default:
             return noConversionStr;
     }

--- a/src/libcommon/utility/utility.cpp
+++ b/src/libcommon/utility/utility.cpp
@@ -101,6 +101,7 @@ const QString CommonUtility::portugueseCode = "pt";
 const QString CommonUtility::polishCode = "pl";
 const QString CommonUtility::norwegianCode = "nb";
 const QString CommonUtility::finnishCode = "fi";
+const QString CommonUtility::danishCode = "da";
 
 static std::random_device rd;
 static std::default_random_engine gen(rd());
@@ -811,7 +812,7 @@ bool CommonUtility::languageCodeIsEnglish(const QString &languageCode) {
 bool CommonUtility::isSupportedLanguage(const QString &languageCode) {
     static const std::unordered_set<QString> supportedLanguages = {englishCode,   frenchCode,  germanCode,     italianCode,
                                                                    spanishCode,   swedishCode, portugueseCode, polishCode,
-                                                                   norwegianCode, finnishCode};
+                                                                   norwegianCode, finnishCode, danishCode};
     return supportedLanguages.contains(languageCode);
 }
 
@@ -841,6 +842,8 @@ QString CommonUtility::languageCode(const Language language) {
             return norwegianCode;
         case Language::Finnish:
             return finnishCode;
+        case Language::Danish:
+            return danishCode;
         case Language::English:
             break;
         case Language::EnumEnd:

--- a/src/libcommon/utility/utility.h
+++ b/src/libcommon/utility/utility.h
@@ -116,6 +116,7 @@ struct COMMON_EXPORT CommonUtility {
         static const QString polishCode;
         static const QString norwegianCode;
         static const QString finnishCode;
+        static const QString danishCode;
         static QString languageCode(Language language);
         static QStringList languageCodeList(Language enforcedLocale);
         static void setupTranslations(QCoreApplication *app, Language enforcedLocale);

--- a/src/server/migration/migrationparams.cpp
+++ b/src/server/migration/migrationparams.cpp
@@ -117,6 +117,8 @@ Language MigrationParams::strToLanguage(QString lang) {
         return Language::Norwegian;
     } else if (lang == "fi") {
         return Language::Finnish;
+    } else if (lang == "da") {
+        return Language::Danish;
     } else {
         return Language::Default;
     }

--- a/test/libcommon/utility/testutility.cpp
+++ b/test/libcommon/utility/testutility.cpp
@@ -490,6 +490,7 @@ void TestUtility::testLanguageCode() {
     CPPUNIT_ASSERT_EQUAL(std::string("pl"), CommonUtility::languageCode(Language::Polish).toStdString());
     CPPUNIT_ASSERT_EQUAL(std::string("nb"), CommonUtility::languageCode(Language::Norwegian).toStdString());
     CPPUNIT_ASSERT_EQUAL(std::string("fi"), CommonUtility::languageCode(Language::Finnish).toStdString());
+    CPPUNIT_ASSERT_EQUAL(std::string("da"), CommonUtility::languageCode(Language::Danish).toStdString());
 
     const auto systemLanguage = QLocale::languageToCode(QLocale::system().language());
     CPPUNIT_ASSERT_EQUAL(systemLanguage.toStdString(), CommonUtility::languageCode(Language::Default).toStdString());
@@ -509,6 +510,7 @@ void TestUtility::testIsSupportedLanguage() {
     CPPUNIT_ASSERT_EQUAL(true, CommonUtility::isSupportedLanguage("pl"));
     CPPUNIT_ASSERT_EQUAL(true, CommonUtility::isSupportedLanguage("nb"));
     CPPUNIT_ASSERT_EQUAL(true, CommonUtility::isSupportedLanguage("fi"));
+    CPPUNIT_ASSERT_EQUAL(true, CommonUtility::isSupportedLanguage("da"));
     CPPUNIT_ASSERT_EQUAL(false, CommonUtility::isSupportedLanguage("ita"));
     CPPUNIT_ASSERT_EQUAL(false, CommonUtility::isSupportedLanguage("zc"));
     CPPUNIT_ASSERT_EQUAL(false, CommonUtility::isSupportedLanguage(""));

--- a/translations/client_da.ts
+++ b/translations/client_da.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="sv_SE">
+<TS version="2.1" language="da_DK">
 <context>
     <name>KDC::AboutDialog</name>
     <message>
@@ -11,34 +11,34 @@
     <message>
         <location filename="../src/gui/aboutdialog.cpp" line="112"/>
         <source>CLOSE</source>
-        <translation>STÄNG</translation>
+        <translation>LUK</translation>
     </message>
     <message>
         <location filename="../src/gui/aboutdialog.cpp" line="123"/>
         <source>Version %1. For more information visit &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
-        <translation>Version %1. För mer information, besök &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
+        <translation>Version %1. For mere information besøg &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
     </message>
     <message>
         <location filename="../src/gui/aboutdialog.cpp" line="126"/>
         <source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
-        <translation>Copyright 2019–%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
+        <translation>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
     </message>
     <message>
         <location filename="../src/gui/aboutdialog.cpp" line="127"/>
         <source>Distributed by %1 and licensed under the &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
-        <translation>Distribueras av %1 och licensieras enligt &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 och %2-logotypen är registrerade varumärken som tillhör %1.&lt;br&gt;&lt;br&gt;</translation>
+        <translation>Distribueret af %1 og licenseret under &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 og %2-logoet er registrerede varemærker tilhørende %1.&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="132"/>
+        <source>&lt;p&gt;&lt;small&gt;Built from &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
+        <translation>&lt;p&gt;&lt;small&gt;Bygget fra &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git-kildekode&lt;/a&gt; den %2, %3 med Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
     </message>
     <message>
         <location filename="../src/gui/aboutdialog.cpp" line="151"/>
         <location filename="../src/gui/aboutdialog.cpp" line="162"/>
         <location filename="../src/gui/aboutdialog.cpp" line="171"/>
         <source>Unable to open folder %1.</source>
-        <translation>Det går inte att öppna mappen %1.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/aboutdialog.cpp" line="132"/>
-        <source>&lt;p&gt;&lt;small&gt;Built from &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
-        <translation>&lt;p&gt;&lt;small&gt;Kompilerad från &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git-källkod&lt;/a&gt; den %2, %3 med Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
+        <translation>Kan ikke åbne mappen %1.</translation>
     </message>
 </context>
 <context>
@@ -46,7 +46,7 @@
     <message>
         <location filename="../src/gui/abstractfileitemwidget.cpp" line="177"/>
         <source>Unable to open folder path %1.</source>
-        <translation>Det går inte att öppna mappsökvägen %1.</translation>
+        <translation>Kan ikke åbne mappestien %1.</translation>
     </message>
 </context>
 <context>
@@ -54,27 +54,27 @@
     <message>
         <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55"/>
         <source>Synchronization will start and you will be able to add files to your %1 folder.</source>
-        <translation>Synkroniseringen startar och du kan lägga till filer i mappen %1.</translation>
+        <translation>Synkronisering starter, og du vil kunne tilføje filer til din %1-mappe.</translation>
     </message>
     <message>
         <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99"/>
         <source>Your kDrive is ready!</source>
-        <translation>Din kDrive är klar!</translation>
+        <translation>Din kDrive er klar!</translation>
     </message>
     <message>
         <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123"/>
         <source>OPEN FOLDER</source>
-        <translation>ÖPPNA MAPP</translation>
+        <translation>ÅBEN MAPPE</translation>
     </message>
     <message>
         <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130"/>
         <source>PARAMETERS</source>
-        <translation>INSTÄLLNINGAR</translation>
+        <translation>INDSTILLINGER</translation>
     </message>
     <message>
         <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138"/>
         <source>Synchronize another drive</source>
-        <translation>Synkronisera en annan enhet</translation>
+        <translation>Synkroniser et andet drev</translation>
     </message>
 </context>
 <context>
@@ -82,50 +82,65 @@
     <message>
         <location filename="../src/gui/adddrivelistwidget.cpp" line="170"/>
         <source>Cancel</source>
-        <translation>Avbryt</translation>
+        <translation>Annuller</translation>
     </message>
     <message>
         <location filename="../src/gui/adddrivelistwidget.cpp" line="177"/>
         <source>NEXT</source>
-        <translation>NÄSTA</translation>
+        <translation>NÆSTE</translation>
     </message>
     <message>
         <location filename="../src/gui/adddrivelistwidget.cpp" line="196"/>
         <source>Select the kDrive you want to synchronize</source>
-        <translation>Välj den kDrive du vill synkronisera</translation>
+        <translation>Vælg den kDrive, du vil synkronisere</translation>
     </message>
     <message>
         <location filename="../src/gui/adddrivelistwidget.cpp" line="234"/>
         <source>Get kDrive for free</source>
-        <translation>Skaffa kDrive gratis</translation>
+        <translation>Få kDrive gratis</translation>
     </message>
     <message>
         <location filename="../src/gui/adddrivelistwidget.cpp" line="244"/>
         <source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
-        <translation>Spara dina bilder, dokument och e-postmeddelanden i Schweiz hos ett oberoende företag som respekterar din integritet. Läs mer</translation>
+        <translation>Gem dine billeder, dokumenter og e-mails i Schweiz hos et uafhængigt selskab, der respekterer privatlivets fred. Læs mere</translation>
     </message>
     <message>
         <location filename="../src/gui/adddrivelistwidget.cpp" line="263"/>
         <source>Test for free</source>
-        <translation>Testa gratis</translation>
+        <translation>Test gratis</translation>
     </message>
 </context>
 <context>
     <name>KDC::AddDriveLiteSyncWidget</name>
     <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112"/>
+        <source>Would you like to activate Lite Sync (Beta) ?</source>
+        <translation>Vil du aktivere Lite Sync (Beta)?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114"/>
+        <source>Would you like to activate Lite Sync ?</source>
+        <translation>Vil du aktivere Lite Sync?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
+        <source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Lite Sync synkroniserer alle dine filer uden at bruge plads på din computer. Du kan gennemse filerne i din kDrive og downloade dem lokalt, når du vil. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Læs mere&lt;/a&gt;</translation>
+    </message>
+    <message>
         <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147"/>
         <source>Conserve your computer space</source>
-        <translation>Spara utrymme på datorn</translation>
+        <translation>Bevar plads på din computer</translation>
     </message>
     <message>
         <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167"/>
         <source>Decide which files should be available online or locally</source>
-        <translation>Bestäm vilka filer som ska vara tillgängliga online eller lokalt</translation>
+        <translation>Beslut, hvilke filer der skal være tilgængelige online eller lokalt</translation>
     </message>
     <message>
         <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187"/>
         <source>LATER</source>
-        <translation>SENARE</translation>
+        <translation>SENERE</translation>
     </message>
     <message>
         <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193"/>
@@ -133,24 +148,9 @@
         <translation>JA</translation>
     </message>
     <message>
-        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
-        <source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation>Lite Sync synkroniserar alla dina filer utan att ta upp utrymme på din dator. Du kan bläddra bland filerna i ditt kDrive och ladda ner dem lokalt när du vill. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Läs mer&lt;/a&gt;</translation>
-    </message>
-    <message>
         <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207"/>
         <source>Unable to open link %1.</source>
-        <translation>Det går inte att öppna länken %1.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112"/>
-        <source>Would you like to activate Lite Sync (Beta) ?</source>
-        <translation>Vill du aktivera Lite Sync (Beta)?</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114"/>
-        <source>Would you like to activate Lite Sync ?</source>
-        <translation>Vill du aktivera Lite Sync?</translation>
+        <translation>Kan ikke åbne linket %1.</translation>
     </message>
 </context>
 <context>
@@ -158,51 +158,51 @@
     <message>
         <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65"/>
         <source>Location of your %1 kDrive</source>
-        <translation>Plats för din %1 kDrive</translation>
+        <translation>Placering af din %1 kDrive</translation>
     </message>
     <message>
         <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155"/>
         <source>Edit folder</source>
-        <translation>Ändra mapp</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
-        <source>END</source>
-        <translation>SLUTFÖR</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
-        <source>Select folder</source>
-        <translation>Välj mapp</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
-        <source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
-        <translation>Innehållet i mappen &lt;b&gt;%1&lt;/b&gt; kommer att synkroniseras i din kDrive</translation>
+        <translation>Rediger mappe</translation>
     </message>
     <message>
         <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212"/>
         <source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
-        <translation>När konfigurationen är klar hittar du alla dina filer i den här mappen. Du kan lägga in nya filer där för att synkronisera dem till din kDrive.</translation>
+        <translation>Du vil finde alle dine filer i denne mappe, når konfigurationen er afsluttet. Du kan placere nye filer der for at synkronisere dem til din kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+        <source>END</source>
+        <translation>AFSLUT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+        <source>CONTINUE</source>
+        <translation>FORTSÆT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
+        <source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
+        <translation>Indholdet af mappen &lt;b&gt;%1&lt;/b&gt; vil blive synkroniseret i din kDrive</translation>
     </message>
     <message>
         <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284"/>
         <source>This folder is not compatible with Lite Sync.&lt;br&gt; 
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt; 
 &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation>Den här mappen är inte kompatibel med Lite Sync.&lt;br&gt; 
-Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&gt; 
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Läs mer&lt;/a&gt;</translation>
+        <translation>Denne mappe er ikke kompatibel med Lite Sync.&lt;br&gt; 
+Vælg venligst en anden mappe. Hvis du fortsætter, deaktiveres Lite Sync.&lt;br&gt; 
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Læs mere&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
+        <source>Select folder</source>
+        <translation>Vælg mappe</translation>
     </message>
     <message>
         <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377"/>
         <source>Unable to open link %1.</source>
-        <translation>Det går inte att öppna länken %1.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
-        <source>CONTINUE</source>
-        <translation>FORTSÄTT</translation>
+        <translation>Kan ikke åbne linket %1.</translation>
     </message>
 </context>
 <context>
@@ -210,32 +210,32 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
     <message>
         <location filename="../src/gui/adddriveloginwidget.cpp" line="69"/>
         <source>Log in from your browser</source>
-        <translation>Logga in från din webbläsare</translation>
+        <translation>Log ind fra din browser</translation>
     </message>
     <message>
         <location filename="../src/gui/adddriveloginwidget.cpp" line="75"/>
         <source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
-        <translation>Din webbläsare bör öppnas automatiskt för att slutföra anslutningen. När anslutningen är upprättad återgår du automatiskt till kDrive.</translation>
+        <translation>Din browser bør åbne automatisk for at fuldføre forbindelsen. Når du er forbundet, vender du automatisk tilbage til kDrive.</translation>
     </message>
     <message>
         <location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
         <source>Open the login page</source>
-        <translation>Öppna inloggningssidan</translation>
+        <translation>Åbn login-siden</translation>
     </message>
     <message>
         <location filename="../src/gui/adddriveloginwidget.cpp" line="119"/>
         <source>Token request failed: %1 - %2</source>
-        <translation>Begäran om token misslyckades: %1 - %2</translation>
+        <translation>Token-anmodning mislykkedes: %1 - %2</translation>
     </message>
     <message>
         <location filename="../src/gui/adddriveloginwidget.cpp" line="133"/>
         <source>Login failed: %1 - %2</source>
-        <translation>Inloggningen misslyckades: %1 - %2</translation>
+        <translation>Login mislykkedes: %1 - %2</translation>
     </message>
     <message>
         <location filename="../src/gui/adddriveloginwidget.cpp" line="141"/>
         <source>Failed to open the login page in your web browser</source>
-        <translation>Det gick inte att öppna inloggningssidan i din webbläsare</translation>
+        <translation>Kunne ikke åbne login-siden i din webbrowser</translation>
     </message>
 </context>
 <context>
@@ -243,27 +243,27 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
     <message>
         <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129"/>
         <source>Select kDrive folders to synchronize on your desktop</source>
-        <translation>Välj vilka kDrive-mappar som ska synkroniseras på din dator</translation>
+        <translation>Vælg kDrive-mapper til synkronisering på din computer</translation>
     </message>
     <message>
         <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174"/>
         <source>CONTINUE</source>
-        <translation>FORTSÄTT</translation>
+        <translation>FORTSÆT</translation>
     </message>
     <message>
         <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187"/>
         <source>Space available on your computer : %1</source>
-        <translation>Ledigt utrymme på din dator: %1</translation>
+        <translation>Tilgængeligt plads på din computer: %1</translation>
     </message>
     <message>
         <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206"/>
         <source>An error occurred while loading the list of subfolders.</source>
-        <translation>Ett fel uppstod vid inläsningen av listan över undermappar.</translation>
+        <translation>Der opstod en fejl under indlæsning af listen over undermapper.</translation>
     </message>
     <message>
         <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210"/>
         <source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
-        <translation>Det går inte att ladda listan över undermappar&lt;br&gt;. Din kDrive kan vara under underhåll. Logga in på &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;webbversionen&lt;/a&gt; för att kontrollera statusen för din kDrive, eller kontakta din administratör.</translation>
+        <translation>Kan ikke indlæse listen over undermapper. Din kDrive er muligvis i vedligeholdelsestilstand.&lt;br&gt;Log venligst ind på &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;webversionen&lt;/a&gt; for at kontrollere din kDrive-status, eller kontakt din administrator.</translation>
     </message>
 </context>
 <context>
@@ -271,17 +271,17 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
     <message>
         <location filename="../src/gui/adddrivewizard.cpp" line="222"/>
         <source>Failed to create local folder %1</source>
-        <translation>Det gick inte att skapa den lokala mappen %1</translation>
+        <translation>Kunne ikke oprette lokal mappe %1</translation>
     </message>
     <message>
         <location filename="../src/gui/adddrivewizard.cpp" line="233"/>
         <source>Failed to create new synchronization</source>
-        <translation>Det gick inte att skapa en ny synkronisering</translation>
+        <translation>Kunne ikke oprette ny synkronisering</translation>
     </message>
     <message>
         <location filename="../src/gui/adddrivewizard.cpp" line="266"/>
         <source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
-        <translation>kDrive %1 är redan synkroniserat på den här datorn. Vill du fortsätta ändå?</translation>
+        <translation>kDrive %1 er allerede synkroniseret på denne computer. Fortsæt alligevel?</translation>
     </message>
 </context>
 <context>
@@ -289,17 +289,17 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
     <message>
         <location filename="../src/gui/appclient.cpp" line="100"/>
         <source>kDrive client is run with bad parameters!</source>
-        <translation>kDrive-klienten körs med felaktiga parametrar!</translation>
+        <translation>kDrive-klienten kører med forkerte parametre!</translation>
     </message>
     <message>
         <location filename="../src/gui/appclient.cpp" line="109"/>
         <source>kDrive client is already running!</source>
-        <translation>kDrive-klienten är redan igång!</translation>
+        <translation>kDrive-klienten kører allerede!</translation>
     </message>
     <message>
         <location filename="../src/gui/appclient.cpp" line="719"/>
         <source>The user %1 is not connected. Please log in again.</source>
-        <translation>Användaren %1 är inte inloggad. Logga in igen.</translation>
+        <translation>Brugeren %1 er ikke tilsluttet. Log venligst ind igen.</translation>
     </message>
 </context>
 <context>
@@ -307,62 +307,62 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
     <message>
         <location filename="../src/server/appserver.cpp" line="1685"/>
         <source>Share link copied to clipboard</source>
-        <translation>Delningslänken har kopierats till urklipp</translation>
+        <translation>Delingslink kopieret til udklipsholderen</translation>
     </message>
     <message numerus="yes">
         <location filename="../src/server/appserver.cpp" line="3773"/>
         <source>%1 and %n other file(s) have been removed.</source>
         <translation>
-            <numerusform>%1 och %n annan fil har tagits bort.</numerusform>
-            <numerusform>%1 och %n andra filer har tagits bort.</numerusform>
+            <numerusform>%1 og %n anden fil er blevet fjernet.</numerusform>
+            <numerusform>%1 og %n andre filer er blevet fjernet.</numerusform>
         </translation>
     </message>
     <message>
         <location filename="../src/server/appserver.cpp" line="3775"/>
         <source>%1 has been removed.</source>
         <comment>%1 names a file.</comment>
-        <translation>%1 har tagits bort.</translation>
+        <translation>%1 er blevet fjernet.</translation>
     </message>
     <message numerus="yes">
         <location filename="../src/server/appserver.cpp" line="3780"/>
         <source>%1 and %n other file(s) have been added.</source>
         <translation>
-            <numerusform>%1 och %n annan fil har lagts till.</numerusform>
-            <numerusform>%1 och %n andra filer har lagts till.</numerusform>
+            <numerusform>%1 og %n anden fil er blevet tilføjet.</numerusform>
+            <numerusform>%1 og %n andre filer er blevet tilføjet.</numerusform>
         </translation>
     </message>
     <message>
         <location filename="../src/server/appserver.cpp" line="3782"/>
         <source>%1 has been added.</source>
         <comment>%1 names a file.</comment>
-        <translation>%1 har lagts till.</translation>
+        <translation>%1 er blevet tilføjet.</translation>
     </message>
     <message numerus="yes">
         <location filename="../src/server/appserver.cpp" line="3787"/>
         <source>%1 and %n other file(s) have been updated.</source>
         <translation>
-            <numerusform>%1 och %n annan fil har uppdaterats.</numerusform>
-            <numerusform>%1 och %n andra filer har uppdaterats.</numerusform>
+            <numerusform>%1 og %n anden fil er blevet opdateret.</numerusform>
+            <numerusform>%1 og %n andre filer er blevet opdateret.</numerusform>
         </translation>
     </message>
     <message>
         <location filename="../src/server/appserver.cpp" line="3789"/>
         <source>%1 has been updated.</source>
         <comment>%1 names a file.</comment>
-        <translation>%1 har uppdaterats.</translation>
+        <translation>%1 er blevet opdateret.</translation>
     </message>
     <message numerus="yes">
         <location filename="../src/server/appserver.cpp" line="3794"/>
         <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
         <translation>
-            <numerusform>%1 har flyttats till %2 och %n annan fil har flyttats.</numerusform>
-            <numerusform>%1 har flyttats till %2 och %n andra filer har flyttats.</numerusform>
+            <numerusform>%1 er blevet flyttet til %2 og %n anden fil er blevet flyttet.</numerusform>
+            <numerusform>%1 er blevet flyttet til %2 og %n andre filer er blevet flyttet.</numerusform>
         </translation>
     </message>
     <message>
         <location filename="../src/server/appserver.cpp" line="3797"/>
         <source>%1 has been moved to %2.</source>
-        <translation>%1 har flyttats till %2.</translation>
+        <translation>%1 er blevet flyttet til %2.</translation>
     </message>
     <message>
         <location filename="../src/server/appserver.cpp" line="3805"/>
@@ -375,7 +375,7 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
     <message>
         <location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102"/>
         <source>No subfolders currently on the server.</source>
-        <translation>Det finns för närvarande inga undermappar på servern.</translation>
+        <translation>Ingen undermapper på serveren i øjeblikket.</translation>
     </message>
 </context>
 <context>
@@ -383,22 +383,22 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
     <message>
         <location filename="../src/gui/betaprogramdialog.cpp" line="69"/>
         <source>Quit the beta program</source>
-        <translation>Avsluta betaprogrammet</translation>
+        <translation>Forlad betaprogrammet</translation>
     </message>
     <message>
         <location filename="../src/gui/betaprogramdialog.cpp" line="69"/>
         <source>Join the beta program</source>
-        <translation>Anmäl dig till betaprogrammet</translation>
+        <translation>Tilmeld betaprogrammet</translation>
     </message>
     <message>
         <location filename="../src/gui/betaprogramdialog.cpp" line="77"/>
         <source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
-        <translation>Få tillgång till nya versioner av applikationen innan de släpps till allmänheten och bidra till att förbättra applikationen genom att skicka oss dina synpunkter.</translation>
+        <translation>Få tidlig adgang til nye versioner af applikationen, før de udgives til offentligheden, og deltag i forbedringen af applikationen ved at sende os dine kommentarer.</translation>
     </message>
     <message>
         <location filename="../src/gui/betaprogramdialog.cpp" line="87"/>
         <source>Benefit from application beta updates</source>
-        <translation>Dra nytta av uppdateringar av betaversionen av appen</translation>
+        <translation>Nyd godt af applikationens beta-opdateringer</translation>
     </message>
     <message>
         <location filename="../src/gui/betaprogramdialog.cpp" line="91"/>
@@ -418,146 +418,145 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
     <message>
         <location filename="../src/gui/betaprogramdialog.cpp" line="141"/>
         <source>I understand</source>
-        <translation>Jag förstår</translation>
+        <translation>Jeg forstår</translation>
     </message>
     <message>
         <location filename="../src/gui/betaprogramdialog.cpp" line="147"/>
         <source>Are you sure you want to leave the beta program?</source>
-        <translation>Är du säker på att du vill lämna betaprogrammet?</translation>
+        <translation>Er du sikker på, at du vil forlade betaprogrammet?</translation>
     </message>
     <message>
         <location filename="../src/gui/betaprogramdialog.cpp" line="161"/>
         <source>Save</source>
-        <translation>Spara</translation>
+        <translation>Gem</translation>
     </message>
     <message>
         <location filename="../src/gui/betaprogramdialog.cpp" line="167"/>
         <source>Cancel</source>
-        <translation>Avbryt</translation>
+        <translation>Annuller</translation>
     </message>
     <message>
         <location filename="../src/gui/betaprogramdialog.cpp" line="228"/>
         <source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
-        <translation>Din nuvarande version av appen kan vara för ny; ditt val träder i kraft när nästa uppdatering blir tillgänglig.</translation>
+        <translation>Din nuværende version af applikationen er måske for ny. Dit valg træder i kraft, når den næste opdatering er tilgængelig.</translation>
     </message>
     <message>
         <location filename="../src/gui/betaprogramdialog.cpp" line="233"/>
         <source>Beta versions may leave unexpectedly or cause instabilities.</source>
-        <translation>Betaversioner kan stängas ner utan förvarning eller orsaka instabilitet.</translation>
+        <translation>Betaversioner kan afsluttes uventet eller forårsage ustabilitet.</translation>
     </message>
 </context>
 <context>
     <name>KDC::ClientGui</name>
     <message>
+        <location filename="../src/gui/clientgui.cpp" line="116"/>
+        <source>Unable to initialize kDrive client</source>
+        <translation>Kan ikke initialisere kDrive-klienten</translation>
+    </message>
+    <message>
         <location filename="../src/gui/clientgui.cpp" line="189"/>
         <source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
-        <translation>Det gick inte att lösa konflikterna för %1 objekt i synkroniseringsmappen: %2</translation>
+        <translation>Kunne ikke løse konflikt(er) på %1 element(er) i synkroniseringsmappen: %2</translation>
     </message>
     <message>
         <location filename="../src/gui/clientgui.cpp" line="242"/>
         <source>Please sign in</source>
-        <translation>Logga in</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="292"/>
-        <source>Folder %1: %2</source>
-        <translation>Mappen %1: %2</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="298"/>
-        <source>There are no sync folders configured.</source>
-        <translation>Det finns inga synkroniseringsmappar konfigurerade.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="1422"/>
-        <source>Synthesis</source>
-        <translation>Sammanfattning</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="1423"/>
-        <source>Preferences</source>
-        <translatorcomment>Préférences</translatorcomment>
-        <translation>Inställningar</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="1424"/>
-        <source>Quit</source>
-        <translation>Avsluta</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="673"/>
-        <source>Undefined State.</source>
-        <translation>Odefinierat tillstånd.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="676"/>
-        <source>Waiting to start syncing.</source>
-        <translation>Väntar på att synkroniseringen ska starta.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="679"/>
-        <source>Sync is running.</source>
-        <translation>Synkroniseringen pågår.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="683"/>
-        <source>Sync was successful, unresolved conflicts.</source>
-        <translation>Synkroniseringen lyckades, men det finns olösta konflikter.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="685"/>
-        <source>Last Sync was successful.</source>
-        <translation>Den senaste synkroniseringen genomfördes utan problem.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="692"/>
-        <source>User Abort.</source>
-        <translation>Användaren avbryter.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="696"/>
-        <source>Sync is paused.</source>
-        <translation>Synkroniseringen är pausad.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="705"/>
-        <source>%1 (Sync is paused)</source>
-        <translation>%1 (Synkroniseringen är pausad)</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="1257"/>
-        <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-        <translation>Vill du verkligen ta bort synkroniseringarna för kontot &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Obs!&lt;/b&gt; Detta raderar inga filer.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="1261"/>
-        <source>REMOVE ALL SYNCHRONIZATIONS</source>
-        <translation>TA BORT ALLA SYNKRONISERINGAR</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="1262"/>
-        <source>CANCEL</source>
-        <translation>AVBRYT</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="1590"/>
-        <source>Failed to start synchronizations!</source>
-        <translation>Det gick inte att starta synkroniseringarna!</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="849"/>
-        <source>Unable to open folder path %1.</source>
-        <translation>Det går inte att öppna mappsökvägen %1.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/clientgui.cpp" line="116"/>
-        <source>Unable to initialize kDrive client</source>
-        <translation>Det går inte att starta kDrive-klienten</translation>
+        <translation>Log venligst ind</translation>
     </message>
     <message>
         <location filename="../src/gui/clientgui.cpp" line="255"/>
         <source>Synchronization is paused</source>
-        <translation>Synkroniseringen är pausad</translation>
+        <translation>Synkronisering er sat på pause</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="292"/>
+        <source>Folder %1: %2</source>
+        <translation>Mappe %1: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="298"/>
+        <source>There are no sync folders configured.</source>
+        <translation>Der er ingen synkroniseringsmapper konfigureret.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="673"/>
+        <source>Undefined State.</source>
+        <translation>Udefineret tilstand.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="676"/>
+        <source>Waiting to start syncing.</source>
+        <translation>Venter på at starte synkroniseringen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="679"/>
+        <source>Sync is running.</source>
+        <translation>Synkronisering kører.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="683"/>
+        <source>Sync was successful, unresolved conflicts.</source>
+        <translation>Synkronisering lykkedes, uløste konflikter.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="685"/>
+        <source>Last Sync was successful.</source>
+        <translation>Seneste synkronisering lykkedes.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="692"/>
+        <source>User Abort.</source>
+        <translation>Bruger afbrød.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="696"/>
+        <source>Sync is paused.</source>
+        <translation>Synkronisering er sat på pause.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="705"/>
+        <source>%1 (Sync is paused)</source>
+        <translation>%1 (Synkronisering er sat på pause)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="849"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Kan ikke åbne mappestien %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1257"/>
+        <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+        <translation>Vil du virkelig fjerne synkroniseringerne for kontoen &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Bemærk:&lt;/b&gt; Dette vil &lt;b&gt;ikke&lt;/b&gt; slette nogen filer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1261"/>
+        <source>REMOVE ALL SYNCHRONIZATIONS</source>
+        <translation>FJERN ALLE SYNKRONISERINGER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1262"/>
+        <source>CANCEL</source>
+        <translation>ANNULLER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1422"/>
+        <source>Synthesis</source>
+        <translation>Oversigt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1423"/>
+        <source>Preferences</source>
+        <translation>Indstillinger</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1424"/>
+        <source>Quit</source>
+        <translation>Afslut</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1590"/>
+        <source>Failed to start synchronizations!</source>
+        <translation>Kunne ikke starte synkroniseringer!</translation>
     </message>
 </context>
 <context>
@@ -565,22 +564,22 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
     <message>
         <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86"/>
         <source>Summary of your local folder synchronization</source>
-        <translation>Sammanfattning av synkroniseringen av din lokala mapp</translation>
+        <translation>Resumé af din lokale mappesynkronisering</translation>
     </message>
     <message>
         <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95"/>
         <source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
-        <translation>Innehållet i mappen på din dator kommer att synkroniseras med mappen på den valda kDrive-enheten och vice versa.</translation>
+        <translation>Indholdet af mappen på din computer vil blive synkroniseret til mappen på den valgte kDrive og omvendt.</translation>
     </message>
     <message>
         <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184"/>
         <source>CANCEL</source>
-        <translation>AVBRYT</translation>
+        <translation>ANNULLER</translation>
     </message>
     <message>
         <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191"/>
         <source>SYNCHRONIZE</source>
-        <translation>SYNKRONISERA</translation>
+        <translation>SYNKRONISER</translation>
     </message>
 </context>
 <context>
@@ -589,104 +588,104 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="96"/>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="120"/>
         <source>Before finishing</source>
-        <translation>Innan du avslutar</translation>
+        <translation>Inden du afslutter</translation>
     </message>
     <message>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="107"/>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="131"/>
         <source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
-        <translation>Följ dessa steg för att säkerställa att Lite Sync fungerar korrekt på din dator och för att slutföra konfigurationen av kDrive.</translation>
+        <translation>Udfør følgende trin for at sikre, at Lite Sync fungerer korrekt på din computer og for at fuldføre konfigurationen af kDrive.</translation>
     </message>
     <message>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="208"/>
         <source>Open your Mac&apos;s &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation>Öppna &lt;b&gt;inställningarna under ”Allmänt”&lt;/b&gt; på din Mac eller  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klicka här&lt;/a&gt;</translation>
+        <translation>Åbn din Macs &lt;b&gt;Generelle indstillinger&lt;/b&gt; eller  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klik her&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="212"/>
         <source>Open your Mac&apos;s &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation>Öppna &lt;b&gt;inställningarna för sekretess och säkerhet&lt;/b&gt; på din Mac eller  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klicka här&lt;/a&gt;</translation>
+        <translation>Åbn din Macs &lt;b&gt;Indstillinger for Privatliv og sikkerhed&lt;/b&gt; eller  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klik her&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="216"/>
         <source>Open your Mac&apos;s &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation>Öppna &lt;b&gt;inställningarna&lt;/b&gt; för &lt;b&gt;Säkerhet och integritet&lt;/b&gt; på din Mac eller  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klicka här&lt;/a&gt;</translation>
+        <translation>Åbn din Macs &lt;b&gt;Indstillinger for Sikkerhed og privatliv&lt;/b&gt; eller  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klik her&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="246"/>
         <source>Go to &lt;b&gt;&quot;Login Items &amp; Extensions&quot;&lt;/b&gt; section and then to &lt;b&gt;&quot;Endpoint Security Extensions&quot;&lt;/b&gt;</source>
-        <translation>Gå till avsnittet &lt;b&gt;”Inloggningsobjekt och tillägg”&lt;/b&gt; och sedan till &lt;b&gt;”Endpoint Security-tillägg”&lt;/b&gt;</translation>
+        <translation>Gå til sektionen &lt;b&gt;&quot;Login-emner og udvidelser&quot;&lt;/b&gt; og derefter til &lt;b&gt;&quot;Endpoint Security Extensions&quot;&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="263"/>
         <source>Authorize the kDrive application</source>
-        <translation>Godkänn appen kDrive</translation>
+        <translation>Godkend kDrive-applikationen</translation>
     </message>
     <message>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="272"/>
         <source>Go to &lt;b&gt;&quot;Security&quot;&lt;/b&gt; section</source>
-        <translation>Gå till avsnittet &lt;b&gt;”Säkerhet”&lt;/b&gt;</translation>
+        <translation>Gå til sektionen &lt;b&gt;&quot;Sikkerhed&quot;&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="289"/>
         <source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
-        <translation>Godkänn kDrive-appen i rutan där det står att kDrive har blockerats</translation>
+        <translation>Godkend kDrive-applikationen i boksen, der angiver, at kDrive er blevet blokeret</translation>
     </message>
     <message>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="299"/>
         <source>Unlock the padlock &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; and authorize the kDrive application</source>
-        <translation>Lås upp hänglåset &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; och godkänn kDrive-appen</translation>
+        <translation>Lås hængelåsen op &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; og godkend kDrive-applikationen</translation>
     </message>
     <message>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="344"/>
         <source>Go to &lt;b&gt;&quot;Privacy &amp; Security&quot;&lt;/b&gt; section and click on &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt; or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation>Gå till avsnittet &lt;b&gt;”Sekretess och säkerhet”&lt;/b&gt; och klicka på &lt;b&gt;”Fullständig disktillgång”&lt;/b&gt; eller &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klicka här&lt;/a&gt;</translation>
+        <translation>Gå til sektionen &lt;b&gt;&quot;Privatliv og sikkerhed&quot;&lt;/b&gt; og klik på &lt;b&gt;&quot;Fuld diskadgang&quot;&lt;/b&gt; eller &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klik her&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="348"/>
         <source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;&quot;Privacy&quot;&lt;/b&gt; tab or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation>Öppna fliken &lt;b&gt;”Sekretess”&lt;/b&gt; i inställningarna för säkerhet och sekretess, eller &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klicka här&lt;/a&gt;</translation>
+        <translation>Stadig i indstillingerne for Sikkerhed og privatliv, åbn fanen &lt;b&gt;&quot;Privatliv&quot;&lt;/b&gt; eller &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klik her&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="376"/>
         <source>Check the &quot;kDrive LiteSync Extension&quot; box then the &quot;kDrive.app&quot; box (if not already checked)</source>
-        <translation>Markera rutan ”kDrive LiteSync Extension” och sedan rutan ”kDrive.app” (om den inte redan är markerad)</translation>
+        <translation>Markér boksen &quot;kDrive LiteSync Extension&quot; og derefter boksen &quot;kDrive.app&quot; (hvis den ikke allerede er markeret)</translation>
     </message>
     <message>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="393"/>
         <source>A restart of the app might be proposed, in this case accept it</source>
-        <translation>Det kan hända att appen föreslår en omstart; i så fall godkänner du den</translation>
+        <translation>En genstart af appen kan blive foreslået. I så fald accepter den</translation>
     </message>
     <message>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="399"/>
         <source>Check the &quot;kDrive LiteSync Extension&quot; box (and &quot;kDrive.app&quot; if it exists) in &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt;</source>
-        <translation>Markera rutan ”kDrive LiteSync Extension” (och ”kDrive.app” om den finns) under &lt;b&gt;”Fullständig diskåtkomst”&lt;/b&gt;</translation>
+        <translation>Markér boksen &quot;kDrive LiteSync Extension&quot; (og &quot;kDrive.app&quot; hvis den findes) under &lt;b&gt;&quot;Fuld diskadgang&quot;&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
         <source>STEP 1</source>
-        <translation>STEG 1</translation>
+        <translation>TRIN 1</translation>
     </message>
     <message>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="496"/>
         <source>(Done)</source>
-        <translation>(Klart)</translation>
+        <translation>(Udført)</translation>
     </message>
     <message>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="496"/>
         <source>STEP 2</source>
-        <translation>STEG 2</translation>
+        <translation>TRIN 2</translation>
     </message>
     <message>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="499"/>
         <source>STEPS PERFORMED</source>
-        <translation>UTFÖRDA STEG</translation>
+        <translation>UDFØRTE TRIN</translation>
     </message>
     <message>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="501"/>
         <source>END</source>
-        <translation>SLUTFÖR</translation>
+        <translation>AFSLUT</translation>
     </message>
 </context>
 <context>
@@ -694,12 +693,12 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
     <message>
         <location filename="../src/gui/custommessagebox.cpp" line="101"/>
         <source>OK</source>
-        <translation>OKEJ</translation>
+        <translation>OK</translation>
     </message>
     <message>
         <location filename="../src/gui/custommessagebox.cpp" line="111"/>
         <source>CANCEL</source>
-        <translation>AVBRYT</translation>
+        <translation>ANNULLER</translation>
     </message>
     <message>
         <location filename="../src/gui/custommessagebox.cpp" line="121"/>
@@ -717,424 +716,424 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
     <message>
         <location filename="../src/gui/debugreporter.cpp" line="37"/>
         <source>Sending of debugging information</source>
-        <translation>Översändning av felsökningsinformation</translation>
+        <translation>Sender fejlretningsoplysninger</translation>
     </message>
     <message>
         <location filename="../src/gui/debugreporter.cpp" line="37"/>
         <source>Cancel</source>
-        <translation>Avbryt</translation>
+        <translation>Annuller</translation>
     </message>
 </context>
 <context>
     <name>KDC::DebuggingDialog</name>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="45"/>
+        <source>Debug</source>
+        <translation>Fejlretning</translation>
+    </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="46"/>
         <source>Info</source>
         <translation>Info</translation>
     </message>
     <message>
-        <location filename="../src/gui/debuggingdialog.cpp" line="45"/>
-        <source>Debug</source>
-        <translation>Felsökning</translation>
-    </message>
-    <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="47"/>
         <source>Warning</source>
-        <translation>Varning</translation>
+        <translation>Advarsel</translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="48"/>
         <source>Error</source>
-        <translation>Fel</translation>
+        <translation>Fejl</translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="49"/>
         <source>Fatal</source>
-        <translation>Dödlig</translation>
+        <translation>Kritisk</translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="74"/>
         <source>Debugging settings</source>
-        <translation>Felsökningsinställningar</translation>
+        <translation>Fejlretningsindstillinger</translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="90"/>
         <source>Save debugging information in a folder on my computer (Recommended)</source>
-        <translation>Spara felsökningsinformation i en mapp på min dator (rekommenderas)</translation>
+        <translation>Gem fejlretningsoplysninger i en mappe på min computer (Anbefalet)</translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="104"/>
         <source>This information enables IT support to determine the origin of an incident.</source>
-        <translation>Med hjälp av denna information kan IT-supporten fastställa var ett fel har sitt ursprung.</translation>
+        <translation>Disse oplysninger giver IT-support mulighed for at fastslå kilden til en hændelse.</translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="114"/>
         <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
-        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Öppna felsökningsmappen&lt;/a&gt;</translation>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Åbn fejlretningsmappe&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="143"/>
         <source>Debug level</source>
-        <translation>Felsökningsnivå</translation>
+        <translation>Fejlretningsniveau</translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="152"/>
         <source>The trace level lets you choose the extent of the debugging information recorded</source>
-        <translation>Med spårningsnivån kan du välja hur mycket felsökningsinformation som ska registreras</translation>
+        <translation>Sporingsniveauet lader dig vælge omfanget af de registrerede fejlretningsoplysninger</translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="179"/>
         <source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
-        <translation>Den utökade fullständiga loggen samlar in en detaljerad historik som kan användas för felsökning. Om du aktiverar den kan det göra att kDrive-programmet går långsammare.</translation>
+        <translation>Den udvidede fulde log indsamler en detaljeret historik, der kan bruges til fejlretning. Aktivering af den kan bremse kDrive-applikationen.</translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="183"/>
         <source>Extended Full Log</source>
-        <translation>Utökad fullständig logg</translation>
+        <translation>Udvidet fuld log</translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="207"/>
         <source>Delete logs older than %1 days</source>
-        <translation>Ta bort loggar som är äldre än %1 dagar</translation>
+        <translation>Slet logfiler ældre end %1 dage</translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="226"/>
         <source>Share the debug folder with Infomaniak support.</source>
-        <translation>Skicka debug-mappen till Infomaniaks support.</translation>
+        <translation>Del fejlretningsmappen med Infomaniak support.</translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="250"/>
         <source>The last session is the periode since the last kDrive start.</source>
-        <translation>Den sista sessionen är tidsperioden sedan kDrive senast startades.</translation>
+        <translation>Den seneste session er perioden siden den seneste kDrive-start.</translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="254"/>
         <source>Share only the last kDrive session</source>
-        <translation>Dela endast den senaste kDrive-sessionen</translation>
+        <translation>Del kun den seneste kDrive-session</translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="285"/>
         <source>  Loading</source>
-        <translation>  Laddar</translation>
+        <translation>  Indlæser</translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="294"/>
         <source>Cancel</source>
-        <translation>Avbryt</translation>
+        <translation>Annuller</translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="320"/>
         <source>SAVE</source>
-        <translation>SPARA</translation>
+        <translation>GEM</translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="327"/>
         <source>CANCEL</source>
-        <translation>AVBRYT</translation>
+        <translation>ANNULLER</translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="471"/>
         <source>Failed to share</source>
-        <translation>Det gick inte att dela</translation>
+        <translation>Deling mislykkedes</translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="481"/>
         <source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
-        <translation>1. Kontrollera att du är inloggad &lt;br&gt;2. Kontrollera att du har konfigurerat minst en kDrive</translation>
+        <translation>1. Kontroller, at du er logget ind &lt;br&gt;2. Kontroller, at du har konfigureret mindst én kDrive</translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="486"/>
         <source> (Connexion interrupted)</source>
-        <translation> (Anslutningen avbröts)</translation>
+        <translation> (Forbindelsen afbrudt)</translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="493"/>
         <source>Share the folder with SwissTransfer &lt;br&gt;</source>
-        <translation>Dela mappen med SwissTransfer &lt;br&gt;</translation>
+        <translation>Del mappen med SwissTransfer &lt;br&gt;</translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="494"/>
         <source> 1. We automatically compressed your log &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;here&lt;/a&gt;.&lt;br&gt;</source>
-        <translation> 1. Vi har automatiskt komprimerat din logg &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;här&lt;/a&gt;.&lt;br&gt;</translation>
+        <translation> 1. Vi komprimerede automatisk din log &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;her&lt;/a&gt;.&lt;br&gt;</translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="496"/>
         <source> 2. Transfer the archive with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
-        <translation> 2. Skicka arkivet via &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
+        <translation> 2. Overfør arkivet med &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="498"/>
         <source> 3. Share the link with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
-        <translation> 3. Dela länken med &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
+        <translation> 3. Del linket med &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="528"/>
         <source>Last upload the %1</source>
-        <translation>Senaste uppladdning: %1</translation>
+        <translation>Seneste upload den %1</translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="556"/>
         <source>Sharing has been cancelled</source>
-        <translation>Delningen har avbrutits</translation>
+        <translation>Deling er annulleret</translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="597"/>
         <source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/debuggingdialog.h" line="70"/>
-        <source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
-        <translation>Hela mappen är stor (&gt; 100 MB) och det kan ta en stund att dela den. För att minska delningstiden rekommenderar vi att du endast delar den senaste kDrive-sessionen.</translation>
+        <translation>Den udvidede fulde log aktiveres via miljøvariablen KDRIVE_FORCE_EXTENDED_LOG. Indstil den til 0 for at deaktivere den.</translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="611"/>
         <source>%1/%2/%3 at %4h%5m and %6s</source>
         <extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
-        <translation>%1/%2/%3 kl. %4:%5 och %6 sekunder</translation>
+        <translation>%1/%2/%3 kl. %4h%5m og %6s</translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="654"/>
         <source>Do you want to save your modifications?</source>
-        <translation>Vill du spara dina ändringar?</translation>
+        <translation>Vil du gemme dine ændringer?</translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="709"/>
         <location filename="../src/gui/debuggingdialog.cpp" line="715"/>
         <source>Unable to open folder %1.</source>
-        <translation>Det går inte att öppna mappen %1.</translation>
+        <translation>Kan ikke åbne mappen %1.</translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="722"/>
         <source>  Share</source>
-        <translation>  Dela</translation>
+        <translation>  Del</translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="732"/>
         <source>  Sharing | step 1/2 %1%</source>
-        <translation>  Dela | steg 1/2 %1%</translation>
+        <translation>  Deler | trin 1/2 %1%</translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="741"/>
         <source>  Sharing | step 2/2 %1%</source>
-        <translation>  Dela | steg 2/2 %1%</translation>
+        <translation>  Deler | trin 2/2 %1%</translation>
     </message>
     <message>
         <location filename="../src/gui/debuggingdialog.cpp" line="751"/>
         <source>  Canceling...</source>
-        <translation>  Avbryter...</translation>
+        <translation>  Annullerer...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.h" line="70"/>
+        <source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
+        <translation>Hele mappen er stor (&gt; 100 MB) og kan tage noget tid at dele. For at reducere delingstiden anbefaler vi, at du kun deler den seneste kDrive-session.</translation>
     </message>
 </context>
 <context>
     <name>KDC::DrivePreferencesWidget</name>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
-        <source>Folders</source>
-        <translation>Mappar</translation>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
+        <source>Synchronization errors and information.</source>
+        <translation>Synkroniseringsfejl og information.</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
-        <source>Notifications</source>
-        <translation>Meddelanden</translation>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
+        <source>Synchronize a local folder</source>
+        <translation>Synkroniser en lokal mappe</translation>
     </message>
     <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
-        <source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
-        <translation>Ett meddelande visas så snart en ny mapp har synkroniserats eller ändrats</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
-        <source>Connected with</source>
-        <translation>I samband med</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
-        <source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-        <translation>Vill du verkligen sluta synkronisera mappen &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Obs!&lt;/b&gt; Detta kommer &lt;b&gt;inte&lt;/b&gt; att radera några filer.</translation>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
+        <source>Do you really want to turn on Lite Sync?</source>
+        <translation>Vil du virkelig aktivere Lite Sync?</translation>
     </message>
     <message>
         <location filename="../src/gui/drivepreferenceswidget.cpp" line="356"/>
         <source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
-        <translation>Denna åtgärd kan ta allt från några sekunder till några minuter, beroende på mappens storlek.</translation>
+        <translation>Denne handling kan tage fra et par sekunder til et par minutter afhængigt af mappens størrelse.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
+        <source>CONFIRM</source>
+        <translation>BEKRÆFT</translation>
     </message>
     <message>
         <location filename="../src/gui/drivepreferenceswidget.cpp" line="360"/>
         <location filename="../src/gui/drivepreferenceswidget.cpp" line="391"/>
         <location filename="../src/gui/drivepreferenceswidget.cpp" line="986"/>
         <source>CANCEL</source>
-        <translation>AVBRYT</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
-        <source>New local folder synchronization failed!</source>
-        <translation>Synkroniseringen av den nya lokala mappen misslyckades!</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
-        <source>Lite Sync activation failed.</source>
-        <translation>Aktiveringen av Lite Sync misslyckades.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
-        <source>Lite Sync deactivation failed.</source>
-        <translation>Det gick inte att inaktivera Lite Sync.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
-        <source>REMOVE FOLDER SYNC CONNECTION</source>
-        <translation>TA BORT SYNKRONISERINGSFÖRBINDELSEN FÖR MAPPEN</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
-        <source>An error occurred while loading the list of subfolders.</source>
-        <translation>Ett fel uppstod vid inläsningen av listan över undermappar.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
-        <source>Enable the notifications for this kDrive</source>
-        <translation>Aktivera aviseringar för denna kDrive</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
-        <source>CONFIRM</source>
-        <translation>BEKRÄFTA</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
-        <source>Synchronization errors and information.</source>
-        <translation>Synkroniseringsfel och information.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
-        <source>Synchronize a local folder</source>
-        <translation>Synkronisera en lokal mapp</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
-        <source>Do you really want to turn on Lite Sync?</source>
-        <translation>Vill du verkligen aktivera Lite Sync?</translation>
+        <translation>ANNULLER</translation>
     </message>
     <message>
         <location filename="../src/gui/drivepreferenceswidget.cpp" line="382"/>
         <source>Do you really want to turn off Lite Sync?</source>
-        <translation>Vill du verkligen stänga av Lite Sync?</translation>
+        <translation>Vil du virkelig deaktivere Lite Sync?</translation>
     </message>
     <message>
         <location filename="../src/gui/drivepreferenceswidget.cpp" line="384"/>
         <source>You don&apos;t have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
-        <translation>Du har inte tillräckligt med utrymme för att synkronisera alla filer på din kDrive (%1 saknas). Om du inaktiverar Lite Sync måste du välja vilka mappar som ska synkroniseras på din dator. Under tiden kommer synkroniseringen av din kDrive att pausas.</translation>
+        <translation>Du har ikke nok plads til at synkronisere alle filerne på din kDrive (%1 mangler). Hvis du deaktiverer Lite Sync, skal du vælge, hvilke mapper der skal synkroniseres på din computer. I mellemtiden sættes synkroniseringen af din kDrive på pause.</translation>
     </message>
     <message>
         <location filename="../src/gui/drivepreferenceswidget.cpp" line="388"/>
         <source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
-        <translation>Om du stänger av Lite Sync kommer alla filer att laddas ner till din dator.</translation>
+        <translation>Hvis du deaktiverer Lite Sync, vil alle filer blive downloadet til din computer.</translation>
     </message>
     <message>
         <location filename="../src/gui/drivepreferenceswidget.cpp" line="627"/>
         <source>Failed to create new synchronization</source>
-        <translation>Det gick inte att skapa en ny synkronisering</translation>
+        <translation>Kunne ikke oprette ny synkronisering</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
+        <source>New local folder synchronization failed!</source>
+        <translation>Ny lokal mappesynkronisering mislykkedes!</translation>
     </message>
     <message>
         <location filename="../src/gui/drivepreferenceswidget.cpp" line="819"/>
         <source>Lite Sync activated.</source>
-        <translation>Lite Sync är aktiverat.</translation>
+        <translation>Lite Sync aktiveret.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
+        <source>Lite Sync activation failed.</source>
+        <translation>Aktivering af Lite Sync mislykkedes.</translation>
     </message>
     <message>
         <location filename="../src/gui/drivepreferenceswidget.cpp" line="837"/>
         <source>Lite Sync deactivated.</source>
-        <translation>Lite Sync är inaktiverat.</translation>
+        <translation>Lite Sync deaktiveret.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
+        <source>Lite Sync deactivation failed.</source>
+        <translation>Deaktivering af Lite Sync mislykkedes.</translation>
     </message>
     <message>
         <location filename="../src/gui/drivepreferenceswidget.cpp" line="899"/>
         <source>This drive is being deleted.</source>
-        <translation>Den här enheten raderas.</translation>
+        <translation>Dette drev slettes.</translation>
     </message>
     <message>
         <location filename="../src/gui/drivepreferenceswidget.cpp" line="962"/>
         <source>Impossible to open item %1</source>
-        <translation>Det går inte att öppna objekt %1</translation>
+        <translation>Kan ikke åbne elementet %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
+        <source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+        <translation>Vil du virkelig stoppe synkroniseringen af mappen &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Bemærk:&lt;/b&gt; Dette vil &lt;b&gt;ikke&lt;/b&gt; slette nogen filer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
+        <source>REMOVE FOLDER SYNC CONNECTION</source>
+        <translation>FJERN MAPPESYNKRONISERINGSFORBINDELSEN</translation>
     </message>
     <message>
         <location filename="../src/gui/drivepreferenceswidget.cpp" line="1007"/>
         <source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
-        <translation>Det gick inte att avbryta synkroniseringen av mappen &lt;i&gt;%1&lt;/i&gt;.</translation>
+        <translation>Kunne ikke stoppe synkroniseringen af mappen &lt;i&gt;%1&lt;/i&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
+        <source>An error occurred while loading the list of subfolders.</source>
+        <translation>Der opstod en fejl under indlæsning af listen over undermapper.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
+        <source>Folders</source>
+        <translation>Mapper</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
+        <source>Notifications</source>
+        <translation>Meddelelser</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
+        <source>Enable the notifications for this kDrive</source>
+        <translation>Aktivér meddelelser for denne kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
+        <source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
+        <translation>En meddelelse vises, så snart en ny mappe er synkroniseret eller ændret</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
+        <source>Connected with</source>
+        <translation>Forbundet med</translation>
     </message>
     <message>
         <location filename="../src/gui/drivepreferenceswidget.cpp" line="1125"/>
         <source>Remove all synchronizations</source>
-        <translation>Ta bort alla synkroniseringar</translation>
+        <translation>Fjern alle synkroniseringer</translation>
     </message>
     <message>
         <location filename="../src/gui/drivepreferenceswidget.cpp" line="1126"/>
         <source>Search in your kDrive</source>
-        <translation>Sök i din kDrive</translation>
+        <translation>Søg i din kDrive</translation>
     </message>
     <message>
         <location filename="../src/gui/drivepreferenceswidget.cpp" line="1127"/>
         <source>Search</source>
-        <translation>Sök</translation>
+        <translation>Søg</translation>
     </message>
 </context>
 <context>
     <name>KDC::DriveSelectionWidget</name>
     <message>
-        <location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
-        <source>Synchronize a kDrive</source>
-        <translation>Synkronisera en kDrive</translation>
-    </message>
-    <message>
         <location filename="../src/gui/driveselectionwidget.cpp" line="150"/>
         <source>Add a kDrive</source>
-        <translation>Lägg till en kDrive</translation>
+        <translation>Tilføj en kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
+        <source>Synchronize a kDrive</source>
+        <translation>Synkroniser en kDrive</translation>
     </message>
 </context>
 <context>
     <name>KDC::ErrorTabWidget</name>
-    <message>
-        <location filename="../src/gui/errortabwidget.cpp" line="179"/>
-        <source>Resolve</source>
-        <translation>Lösa</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/errortabwidget.cpp" line="180"/>
-        <source>Conflicted item(s)</source>
-        <translation>Konflikterande objekt</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/errortabwidget.cpp" line="181"/>
-        <source>Item(s) with unsupported characters</source>
-        <translation>Objekt med tecken som inte stöds</translation>
-    </message>
     <message>
         <location filename="../src/gui/errortabwidget.cpp" line="92"/>
         <location filename="../src/gui/errortabwidget.cpp" line="135"/>
         <location filename="../src/gui/errortabwidget.cpp" line="178"/>
         <location filename="../src/gui/errortabwidget.cpp" line="186"/>
         <source>Clear history</source>
-        <translation>Rensa historiken</translation>
+        <translation>Ryd historik</translation>
     </message>
     <message>
         <location filename="../src/gui/errortabwidget.cpp" line="176"/>
         <source>To Resolve</source>
-        <translation>Att lösa</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/errortabwidget.cpp" line="184"/>
-        <source>Automatically resolved</source>
-        <translation>Löst automatiskt</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/errortabwidget.cpp" line="185"/>
-        <source>problem(s) solved</source>
-        <translation>problem löst</translation>
+        <translation>Skal løses</translation>
     </message>
     <message>
         <location filename="../src/gui/errortabwidget.cpp" line="177"/>
         <source>problem(s) detected</source>
-        <translation>problem har upptäckts</translation>
+        <translation>problem(er) opdaget</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="179"/>
+        <source>Resolve</source>
+        <translation>Løs</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="180"/>
+        <source>Conflicted item(s)</source>
+        <translation>Konfliktende element(er)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="181"/>
+        <source>Item(s) with unsupported characters</source>
+        <translation>Element(er) med ikke-understøttede tegn</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="184"/>
+        <source>Automatically resolved</source>
+        <translation>Automatisk løst</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="185"/>
+        <source>problem(s) solved</source>
+        <translation>problem(er) løst</translation>
     </message>
 </context>
 <context>
@@ -1143,18 +1142,18 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <location filename="../src/gui/errorsmenubarwidget.cpp" line="84"/>
         <location filename="../src/gui/errorsmenubarwidget.cpp" line="103"/>
         <source>Synchronization conflicts or errors</source>
-        <translation>Synkroniseringskonflikter eller fel</translation>
+        <translation>Synkroniseringskonflikter eller fejl</translation>
     </message>
     <message>
         <location filename="../src/gui/errorsmenubarwidget.cpp" line="86"/>
         <location filename="../src/gui/errorsmenubarwidget.cpp" line="105"/>
         <source>Errors</source>
-        <translation>Fel</translation>
+        <translation>Fejl</translation>
     </message>
     <message>
         <location filename="../src/gui/errorsmenubarwidget.cpp" line="101"/>
         <source>Back to preferences</source>
-        <translation>Tillbaka till inställningar</translation>
+        <translation>Tilbage til indstillinger</translation>
     </message>
 </context>
 <context>
@@ -1162,30 +1161,30 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
     <message>
         <location filename="../src/gui/errorspopup.cpp" line="73"/>
         <source>Some files couldn&apos;t be synchronized on the following kDrive(s) :</source>
-        <translation>Vissa filer kunde inte synkroniseras på följande kDrive-enheter:</translation>
+        <translation>Nogle filer kunne ikke synkroniseres på følgende kDrive(s):</translation>
     </message>
     <message>
         <location filename="../src/gui/errorspopup.cpp" line="95"/>
         <source> (%1 error(s))</source>
-        <translation> (%1 fel)</translation>
+        <translation> (%1 fejl)</translation>
     </message>
     <message>
         <location filename="../src/gui/errorspopup.cpp" line="101"/>
         <source> (%1 information(s))</source>
-        <translation> (%1 uppgift(er))</translation>
+        <translation> (%1 information(er))</translation>
     </message>
     <message>
         <location filename="../src/gui/errorspopup.cpp" line="107"/>
         <source> (%1 error(s) and %2 information(s))</source>
-        <translation> (%1 fel och %2 uppgifter)</translation>
+        <translation> (%1 fejl og %2 information(er))</translation>
     </message>
     <message numerus="yes">
         <location filename="../src/gui/errorspopup.cpp" line="147"/>
         <source>Generic errors (%n warning(s) or error(s))</source>
         <comment>Number of warnings or errors</comment>
         <translation>
-            <numerusform>Allmänna fel (%n varning eller fel)</numerusform>
-            <numerusform>Allmänna fel (%n varningar eller fel)</numerusform>
+            <numerusform>Generiske fejl (%n advarsel eller fejl)</numerusform>
+            <numerusform>Generiske fejl (%n advarsler eller fejl)</numerusform>
         </translation>
     </message>
 </context>
@@ -1194,57 +1193,57 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
     <message>
         <location filename="../src/gui/fileexclusiondialog.cpp" line="78"/>
         <source>Excluded files</source>
-        <translation>Undantagna filer</translation>
+        <translation>Ekskluderede filer</translation>
     </message>
     <message>
         <location filename="../src/gui/fileexclusiondialog.cpp" line="86"/>
         <source>Add files or folders that will not be synchronized on your computer.</source>
-        <translation>Lägg till filer eller mappar som inte ska synkroniseras på din dator.</translation>
+        <translation>Tilføj filer eller mapper, der ikke synkroniseres på din computer.</translation>
     </message>
     <message>
         <location filename="../src/gui/fileexclusiondialog.cpp" line="97"/>
         <source>Add</source>
-        <translation>Lägg till</translation>
+        <translation>Tilføj</translation>
     </message>
     <message>
         <location filename="../src/gui/fileexclusiondialog.cpp" line="109"/>
         <source>NAME</source>
-        <translation>NAMN</translation>
+        <translation>NAVN</translation>
     </message>
     <message>
         <location filename="../src/gui/fileexclusiondialog.cpp" line="114"/>
         <source>WARNING</source>
-        <translation>VARNING</translation>
+        <translation>ADVARSEL</translation>
     </message>
     <message>
         <location filename="../src/gui/fileexclusiondialog.cpp" line="149"/>
         <source>SAVE</source>
-        <translation>SPARA</translation>
+        <translation>GEM</translation>
     </message>
     <message>
         <location filename="../src/gui/fileexclusiondialog.cpp" line="156"/>
         <source>CANCEL</source>
-        <translation>AVBRYT</translation>
+        <translation>ANNULLER</translation>
     </message>
     <message>
         <location filename="../src/gui/fileexclusiondialog.cpp" line="304"/>
         <source>Do you want to save your modifications?</source>
-        <translation>Vill du spara dina ändringar?</translation>
+        <translation>Vil du gemme dine ændringer?</translation>
     </message>
     <message>
         <location filename="../src/gui/fileexclusiondialog.cpp" line="353"/>
         <source>Exclusion template already exists!</source>
-        <translation>Mallen för uteslutning finns redan!</translation>
+        <translation>Eksklusionsskabelon eksisterer allerede!</translation>
     </message>
     <message>
         <location filename="../src/gui/fileexclusiondialog.cpp" line="374"/>
         <source>Do you really want to delete?</source>
-        <translation>Vill du verkligen ta bort det?</translation>
+        <translation>Vil du virkelig slette?</translation>
     </message>
     <message>
         <location filename="../src/gui/fileexclusiondialog.cpp" line="434"/>
         <source>Cannot save changes!</source>
-        <translation>Det går inte att spara ändringarna!</translation>
+        <translation>Kan ikke gemme ændringer!</translation>
     </message>
 </context>
 <context>
@@ -1252,12 +1251,12 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
     <message>
         <location filename="../src/gui/fileexclusionnamedialog.cpp" line="58"/>
         <source>VALIDATE</source>
-        <translation>BEKRÄFTA</translation>
+        <translation>GODKEND</translation>
     </message>
     <message>
         <location filename="../src/gui/fileexclusionnamedialog.cpp" line="65"/>
         <source>CANCEL</source>
-        <translation>AVBRYT</translation>
+        <translation>ANNULLER</translation>
     </message>
 </context>
 <context>
@@ -1266,136 +1265,136 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
         <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67"/>
         <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73"/>
         <source>Unable to open link %1.</source>
-        <translation>Det går inte att öppna länken %1.</translation>
+        <translation>Kan ikke åbne linket %1.</translation>
     </message>
     <message>
         <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122"/>
         <source>Solve conflict(s)</source>
-        <translation>Lösa konflikter</translation>
+        <translation>Løs konflikt(er)</translation>
     </message>
     <message>
         <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140"/>
         <source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
-        <translation>&lt;b&gt;Vad vill du göra med den/de %1 objektet/objekten som är i konflikt?&lt;/b&gt;</translation>
+        <translation>&lt;b&gt;Hvad vil du gøre med de %1 konfliktende element(er)?&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143"/>
         <source>Save my changes and replace other users&apos; versions.</source>
-        <translation>Spara mina ändringar och ersätt andra användares versioner.</translation>
+        <translation>Gem mine ændringer og erstat andre brugeres versioner.</translation>
     </message>
     <message>
         <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147"/>
         <source>Undo my changes and keep other users&apos; versions.</source>
-        <translation>Ångra mina ändringar och behåll andra användares versioner.</translation>
+        <translation>Fortryd mine ændringer og behold andre brugeres versioner.</translation>
     </message>
     <message>
         <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169"/>
         <source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
-        <translation>Dina ändringar kan raderas permanent. De går inte att återställa via kDrive-webbappen.</translation>
+        <translation>Dine ændringer kan blive slettet permanent. De kan ikke gendannes fra kDrive-webapplikationen.</translation>
     </message>
     <message>
         <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171"/>
         <source>&lt;a style=%1 href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation>&lt;a style=%1 href=&quot;%2&quot;&gt;Läs mer&lt;/a&gt;</translation>
+        <translation>&lt;a style=%1 href=&quot;%2&quot;&gt;Læs mere&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175"/>
         <source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
-        <translation>Dina ändringar kommer att raderas permanent. De kan inte återställas via kDrive-webbappen.</translation>
+        <translation>Dine ændringer vil blive slettet permanent. De kan ikke gendannes fra kDrive-webapplikationen.</translation>
     </message>
     <message>
         <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191"/>
         <source>Show item(s)</source>
-        <translation>Visa objekt</translation>
+        <translation>Vis element(er)</translation>
     </message>
     <message>
         <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228"/>
         <source>VALIDATE</source>
-        <translation>BEKRÄFTA</translation>
+        <translation>GODKEND</translation>
     </message>
     <message>
         <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234"/>
         <source>CANCEL</source>
-        <translation>AVBRYT</translation>
+        <translation>ANNULLER</translation>
     </message>
     <message>
         <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251"/>
         <source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
-        <translation>Flera användare har gjort ändringar i dessa filer på olika ställen (online på kDrive, på en dator eller i en mobil). Mappar som innehåller dessa filer kan också ha raderats.&lt;br&gt;</translation>
+        <translation>Disse filer er blevet ændret af flere brugere på flere steder (online på kDrive, en computer eller en mobilenhed). Mapper, der indeholder disse filer, kan også være blevet slettet.&lt;br&gt;</translation>
     </message>
     <message>
         <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253"/>
         <source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation>Den lokala versionen av din artikel &lt;b&gt;är inte synkroniserad&lt;/b&gt; med kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Läs mer&lt;/a&gt;</translation>
+        <translation>Den lokale version af dit element &lt;b&gt;er ikke synkroniseret&lt;/b&gt; med kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Læs mere&lt;/a&gt;</translation>
     </message>
 </context>
 <context>
     <name>KDC::FolderItemWidget</name>
     <message>
-        <location filename="../src/gui/folderitemwidget.cpp" line="458"/>
-        <source>More actions</source>
-        <translation>Fler åtgärder</translation>
-    </message>
-    <message>
         <location filename="../src/gui/folderitemwidget.cpp" line="188"/>
         <location filename="../src/gui/folderitemwidget.cpp" line="476"/>
         <source>Synchronized into &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</source>
-        <translation>Synkroniserad till &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</translation>
+        <translation>Synkroniseret i &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../src/gui/folderitemwidget.cpp" line="343"/>
         <source>Activate Lite Sync</source>
-        <translation>Aktivera Lite Sync</translation>
+        <translation>Aktivér Lite Sync</translation>
     </message>
     <message>
         <location filename="../src/gui/folderitemwidget.cpp" line="345"/>
         <source>Activate Lite Sync (Beta)</source>
-        <translation>Aktivera Lite Sync (Beta)</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/folderitemwidget.cpp" line="481"/>
-        <source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
-        <translation>Mappar som inte är markerade flyttas till papperskorgen om de innehåller objekt som är offline. Mappar som synkroniserats till kDrive förblir tillgängliga online.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/folderitemwidget.cpp" line="485"/>
-        <source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
-        <translation>Mappar som inte är markerade kommer att flyttas till papperskorgen. Mappar som synkroniserats till kDrive kommer att förbli tillgängliga online.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/folderitemwidget.cpp" line="488"/>
-        <source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
-        <translation>Mappar som inte är markerade kommer att raderas &lt;b&gt;permanent&lt;/b&gt; från datorn. Mappar som synkroniserats till kDrive kommer att finnas kvar online.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/folderitemwidget.cpp" line="493"/>
-        <source>Cancel</source>
-        <translation>Avbryt</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/folderitemwidget.cpp" line="494"/>
-        <source>VALIDATE</source>
-        <translation>BEKRÄFTA</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/folderitemwidget.cpp" line="365"/>
-        <source>Pause synchronization</source>
-        <translation>Pausa synkroniseringen</translation>
+        <translation>Aktivér Lite Sync (Beta)</translation>
     </message>
     <message>
         <location filename="../src/gui/folderitemwidget.cpp" line="354"/>
         <source>Deactivate Lite Sync</source>
-        <translation>Inaktivera Lite Sync</translation>
+        <translation>Deaktivér Lite Sync</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="365"/>
+        <source>Pause synchronization</source>
+        <translation>Sæt synkronisering på pause</translation>
     </message>
     <message>
         <location filename="../src/gui/folderitemwidget.cpp" line="375"/>
         <source>Resume synchronization</source>
-        <translation>Fortsätt synkroniseringen</translation>
+        <translation>Genoptag synkronisering</translation>
     </message>
     <message>
         <location filename="../src/gui/folderitemwidget.cpp" line="386"/>
         <source>Remove synchronization</source>
-        <translation>Avaktivera synkronisering</translation>
+        <translation>Fjern synkronisering</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="458"/>
+        <source>More actions</source>
+        <translation>Flere handlinger</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="481"/>
+        <source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
+        <translation>Ikke-valgte mapper flyttes til papirkurven, forudsat at de indeholder offline-elementer. Mapper synkroniseret til kDrive forbliver tilgængelige online.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="485"/>
+        <source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
+        <translation>Ikke-valgte mapper flyttes til papirkurven. Mapper synkroniseret til kDrive forbliver tilgængelige online.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="488"/>
+        <source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
+        <translation>Ikke-valgte mapper vil blive &lt;b&gt;permanent&lt;/b&gt; slettet fra computeren. Mapper synkroniseret til kDrive forbliver tilgængelige online.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="493"/>
+        <source>Cancel</source>
+        <translation>Annuller</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="494"/>
+        <source>VALIDATE</source>
+        <translation>GODKEND</translation>
     </message>
 </context>
 <context>
@@ -1403,7 +1402,7 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
     <message>
         <location filename="../src/gui/genericerroritemwidget.cpp" line="85"/>
         <source>Unable to open folder path %1.</source>
-        <translation>Det går inte att öppna mappsökvägen %1.</translation>
+        <translation>Kan ikke åbne mappestien %1.</translation>
     </message>
 </context>
 <context>
@@ -1411,22 +1410,22 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
     <message>
         <location filename="../src/gui/litesyncappdialog.cpp" line="48"/>
         <source>Application Id</source>
-        <translation>Applikations-ID</translation>
+        <translation>Applikations-id</translation>
     </message>
     <message>
         <location filename="../src/gui/litesyncappdialog.cpp" line="98"/>
         <source>Application Name</source>
-        <translation>Programnamn</translation>
+        <translation>Applikationsnavn</translation>
     </message>
     <message>
         <location filename="../src/gui/litesyncappdialog.cpp" line="121"/>
         <source>VALIDATE</source>
-        <translation>BEKRÄFTA</translation>
+        <translation>GODKEND</translation>
     </message>
     <message>
         <location filename="../src/gui/litesyncappdialog.cpp" line="128"/>
         <source>CANCEL</source>
-        <translation>AVBRYT</translation>
+        <translation>ANNULLER</translation>
     </message>
 </context>
 <context>
@@ -1434,12 +1433,12 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
     <message>
         <location filename="../src/gui/litesyncdialog.cpp" line="91"/>
         <source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are &quot;online&quot;. Add them in the list below to avoid this behaviour.</source>
-        <translation>Vissa appar (säkerhetskopieringsappar, antivirusprogram...) får åtkomst till dina filer, vilket gör att de laddas ner när de är ”uppkopplade”. Lägg till dem i listan nedan för att undvika detta.</translation>
+        <translation>Nogle apps (sikkerhedskopiering, antivirus...) tilgår dine filer, hvilket fører til, at de downloades, når de er &quot;online&quot;. Tilføj dem i listen nedenfor for at undgå dette.</translation>
     </message>
     <message>
         <location filename="../src/gui/litesyncdialog.cpp" line="103"/>
         <source>Add</source>
-        <translation>Lägg till</translation>
+        <translation>Tilføj</translation>
     </message>
     <message>
         <location filename="../src/gui/litesyncdialog.cpp" line="115"/>
@@ -1449,32 +1448,32 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
     <message>
         <location filename="../src/gui/litesyncdialog.cpp" line="120"/>
         <source>NAME</source>
-        <translation>NAMN</translation>
+        <translation>NAVN</translation>
     </message>
     <message>
         <location filename="../src/gui/litesyncdialog.cpp" line="154"/>
         <source>SAVE</source>
-        <translation>SPARA</translation>
+        <translation>GEM</translation>
     </message>
     <message>
         <location filename="../src/gui/litesyncdialog.cpp" line="161"/>
         <source>CANCEL</source>
-        <translation>AVBRYT</translation>
+        <translation>ANNULLER</translation>
     </message>
     <message>
         <location filename="../src/gui/litesyncdialog.cpp" line="295"/>
         <source>Do you want to save your modifications?</source>
-        <translation>Vill du spara dina ändringar?</translation>
+        <translation>Vil du gemme dine ændringer?</translation>
     </message>
     <message>
         <location filename="../src/gui/litesyncdialog.cpp" line="337"/>
         <source>Do you really want to delete?</source>
-        <translation>Vill du verkligen ta bort det?</translation>
+        <translation>Vil du virkelig slette?</translation>
     </message>
     <message>
         <location filename="../src/gui/litesyncdialog.cpp" line="374"/>
         <source>Cannot save changes!</source>
-        <translation>Det går inte att spara ändringarna!</translation>
+        <translation>Kan ikke gemme ændringer!</translation>
     </message>
 </context>
 <context>
@@ -1482,52 +1481,51 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
     <message>
         <location filename="../src/gui/localfolderdialog.cpp" line="63"/>
         <source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
-        <translation>Vilken mapp på din dator vill du&lt;br&gt;synkronisera?</translation>
+        <translation>Hvilken mappe på din computer vil du&lt;br&gt;synkronisere?</translation>
     </message>
     <message>
         <location filename="../src/gui/localfolderdialog.cpp" line="72"/>
         <source>The content of this folder will be synchronized on the kDrive</source>
-        <translation>Innehållet i den här mappen kommer att synkroniseras på kDrive</translation>
+        <translation>Indholdet af denne mappe vil blive synkroniseret på kDrive</translation>
     </message>
     <message>
         <location filename="../src/gui/localfolderdialog.cpp" line="91"/>
         <source>Select a folder</source>
-        <translation>Välj en mapp</translation>
+        <translation>Vælg en mappe</translation>
     </message>
     <message>
         <location filename="../src/gui/localfolderdialog.cpp" line="131"/>
         <source>Edit folder</source>
-        <translation>Ändra mapp</translation>
+        <translation>Rediger mappe</translation>
     </message>
     <message>
         <location filename="../src/gui/localfolderdialog.cpp" line="166"/>
         <source>CANCEL</source>
-        <translation>AVBRYT</translation>
+        <translation>ANNULLER</translation>
     </message>
     <message>
         <location filename="../src/gui/localfolderdialog.cpp" line="173"/>
         <source>CONTINUE</source>
-        <translation>FORTSÄTT</translation>
+        <translation>FORTSÆT</translation>
     </message>
     <message>
         <location filename="../src/gui/localfolderdialog.cpp" line="210"/>
         <source>This folder is not compatible with Lite Sync.&lt;br&gt;
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt;
 &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation>Den här mappen är inte kompatibel med Lite Sync.&lt;br&gt;
-Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&gt;
-
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Läs mer&lt;/a&gt;</translation>
+        <translation>Denne mappe er ikke kompatibel med Lite Sync.&lt;br&gt;
+Vælg venligst en anden mappe. Hvis du fortsætter, deaktiveres Lite Sync.&lt;br&gt;
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Læs mere&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../src/gui/localfolderdialog.cpp" line="233"/>
         <source>Select folder</source>
-        <translation>Välj mapp</translation>
+        <translation>Vælg mappe</translation>
     </message>
     <message>
         <location filename="../src/gui/localfolderdialog.cpp" line="292"/>
         <source>Unable to open link %1.</source>
-        <translation>Det går inte att öppna länken %1.</translation>
+        <translation>Kan ikke åbne linket %1.</translation>
     </message>
 </context>
 <context>
@@ -1535,12 +1533,12 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
     <message>
         <location filename="../src/libcommongui/logger.cpp" line="189"/>
         <source>Error</source>
-        <translation>Fel</translation>
+        <translation>Fejl</translation>
     </message>
     <message>
         <location filename="../src/libcommongui/logger.cpp" line="189"/>
         <source>&lt;nobr&gt;File &apos;%1&apos;&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
-        <translation>&lt;nobr&gt;Filen &amp;#x27;%1&amp;#x27;&lt;br/&gt;kan inte öppnas för skrivning.&lt;br/&gt;&lt;br/&gt;Logginformationen kan &lt;b&gt;inte&lt;/b&gt; sparas!&lt;/nobr&gt;</translation>
+        <translation>&lt;nobr&gt;Filen &apos;%1&apos;&lt;br/&gt;kan ikke åbnes til skrivning.&lt;br/&gt;&lt;br/&gt;Logoutputtet kan &lt;b&gt;ikke&lt;/b&gt; gemmes!&lt;/nobr&gt;</translation>
     </message>
 </context>
 <context>
@@ -1548,37 +1546,26 @@ Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&g
     <message>
         <location filename="../src/gui/mainmenubarwidget.cpp" line="115"/>
         <source>Preferences</source>
-        <translation>Inställningar</translation>
+        <translation>Indstillinger</translation>
     </message>
     <message>
         <location filename="../src/gui/mainmenubarwidget.cpp" line="116"/>
         <source>Help</source>
-        <translation>Hjälp</translation>
+        <translation>Hjælp</translation>
     </message>
 </context>
 <context>
     <name>KDC::ParametersDialog</name>
     <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1082"/>
-        <source>Unable to open folder path %1.</source>
-        <translation>Det går inte att öppna mappsökvägen %1.</translation>
+        <location filename="../src/gui/parametersdialog.cpp" line="320"/>
+        <source>kDrive needs to have write access to your computer&apos;s temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
+        <translation>kDrive skal have skriveadgang til din computers midlertidige mappe.&lt;br&gt;Genstart venligst kDrive-appen for at løse dette problem.</translation>
     </message>
     <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1096"/>
-        <source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
-        <translation>Överföringen är klar!&lt;br&gt;Ange referensnummer &lt;b&gt;%1&lt;/b&gt; i felrapporter.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1118"/>
-        <source>No kDrive configured!</source>
-        <translation>kDrive är inte konfigurerat!</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1097"/>
-        <source>Transmission failed!
-Please, use the following link to send the logs to the support: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</source>
-        <translation>Överföringen misslyckades!
-Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</translation>
+        <location filename="../src/gui/parametersdialog.cpp" line="330"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="487"/>
+        <source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>Der er opstået en teknisk fejl.&lt;br&gt;Synkronisering genoptages hurtigst muligt. Kontakt venligst vores supportteam, hvis fejlen fortsætter.</translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="337"/>
@@ -1587,365 +1574,376 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <location filename="../src/gui/parametersdialog.cpp" line="546"/>
         <location filename="../src/gui/parametersdialog.cpp" line="560"/>
         <source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-        <translation>Ett tekniskt fel har uppstått (fel %1).&lt;br&gt;Rensa historiken och kontakta vår support om felet kvarstår.</translation>
+        <translation>Der er opstået en teknisk fejl (fejl %1).&lt;br&gt;Ryd venligst historikken, og hvis fejlen fortsætter, kontakt vores supportteam.</translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="342"/>
         <source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
-        <translation>Det verkar som om tidsgränsen för din nätverksanslutning är inställd på ett för lågt värde för att programmet ska fungera korrekt (fel %1).&lt;br&gt;Kontrollera din nätverkskonfiguration.</translation>
+        <translation>Det ser ud til, at din netværksforbindelse er konfigureret med en for lav timeout til, at applikationen kan fungere korrekt (fejl %1).&lt;br&gt;Kontroller venligst din netværkskonfiguration.</translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="347"/>
         <location filename="../src/gui/parametersdialog.cpp" line="516"/>
         <source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
-        <translation>Det går inte att ansluta till kDrive-servern (fel %1).&lt;br&gt;Försöker ansluta igen. Kontrollera din internetanslutning och din brandvägg.</translation>
+        <translation>Kan ikke oprette forbindelse til kDrive-serveren (fejl %1).&lt;br&gt;Forsøger at genoprette forbindelsen. Kontroller venligst din internetforbindelse og firewall.</translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="352"/>
         <source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
-        <translation>Ett inloggningsproblem har uppstått (fel %1).&lt;br&gt;Logga in igen. Om felet kvarstår, kontakta vår support.</translation>
+        <translation>Der er opstået et loginproblem (fejl %1).&lt;br&gt;Log venligst ind igen, og hvis fejlen fortsætter, kontakt vores supportteam.</translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="356"/>
         <source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
-        <translation>En ny version av appen finns tillgänglig. Uppdatera&lt;br&gt;appen för att kunna fortsätta använda den.</translation>
+        <translation>En ny version af applikationen er tilgængelig.&lt;br&gt;Opdater venligst applikationen for at fortsætte med at bruge den.</translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="360"/>
         <source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
-        <translation>Uppladdningen av loggen misslyckades (fel %1).&lt;br&gt;Försök igen senare.</translation>
+        <translation>Log-upload mislykkedes (fejl %1).&lt;br&gt;Prøv venligst igen senere.</translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="385"/>
         <source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
-        <translation>Synkroniseringsmappen är inte längre tillgänglig (fel %1).&lt;br&gt;Synkroniseringen återupptas så snart mappen blir tillgänglig.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="532"/>
-        <source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
-        <translation>Synkroniseringsmappen har ersatts eller flyttats på ett sätt som förhindrar synkronisering (fel %1).&lt;br&gt;Detta kan inträffa efter att mappen har kopierats, flyttats eller återställts.&lt;br&gt;För att åtgärda detta, skapa en ny synkronisering med en ny mapp.&lt;br&gt;Obs! Om det finns osynkroniserade ändringar i den gamla mappen måste du kopiera dem manuellt till den nya.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="397"/>
-        <source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
-        <translation>Det finns inte tillräckligt med minne kvar på din dator.&lt;br&gt;Synkroniseringen har avbrutits.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="320"/>
-        <source>kDrive needs to have write access to your computer&apos;s temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
-        <translation>kDrive måste ha skrivbehörighet till datorns temporära katalog.&lt;br&gt;Starta om kDrive-appen för att lösa problemet.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="330"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="487"/>
-        <source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>Ett tekniskt fel har uppstått.&lt;br&gt;Synkroniseringen återupptas så snart som möjligt. Kontakta vår support om felet kvarstår.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="401"/>
-        <source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing &apos;/etc/sysctl.conf&apos;.</source>
-        <translation>Antalet inotify-övervakningar är otillräckligt (fel %1).&lt;br&gt;Du kan öka detta antal genom att redigera filen &amp;#x27;/etc/sysctl.conf&amp;#x27;.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="406"/>
-        <source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
-        <translation>Det går inte att starta synkroniseringen (fel %1).&lt;br&gt;Du måste ge behörighet till:&lt;br&gt;– kDrive i Systeminställningar &gt;&gt; Allmänt &gt;&gt; Inloggningsobjekt och tillägg &gt;&gt; Tillägg för&lt;br&gt;Endpoint Security– kDrive LiteSync-tillägget i Systeminställningar &gt;&gt; Sekretess och säkerhet &gt;&gt; Fullständig disktillgång.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="419"/>
-        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-        <translation>Det går inte att starta tillägget Lite Sync (fel %1).&lt;br&gt;Kontrollera att tillägget Lite Sync är installerat och att tjänsten Windows Search är aktiverad.&lt;br&gt;Rensa historiken, starta om datorn och kontakta vår support om felet kvarstår.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="424"/>
-        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-        <translation>Det går inte att starta tillägget Lite Sync (fel %1).&lt;br&gt;Kontrollera att tillägget Lite Sync har rätt behörigheter och är igång.&lt;br&gt;Rensa historiken, starta om och kontakta vår support om felet kvarstår.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="429"/>
-        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-        <translation>Det går inte att starta Lite Sync-tillägget (fel %1).&lt;br&gt;Rensa historiken, starta om och kontakta vår support om felet kvarstår.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="435"/>
-        <source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
-        <translation>En fil eller mapp i din synkroniseringsmapp verkar vara skadad.&lt;br&gt;Synkroniseringen har avbrutits.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="449"/>
-        <source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>kDrive är i underhållsläge.&lt;br&gt;Synkroniseringen kommer att återupptas så snart som möjligt. Kontakta vår support om felet kvarstår.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="455"/>
-        <source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-        <translation>kDrive är blockerat.&lt;br&gt;Förnya kDrive. Om inga åtgärder vidtas kommer uppgifterna att raderas permanent och det går inte att återställa dem.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="460"/>
-        <source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-        <translation>kDrive är spärrat.&lt;br&gt;Kontakta en administratör för att återställa kDrive. Om inga åtgärder vidtas kommer uppgifterna att raderas permanent och det går inte att återställa dem.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="466"/>
-        <source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>kDrive startar upp.&lt;br&gt;Synkroniseringen kommer att återupptas så snart som möjligt. Kontakta vår support om felet kvarstår.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="475"/>
-        <source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
-        <translation>kDrive är inaktivt.&lt;br&gt;Logga in på &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web&lt;/a&gt;versionen för att kontrollera statusen för ditt kDrive, eller kontakta din administratör.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="479"/>
-        <source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive&apos;s status, or contact your administrator.</source>
-        <translation>kDrive är inaktivt.&lt;br&gt;Logga in på webbversionen för att kontrollera statusen för ditt kDrive, eller kontakta din administratör.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="483"/>
-        <source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
-        <translation>Du har inte behörighet att komma åt denna kDrive.&lt;br&gt;Synkroniseringen har pausats. Kontakta en administratör.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="493"/>
-        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>Ett tekniskt fel har uppstått (fel %1).&lt;br&gt;Synkroniseringen återupptas så snart som möjligt. Kontakta vår support om felet kvarstår.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="512"/>
-        <source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-        <translation>Nätverksanslutningarna har avbrutits av kärnan (fel %1).&lt;br&gt;Rensa historiken och kontakta vår support om felet kvarstår.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="522"/>
-        <source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
-        <translation>Tyvärr gick det inte att överföra din gamla konfiguration.&lt;br&gt;Programmet kommer att använda en tom konfiguration.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="526"/>
-        <source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
-        <translation>Tyvärr gick det inte att överföra din gamla proxykonfiguration, eftersom SOCKS5-proxyservrar inte stöds för närvarande.&lt;br&gt;Programmet kommer istället att använda systemets proxyinställningar.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="539"/>
-        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
-        <translation>Ett tekniskt fel har uppstått (fel %1).&lt;br&gt;Synkroniseringen har startats om. Rensa historiken och kontakta vår support om felet kvarstår.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="550"/>
-        <source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
-        <translation>Ett fel har uppstått vid åtkomst till synkroniseringsdatabasen (fel %1).&lt;br&gt;Synkroniseringen har avbrutits.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="564"/>
-        <source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
-        <translation>Ett inloggningsproblem har uppstått (fel %1).&lt;br&gt;Tokenet är ogiltigt eller har återkallats.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="569"/>
-        <source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
-        <translation>Nästlade synkroniseringar är inte tillåtna (fel %1).&lt;br&gt;Du bör endast behålla synkroniseringar där mapparna inte är nästlade.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="573"/>
-        <source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
-        <translation>Synkroniseringsmappen på den fjärranslutna kDrive-enheten finns inte längre eller är inte längre tillgänglig (fel %1).&lt;br&gt;Du måste återställa den, återställa åtkomsträttigheterna eller ta bort och skapa synkroniseringen på nytt.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="580"/>
-        <source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
-        <translation>Fel vid tolkning av filnamn (fel %1).&lt;br&gt;Specialtecken som dubbla citattecken, bakstreck eller radbrytningar kan orsaka fel vid tolkningen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="722"/>
-        <source>You are not allowed to move item to &quot;%1&quot;.&lt;br&gt;It will be restored into its original parent folder.</source>
-        <translation>Du får inte flytta objektet till &amp;quot;%1&amp;quot;.&lt;br&gt;Det kommer att återställas till sin ursprungliga överordnade mapp.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="814"/>
-        <source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
-        <translation>Det finns inte tillräckligt med utrymme kvar på din dator.&lt;br&gt;Nedladdningen har avbrutits.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="609"/>
-        <source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
-        <translation>Denna komponent har flyttats till en annan plats.&lt;br&gt;Den lokala åtgärden har avbrutits.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="618"/>
-        <source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
-        <translation>Det finns redan ett element med samma namn på den här platsen.&lt;br&gt;Det lokala elementet har bytt namn.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="614"/>
-        <source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
-        <translation>Det finns redan ett element med samma namn på den här platsen.&lt;br&gt;Den lokala åtgärden har avbrutits.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="393"/>
-        <source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
-        <translation>Det finns inte tillräckligt med utrymme kvar på din dator.&lt;br&gt;Synkroniseringen har avbrutits.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="622"/>
-        <source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
-        <translation>Filen redigerades samtidigt av en annan användare.&lt;br&gt;Dina ändringar har sparats i en kopia.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="626"/>
-        <source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
-        <translation>En annan användare har flyttat en överordnad mapp till målplatsen.&lt;br&gt;Den lokala åtgärden har avbrutits.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="692"/>
-        <source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Artikelnamnet innehåller endast mellanslag.&lt;br&gt;Det har tillfälligt lagts till på svartlistan.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="703"/>
-        <source>Either you are not allowed to create an item, or another item already exists with the same name.&lt;br&gt;The item has been excluded from synchronization.</source>
-        <translation>Antingen har du inte behörighet att skapa ett objekt, eller så finns det redan ett objekt med samma namn.&lt;br&gt;Objektet har undantagits från synkroniseringen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="708"/>
-        <source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
-        <translation>Du har inte behörighet att redigera objektet.&lt;br&gt;Filen med dina ändringar har bytt namn och har undantagits från synkroniseringen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="716"/>
-        <source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
-        <translation>Du får inte byta namn på objektet.&lt;br&gt;Det återställs till sitt ursprungliga namn.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="727"/>
-        <source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
-        <translation>Du får inte ta bort objektet.&lt;br&gt;Det återställs till sin ursprungliga plats.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="732"/>
-        <source>Failed to move this item to trash, it has been blacklisted.</source>
-        <translation>Det gick inte att flytta objektet till papperskorgen; det har lagts till i svartlistan.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="748"/>
-        <source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
-        <translation>Filen har ändrats lokalt samtidigt som den har raderats på den fjärranslutna kDrive-enheten. En&lt;br&gt;lokal kopia har sparats i räddningsmappen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="765"/>
-        <source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
-        <translation>Den åtgärd som utförts på objektet är inte tillåten.&lt;br&gt;Objektet har tillfälligt lagts till i svartlistan.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="771"/>
-        <source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
-        <translation>Åtgärden som utfördes på detta objekt misslyckades.&lt;br&gt;Objektet har tillfälligt lagts till i svartlistan.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="776"/>
-        <source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
-        <translation>Filen är för stor för att laddas upp. Den har tillfälligt blockerats.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="782"/>
-        <source>Impossible to download the file.</source>
-        <translation>Det går inte att ladda ner filen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="779"/>
-        <source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
-        <translation>Du har överskridit din kvot. Öka din lagringskvot för att återaktivera filuppladdning.</translation>
+        <translation>Synkroniseringsmappen er ikke længere tilgængelig (fejl %1).&lt;br&gt;Synkronisering genoptages, så snart mappen er tilgængelig.</translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="389"/>
         <source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
-        <translation>Enheten som innehåller din synkroniseringsmapp är inte längre ansluten (fel %1).&lt;br&gt;Anslut den igen för att återuppta synkroniseringen.</translation>
+        <translation>Drevet, der indeholder din synkroniseringsmappe, er ikke længere tilsluttet (fejl %1).&lt;br&gt;Tilslut det venligst igen for at genoptage synkroniseringen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="393"/>
+        <source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>Der er ikke nok plads tilbage på din computer.&lt;br&gt;Synkronisering er stoppet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="397"/>
+        <source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>Der er ikke nok hukommelse tilbage på din maskine.&lt;br&gt;Synkronisering er stoppet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="401"/>
+        <source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing &apos;/etc/sysctl.conf&apos;.</source>
+        <translation>Antallet af inotify-overvågninger er utilstrækkeligt (fejl %1).&lt;br&gt;Du kan hæve dette antal ved at redigere &apos;/etc/sysctl.conf&apos;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="406"/>
+        <source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
+        <translation>Kan ikke starte synkronisering (fejl %1).&lt;br&gt;Du skal tillade:&lt;br&gt;- kDrive i Systemindstillinger &gt;&gt; Generelt &gt;&gt; Login-emner og udvidelser &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension i Systemindstillinger &gt;&gt; Privatliv og sikkerhed &gt;&gt; Fuld diskadgang.</translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="413"/>
         <source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
-        <translation>Det går inte att starta synkroniseringen (fel %1).&lt;br&gt;Processen LiteSyncExt körs inte just nu. Synkroniseringen återupptas så snart processen har startats.</translation>
+        <translation>Kan ikke starte synkronisering (fejl %1).&lt;br&gt;LiteSyncExt-processen kører ikke i øjeblikket. Synkronisering genoptages, så snart den er startet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="419"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Kan ikke starte Lite Sync-plugin (fejl %1).&lt;br&gt;Kontroller, at Lite Sync-udvidelsen er installeret, og at Windows Search-tjenesten er aktiveret.&lt;br&gt;Ryd venligst historikken, genstart, og hvis fejlen fortsætter, kontakt vores supportteam.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="424"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Kan ikke starte Lite Sync-plugin (fejl %1).&lt;br&gt;Kontroller, at Lite Sync-udvidelsen har de korrekte tilladelser og kører.&lt;br&gt;Ryd venligst historikken, genstart, og hvis fejlen fortsætter, kontakt vores supportteam.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="429"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Kan ikke starte Lite Sync-plugin (fejl %1).&lt;br&gt;Ryd venligst historikken, genstart, og hvis fejlen fortsætter, kontakt vores supportteam.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="435"/>
+        <source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>En fil eller mappe inde i din synkroniseringsmappe ser ud til at være beskadiget.&lt;br&gt;Synkronisering er stoppet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="449"/>
+        <source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>kDrive er i vedligeholdelsestilstand.&lt;br&gt;Synkronisering begynder igen hurtigst muligt. Kontakt venligst vores supportteam, hvis fejlen fortsætter.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="455"/>
+        <source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+        <translation>kDrive er blokeret.&lt;br&gt;Forny venligst kDrive. Hvis der ikke handles, vil dataene blive slettet permanent og det vil være umuligt at gendanne dem.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="460"/>
+        <source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+        <translation>kDrive er blokeret.&lt;br&gt;Kontakt venligst en administrator for at forny kDrive. Hvis der ikke handles, vil dataene blive slettet permanent og det vil være umuligt at gendanne dem.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="466"/>
+        <source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>kDrive vågner.&lt;br&gt;Synkronisering begynder igen hurtigst muligt. Kontakt venligst vores supportteam, hvis fejlen fortsætter.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="475"/>
+        <source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>kDrive er i dvaletilstand.&lt;br&gt;Log venligst ind på &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;webversionen&lt;/a&gt; for at kontrollere din kDrive-status, eller kontakt din administrator.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="479"/>
+        <source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>kDrive er i dvaletilstand.&lt;br&gt;Log venligst ind på webversionen for at kontrollere din kDrive-status, eller kontakt din administrator.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="483"/>
+        <source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
+        <translation>Du har ikke adgang til denne kDrive.&lt;br&gt;Synkronisering er sat på pause. Kontakt venligst en administrator.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="493"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>Der er opstået en teknisk fejl (fejl %1).&lt;br&gt;Synkronisering genoptages hurtigst muligt. Kontakt venligst vores supportteam, hvis fejlen fortsætter.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="512"/>
+        <source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>Netværksforbindelserne er blevet afbrudt af kernen (fejl %1).&lt;br&gt;Ryd venligst historikken, og hvis fejlen fortsætter, kontakt vores supportteam.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="522"/>
+        <source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
+        <translation>Desværre kunne din gamle konfiguration ikke migreres.&lt;br&gt;Applikationen vil bruge en tom konfiguration.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="526"/>
+        <source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
+        <translation>Desværre kunne din gamle proxykonfiguration ikke migreres, SOCKS5-proxyer understøttes ikke i øjeblikket.&lt;br&gt;Applikationen vil i stedet bruge systemets proxyindstillinger.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="532"/>
+        <source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
+        <translation>Synkroniseringsmappen er blevet erstattet eller flyttet på en måde, der forhindrer synkronisering (fejl %1).&lt;br&gt;Dette kan ske efter kopiering, flytning eller gendannelse af mappen.&lt;br&gt;For at løse dette, opret venligst en ny synkronisering med en ny mappe.&lt;br&gt;Bemærk: Hvis du har usynkroniserede ændringer i den gamle mappe, skal du kopiere dem manuelt til den nye.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="539"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
+        <translation>Der er opstået en teknisk fejl (fejl %1).&lt;br&gt;Synkronisering er genstartet. Ryd venligst historikken, og hvis fejlen fortsætter, kontakt vores supportteam.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="550"/>
+        <source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
+        <translation>Der er opstået en fejl ved adgang til synkroniseringsdatabasen (fejl %1).&lt;br&gt;Synkronisering er stoppet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="564"/>
+        <source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
+        <translation>Der er opstået et loginproblem (fejl %1).&lt;br&gt;Token er ugyldigt eller tilbagekaldt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="569"/>
+        <source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
+        <translation>Indlejrede synkroniseringer er forbudte (fejl %1).&lt;br&gt;Du bør kun beholde synkroniseringer, hvis mapper ikke er indlejrede.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="573"/>
+        <source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
+        <translation>Synkroniseringsmappen på den fjernliggende kDrive eksisterer ikke længere eller er ikke længere tilgængelig (fejl %1).&lt;br&gt;Du skal gendanne den eller give den adgangsrettigheder tilbage eller slette/genoprette synkroniseringen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="580"/>
+        <source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
+        <translation>Filnavnfejl ved parsing (fejl %1).&lt;br&gt;Specialtegn som anførselstegn, omvendte skråstreger eller linjeskift kan forårsage parsing-fejl.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="609"/>
+        <source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>Dette element er blevet flyttet et andet sted hen.&lt;br&gt;Den lokale handling er annulleret.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="614"/>
+        <source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>Et element med samme navn eksisterer allerede på denne placering.&lt;br&gt;Den lokale handling er annulleret.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="618"/>
+        <source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
+        <translation>Et element med samme navn eksisterer allerede på denne placering.&lt;br&gt;Det lokale element er omdøbt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="622"/>
+        <source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
+        <translation>Filen blev ændret på samme tid af en anden bruger.&lt;br&gt;Dine ændringer er gemt i en kopi.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="626"/>
+        <source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>En anden bruger har flyttet en overordnet mappe til destinationen.&lt;br&gt;Den lokale handling er annulleret.</translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="649"/>
         <source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Ett befintligt objekt har ett identiskt namn med samma versaler och gemener.&lt;br&gt;Det har tillfälligt blockerats.</translation>
+        <translation>Et eksisterende element har et identisk navn med de samme store og små bogstaver.&lt;br&gt;Det er midlertidigt sortlistet.</translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="656"/>
         <source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Produktnamnet innehåller ett tecken som inte stöds.&lt;br&gt;Det har tillfälligt blockerats.</translation>
+        <translation>Elementnavnet indeholder et ikke-understøttet tegn.&lt;br&gt;Det er midlertidigt sortlistet.</translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="662"/>
         <source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Objektnamnet slutar med ett mellanslag, vilket inte är tillåtet i ditt operativsystem.&lt;br&gt;Det har tillfälligt lagts till i svartlistan.</translation>
+        <translation>Elementnavnet afsluttes med et mellemrum, hvilket er forbudt på dit operativsystem.&lt;br&gt;Det er midlertidigt sortlistet.</translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="668"/>
         <source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Det här objektnamnet är reserverat av ditt operativsystem.&lt;br&gt;Det har tillfälligt lagts till i svartlistan.</translation>
+        <translation>Dette elementnavn er reserveret af dit operativsystem.&lt;br&gt;Det er midlertidigt sortlistet.</translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="674"/>
         <source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Artikelnamnet är för långt.&lt;br&gt;Det har tillfälligt blockerats.</translation>
+        <translation>Elementnavnet er for langt.&lt;br&gt;Det er midlertidigt sortlistet.</translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="680"/>
         <source>The item path is too long.&lt;br&gt;It has been ignored.</source>
-        <translation>Sökvägen är för lång.&lt;br&gt;Den har ignorerats.</translation>
+        <translation>Elementstien er for lang.&lt;br&gt;Det er ignoreret.</translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="686"/>
         <source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
-        <translation>Objektnamnet innehåller ett nytt Unicode-tecken som ännu inte stöds av ditt filsystem.&lt;br&gt;Det har uteslutits från synkroniseringen.</translation>
+        <translation>Elementnavnet indeholder et nyere UNICODE-tegn, der endnu ikke understøttes af dit filsystem.&lt;br&gt;Det er udelukket fra synkronisering.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="692"/>
+        <source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Elementnavnet indeholder kun mellemrum.&lt;br&gt;Det er midlertidigt sortlistet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="703"/>
+        <source>Either you are not allowed to create an item, or another item already exists with the same name.&lt;br&gt;The item has been excluded from synchronization.</source>
+        <translation>Enten har du ikke tilladelse til at oprette et element, eller der eksisterer allerede et andet element med samme navn.&lt;br&gt;Elementet er udelukket fra synkronisering.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="708"/>
+        <source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
+        <translation>Du har ikke tilladelse til at redigere elementet.&lt;br&gt;Filen med dine ændringer er omdøbt og udelukket fra synkronisering.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="716"/>
+        <source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
+        <translation>Du har ikke tilladelse til at omdøbe elementet.&lt;br&gt;Det vil blive gendannet med sit originale navn.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="722"/>
+        <source>You are not allowed to move item to &quot;%1&quot;.&lt;br&gt;It will be restored into its original parent folder.</source>
+        <translation>Du har ikke tilladelse til at flytte elementet til &quot;%1&quot;.&lt;br&gt;Det vil blive gendannet i sin originale overordnede mappe.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="727"/>
+        <source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
+        <translation>Du har ikke tilladelse til at slette elementet.&lt;br&gt;Det vil blive gendannet på sin originale placering.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="732"/>
+        <source>Failed to move this item to trash, it has been blacklisted.</source>
+        <translation>Kunne ikke flytte dette element til papirkurven, det er sortlistet.</translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="735"/>
         <source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
-        <translation>Det gick inte att synkronisera det här objektet. Det har tillfälligt lagts till i svartlistan.&lt;br&gt;Ett nytt försök att synkronisera det kommer att göras om en timme eller nästa gång programmet startas.</translation>
+        <translation>Kunne ikke synkronisere dette element. Det er midlertidigt sortlistet.&lt;br&gt;Et nyt forsøg på at synkronisere det vil blive foretaget om en time eller ved næste opstart af applikationen.</translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="740"/>
         <source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
-        <translation>Denna post har undantagits från synkroniseringen genom en anpassad mall.&lt;br&gt;Du kan inaktivera denna typ av avisering under Inställningar</translation>
+        <translation>Dette element er udelukket fra synkronisering af en brugerdefineret skabelon.&lt;br&gt;Du kan deaktivere denne type meddelelse fra Indstillinger</translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="745"/>
         <source>This item has been excluded from sync because it is a hard link.</source>
-        <translation>Den här posten har uteslutits från synkroniseringen eftersom det är en hård länk.</translation>
+        <translation>Dette element er udelukket fra synkronisering, fordi det er et hårdt link.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="748"/>
+        <source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
+        <translation>Filen er blevet ændret lokalt, mens den er blevet slettet på den fjernliggende kDrive.&lt;br&gt;Den lokale kopi er gemt i redningmappen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="765"/>
+        <source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
+        <translation>Handlingen udført på elementet er forbudt.&lt;br&gt;Elementet er midlertidigt sortlistet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="771"/>
+        <source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
+        <translation>Handlingen udført på dette element mislykkedes.&lt;br&gt;Elementet er midlertidigt sortlistet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="776"/>
+        <source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
+        <translation>Filen er for stor til at blive uploadet. Den er midlertidigt sortlistet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="779"/>
+        <source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
+        <translation>Du har overskredet din kvota. Øg din pladskvota for at genaktivere filuploads.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="782"/>
+        <source>Impossible to download the file.</source>
+        <translation>Kan ikke downloade filen.</translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="785"/>
         <source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
-        <translation>Den här artikeln är för närvarande upptagen av en annan användare som är inloggad.&lt;br&gt;Vi försöker ladda upp dina ändringar igen senare.</translation>
+        <translation>Dette element er i øjeblikket låst af en anden bruger online.&lt;br&gt;Vi vil forsøge at uploade dine ændringer igen senere.</translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="790"/>
         <location filename="../src/gui/parametersdialog.cpp" line="834"/>
         <source>Synchronization error.</source>
-        <translation>Synkroniseringsfel.</translation>
+        <translation>Synkroniseringsfejl.</translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="810"/>
         <source>Can&apos;t access item.&lt;br&gt;Please fix the read and write permissions.</source>
-        <translation>Det går inte att komma åt objektet.&lt;br&gt;Kontrollera läs- och skrivbehörigheterna.</translation>
+        <translation>Kan ikke tilgå elementet.&lt;br&gt;Ret venligst læse- og skrivetilladelserne.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="814"/>
+        <source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
+        <translation>Der er ikke nok plads tilbage på din computer.&lt;br&gt;Downloaden er annulleret.</translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="818"/>
         <source>System error.</source>
-        <translation>Systemfel.</translation>
+        <translation>Systemfejl.</translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="825"/>
         <source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Objektet finns redan på den andra sidan.&lt;br&gt;Det har tillfälligt blockerats.</translation>
+        <translation>Elementet eksisterer allerede på den anden side.&lt;br&gt;Det er midlertidigt sortlistet.</translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="840"/>
         <source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-        <translation>Ett tekniskt fel har uppstått.&lt;br&gt;Rensa historiken och kontakta vår support om felet kvarstår.</translation>
+        <translation>Der er opstået en teknisk fejl.&lt;br&gt;Ryd venligst historikken, og hvis fejlen fortsætter, kontakt vores supportteam.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1082"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Kan ikke åbne mappestien %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1096"/>
+        <source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
+        <translation>Transmission gennemført!&lt;br&gt;Referer venligst til id&apos;et &lt;b&gt;%1&lt;/b&gt; i fejlrapporter.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1097"/>
+        <source>Transmission failed!
+Please, use the following link to send the logs to the support: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</source>
+        <translation>Transmission mislykkedes!
+Brug venligst følgende link til at sende loggene til support: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1118"/>
+        <source>No kDrive configured!</source>
+        <translation>Ingen kDrive konfigureret!</translation>
     </message>
 </context>
 <context>
@@ -1953,7 +1951,7 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
     <message>
         <location filename="../src/gui/preferencesblocwidget.cpp" line="187"/>
         <source>This synchronization is being deleted.</source>
-        <translation>Denna synkronisering raderas.</translation>
+        <translation>Denne synkronisering slettes.</translation>
     </message>
 </context>
 <context>
@@ -1961,65 +1959,160 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
     <message>
         <location filename="../src/gui/preferencesmenubarwidget.cpp" line="63"/>
         <source>Back to drive list</source>
-        <translation>Tillbaka till listan över körningar</translation>
+        <translation>Tilbage til drevlisten</translation>
     </message>
     <message>
         <location filename="../src/gui/preferencesmenubarwidget.cpp" line="64"/>
         <source>Preferences</source>
-        <translation>Inställningar</translation>
+        <translation>Indstillinger</translation>
     </message>
 </context>
 <context>
     <name>KDC::PreferencesWidget</name>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="466"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Kan ikke åbne mappen %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="478"/>
+        <source>Unable to open link %1.</source>
+        <translation>Kan ikke åbne linket %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="483"/>
+        <source>Invalid link %1.</source>
+        <translation>Ugyldigt link %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="490"/>
+        <source>Some process failed to run.</source>
+        <translation>Nogle processer kunne ikke køre.</translation>
+    </message>
+    <message>
         <location filename="../src/gui/preferenceswidget.cpp" line="491"/>
         <source>General</source>
-        <translation>Allmänt</translation>
+        <translation>Generelt</translation>
     </message>
     <message>
         <location filename="../src/gui/preferenceswidget.cpp" line="493"/>
         <source>Activate dark theme</source>
-        <translation>Aktivera mörkt tema</translation>
+        <translation>Aktivér mørkt tema</translation>
     </message>
     <message>
         <location filename="../src/gui/preferenceswidget.cpp" line="495"/>
         <source>Activate monochrome icons</source>
-        <translation>Aktivera monokroma ikoner</translation>
+        <translation>Aktivér monokrome ikoner</translation>
     </message>
     <message>
         <location filename="../src/gui/preferenceswidget.cpp" line="496"/>
         <source>Launch kDrive at startup</source>
-        <translation>Starta kDrive vid uppstart</translation>
+        <translation>Start kDrive ved opstart</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="497"/>
+        <source>Language</source>
+        <translation>Sprog</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="498"/>
+        <source>Move deleted files to my computer&apos;s trash</source>
+        <translation>Flyt slettede filer til min computers papirkurv</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="499"/>
+        <source>Some files or folders may not be moved to the computer&apos;s trash.</source>
+        <translation>Nogle filer eller mapper kan måske ikke flyttes til computerens papirkurv.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="500"/>
+        <source>You can always retrieve already synced files from the kDrive web application trash.</source>
+        <translation>Du kan altid hente allerede synkroniserede filer fra kDrive-webapplikationens papirkurv.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="502"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Læs mere&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="505"/>
+        <source>Default</source>
+        <translation>Standard</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="506"/>
+        <source>English</source>
+        <translation>Engelsk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="507"/>
+        <source>French</source>
+        <translation>Fransk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="508"/>
+        <source>German</source>
+        <translation>Tysk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="509"/>
+        <source>Spanish</source>
+        <translation>Spansk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="510"/>
+        <source>Italian</source>
+        <translation>Italiensk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="511"/>
+        <source>Swedish</source>
+        <translation>Svensk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="512"/>
+        <source>Portuguese</source>
+        <translation>Portugisisk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="513"/>
+        <source>Polish</source>
+        <translation>Polsk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="514"/>
+        <source>Norwegian</source>
+        <translation>Norsk</translation>
     </message>
     <message>
         <location filename="../src/gui/preferenceswidget.cpp" line="515"/>
         <source>Finnish</source>
-        <translation>Finska</translation>
+        <translation>Finsk</translation>
     </message>
     <message>
         <location filename="../src/gui/preferenceswidget.cpp" line="516"/>
         <source>Danish</source>
-        <translation>Danska</translation>
+        <translation>Dansk</translation>
     </message>
     <message>
         <location filename="../src/gui/preferenceswidget.cpp" line="522"/>
         <source>Advanced</source>
-        <translation>Avancerat</translation>
+        <translation>Avanceret</translation>
     </message>
     <message>
         <location filename="../src/gui/preferenceswidget.cpp" line="523"/>
         <source>Debugging information</source>
-        <translation>Felsökningsinformation</translation>
+        <translation>Fejlretningsoplysninger</translation>
     </message>
     <message>
         <location filename="../src/gui/preferenceswidget.cpp" line="525"/>
         <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
-        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Öppna felsökningsmappen&lt;/a&gt;</translation>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Åbn fejlretningsmappe&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../src/gui/preferenceswidget.cpp" line="526"/>
         <source>Files to exclude</source>
-        <translation>Filer att exkludera</translation>
+        <translation>Filer der skal ekskluderes</translation>
     </message>
     <message>
         <location filename="../src/gui/preferenceswidget.cpp" line="527"/>
@@ -2027,104 +2120,9 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <translation>Proxyserver</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="511"/>
-        <source>Swedish</source>
-        <translation>Svenska</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="512"/>
-        <source>Portuguese</source>
-        <translation>Portugisiska</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="513"/>
-        <source>Polish</source>
-        <translation>Polska</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="514"/>
-        <source>Norwegian</source>
-        <translation>Norska</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="466"/>
-        <source>Unable to open folder %1.</source>
-        <translation>Det går inte att öppna mappen %1.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="478"/>
-        <source>Unable to open link %1.</source>
-        <translation>Det går inte att öppna länken %1.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="483"/>
-        <source>Invalid link %1.</source>
-        <translation>Ogiltig länk %1.</translation>
-    </message>
-    <message>
         <location filename="../src/gui/preferenceswidget.cpp" line="529"/>
         <source>Lite Sync</source>
         <translation>Lite Sync</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="497"/>
-        <source>Language</source>
-        <translation>Språk</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="490"/>
-        <source>Some process failed to run.</source>
-        <translation>Någon process kunde inte köras.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="498"/>
-        <source>Move deleted files to my computer&apos;s trash</source>
-        <translation>Flytta borttagna filer till datorns papperskorg</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="499"/>
-        <source>Some files or folders may not be moved to the computer&apos;s trash.</source>
-        <translation>Vissa filer eller mappar kanske inte kan flyttas till datorns papperskorg.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="500"/>
-        <source>You can always retrieve already synced files from the kDrive web application trash.</source>
-        <translation>Du kan alltid återställa redan synkroniserade filer från papperskorgen i kDrives webbapp.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="502"/>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Läs mer&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="506"/>
-        <source>English</source>
-        <translation>Engelska</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="507"/>
-        <source>French</source>
-        <translation>Franska</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="508"/>
-        <source>German</source>
-        <translation>Tyska</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="509"/>
-        <source>Spanish</source>
-        <translation>Spanska</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="510"/>
-        <source>Italian</source>
-        <translation>Italienska</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="505"/>
-        <source>Default</source>
-        <translation>Standard</translation>
     </message>
 </context>
 <context>
@@ -2132,7 +2130,7 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
     <message>
         <location filename="../src/gui/progressbarwidget.cpp" line="70"/>
         <source>%1 in use</source>
-        <translation>%1 används</translation>
+        <translation>%1 i brug</translation>
     </message>
 </context>
 <context>
@@ -2155,62 +2153,62 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
     <message>
         <location filename="../src/gui/proxyserverdialog.cpp" line="90"/>
         <source>Use system parameters</source>
-        <translation>Använd systemparametrar</translation>
+        <translation>Brug systemparametre</translation>
     </message>
     <message>
         <location filename="../src/gui/proxyserverdialog.cpp" line="95"/>
         <source>Indicate a proxy manually</source>
-        <translation>Ange en fullmaktsinnehavare manuellt</translation>
+        <translation>Angiv en proxy manuelt</translation>
     </message>
     <message>
         <location filename="../src/gui/proxyserverdialog.cpp" line="131"/>
         <source>Port</source>
-        <translation>Hamn</translation>
+        <translation>Port</translation>
     </message>
     <message>
         <location filename="../src/gui/proxyserverdialog.cpp" line="144"/>
         <source>Address of the proxy server</source>
-        <translation>Proxyserverns adress</translation>
+        <translation>Adresse på proxyserveren</translation>
     </message>
     <message>
         <location filename="../src/gui/proxyserverdialog.cpp" line="150"/>
         <source>Authentication needed</source>
-        <translation>Inloggning krävs</translation>
+        <translation>Godkendelse krævet</translation>
     </message>
     <message>
         <location filename="../src/gui/proxyserverdialog.cpp" line="165"/>
         <source>User</source>
-        <translation>Användare</translation>
+        <translation>Bruger</translation>
     </message>
     <message>
         <location filename="../src/gui/proxyserverdialog.cpp" line="171"/>
         <source>Password</source>
-        <translation>Lösenord</translation>
+        <translation>Adgangskode</translation>
     </message>
     <message>
         <location filename="../src/gui/proxyserverdialog.cpp" line="185"/>
         <source>SAVE</source>
-        <translation>SPARA</translation>
+        <translation>GEM</translation>
     </message>
     <message>
         <location filename="../src/gui/proxyserverdialog.cpp" line="192"/>
         <source>CANCEL</source>
-        <translation>AVBRYT</translation>
+        <translation>ANNULLER</translation>
     </message>
     <message>
         <location filename="../src/gui/proxyserverdialog.cpp" line="286"/>
         <source>Do you want to save your modifications?</source>
-        <translation>Vill du spara dina ändringar?</translation>
+        <translation>Vil du gemme dine ændringer?</translation>
     </message>
     <message>
         <location filename="../src/gui/proxyserverdialog.cpp" line="295"/>
         <source>Unable to save, all mandatory fields are not completed!</source>
-        <translation>Det går inte att spara, eftersom alla obligatoriska fält inte är ifyllda!</translation>
+        <translation>Kan ikke gemme, ikke alle obligatoriske felter er udfyldt!</translation>
     </message>
     <message>
         <location filename="../src/gui/proxyserverdialog.cpp" line="316"/>
         <source>Proxy not found, save anyway?</source>
-        <translation>Proxy hittades inte, vill du spara ändå?</translation>
+        <translation>Proxy ikke fundet, gem alligevel?</translation>
     </message>
 </context>
 <context>
@@ -2218,27 +2216,27 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
     <message>
         <location filename="../src/gui/resourcesmanagerdialog.cpp" line="55"/>
         <source>Resources Manager</source>
-        <translation>Resursansvarig</translation>
+        <translation>Ressourcemanager</translation>
     </message>
     <message>
         <location filename="../src/gui/resourcesmanagerdialog.cpp" line="65"/>
         <source>Maximum CPU usage allowed</source>
-        <translation>Högsta tillåtna CPU-användning</translation>
+        <translation>Maksimal tilladt CPU-brug</translation>
     </message>
     <message>
         <location filename="../src/gui/resourcesmanagerdialog.cpp" line="96"/>
         <source>SAVE</source>
-        <translation>SPARA</translation>
+        <translation>GEM</translation>
     </message>
     <message>
         <location filename="../src/gui/resourcesmanagerdialog.cpp" line="103"/>
         <source>CANCEL</source>
-        <translation>AVBRYT</translation>
+        <translation>ANNULLER</translation>
     </message>
     <message>
         <location filename="../src/gui/resourcesmanagerdialog.cpp" line="122"/>
         <source>Do you want to save your modifications?</source>
-        <translation>Vill du spara dina ändringar?</translation>
+        <translation>Vil du gemme dine ændringer?</translation>
     </message>
 </context>
 <context>
@@ -2246,37 +2244,37 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
     <message>
         <location filename="../src/gui/serverbasefolderdialog.cpp" line="81"/>
         <source>Select a folder on your kDrive</source>
-        <translation>Välj en mapp på din kDrive</translation>
+        <translation>Vælg en mappe på din kDrive</translation>
     </message>
     <message>
         <location filename="../src/gui/serverbasefolderdialog.cpp" line="90"/>
         <source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
-        <translation>Innehållet i den valda mappen kommer att synkroniseras till mappen &lt;b&gt;%1&lt;/b&gt;.</translation>
+        <translation>Indholdet af den valgte mappe vil blive synkroniseret i mappen &lt;b&gt;%1&lt;/b&gt;.</translation>
     </message>
     <message>
         <location filename="../src/gui/serverbasefolderdialog.cpp" line="134"/>
         <source>CONTINUE</source>
-        <translation>FORTSÄTT</translation>
+        <translation>FORTSÆT</translation>
     </message>
     <message>
         <location filename="../src/gui/serverbasefolderdialog.cpp" line="150"/>
         <source>Space available on your computer for the current folder : %1</source>
-        <translation>Ledig utrymme på din dator för den aktuella mappen: %1</translation>
+        <translation>Tilgængeligt plads på din computer til den aktuelle mappe: %1</translation>
     </message>
     <message>
         <location filename="../src/gui/serverbasefolderdialog.cpp" line="190"/>
         <source>This folder is already being synced.</source>
-        <translation>Den här mappen synkroniseras redan.</translation>
+        <translation>Denne mappe synkroniseres allerede.</translation>
     </message>
     <message>
         <location filename="../src/gui/serverbasefolderdialog.cpp" line="204"/>
         <source>CONFIRM</source>
-        <translation>BEKRÄFTA</translation>
+        <translation>BEKRÆFT</translation>
     </message>
     <message>
         <location filename="../src/gui/serverbasefolderdialog.cpp" line="205"/>
         <source>CANCEL</source>
-        <translation>AVBRYT</translation>
+        <translation>ANNULLER</translation>
     </message>
 </context>
 <context>
@@ -2284,17 +2282,17 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
     <message>
         <location filename="../src/gui/serverfoldersdialog.cpp" line="80"/>
         <source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
-        <translation>Mappen &lt;b&gt;%1&lt;/b&gt; innehåller undermappar.&lt;br&gt; Välj de som du vill synkronisera</translation>
+        <translation>Mappen &lt;b&gt;%1&lt;/b&gt; indeholder undermapper,&lt;br&gt; vælg dem, du vil synkronisere</translation>
     </message>
     <message>
         <location filename="../src/gui/serverfoldersdialog.cpp" line="110"/>
         <source>CONTINUE</source>
-        <translation>FORTSÄTT</translation>
+        <translation>FORTSÆT</translation>
     </message>
     <message>
         <location filename="../src/gui/serverfoldersdialog.cpp" line="146"/>
         <source>No subfolders currently on the server.</source>
-        <translation>Det finns för närvarande inga undermappar på servern.</translation>
+        <translation>Ingen undermapper på serveren i øjeblikket.</translation>
     </message>
 </context>
 <context>
@@ -2302,71 +2300,141 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
     <message>
         <location filename="../src/gui/statusbarwidget.cpp" line="178"/>
         <source>Resume kDrive &quot;%1&quot; synchronization</source>
-        <translation>Återuppta synkroniseringen av kDrive &amp;quot;%1&amp;quot;</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/statusbarwidget.cpp" line="180"/>
-        <source>Resume all kDrives synchronization</source>
-        <translation>Återuppta all synkronisering av kDrives</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/statusbarwidget.cpp" line="183"/>
-        <source>Pause kDrive &quot;%1&quot; synchronization</source>
-        <translation>Avbryt synkroniseringen av kDrive &amp;quot;%1&amp;quot;</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/statusbarwidget.cpp" line="184"/>
-        <location filename="../src/gui/statusbarwidget.cpp" line="321"/>
-        <source>Pause synchronization</source>
-        <translation>Pausa synkroniseringen</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/statusbarwidget.cpp" line="185"/>
-        <source>Pause all kDrives synchronization</source>
-        <translation>Pausa all synkronisering av kDrives</translation>
+        <translation>Genoptag synkronisering af kDrive &quot;%1&quot;</translation>
     </message>
     <message>
         <location filename="../src/gui/statusbarwidget.cpp" line="179"/>
         <location filename="../src/gui/statusbarwidget.cpp" line="322"/>
         <source>Resume synchronization</source>
-        <translation>Fortsätt synkroniseringen</translation>
+        <translation>Genoptag synkronisering</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="180"/>
+        <source>Resume all kDrives synchronization</source>
+        <translation>Genoptag synkronisering af alle kDrives</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="183"/>
+        <source>Pause kDrive &quot;%1&quot; synchronization</source>
+        <translation>Sæt synkronisering af kDrive &quot;%1&quot; på pause</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="184"/>
+        <location filename="../src/gui/statusbarwidget.cpp" line="321"/>
+        <source>Pause synchronization</source>
+        <translation>Sæt synkronisering på pause</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="185"/>
+        <source>Pause all kDrives synchronization</source>
+        <translation>Sæt synkronisering af alle kDrives på pause</translation>
     </message>
 </context>
 <context>
     <name>KDC::SynchronizedItemWidget</name>
     <message>
-        <location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
-        <source>Copy share link</source>
-        <translation>Kopiera delningslänken</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
-        <source>Display on kdrive.infomaniak.com</source>
-        <translation>Visas på kdrive.infomaniak.com</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
-        <source>Show in folder</source>
-        <translation>Visa i mappen</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
-        <source>More actions</source>
-        <translation>Fler åtgärder</translation>
-    </message>
-    <message>
         <location filename="../src/gui/synchronizeditemwidget.cpp" line="317"/>
         <source>Open</source>
-        <translation>Öppna</translation>
+        <translation>Åbn</translation>
     </message>
     <message>
         <location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
         <source>Add to favorites</source>
-        <translation>Lägg till i favoriter</translation>
+        <translation>Føj til favoritter</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
+        <source>Copy share link</source>
+        <translation>Kopiér delingslink</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
+        <source>Display on kdrive.infomaniak.com</source>
+        <translation>Vis på kdrive.infomaniak.com</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
+        <source>Show in folder</source>
+        <translation>Vis i mappe</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
+        <source>More actions</source>
+        <translation>Flere handlinger</translation>
     </message>
 </context>
 <context>
     <name>KDC::SynthesisBar</name>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="149"/>
+        <source>Unable to open folder url %1.</source>
+        <translation>Kan ikke åbne mappen-url %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="219"/>
+        <source>Open in folder</source>
+        <translation>Åbn i mappe</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="257"/>
+        <source>Open %1 web version</source>
+        <translation>Åbn %1 webversion</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="267"/>
+        <source>Drive parameters</source>
+        <translation>Drevindstillinger</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="280"/>
+        <source>Notifications disabled until %1</source>
+        <translation>Meddelelser deaktiveret indtil %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="281"/>
+        <source>Disable Notifications</source>
+        <translation>Deaktivér meddelelser</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="314"/>
+        <source>Application preferences</source>
+        <translation>Applikationsindstillinger</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="322"/>
+        <source>Need help</source>
+        <translation>Brug for hjælp</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="330"/>
+        <source>Send feedbacks</source>
+        <translation>Send feedback</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="338"/>
+        <source>Quit kDrive</source>
+        <translation>Afslut kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="401"/>
+        <source>Unable to access web site %1.</source>
+        <translation>Kan ikke tilgå webstedet %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="492"/>
+        <source>Show errors and informations</source>
+        <translation>Vis fejl og information</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="493"/>
+        <source>Show informations</source>
+        <translation>Vis information</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="494"/>
+        <source>More actions</source>
+        <translation>Flere handlinger</translation>
+    </message>
     <message>
         <location filename="../src/gui/synthesisbar.cpp" line="495"/>
         <location filename="../src/gui/synthesisbar.cpp" line="502"/>
@@ -2376,172 +2444,57 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
     <message>
         <location filename="../src/gui/synthesisbar.cpp" line="496"/>
         <source>During 1 hour</source>
-        <translation>Under 1 timme</translation>
+        <translation>I 1 time</translation>
     </message>
     <message>
         <location filename="../src/gui/synthesisbar.cpp" line="497"/>
         <location filename="../src/gui/synthesisbar.cpp" line="504"/>
         <source>Until tomorrow 8:00AM</source>
-        <translation>Fram till imorgon kl. 08.00</translation>
+        <translation>Til i morgen kl. 8:00</translation>
     </message>
     <message>
         <location filename="../src/gui/synthesisbar.cpp" line="498"/>
         <source>During 3 days</source>
-        <translation>Under tre dagar</translation>
+        <translation>I 3 dage</translation>
     </message>
     <message>
         <location filename="../src/gui/synthesisbar.cpp" line="499"/>
         <source>During 1 week</source>
-        <translation>Under en vecka</translation>
+        <translation>I 1 uge</translation>
     </message>
     <message>
         <location filename="../src/gui/synthesisbar.cpp" line="500"/>
         <location filename="../src/gui/synthesisbar.cpp" line="507"/>
         <source>Always</source>
-        <translation>Alltid</translation>
+        <translation>Altid</translation>
     </message>
     <message>
         <location filename="../src/gui/synthesisbar.cpp" line="503"/>
         <source>For 1 more hour</source>
-        <translation>I ytterligare 1 timme</translation>
+        <translation>I 1 time mere</translation>
     </message>
     <message>
         <location filename="../src/gui/synthesisbar.cpp" line="505"/>
         <source>For 3 more days</source>
-        <translation>I ytterligare 3 dagar</translation>
+        <translation>I 3 dage mere</translation>
     </message>
     <message>
         <location filename="../src/gui/synthesisbar.cpp" line="506"/>
         <source>For 1 more week</source>
-        <translation>Ytterligare en vecka</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="149"/>
-        <source>Unable to open folder url %1.</source>
-        <translation>Det går inte att öppna mappen med adressen %1.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="219"/>
-        <source>Open in folder</source>
-        <translation>Öppna i mappen</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="257"/>
-        <source>Open %1 web version</source>
-        <translation>Öppna webbversionen av %1</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="267"/>
-        <source>Drive parameters</source>
-        <translation>Drivparametrar</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="280"/>
-        <source>Notifications disabled until %1</source>
-        <translation>Meddelanden är inaktiverade fram till %1</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="281"/>
-        <source>Disable Notifications</source>
-        <translation>Inaktivera aviseringar</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="314"/>
-        <source>Application preferences</source>
-        <translation>Inställningar för applikationen</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="322"/>
-        <source>Need help</source>
-        <translation>Behöver du hjälp?</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="330"/>
-        <source>Send feedbacks</source>
-        <translation>Skicka synpunkter</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="338"/>
-        <source>Quit kDrive</source>
-        <translation>Avsluta kDrive</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="401"/>
-        <source>Unable to access web site %1.</source>
-        <translation>Det går inte att komma åt webbplatsen %1.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="492"/>
-        <source>Show errors and informations</source>
-        <translation>Visa fel och information</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="493"/>
-        <source>Show informations</source>
-        <translation>Visa information</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesisbar.cpp" line="494"/>
-        <source>More actions</source>
-        <translation>Fler åtgärder</translation>
+        <translation>I 1 uge mere</translation>
     </message>
 </context>
 <context>
     <name>KDC::SynthesisPopover</name>
     <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1181"/>
-        <source>Update kDrive App</source>
-        <translation>Uppdatera kDrive-appen</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1182"/>
-        <source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
-        <translation>Denna version av kDrive-appen stöds inte längre. Uppdatera appen för att få tillgång till de senaste funktionerna och förbättringarna.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="978"/>
-        <source>Update</source>
-        <translation>Uppdatering</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1187"/>
-        <source>Please download the latest version on the website.</source>
-        <translation>Ladda gärna ner den senaste versionen från webbplatsen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="981"/>
-        <source>Update download in progress</source>
-        <translation>Uppdateringen hämtas just nu</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="984"/>
-        <source>Looking for update...</source>
-        <translation>Väntar på uppdatering...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="987"/>
-        <source>Manual update</source>
-        <translation>Manuell uppdatering</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="990"/>
-        <source>Unavailable</source>
-        <translation>Ej tillgängligt</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1200"/>
-        <source>You can synchronize files &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;from your computer&lt;/a&gt; or on &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
-        <translation>Du kan synkronisera filer &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;från din dator&lt;/a&gt; eller från &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
-    </message>
-    <message>
         <location filename="../src/gui/synthesispopover.cpp" line="446"/>
         <source>Synchronized</source>
-        <translation>Synkroniserad</translation>
+        <translation>Synkroniseret</translation>
     </message>
     <message>
         <location filename="../src/gui/synthesispopover.cpp" line="450"/>
         <source>Favorites</source>
-        <translation>Favoriter</translation>
+        <translation>Favoritter</translation>
     </message>
     <message>
         <location filename="../src/gui/synthesispopover.cpp" line="454"/>
@@ -2549,40 +2502,85 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <translation>Aktivitet</translation>
     </message>
     <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="586"/>
+        <source>Unable to open folder url %1.</source>
+        <translation>Kan ikke åbne mappen-url %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="978"/>
+        <source>Update</source>
+        <translation>Opdater</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="981"/>
+        <source>Update download in progress</source>
+        <translation>Opdateringsdownload i gang</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="984"/>
+        <source>Looking for update...</source>
+        <translation>Søger efter opdatering...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="987"/>
+        <source>Manual update</source>
+        <translation>Manuel opdatering</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="990"/>
+        <source>Unavailable</source>
+        <translation>Ikke tilgængelig</translation>
+    </message>
+    <message>
         <location filename="../src/gui/synthesispopover.cpp" line="1133"/>
         <location filename="../src/gui/synthesispopover.cpp" line="1180"/>
         <source>Not implemented!</source>
-        <translation>Har inte implementerats!</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1184"/>
-        <source>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Click here to download manually&lt;/a&gt;</source>
-        <translation>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Klicka här för att ladda ner manuellt&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1193"/>
-        <source>No synchronized folder for this Drive!</source>
-        <translation>Det finns ingen synkroniserad mapp för den här Drive-kontot!</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="1196"/>
-        <source>No kDrive configured!</source>
-        <translation>kDrive är inte konfigurerat!</translation>
+        <translation>Ikke implementeret!</translation>
     </message>
     <message>
         <location filename="../src/gui/synthesispopover.cpp" line="1161"/>
         <source>Unable to open link %1.</source>
-        <translation>Det går inte att öppna länken %1.</translation>
+        <translation>Kan ikke åbne linket %1.</translation>
     </message>
     <message>
         <location filename="../src/gui/synthesispopover.cpp" line="1173"/>
         <source>Invalid link %1.</source>
-        <translation>Ogiltig länk %1.</translation>
+        <translation>Ugyldigt link %1.</translation>
     </message>
     <message>
-        <location filename="../src/gui/synthesispopover.cpp" line="586"/>
-        <source>Unable to open folder url %1.</source>
-        <translation>Det går inte att öppna mappen med adressen %1.</translation>
+        <location filename="../src/gui/synthesispopover.cpp" line="1181"/>
+        <source>Update kDrive App</source>
+        <translation>Opdater kDrive-appen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1182"/>
+        <source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
+        <translation>Denne version af kDrive-appen understøttes ikke længere. For at få adgang til de nyeste funktioner og forbedringer, opdater venligst.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1184"/>
+        <source>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Click here to download manually&lt;/a&gt;</source>
+        <translation>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Klik her for at downloade manuelt&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1187"/>
+        <source>Please download the latest version on the website.</source>
+        <translation>Download venligst den nyeste version på webstedet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1193"/>
+        <source>No synchronized folder for this Drive!</source>
+        <translation>Ingen synkroniseret mappe for dette drev!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1196"/>
+        <source>No kDrive configured!</source>
+        <translation>Ingen kDrive konfigureret!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1200"/>
+        <source>You can synchronize files &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;from your computer&lt;/a&gt; or on &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
+        <translation>Du kan synkronisere filer &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;fra din computer&lt;/a&gt; eller på &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
     </message>
 </context>
 <context>
@@ -2590,22 +2588,22 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
     <message>
         <location filename="../src/gui/updater/updatedialog.cpp" line="61"/>
         <source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
-        <translation>&lt;p&gt;Den nya versionen &lt;b&gt;%1&lt;/b&gt; av %2-klienten är tillgänglig och har hämtats.&lt;/p&gt;&lt;p&gt;Den installerade versionen är %3.&lt;/p&gt;</translation>
+        <translation>&lt;p&gt;Den nye version &lt;b&gt;%1&lt;/b&gt; af %2-klienten er tilgængelig og er downloadet.&lt;/p&gt;&lt;p&gt;Den installerede version er %3.&lt;/p&gt;</translation>
     </message>
     <message>
         <location filename="../src/gui/updater/updatedialog.cpp" line="95"/>
         <source>Skip this version</source>
-        <translation>Hoppa över den här versionen</translation>
+        <translation>Spring denne version over</translation>
     </message>
     <message>
         <location filename="../src/gui/updater/updatedialog.cpp" line="103"/>
         <source>Remind me later</source>
-        <translation>Påminn mig senare</translation>
+        <translation>Påmind mig senere</translation>
     </message>
     <message>
         <location filename="../src/gui/updater/updatedialog.cpp" line="109"/>
         <source>Install update</source>
-        <translation>Installera uppdatering</translation>
+        <translation>Installer opdatering</translation>
     </message>
 </context>
 <context>
@@ -2613,12 +2611,12 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
     <message>
         <location filename="../src/server/updater/updatemanager.cpp" line="86"/>
         <source>New update available.</source>
-        <translation>En ny uppdatering finns tillgänglig.</translation>
+        <translation>Ny opdatering tilgængelig.</translation>
     </message>
     <message>
         <location filename="../src/server/updater/updatemanager.cpp" line="87"/>
         <source>Version %1 is available for download.</source>
-        <translation>Version %1 finns tillgänglig för nedladdning.</translation>
+        <translation>Version %1 er tilgængelig til download.</translation>
     </message>
 </context>
 <context>
@@ -2626,20 +2624,15 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
     <message>
         <location filename="../src/gui/userselectionwidget.cpp" line="131"/>
         <source>Add an account</source>
-        <translation>Lägg till ett konto</translation>
+        <translation>Tilføj en konto</translation>
     </message>
 </context>
 <context>
     <name>KDC::VersionWidget</name>
     <message>
-        <location filename="../src/gui/versionwidget.cpp" line="295"/>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</source>
-        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</translation>
-    </message>
-    <message>
         <location filename="../src/gui/versionwidget.cpp" line="169"/>
         <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Show release note&lt;/a&gt;</source>
-        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Visa informationsnot&lt;/a&gt;</translation>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Vis frigivelsesbemærkninger&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../src/gui/versionwidget.cpp" line="172"/>
@@ -2649,52 +2642,52 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
     <message>
         <location filename="../src/gui/versionwidget.cpp" line="173"/>
         <source>UPDATE</source>
-        <translation>UPPDATERING</translation>
+        <translation>OPDATER</translation>
     </message>
     <message>
         <location filename="../src/gui/versionwidget.cpp" line="197"/>
         <source>%1 is up to date!</source>
-        <translation>%1 är uppdaterad!</translation>
+        <translation>%1 er opdateret!</translation>
     </message>
     <message>
         <location filename="../src/gui/versionwidget.cpp" line="201"/>
         <source>Checking update on server...</source>
-        <translation>Kontrollerar uppdateringar på servern...</translation>
+        <translation>Søger efter opdatering på serveren...</translation>
     </message>
     <message>
         <location filename="../src/gui/versionwidget.cpp" line="205"/>
         <source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;here&lt;/a&gt;.</source>
-        <translation>En uppdatering finns tillgänglig: %1.&lt;br&gt;Ladda ner den &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;här&lt;/a&gt;.</translation>
+        <translation>En opdatering er tilgængelig: %1.&lt;br&gt;Download den venligst fra &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;her&lt;/a&gt;.</translation>
     </message>
     <message>
         <location filename="../src/gui/versionwidget.cpp" line="212"/>
         <source>An update is available: %1</source>
-        <translation>En uppdatering finns tillgänglig: %1</translation>
+        <translation>En opdatering er tilgængelig: %1</translation>
     </message>
     <message>
         <location filename="../src/gui/versionwidget.cpp" line="218"/>
         <source>Downloading %1. Please wait...</source>
-        <translation>Hämtar %1. Vänta...</translation>
+        <translation>Downloader %1. Vent venligst...</translation>
     </message>
     <message>
         <location filename="../src/gui/versionwidget.cpp" line="223"/>
         <source>Could not check for new updates.</source>
-        <translation>Det gick inte att söka efter nya uppdateringar.</translation>
+        <translation>Kunne ikke søge efter nye opdateringer.</translation>
     </message>
     <message>
         <location filename="../src/gui/versionwidget.cpp" line="227"/>
         <source>An error occurred during update.</source>
-        <translation>Ett fel uppstod under uppdateringen.</translation>
+        <translation>Der opstod en fejl under opdateringen.</translation>
     </message>
     <message>
         <location filename="../src/gui/versionwidget.cpp" line="231"/>
         <source>Could not download update.</source>
-        <translation>Det gick inte att ladda ner uppdateringen.</translation>
+        <translation>Kunne ikke downloade opdateringen.</translation>
     </message>
     <message>
         <location filename="../src/gui/versionwidget.cpp" line="235"/>
         <source>Update disabled.</source>
-        <translation>Uppdateringen är inaktiverad.</translation>
+        <translation>Opdatering deaktiveret.</translation>
     </message>
     <message>
         <location filename="../src/gui/versionwidget.cpp" line="251"/>
@@ -2704,145 +2697,150 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
     <message>
         <location filename="../src/gui/versionwidget.cpp" line="252"/>
         <source>Get early access to new versions of the application</source>
-        <translation>Få tidig tillgång till nya versioner av applikationen</translation>
+        <translation>Få tidlig adgang til nye versioner af applikationen</translation>
     </message>
     <message>
         <location filename="../src/gui/versionwidget.cpp" line="256"/>
         <source>Join</source>
-        <translation>Gå med</translation>
+        <translation>Tilmeld</translation>
     </message>
     <message>
         <location filename="../src/gui/versionwidget.cpp" line="259"/>
         <source>Modify</source>
-        <translation>Ändra</translation>
+        <translation>Rediger</translation>
     </message>
     <message>
         <location filename="../src/gui/versionwidget.cpp" line="259"/>
         <source>Quit</source>
-        <translation>Avsluta</translation>
+        <translation>Afslut</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="295"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/gui/parameterscache.cpp" line="59"/>
-        <source>Unable to save parameters, please retry later.</source>
-        <translation>Det gick inte att spara parametrarna. Försök igen senare.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parameterscache.cpp" line="60"/>
-        <source>Unable to save parameters!</source>
-        <translation>Det går inte att spara parametrarna!</translation>
-    </message>
-    <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="461"/>
-        <source>The parent folder is a sync folder or contained in one</source>
-        <translation>Överordnad mapp är en synkroniseringsmapp eller ingår i en sådan</translation>
-    </message>
-    <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="495"/>
-        <source>Can&apos;t find a valid path</source>
-        <translation>Det går inte att hitta en giltig sökväg</translation>
-    </message>
-    <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2108"/>
-        <source>No valid folder selected!</source>
-        <translation>Ingen giltig mapp har valts!</translation>
-    </message>
-    <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2119"/>
-        <source>The selected path does not exist!</source>
-        <translation>Den valda sökvägen finns inte!</translation>
-    </message>
-    <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2124"/>
-        <source>The selected path is not a folder!</source>
-        <translation>Den valda sökvägen är ingen mapp!</translation>
-    </message>
-    <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2129"/>
-        <source>You have no permission to write to the selected folder!</source>
-        <translation>Du har inte behörighet att skriva till den valda mappen!</translation>
-    </message>
-    <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2159"/>
-        <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
-        <translation>Den lokala mappen %1 innehåller en mapp som redan är synkroniserad. Välj en annan!</translation>
-    </message>
-    <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2167"/>
-        <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
-        <translation>Den lokala mappen %1 finns i en mapp som redan är synkroniserad. Välj en annan mapp!</translation>
-    </message>
-    <message>
-        <location filename="../src/server/requests/serverrequests.cpp" line="2175"/>
-        <source>The local folder %1 is already synced. Please pick another one!</source>
-        <translation>Den lokala mappen %1 är redan synkroniserad. Välj en annan!</translation>
-    </message>
-    <message>
         <location filename="../src/gui/folderitemwidget.cpp" line="42"/>
         <source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
-        <translation>Lite sync (Beta) är aktiverat. Filerna från kDrive sparas i molnet och tar inte upp lagringsutrymme på din dator.</translation>
+        <translation>Lite Sync (Beta) er aktiveret. Filer fra kDrive forbliver i skyen og bruger ikke din computers lagerplads.</translation>
     </message>
     <message>
         <location filename="../src/gui/folderitemwidget.cpp" line="45"/>
         <source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
-        <translation>Lite sync (Beta) är inaktiverat. kDrive-filerna använder lagringsutrymmet på din dator.</translation>
+        <translation>Lite Sync (Beta) er deaktiveret. kDrive-filerne bruger din computers lagerplads.</translation>
     </message>
     <message>
         <location filename="../src/gui/folderitemwidget.cpp" line="48"/>
         <source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
-        <translation>Lite-synkronisering är aktiverad. Filerna från kDrive sparas i molnet och tar inte upp lagringsutrymme på din dator.</translation>
+        <translation>Lite Sync er aktiveret. Filer fra kDrive forbliver i skyen og bruger ikke din computers lagerplads.</translation>
     </message>
     <message>
         <location filename="../src/gui/folderitemwidget.cpp" line="50"/>
         <source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
-        <translation>Lite sync är inaktiverat. kDrive-filerna använder lagringsutrymmet på din dator.</translation>
+        <translation>Lite Sync er deaktiveret. kDrive-filerne bruger din computers lagerplads.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parameterscache.cpp" line="59"/>
+        <source>Unable to save parameters, please retry later.</source>
+        <translation>Kan ikke gemme parametre. Prøv venligst igen senere.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parameterscache.cpp" line="60"/>
+        <source>Unable to save parameters!</source>
+        <translation>Kan ikke gemme parametre!</translation>
     </message>
     <message>
         <location filename="../src/server/comm/extensionjob.cpp" line="1175"/>
         <source>Make available locally</source>
-        <translation>Gör tillgängligt lokalt</translation>
+        <translation>Gør tilgængeligt lokalt</translation>
     </message>
     <message>
         <location filename="../src/server/comm/extensionjob.cpp" line="1179"/>
         <source>Free up local space</source>
-        <translation>Frigör lokalt lagringsutrymme</translation>
+        <translation>Frigør lokal plads</translation>
     </message>
     <message>
         <location filename="../src/server/comm/extensionjob.cpp" line="1183"/>
         <source>Cancel free up local space</source>
-        <translation>Avbryt för att frigöra lokalt utrymme</translation>
+        <translation>Annuller frigørelse af lokal plads</translation>
     </message>
     <message>
         <location filename="../src/server/comm/extensionjob.cpp" line="1187"/>
         <source>Cancel make available locally</source>
-        <translation>Avbryt lokal tillgängliggöring</translation>
+        <translation>Annuller gør tilgængeligt lokalt</translation>
     </message>
     <message>
         <location filename="../src/server/comm/extensionjob.cpp" line="1191"/>
         <source>Resharing this file is not allowed</source>
-        <translation>Det är inte tillåtet att vidarebefordra den här filen</translation>
+        <translation>Gendeling af denne fil er ikke tilladt</translation>
     </message>
     <message>
         <location filename="../src/server/comm/extensionjob.cpp" line="1192"/>
         <source>Resharing this folder is not allowed</source>
-        <translation>Det är inte tillåtet att dela den här mappen vidare</translation>
+        <translation>Gendeling af denne mappe er ikke tilladt</translation>
     </message>
     <message>
         <location filename="../src/server/comm/extensionjob.cpp" line="1196"/>
         <source>Copy public share link</source>
-        <translation>Kopiera länken till den offentliga delningen</translation>
+        <translation>Kopiér offentligt delingslink</translation>
     </message>
     <message>
         <location filename="../src/server/comm/extensionjob.cpp" line="1200"/>
         <source>Copy private share link</source>
-        <translation>Kopiera länken till den privata delningen</translation>
+        <translation>Kopiér privat delingslink</translation>
     </message>
     <message>
         <location filename="../src/server/comm/extensionjob.cpp" line="1204"/>
         <source>Open in browser</source>
-        <translation>Öppna i webbläsaren</translation>
+        <translation>Åbn i browser</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="461"/>
+        <source>The parent folder is a sync folder or contained in one</source>
+        <translation>Den overordnede mappe er en synkroniseringsmappe eller er indeholdt i en</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="495"/>
+        <source>Can&apos;t find a valid path</source>
+        <translation>Kan ikke finde en gyldig sti</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2108"/>
+        <source>No valid folder selected!</source>
+        <translation>Ingen gyldig mappe valgt!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2119"/>
+        <source>The selected path does not exist!</source>
+        <translation>Den valgte sti eksisterer ikke!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2124"/>
+        <source>The selected path is not a folder!</source>
+        <translation>Den valgte sti er ikke en mappe!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2129"/>
+        <source>You have no permission to write to the selected folder!</source>
+        <translation>Du har ikke tilladelse til at skrive til den valgte mappe!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2159"/>
+        <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
+        <translation>Den lokale mappe %1 indeholder en mappe, der allerede er synkroniseret. Vælg venligst en anden!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2167"/>
+        <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
+        <translation>Den lokale mappe %1 er indeholdt i en mappe, der allerede er synkroniseret. Vælg venligst en anden!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2175"/>
+        <source>The local folder %1 is already synced. Please pick another one!</source>
+        <translation>Den lokale mappe %1 er allerede synkroniseret. Vælg venligst en anden!</translation>
     </message>
 </context>
 <context>
@@ -2850,11 +2848,59 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
     <message>
         <location filename="../src/server/appserver.cpp" line="133"/>
         <source>kDrive application will close due to a fatal error.</source>
-        <translation>kDrive-programmet kommer att stängas på grund av ett allvarligt fel.</translation>
+        <translation>kDrive-applikationen lukker på grund af en kritisk fejl.</translation>
     </message>
 </context>
 <context>
     <name>Utility</name>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="41"/>
+        <source>%n year(s)</source>
+        <translation>
+            <numerusform>%n år</numerusform>
+            <numerusform>%n år</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="42"/>
+        <source>%n month(s)</source>
+        <translation>
+            <numerusform>%n måned</numerusform>
+            <numerusform>%n måneder</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="43"/>
+        <source>%n day(s)</source>
+        <translation>
+            <numerusform>%n dag</numerusform>
+            <numerusform>%n dage</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="44"/>
+        <source>%n hour(s)</source>
+        <translation>
+            <numerusform>%n time</numerusform>
+            <numerusform>%n timer</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="45"/>
+        <source>%n minute(s)</source>
+        <translation>
+            <numerusform>%n minut</numerusform>
+            <numerusform>%n minutter</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="46"/>
+        <source>%n second(s)</source>
+        <translation>
+            <numerusform>%n sekund</numerusform>
+            <numerusform>%n sekunder</numerusform>
+        </translation>
+    </message>
     <message>
         <location filename="../src/libcommongui/utility/utility.cpp" line="97"/>
         <source>%L1 GB</source>
@@ -2875,175 +2921,127 @@ Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=
         <source>%L1 B</source>
         <translation>%L1 B</translation>
     </message>
-    <message numerus="yes">
-        <location filename="../src/libcommongui/utility/utility.cpp" line="41"/>
-        <source>%n year(s)</source>
-        <translation>
-            <numerusform>%n år</numerusform>
-            <numerusform>%n år</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/libcommongui/utility/utility.cpp" line="42"/>
-        <source>%n month(s)</source>
-        <translation>
-            <numerusform>%n månad</numerusform>
-            <numerusform>%n månader</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/libcommongui/utility/utility.cpp" line="43"/>
-        <source>%n day(s)</source>
-        <translation>
-            <numerusform>%n dag</numerusform>
-            <numerusform>%n dagar</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/libcommongui/utility/utility.cpp" line="44"/>
-        <source>%n hour(s)</source>
-        <translation>
-            <numerusform>%n timme</numerusform>
-            <numerusform>%n timmar</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/libcommongui/utility/utility.cpp" line="45"/>
-        <source>%n minute(s)</source>
-        <translation>
-            <numerusform>%n minut</numerusform>
-            <numerusform>%n minuter</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/libcommongui/utility/utility.cpp" line="46"/>
-        <source>%n second(s)</source>
-        <translation>
-            <numerusform>%n sekund</numerusform>
-            <numerusform>%n sekunder</numerusform>
-        </translation>
-    </message>
 </context>
 <context>
     <name>utility</name>
     <message>
         <location filename="../src/gui/guiutility.cpp" line="84"/>
         <source>Could not open browser</source>
-        <translation>Det gick inte att öppna webbläsaren</translation>
+        <translation>Kunne ikke åbne browser</translation>
     </message>
     <message>
         <location filename="../src/gui/guiutility.cpp" line="85"/>
         <source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
-        <translation>Det uppstod ett fel när webbläsaren startades för att öppna webbadressen %1. Kanske har ingen standardwebbläsare angetts?</translation>
+        <translation>Der opstod en fejl ved åbning af browseren for at gå til URL %1. Måske er der ikke konfigureret en standardbrowser?</translation>
     </message>
     <message>
         <location filename="../src/gui/guiutility.cpp" line="104"/>
         <source>Could not open email client</source>
-        <translation>Det gick inte att öppna e-postprogrammet</translation>
+        <translation>Kunne ikke åbne e-mailklient</translation>
     </message>
     <message>
         <location filename="../src/gui/guiutility.cpp" line="105"/>
         <source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
-        <translation>Det uppstod ett fel när e-postprogrammet startades för att skapa ett nytt meddelande. Kanske har inget standardprogram för e-post konfigurerats?</translation>
+        <translation>Der opstod en fejl ved åbning af e-mailklienten for at oprette en ny besked. Måske er der ikke konfigureret en standard e-mailklient?</translation>
     </message>
     <message>
         <location filename="../src/gui/guiutility.cpp" line="324"/>
         <source>You are not connected anymore. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Log in&lt;/a&gt;</source>
-        <translation>Du är inte inloggad längre. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Logga in&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="347"/>
-        <source>Sync in progress (Step %1/%2).</source>
-        <translation>Synkronisering pågår (Steg %1/%2).</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="353"/>
-        <source>Sync in progress.</source>
-        <translation>Synkronisering pågår.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="364"/>
-        <source>Some files couldn&apos;t be synchronized. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation>Vissa filer kunde inte synkroniseras. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Läs mer&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="370"/>
-        <source>Synchronization pausing ...</source>
-        <translation>Synkroniseringen pausas ...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="570"/>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
-        <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan inte väljas eftersom en annan synkronisering använder samma mapp.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="576"/>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-        <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan inte väljas eftersom den innehåller den synkroniserade mappen &lt;b&gt;%2&lt;/b&gt;.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="584"/>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-        <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan inte väljas eftersom den ingår i den synkroniserade mappen &lt;b&gt;%2&lt;/b&gt;.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="595"/>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
-        <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan inte väljas som synkroniseringsmapp. Välj en annan mapp.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="599"/>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
-        <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan inte väljas som synkroniseringsmapp. Välj en annan mapp. Föreslagen mapp: &lt;b&gt;%2&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="653"/>
-        <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
-        <translation>Du har uteslutit mer än %1 mappar. Observera att detta kommer att påverka synkroniseringsprestandan.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="662"/>
-        <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
-        <translation>Du kan inte utesluta fler än %1 mappar. Avmarkera mapparna på högre nivå.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="351"/>
-        <source>Synchronization starting</source>
-        <translation>Synkroniseringen påbörjas</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="374"/>
-        <source>Synchronization paused.</source>
-        <translation>Synkroniseringen har pausats.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="336"/>
-        <source>Sync in progress (%1 of %2)</source>
-        <translation>Synkronisering pågår (%1 av %2)</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="340"/>
-        <source>Sync in progress (%1 of %2)
-%3 left...</source>
-        <translation>Synkronisering pågår (%1 av %2)
-%3 kvar...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="358"/>
-        <source>You are up to date, unresolved conflicts.</source>
-        <translation>Du har aktuella, olösta konflikter.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/guiutility.cpp" line="360"/>
-        <source>You are up to date!</source>
-        <translation>Nu är du uppdaterad!</translation>
+        <translation>Du er ikke længere forbundet. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Log ind&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../src/gui/guiutility.cpp" line="329"/>
         <source>No folder to synchronize
 You can add one from the kDrive settings.</source>
-        <translation>Ingen mapp att synkronisera
-Du kan lägga till en i kDrive-inställningarna.</translation>
+        <translation>Ingen mappe at synkronisere
+Du kan tilføje en fra kDrive-indstillingerne.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="336"/>
+        <source>Sync in progress (%1 of %2)</source>
+        <translation>Synkronisering i gang (%1 af %2)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="340"/>
+        <source>Sync in progress (%1 of %2)
+%3 left...</source>
+        <translation>Synkronisering i gang (%1 af %2)
+%3 tilbage...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="347"/>
+        <source>Sync in progress (Step %1/%2).</source>
+        <translation>Synkronisering i gang (Trin %1/%2).</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="351"/>
+        <source>Synchronization starting</source>
+        <translation>Synkronisering starter</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="353"/>
+        <source>Sync in progress.</source>
+        <translation>Synkronisering i gang.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="358"/>
+        <source>You are up to date, unresolved conflicts.</source>
+        <translation>Du er opdateret, uløste konflikter.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="360"/>
+        <source>You are up to date!</source>
+        <translation>Du er opdateret!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="364"/>
+        <source>Some files couldn&apos;t be synchronized. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Nogle filer kunne ikke synkroniseres. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Læs mere&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="370"/>
+        <source>Synchronization pausing ...</source>
+        <translation>Synkronisering sætter på pause...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="374"/>
+        <source>Synchronization paused.</source>
+        <translation>Synkronisering sat på pause.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="570"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
+        <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke vælges, fordi en anden synkronisering bruger samme mappe.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="576"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+        <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke vælges, fordi den indeholder den synkroniserede mappe &lt;b&gt;%2&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="584"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+        <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke vælges, fordi den er indeholdt i den synkroniserede mappe &lt;b&gt;%2&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="595"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
+        <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke vælges som synkroniseringsmappe. Vælg venligst en anden mappe.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="599"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
+        <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke vælges som synkroniseringsmappe. Vælg venligst en anden mappe. Foreslået mappe: &lt;b&gt;%2&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="653"/>
+        <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
+        <translation>Du har ekskluderet mere end %1 mapper. Bemærk, at dette vil påvirke synkroniseringsydelsen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="662"/>
+        <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
+        <translation>Du kan ikke ekskludere mere end %1 mapper. Fravælg venligst mapper på højere niveau.</translation>
     </message>
 </context>
 </TS>

--- a/translations/client_de.ts
+++ b/translations/client_de.ts
@@ -1997,27 +1997,32 @@ Bitte verwenden Sie den folgenden Link, um die Protokolle an den Support zu send
         <translation>Finnisch</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="521"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="516"/>
+        <source>Danish</source>
+        <translation>Dänisch</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="522"/>
         <source>Advanced</source>
         <translation>Erweitert</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="522"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="523"/>
         <source>Debugging information</source>
         <translation>Debugging-Informationen</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="524"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="525"/>
         <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
         <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Debugging-Ordner öffnen&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="525"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="526"/>
         <source>Files to exclude</source>
         <translation>Auszuschliessende Dateien</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="526"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="527"/>
         <source>Proxy server</source>
         <translation>Proxy-Server</translation>
     </message>
@@ -2057,7 +2062,7 @@ Bitte verwenden Sie den folgenden Link, um die Protokolle an den Support zu send
         <translation>Ungültiger Link %1.</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="528"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="529"/>
         <source>Lite Sync</source>
         <translation>Lite Sync</translation>
     </message>
@@ -2920,19 +2925,6 @@ Bitte verwenden Sie den folgenden Link, um die Protokolle an den Support zu send
     </message>
 </context>
 <context>
-    <name>main.cpp</name>
-    <message>
-        <location filename="../src/gui/mainclient.cpp" line="49"/>
-        <source>System Tray not available</source>
-        <translation>Systemleiste nicht verfügbar</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/mainclient.cpp" line="48"/>
-        <source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as &apos;trayer&apos; and try again.</source>
-        <translation>%1 benötigt eine funktionierende Systemablage (System Tray). Wenn Sie XFCE verwenden, folgen Sie bitte &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;diesen Anweisungen&lt;/a&gt;. Andernfalls installieren Sie bitte eine System-Tray-Anwendung wie „trayer" und versuchen Sie es erneut.</translation>
-    </message>
-</context>
-<context>
     <name>utility</name>
     <message>
         <location filename="../src/gui/guiutility.cpp" line="84"/>
@@ -3019,12 +3011,12 @@ Sie können eines über die kDrive-Einstellungen hinzufügen.</translation>
         <translation>Der Ordner &lt;b&gt;%1&lt;/b&gt; kann nicht als Synchronisationsordner ausgewählt werden. Bitte wählen Sie einen anderen Ordner. Vorgeschlagener Ordner: &lt;b&gt;%2&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/guiutility.cpp" line="651"/>
+        <location filename="../src/gui/guiutility.cpp" line="653"/>
         <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
         <translation>Sie haben mehr als %1 Ordner ausgeschlossen. Bitte beachten Sie, dass dies die Synchronisierungsleistung beeinträchtigt.</translation>
     </message>
     <message>
-        <location filename="../src/gui/guiutility.cpp" line="660"/>
+        <location filename="../src/gui/guiutility.cpp" line="662"/>
         <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
         <translation>Sie können maximal %1 Ordner ausschließen. Bitte deaktivieren Sie die übergeordneten Ordner.</translation>
     </message>

--- a/translations/client_es.ts
+++ b/translations/client_es.ts
@@ -1995,27 +1995,32 @@ Por favor, utilice el siguiente enlace para enviar los registros al soporte: &lt
         <translation>Finlandés</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="521"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="516"/>
+        <source>Danish</source>
+        <translation>Danés</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="522"/>
         <source>Advanced</source>
         <translation>Avanzado</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="522"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="523"/>
         <source>Debugging information</source>
         <translation>Información de depuración</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="524"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="525"/>
         <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
         <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Abrir carpeta de depuración&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="525"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="526"/>
         <source>Files to exclude</source>
         <translation>Archivos a excluir</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="526"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="527"/>
         <source>Proxy server</source>
         <translation>Servidor proxy</translation>
     </message>
@@ -2055,7 +2060,7 @@ Por favor, utilice el siguiente enlace para enviar los registros al soporte: &lt
         <translation>Enlace %1 no válido.</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="528"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="529"/>
         <source>Lite Sync</source>
         <translation>Lite Sync</translation>
     </message>
@@ -2918,19 +2923,6 @@ Por favor, utilice el siguiente enlace para enviar los registros al soporte: &lt
     </message>
 </context>
 <context>
-    <name>main.cpp</name>
-    <message>
-        <location filename="../src/gui/mainclient.cpp" line="49"/>
-        <source>System Tray not available</source>
-        <translation>Bandeja del sistema no disponible</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/mainclient.cpp" line="48"/>
-        <source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as &apos;trayer&apos; and try again.</source>
-        <translation>%1 requiere una bandeja del sistema funcional. Si está utilizando XFCE, siga &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;estas instrucciones&lt;/a&gt;. De lo contrario, instale una aplicación de bandeja del sistema como «trayer» e inténtelo de nuevo.</translation>
-    </message>
-</context>
-<context>
     <name>utility</name>
     <message>
         <location filename="../src/gui/guiutility.cpp" line="84"/>
@@ -3017,12 +3009,12 @@ quedan %3...</translation>
         <translation>La carpeta &lt;b&gt;%1&lt;/b&gt; no puede seleccionarse como carpeta de sincronización. Por favor, seleccione otra carpeta. Carpeta sugerida: &lt;b&gt;%2&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/guiutility.cpp" line="651"/>
+        <location filename="../src/gui/guiutility.cpp" line="653"/>
         <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
         <translation>Ha excluido más de %1 carpetas, tenga en cuenta que esto afectará el rendimiento de la sincronización.</translation>
     </message>
     <message>
-        <location filename="../src/gui/guiutility.cpp" line="660"/>
+        <location filename="../src/gui/guiutility.cpp" line="662"/>
         <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
         <translation>No se pueden excluir más de %1 carpetas. Desmarque las carpetas de nivel superior.</translation>
     </message>

--- a/translations/client_fi.ts
+++ b/translations/client_fi.ts
@@ -1,3042 +1,3047 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="fi_FI">
-    <context>
-        <name>KDC::AboutDialog</name>
-        <message>
-            <location filename="../src/gui/aboutdialog.cpp" line="73" />
-            <source>About</source>
-            <translation>Tietoja</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/aboutdialog.cpp" line="112" />
-            <source>CLOSE</source>
-            <translation>SULJE</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/aboutdialog.cpp" line="123" />
-            <source>Version %1. For more information visit &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
-            <translation>Versio %1. Lisätietoja: &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/aboutdialog.cpp" line="126" />
-            <source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
-            <translation>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/aboutdialog.cpp" line="127" />
-            <source>Distributed by %1 and licensed under the &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
-            <translation>%1 jakaa ja lisensoi &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;-lisenssin alla.&lt;br&gt;&lt;br&gt;%2 ja %2-logo ovat %1:n rekisteröityjä tavaramerkkejä.&lt;br&gt;&lt;br&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/aboutdialog.cpp" line="132" />
-            <source>&lt;p&gt;&lt;small&gt;Built from &lt;a style="color: #489EF3" href="%1"&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
-            <translation>&lt;p&gt;&lt;small&gt;Rakennettu &lt;a style="color: #489EF3" href="%1"&gt;Git-lähteistä&lt;/a&gt; %2, %3 käyttäen Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/aboutdialog.cpp" line="151" />
-            <location filename="../src/gui/aboutdialog.cpp" line="162" />
-            <location filename="../src/gui/aboutdialog.cpp" line="171" />
-            <source>Unable to open folder %1.</source>
-            <translation>Kansiota %1 ei voi avata.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::AbstractFileItemWidget</name>
-        <message>
-            <location filename="../src/gui/abstractfileitemwidget.cpp" line="177" />
-            <source>Unable to open folder path %1.</source>
-            <translation>Kansion polkua %1 ei voi avata.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::AddDriveConfirmationWidget</name>
-        <message>
-            <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55" />
-            <source>Synchronization will start and you will be able to add files to your %1 folder.</source>
-            <translation>Synkronointi käynnistyy ja voit lisätä tiedostoja %1-kansioon.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99" />
-            <source>Your kDrive is ready!</source>
-            <translation>kDrive on valmis!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123" />
-            <source>OPEN FOLDER</source>
-            <translation>AVAA KANSIO</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130" />
-            <source>PARAMETERS</source>
-            <translation>ASETUKSET</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138" />
-            <source>Synchronize another drive</source>
-            <translation>Synkronoi toinen asema</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::AddDriveListWidget</name>
-        <message>
-            <location filename="../src/gui/adddrivelistwidget.cpp" line="170" />
-            <source>Cancel</source>
-            <translation>Peruuta</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelistwidget.cpp" line="177" />
-            <source>NEXT</source>
-            <translation>SEURAAVA</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelistwidget.cpp" line="196" />
-            <source>Select the kDrive you want to synchronize</source>
-            <translation>Valitse synkronoitava kDrive</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelistwidget.cpp" line="234" />
-            <source>Get kDrive for free</source>
-            <translation>Hanki kDrive ilmaiseksi</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelistwidget.cpp" line="244" />
-            <source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
-            <translation>Tallenna kuvasi, asiakirjasi ja sähköpostisi Sveitsiin riippumattomassa yrityksessä, joka kunnioittaa yksityisyyttä. Lue lisää</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelistwidget.cpp" line="263" />
-            <source>Test for free</source>
-            <translation>Kokeile ilmaiseksi</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::AddDriveLiteSyncWidget</name>
-        <message>
-            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112" />
-            <source>Would you like to activate Lite Sync (Beta) ?</source>
-            <translation>Haluatko aktivoida Lite Sync (Beta)?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114" />
-            <source>Would you like to activate Lite Sync ?</source>
-            <translation>Haluatko aktivoida Lite Sync?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125" />
-            <source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-            <translation>Lite Sync synkronoi kaikki tiedostosi käyttämättä tietokoneen tallennustilaa. Voit selata kDrive-tiedostojasi ja ladata ne paikallisesti milloin tahansa. &lt;a style="%1" href="%2"&gt;Lue lisää&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147" />
-            <source>Conserve your computer space</source>
-            <translation>Säästä tietokoneen tallennustilaa</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167" />
-            <source>Decide which files should be available online or locally</source>
-            <translation>Päätä, mitkä tiedostot ovat saatavilla verkossa tai paikallisesti</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187" />
-            <source>LATER</source>
-            <translation>MYÖHEMMIN</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193" />
-            <source>YES</source>
-            <translation>KYLLÄ</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207" />
-            <source>Unable to open link %1.</source>
-            <translation>Linkkiä %1 ei voi avata.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::AddDriveLocalFolderWidget</name>
-        <message>
-            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65" />
-            <source>Location of your %1 kDrive</source>
-            <translation>%1 kDrive -aseman sijainti</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155" />
-            <source>Edit folder</source>
-            <translation>Muokkaa kansiota</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212" />
-            <source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
-            <translation>Löydät kaikki tiedostosi tästä kansiosta konfiguroinnin jälkeen. Voit lisätä uusia tiedostoja kansioon synkronoidaksesi ne kDriveen.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246" />
-            <source>END</source>
-            <translation>LOPETA</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246" />
-            <source>CONTINUE</source>
-            <translation>JATKA</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264" />
-            <source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
-            <translation>&lt;b&gt;%1&lt;/b&gt;-kansion sisältö synkronoidaan kDriveen</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284" />
-            <source>This folder is not compatible with Lite Sync.&lt;br&gt; 
+<context>
+    <name>KDC::AboutDialog</name>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="73"/>
+        <source>About</source>
+        <translation>Tietoja</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="112"/>
+        <source>CLOSE</source>
+        <translation>SULJE</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="123"/>
+        <source>Version %1. For more information visit &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
+        <translation>Versio %1. Lisätietoja: &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="126"/>
+        <source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
+        <translation>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="127"/>
+        <source>Distributed by %1 and licensed under the &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
+        <translation>%1 jakaa ja lisensoi &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;-lisenssin alla.&lt;br&gt;&lt;br&gt;%2 ja %2-logo ovat %1:n rekisteröityjä tavaramerkkejä.&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="132"/>
+        <source>&lt;p&gt;&lt;small&gt;Built from &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
+        <translation>&lt;p&gt;&lt;small&gt;Rakennettu &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git-lähteistä&lt;/a&gt; %2, %3 käyttäen Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="151"/>
+        <location filename="../src/gui/aboutdialog.cpp" line="162"/>
+        <location filename="../src/gui/aboutdialog.cpp" line="171"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Kansiota %1 ei voi avata.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AbstractFileItemWidget</name>
+    <message>
+        <location filename="../src/gui/abstractfileitemwidget.cpp" line="177"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Kansion polkua %1 ei voi avata.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AddDriveConfirmationWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55"/>
+        <source>Synchronization will start and you will be able to add files to your %1 folder.</source>
+        <translation>Synkronointi käynnistyy ja voit lisätä tiedostoja %1-kansioon.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99"/>
+        <source>Your kDrive is ready!</source>
+        <translation>kDrive on valmis!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123"/>
+        <source>OPEN FOLDER</source>
+        <translation>AVAA KANSIO</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130"/>
+        <source>PARAMETERS</source>
+        <translation>ASETUKSET</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138"/>
+        <source>Synchronize another drive</source>
+        <translation>Synkronoi toinen asema</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AddDriveListWidget</name>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="170"/>
+        <source>Cancel</source>
+        <translation>Peruuta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="177"/>
+        <source>NEXT</source>
+        <translation>SEURAAVA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="196"/>
+        <source>Select the kDrive you want to synchronize</source>
+        <translation>Valitse synkronoitava kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="234"/>
+        <source>Get kDrive for free</source>
+        <translation>Hanki kDrive ilmaiseksi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="244"/>
+        <source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
+        <translation>Tallenna kuvasi, asiakirjasi ja sähköpostisi Sveitsiin riippumattomassa yrityksessä, joka kunnioittaa yksityisyyttä. Lue lisää</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="263"/>
+        <source>Test for free</source>
+        <translation>Kokeile ilmaiseksi</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AddDriveLiteSyncWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112"/>
+        <source>Would you like to activate Lite Sync (Beta) ?</source>
+        <translation>Haluatko aktivoida Lite Sync (Beta)?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114"/>
+        <source>Would you like to activate Lite Sync ?</source>
+        <translation>Haluatko aktivoida Lite Sync?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
+        <source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Lite Sync synkronoi kaikki tiedostosi käyttämättä tietokoneen tallennustilaa. Voit selata kDrive-tiedostojasi ja ladata ne paikallisesti milloin tahansa. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Lue lisää&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147"/>
+        <source>Conserve your computer space</source>
+        <translation>Säästä tietokoneen tallennustilaa</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167"/>
+        <source>Decide which files should be available online or locally</source>
+        <translation>Päätä, mitkä tiedostot ovat saatavilla verkossa tai paikallisesti</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187"/>
+        <source>LATER</source>
+        <translation>MYÖHEMMIN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193"/>
+        <source>YES</source>
+        <translation>KYLLÄ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207"/>
+        <source>Unable to open link %1.</source>
+        <translation>Linkkiä %1 ei voi avata.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AddDriveLocalFolderWidget</name>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65"/>
+        <source>Location of your %1 kDrive</source>
+        <translation>%1 kDrive -aseman sijainti</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155"/>
+        <source>Edit folder</source>
+        <translation>Muokkaa kansiota</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212"/>
+        <source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
+        <translation>Löydät kaikki tiedostosi tästä kansiosta konfiguroinnin jälkeen. Voit lisätä uusia tiedostoja kansioon synkronoidaksesi ne kDriveen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+        <source>END</source>
+        <translation>LOPETA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+        <source>CONTINUE</source>
+        <translation>JATKA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
+        <source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
+        <translation>&lt;b&gt;%1&lt;/b&gt;-kansion sisältö synkronoidaan kDriveen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284"/>
+        <source>This folder is not compatible with Lite Sync.&lt;br&gt; 
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt; 
-&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-            <translation>Tämä kansio ei ole yhteensopiva Lite Sync -toiminnon kanssa.&lt;br&gt; 
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Tämä kansio ei ole yhteensopiva Lite Sync -toiminnon kanssa.&lt;br&gt; 
 Valitse toinen kansio. Jos jatkat, Lite Sync poistetaan käytöstä.&lt;br&gt; 
-&lt;a style="%1" href="%2"&gt;Lue lisää&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297" />
-            <source>Select folder</source>
-            <translation>Valitse kansio</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377" />
-            <source>Unable to open link %1.</source>
-            <translation>Linkkiä %1 ei voi avata.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::AddDriveLoginWidget</name>
-        <message>
-            <location filename="../src/gui/adddriveloginwidget.cpp" line="69" />
-            <source>Log in from your browser</source>
-            <translation>Kirjaudu sisään selaimella</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveloginwidget.cpp" line="75" />
-            <source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
-            <translation>Selaimesi avautuu automaattisesti yhteyden muodostamiseksi. Kun olet kirjautunut, palaat automaattisesti kDriveen.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveloginwidget.cpp" line="85" />
-            <source>Open the login page</source>
-            <translation>Avaa kirjautumissivu</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveloginwidget.cpp" line="119" />
-            <source>Token request failed: %1 - %2</source>
-            <translation>Tunnuksen pyyntö epäonnistui: %1 - %2</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveloginwidget.cpp" line="133" />
-            <source>Login failed: %1 - %2</source>
-            <translation>Kirjautuminen epäonnistui: %1 - %2</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveloginwidget.cpp" line="141" />
-            <source>Failed to open the login page in your web browser</source>
-            <translation>Kirjautumissivun avaaminen selaimessa epäonnistui</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::AddDriveServerFoldersWidget</name>
-        <message>
-            <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129" />
-            <source>Select kDrive folders to synchronize on your desktop</source>
-            <translation>Valitse synkronoitavat kDrive-kansiot tietokoneellesi</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174" />
-            <source>CONTINUE</source>
-            <translation>JATKA</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187" />
-            <source>Space available on your computer : %1</source>
-            <translation>Tietokoneella vapaata tilaa: %1</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206" />
-            <source>An error occurred while loading the list of subfolders.</source>
-            <translation>Alikansioiden listan lataaminen epäonnistui.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210" />
-            <source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
-            <translation>Alikansioiden listaa ei voi ladata. kDrive saattaa olla huoltotilassa.&lt;br&gt;Kirjaudu &lt;a style="%1" href="%2"&gt;verkkoversioon&lt;/a&gt; tarkistaaksesi kDriven tilan tai ota yhteyttä järjestelmänvalvojaasi.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::AddDriveWizard</name>
-        <message>
-            <location filename="../src/gui/adddrivewizard.cpp" line="222" />
-            <source>Failed to create local folder %1</source>
-            <translation>Paikallisen kansion %1 luominen epäonnistui</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivewizard.cpp" line="233" />
-            <source>Failed to create new synchronization</source>
-            <translation>Uuden synkronoinnin luominen epäonnistui</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/adddrivewizard.cpp" line="266" />
-            <source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
-            <translation>kDrive %1 on jo synkronoitu tällä tietokoneella. Jatketaanko?</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::AppClient</name>
-        <message>
-            <location filename="../src/gui/appclient.cpp" line="100" />
-            <source>kDrive client is run with bad parameters!</source>
-            <translation>kDrive-asiakas käynnistettiin virheellisillä parametreillä!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/appclient.cpp" line="109" />
-            <source>kDrive client is already running!</source>
-            <translation>kDrive-asiakas on jo käynnissä!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/appclient.cpp" line="719" />
-            <source>The user %1 is not connected. Please log in again.</source>
-            <translation>Käyttäjä %1 ei ole kirjautunut. Kirjaudu uudelleen.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::AppServer</name>
-        <message>
-            <location filename="../src/server/appserver.cpp" line="1685" />
-            <source>Share link copied to clipboard</source>
-            <translation>Jakolinkki kopioitu leikepöydälle</translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/server/appserver.cpp" line="3773" />
-            <source>%1 and %n other file(s) have been removed.</source>
-            <translation>
-                <numerusform>%1 ja %n muu tiedosto on poistettu.</numerusform>
-                <numerusform>%1 ja %n muuta tiedostoa on poistettu.</numerusform>
-            </translation>
-        </message>
-        <message>
-            <location filename="../src/server/appserver.cpp" line="3775" />
-            <source>%1 has been removed.</source>
-            <comment>%1 names a file.</comment>
-            <translation>%1 on poistettu.</translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/server/appserver.cpp" line="3780" />
-            <source>%1 and %n other file(s) have been added.</source>
-            <translation>
-                <numerusform>%1 ja %n muu tiedosto on lisätty.</numerusform>
-                <numerusform>%1 ja %n muuta tiedostoa on lisätty.</numerusform>
-            </translation>
-        </message>
-        <message>
-            <location filename="../src/server/appserver.cpp" line="3782" />
-            <source>%1 has been added.</source>
-            <comment>%1 names a file.</comment>
-            <translation>%1 on lisätty.</translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/server/appserver.cpp" line="3787" />
-            <source>%1 and %n other file(s) have been updated.</source>
-            <translation>
-                <numerusform>%1 ja %n muu tiedosto on päivitetty.</numerusform>
-                <numerusform>%1 ja %n muuta tiedostoa on päivitetty.</numerusform>
-            </translation>
-        </message>
-        <message>
-            <location filename="../src/server/appserver.cpp" line="3789" />
-            <source>%1 has been updated.</source>
-            <comment>%1 names a file.</comment>
-            <translation>%1 on päivitetty.</translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/server/appserver.cpp" line="3794" />
-            <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
-            <translation>
-                <numerusform>%1 on siirretty kohteeseen %2 ja %n muu tiedosto on siirretty.</numerusform>
-                <numerusform>%1 on siirretty kohteeseen %2 ja %n muuta tiedostoa on siirretty.</numerusform>
-            </translation>
-        </message>
-        <message>
-            <location filename="../src/server/appserver.cpp" line="3797" />
-            <source>%1 has been moved to %2.</source>
-            <translation>%1 on siirretty kohteeseen %2.</translation>
-        </message>
-        <message>
-            <location filename="../src/server/appserver.cpp" line="3805" />
-            <source>Sync Activity</source>
-            <translation>Synkronointiaktiviteetti</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::BaseFolderTreeItemWidget</name>
-        <message>
-            <location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102" />
-            <source>No subfolders currently on the server.</source>
-            <translation>Palvelimella ei ole alikansioita tällä hetkellä.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::BetaProgramDialog</name>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="69" />
-            <source>Quit the beta program</source>
-            <translation>Poistu beta-ohjelmasta</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="69" />
-            <source>Join the beta program</source>
-            <translation>Liity beta-ohjelmaan</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="77" />
-            <source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
-            <translation>Saa varhainen pääsy sovelluksen uusiin versioihin ennen niiden julkaisua ja osallistu sovelluksen kehittämiseen lähettämällä kommenttisi.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="87" />
-            <source>Benefit from application beta updates</source>
-            <translation>Hyödy sovelluksen beta-päivityksistä</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="91" />
-            <source>No</source>
-            <translation>Ei</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="92" />
-            <source>Public beta version</source>
-            <translation>Julkinen beta-versio</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="93" />
-            <source>Internal beta version</source>
-            <translation>Sisäinen beta-versio</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="141" />
-            <source>I understand</source>
-            <translation>Ymmärrän</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="147" />
-            <source>Are you sure you want to leave the beta program?</source>
-            <translation>Oletko varma, että haluat poistua beta-ohjelmasta?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="161" />
-            <source>Save</source>
-            <translation>Tallenna</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="167" />
-            <source>Cancel</source>
-            <translation>Peruuta</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="228" />
-            <source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
-            <translation>Sovelluksesi nykyinen versio saattaa olla liian uusi; valintasi astuu voimaan seuraavan päivityksen yhteydessä.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/betaprogramdialog.cpp" line="233" />
-            <source>Beta versions may leave unexpectedly or cause instabilities.</source>
-            <translation>Beta-versiot saattavat kaatua odottamatta tai aiheuttaa epävakautta.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::ClientGui</name>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="116" />
-            <source>Unable to initialize kDrive client</source>
-            <translation>kDrive-asiakkaan alustaminen epäonnistui</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="189" />
-            <source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
-            <translation>Ristiriitojen korjaaminen kohteessa %1 synkronointikansiossa epäonnistui: %2</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="242" />
-            <source>Please sign in</source>
-            <translation>Kirjaudu sisään</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="255" />
-            <source>Synchronization is paused</source>
-            <translation>Synkronointi on keskeytetty</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="292" />
-            <source>Folder %1: %2</source>
-            <translation>Kansio %1: %2</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="298" />
-            <source>There are no sync folders configured.</source>
-            <translation>Synkronointikansioita ei ole määritetty.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="673" />
-            <source>Undefined State.</source>
-            <translation>Määrittelemätön tila.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="676" />
-            <source>Waiting to start syncing.</source>
-            <translation>Odotetaan synkronoinnin käynnistymistä.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="679" />
-            <source>Sync is running.</source>
-            <translation>Synkronointi käynnissä.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="683" />
-            <source>Sync was successful, unresolved conflicts.</source>
-            <translation>Synkronointi onnistui, ratkaisemattomia ristiriitoja.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="685" />
-            <source>Last Sync was successful.</source>
-            <translation>Viimeisin synkronointi onnistui.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="692" />
-            <source>User Abort.</source>
-            <translation>Käyttäjä keskeytti.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="696" />
-            <source>Sync is paused.</source>
-            <translation>Synkronointi on keskeytetty.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="705" />
-            <source>%1 (Sync is paused)</source>
-            <translation>%1 (Synkronointi keskeytetty)</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="849" />
-            <source>Unable to open folder path %1.</source>
-            <translation>Kansion polkua %1 ei voi avata.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="1257" />
-            <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-            <translation>Haluatko todella poistaa tilin &lt;i&gt;%1&lt;/i&gt; synkronoinnit?&lt;br&gt;&lt;b&gt;Huom:&lt;/b&gt; Tämä &lt;b&gt;ei&lt;/b&gt; poista tiedostoja.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="1261" />
-            <source>REMOVE ALL SYNCHRONIZATIONS</source>
-            <translation>POISTA KAIKKI SYNKRONOINNIT</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="1262" />
-            <source>CANCEL</source>
-            <translation>PERUUTA</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="1422" />
-            <source>Synthesis</source>
-            <translation>Yhteenveto</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="1423" />
-            <source>Preferences</source>
-            <translation>Asetukset</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="1424" />
-            <source>Quit</source>
-            <translation>Lopeta</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/clientgui.cpp" line="1590" />
-            <source>Failed to start synchronizations!</source>
-            <translation>Synkronointien käynnistäminen epäonnistui!</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::ConfirmSynchronizationDialog</name>
-        <message>
-            <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86" />
-            <source>Summary of your local folder synchronization</source>
-            <translation>Yhteenveto paikallisen kansion synkronoinnista</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95" />
-            <source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
-            <translation>Tietokoneesi kansion sisältö synkronoidaan valitun kDriven kansioon ja päinvastoin.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184" />
-            <source>CANCEL</source>
-            <translation>PERUUTA</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191" />
-            <source>SYNCHRONIZE</source>
-            <translation>SYNKRONOI</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::CustomExtensionSetupWidget</name>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="96" />
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="120" />
-            <source>Before finishing</source>
-            <translation>Ennen viimeistelyä</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="107" />
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="131" />
-            <source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
-            <translation>Suorita seuraavat vaiheet varmistaaksesi, että Lite Sync toimii oikein tietokoneellasi ja viimeistelläksesi kDriven konfiguroinnin.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="208" />
-            <source>Open your Mac's &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-            <translation>Avaa Macin &lt;b&gt;Yleiset asetukset&lt;/b&gt; tai &lt;a style="%1" href="%2"&gt;napsauta tästä&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="212" />
-            <source>Open your Mac's &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-            <translation>Avaa Macin &lt;b&gt;Tietosuoja- ja turva-asetukset&lt;/b&gt; tai &lt;a style="%1" href="%2"&gt;napsauta tästä&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="216" />
-            <source>Open your Mac's &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-            <translation>Avaa Macin &lt;b&gt;Turvallisuus- ja tietosuoja-asetukset&lt;/b&gt; tai &lt;a style="%1" href="%2"&gt;napsauta tästä&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="246" />
-            <source>Go to &lt;b&gt;"Login Items &amp; Extensions"&lt;/b&gt; section and then to &lt;b&gt;"Endpoint Security Extensions"&lt;/b&gt;</source>
-            <translation>Siirry &lt;b&gt;"Kirjautumisobjektit ja laajennukset"&lt;/b&gt;-osioon ja sitten &lt;b&gt;"Endpoint Security Extensions"&lt;/b&gt;-osioon</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="263" />
-            <source>Authorize the kDrive application</source>
-            <translation>Valtuuta kDrive-sovellus</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="272" />
-            <source>Go to &lt;b&gt;"Security"&lt;/b&gt; section</source>
-            <translation>Siirry &lt;b&gt;"Turvallisuus"&lt;/b&gt;-osioon</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="289" />
-            <source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
-            <translation>Valtuuta kDrive-sovellus ruudussa, jossa ilmoitetaan kDriven olevan estetty</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="299" />
-            <source>Unlock the padlock &lt;img src=":/client/resources/icons/actions/lock.png"&gt; and authorize the kDrive application</source>
-            <translation>Avaa lukko &lt;img src=":/client/resources/icons/actions/lock.png"&gt; ja valtuuta kDrive-sovellus</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="344" />
-            <source>Go to &lt;b&gt;"Privacy &amp; Security"&lt;/b&gt; section and click on &lt;b&gt;"Full Disk Access"&lt;/b&gt; or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-            <translation>Siirry &lt;b&gt;"Tietosuoja ja turvallisuus"&lt;/b&gt;-osioon ja napsauta &lt;b&gt;"Täysi levynkäyttöoikeus"&lt;/b&gt; tai &lt;a style="%1" href="%2"&gt;napsauta tästä&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="348" />
-            <source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;"Privacy"&lt;/b&gt; tab or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-            <translation>Turvallisuus- ja tietosuoja-asetuksissa avaa &lt;b&gt;"Tietosuoja"&lt;/b&gt;-välilehti tai &lt;a style="%1" href="%2"&gt;napsauta tästä&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="376" />
-            <source>Check the "kDrive LiteSync Extension" box then the "kDrive.app" box (if not already checked)</source>
-            <translation>Valitse "kDrive LiteSync Extension" -ruutu ja sitten "kDrive.app"-ruutu (jos ei vielä valittu)</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="393" />
-            <source>A restart of the app might be proposed, in this case accept it</source>
-            <translation>Sovelluksen uudelleenkäynnistystä saatetaan ehdottaa; hyväksy se siinä tapauksessa</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="399" />
-            <source>Check the "kDrive LiteSync Extension" box (and "kDrive.app" if it exists) in &lt;b&gt;"Full Disk Access"&lt;/b&gt;</source>
-            <translation>Valitse "kDrive LiteSync Extension" -ruutu (ja "kDrive.app", jos se on olemassa) kohdassa &lt;b&gt;"Täysi levynkäyttöoikeus"&lt;/b&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="495" />
-            <source>STEP 1</source>
-            <translation>VAIHE 1</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="495" />
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="496" />
-            <source>(Done)</source>
-            <translation>(Valmis)</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="496" />
-            <source>STEP 2</source>
-            <translation>VAIHE 2</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="499" />
-            <source>STEPS PERFORMED</source>
-            <translation>VAIHEET SUORITETTU</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/customextensionsetupwidget.cpp" line="501" />
-            <source>END</source>
-            <translation>LOPETA</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::CustomMessageBox</name>
-        <message>
-            <location filename="../src/gui/custommessagebox.cpp" line="101" />
-            <source>OK</source>
-            <translation>OK</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/custommessagebox.cpp" line="111" />
-            <source>CANCEL</source>
-            <translation>PERUUTA</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/custommessagebox.cpp" line="121" />
-            <source>YES</source>
-            <translation>KYLLÄ</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/custommessagebox.cpp" line="131" />
-            <source>NO</source>
-            <translation>EI</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::DebugReporter</name>
-        <message>
-            <location filename="../src/gui/debugreporter.cpp" line="37" />
-            <source>Sending of debugging information</source>
-            <translation>Lähetetään virheenkorjaustietoja</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debugreporter.cpp" line="37" />
-            <source>Cancel</source>
-            <translation>Peruuta</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::DebuggingDialog</name>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="45" />
-            <source>Debug</source>
-            <translation>Virheenkorjaus</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="46" />
-            <source>Info</source>
-            <translation>Tiedot</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="47" />
-            <source>Warning</source>
-            <translation>Varoitus</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="48" />
-            <source>Error</source>
-            <translation>Virhe</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="49" />
-            <source>Fatal</source>
-            <translation>Kriittinen</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="74" />
-            <source>Debugging settings</source>
-            <translation>Virheenkorjausasetukset</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="90" />
-            <source>Save debugging information in a folder on my computer (Recommended)</source>
-            <translation>Tallenna virheenkorjaustiedot kansioon tietokoneellani (Suositeltu)</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="104" />
-            <source>This information enables IT support to determine the origin of an incident.</source>
-            <translation>Nämä tiedot auttavat IT-tukea selvittämään tapauksen alkuperän.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="114" />
-            <source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
-            <translation>&lt;a style="%1" href="%2"&gt;Avaa virheenkorjauskansio&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="143" />
-            <source>Debug level</source>
-            <translation>Virheenkorjaustaso</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="152" />
-            <source>The trace level lets you choose the extent of the debugging information recorded</source>
-            <translation>Jäljitystaso antaa sinun valita tallennettavien virheenkorjaustietojen laajuuden</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="179" />
-            <source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
-            <translation>Laajennettu täysloki kerää yksityiskohtaisen historian virheenkorjausta varten. Sen käyttöönotto voi hidastaa kDrive-sovellusta.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="183" />
-            <source>Extended Full Log</source>
-            <translation>Laajennettu täysloki</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="207" />
-            <source>Delete logs older than %1 days</source>
-            <translation>Poista lokeja, jotka ovat vanhempia kuin %1 päivää</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="226" />
-            <source>Share the debug folder with Infomaniak support.</source>
-            <translation>Jaa virheenkorjauskansio Infomaniakille.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="250" />
-            <source>The last session is the periode since the last kDrive start.</source>
-            <translation>Viimeinen istunto on ajanjakso viimeisimmästä kDriven käynnistyksestä.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="254" />
-            <source>Share only the last kDrive session</source>
-            <translation>Jaa vain viimeisin kDrive-istunto</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="285" />
-            <source>  Loading</source>
-            <translation>  Ladataan</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="294" />
-            <source>Cancel</source>
-            <translation>Peruuta</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="320" />
-            <source>SAVE</source>
-            <translation>TALLENNA</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="327" />
-            <source>CANCEL</source>
-            <translation>PERUUTA</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="471" />
-            <source>Failed to share</source>
-            <translation>Jakaminen epäonnistui</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="481" />
-            <source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
-            <translation>1. Tarkista, että olet kirjautunut sisään &lt;br&gt;2. Tarkista, että olet määrittänyt vähintään yhden kDriven</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="486" />
-            <source> (Connexion interrupted)</source>
-            <translation> (Yhteys katkaistu)</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="493" />
-            <source>Share the folder with SwissTransfer &lt;br&gt;</source>
-            <translation>Jaa kansio SwissTransferillä &lt;br&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="494" />
-            <source> 1. We automatically compressed your log &lt;a style="%1" href="%2"&gt;here&lt;/a&gt;.&lt;br&gt;</source>
-            <translation> 1. Pakkasimme lokisi automaattisesti &lt;a style="%1" href="%2"&gt;tähän&lt;/a&gt;.&lt;br&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="496" />
-            <source> 2. Transfer the archive with &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
-            <translation> 2. Siirrä arkisto &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;-palvelun avulla&lt;br&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="498" />
-            <source> 3. Share the link with &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
-            <translation> 3. Jaa linkki osoitteeseen &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="528" />
-            <source>Last upload the %1</source>
-            <translation>Viimeisin lähetys %1</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="556" />
-            <source>Sharing has been cancelled</source>
-            <translation>Jakaminen on peruutettu</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="597" />
-            <source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
-            <translation>Laajennettu täysloki on aktivoitu KDRIVE_FORCE_EXTENDED_LOG-ympäristömuuttujalla. Aseta se arvoon 0 poistaaksesi sen käytöstä.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="611" />
-            <source>%1/%2/%3 at %4h%5m and %6s</source>
-            <extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
-            <translation>%1/%2/%3 klo %4:%5:%6</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="654" />
-            <source>Do you want to save your modifications?</source>
-            <translation>Haluatko tallentaa muutokset?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="709" />
-            <location filename="../src/gui/debuggingdialog.cpp" line="715" />
-            <source>Unable to open folder %1.</source>
-            <translation>Kansiota %1 ei voi avata.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="722" />
-            <source>  Share</source>
-            <translation>  Jaa</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="732" />
-            <source>  Sharing | step 1/2 %1%</source>
-            <translation>  Jaetaan | vaihe 1/2 %1%</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="741" />
-            <source>  Sharing | step 2/2 %1%</source>
-            <translation>  Jaetaan | vaihe 2/2 %1%</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.cpp" line="751" />
-            <source>  Canceling...</source>
-            <translation>  Peruutetaan...</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/debuggingdialog.h" line="70" />
-            <source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
-            <translation>Koko kansio on suuri (&gt; 100 Mt) ja jakaminen voi kestää jonkin aikaa. Jakamisajan lyhentämiseksi suosittelemme jakamaan vain viimeisimmän kDrive-istunnon.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::DrivePreferencesWidget</name>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="120" />
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1117" />
-            <source>Synchronization errors and information.</source>
-            <translation>Synkronointivirheet ja tiedot.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="144" />
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1119" />
-            <source>Synchronize a local folder</source>
-            <translation>Synkronoi paikallinen kansio</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="355" />
-            <source>Do you really want to turn on Lite Sync?</source>
-            <translation>Haluatko todella ottaa Lite Sync käyttöön?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="356" />
-            <source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
-            <translation>Tämä toiminto voi kestää muutamasta sekunnista muutamaan minuuttiin kansion koosta riippuen.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="359" />
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="390" />
-            <source>CONFIRM</source>
-            <translation>VAHVISTA</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="360" />
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="391" />
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="986" />
-            <source>CANCEL</source>
-            <translation>PERUUTA</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="382" />
-            <source>Do you really want to turn off Lite Sync?</source>
-            <translation>Haluatko todella poistaa Lite Sync käytöstä?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="384" />
-            <source>You don't have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
-            <translation>Sinulla ei ole tarpeeksi tilaa kaikkien kDrive-tiedostojen synkronointiin (%1 puuttuu). Jos poistat Lite Sync käytöstä, sinun on valittava synkronoitavat kansiot tietokoneellasi. Sillä välin kDriven synkronointi keskeytetään.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="388" />
-            <source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
-            <translation>Jos poistat Lite Sync käytöstä, kaikki tiedostot ladataan tietokoneellesi.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="627" />
-            <source>Failed to create new synchronization</source>
-            <translation>Uuden synkronoinnin luominen epäonnistui</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="645" />
-            <source>New local folder synchronization failed!</source>
-            <translation>Uuden paikallisen kansion synkronointi epäonnistui!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="819" />
-            <source>Lite Sync activated.</source>
-            <translation>Lite Sync aktivoitu.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="823" />
-            <source>Lite Sync activation failed.</source>
-            <translation>Lite Sync -aktivointi epäonnistui.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="837" />
-            <source>Lite Sync deactivated.</source>
-            <translation>Lite Sync poistettu käytöstä.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="841" />
-            <source>Lite Sync deactivation failed.</source>
-            <translation>Lite Sync -deaktivointi epäonnistui.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="899" />
-            <source>This drive is being deleted.</source>
-            <translation>Tämä asema poistetaan.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="962" />
-            <source>Impossible to open item %1</source>
-            <translation>Kohteen %1 avaaminen ei onnistu</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="981" />
-            <source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-            <translation>Haluatko todella lopettaa kansion &lt;i&gt;%1&lt;/i&gt; synkronoinnin?&lt;br&gt;&lt;b&gt;Huom:&lt;/b&gt; Tämä &lt;b&gt;ei&lt;/b&gt; poista tiedostoja.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="985" />
-            <source>REMOVE FOLDER SYNC CONNECTION</source>
-            <translation>POISTA KANSION SYNKRONOINTIYHTEYS</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1007" />
-            <source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
-            <translation>Kansion &lt;i&gt;%1&lt;/i&gt; synkronoinnin pysäyttäminen epäonnistui.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1048" />
-            <source>An error occurred while loading the list of subfolders.</source>
-            <translation>Alikansioiden listan lataaminen epäonnistui.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1118" />
-            <source>Folders</source>
-            <translation>Kansiot</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1120" />
-            <source>Notifications</source>
-            <translation>Ilmoitukset</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1121" />
-            <source>Enable the notifications for this kDrive</source>
-            <translation>Ota tämän kDriven ilmoitukset käyttöön</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1123" />
-            <source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
-            <translation>Ilmoitus näytetään heti, kun uusi kansio on synkronoitu tai muokattu</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1124" />
-            <source>Connected with</source>
-            <translation>Yhdistetty:</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1125" />
-            <source>Remove all synchronizations</source>
-            <translation>Poista kaikki synkronoinnit</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1126" />
-            <source>Search in your kDrive</source>
-            <translation>Hae kDrivesta</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/drivepreferenceswidget.cpp" line="1127" />
-            <source>Search</source>
-            <translation>Haku</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::DriveSelectionWidget</name>
-        <message>
-            <location filename="../src/gui/driveselectionwidget.cpp" line="150" />
-            <source>Add a kDrive</source>
-            <translation>Lisää kDrive</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/driveselectionwidget.cpp" line="216" />
-            <source>Synchronize a kDrive</source>
-            <translation>Synkronoi kDrive</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::ErrorTabWidget</name>
-        <message>
-            <location filename="../src/gui/errortabwidget.cpp" line="92" />
-            <location filename="../src/gui/errortabwidget.cpp" line="135" />
-            <location filename="../src/gui/errortabwidget.cpp" line="178" />
-            <location filename="../src/gui/errortabwidget.cpp" line="186" />
-            <source>Clear history</source>
-            <translation>Tyhjennä historia</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errortabwidget.cpp" line="176" />
-            <source>To Resolve</source>
-            <translation>Ratkaistavana</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errortabwidget.cpp" line="177" />
-            <source>problem(s) detected</source>
-            <translation>havaittu ongelma(t)</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errortabwidget.cpp" line="179" />
-            <source>Resolve</source>
-            <translation>Ratkaise</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errortabwidget.cpp" line="180" />
-            <source>Conflicted item(s)</source>
-            <translation>Ristiriitainen kohde (kohteet)</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errortabwidget.cpp" line="181" />
-            <source>Item(s) with unsupported characters</source>
-            <translation>Kohde(et), joissa on ei-tuettuja merkkejä</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errortabwidget.cpp" line="184" />
-            <source>Automatically resolved</source>
-            <translation>Automaattisesti ratkaistu</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errortabwidget.cpp" line="185" />
-            <source>problem(s) solved</source>
-            <translation>ratkaistut ongelma(t)</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::ErrorsMenuBarWidget</name>
-        <message>
-            <location filename="../src/gui/errorsmenubarwidget.cpp" line="84" />
-            <location filename="../src/gui/errorsmenubarwidget.cpp" line="103" />
-            <source>Synchronization conflicts or errors</source>
-            <translation>Synkronointiristiriidat tai -virheet</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errorsmenubarwidget.cpp" line="86" />
-            <location filename="../src/gui/errorsmenubarwidget.cpp" line="105" />
-            <source>Errors</source>
-            <translation>Virheet</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errorsmenubarwidget.cpp" line="101" />
-            <source>Back to preferences</source>
-            <translation>Takaisin asetuksiin</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::ErrorsPopup</name>
-        <message>
-            <location filename="../src/gui/errorspopup.cpp" line="73" />
-            <source>Some files couldn't be synchronized on the following kDrive(s) :</source>
-            <translation>Joitakin tiedostoja ei voitu synkronoida seuraavilla kDrive-asemilla:</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errorspopup.cpp" line="95" />
-            <source> (%1 error(s))</source>
-            <translation> (%1 virhe(ttä))</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errorspopup.cpp" line="101" />
-            <source> (%1 information(s))</source>
-            <translation> (%1 tiedote(tta))</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/errorspopup.cpp" line="107" />
-            <source> (%1 error(s) and %2 information(s))</source>
-            <translation> (%1 virhe(ttä) ja %2 tiedote(tta))</translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/gui/errorspopup.cpp" line="147" />
-            <source>Generic errors (%n warning(s) or error(s))</source>
-            <comment>Number of warnings or errors</comment>
-            <translation>
-                <numerusform>Yleiset virheet (%n varoitus tai virhe)</numerusform>
-                <numerusform>Yleiset virheet (%n varoitusta tai virhettä)</numerusform>
-            </translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::FileExclusionDialog</name>
-        <message>
-            <location filename="../src/gui/fileexclusiondialog.cpp" line="78" />
-            <source>Excluded files</source>
-            <translation>Poissuljetut tiedostot</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fileexclusiondialog.cpp" line="86" />
-            <source>Add files or folders that will not be synchronized on your computer.</source>
-            <translation>Lisää tiedostoja tai kansioita, joita ei synkronoida tietokoneellesi.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fileexclusiondialog.cpp" line="97" />
-            <source>Add</source>
-            <translation>Lisää</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fileexclusiondialog.cpp" line="109" />
-            <source>NAME</source>
-            <translation>NIMI</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fileexclusiondialog.cpp" line="114" />
-            <source>WARNING</source>
-            <translation>VAROITUS</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fileexclusiondialog.cpp" line="149" />
-            <source>SAVE</source>
-            <translation>TALLENNA</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fileexclusiondialog.cpp" line="156" />
-            <source>CANCEL</source>
-            <translation>PERUUTA</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fileexclusiondialog.cpp" line="304" />
-            <source>Do you want to save your modifications?</source>
-            <translation>Haluatko tallentaa muutokset?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fileexclusiondialog.cpp" line="353" />
-            <source>Exclusion template already exists!</source>
-            <translation>Poissulkumalli on jo olemassa!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fileexclusiondialog.cpp" line="374" />
-            <source>Do you really want to delete?</source>
-            <translation>Haluatko todella poistaa?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fileexclusiondialog.cpp" line="434" />
-            <source>Cannot save changes!</source>
-            <translation>Muutoksia ei voi tallentaa!</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::FileExclusionNameDialog</name>
-        <message>
-            <location filename="../src/gui/fileexclusionnamedialog.cpp" line="58" />
-            <source>VALIDATE</source>
-            <translation>VAHVISTA</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fileexclusionnamedialog.cpp" line="65" />
-            <source>CANCEL</source>
-            <translation>PERUUTA</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::FixConflictingFilesDialog</name>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67" />
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73" />
-            <source>Unable to open link %1.</source>
-            <translation>Linkkiä %1 ei voi avata.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122" />
-            <source>Solve conflict(s)</source>
-            <translation>Ratkaise ristiriita(t)</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140" />
-            <source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
-            <translation>&lt;b&gt;Mitä haluat tehdä %1 ristiriitaiselle kohteelle?&lt;/b&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143" />
-            <source>Save my changes and replace other users' versions.</source>
-            <translation>Tallenna muutokseni ja korvaa muiden käyttäjien versiot.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147" />
-            <source>Undo my changes and keep other users' versions.</source>
-            <translation>Kumoa muutokseni ja säilytä muiden käyttäjien versiot.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169" />
-            <source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
-            <translation>Muutoksesi voidaan poistaa pysyvästi. Niitä ei voi palauttaa kDrive-verkkosovelluksesta.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171" />
-            <source>&lt;a style=%1 href="%2"&gt;Learn more&lt;/a&gt;</source>
-            <translation>&lt;a style=%1 href="%2"&gt;Lue lisää&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175" />
-            <source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
-            <translation>Muutoksesi poistetaan pysyvästi. Niitä ei voi palauttaa kDrive-verkkosovelluksesta.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191" />
-            <source>Show item(s)</source>
-            <translation>Näytä kohde(et)</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228" />
-            <source>VALIDATE</source>
-            <translation>VAHVISTA</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234" />
-            <source>CANCEL</source>
-            <translation>PERUUTA</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251" />
-            <source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
-            <translation>Useat käyttäjät ovat muokanneet näitä tiedostoja useissa paikoissa (kDrivessa verkossa, tietokoneella tai mobiililaitteella). Myös nämä tiedostot sisältävät kansiot on saatettu poistaa.&lt;br&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253" />
-            <source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Learn more&lt;/a&gt;</source>
-            <translation>Kohteesi paikallinen versio &lt;b&gt;ei ole synkronoitu&lt;/b&gt; kDriven kanssa. &lt;a style="color: #489EF3" href="%1"&gt;Lue lisää&lt;/a&gt;</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::FolderItemWidget</name>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="188" />
-            <location filename="../src/gui/folderitemwidget.cpp" line="476" />
-            <source>Synchronized into &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</source>
-            <translation>Synkronoitu kohteeseen &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="343" />
-            <source>Activate Lite Sync</source>
-            <translation>Ota Lite Sync käyttöön</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="345" />
-            <source>Activate Lite Sync (Beta)</source>
-            <translation>Ota Lite Sync (Beta) käyttöön</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="354" />
-            <source>Deactivate Lite Sync</source>
-            <translation>Poista Lite Sync käytöstä</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="365" />
-            <source>Pause synchronization</source>
-            <translation>Keskeytä synkronointi</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="375" />
-            <source>Resume synchronization</source>
-            <translation>Jatka synkronointia</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="386" />
-            <source>Remove synchronization</source>
-            <translation>Poista synkronointi</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="458" />
-            <source>More actions</source>
-            <translation>Lisää toimintoja</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="481" />
-            <source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
-            <translation>Valitsemattomat kansiot siirretään roskakoriin, jos ne sisältävät offline-kohteita. kDriveen synkronoidut kansiot pysyvät saatavilla verkossa.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="485" />
-            <source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
-            <translation>Valitsemattomat kansiot siirretään roskakoriin. kDriveen synkronoidut kansiot pysyvät saatavilla verkossa.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="488" />
-            <source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
-            <translation>Valitsemattomat kansiot poistetaan &lt;b&gt;pysyvästi&lt;/b&gt; tietokoneelta. kDriveen synkronoidut kansiot pysyvät saatavilla verkossa.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="493" />
-            <source>Cancel</source>
-            <translation>Peruuta</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="494" />
-            <source>VALIDATE</source>
-            <translation>VAHVISTA</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::GenericErrorItemWidget</name>
-        <message>
-            <location filename="../src/gui/genericerroritemwidget.cpp" line="85" />
-            <source>Unable to open folder path %1.</source>
-            <translation>Kansion polkua %1 ei voi avata.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::LiteSyncAppDialog</name>
-        <message>
-            <location filename="../src/gui/litesyncappdialog.cpp" line="48" />
-            <source>Application Id</source>
-            <translation>Sovelluksen tunnus</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/litesyncappdialog.cpp" line="98" />
-            <source>Application Name</source>
-            <translation>Sovelluksen nimi</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/litesyncappdialog.cpp" line="121" />
-            <source>VALIDATE</source>
-            <translation>VAHVISTA</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/litesyncappdialog.cpp" line="128" />
-            <source>CANCEL</source>
-            <translation>PERUUTA</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::LiteSyncDialog</name>
-        <message>
-            <location filename="../src/gui/litesyncdialog.cpp" line="91" />
-            <source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are "online". Add them in the list below to avoid this behaviour.</source>
-            <translation>Jotkut sovellukset (varmuuskopiointi, virustorjunta...) käyttävät tiedostojasi, mikä johtaa niiden lataamiseen, kun ne ovat "verkossa". Lisää ne alla olevaan luetteloon tämän käyttäytymisen välttämiseksi.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/litesyncdialog.cpp" line="103" />
-            <source>Add</source>
-            <translation>Lisää</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/litesyncdialog.cpp" line="115" />
-            <source>APPLICATION ID</source>
-            <translation>SOVELLUKSEN TUNNUS</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/litesyncdialog.cpp" line="120" />
-            <source>NAME</source>
-            <translation>NIMI</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/litesyncdialog.cpp" line="154" />
-            <source>SAVE</source>
-            <translation>TALLENNA</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/litesyncdialog.cpp" line="161" />
-            <source>CANCEL</source>
-            <translation>PERUUTA</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/litesyncdialog.cpp" line="295" />
-            <source>Do you want to save your modifications?</source>
-            <translation>Haluatko tallentaa muutokset?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/litesyncdialog.cpp" line="337" />
-            <source>Do you really want to delete?</source>
-            <translation>Haluatko todella poistaa?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/litesyncdialog.cpp" line="374" />
-            <source>Cannot save changes!</source>
-            <translation>Muutoksia ei voi tallentaa!</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::LocalFolderDialog</name>
-        <message>
-            <location filename="../src/gui/localfolderdialog.cpp" line="63" />
-            <source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
-            <translation>Minkä tietokoneen kansion haluat&lt;br&gt;synkronoida?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/localfolderdialog.cpp" line="72" />
-            <source>The content of this folder will be synchronized on the kDrive</source>
-            <translation>Tämän kansion sisältö synkronoidaan kDriveen</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/localfolderdialog.cpp" line="91" />
-            <source>Select a folder</source>
-            <translation>Valitse kansio</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/localfolderdialog.cpp" line="131" />
-            <source>Edit folder</source>
-            <translation>Muokkaa kansiota</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/localfolderdialog.cpp" line="166" />
-            <source>CANCEL</source>
-            <translation>PERUUTA</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/localfolderdialog.cpp" line="173" />
-            <source>CONTINUE</source>
-            <translation>JATKA</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/localfolderdialog.cpp" line="210" />
-            <source>This folder is not compatible with Lite Sync.&lt;br&gt;
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Lue lisää&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
+        <source>Select folder</source>
+        <translation>Valitse kansio</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377"/>
+        <source>Unable to open link %1.</source>
+        <translation>Linkkiä %1 ei voi avata.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AddDriveLoginWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="69"/>
+        <source>Log in from your browser</source>
+        <translation>Kirjaudu sisään selaimella</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="75"/>
+        <source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
+        <translation>Selaimesi avautuu automaattisesti yhteyden muodostamiseksi. Kun olet kirjautunut, palaat automaattisesti kDriveen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
+        <source>Open the login page</source>
+        <translation>Avaa kirjautumissivu</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="119"/>
+        <source>Token request failed: %1 - %2</source>
+        <translation>Tunnuksen pyyntö epäonnistui: %1 - %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="133"/>
+        <source>Login failed: %1 - %2</source>
+        <translation>Kirjautuminen epäonnistui: %1 - %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="141"/>
+        <source>Failed to open the login page in your web browser</source>
+        <translation>Kirjautumissivun avaaminen selaimessa epäonnistui</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AddDriveServerFoldersWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129"/>
+        <source>Select kDrive folders to synchronize on your desktop</source>
+        <translation>Valitse synkronoitavat kDrive-kansiot tietokoneellesi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174"/>
+        <source>CONTINUE</source>
+        <translation>JATKA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187"/>
+        <source>Space available on your computer : %1</source>
+        <translation>Tietokoneella vapaata tilaa: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206"/>
+        <source>An error occurred while loading the list of subfolders.</source>
+        <translation>Alikansioiden listan lataaminen epäonnistui.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210"/>
+        <source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>Alikansioiden listaa ei voi ladata. kDrive saattaa olla huoltotilassa.&lt;br&gt;Kirjaudu &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;verkkoversioon&lt;/a&gt; tarkistaaksesi kDriven tilan tai ota yhteyttä järjestelmänvalvojaasi.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AddDriveWizard</name>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="222"/>
+        <source>Failed to create local folder %1</source>
+        <translation>Paikallisen kansion %1 luominen epäonnistui</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="233"/>
+        <source>Failed to create new synchronization</source>
+        <translation>Uuden synkronoinnin luominen epäonnistui</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="266"/>
+        <source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
+        <translation>kDrive %1 on jo synkronoitu tällä tietokoneella. Jatketaanko?</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AppClient</name>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="100"/>
+        <source>kDrive client is run with bad parameters!</source>
+        <translation>kDrive-asiakas käynnistettiin virheellisillä parametreillä!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="109"/>
+        <source>kDrive client is already running!</source>
+        <translation>kDrive-asiakas on jo käynnissä!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="719"/>
+        <source>The user %1 is not connected. Please log in again.</source>
+        <translation>Käyttäjä %1 ei ole kirjautunut. Kirjaudu uudelleen.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::AppServer</name>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="1685"/>
+        <source>Share link copied to clipboard</source>
+        <translation>Jakolinkki kopioitu leikepöydälle</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3773"/>
+        <source>%1 and %n other file(s) have been removed.</source>
+        <translation>
+            <numerusform>%1 ja %n muu tiedosto on poistettu.</numerusform>
+            <numerusform>%1 ja %n muuta tiedostoa on poistettu.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3775"/>
+        <source>%1 has been removed.</source>
+        <comment>%1 names a file.</comment>
+        <translation>%1 on poistettu.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3780"/>
+        <source>%1 and %n other file(s) have been added.</source>
+        <translation>
+            <numerusform>%1 ja %n muu tiedosto on lisätty.</numerusform>
+            <numerusform>%1 ja %n muuta tiedostoa on lisätty.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3782"/>
+        <source>%1 has been added.</source>
+        <comment>%1 names a file.</comment>
+        <translation>%1 on lisätty.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3787"/>
+        <source>%1 and %n other file(s) have been updated.</source>
+        <translation>
+            <numerusform>%1 ja %n muu tiedosto on päivitetty.</numerusform>
+            <numerusform>%1 ja %n muuta tiedostoa on päivitetty.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3789"/>
+        <source>%1 has been updated.</source>
+        <comment>%1 names a file.</comment>
+        <translation>%1 on päivitetty.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3794"/>
+        <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
+        <translation>
+            <numerusform>%1 on siirretty kohteeseen %2 ja %n muu tiedosto on siirretty.</numerusform>
+            <numerusform>%1 on siirretty kohteeseen %2 ja %n muuta tiedostoa on siirretty.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3797"/>
+        <source>%1 has been moved to %2.</source>
+        <translation>%1 on siirretty kohteeseen %2.</translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3805"/>
+        <source>Sync Activity</source>
+        <translation>Synkronointiaktiviteetti</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::BaseFolderTreeItemWidget</name>
+    <message>
+        <location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102"/>
+        <source>No subfolders currently on the server.</source>
+        <translation>Palvelimella ei ole alikansioita tällä hetkellä.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::BetaProgramDialog</name>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="69"/>
+        <source>Quit the beta program</source>
+        <translation>Poistu beta-ohjelmasta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="69"/>
+        <source>Join the beta program</source>
+        <translation>Liity beta-ohjelmaan</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="77"/>
+        <source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
+        <translation>Saa varhainen pääsy sovelluksen uusiin versioihin ennen niiden julkaisua ja osallistu sovelluksen kehittämiseen lähettämällä kommenttisi.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="87"/>
+        <source>Benefit from application beta updates</source>
+        <translation>Hyödy sovelluksen beta-päivityksistä</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="91"/>
+        <source>No</source>
+        <translation>Ei</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="92"/>
+        <source>Public beta version</source>
+        <translation>Julkinen beta-versio</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="93"/>
+        <source>Internal beta version</source>
+        <translation>Sisäinen beta-versio</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="141"/>
+        <source>I understand</source>
+        <translation>Ymmärrän</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="147"/>
+        <source>Are you sure you want to leave the beta program?</source>
+        <translation>Oletko varma, että haluat poistua beta-ohjelmasta?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="161"/>
+        <source>Save</source>
+        <translation>Tallenna</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="167"/>
+        <source>Cancel</source>
+        <translation>Peruuta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="228"/>
+        <source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
+        <translation>Sovelluksesi nykyinen versio saattaa olla liian uusi; valintasi astuu voimaan seuraavan päivityksen yhteydessä.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="233"/>
+        <source>Beta versions may leave unexpectedly or cause instabilities.</source>
+        <translation>Beta-versiot saattavat kaatua odottamatta tai aiheuttaa epävakautta.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ClientGui</name>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="116"/>
+        <source>Unable to initialize kDrive client</source>
+        <translation>kDrive-asiakkaan alustaminen epäonnistui</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="189"/>
+        <source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
+        <translation>Ristiriitojen korjaaminen kohteessa %1 synkronointikansiossa epäonnistui: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="242"/>
+        <source>Please sign in</source>
+        <translation>Kirjaudu sisään</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="255"/>
+        <source>Synchronization is paused</source>
+        <translation>Synkronointi on keskeytetty</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="292"/>
+        <source>Folder %1: %2</source>
+        <translation>Kansio %1: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="298"/>
+        <source>There are no sync folders configured.</source>
+        <translation>Synkronointikansioita ei ole määritetty.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="673"/>
+        <source>Undefined State.</source>
+        <translation>Määrittelemätön tila.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="676"/>
+        <source>Waiting to start syncing.</source>
+        <translation>Odotetaan synkronoinnin käynnistymistä.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="679"/>
+        <source>Sync is running.</source>
+        <translation>Synkronointi käynnissä.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="683"/>
+        <source>Sync was successful, unresolved conflicts.</source>
+        <translation>Synkronointi onnistui, ratkaisemattomia ristiriitoja.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="685"/>
+        <source>Last Sync was successful.</source>
+        <translation>Viimeisin synkronointi onnistui.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="692"/>
+        <source>User Abort.</source>
+        <translation>Käyttäjä keskeytti.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="696"/>
+        <source>Sync is paused.</source>
+        <translation>Synkronointi on keskeytetty.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="705"/>
+        <source>%1 (Sync is paused)</source>
+        <translation>%1 (Synkronointi keskeytetty)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="849"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Kansion polkua %1 ei voi avata.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1257"/>
+        <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+        <translation>Haluatko todella poistaa tilin &lt;i&gt;%1&lt;/i&gt; synkronoinnit?&lt;br&gt;&lt;b&gt;Huom:&lt;/b&gt; Tämä &lt;b&gt;ei&lt;/b&gt; poista tiedostoja.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1261"/>
+        <source>REMOVE ALL SYNCHRONIZATIONS</source>
+        <translation>POISTA KAIKKI SYNKRONOINNIT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1262"/>
+        <source>CANCEL</source>
+        <translation>PERUUTA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1422"/>
+        <source>Synthesis</source>
+        <translation>Yhteenveto</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1423"/>
+        <source>Preferences</source>
+        <translation>Asetukset</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1424"/>
+        <source>Quit</source>
+        <translation>Lopeta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1590"/>
+        <source>Failed to start synchronizations!</source>
+        <translation>Synkronointien käynnistäminen epäonnistui!</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ConfirmSynchronizationDialog</name>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86"/>
+        <source>Summary of your local folder synchronization</source>
+        <translation>Yhteenveto paikallisen kansion synkronoinnista</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95"/>
+        <source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
+        <translation>Tietokoneesi kansion sisältö synkronoidaan valitun kDriven kansioon ja päinvastoin.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184"/>
+        <source>CANCEL</source>
+        <translation>PERUUTA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191"/>
+        <source>SYNCHRONIZE</source>
+        <translation>SYNKRONOI</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::CustomExtensionSetupWidget</name>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="96"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="120"/>
+        <source>Before finishing</source>
+        <translation>Ennen viimeistelyä</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="107"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="131"/>
+        <source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
+        <translation>Suorita seuraavat vaiheet varmistaaksesi, että Lite Sync toimii oikein tietokoneellasi ja viimeistelläksesi kDriven konfiguroinnin.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="208"/>
+        <source>Open your Mac&apos;s &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Avaa Macin &lt;b&gt;Yleiset asetukset&lt;/b&gt; tai &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;napsauta tästä&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="212"/>
+        <source>Open your Mac&apos;s &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Avaa Macin &lt;b&gt;Tietosuoja- ja turva-asetukset&lt;/b&gt; tai &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;napsauta tästä&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="216"/>
+        <source>Open your Mac&apos;s &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Avaa Macin &lt;b&gt;Turvallisuus- ja tietosuoja-asetukset&lt;/b&gt; tai &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;napsauta tästä&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="246"/>
+        <source>Go to &lt;b&gt;&quot;Login Items &amp; Extensions&quot;&lt;/b&gt; section and then to &lt;b&gt;&quot;Endpoint Security Extensions&quot;&lt;/b&gt;</source>
+        <translation>Siirry &lt;b&gt;&quot;Kirjautumisobjektit ja laajennukset&quot;&lt;/b&gt;-osioon ja sitten &lt;b&gt;&quot;Endpoint Security Extensions&quot;&lt;/b&gt;-osioon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="263"/>
+        <source>Authorize the kDrive application</source>
+        <translation>Valtuuta kDrive-sovellus</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="272"/>
+        <source>Go to &lt;b&gt;&quot;Security&quot;&lt;/b&gt; section</source>
+        <translation>Siirry &lt;b&gt;&quot;Turvallisuus&quot;&lt;/b&gt;-osioon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="289"/>
+        <source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
+        <translation>Valtuuta kDrive-sovellus ruudussa, jossa ilmoitetaan kDriven olevan estetty</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="299"/>
+        <source>Unlock the padlock &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; and authorize the kDrive application</source>
+        <translation>Avaa lukko &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; ja valtuuta kDrive-sovellus</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="344"/>
+        <source>Go to &lt;b&gt;&quot;Privacy &amp; Security&quot;&lt;/b&gt; section and click on &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt; or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Siirry &lt;b&gt;&quot;Tietosuoja ja turvallisuus&quot;&lt;/b&gt;-osioon ja napsauta &lt;b&gt;&quot;Täysi levynkäyttöoikeus&quot;&lt;/b&gt; tai &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;napsauta tästä&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="348"/>
+        <source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;&quot;Privacy&quot;&lt;/b&gt; tab or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Turvallisuus- ja tietosuoja-asetuksissa avaa &lt;b&gt;&quot;Tietosuoja&quot;&lt;/b&gt;-välilehti tai &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;napsauta tästä&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="376"/>
+        <source>Check the &quot;kDrive LiteSync Extension&quot; box then the &quot;kDrive.app&quot; box (if not already checked)</source>
+        <translation>Valitse &quot;kDrive LiteSync Extension&quot; -ruutu ja sitten &quot;kDrive.app&quot;-ruutu (jos ei vielä valittu)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="393"/>
+        <source>A restart of the app might be proposed, in this case accept it</source>
+        <translation>Sovelluksen uudelleenkäynnistystä saatetaan ehdottaa; hyväksy se siinä tapauksessa</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="399"/>
+        <source>Check the &quot;kDrive LiteSync Extension&quot; box (and &quot;kDrive.app&quot; if it exists) in &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt;</source>
+        <translation>Valitse &quot;kDrive LiteSync Extension&quot; -ruutu (ja &quot;kDrive.app&quot;, jos se on olemassa) kohdassa &lt;b&gt;&quot;Täysi levynkäyttöoikeus&quot;&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
+        <source>STEP 1</source>
+        <translation>VAIHE 1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="496"/>
+        <source>(Done)</source>
+        <translation>(Valmis)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="496"/>
+        <source>STEP 2</source>
+        <translation>VAIHE 2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="499"/>
+        <source>STEPS PERFORMED</source>
+        <translation>VAIHEET SUORITETTU</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="501"/>
+        <source>END</source>
+        <translation>LOPETA</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::CustomMessageBox</name>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="101"/>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="111"/>
+        <source>CANCEL</source>
+        <translation>PERUUTA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="121"/>
+        <source>YES</source>
+        <translation>KYLLÄ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="131"/>
+        <source>NO</source>
+        <translation>EI</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::DebugReporter</name>
+    <message>
+        <location filename="../src/gui/debugreporter.cpp" line="37"/>
+        <source>Sending of debugging information</source>
+        <translation>Lähetetään virheenkorjaustietoja</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debugreporter.cpp" line="37"/>
+        <source>Cancel</source>
+        <translation>Peruuta</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::DebuggingDialog</name>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="45"/>
+        <source>Debug</source>
+        <translation>Virheenkorjaus</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="46"/>
+        <source>Info</source>
+        <translation>Tiedot</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="47"/>
+        <source>Warning</source>
+        <translation>Varoitus</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="48"/>
+        <source>Error</source>
+        <translation>Virhe</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="49"/>
+        <source>Fatal</source>
+        <translation>Kriittinen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="74"/>
+        <source>Debugging settings</source>
+        <translation>Virheenkorjausasetukset</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="90"/>
+        <source>Save debugging information in a folder on my computer (Recommended)</source>
+        <translation>Tallenna virheenkorjaustiedot kansioon tietokoneellani (Suositeltu)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="104"/>
+        <source>This information enables IT support to determine the origin of an incident.</source>
+        <translation>Nämä tiedot auttavat IT-tukea selvittämään tapauksen alkuperän.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="114"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Avaa virheenkorjauskansio&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="143"/>
+        <source>Debug level</source>
+        <translation>Virheenkorjaustaso</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="152"/>
+        <source>The trace level lets you choose the extent of the debugging information recorded</source>
+        <translation>Jäljitystaso antaa sinun valita tallennettavien virheenkorjaustietojen laajuuden</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="179"/>
+        <source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
+        <translation>Laajennettu täysloki kerää yksityiskohtaisen historian virheenkorjausta varten. Sen käyttöönotto voi hidastaa kDrive-sovellusta.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="183"/>
+        <source>Extended Full Log</source>
+        <translation>Laajennettu täysloki</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="207"/>
+        <source>Delete logs older than %1 days</source>
+        <translation>Poista lokeja, jotka ovat vanhempia kuin %1 päivää</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="226"/>
+        <source>Share the debug folder with Infomaniak support.</source>
+        <translation>Jaa virheenkorjauskansio Infomaniakille.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="250"/>
+        <source>The last session is the periode since the last kDrive start.</source>
+        <translation>Viimeinen istunto on ajanjakso viimeisimmästä kDriven käynnistyksestä.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="254"/>
+        <source>Share only the last kDrive session</source>
+        <translation>Jaa vain viimeisin kDrive-istunto</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="285"/>
+        <source>  Loading</source>
+        <translation>  Ladataan</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="294"/>
+        <source>Cancel</source>
+        <translation>Peruuta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="320"/>
+        <source>SAVE</source>
+        <translation>TALLENNA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="327"/>
+        <source>CANCEL</source>
+        <translation>PERUUTA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="471"/>
+        <source>Failed to share</source>
+        <translation>Jakaminen epäonnistui</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="481"/>
+        <source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
+        <translation>1. Tarkista, että olet kirjautunut sisään &lt;br&gt;2. Tarkista, että olet määrittänyt vähintään yhden kDriven</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="486"/>
+        <source> (Connexion interrupted)</source>
+        <translation> (Yhteys katkaistu)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="493"/>
+        <source>Share the folder with SwissTransfer &lt;br&gt;</source>
+        <translation>Jaa kansio SwissTransferillä &lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="494"/>
+        <source> 1. We automatically compressed your log &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;here&lt;/a&gt;.&lt;br&gt;</source>
+        <translation> 1. Pakkasimme lokisi automaattisesti &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;tähän&lt;/a&gt;.&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="496"/>
+        <source> 2. Transfer the archive with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
+        <translation> 2. Siirrä arkisto &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;-palvelun avulla&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="498"/>
+        <source> 3. Share the link with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
+        <translation> 3. Jaa linkki osoitteeseen &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="528"/>
+        <source>Last upload the %1</source>
+        <translation>Viimeisin lähetys %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="556"/>
+        <source>Sharing has been cancelled</source>
+        <translation>Jakaminen on peruutettu</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="597"/>
+        <source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
+        <translation>Laajennettu täysloki on aktivoitu KDRIVE_FORCE_EXTENDED_LOG-ympäristömuuttujalla. Aseta se arvoon 0 poistaaksesi sen käytöstä.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="611"/>
+        <source>%1/%2/%3 at %4h%5m and %6s</source>
+        <extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
+        <translation>%1/%2/%3 klo %4:%5:%6</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="654"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Haluatko tallentaa muutokset?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="709"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="715"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Kansiota %1 ei voi avata.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="722"/>
+        <source>  Share</source>
+        <translation>  Jaa</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="732"/>
+        <source>  Sharing | step 1/2 %1%</source>
+        <translation>  Jaetaan | vaihe 1/2 %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="741"/>
+        <source>  Sharing | step 2/2 %1%</source>
+        <translation>  Jaetaan | vaihe 2/2 %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="751"/>
+        <source>  Canceling...</source>
+        <translation>  Peruutetaan...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.h" line="70"/>
+        <source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
+        <translation>Koko kansio on suuri (&gt; 100 Mt) ja jakaminen voi kestää jonkin aikaa. Jakamisajan lyhentämiseksi suosittelemme jakamaan vain viimeisimmän kDrive-istunnon.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::DrivePreferencesWidget</name>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
+        <source>Synchronization errors and information.</source>
+        <translation>Synkronointivirheet ja tiedot.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
+        <source>Synchronize a local folder</source>
+        <translation>Synkronoi paikallinen kansio</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
+        <source>Do you really want to turn on Lite Sync?</source>
+        <translation>Haluatko todella ottaa Lite Sync käyttöön?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="356"/>
+        <source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
+        <translation>Tämä toiminto voi kestää muutamasta sekunnista muutamaan minuuttiin kansion koosta riippuen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
+        <source>CONFIRM</source>
+        <translation>VAHVISTA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="360"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="391"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="986"/>
+        <source>CANCEL</source>
+        <translation>PERUUTA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="382"/>
+        <source>Do you really want to turn off Lite Sync?</source>
+        <translation>Haluatko todella poistaa Lite Sync käytöstä?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="384"/>
+        <source>You don&apos;t have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
+        <translation>Sinulla ei ole tarpeeksi tilaa kaikkien kDrive-tiedostojen synkronointiin (%1 puuttuu). Jos poistat Lite Sync käytöstä, sinun on valittava synkronoitavat kansiot tietokoneellasi. Sillä välin kDriven synkronointi keskeytetään.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="388"/>
+        <source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
+        <translation>Jos poistat Lite Sync käytöstä, kaikki tiedostot ladataan tietokoneellesi.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="627"/>
+        <source>Failed to create new synchronization</source>
+        <translation>Uuden synkronoinnin luominen epäonnistui</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
+        <source>New local folder synchronization failed!</source>
+        <translation>Uuden paikallisen kansion synkronointi epäonnistui!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="819"/>
+        <source>Lite Sync activated.</source>
+        <translation>Lite Sync aktivoitu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
+        <source>Lite Sync activation failed.</source>
+        <translation>Lite Sync -aktivointi epäonnistui.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="837"/>
+        <source>Lite Sync deactivated.</source>
+        <translation>Lite Sync poistettu käytöstä.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
+        <source>Lite Sync deactivation failed.</source>
+        <translation>Lite Sync -deaktivointi epäonnistui.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="899"/>
+        <source>This drive is being deleted.</source>
+        <translation>Tämä asema poistetaan.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="962"/>
+        <source>Impossible to open item %1</source>
+        <translation>Kohteen %1 avaaminen ei onnistu</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
+        <source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+        <translation>Haluatko todella lopettaa kansion &lt;i&gt;%1&lt;/i&gt; synkronoinnin?&lt;br&gt;&lt;b&gt;Huom:&lt;/b&gt; Tämä &lt;b&gt;ei&lt;/b&gt; poista tiedostoja.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
+        <source>REMOVE FOLDER SYNC CONNECTION</source>
+        <translation>POISTA KANSION SYNKRONOINTIYHTEYS</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1007"/>
+        <source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
+        <translation>Kansion &lt;i&gt;%1&lt;/i&gt; synkronoinnin pysäyttäminen epäonnistui.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
+        <source>An error occurred while loading the list of subfolders.</source>
+        <translation>Alikansioiden listan lataaminen epäonnistui.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
+        <source>Folders</source>
+        <translation>Kansiot</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
+        <source>Notifications</source>
+        <translation>Ilmoitukset</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
+        <source>Enable the notifications for this kDrive</source>
+        <translation>Ota tämän kDriven ilmoitukset käyttöön</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
+        <source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
+        <translation>Ilmoitus näytetään heti, kun uusi kansio on synkronoitu tai muokattu</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
+        <source>Connected with</source>
+        <translation>Yhdistetty:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1125"/>
+        <source>Remove all synchronizations</source>
+        <translation>Poista kaikki synkronoinnit</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1126"/>
+        <source>Search in your kDrive</source>
+        <translation>Hae kDrivesta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1127"/>
+        <source>Search</source>
+        <translation>Haku</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::DriveSelectionWidget</name>
+    <message>
+        <location filename="../src/gui/driveselectionwidget.cpp" line="150"/>
+        <source>Add a kDrive</source>
+        <translation>Lisää kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
+        <source>Synchronize a kDrive</source>
+        <translation>Synkronoi kDrive</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ErrorTabWidget</name>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="92"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="135"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="178"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="186"/>
+        <source>Clear history</source>
+        <translation>Tyhjennä historia</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="176"/>
+        <source>To Resolve</source>
+        <translation>Ratkaistavana</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="177"/>
+        <source>problem(s) detected</source>
+        <translation>havaittu ongelma(t)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="179"/>
+        <source>Resolve</source>
+        <translation>Ratkaise</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="180"/>
+        <source>Conflicted item(s)</source>
+        <translation>Ristiriitainen kohde (kohteet)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="181"/>
+        <source>Item(s) with unsupported characters</source>
+        <translation>Kohde(et), joissa on ei-tuettuja merkkejä</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="184"/>
+        <source>Automatically resolved</source>
+        <translation>Automaattisesti ratkaistu</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="185"/>
+        <source>problem(s) solved</source>
+        <translation>ratkaistut ongelma(t)</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ErrorsMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="84"/>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="103"/>
+        <source>Synchronization conflicts or errors</source>
+        <translation>Synkronointiristiriidat tai -virheet</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="86"/>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="105"/>
+        <source>Errors</source>
+        <translation>Virheet</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="101"/>
+        <source>Back to preferences</source>
+        <translation>Takaisin asetuksiin</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ErrorsPopup</name>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="73"/>
+        <source>Some files couldn&apos;t be synchronized on the following kDrive(s) :</source>
+        <translation>Joitakin tiedostoja ei voitu synkronoida seuraavilla kDrive-asemilla:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="95"/>
+        <source> (%1 error(s))</source>
+        <translation> (%1 virhe(ttä))</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="101"/>
+        <source> (%1 information(s))</source>
+        <translation> (%1 tiedote(tta))</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="107"/>
+        <source> (%1 error(s) and %2 information(s))</source>
+        <translation> (%1 virhe(ttä) ja %2 tiedote(tta))</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/errorspopup.cpp" line="147"/>
+        <source>Generic errors (%n warning(s) or error(s))</source>
+        <comment>Number of warnings or errors</comment>
+        <translation>
+            <numerusform>Yleiset virheet (%n varoitus tai virhe)</numerusform>
+            <numerusform>Yleiset virheet (%n varoitusta tai virhettä)</numerusform>
+        </translation>
+    </message>
+</context>
+<context>
+    <name>KDC::FileExclusionDialog</name>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="78"/>
+        <source>Excluded files</source>
+        <translation>Poissuljetut tiedostot</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="86"/>
+        <source>Add files or folders that will not be synchronized on your computer.</source>
+        <translation>Lisää tiedostoja tai kansioita, joita ei synkronoida tietokoneellesi.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="97"/>
+        <source>Add</source>
+        <translation>Lisää</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="109"/>
+        <source>NAME</source>
+        <translation>NIMI</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="114"/>
+        <source>WARNING</source>
+        <translation>VAROITUS</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="149"/>
+        <source>SAVE</source>
+        <translation>TALLENNA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="156"/>
+        <source>CANCEL</source>
+        <translation>PERUUTA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="304"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Haluatko tallentaa muutokset?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="353"/>
+        <source>Exclusion template already exists!</source>
+        <translation>Poissulkumalli on jo olemassa!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="374"/>
+        <source>Do you really want to delete?</source>
+        <translation>Haluatko todella poistaa?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="434"/>
+        <source>Cannot save changes!</source>
+        <translation>Muutoksia ei voi tallentaa!</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::FileExclusionNameDialog</name>
+    <message>
+        <location filename="../src/gui/fileexclusionnamedialog.cpp" line="58"/>
+        <source>VALIDATE</source>
+        <translation>VAHVISTA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusionnamedialog.cpp" line="65"/>
+        <source>CANCEL</source>
+        <translation>PERUUTA</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::FixConflictingFilesDialog</name>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67"/>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73"/>
+        <source>Unable to open link %1.</source>
+        <translation>Linkkiä %1 ei voi avata.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122"/>
+        <source>Solve conflict(s)</source>
+        <translation>Ratkaise ristiriita(t)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140"/>
+        <source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
+        <translation>&lt;b&gt;Mitä haluat tehdä %1 ristiriitaiselle kohteelle?&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143"/>
+        <source>Save my changes and replace other users&apos; versions.</source>
+        <translation>Tallenna muutokseni ja korvaa muiden käyttäjien versiot.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147"/>
+        <source>Undo my changes and keep other users&apos; versions.</source>
+        <translation>Kumoa muutokseni ja säilytä muiden käyttäjien versiot.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169"/>
+        <source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
+        <translation>Muutoksesi voidaan poistaa pysyvästi. Niitä ei voi palauttaa kDrive-verkkosovelluksesta.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171"/>
+        <source>&lt;a style=%1 href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a style=%1 href=&quot;%2&quot;&gt;Lue lisää&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175"/>
+        <source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
+        <translation>Muutoksesi poistetaan pysyvästi. Niitä ei voi palauttaa kDrive-verkkosovelluksesta.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191"/>
+        <source>Show item(s)</source>
+        <translation>Näytä kohde(et)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228"/>
+        <source>VALIDATE</source>
+        <translation>VAHVISTA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234"/>
+        <source>CANCEL</source>
+        <translation>PERUUTA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251"/>
+        <source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
+        <translation>Useat käyttäjät ovat muokanneet näitä tiedostoja useissa paikoissa (kDrivessa verkossa, tietokoneella tai mobiililaitteella). Myös nämä tiedostot sisältävät kansiot on saatettu poistaa.&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253"/>
+        <source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Kohteesi paikallinen versio &lt;b&gt;ei ole synkronoitu&lt;/b&gt; kDriven kanssa. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Lue lisää&lt;/a&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::FolderItemWidget</name>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="188"/>
+        <location filename="../src/gui/folderitemwidget.cpp" line="476"/>
+        <source>Synchronized into &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</source>
+        <translation>Synkronoitu kohteeseen &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="343"/>
+        <source>Activate Lite Sync</source>
+        <translation>Ota Lite Sync käyttöön</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="345"/>
+        <source>Activate Lite Sync (Beta)</source>
+        <translation>Ota Lite Sync (Beta) käyttöön</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="354"/>
+        <source>Deactivate Lite Sync</source>
+        <translation>Poista Lite Sync käytöstä</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="365"/>
+        <source>Pause synchronization</source>
+        <translation>Keskeytä synkronointi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="375"/>
+        <source>Resume synchronization</source>
+        <translation>Jatka synkronointia</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="386"/>
+        <source>Remove synchronization</source>
+        <translation>Poista synkronointi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="458"/>
+        <source>More actions</source>
+        <translation>Lisää toimintoja</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="481"/>
+        <source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
+        <translation>Valitsemattomat kansiot siirretään roskakoriin, jos ne sisältävät offline-kohteita. kDriveen synkronoidut kansiot pysyvät saatavilla verkossa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="485"/>
+        <source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
+        <translation>Valitsemattomat kansiot siirretään roskakoriin. kDriveen synkronoidut kansiot pysyvät saatavilla verkossa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="488"/>
+        <source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
+        <translation>Valitsemattomat kansiot poistetaan &lt;b&gt;pysyvästi&lt;/b&gt; tietokoneelta. kDriveen synkronoidut kansiot pysyvät saatavilla verkossa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="493"/>
+        <source>Cancel</source>
+        <translation>Peruuta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="494"/>
+        <source>VALIDATE</source>
+        <translation>VAHVISTA</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::GenericErrorItemWidget</name>
+    <message>
+        <location filename="../src/gui/genericerroritemwidget.cpp" line="85"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Kansion polkua %1 ei voi avata.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::LiteSyncAppDialog</name>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="48"/>
+        <source>Application Id</source>
+        <translation>Sovelluksen tunnus</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="98"/>
+        <source>Application Name</source>
+        <translation>Sovelluksen nimi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="121"/>
+        <source>VALIDATE</source>
+        <translation>VAHVISTA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="128"/>
+        <source>CANCEL</source>
+        <translation>PERUUTA</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::LiteSyncDialog</name>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="91"/>
+        <source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are &quot;online&quot;. Add them in the list below to avoid this behaviour.</source>
+        <translation>Jotkut sovellukset (varmuuskopiointi, virustorjunta...) käyttävät tiedostojasi, mikä johtaa niiden lataamiseen, kun ne ovat &quot;verkossa&quot;. Lisää ne alla olevaan luetteloon tämän käyttäytymisen välttämiseksi.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="103"/>
+        <source>Add</source>
+        <translation>Lisää</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="115"/>
+        <source>APPLICATION ID</source>
+        <translation>SOVELLUKSEN TUNNUS</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="120"/>
+        <source>NAME</source>
+        <translation>NIMI</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="154"/>
+        <source>SAVE</source>
+        <translation>TALLENNA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="161"/>
+        <source>CANCEL</source>
+        <translation>PERUUTA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="295"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Haluatko tallentaa muutokset?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="337"/>
+        <source>Do you really want to delete?</source>
+        <translation>Haluatko todella poistaa?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="374"/>
+        <source>Cannot save changes!</source>
+        <translation>Muutoksia ei voi tallentaa!</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::LocalFolderDialog</name>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="63"/>
+        <source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
+        <translation>Minkä tietokoneen kansion haluat&lt;br&gt;synkronoida?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="72"/>
+        <source>The content of this folder will be synchronized on the kDrive</source>
+        <translation>Tämän kansion sisältö synkronoidaan kDriveen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="91"/>
+        <source>Select a folder</source>
+        <translation>Valitse kansio</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="131"/>
+        <source>Edit folder</source>
+        <translation>Muokkaa kansiota</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="166"/>
+        <source>CANCEL</source>
+        <translation>PERUUTA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="173"/>
+        <source>CONTINUE</source>
+        <translation>JATKA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="210"/>
+        <source>This folder is not compatible with Lite Sync.&lt;br&gt;
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt;
-&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-            <translation>Tämä kansio ei ole yhteensopiva Lite Sync -toiminnon kanssa.&lt;br&gt;
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Tämä kansio ei ole yhteensopiva Lite Sync -toiminnon kanssa.&lt;br&gt;
 Valitse toinen kansio. Jos jatkat, Lite Sync poistetaan käytöstä.&lt;br&gt;
-&lt;a style="%1" href="%2"&gt;Lue lisää&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/localfolderdialog.cpp" line="233" />
-            <source>Select folder</source>
-            <translation>Valitse kansio</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/localfolderdialog.cpp" line="292" />
-            <source>Unable to open link %1.</source>
-            <translation>Linkkiä %1 ei voi avata.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::Logger</name>
-        <message>
-            <location filename="../src/libcommongui/logger.cpp" line="189" />
-            <source>Error</source>
-            <translation>Virhe</translation>
-        </message>
-        <message>
-            <location filename="../src/libcommongui/logger.cpp" line="189" />
-            <source>&lt;nobr&gt;File '%1'&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
-            <translation>&lt;nobr&gt;Tiedostoa '%1'&lt;br/&gt;ei voi avata kirjoittamista varten.&lt;br/&gt;&lt;br/&gt;Lokia &lt;b&gt;ei&lt;/b&gt; voi tallentaa!&lt;/nobr&gt;</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::MainMenuBarWidget</name>
-        <message>
-            <location filename="../src/gui/mainmenubarwidget.cpp" line="115" />
-            <source>Preferences</source>
-            <translation>Asetukset</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/mainmenubarwidget.cpp" line="116" />
-            <source>Help</source>
-            <translation>Ohje</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::ParametersDialog</name>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="320" />
-            <source>kDrive needs to have write access to your computer's temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
-            <translation>kDrivella on oltava kirjoitusoikeus tietokoneesi väliaikaiseen hakemistoon.&lt;br&gt;Käynnistä kDrive-sovellus uudelleen ratkaistaksesi tämän ongelman.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="330" />
-            <location filename="../src/gui/parametersdialog.cpp" line="487" />
-            <source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-            <translation>Tekninen virhe on tapahtunut.&lt;br&gt;Synkronointi jatkuu mahdollisimman pian. Ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="337" />
-            <location filename="../src/gui/parametersdialog.cpp" line="440" />
-            <location filename="../src/gui/parametersdialog.cpp" line="506" />
-            <location filename="../src/gui/parametersdialog.cpp" line="546" />
-            <location filename="../src/gui/parametersdialog.cpp" line="560" />
-            <source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-            <translation>Tekninen virhe on tapahtunut (virhe %1).&lt;br&gt;Tyhjennä historia ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="342" />
-            <source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
-            <translation>Verkkoyhteyden aikakatkaisuarvo näyttää olevan liian pieni sovelluksen oikeaa toimintaa varten (virhe %1).&lt;br&gt;Tarkista verkkoasetuksesi.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="347" />
-            <location filename="../src/gui/parametersdialog.cpp" line="516" />
-            <source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
-            <translation>kDrive-palvelimeen ei saada yhteyttä (virhe %1).&lt;br&gt;Yritetään yhdistää uudelleen. Tarkista Internet-yhteys ja palomuuri.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="352" />
-            <source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
-            <translation>Kirjautumisvirhe (virhe %1).&lt;br&gt;Kirjaudu uudelleen ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="356" />
-            <source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
-            <translation>Sovelluksesta on saatavilla uusi versio.&lt;br&gt;Päivitä sovellus jatkaaksesi sen käyttöä.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="360" />
-            <source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
-            <translation>Lokin lähetys epäonnistui (virhe %1).&lt;br&gt;Yritä myöhemmin uudelleen.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="385" />
-            <source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
-            <translation>Synkronointikansio ei ole enää käytettävissä (virhe %1).&lt;br&gt;Synkronointi jatkuu heti, kun kansio on taas käytettävissä.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="389" />
-            <source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
-            <translation>Synkronointikansion sisältävä asema ei ole enää yhteydessä (virhe %1).&lt;br&gt;Yhdistä se uudelleen jatkaaksesi synkronointia.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="393" />
-            <source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
-            <translation>Tietokoneellasi ei ole tarpeeksi tilaa.&lt;br&gt;Synkronointi on pysäytetty.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="397" />
-            <source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
-            <translation>Tietokoneellasi ei ole tarpeeksi muistia.&lt;br&gt;Synkronointi on pysäytetty.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="401" />
-            <source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing '/etc/sysctl.conf'.</source>
-            <translation>Inotify-tarkkailijamäärä on riittämätön (virhe %1).&lt;br&gt;Voit kasvattaa tätä lukua muokkaamalla '/etc/sysctl.conf'-tiedostoa.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="406" />
-            <source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
-            <translation>Synkronointia ei voi käynnistää (virhe %1).&lt;br&gt;Sinun on sallittava:&lt;br&gt;- kDrive kohdassa Järjestelmäasetukset &gt;&gt; Yleiset &gt;&gt; Kirjautumisobjektit ja laajennukset &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension kohdassa Järjestelmäasetukset &gt;&gt; Tietosuoja ja turvallisuus &gt;&gt; Täysi levynkäyttöoikeus.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="413" />
-            <source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
-            <translation>Synkronointia ei voi käynnistää (virhe %1).&lt;br&gt;LiteSyncExt-prosessi ei ole käynnissä. Synkronointi jatkuu heti, kun se käynnistyy.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="419" />
-            <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-            <translation>Lite Sync -laajennusta ei voi käynnistää (virhe %1).&lt;br&gt;Tarkista, että Lite Sync -laajennus on asennettu ja Windowsin hakupalvelu on käytössä.&lt;br&gt;Tyhjennä historia, käynnistä uudelleen ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="424" />
-            <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-            <translation>Lite Sync -laajennusta ei voi käynnistää (virhe %1).&lt;br&gt;Tarkista, että Lite Sync -laajennuksella on oikeat käyttöoikeudet ja se on käynnissä.&lt;br&gt;Tyhjennä historia, käynnistä uudelleen ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="429" />
-            <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-            <translation>Lite Sync -laajennusta ei voi käynnistää (virhe %1).&lt;br&gt;Tyhjennä historia, käynnistä uudelleen ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="435" />
-            <source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
-            <translation>Synkronointikansiossa oleva tiedosto tai kansio näyttää vioittuneelta.&lt;br&gt;Synkronointi on pysäytetty.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="449" />
-            <source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-            <translation>kDrive on huoltotilassa.&lt;br&gt;Synkronointi alkaa uudelleen mahdollisimman pian. Ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="455" />
-            <source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-            <translation>kDrive on estetty.&lt;br&gt;Uudista kDrive. Jos toimenpiteitä ei tehdä, tiedot poistetaan pysyvästi eikä niitä voi palauttaa.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="460" />
-            <source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-            <translation>kDrive on estetty.&lt;br&gt;Ota yhteyttä järjestelmänvalvojaan kDriven uudistamiseksi. Jos toimenpiteitä ei tehdä, tiedot poistetaan pysyvästi eikä niitä voi palauttaa.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="466" />
-            <source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-            <translation>kDrive herää.&lt;br&gt;Synkronointi alkaa uudelleen mahdollisimman pian. Ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="475" />
-            <source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
-            <translation>kDrive on lepotilassa.&lt;br&gt;Kirjaudu &lt;a style="%1" href="%2"&gt;verkkoversioon&lt;/a&gt; tarkistaaksesi kDriven tilan tai ota yhteyttä järjestelmänvalvojaasi.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="479" />
-            <source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive's status, or contact your administrator.</source>
-            <translation>kDrive on lepotilassa.&lt;br&gt;Kirjaudu verkkoversioon tarkistaaksesi kDriven tilan tai ota yhteyttä järjestelmänvalvojaasi.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="483" />
-            <source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
-            <translation>Sinulla ei ole oikeutta käyttää tätä kDrivea.&lt;br&gt;Synkronointi on keskeytetty. Ota yhteyttä järjestelmänvalvojaan.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="493" />
-            <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-            <translation>Tekninen virhe on tapahtunut (virhe %1).&lt;br&gt;Synkronointi jatkuu mahdollisimman pian. Ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="512" />
-            <source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-            <translation>Käyttöjärjestelmän ydin katkaisi verkkoyhteydet (virhe %1).&lt;br&gt;Tyhjennä historia ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="522" />
-            <source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
-            <translation>Vanhaa konfiguraatiota ei valitettavasti voitu siirtää.&lt;br&gt;Sovellus käyttää tyhjää konfiguraatiota.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="526" />
-            <source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
-            <translation>Vanhaa välityspalvelinasetusten konfiguraatiota ei valitettavasti voitu siirtää, SOCKS5-välityspalvelimia ei tueta tällä hetkellä.&lt;br&gt;Sovellus käyttää järjestelmän välityspalvelinasetuksia.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="532" />
-            <source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
-            <translation>Synkronointikansio on korvattu tai siirretty tavalla, joka estää synkronoinnin (virhe %1).&lt;br&gt;Tämä voi tapahtua kansion kopioinnin, siirtämisen tai palauttamisen jälkeen.&lt;br&gt;Korjataksesi tämän, luo uusi synkronointi uuteen kansioon.&lt;br&gt;Huom: jos vanhassa kansiossa on synkronoimattomia muutoksia, ne täytyy kopioida manuaalisesti uuteen kansioon.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="539" />
-            <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
-            <translation>Tekninen virhe on tapahtunut (virhe %1).&lt;br&gt;Synkronointi on käynnistetty uudelleen. Tyhjennä historia ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="550" />
-            <source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
-            <translation>Synkronointitietokannan käyttämisessä tapahtui virhe (virhe %1).&lt;br&gt;Synkronointi on pysäytetty.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="564" />
-            <source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
-            <translation>Kirjautumisvirhe (virhe %1).&lt;br&gt;Tunnus on virheellinen tai peruutettu.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="569" />
-            <source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
-            <translation>Sisäkkäiset synkronoinnit ovat kiellettyjä (virhe %1).&lt;br&gt;Säilytä vain synkronoinnit, joiden kansiot eivät ole sisäkkäisiä.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="573" />
-            <source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
-            <translation>kDriven etäpalvelimella oleva synkronointikansio ei ole enää olemassa tai käytettävissä (virhe %1).&lt;br&gt;Sinun on palautettava se tai annettava sille takaisin käyttöoikeudet tai poistettava/luotava synkronointi uudelleen.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="580" />
-            <source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
-            <translation>Tiedostonimen jäsennysvirhe (virhe %1).&lt;br&gt;Erikoismerkit kuten lainausmerkit, kenoviivat tai rivinvaihdot voivat aiheuttaa jäsennysvirheitä.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="609" />
-            <source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
-            <translation>Tämä elementti on siirretty muualle.&lt;br&gt;Paikallinen toiminto on peruutettu.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="614" />
-            <source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
-            <translation>Samanlaisella nimellä oleva elementti on jo olemassa tässä sijainnissa.&lt;br&gt;Paikallinen toiminto on peruutettu.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="618" />
-            <source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
-            <translation>Samanlaisella nimellä oleva elementti on jo olemassa tässä sijainnissa.&lt;br&gt;Paikallinen elementti on nimetty uudelleen.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="622" />
-            <source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
-            <translation>Toinen käyttäjä muokkasi tiedostoa samanaikaisesti.&lt;br&gt;Muutoksesi on tallennettu kopioon.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="626" />
-            <source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
-            <translation>Toinen käyttäjä on siirtänyt kohteen ylätason kansion.&lt;br&gt;Paikallinen toiminto on peruutettu.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="649" />
-            <source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
-            <translation>Olemassa olevalla kohteella on sama nimi samoilla kirjainkoolla.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="656" />
-            <source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
-            <translation>Kohteen nimi sisältää ei-tuetun merkin.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="662" />
-            <source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-            <translation>Kohteen nimi päättyy välilyöntiin, mikä on kiellettyä käyttöjärjestelmässäsi.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="668" />
-            <source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-            <translation>Tämä nimi on varattu käyttöjärjestelmässäsi.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="674" />
-            <source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
-            <translation>Kohteen nimi on liian pitkä.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="680" />
-            <source>The item path is too long.&lt;br&gt;It has been ignored.</source>
-            <translation>Kohteen polku on liian pitkä.&lt;br&gt;Se on ohitettu.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="686" />
-            <source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
-            <translation>Kohteen nimi sisältää uuden Unicode-merkin, jota tiedostojärjestelmäsi ei vielä tue.&lt;br&gt;Se on suljettu pois synkronoinnista.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="692" />
-            <source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
-            <translation>Kohteen nimi sisältää vain välilyöntejä.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="703" />
-            <source>Either you are not allowed to create an item, or another item already exists with the same name.&lt;br&gt;The item has been excluded from synchronization.</source>
-            <translation>Sinulla ei ole oikeutta luoda kohdetta tai samalla nimellä on jo olemassa oleva kohde.&lt;br&gt;Kohde on suljettu pois synkronoinnista.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="708" />
-            <source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
-            <translation>Sinulla ei ole oikeutta muokata kohdetta.&lt;br&gt;Muutoksesi sisältävä tiedosto on nimetty uudelleen ja suljettu pois synkronoinnista.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="716" />
-            <source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
-            <translation>Sinulla ei ole oikeutta nimetä kohdetta uudelleen.&lt;br&gt;Se palautetaan alkuperäisellä nimellään.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="722" />
-            <source>You are not allowed to move item to "%1".&lt;br&gt;It will be restored into its original parent folder.</source>
-            <translation>Sinulla ei ole oikeutta siirtää kohdetta kohteeseen "%1".&lt;br&gt;Se palautetaan alkuperäiseen yläkansioonsa.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="727" />
-            <source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
-            <translation>Sinulla ei ole oikeutta poistaa kohdetta.&lt;br&gt;Se palautetaan alkuperäiseen sijaintiinsa.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="732" />
-            <source>Failed to move this item to trash, it has been blacklisted.</source>
-            <translation>Kohteen siirtäminen roskakoriin epäonnistui, se on lisätty estolistalle.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="735" />
-            <source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
-            <translation>Kohteen synkronointi epäonnistui. Se on lisätty väliaikaisesti estolistalle.&lt;br&gt;Synkronointia yritetään uudelleen tunnin kuluttua tai seuraavalla sovelluksen käynnistyksellä.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="740" />
-            <source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
-            <translation>Tämä kohde on suljettu synkronoinnista mukautetun mallin avulla.&lt;br&gt;Voit poistaa tämän tyyppiset ilmoitukset käytöstä Asetuksissa</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="745" />
-            <source>This item has been excluded from sync because it is a hard link.</source>
-            <translation>Tämä kohde on suljettu synkronoinnista, koska se on kova linkki.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="748" />
-            <source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
-            <translation>Tiedostoa on muokattu paikallisesti, kun se on poistettu etä-kDrivesta.&lt;br&gt;Paikallinen kopio on tallennettu pelastuskansioon.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="765" />
-            <source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
-            <translation>Kohteelle suoritettu toiminto on kielletty.&lt;br&gt;Kohde on lisätty väliaikaisesti estolistalle.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="771" />
-            <source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
-            <translation>Kohteelle suoritettu toiminto epäonnistui.&lt;br&gt;Kohde on lisätty väliaikaisesti estolistalle.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="776" />
-            <source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
-            <translation>Tiedosto on liian suuri ladattavaksi. Se on lisätty väliaikaisesti estolistalle.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="779" />
-            <source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
-            <translation>Olet ylittänyt kiintiösi. Kasvata tallennustilaasi ottaaksesi tiedostojen lataamisen uudelleen käyttöön.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="782" />
-            <source>Impossible to download the file.</source>
-            <translation>Tiedostoa ei voi ladata.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="785" />
-            <source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
-            <translation>Toinen käyttäjä on tällä hetkellä lukinnut tämän kohteen verkossa.&lt;br&gt;Yritämme ladata muutoksesi myöhemmin uudelleen.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="790" />
-            <location filename="../src/gui/parametersdialog.cpp" line="834" />
-            <source>Synchronization error.</source>
-            <translation>Synkronointivirhe.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="810" />
-            <source>Can't access item.&lt;br&gt;Please fix the read and write permissions.</source>
-            <translation>Kohdetta ei voi käyttää.&lt;br&gt;Korjaa luku- ja kirjoitusoikeudet.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="814" />
-            <source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
-            <translation>Tietokoneellasi ei ole tarpeeksi tilaa.&lt;br&gt;Lataus on peruutettu.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="818" />
-            <source>System error.</source>
-            <translation>Järjestelmävirhe.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="825" />
-            <source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
-            <translation>Kohde on jo olemassa toisella puolella.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="840" />
-            <source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-            <translation>Tekninen virhe on tapahtunut.&lt;br&gt;Tyhjennä historia ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="1082" />
-            <source>Unable to open folder path %1.</source>
-            <translation>Kansion polkua %1 ei voi avata.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="1096" />
-            <source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
-            <translation>Siirto valmis!&lt;br&gt;Viittaa tunnukseen &lt;b&gt;%1&lt;/b&gt; virheraporteissa.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="1097" />
-            <source>Transmission failed!
-Please, use the following link to send the logs to the support: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</source>
-            <translation>Siirto epäonnistui!
-Käytä seuraavaa linkkiä lähettääksesi lokit tuelle: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parametersdialog.cpp" line="1118" />
-            <source>No kDrive configured!</source>
-            <translation>kDrivea ei ole määritetty!</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::PreferencesBlocWidget</name>
-        <message>
-            <location filename="../src/gui/preferencesblocwidget.cpp" line="187" />
-            <source>This synchronization is being deleted.</source>
-            <translation>Tätä synkronointia poistetaan.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::PreferencesMenuBarWidget</name>
-        <message>
-            <location filename="../src/gui/preferencesmenubarwidget.cpp" line="63" />
-            <source>Back to drive list</source>
-            <translation>Takaisin asemaluetteloon</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferencesmenubarwidget.cpp" line="64" />
-            <source>Preferences</source>
-            <translation>Asetukset</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::PreferencesWidget</name>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="466" />
-            <source>Unable to open folder %1.</source>
-            <translation>Kansiota %1 ei voi avata.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="478" />
-            <source>Unable to open link %1.</source>
-            <translation>Linkkiä %1 ei voi avata.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="483" />
-            <source>Invalid link %1.</source>
-            <translation>Virheellinen linkki %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="490" />
-            <source>Some process failed to run.</source>
-            <translation>Joidenkin prosessien käynnistyminen epäonnistui.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="491" />
-            <source>General</source>
-            <translation>Yleiset</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="493" />
-            <source>Activate dark theme</source>
-            <translation>Ota tumma teema käyttöön</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="495" />
-            <source>Activate monochrome icons</source>
-            <translation>Ota yksivärisiä kuvakkeita käyttöön</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="496" />
-            <source>Launch kDrive at startup</source>
-            <translation>Käynnistä kDrive automaattisesti</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="497" />
-            <source>Language</source>
-            <translation>Kieli</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="498" />
-            <source>Move deleted files to my computer's trash</source>
-            <translation>Siirrä poistetut tiedostot tietokoneen roskakoriin</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="499" />
-            <source>Some files or folders may not be moved to the computer's trash.</source>
-            <translation>Joitakin tiedostoja tai kansioita ei ehkä voi siirtää tietokoneen roskakoriin.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="500" />
-            <source>You can always retrieve already synced files from the kDrive web application trash.</source>
-            <translation>Voit aina palauttaa jo synkronoidut tiedostot kDriven verkkosovelluksen roskakorista.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="502" />
-            <source>&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-            <translation>&lt;a style="%1" href="%2"&gt;Lue lisää&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="505" />
-            <source>Default</source>
-            <translation>Oletus</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="506" />
-            <source>English</source>
-            <translation>Englanti</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="507" />
-            <source>French</source>
-            <translation>Ranska</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="508" />
-            <source>German</source>
-            <translation>Saksa</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="509" />
-            <source>Spanish</source>
-            <translation>Espanja</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="510" />
-            <source>Italian</source>
-            <translation>Italia</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="511" />
-            <source>Swedish</source>
-            <translation>Ruotsi</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="512" />
-            <source>Portuguese</source>
-            <translation>Portugali</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="513" />
-            <source>Polish</source>
-            <translation>Puola</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="514" />
-            <source>Norwegian</source>
-            <translation>Norja</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="515" />
-            <source>Finnish</source>
-            <translation>Suomi</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="521" />
-            <source>Advanced</source>
-            <translation>Lisäasetukset</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="522" />
-            <source>Debugging information</source>
-            <translation>Virheenkorjaustiedot</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="524" />
-            <source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
-            <translation>&lt;a style="%1" href="%2"&gt;Avaa virheenkorjauskansio&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="525" />
-            <source>Files to exclude</source>
-            <translation>Suljettavat tiedostot</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="526" />
-            <source>Proxy server</source>
-            <translation>Välityspalvelin</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/preferenceswidget.cpp" line="528" />
-            <source>Lite Sync</source>
-            <translation>Lite Sync</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::ProgressBarWidget</name>
-        <message>
-            <location filename="../src/gui/progressbarwidget.cpp" line="70" />
-            <source>%1 in use</source>
-            <translation>%1 käytössä</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::ProxyServerDialog</name>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="50" />
-            <source>HTTP(S) Proxy</source>
-            <translation>HTTP(S)-välityspalvelin</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="73" />
-            <source>Proxy server</source>
-            <translation>Välityspalvelin</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="85" />
-            <source>No proxy server</source>
-            <translation>Ei välityspalvelinta</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="90" />
-            <source>Use system parameters</source>
-            <translation>Käytä järjestelmäasetuksia</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="95" />
-            <source>Indicate a proxy manually</source>
-            <translation>Määritä välityspalvelin manuaalisesti</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="131" />
-            <source>Port</source>
-            <translation>Portti</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="144" />
-            <source>Address of the proxy server</source>
-            <translation>Välityspalvelimen osoite</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="150" />
-            <source>Authentication needed</source>
-            <translation>Todennus vaaditaan</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="165" />
-            <source>User</source>
-            <translation>Käyttäjä</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="171" />
-            <source>Password</source>
-            <translation>Salasana</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="185" />
-            <source>SAVE</source>
-            <translation>TALLENNA</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="192" />
-            <source>CANCEL</source>
-            <translation>PERUUTA</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="286" />
-            <source>Do you want to save your modifications?</source>
-            <translation>Haluatko tallentaa muutokset?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="295" />
-            <source>Unable to save, all mandatory fields are not completed!</source>
-            <translation>Tallennus epäonnistui, kaikki pakolliset kentät eivät ole täytetty!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/proxyserverdialog.cpp" line="316" />
-            <source>Proxy not found, save anyway?</source>
-            <translation>Välityspalvelinta ei löydy, tallennetaanko silti?</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::ResourcesManagerDialog</name>
-        <message>
-            <location filename="../src/gui/resourcesmanagerdialog.cpp" line="55" />
-            <source>Resources Manager</source>
-            <translation>Resurssien hallinta</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/resourcesmanagerdialog.cpp" line="65" />
-            <source>Maximum CPU usage allowed</source>
-            <translation>Suurin sallittu suorittimen käyttö</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/resourcesmanagerdialog.cpp" line="96" />
-            <source>SAVE</source>
-            <translation>TALLENNA</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/resourcesmanagerdialog.cpp" line="103" />
-            <source>CANCEL</source>
-            <translation>PERUUTA</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/resourcesmanagerdialog.cpp" line="122" />
-            <source>Do you want to save your modifications?</source>
-            <translation>Haluatko tallentaa muutokset?</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::ServerBaseFolderDialog</name>
-        <message>
-            <location filename="../src/gui/serverbasefolderdialog.cpp" line="81" />
-            <source>Select a folder on your kDrive</source>
-            <translation>Valitse kansio kDrivesta</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/serverbasefolderdialog.cpp" line="90" />
-            <source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
-            <translation>Valitun kansion sisältö synkronoidaan &lt;b&gt;%1&lt;/b&gt;-kansioon.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/serverbasefolderdialog.cpp" line="134" />
-            <source>CONTINUE</source>
-            <translation>JATKA</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/serverbasefolderdialog.cpp" line="150" />
-            <source>Space available on your computer for the current folder : %1</source>
-            <translation>Nykyisen kansion tilaa tietokoneella: %1</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/serverbasefolderdialog.cpp" line="190" />
-            <source>This folder is already being synced.</source>
-            <translation>Tämä kansio on jo synkronoinnissa.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/serverbasefolderdialog.cpp" line="204" />
-            <source>CONFIRM</source>
-            <translation>VAHVISTA</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/serverbasefolderdialog.cpp" line="205" />
-            <source>CANCEL</source>
-            <translation>PERUUTA</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::ServerFoldersDialog</name>
-        <message>
-            <location filename="../src/gui/serverfoldersdialog.cpp" line="80" />
-            <source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
-            <translation>&lt;b&gt;%1&lt;/b&gt;-kansio sisältää alikansioita,&lt;br&gt; valitse synkronoitavat kansiot</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/serverfoldersdialog.cpp" line="110" />
-            <source>CONTINUE</source>
-            <translation>JATKA</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/serverfoldersdialog.cpp" line="146" />
-            <source>No subfolders currently on the server.</source>
-            <translation>Palvelimella ei ole alikansioita tällä hetkellä.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::StatusBarWidget</name>
-        <message>
-            <location filename="../src/gui/statusbarwidget.cpp" line="178" />
-            <source>Resume kDrive "%1" synchronization</source>
-            <translation>Jatka kDrive "%1" synkronointia</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/statusbarwidget.cpp" line="179" />
-            <location filename="../src/gui/statusbarwidget.cpp" line="322" />
-            <source>Resume synchronization</source>
-            <translation>Jatka synkronointia</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/statusbarwidget.cpp" line="180" />
-            <source>Resume all kDrives synchronization</source>
-            <translation>Jatka kaikkien kDrive-asemien synkronointia</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/statusbarwidget.cpp" line="183" />
-            <source>Pause kDrive "%1" synchronization</source>
-            <translation>Keskeytä kDrive "%1" synkronointi</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/statusbarwidget.cpp" line="184" />
-            <location filename="../src/gui/statusbarwidget.cpp" line="321" />
-            <source>Pause synchronization</source>
-            <translation>Keskeytä synkronointi</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/statusbarwidget.cpp" line="185" />
-            <source>Pause all kDrives synchronization</source>
-            <translation>Keskeytä kaikkien kDrive-asemien synkronointi</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::SynchronizedItemWidget</name>
-        <message>
-            <location filename="../src/gui/synchronizeditemwidget.cpp" line="317" />
-            <source>Open</source>
-            <translation>Avaa</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synchronizeditemwidget.cpp" line="325" />
-            <source>Add to favorites</source>
-            <translation>Lisää suosikkeihin</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synchronizeditemwidget.cpp" line="333" />
-            <source>Copy share link</source>
-            <translation>Kopioi jakolinkki</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synchronizeditemwidget.cpp" line="342" />
-            <source>Display on kdrive.infomaniak.com</source>
-            <translation>Näytä kdrive.infomaniak.com-sivustolla</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synchronizeditemwidget.cpp" line="387" />
-            <source>Show in folder</source>
-            <translation>Näytä kansiossa</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synchronizeditemwidget.cpp" line="388" />
-            <source>More actions</source>
-            <translation>Lisää toimintoja</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::SynthesisBar</name>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="149" />
-            <source>Unable to open folder url %1.</source>
-            <translation>Kansion URL-osoitetta %1 ei voi avata.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="219" />
-            <source>Open in folder</source>
-            <translation>Avaa kansiossa</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="257" />
-            <source>Open %1 web version</source>
-            <translation>Avaa %1 verkkoversio</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="267" />
-            <source>Drive parameters</source>
-            <translation>Aseman asetukset</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="280" />
-            <source>Notifications disabled until %1</source>
-            <translation>Ilmoitukset poistettu käytöstä %1 asti</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="281" />
-            <source>Disable Notifications</source>
-            <translation>Poista ilmoitukset käytöstä</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="314" />
-            <source>Application preferences</source>
-            <translation>Sovelluksen asetukset</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="322" />
-            <source>Need help</source>
-            <translation>Tarvitsetko apua</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="330" />
-            <source>Send feedbacks</source>
-            <translation>Lähetä palautetta</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="338" />
-            <source>Quit kDrive</source>
-            <translation>Lopeta kDrive</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="401" />
-            <source>Unable to access web site %1.</source>
-            <translation>Verkkosivustolle %1 ei pääse.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="492" />
-            <source>Show errors and informations</source>
-            <translation>Näytä virheet ja tiedotteet</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="493" />
-            <source>Show informations</source>
-            <translation>Näytä tiedotteet</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="494" />
-            <source>More actions</source>
-            <translation>Lisää toimintoja</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="495" />
-            <location filename="../src/gui/synthesisbar.cpp" line="502" />
-            <source>Never</source>
-            <translation>Ei koskaan</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="496" />
-            <source>During 1 hour</source>
-            <translation>1 tunnin ajaksi</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="497" />
-            <location filename="../src/gui/synthesisbar.cpp" line="504" />
-            <source>Until tomorrow 8:00AM</source>
-            <translation>Huomiseen klo 8:00 asti</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="498" />
-            <source>During 3 days</source>
-            <translation>3 päivän ajaksi</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="499" />
-            <source>During 1 week</source>
-            <translation>1 viikon ajaksi</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="500" />
-            <location filename="../src/gui/synthesisbar.cpp" line="507" />
-            <source>Always</source>
-            <translation>Aina</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="503" />
-            <source>For 1 more hour</source>
-            <translation>1 tunti lisää</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="505" />
-            <source>For 3 more days</source>
-            <translation>3 päivää lisää</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesisbar.cpp" line="506" />
-            <source>For 1 more week</source>
-            <translation>1 viikko lisää</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::SynthesisPopover</name>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="446" />
-            <source>Synchronized</source>
-            <translation>Synkronoitu</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="450" />
-            <source>Favorites</source>
-            <translation>Suosikit</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="454" />
-            <source>Activity</source>
-            <translation>Toiminta</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="586" />
-            <source>Unable to open folder url %1.</source>
-            <translation>Kansion URL-osoitetta %1 ei voi avata.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="978" />
-            <source>Update</source>
-            <translation>Päivitä</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="981" />
-            <source>Update download in progress</source>
-            <translation>Päivitystä ladataan</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="984" />
-            <source>Looking for update...</source>
-            <translation>Etsitään päivitystä...</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="987" />
-            <source>Manual update</source>
-            <translation>Manuaalinen päivitys</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="990" />
-            <source>Unavailable</source>
-            <translation>Ei saatavilla</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="1133" />
-            <location filename="../src/gui/synthesispopover.cpp" line="1180" />
-            <source>Not implemented!</source>
-            <translation>Ei toteutettu!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="1161" />
-            <source>Unable to open link %1.</source>
-            <translation>Linkkiä %1 ei voi avata.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="1173" />
-            <source>Invalid link %1.</source>
-            <translation>Virheellinen linkki %1.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="1181" />
-            <source>Update kDrive App</source>
-            <translation>Päivitä kDrive-sovellus</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="1182" />
-            <source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
-            <translation>Tätä kDrive-sovellusversiota ei enää tueta. Päivitä sovellus uusimpiin ominaisuuksiin pääsemiseksi.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="1184" />
-            <source>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Click here to download manually&lt;/a&gt;</source>
-            <translation>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Napsauta tästä ladataksesi manuaalisesti&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="1187" />
-            <source>Please download the latest version on the website.</source>
-            <translation>Lataa uusin versio verkkosivustolta.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="1193" />
-            <source>No synchronized folder for this Drive!</source>
-            <translation>Tälle asemalle ei ole synkronoitua kansiota!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="1196" />
-            <source>No kDrive configured!</source>
-            <translation>kDrivea ei ole määritetty!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/synthesispopover.cpp" line="1200" />
-            <source>You can synchronize files &lt;a style="%1" href="%2"&gt;from your computer&lt;/a&gt; or on &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
-            <translation>Voit synkronoida tiedostoja &lt;a style="%1" href="%2"&gt;tietokoneeltasi&lt;/a&gt; tai &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;-sivustolla.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::UpdateDialog</name>
-        <message>
-            <location filename="../src/gui/updater/updatedialog.cpp" line="61" />
-            <source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
-            <translation>&lt;p&gt;%2-asiakkaan uusi versio &lt;b&gt;%1&lt;/b&gt; on saatavilla ja ladattu.&lt;/p&gt;&lt;p&gt;Asennettu versio on %3.&lt;/p&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/updater/updatedialog.cpp" line="95" />
-            <source>Skip this version</source>
-            <translation>Ohita tämä versio</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/updater/updatedialog.cpp" line="103" />
-            <source>Remind me later</source>
-            <translation>Muistuta myöhemmin</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/updater/updatedialog.cpp" line="109" />
-            <source>Install update</source>
-            <translation>Asenna päivitys</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::UpdateManager</name>
-        <message>
-            <location filename="../src/server/updater/updatemanager.cpp" line="86" />
-            <source>New update available.</source>
-            <translation>Uusi päivitys saatavilla.</translation>
-        </message>
-        <message>
-            <location filename="../src/server/updater/updatemanager.cpp" line="87" />
-            <source>Version %1 is available for download.</source>
-            <translation>Versio %1 on ladattavissa.</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::UserSelectionWidget</name>
-        <message>
-            <location filename="../src/gui/userselectionwidget.cpp" line="131" />
-            <source>Add an account</source>
-            <translation>Lisää tili</translation>
-        </message>
-    </context>
-    <context>
-        <name>KDC::VersionWidget</name>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="169" />
-            <source>&lt;a style="%1" href="%2"&gt;Show release note&lt;/a&gt;</source>
-            <translation>&lt;a style="%1" href="%2"&gt;Näytä julkaisutiedot&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="172" />
-            <source>Version</source>
-            <translation>Versio</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="173" />
-            <source>UPDATE</source>
-            <translation>PÄIVITÄ</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="197" />
-            <source>%1 is up to date!</source>
-            <translation>%1 on ajan tasalla!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="201" />
-            <source>Checking update on server...</source>
-            <translation>Tarkistetaan päivitystä palvelimelta...</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="205" />
-            <source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style="%2" href="%3"&gt;here&lt;/a&gt;.</source>
-            <translation>Päivitys on saatavilla: %1.&lt;br&gt;Lataa se &lt;a style="%2" href="%3"&gt;täältä&lt;/a&gt;.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="212" />
-            <source>An update is available: %1</source>
-            <translation>Päivitys on saatavilla: %1</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="218" />
-            <source>Downloading %1. Please wait...</source>
-            <translation>Ladataan %1. Odota...</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="223" />
-            <source>Could not check for new updates.</source>
-            <translation>Päivitysten tarkistus epäonnistui.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="227" />
-            <source>An error occurred during update.</source>
-            <translation>Päivityksen aikana tapahtui virhe.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="231" />
-            <source>Could not download update.</source>
-            <translation>Päivityksen lataaminen epäonnistui.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="235" />
-            <source>Update disabled.</source>
-            <translation>Päivitys poistettu käytöstä.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="251" />
-            <source>Beta program</source>
-            <translation>Beta-ohjelma</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="252" />
-            <source>Get early access to new versions of the application</source>
-            <translation>Saa varhainen pääsy sovelluksen uusiin versioihin</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="256" />
-            <source>Join</source>
-            <translation>Liity</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="259" />
-            <source>Modify</source>
-            <translation>Muokkaa</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="259" />
-            <source>Quit</source>
-            <translation>Lopeta</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/versionwidget.cpp" line="295" />
-            <source>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</source>
-            <translation>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</translation>
-        </message>
-    </context>
-    <context>
-        <name>QObject</name>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="42" />
-            <source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
-            <translation>Lite sync (Beta) on käytössä. kDriven tiedostot pysyvät pilvessä eivätkä käytä tietokoneen tallennustilaa.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="45" />
-            <source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
-            <translation>Lite sync (Beta) ei ole käytössä. kDriven tiedostot käyttävät tietokoneen tallennustilaa.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="48" />
-            <source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
-            <translation>Lite sync on käytössä. kDriven tiedostot pysyvät pilvessä eivätkä käytä tietokoneen tallennustilaa.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/folderitemwidget.cpp" line="50" />
-            <source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
-            <translation>Lite sync ei ole käytössä. kDriven tiedostot käyttävät tietokoneen tallennustilaa.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parameterscache.cpp" line="59" />
-            <source>Unable to save parameters, please retry later.</source>
-            <translation>Parametrien tallentaminen epäonnistui, yritä myöhemmin uudelleen.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/parameterscache.cpp" line="60" />
-            <source>Unable to save parameters!</source>
-            <translation>Parametreja ei voi tallentaa!</translation>
-        </message>
-        <message>
-            <location filename="../src/server/comm/extensionjob.cpp" line="1175" />
-            <source>Make available locally</source>
-            <translation>Tee saataville paikallisesti</translation>
-        </message>
-        <message>
-            <location filename="../src/server/comm/extensionjob.cpp" line="1179" />
-            <source>Free up local space</source>
-            <translation>Vapauta paikallista tilaa</translation>
-        </message>
-        <message>
-            <location filename="../src/server/comm/extensionjob.cpp" line="1183" />
-            <source>Cancel free up local space</source>
-            <translation>Peruuta paikallisen tilan vapautus</translation>
-        </message>
-        <message>
-            <location filename="../src/server/comm/extensionjob.cpp" line="1187" />
-            <source>Cancel make available locally</source>
-            <translation>Peruuta paikallinen saatavillaolo</translation>
-        </message>
-        <message>
-            <location filename="../src/server/comm/extensionjob.cpp" line="1191" />
-            <source>Resharing this file is not allowed</source>
-            <translation>Tämän tiedoston jakaminen uudelleen ei ole sallittu</translation>
-        </message>
-        <message>
-            <location filename="../src/server/comm/extensionjob.cpp" line="1192" />
-            <source>Resharing this folder is not allowed</source>
-            <translation>Tämän kansion jakaminen uudelleen ei ole sallittu</translation>
-        </message>
-        <message>
-            <location filename="../src/server/comm/extensionjob.cpp" line="1196" />
-            <source>Copy public share link</source>
-            <translation>Kopioi julkinen jakolinkki</translation>
-        </message>
-        <message>
-            <location filename="../src/server/comm/extensionjob.cpp" line="1200" />
-            <source>Copy private share link</source>
-            <translation>Kopioi yksityinen jakolinkki</translation>
-        </message>
-        <message>
-            <location filename="../src/server/comm/extensionjob.cpp" line="1204" />
-            <source>Open in browser</source>
-            <translation>Avaa selaimessa</translation>
-        </message>
-        <message>
-            <location filename="../src/server/requests/serverrequests.cpp" line="461" />
-            <source>The parent folder is a sync folder or contained in one</source>
-            <translation>Ylätason kansio on synkronointikansio tai sisältyy yhteen</translation>
-        </message>
-        <message>
-            <location filename="../src/server/requests/serverrequests.cpp" line="495" />
-            <source>Can't find a valid path</source>
-            <translation>Kelvollista polkua ei löydy</translation>
-        </message>
-        <message>
-            <location filename="../src/server/requests/serverrequests.cpp" line="2108" />
-            <source>No valid folder selected!</source>
-            <translation>Kelvollista kansiota ei ole valittu!</translation>
-        </message>
-        <message>
-            <location filename="../src/server/requests/serverrequests.cpp" line="2119" />
-            <source>The selected path does not exist!</source>
-            <translation>Valittu polku ei ole olemassa!</translation>
-        </message>
-        <message>
-            <location filename="../src/server/requests/serverrequests.cpp" line="2124" />
-            <source>The selected path is not a folder!</source>
-            <translation>Valittu polku ei ole kansio!</translation>
-        </message>
-        <message>
-            <location filename="../src/server/requests/serverrequests.cpp" line="2129" />
-            <source>You have no permission to write to the selected folder!</source>
-            <translation>Sinulla ei ole kirjoitusoikeutta valittuun kansioon!</translation>
-        </message>
-        <message>
-            <location filename="../src/server/requests/serverrequests.cpp" line="2159" />
-            <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
-            <translation>Paikallinen kansio %1 sisältää jo synkronoidun kansion. Valitse toinen!</translation>
-        </message>
-        <message>
-            <location filename="../src/server/requests/serverrequests.cpp" line="2167" />
-            <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
-            <translation>Paikallinen kansio %1 on jo synkronoidun kansion sisällä. Valitse toinen!</translation>
-        </message>
-        <message>
-            <location filename="../src/server/requests/serverrequests.cpp" line="2175" />
-            <source>The local folder %1 is already synced. Please pick another one!</source>
-            <translation>Paikallinen kansio %1 on jo synkronoitu. Valitse toinen!</translation>
-        </message>
-    </context>
-    <context>
-        <name>SharedTools::QtSingleApplication</name>
-        <message>
-            <location filename="../src/server/appserver.cpp" line="133" />
-            <source>kDrive application will close due to a fatal error.</source>
-            <translation>kDrive-sovellus suljetaan kriittisen virheen vuoksi.</translation>
-        </message>
-    </context>
-    <context>
-        <name>Utility</name>
-        <message numerus="yes">
-            <location filename="../src/libcommongui/utility/utility.cpp" line="41" />
-            <source>%n year(s)</source>
-            <translation>
-                <numerusform>%n vuosi</numerusform>
-                <numerusform>%n vuotta</numerusform>
-            </translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/libcommongui/utility/utility.cpp" line="42" />
-            <source>%n month(s)</source>
-            <translation>
-                <numerusform>%n kuukausi</numerusform>
-                <numerusform>%n kuukautta</numerusform>
-            </translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/libcommongui/utility/utility.cpp" line="43" />
-            <source>%n day(s)</source>
-            <translation>
-                <numerusform>%n päivä</numerusform>
-                <numerusform>%n päivää</numerusform>
-            </translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/libcommongui/utility/utility.cpp" line="44" />
-            <source>%n hour(s)</source>
-            <translation>
-                <numerusform>%n tunti</numerusform>
-                <numerusform>%n tuntia</numerusform>
-            </translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/libcommongui/utility/utility.cpp" line="45" />
-            <source>%n minute(s)</source>
-            <translation>
-                <numerusform>%n minuutti</numerusform>
-                <numerusform>%n minuuttia</numerusform>
-            </translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/libcommongui/utility/utility.cpp" line="46" />
-            <source>%n second(s)</source>
-            <translation>
-                <numerusform>%n sekunti</numerusform>
-                <numerusform>%n sekuntia</numerusform>
-            </translation>
-        </message>
-        <message>
-            <location filename="../src/libcommongui/utility/utility.cpp" line="97" />
-            <source>%L1 GB</source>
-            <translation>%L1 GB</translation>
-        </message>
-        <message>
-            <location filename="../src/libcommongui/utility/utility.cpp" line="101" />
-            <source>%L1 MB</source>
-            <translation>%L1 MB</translation>
-        </message>
-        <message>
-            <location filename="../src/libcommongui/utility/utility.cpp" line="105" />
-            <source>%L1 KB</source>
-            <translation>%L1 KB</translation>
-        </message>
-        <message>
-            <location filename="../src/libcommongui/utility/utility.cpp" line="108" />
-            <source>%L1 B</source>
-            <translation>%L1 B</translation>
-        </message>
-    </context>
-    <context>
-        <name>utility</name>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="84" />
-            <source>Could not open browser</source>
-            <translation>Selainta ei voi avata</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="85" />
-            <source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
-            <translation>Selaimen käynnistäminen URL-osoitteeseen %1 siirtymiseksi epäonnistui. Onko oletusselain määritetty?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="104" />
-            <source>Could not open email client</source>
-            <translation>Sähköpostiohjelmaa ei voi avata</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="105" />
-            <source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
-            <translation>Sähköpostiohjelman käynnistäminen uuden viestin luomiseksi epäonnistui. Onko oletussähköpostiohjelma määritetty?</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="324" />
-            <source>You are not connected anymore. &lt;a style="%1" href="%2"&gt;Log in&lt;/a&gt;</source>
-            <translation>Et ole enää kirjautunut. &lt;a style="%1" href="%2"&gt;Kirjaudu sisään&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="329" />
-            <source>No folder to synchronize
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Lue lisää&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="233"/>
+        <source>Select folder</source>
+        <translation>Valitse kansio</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="292"/>
+        <source>Unable to open link %1.</source>
+        <translation>Linkkiä %1 ei voi avata.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::Logger</name>
+    <message>
+        <location filename="../src/libcommongui/logger.cpp" line="189"/>
+        <source>Error</source>
+        <translation>Virhe</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/logger.cpp" line="189"/>
+        <source>&lt;nobr&gt;File &apos;%1&apos;&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
+        <translation>&lt;nobr&gt;Tiedostoa &apos;%1&apos;&lt;br/&gt;ei voi avata kirjoittamista varten.&lt;br/&gt;&lt;br/&gt;Lokia &lt;b&gt;ei&lt;/b&gt; voi tallentaa!&lt;/nobr&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::MainMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/mainmenubarwidget.cpp" line="115"/>
+        <source>Preferences</source>
+        <translation>Asetukset</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/mainmenubarwidget.cpp" line="116"/>
+        <source>Help</source>
+        <translation>Ohje</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ParametersDialog</name>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="320"/>
+        <source>kDrive needs to have write access to your computer&apos;s temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
+        <translation>kDrivella on oltava kirjoitusoikeus tietokoneesi väliaikaiseen hakemistoon.&lt;br&gt;Käynnistä kDrive-sovellus uudelleen ratkaistaksesi tämän ongelman.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="330"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="487"/>
+        <source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>Tekninen virhe on tapahtunut.&lt;br&gt;Synkronointi jatkuu mahdollisimman pian. Ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="337"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="440"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="506"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="546"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="560"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>Tekninen virhe on tapahtunut (virhe %1).&lt;br&gt;Tyhjennä historia ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="342"/>
+        <source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
+        <translation>Verkkoyhteyden aikakatkaisuarvo näyttää olevan liian pieni sovelluksen oikeaa toimintaa varten (virhe %1).&lt;br&gt;Tarkista verkkoasetuksesi.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="347"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="516"/>
+        <source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
+        <translation>kDrive-palvelimeen ei saada yhteyttä (virhe %1).&lt;br&gt;Yritetään yhdistää uudelleen. Tarkista Internet-yhteys ja palomuuri.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="352"/>
+        <source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
+        <translation>Kirjautumisvirhe (virhe %1).&lt;br&gt;Kirjaudu uudelleen ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="356"/>
+        <source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
+        <translation>Sovelluksesta on saatavilla uusi versio.&lt;br&gt;Päivitä sovellus jatkaaksesi sen käyttöä.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="360"/>
+        <source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
+        <translation>Lokin lähetys epäonnistui (virhe %1).&lt;br&gt;Yritä myöhemmin uudelleen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="385"/>
+        <source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
+        <translation>Synkronointikansio ei ole enää käytettävissä (virhe %1).&lt;br&gt;Synkronointi jatkuu heti, kun kansio on taas käytettävissä.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="389"/>
+        <source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
+        <translation>Synkronointikansion sisältävä asema ei ole enää yhteydessä (virhe %1).&lt;br&gt;Yhdistä se uudelleen jatkaaksesi synkronointia.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="393"/>
+        <source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>Tietokoneellasi ei ole tarpeeksi tilaa.&lt;br&gt;Synkronointi on pysäytetty.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="397"/>
+        <source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>Tietokoneellasi ei ole tarpeeksi muistia.&lt;br&gt;Synkronointi on pysäytetty.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="401"/>
+        <source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing &apos;/etc/sysctl.conf&apos;.</source>
+        <translation>Inotify-tarkkailijamäärä on riittämätön (virhe %1).&lt;br&gt;Voit kasvattaa tätä lukua muokkaamalla &apos;/etc/sysctl.conf&apos;-tiedostoa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="406"/>
+        <source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
+        <translation>Synkronointia ei voi käynnistää (virhe %1).&lt;br&gt;Sinun on sallittava:&lt;br&gt;- kDrive kohdassa Järjestelmäasetukset &gt;&gt; Yleiset &gt;&gt; Kirjautumisobjektit ja laajennukset &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension kohdassa Järjestelmäasetukset &gt;&gt; Tietosuoja ja turvallisuus &gt;&gt; Täysi levynkäyttöoikeus.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="413"/>
+        <source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
+        <translation>Synkronointia ei voi käynnistää (virhe %1).&lt;br&gt;LiteSyncExt-prosessi ei ole käynnissä. Synkronointi jatkuu heti, kun se käynnistyy.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="419"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Lite Sync -laajennusta ei voi käynnistää (virhe %1).&lt;br&gt;Tarkista, että Lite Sync -laajennus on asennettu ja Windowsin hakupalvelu on käytössä.&lt;br&gt;Tyhjennä historia, käynnistä uudelleen ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="424"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Lite Sync -laajennusta ei voi käynnistää (virhe %1).&lt;br&gt;Tarkista, että Lite Sync -laajennuksella on oikeat käyttöoikeudet ja se on käynnissä.&lt;br&gt;Tyhjennä historia, käynnistä uudelleen ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="429"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Lite Sync -laajennusta ei voi käynnistää (virhe %1).&lt;br&gt;Tyhjennä historia, käynnistä uudelleen ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="435"/>
+        <source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>Synkronointikansiossa oleva tiedosto tai kansio näyttää vioittuneelta.&lt;br&gt;Synkronointi on pysäytetty.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="449"/>
+        <source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>kDrive on huoltotilassa.&lt;br&gt;Synkronointi alkaa uudelleen mahdollisimman pian. Ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="455"/>
+        <source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+        <translation>kDrive on estetty.&lt;br&gt;Uudista kDrive. Jos toimenpiteitä ei tehdä, tiedot poistetaan pysyvästi eikä niitä voi palauttaa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="460"/>
+        <source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+        <translation>kDrive on estetty.&lt;br&gt;Ota yhteyttä järjestelmänvalvojaan kDriven uudistamiseksi. Jos toimenpiteitä ei tehdä, tiedot poistetaan pysyvästi eikä niitä voi palauttaa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="466"/>
+        <source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>kDrive herää.&lt;br&gt;Synkronointi alkaa uudelleen mahdollisimman pian. Ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="475"/>
+        <source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>kDrive on lepotilassa.&lt;br&gt;Kirjaudu &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;verkkoversioon&lt;/a&gt; tarkistaaksesi kDriven tilan tai ota yhteyttä järjestelmänvalvojaasi.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="479"/>
+        <source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>kDrive on lepotilassa.&lt;br&gt;Kirjaudu verkkoversioon tarkistaaksesi kDriven tilan tai ota yhteyttä järjestelmänvalvojaasi.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="483"/>
+        <source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
+        <translation>Sinulla ei ole oikeutta käyttää tätä kDrivea.&lt;br&gt;Synkronointi on keskeytetty. Ota yhteyttä järjestelmänvalvojaan.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="493"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>Tekninen virhe on tapahtunut (virhe %1).&lt;br&gt;Synkronointi jatkuu mahdollisimman pian. Ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="512"/>
+        <source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>Käyttöjärjestelmän ydin katkaisi verkkoyhteydet (virhe %1).&lt;br&gt;Tyhjennä historia ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="522"/>
+        <source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
+        <translation>Vanhaa konfiguraatiota ei valitettavasti voitu siirtää.&lt;br&gt;Sovellus käyttää tyhjää konfiguraatiota.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="526"/>
+        <source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
+        <translation>Vanhaa välityspalvelinasetusten konfiguraatiota ei valitettavasti voitu siirtää, SOCKS5-välityspalvelimia ei tueta tällä hetkellä.&lt;br&gt;Sovellus käyttää järjestelmän välityspalvelinasetuksia.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="532"/>
+        <source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
+        <translation>Synkronointikansio on korvattu tai siirretty tavalla, joka estää synkronoinnin (virhe %1).&lt;br&gt;Tämä voi tapahtua kansion kopioinnin, siirtämisen tai palauttamisen jälkeen.&lt;br&gt;Korjataksesi tämän, luo uusi synkronointi uuteen kansioon.&lt;br&gt;Huom: jos vanhassa kansiossa on synkronoimattomia muutoksia, ne täytyy kopioida manuaalisesti uuteen kansioon.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="539"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
+        <translation>Tekninen virhe on tapahtunut (virhe %1).&lt;br&gt;Synkronointi on käynnistetty uudelleen. Tyhjennä historia ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="550"/>
+        <source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
+        <translation>Synkronointitietokannan käyttämisessä tapahtui virhe (virhe %1).&lt;br&gt;Synkronointi on pysäytetty.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="564"/>
+        <source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
+        <translation>Kirjautumisvirhe (virhe %1).&lt;br&gt;Tunnus on virheellinen tai peruutettu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="569"/>
+        <source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
+        <translation>Sisäkkäiset synkronoinnit ovat kiellettyjä (virhe %1).&lt;br&gt;Säilytä vain synkronoinnit, joiden kansiot eivät ole sisäkkäisiä.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="573"/>
+        <source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
+        <translation>kDriven etäpalvelimella oleva synkronointikansio ei ole enää olemassa tai käytettävissä (virhe %1).&lt;br&gt;Sinun on palautettava se tai annettava sille takaisin käyttöoikeudet tai poistettava/luotava synkronointi uudelleen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="580"/>
+        <source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
+        <translation>Tiedostonimen jäsennysvirhe (virhe %1).&lt;br&gt;Erikoismerkit kuten lainausmerkit, kenoviivat tai rivinvaihdot voivat aiheuttaa jäsennysvirheitä.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="609"/>
+        <source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>Tämä elementti on siirretty muualle.&lt;br&gt;Paikallinen toiminto on peruutettu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="614"/>
+        <source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>Samanlaisella nimellä oleva elementti on jo olemassa tässä sijainnissa.&lt;br&gt;Paikallinen toiminto on peruutettu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="618"/>
+        <source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
+        <translation>Samanlaisella nimellä oleva elementti on jo olemassa tässä sijainnissa.&lt;br&gt;Paikallinen elementti on nimetty uudelleen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="622"/>
+        <source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
+        <translation>Toinen käyttäjä muokkasi tiedostoa samanaikaisesti.&lt;br&gt;Muutoksesi on tallennettu kopioon.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="626"/>
+        <source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>Toinen käyttäjä on siirtänyt kohteen ylätason kansion.&lt;br&gt;Paikallinen toiminto on peruutettu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="649"/>
+        <source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Olemassa olevalla kohteella on sama nimi samoilla kirjainkoolla.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="656"/>
+        <source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Kohteen nimi sisältää ei-tuetun merkin.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="662"/>
+        <source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Kohteen nimi päättyy välilyöntiin, mikä on kiellettyä käyttöjärjestelmässäsi.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="668"/>
+        <source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Tämä nimi on varattu käyttöjärjestelmässäsi.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="674"/>
+        <source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Kohteen nimi on liian pitkä.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="680"/>
+        <source>The item path is too long.&lt;br&gt;It has been ignored.</source>
+        <translation>Kohteen polku on liian pitkä.&lt;br&gt;Se on ohitettu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="686"/>
+        <source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+        <translation>Kohteen nimi sisältää uuden Unicode-merkin, jota tiedostojärjestelmäsi ei vielä tue.&lt;br&gt;Se on suljettu pois synkronoinnista.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="692"/>
+        <source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Kohteen nimi sisältää vain välilyöntejä.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="703"/>
+        <source>Either you are not allowed to create an item, or another item already exists with the same name.&lt;br&gt;The item has been excluded from synchronization.</source>
+        <translation>Sinulla ei ole oikeutta luoda kohdetta tai samalla nimellä on jo olemassa oleva kohde.&lt;br&gt;Kohde on suljettu pois synkronoinnista.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="708"/>
+        <source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
+        <translation>Sinulla ei ole oikeutta muokata kohdetta.&lt;br&gt;Muutoksesi sisältävä tiedosto on nimetty uudelleen ja suljettu pois synkronoinnista.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="716"/>
+        <source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
+        <translation>Sinulla ei ole oikeutta nimetä kohdetta uudelleen.&lt;br&gt;Se palautetaan alkuperäisellä nimellään.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="722"/>
+        <source>You are not allowed to move item to &quot;%1&quot;.&lt;br&gt;It will be restored into its original parent folder.</source>
+        <translation>Sinulla ei ole oikeutta siirtää kohdetta kohteeseen &quot;%1&quot;.&lt;br&gt;Se palautetaan alkuperäiseen yläkansioonsa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="727"/>
+        <source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
+        <translation>Sinulla ei ole oikeutta poistaa kohdetta.&lt;br&gt;Se palautetaan alkuperäiseen sijaintiinsa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="732"/>
+        <source>Failed to move this item to trash, it has been blacklisted.</source>
+        <translation>Kohteen siirtäminen roskakoriin epäonnistui, se on lisätty estolistalle.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="735"/>
+        <source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
+        <translation>Kohteen synkronointi epäonnistui. Se on lisätty väliaikaisesti estolistalle.&lt;br&gt;Synkronointia yritetään uudelleen tunnin kuluttua tai seuraavalla sovelluksen käynnistyksellä.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="740"/>
+        <source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
+        <translation>Tämä kohde on suljettu synkronoinnista mukautetun mallin avulla.&lt;br&gt;Voit poistaa tämän tyyppiset ilmoitukset käytöstä Asetuksissa</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="745"/>
+        <source>This item has been excluded from sync because it is a hard link.</source>
+        <translation>Tämä kohde on suljettu synkronoinnista, koska se on kova linkki.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="748"/>
+        <source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
+        <translation>Tiedostoa on muokattu paikallisesti, kun se on poistettu etä-kDrivesta.&lt;br&gt;Paikallinen kopio on tallennettu pelastuskansioon.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="765"/>
+        <source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
+        <translation>Kohteelle suoritettu toiminto on kielletty.&lt;br&gt;Kohde on lisätty väliaikaisesti estolistalle.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="771"/>
+        <source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
+        <translation>Kohteelle suoritettu toiminto epäonnistui.&lt;br&gt;Kohde on lisätty väliaikaisesti estolistalle.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="776"/>
+        <source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
+        <translation>Tiedosto on liian suuri ladattavaksi. Se on lisätty väliaikaisesti estolistalle.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="779"/>
+        <source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
+        <translation>Olet ylittänyt kiintiösi. Kasvata tallennustilaasi ottaaksesi tiedostojen lataamisen uudelleen käyttöön.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="782"/>
+        <source>Impossible to download the file.</source>
+        <translation>Tiedostoa ei voi ladata.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="785"/>
+        <source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
+        <translation>Toinen käyttäjä on tällä hetkellä lukinnut tämän kohteen verkossa.&lt;br&gt;Yritämme ladata muutoksesi myöhemmin uudelleen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="790"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="834"/>
+        <source>Synchronization error.</source>
+        <translation>Synkronointivirhe.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="810"/>
+        <source>Can&apos;t access item.&lt;br&gt;Please fix the read and write permissions.</source>
+        <translation>Kohdetta ei voi käyttää.&lt;br&gt;Korjaa luku- ja kirjoitusoikeudet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="814"/>
+        <source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
+        <translation>Tietokoneellasi ei ole tarpeeksi tilaa.&lt;br&gt;Lataus on peruutettu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="818"/>
+        <source>System error.</source>
+        <translation>Järjestelmävirhe.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="825"/>
+        <source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Kohde on jo olemassa toisella puolella.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="840"/>
+        <source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>Tekninen virhe on tapahtunut.&lt;br&gt;Tyhjennä historia ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1082"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Kansion polkua %1 ei voi avata.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1096"/>
+        <source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
+        <translation>Siirto valmis!&lt;br&gt;Viittaa tunnukseen &lt;b&gt;%1&lt;/b&gt; virheraporteissa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1097"/>
+        <source>Transmission failed!
+Please, use the following link to send the logs to the support: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</source>
+        <translation>Siirto epäonnistui!
+Käytä seuraavaa linkkiä lähettääksesi lokit tuelle: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1118"/>
+        <source>No kDrive configured!</source>
+        <translation>kDrivea ei ole määritetty!</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::PreferencesBlocWidget</name>
+    <message>
+        <location filename="../src/gui/preferencesblocwidget.cpp" line="187"/>
+        <source>This synchronization is being deleted.</source>
+        <translation>Tätä synkronointia poistetaan.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::PreferencesMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/preferencesmenubarwidget.cpp" line="63"/>
+        <source>Back to drive list</source>
+        <translation>Takaisin asemaluetteloon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferencesmenubarwidget.cpp" line="64"/>
+        <source>Preferences</source>
+        <translation>Asetukset</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::PreferencesWidget</name>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="466"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Kansiota %1 ei voi avata.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="478"/>
+        <source>Unable to open link %1.</source>
+        <translation>Linkkiä %1 ei voi avata.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="483"/>
+        <source>Invalid link %1.</source>
+        <translation>Virheellinen linkki %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="490"/>
+        <source>Some process failed to run.</source>
+        <translation>Joidenkin prosessien käynnistyminen epäonnistui.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="491"/>
+        <source>General</source>
+        <translation>Yleiset</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="493"/>
+        <source>Activate dark theme</source>
+        <translation>Ota tumma teema käyttöön</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="495"/>
+        <source>Activate monochrome icons</source>
+        <translation>Ota yksivärisiä kuvakkeita käyttöön</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="496"/>
+        <source>Launch kDrive at startup</source>
+        <translation>Käynnistä kDrive automaattisesti</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="497"/>
+        <source>Language</source>
+        <translation>Kieli</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="498"/>
+        <source>Move deleted files to my computer&apos;s trash</source>
+        <translation>Siirrä poistetut tiedostot tietokoneen roskakoriin</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="499"/>
+        <source>Some files or folders may not be moved to the computer&apos;s trash.</source>
+        <translation>Joitakin tiedostoja tai kansioita ei ehkä voi siirtää tietokoneen roskakoriin.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="500"/>
+        <source>You can always retrieve already synced files from the kDrive web application trash.</source>
+        <translation>Voit aina palauttaa jo synkronoidut tiedostot kDriven verkkosovelluksen roskakorista.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="502"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Lue lisää&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="505"/>
+        <source>Default</source>
+        <translation>Oletus</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="506"/>
+        <source>English</source>
+        <translation>Englanti</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="507"/>
+        <source>French</source>
+        <translation>Ranska</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="508"/>
+        <source>German</source>
+        <translation>Saksa</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="509"/>
+        <source>Spanish</source>
+        <translation>Espanja</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="510"/>
+        <source>Italian</source>
+        <translation>Italia</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="511"/>
+        <source>Swedish</source>
+        <translation>Ruotsi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="512"/>
+        <source>Portuguese</source>
+        <translation>Portugali</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="513"/>
+        <source>Polish</source>
+        <translation>Puola</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="514"/>
+        <source>Norwegian</source>
+        <translation>Norja</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="515"/>
+        <source>Finnish</source>
+        <translation>Suomi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="516"/>
+        <source>Danish</source>
+        <translation>Tanska</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="522"/>
+        <source>Advanced</source>
+        <translation>Lisäasetukset</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="523"/>
+        <source>Debugging information</source>
+        <translation>Virheenkorjaustiedot</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="525"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Avaa virheenkorjauskansio&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="526"/>
+        <source>Files to exclude</source>
+        <translation>Suljettavat tiedostot</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="527"/>
+        <source>Proxy server</source>
+        <translation>Välityspalvelin</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="529"/>
+        <source>Lite Sync</source>
+        <translation>Lite Sync</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ProgressBarWidget</name>
+    <message>
+        <location filename="../src/gui/progressbarwidget.cpp" line="70"/>
+        <source>%1 in use</source>
+        <translation>%1 käytössä</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ProxyServerDialog</name>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="50"/>
+        <source>HTTP(S) Proxy</source>
+        <translation>HTTP(S)-välityspalvelin</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="73"/>
+        <source>Proxy server</source>
+        <translation>Välityspalvelin</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="85"/>
+        <source>No proxy server</source>
+        <translation>Ei välityspalvelinta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="90"/>
+        <source>Use system parameters</source>
+        <translation>Käytä järjestelmäasetuksia</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="95"/>
+        <source>Indicate a proxy manually</source>
+        <translation>Määritä välityspalvelin manuaalisesti</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="131"/>
+        <source>Port</source>
+        <translation>Portti</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="144"/>
+        <source>Address of the proxy server</source>
+        <translation>Välityspalvelimen osoite</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="150"/>
+        <source>Authentication needed</source>
+        <translation>Todennus vaaditaan</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="165"/>
+        <source>User</source>
+        <translation>Käyttäjä</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="171"/>
+        <source>Password</source>
+        <translation>Salasana</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="185"/>
+        <source>SAVE</source>
+        <translation>TALLENNA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="192"/>
+        <source>CANCEL</source>
+        <translation>PERUUTA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="286"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Haluatko tallentaa muutokset?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="295"/>
+        <source>Unable to save, all mandatory fields are not completed!</source>
+        <translation>Tallennus epäonnistui, kaikki pakolliset kentät eivät ole täytetty!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="316"/>
+        <source>Proxy not found, save anyway?</source>
+        <translation>Välityspalvelinta ei löydy, tallennetaanko silti?</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ResourcesManagerDialog</name>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="55"/>
+        <source>Resources Manager</source>
+        <translation>Resurssien hallinta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="65"/>
+        <source>Maximum CPU usage allowed</source>
+        <translation>Suurin sallittu suorittimen käyttö</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="96"/>
+        <source>SAVE</source>
+        <translation>TALLENNA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="103"/>
+        <source>CANCEL</source>
+        <translation>PERUUTA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="122"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Haluatko tallentaa muutokset?</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ServerBaseFolderDialog</name>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="81"/>
+        <source>Select a folder on your kDrive</source>
+        <translation>Valitse kansio kDrivesta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="90"/>
+        <source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
+        <translation>Valitun kansion sisältö synkronoidaan &lt;b&gt;%1&lt;/b&gt;-kansioon.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="134"/>
+        <source>CONTINUE</source>
+        <translation>JATKA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="150"/>
+        <source>Space available on your computer for the current folder : %1</source>
+        <translation>Nykyisen kansion tilaa tietokoneella: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="190"/>
+        <source>This folder is already being synced.</source>
+        <translation>Tämä kansio on jo synkronoinnissa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="204"/>
+        <source>CONFIRM</source>
+        <translation>VAHVISTA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="205"/>
+        <source>CANCEL</source>
+        <translation>PERUUTA</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::ServerFoldersDialog</name>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="80"/>
+        <source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
+        <translation>&lt;b&gt;%1&lt;/b&gt;-kansio sisältää alikansioita,&lt;br&gt; valitse synkronoitavat kansiot</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="110"/>
+        <source>CONTINUE</source>
+        <translation>JATKA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="146"/>
+        <source>No subfolders currently on the server.</source>
+        <translation>Palvelimella ei ole alikansioita tällä hetkellä.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::StatusBarWidget</name>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="178"/>
+        <source>Resume kDrive &quot;%1&quot; synchronization</source>
+        <translation>Jatka kDrive &quot;%1&quot; synkronointia</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="179"/>
+        <location filename="../src/gui/statusbarwidget.cpp" line="322"/>
+        <source>Resume synchronization</source>
+        <translation>Jatka synkronointia</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="180"/>
+        <source>Resume all kDrives synchronization</source>
+        <translation>Jatka kaikkien kDrive-asemien synkronointia</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="183"/>
+        <source>Pause kDrive &quot;%1&quot; synchronization</source>
+        <translation>Keskeytä kDrive &quot;%1&quot; synkronointi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="184"/>
+        <location filename="../src/gui/statusbarwidget.cpp" line="321"/>
+        <source>Pause synchronization</source>
+        <translation>Keskeytä synkronointi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="185"/>
+        <source>Pause all kDrives synchronization</source>
+        <translation>Keskeytä kaikkien kDrive-asemien synkronointi</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::SynchronizedItemWidget</name>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="317"/>
+        <source>Open</source>
+        <translation>Avaa</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
+        <source>Add to favorites</source>
+        <translation>Lisää suosikkeihin</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
+        <source>Copy share link</source>
+        <translation>Kopioi jakolinkki</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
+        <source>Display on kdrive.infomaniak.com</source>
+        <translation>Näytä kdrive.infomaniak.com-sivustolla</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
+        <source>Show in folder</source>
+        <translation>Näytä kansiossa</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
+        <source>More actions</source>
+        <translation>Lisää toimintoja</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::SynthesisBar</name>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="149"/>
+        <source>Unable to open folder url %1.</source>
+        <translation>Kansion URL-osoitetta %1 ei voi avata.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="219"/>
+        <source>Open in folder</source>
+        <translation>Avaa kansiossa</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="257"/>
+        <source>Open %1 web version</source>
+        <translation>Avaa %1 verkkoversio</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="267"/>
+        <source>Drive parameters</source>
+        <translation>Aseman asetukset</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="280"/>
+        <source>Notifications disabled until %1</source>
+        <translation>Ilmoitukset poistettu käytöstä %1 asti</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="281"/>
+        <source>Disable Notifications</source>
+        <translation>Poista ilmoitukset käytöstä</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="314"/>
+        <source>Application preferences</source>
+        <translation>Sovelluksen asetukset</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="322"/>
+        <source>Need help</source>
+        <translation>Tarvitsetko apua</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="330"/>
+        <source>Send feedbacks</source>
+        <translation>Lähetä palautetta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="338"/>
+        <source>Quit kDrive</source>
+        <translation>Lopeta kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="401"/>
+        <source>Unable to access web site %1.</source>
+        <translation>Verkkosivustolle %1 ei pääse.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="492"/>
+        <source>Show errors and informations</source>
+        <translation>Näytä virheet ja tiedotteet</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="493"/>
+        <source>Show informations</source>
+        <translation>Näytä tiedotteet</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="494"/>
+        <source>More actions</source>
+        <translation>Lisää toimintoja</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="495"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="502"/>
+        <source>Never</source>
+        <translation>Ei koskaan</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="496"/>
+        <source>During 1 hour</source>
+        <translation>1 tunnin ajaksi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="497"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="504"/>
+        <source>Until tomorrow 8:00AM</source>
+        <translation>Huomiseen klo 8:00 asti</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="498"/>
+        <source>During 3 days</source>
+        <translation>3 päivän ajaksi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="499"/>
+        <source>During 1 week</source>
+        <translation>1 viikon ajaksi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="500"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="507"/>
+        <source>Always</source>
+        <translation>Aina</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="503"/>
+        <source>For 1 more hour</source>
+        <translation>1 tunti lisää</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="505"/>
+        <source>For 3 more days</source>
+        <translation>3 päivää lisää</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="506"/>
+        <source>For 1 more week</source>
+        <translation>1 viikko lisää</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::SynthesisPopover</name>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="446"/>
+        <source>Synchronized</source>
+        <translation>Synkronoitu</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="450"/>
+        <source>Favorites</source>
+        <translation>Suosikit</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="454"/>
+        <source>Activity</source>
+        <translation>Toiminta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="586"/>
+        <source>Unable to open folder url %1.</source>
+        <translation>Kansion URL-osoitetta %1 ei voi avata.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="978"/>
+        <source>Update</source>
+        <translation>Päivitä</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="981"/>
+        <source>Update download in progress</source>
+        <translation>Päivitystä ladataan</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="984"/>
+        <source>Looking for update...</source>
+        <translation>Etsitään päivitystä...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="987"/>
+        <source>Manual update</source>
+        <translation>Manuaalinen päivitys</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="990"/>
+        <source>Unavailable</source>
+        <translation>Ei saatavilla</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1133"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1180"/>
+        <source>Not implemented!</source>
+        <translation>Ei toteutettu!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1161"/>
+        <source>Unable to open link %1.</source>
+        <translation>Linkkiä %1 ei voi avata.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1173"/>
+        <source>Invalid link %1.</source>
+        <translation>Virheellinen linkki %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1181"/>
+        <source>Update kDrive App</source>
+        <translation>Päivitä kDrive-sovellus</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1182"/>
+        <source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
+        <translation>Tätä kDrive-sovellusversiota ei enää tueta. Päivitä sovellus uusimpiin ominaisuuksiin pääsemiseksi.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1184"/>
+        <source>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Click here to download manually&lt;/a&gt;</source>
+        <translation>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Napsauta tästä ladataksesi manuaalisesti&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1187"/>
+        <source>Please download the latest version on the website.</source>
+        <translation>Lataa uusin versio verkkosivustolta.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1193"/>
+        <source>No synchronized folder for this Drive!</source>
+        <translation>Tälle asemalle ei ole synkronoitua kansiota!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1196"/>
+        <source>No kDrive configured!</source>
+        <translation>kDrivea ei ole määritetty!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1200"/>
+        <source>You can synchronize files &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;from your computer&lt;/a&gt; or on &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
+        <translation>Voit synkronoida tiedostoja &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;tietokoneeltasi&lt;/a&gt; tai &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;-sivustolla.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::UpdateDialog</name>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="61"/>
+        <source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;%2-asiakkaan uusi versio &lt;b&gt;%1&lt;/b&gt; on saatavilla ja ladattu.&lt;/p&gt;&lt;p&gt;Asennettu versio on %3.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="95"/>
+        <source>Skip this version</source>
+        <translation>Ohita tämä versio</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="103"/>
+        <source>Remind me later</source>
+        <translation>Muistuta myöhemmin</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="109"/>
+        <source>Install update</source>
+        <translation>Asenna päivitys</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::UpdateManager</name>
+    <message>
+        <location filename="../src/server/updater/updatemanager.cpp" line="86"/>
+        <source>New update available.</source>
+        <translation>Uusi päivitys saatavilla.</translation>
+    </message>
+    <message>
+        <location filename="../src/server/updater/updatemanager.cpp" line="87"/>
+        <source>Version %1 is available for download.</source>
+        <translation>Versio %1 on ladattavissa.</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::UserSelectionWidget</name>
+    <message>
+        <location filename="../src/gui/userselectionwidget.cpp" line="131"/>
+        <source>Add an account</source>
+        <translation>Lisää tili</translation>
+    </message>
+</context>
+<context>
+    <name>KDC::VersionWidget</name>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="169"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Show release note&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Näytä julkaisutiedot&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="172"/>
+        <source>Version</source>
+        <translation>Versio</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="173"/>
+        <source>UPDATE</source>
+        <translation>PÄIVITÄ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="197"/>
+        <source>%1 is up to date!</source>
+        <translation>%1 on ajan tasalla!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="201"/>
+        <source>Checking update on server...</source>
+        <translation>Tarkistetaan päivitystä palvelimelta...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="205"/>
+        <source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;here&lt;/a&gt;.</source>
+        <translation>Päivitys on saatavilla: %1.&lt;br&gt;Lataa se &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;täältä&lt;/a&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="212"/>
+        <source>An update is available: %1</source>
+        <translation>Päivitys on saatavilla: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="218"/>
+        <source>Downloading %1. Please wait...</source>
+        <translation>Ladataan %1. Odota...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="223"/>
+        <source>Could not check for new updates.</source>
+        <translation>Päivitysten tarkistus epäonnistui.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="227"/>
+        <source>An error occurred during update.</source>
+        <translation>Päivityksen aikana tapahtui virhe.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="231"/>
+        <source>Could not download update.</source>
+        <translation>Päivityksen lataaminen epäonnistui.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="235"/>
+        <source>Update disabled.</source>
+        <translation>Päivitys poistettu käytöstä.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="251"/>
+        <source>Beta program</source>
+        <translation>Beta-ohjelma</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="252"/>
+        <source>Get early access to new versions of the application</source>
+        <translation>Saa varhainen pääsy sovelluksen uusiin versioihin</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="256"/>
+        <source>Join</source>
+        <translation>Liity</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="259"/>
+        <source>Modify</source>
+        <translation>Muokkaa</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="259"/>
+        <source>Quit</source>
+        <translation>Lopeta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="295"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="42"/>
+        <source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
+        <translation>Lite sync (Beta) on käytössä. kDriven tiedostot pysyvät pilvessä eivätkä käytä tietokoneen tallennustilaa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="45"/>
+        <source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
+        <translation>Lite sync (Beta) ei ole käytössä. kDriven tiedostot käyttävät tietokoneen tallennustilaa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="48"/>
+        <source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
+        <translation>Lite sync on käytössä. kDriven tiedostot pysyvät pilvessä eivätkä käytä tietokoneen tallennustilaa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="50"/>
+        <source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
+        <translation>Lite sync ei ole käytössä. kDriven tiedostot käyttävät tietokoneen tallennustilaa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parameterscache.cpp" line="59"/>
+        <source>Unable to save parameters, please retry later.</source>
+        <translation>Parametrien tallentaminen epäonnistui, yritä myöhemmin uudelleen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parameterscache.cpp" line="60"/>
+        <source>Unable to save parameters!</source>
+        <translation>Parametreja ei voi tallentaa!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1175"/>
+        <source>Make available locally</source>
+        <translation>Tee saataville paikallisesti</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1179"/>
+        <source>Free up local space</source>
+        <translation>Vapauta paikallista tilaa</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1183"/>
+        <source>Cancel free up local space</source>
+        <translation>Peruuta paikallisen tilan vapautus</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1187"/>
+        <source>Cancel make available locally</source>
+        <translation>Peruuta paikallinen saatavillaolo</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1191"/>
+        <source>Resharing this file is not allowed</source>
+        <translation>Tämän tiedoston jakaminen uudelleen ei ole sallittu</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1192"/>
+        <source>Resharing this folder is not allowed</source>
+        <translation>Tämän kansion jakaminen uudelleen ei ole sallittu</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1196"/>
+        <source>Copy public share link</source>
+        <translation>Kopioi julkinen jakolinkki</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1200"/>
+        <source>Copy private share link</source>
+        <translation>Kopioi yksityinen jakolinkki</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1204"/>
+        <source>Open in browser</source>
+        <translation>Avaa selaimessa</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="461"/>
+        <source>The parent folder is a sync folder or contained in one</source>
+        <translation>Ylätason kansio on synkronointikansio tai sisältyy yhteen</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="495"/>
+        <source>Can&apos;t find a valid path</source>
+        <translation>Kelvollista polkua ei löydy</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2108"/>
+        <source>No valid folder selected!</source>
+        <translation>Kelvollista kansiota ei ole valittu!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2119"/>
+        <source>The selected path does not exist!</source>
+        <translation>Valittu polku ei ole olemassa!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2124"/>
+        <source>The selected path is not a folder!</source>
+        <translation>Valittu polku ei ole kansio!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2129"/>
+        <source>You have no permission to write to the selected folder!</source>
+        <translation>Sinulla ei ole kirjoitusoikeutta valittuun kansioon!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2159"/>
+        <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
+        <translation>Paikallinen kansio %1 sisältää jo synkronoidun kansion. Valitse toinen!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2167"/>
+        <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
+        <translation>Paikallinen kansio %1 on jo synkronoidun kansion sisällä. Valitse toinen!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2175"/>
+        <source>The local folder %1 is already synced. Please pick another one!</source>
+        <translation>Paikallinen kansio %1 on jo synkronoitu. Valitse toinen!</translation>
+    </message>
+</context>
+<context>
+    <name>SharedTools::QtSingleApplication</name>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="133"/>
+        <source>kDrive application will close due to a fatal error.</source>
+        <translation>kDrive-sovellus suljetaan kriittisen virheen vuoksi.</translation>
+    </message>
+</context>
+<context>
+    <name>Utility</name>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="41"/>
+        <source>%n year(s)</source>
+        <translation>
+            <numerusform>%n vuosi</numerusform>
+            <numerusform>%n vuotta</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="42"/>
+        <source>%n month(s)</source>
+        <translation>
+            <numerusform>%n kuukausi</numerusform>
+            <numerusform>%n kuukautta</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="43"/>
+        <source>%n day(s)</source>
+        <translation>
+            <numerusform>%n päivä</numerusform>
+            <numerusform>%n päivää</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="44"/>
+        <source>%n hour(s)</source>
+        <translation>
+            <numerusform>%n tunti</numerusform>
+            <numerusform>%n tuntia</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="45"/>
+        <source>%n minute(s)</source>
+        <translation>
+            <numerusform>%n minuutti</numerusform>
+            <numerusform>%n minuuttia</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="46"/>
+        <source>%n second(s)</source>
+        <translation>
+            <numerusform>%n sekunti</numerusform>
+            <numerusform>%n sekuntia</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="97"/>
+        <source>%L1 GB</source>
+        <translation>%L1 GB</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="101"/>
+        <source>%L1 MB</source>
+        <translation>%L1 MB</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="105"/>
+        <source>%L1 KB</source>
+        <translation>%L1 KB</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="108"/>
+        <source>%L1 B</source>
+        <translation>%L1 B</translation>
+    </message>
+</context>
+<context>
+    <name>utility</name>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="84"/>
+        <source>Could not open browser</source>
+        <translation>Selainta ei voi avata</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="85"/>
+        <source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
+        <translation>Selaimen käynnistäminen URL-osoitteeseen %1 siirtymiseksi epäonnistui. Onko oletusselain määritetty?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="104"/>
+        <source>Could not open email client</source>
+        <translation>Sähköpostiohjelmaa ei voi avata</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="105"/>
+        <source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
+        <translation>Sähköpostiohjelman käynnistäminen uuden viestin luomiseksi epäonnistui. Onko oletussähköpostiohjelma määritetty?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="324"/>
+        <source>You are not connected anymore. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Log in&lt;/a&gt;</source>
+        <translation>Et ole enää kirjautunut. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Kirjaudu sisään&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="329"/>
+        <source>No folder to synchronize
 You can add one from the kDrive settings.</source>
-            <translation>Ei synkronoitavaa kansiota
+        <translation>Ei synkronoitavaa kansiota
 Voit lisätä sellaisen kDriven asetuksista.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="336" />
-            <source>Sync in progress (%1 of %2)</source>
-            <translation>Synkronointi käynnissä (%1/%2)</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="340" />
-            <source>Sync in progress (%1 of %2)
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="336"/>
+        <source>Sync in progress (%1 of %2)</source>
+        <translation>Synkronointi käynnissä (%1/%2)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="340"/>
+        <source>Sync in progress (%1 of %2)
 %3 left...</source>
-            <translation>Synkronointi käynnissä (%1/%2)
+        <translation>Synkronointi käynnissä (%1/%2)
 %3 jäljellä...</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="347" />
-            <source>Sync in progress (Step %1/%2).</source>
-            <translation>Synkronointi käynnissä (vaihe %1/%2).</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="351" />
-            <source>Synchronization starting</source>
-            <translation>Synkronointi alkaa</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="353" />
-            <source>Sync in progress.</source>
-            <translation>Synkronointi käynnissä.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="358" />
-            <source>You are up to date, unresolved conflicts.</source>
-            <translation>Olet ajan tasalla, ratkaisemattomia ristiriitoja.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="360" />
-            <source>You are up to date!</source>
-            <translation>Olet ajan tasalla!</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="364" />
-            <source>Some files couldn't be synchronized. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-            <translation>Joitakin tiedostoja ei voitu synkronoida. &lt;a style="%1" href="%2"&gt;Lue lisää&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="370" />
-            <source>Synchronization pausing ...</source>
-            <translation>Synkronointi keskeytymässä...</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="374" />
-            <source>Synchronization paused.</source>
-            <translation>Synkronointi keskeytetty.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="570" />
-            <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
-            <translation>Kansiota &lt;b&gt;%1&lt;/b&gt; ei voi valita, koska toinen synkronointi käyttää samaa kansiota.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="576" />
-            <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-            <translation>Kansiota &lt;b&gt;%1&lt;/b&gt; ei voi valita, koska se sisältää synkronoidun kansion &lt;b&gt;%2&lt;/b&gt;.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="584" />
-            <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-            <translation>Kansiota &lt;b&gt;%1&lt;/b&gt; ei voi valita, koska se on synkronoidun kansion &lt;b&gt;%2&lt;/b&gt; sisällä.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="595" />
-            <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
-            <translation>Kansiota &lt;b&gt;%1&lt;/b&gt; ei voi valita synkronointikansioksi. Valitse toinen kansio.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="599" />
-            <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
-            <translation>Kansiota &lt;b&gt;%1&lt;/b&gt; ei voi valita synkronointikansioksi. Valitse toinen kansio. Ehdotettu kansio: &lt;b&gt;%2&lt;/b&gt;</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="651" />
-            <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
-            <translation>Olet sulkenut pois enemmän kuin %1 kansiota, huomaa, että tämä vaikuttaa synkronoinnin suorituskykyyn.</translation>
-        </message>
-        <message>
-            <location filename="../src/gui/guiutility.cpp" line="660" />
-            <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
-            <translation>Et voi sulkea pois enemmän kuin %1 kansiota. Poista ylätason kansioiden valinta.</translation>
-        </message>
-    </context>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="347"/>
+        <source>Sync in progress (Step %1/%2).</source>
+        <translation>Synkronointi käynnissä (vaihe %1/%2).</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="351"/>
+        <source>Synchronization starting</source>
+        <translation>Synkronointi alkaa</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="353"/>
+        <source>Sync in progress.</source>
+        <translation>Synkronointi käynnissä.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="358"/>
+        <source>You are up to date, unresolved conflicts.</source>
+        <translation>Olet ajan tasalla, ratkaisemattomia ristiriitoja.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="360"/>
+        <source>You are up to date!</source>
+        <translation>Olet ajan tasalla!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="364"/>
+        <source>Some files couldn&apos;t be synchronized. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Joitakin tiedostoja ei voitu synkronoida. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Lue lisää&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="370"/>
+        <source>Synchronization pausing ...</source>
+        <translation>Synkronointi keskeytymässä...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="374"/>
+        <source>Synchronization paused.</source>
+        <translation>Synkronointi keskeytetty.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="570"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
+        <translation>Kansiota &lt;b&gt;%1&lt;/b&gt; ei voi valita, koska toinen synkronointi käyttää samaa kansiota.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="576"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+        <translation>Kansiota &lt;b&gt;%1&lt;/b&gt; ei voi valita, koska se sisältää synkronoidun kansion &lt;b&gt;%2&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="584"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+        <translation>Kansiota &lt;b&gt;%1&lt;/b&gt; ei voi valita, koska se on synkronoidun kansion &lt;b&gt;%2&lt;/b&gt; sisällä.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="595"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
+        <translation>Kansiota &lt;b&gt;%1&lt;/b&gt; ei voi valita synkronointikansioksi. Valitse toinen kansio.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="599"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
+        <translation>Kansiota &lt;b&gt;%1&lt;/b&gt; ei voi valita synkronointikansioksi. Valitse toinen kansio. Ehdotettu kansio: &lt;b&gt;%2&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="653"/>
+        <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
+        <translation>Olet sulkenut pois enemmän kuin %1 kansiota, huomaa, että tämä vaikuttaa synkronoinnin suorituskykyyn.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="662"/>
+        <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
+        <translation>Et voi sulkea pois enemmän kuin %1 kansiota. Poista ylätason kansioiden valinta.</translation>
+    </message>
+</context>
 </TS>

--- a/translations/client_fr.ts
+++ b/translations/client_fr.ts
@@ -1996,27 +1996,32 @@ Veuillez utiliser le lien suivant pour envoyer les logs au support: &lt;a style=
         <translation>Finnois</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="521"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="516"/>
+        <source>Danish</source>
+        <translation>Danois</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="522"/>
         <source>Advanced</source>
         <translation>Avancé</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="522"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="523"/>
         <source>Debugging information</source>
         <translation>Informations de débogage</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="524"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="525"/>
         <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
         <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Ouvrir le dossier de débogage&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="525"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="526"/>
         <source>Files to exclude</source>
         <translation>Fichiers à exclure</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="526"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="527"/>
         <source>Proxy server</source>
         <translation>Serveur proxy</translation>
     </message>
@@ -2056,7 +2061,7 @@ Veuillez utiliser le lien suivant pour envoyer les logs au support: &lt;a style=
         <translation>Lien %1 invalide.</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="528"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="529"/>
         <source>Lite Sync</source>
         <translation>Lite Sync</translation>
     </message>
@@ -2919,19 +2924,6 @@ Veuillez utiliser le lien suivant pour envoyer les logs au support: &lt;a style=
     </message>
 </context>
 <context>
-    <name>main.cpp</name>
-    <message>
-        <location filename="../src/gui/mainclient.cpp" line="49"/>
-        <source>System Tray not available</source>
-        <translation>Zone de notification indisponible</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/mainclient.cpp" line="48"/>
-        <source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as &apos;trayer&apos; and try again.</source>
-        <translation>%1 nécessite une zone de notification (system tray) fonctionnelle. Si vous utilisez XFCE, veuillez suivre &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;ces instructions&lt;/a&gt;. Sinon, veuillez installer une application de zone de notification telle que « trayer » et réessayer.</translation>
-    </message>
-</context>
-<context>
     <name>utility</name>
     <message>
         <location filename="../src/gui/guiutility.cpp" line="84"/>
@@ -3004,12 +2996,12 @@ Veuillez utiliser le lien suivant pour envoyer les logs au support: &lt;a style=
         <translation>Le dossier &lt;b&gt;%1&lt;/b&gt; ne peut pas être sélectionné comme dossier de synchronisation. Veuillez sélectionner un autre dossier. Dossier suggéré : &lt;b&gt;%2&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/guiutility.cpp" line="651"/>
+        <location filename="../src/gui/guiutility.cpp" line="653"/>
         <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
         <translation>Vous avez exclu plus de %1 dossiers. Veuillez noter que cela affectera les performances de synchronisation.</translation>
     </message>
     <message>
-        <location filename="../src/gui/guiutility.cpp" line="660"/>
+        <location filename="../src/gui/guiutility.cpp" line="662"/>
         <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
         <translation>Vous ne pouvez pas exclure plus de %1 dossiers. Veuillez décocher les dossiers de niveau supérieur.</translation>
     </message>

--- a/translations/client_it.ts
+++ b/translations/client_it.ts
@@ -1996,27 +1996,32 @@ Accedi alla versione web per verificare lo stato del tuo kDrive oppure contatta 
         <translation>Finlandese</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="521"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="516"/>
+        <source>Danish</source>
+        <translation>Danese</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="522"/>
         <source>Advanced</source>
         <translation>Avanzate</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="522"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="523"/>
         <source>Debugging information</source>
         <translation>Informazioni di debug</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="524"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="525"/>
         <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
         <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Apri cartella di debug&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="525"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="526"/>
         <source>Files to exclude</source>
         <translation>File da escludere</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="526"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="527"/>
         <source>Proxy server</source>
         <translation>Server proxy</translation>
     </message>
@@ -2056,7 +2061,7 @@ Accedi alla versione web per verificare lo stato del tuo kDrive oppure contatta 
         <translation>Link %1 non valido.</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="528"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="529"/>
         <source>Lite Sync</source>
         <translation>Lite Sync</translation>
     </message>
@@ -2920,19 +2925,6 @@ Accedi alla versione web per verificare lo stato del tuo kDrive oppure contatta 
     </message>
 </context>
 <context>
-    <name>main.cpp</name>
-    <message>
-        <location filename="../src/gui/mainclient.cpp" line="49"/>
-        <source>System Tray not available</source>
-        <translation>Area di notifica non disponibile</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/mainclient.cpp" line="48"/>
-        <source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as &apos;trayer&apos; and try again.</source>
-        <translation>%1 richiede un&apos;area di notifica (system tray) funzionante. Se utilizzi XFCE, segui &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;queste istruzioni&lt;/a&gt;. In caso contrario, installa un&apos;applicazione per l&apos;area di notifica come &quot;trayer&quot; e riprova.</translation>
-    </message>
-</context>
-<context>
     <name>utility</name>
     <message>
         <location filename="../src/gui/guiutility.cpp" line="84"/>
@@ -3019,12 +3011,12 @@ Puoi aggiungerne uno dalle impostazioni di kDrive.</translation>
         <translation>La cartella &lt;b&gt;%1&lt;/b&gt; non può essere selezionata come cartella di sincronizzazione. Selezionare un&apos;altra cartella. Cartella suggerita: &lt;b&gt;%2&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/guiutility.cpp" line="651"/>
+        <location filename="../src/gui/guiutility.cpp" line="653"/>
         <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
         <translation>Hai escluso più di %1 cartelle. Tieni presente che ciò influirà sulle prestazioni di sincronizzazione.</translation>
     </message>
     <message>
-        <location filename="../src/gui/guiutility.cpp" line="660"/>
+        <location filename="../src/gui/guiutility.cpp" line="662"/>
         <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
         <translation>Non puoi escludere più di %1 cartelle. Deseleziona le cartelle di livello superiore.</translation>
     </message>

--- a/translations/client_nb.ts
+++ b/translations/client_nb.ts
@@ -1997,27 +1997,32 @@ Bruk følgende lenke for å sende loggfilene til kundestøtte: &lt;a style=&quot
         <translation>Finsk</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="521"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="516"/>
+        <source>Danish</source>
+        <translation>Dansk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="522"/>
         <source>Advanced</source>
         <translation>Avansert</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="522"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="523"/>
         <source>Debugging information</source>
         <translation>Feilsokingsinformasjon</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="524"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="525"/>
         <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
         <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Åpne feilsøkingsmappen&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="525"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="526"/>
         <source>Files to exclude</source>
         <translation>Filer som skal utelukkes</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="526"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="527"/>
         <source>Proxy server</source>
         <translation>Proxyserver</translation>
     </message>
@@ -2057,7 +2062,7 @@ Bruk følgende lenke for å sende loggfilene til kundestøtte: &lt;a style=&quot
         <translation>Ugyldig lenke %1.</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="528"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="529"/>
         <source>Lite Sync</source>
         <translation>Lite Sync</translation>
     </message>
@@ -2992,12 +2997,12 @@ Bruk følgende lenke for å sende loggfilene til kundestøtte: &lt;a style=&quot
         <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke velges som synkroniseringsmappe. Vennligst velg en annen mappe. Forslag til mappe: &lt;b&gt;%2&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/guiutility.cpp" line="651"/>
+        <location filename="../src/gui/guiutility.cpp" line="653"/>
         <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
         <translation>Du har ekskludert mer enn %1 mapper. Vær oppmerksom på at dette vil påvirke synkroniseringsytelsen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/guiutility.cpp" line="660"/>
+        <location filename="../src/gui/guiutility.cpp" line="662"/>
         <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
         <translation>Du kan ikke ekskludere mer enn 1 % av mappene. Fjern merket for mapper på høyere nivå.</translation>
     </message>

--- a/translations/client_pl.ts
+++ b/translations/client_pl.ts
@@ -2002,27 +2002,32 @@ Proszę skorzystać z poniższego linku, aby przesłać logi do działu pomocy t
         <translation>Fiński</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="521"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="516"/>
+        <source>Danish</source>
+        <translation>Duński</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="522"/>
         <source>Advanced</source>
         <translation>Zaawansowane</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="522"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="523"/>
         <source>Debugging information</source>
         <translation>Informacje debugowania</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="524"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="525"/>
         <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
         <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Otwórz folder debugowania&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="525"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="526"/>
         <source>Files to exclude</source>
         <translation>Pliki do wykluczenia</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="526"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="527"/>
         <source>Proxy server</source>
         <translation>Serwer proxy</translation>
     </message>
@@ -2062,7 +2067,7 @@ Proszę skorzystać z poniższego linku, aby przesłać logi do działu pomocy t
         <translation>Nieprawidłowy link %1.</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="528"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="529"/>
         <source>Lite Sync</source>
         <translation>Lite Sync</translation>
     </message>
@@ -3003,12 +3008,12 @@ Proszę skorzystać z poniższego linku, aby przesłać logi do działu pomocy t
         <translation>Folder &lt;b&gt;%1&lt;/b&gt; nie może zostać wybrany jako folder synchronizacji. Wybierz inny folder. Sugerowany folder: &lt;b&gt;%2&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/guiutility.cpp" line="651"/>
+        <location filename="../src/gui/guiutility.cpp" line="653"/>
         <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
         <translation>Wykluczyłeś ponad %1 folderów. Pamiętaj, że wpłynie to na wydajność synchronizacji.</translation>
     </message>
     <message>
-        <location filename="../src/gui/guiutility.cpp" line="660"/>
+        <location filename="../src/gui/guiutility.cpp" line="662"/>
         <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
         <translation>Nie można wykluczyć więcej niż %1 folderów. Proszę odznaczyć foldery wyższego poziomu.</translation>
     </message>

--- a/translations/client_pt.ts
+++ b/translations/client_pt.ts
@@ -1997,27 +1997,32 @@ Por favor, utilize o seguinte link para enviar os registos para o apoio técnico
         <translation>Finlandês</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="521"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="516"/>
+        <source>Danish</source>
+        <translation>Dinamarquês</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="522"/>
         <source>Advanced</source>
         <translation>Avancado</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="522"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="523"/>
         <source>Debugging information</source>
         <translation>Informacoes de depuracao</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="524"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="525"/>
         <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
         <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Abrir a pasta de depuração&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="525"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="526"/>
         <source>Files to exclude</source>
         <translation>Ficheiros a excluir</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="526"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="527"/>
         <source>Proxy server</source>
         <translation>Servidor proxy</translation>
     </message>
@@ -2057,7 +2062,7 @@ Por favor, utilize o seguinte link para enviar os registos para o apoio técnico
         <translation>Ligacao invalida %1.</translation>
     </message>
     <message>
-        <location filename="../src/gui/preferenceswidget.cpp" line="528"/>
+        <location filename="../src/gui/preferenceswidget.cpp" line="529"/>
         <source>Lite Sync</source>
         <translation>Lite Sync</translation>
     </message>
@@ -2992,12 +2997,12 @@ Por favor, utilize o seguinte link para enviar os registos para o apoio técnico
         <translation>A pasta &lt;b&gt;%1&lt;/b&gt; não pode ser selecionada como pasta de sincronização. Por favor, selecione outra pasta. Pasta sugerida: &lt;b&gt;%2&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/guiutility.cpp" line="651"/>
+        <location filename="../src/gui/guiutility.cpp" line="653"/>
         <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
         <translation>Excluiu mais de %1 pastas; tenha em atenção que isto irá afetar o desempenho da sincronização.</translation>
     </message>
     <message>
-        <location filename="../src/gui/guiutility.cpp" line="660"/>
+        <location filename="../src/gui/guiutility.cpp" line="662"/>
         <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
         <translation>Não é possível excluir mais do que %1 pastas. Desmarque as pastas de nível superior.</translation>
     </message>

--- a/translations/update_ui_translations.py
+++ b/translations/update_ui_translations.py
@@ -49,6 +49,7 @@ DEEPL_LANGUAGE_CODES = {
     "it": "IT",
     "nb": "NB",
     "fi": "FI",
+    "da": "DA",
     "pl": "PL",
     "sv": "SV",
     "pt": "PT-PT",
@@ -84,7 +85,7 @@ def fill_missing_translations(git_dir_path, language):
     
     
 
-languages = ["de", "es", "fr", "it", "sv", "pt", "pl", "nb", "fi"]
+languages = ["de", "es", "fr", "it", "sv", "pt", "pl", "nb", "fi", "da"]
 
 for language in languages:
     fill_missing_translations(args.git_dir_path, language)


### PR DESCRIPTION
## Summary

Add Danish (da) as a supported UI language in the kDrive desktop client.

## Changes

### C++ / Infrastructure
- Add `Language::Danish` to the `Language` enum (`cstypes.h`)
- Add `danishCode` constant and support in `languageCode()`, `isSupportedLanguage()` (`utility.h/.cpp`)
- Add `QLocale::Danish` mapping in `guiutility.cpp`
- Add Danish entry to the language selector combo box (`preferenceswidget.cpp`)
- Add `"da"` parsing in `migrationparams.cpp`
- Add test assertions for Danish in `testutility.cpp`
- Add `*_da.qm` to AppImage translation filter (`build-release-appimage.sh`)
- Add `"da": "DA"` to `DEEPL_LANGUAGE_CODES` in `update_ui_translations.py`

### Translations
- Add `translations/client_da.ts` with 559 Danish translations
- Add "Danish" entry to all existing `.ts` files (de, es, fi, fr, it, nb, pl, pt, sv)
- Run `lupdate` to update line references and remove obsolete entries

## Dependencies

Depends on #1843 (Finnish localization — must be merged first).