### PR TITLE
refactor(appcache): graph-backed cache foundation with selection and onboarding stores

### DIFF
--- a/src/gui4/linux/AGENTS.md
+++ b/src/gui4/linux/AGENTS.md
@@ -23,6 +23,8 @@
   default. `linux-v4/main` is the Linux v4 integration branch regularly rebased on `develop`.
 - For shared infrastructure classes, document the class role explicitly in the header comment (and non-role when
   relevant).
+- In range-for loops over associative containers, prefer `std::views::keys` / `std::views::values` over structured
+  bindings with an unused `_` element when only keys or only values are needed.
 
 ## Scope
 
@@ -42,9 +44,12 @@
   (`begin/end/isActionPending/isServicePending`).
 - `app/services/serviceeventbus.*`: shared high-level service event hub (single UI subscription point for generic
   cross-service failures). Owned once by `AppClientLinux` and injected by reference into app services.
-- `app/cache/appcache.*`: central observable cache (`AppCache` QObject) — typed snapshots and incremental
-  `upsert*`/`remove*` slots for users, accounts, drives, available drives, syncs, and errors; QML models and
-  services read from it instead of parsing transport payloads directly.
+- `app/cache/appcache.*`: durable graph-backed cache (`AppCache` QObject) — owns configured users/accounts/drives/syncs,
+  split sync/server errors, per-user available drives, cascade removals, and derived read models.
+- `app/cache/cachetypes.h`: cache read models and onboarding keys (`SyncContext`, `DriveContext`,
+  `AvailableDriveContext`, `AvailableDriveKey`, `PendingSyncConfig`).
+- `app/cache/mainselectionstore.*`: sync-first main-shell selection owner (`currentSyncDbId`) and selection healing.
+- `app/cache/onboardingstate.*`: onboarding-only selected user, selected available-drive keys, and pending sync configs.
 - `ui/`: QML shell and design tokens.
 
 ## Build And Validation
@@ -76,6 +81,10 @@ cmake --build build-linux/build/build/Debug --target kdrive_qml -- -j 12
   `ServiceEventBus` for transient events, `ServiceActionTracker` for durable pending-action state.
 - Do not create per-service formatted error-string state for UI display; services emit generic bus signals and keep
   structured backend error information in request handlers/logs.
+- `AppCache`, `MainSelectionStore`, and `OnboardingState` mutations must run on the Qt main thread.
+- `AppCache` must not own mutable main selection; derive main context through `MainSelectionStore.currentSyncDbId`.
+- Store available drives per user via `AppCache::replaceAvailableDrivesForUser(...)`; do not reintroduce a global
+  available-drives snapshot.
 
 ## IPC And Error Handling
 

--- a/src/gui4/linux/AGENTS.md
+++ b/src/gui4/linux/AGENTS.md
@@ -49,6 +49,7 @@
 - `app/cache/cachetypes.h`: cache read models and onboarding keys (`SyncContext`, `DriveContext`,
   `AvailableDriveContext`, `AvailableDriveKey`, `PendingSyncConfig`).
 - `app/cache/mainselectionstore.*`: sync-first main-shell selection owner (`currentSyncDbId`) and selection healing.
+  - emits `currentSyncContextChanged()` as a coarse invalidation signal when the current sync context stays selected but the underlying cache graph changes.
 - `app/cache/onboardingstate.*`: onboarding-only selected user, selected available-drive keys, and pending sync configs.
 - `ui/`: QML shell and design tokens.
 

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -18,6 +18,8 @@ set(GUI_SOURCE_FILES # C++ files for the GUI application
         app/cache/appcache.h
         app/cache/mainselectionstore.cpp
         app/cache/mainselectionstore.h
+        app/cache/onboardingstate.cpp
+        app/cache/onboardingstate.h
         communicationlayer/ipcclient.cpp
         communicationlayer/ipcclient.h
         communicationlayer/signaldispatcher.cpp

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -16,6 +16,9 @@ set(GUI_SOURCE_FILES # C++ files for the GUI application
         appclientlinux.h
         app/cache/appcache.cpp
         app/cache/appcache.h
+        app/cache/appcachegraph.cpp
+        app/cache/appcachequeries.cpp
+        app/cache/cachetypes.h
         app/cache/mainselectionstore.cpp
         app/cache/mainselectionstore.h
         app/cache/onboardingstate.cpp

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -16,6 +16,8 @@ set(GUI_SOURCE_FILES # C++ files for the GUI application
         appclientlinux.h
         app/cache/appcache.cpp
         app/cache/appcache.h
+        app/cache/mainselectionstore.cpp
+        app/cache/mainselectionstore.h
         communicationlayer/ipcclient.cpp
         communicationlayer/ipcclient.h
         communicationlayer/signaldispatcher.cpp

--- a/src/gui4/linux/app/cache/appcache.cpp
+++ b/src/gui4/linux/app/cache/appcache.cpp
@@ -28,6 +28,7 @@ AppCache::AppCache(QObject *const parent) :
     QObject(parent) {}
 
 void AppCache::clearAll() {
+    qCInfo(lcAppCache) << "Cache cleared";
     const bool hadUsers = !_usersByDbId.empty();
     const bool hadAccounts = !_accountsByDbId.empty();
     const bool hadDrives = !_drivesByDbId.empty();
@@ -74,6 +75,7 @@ void AppCache::replaceAccounts(const std::vector<AccountInfo> &accounts) {
     _accountsByDbId.clear();
     for (const auto &info: accounts) {
         if (!_usersByDbId.contains(info.userDbId())) {
+            qCWarning(lcAppCache) << "Account dropped during replace | accountDbId:" << info.dbId() << "/ unknown userDbId:" << info.userDbId();
             continue;
         }
         _accountsByDbId[info.dbId()] = AccountNode{info, info.userDbId(), {}};
@@ -92,6 +94,7 @@ void AppCache::replaceDrives(const std::vector<DriveInfo> &drives) {
     _drivesByDbId.clear();
     for (const auto &info: drives) {
         if (!_accountsByDbId.contains(info.accountDbId())) {
+            qCWarning(lcAppCache) << "Drive dropped during replace | driveDbId:" << info.dbId() << "/ unknown accountDbId:" << info.accountDbId();
             continue;
         }
         _drivesByDbId[info.dbId()] = DriveNode{info, info.accountDbId(), {}};
@@ -109,6 +112,7 @@ void AppCache::replaceSyncs(const std::vector<SyncInfo> &syncs) {
     _syncsByDbId.clear();
     for (const auto &info: syncs) {
         if (!_drivesByDbId.contains(info.driveDbId())) {
+            qCWarning(lcAppCache) << "Sync dropped during replace | syncDbId:" << info.dbId() << "/ unknown driveDbId:" << info.driveDbId();
             continue;
         }
         _syncsByDbId[info.dbId()] = SyncNode{info, info.driveDbId(), {}};
@@ -125,6 +129,7 @@ void AppCache::replaceSyncErrors(const std::vector<ErrorInfo> &errors) {
     _syncErrorsByDbId.clear();
     for (const auto &info: errors) {
         if (!_syncsByDbId.contains(info.syncDbId())) {
+            qCWarning(lcAppCache) << "Sync error dropped during replace | errorDbId:" << info.dbId() << "/ unknown syncDbId:" << info.syncDbId();
             continue;
         }
         _syncErrorsByDbId[info.dbId()] = info;
@@ -170,6 +175,7 @@ void AppCache::clearAllAvailableDrives() {
 void AppCache::upsertUser(const UserInfo &info) {
     auto &node = _usersByDbId[info.dbId()];
     node.info = info;
+    qCDebug(lcAppCache) << "User upserted | dbId:" << info.dbId();
     emit usersChanged();
 }
 
@@ -178,6 +184,7 @@ void AppCache::removeUser(const UserDbId userDbId) {
     if (userIt == _usersByDbId.end()) {
         return;
     }
+    qCDebug(lcAppCache) << "User removed | dbId:" << userDbId;
 
     for (const auto accountDbIds = userIt->second.accountDbIds; const auto accountDbId: accountDbIds) {
         removeAccountCascade(accountDbId);
@@ -195,6 +202,7 @@ void AppCache::removeUser(const UserDbId userDbId) {
 
 void AppCache::upsertAccount(const AccountInfo &info) {
     if (!_usersByDbId.contains(info.userDbId())) {
+        qCWarning(lcAppCache) << "Account upsert dropped | accountDbId:" << info.dbId() << "/ unknown userDbId:" << info.userDbId();
         return;
     }
 
@@ -207,6 +215,7 @@ void AppCache::upsertAccount(const AccountInfo &info) {
     node.info = info;
     node.parentUserDbId = info.userDbId();
     linkAccountToUser(info.dbId(), info.userDbId());
+    qCDebug(lcAppCache) << "Account upserted | dbId:" << info.dbId() << "/ userDbId:" << info.userDbId();
     emit accountsChanged();
 }
 
@@ -214,6 +223,7 @@ void AppCache::removeAccount(const AccountDbId accountDbId) {
     if (!_accountsByDbId.contains(accountDbId)) {
         return;
     }
+    qCDebug(lcAppCache) << "Account removed | dbId:" << accountDbId;
     removeAccountCascade(accountDbId);
     emit accountsChanged();
     emit drivesChanged();
@@ -223,6 +233,7 @@ void AppCache::removeAccount(const AccountDbId accountDbId) {
 
 void AppCache::upsertDrive(const DriveInfo &info) {
     if (!_accountsByDbId.contains(info.accountDbId())) {
+        qCWarning(lcAppCache) << "Drive upsert dropped | driveDbId:" << info.dbId() << "/ unknown accountDbId:" << info.accountDbId();
         return;
     }
 
@@ -235,6 +246,7 @@ void AppCache::upsertDrive(const DriveInfo &info) {
     node.info = info;
     node.parentAccountDbId = info.accountDbId();
     linkDriveToAccount(info.dbId(), info.accountDbId());
+    qCDebug(lcAppCache) << "Drive upserted | dbId:" << info.dbId() << "/ accountDbId:" << info.accountDbId();
     emit drivesChanged();
 }
 
@@ -242,6 +254,7 @@ void AppCache::removeDrive(const DriveDbId driveDbId) {
     if (!_drivesByDbId.contains(driveDbId)) {
         return;
     }
+    qCDebug(lcAppCache) << "Drive removed | dbId:" << driveDbId;
     removeDriveCascade(driveDbId);
     emit drivesChanged();
     emit syncsChanged();
@@ -250,6 +263,7 @@ void AppCache::removeDrive(const DriveDbId driveDbId) {
 
 void AppCache::upsertSync(const SyncInfo &info) {
     if (!_drivesByDbId.contains(info.driveDbId())) {
+        qCWarning(lcAppCache) << "Sync upsert dropped | syncDbId:" << info.dbId() << "/ unknown driveDbId:" << info.driveDbId();
         return;
     }
 
@@ -262,6 +276,7 @@ void AppCache::upsertSync(const SyncInfo &info) {
     node.info = info;
     node.parentDriveDbId = info.driveDbId();
     linkSyncToDrive(info.dbId(), info.driveDbId());
+    qCDebug(lcAppCache) << "Sync upserted | dbId:" << info.dbId() << "/ driveDbId:" << info.driveDbId();
     emit syncsChanged();
 }
 
@@ -269,6 +284,7 @@ void AppCache::removeSync(const SyncDbId syncDbId) {
     if (!_syncsByDbId.contains(syncDbId)) {
         return;
     }
+    qCDebug(lcAppCache) << "Sync removed | dbId:" << syncDbId;
     removeSyncCascade(syncDbId);
     emit syncsChanged();
     emit syncErrorsChanged();
@@ -276,6 +292,7 @@ void AppCache::removeSync(const SyncDbId syncDbId) {
 
 void AppCache::upsertSyncError(const ErrorInfo &info) {
     if (!_syncsByDbId.contains(info.syncDbId())) {
+        qCWarning(lcAppCache) << "Sync error upsert dropped | errorDbId:" << info.dbId() << "/ unknown syncDbId:" << info.syncDbId();
         return;
     }
 
@@ -286,6 +303,7 @@ void AppCache::upsertSyncError(const ErrorInfo &info) {
 
     _syncErrorsByDbId[info.dbId()] = info;
     linkErrorToSync(info.dbId(), info.syncDbId());
+    qCDebug(lcAppCache) << "Sync error upserted | dbId:" << info.dbId() << "/ syncDbId:" << info.syncDbId();
     emit syncErrorsChanged();
 }
 
@@ -294,6 +312,7 @@ void AppCache::removeSyncError(const ErrorDbId errorDbId) {
     if (errorIt == _syncErrorsByDbId.end()) {
         return;
     }
+    qCDebug(lcAppCache) << "Sync error removed | dbId:" << errorDbId;
     unlinkErrorFromSync(errorDbId, errorIt->second.syncDbId());
     _syncErrorsByDbId.erase(errorIt);
     emit syncErrorsChanged();

--- a/src/gui4/linux/app/cache/appcache.cpp
+++ b/src/gui4/linux/app/cache/appcache.cpp
@@ -16,251 +16,302 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+
 #include "appcache.h"
 
-#include <algorithm>
-
-namespace {
-/**
- * Inserts @p value into @p list if no element matches @p id, or replaces the matching element.
- * @tparam T       Element type stored in the list.
- * @tparam IdType  Type of the identifier used for lookup.
- * @tparam Getter  Callable of signature `IdType(const T &)` that extracts the id from an element.
- * @param list     The vector to update.
- * @param value    The new element to insert or use as replacement.
- * @param id       The identifier to look up.
- * @param getter   Callable that returns the id of a given element.
- */
-template<typename T, typename IdType, typename Getter>
-void upsertById(std::vector<T> &list, const T &value, IdType id, Getter getter) {
-    const auto it = std::ranges::find_if(list, [id, getter](const T &existing) { return getter(existing) == id; });
-    if (it == list.end()) {
-        list.push_back(value);
-        return;
-    }
-    *it = value;
-}
-
-/**
- * Removes from @p list all elements whose id matches @p id.
- * @tparam T       Element type stored in the list.
- * @tparam IdType  Type of the identifier used for lookup.
- * @tparam Getter  Callable of signature `IdType(const T &)` that extracts the id from an element.
- * @param list     The vector to update.
- * @param id       The identifier of the element to remove.
- * @param getter   Callable that returns the id of a given element.
- * @return         `true` if at least one element was removed, `false` otherwise.
- */
-template<typename T, typename IdType, typename Getter>
-bool removeById(std::vector<T> &list, IdType id, Getter getter) {
-    const auto erasedCount = std::erase_if(list, [id, getter](const T &value) { return getter(value) == id; });
-    return erasedCount > 0;
-}
-} // namespace
+#include <ranges>
+#include <utility>
 
 namespace KDC {
 
 AppCache::AppCache(QObject *const parent) :
     QObject(parent) {}
 
-qint64 AppCache::selectedUserDbId() const {
-    return static_cast<qint64>(_selectedUserDbId);
-}
-
-qint64 AppCache::selectedDriveDbId() const {
-    return static_cast<qint64>(_selectedDriveDbId);
-}
-
-qint64 AppCache::selectedSyncDbId() const {
-    return static_cast<qint64>(_selectedSyncDbId);
-}
-
-void AppCache::setConnected(const bool connected) {
-    if (_connected == connected) {
-        return;
-    }
-    _connected = connected;
-    emit connectedChanged();
-}
-
-void AppCache::setSelectedUserDbId(const qint64 userDbId) {
-    const auto typedUserDbId = static_cast<UserDbId>(userDbId);
-    if (_selectedUserDbId == typedUserDbId) {
-        return;
-    }
-    _selectedUserDbId = typedUserDbId;
-
-    const bool hadAvailableDrives = !_availableDrives.empty();
-    _availableDrives.clear();
-
-    emit selectedUserDbIdChanged();
-    if (hadAvailableDrives) {
-        emit availableDrivesChanged();
-    }
-}
-
-void AppCache::setSelectedDriveDbId(const qint64 driveDbId) {
-    const auto typedDriveDbId = static_cast<DriveDbId>(driveDbId);
-    if (_selectedDriveDbId == typedDriveDbId) {
-        return;
-    }
-    _selectedDriveDbId = typedDriveDbId;
-    emit selectedDriveDbIdChanged();
-}
-
-void AppCache::setSelectedSyncDbId(const qint64 syncDbId) {
-    const auto typedSyncDbId = static_cast<SyncDbId>(syncDbId);
-    if (_selectedSyncDbId == typedSyncDbId) {
-        return;
-    }
-    _selectedSyncDbId = typedSyncDbId;
-    emit selectedSyncDbIdChanged();
-}
-
 void AppCache::clearAll() {
-    // Connection state is intentionally preserved: cache content and transport connectivity are orthogonal.
-    const bool usersListChanged = !_users.empty();
-    const bool accountsListChanged = !_accounts.empty();
-    const bool drivesListChanged = !_drives.empty();
-    const bool availableDrivesListChanged = !_availableDrives.empty();
-    const bool syncsListChanged = !_syncs.empty();
-    const bool errorsListChanged = !_errors.empty();
-    const bool userSelectionChanged = _selectedUserDbId != 0;
-    const bool driveSelectionChanged = _selectedDriveDbId != 0;
-    const bool syncSelectionChanged = _selectedSyncDbId != 0;
+    const bool hadUsers = !_usersByDbId.empty();
+    const bool hadAccounts = !_accountsByDbId.empty();
+    const bool hadDrives = !_drivesByDbId.empty();
+    const bool hadSyncs = !_syncsByDbId.empty();
+    const bool hadSyncErrors = !_syncErrorsByDbId.empty();
+    const bool hadServerErrors = !_serverErrorsByDbId.empty();
+    const bool hadAvailableDrives = !_availableDrivesByUserDbId.empty();
 
-    _users.clear();
-    _accounts.clear();
-    _drives.clear();
-    _availableDrives.clear();
-    _syncs.clear();
-    _errors.clear();
-    _selectedUserDbId = 0;
-    _selectedDriveDbId = 0;
-    _selectedSyncDbId = 0;
+    _usersByDbId.clear();
+    _accountsByDbId.clear();
+    _drivesByDbId.clear();
+    _syncsByDbId.clear();
+    _syncErrorsByDbId.clear();
+    _serverErrorsByDbId.clear();
+    _availableDrivesByUserDbId.clear();
 
-    if (usersListChanged) emit usersChanged();
-    if (accountsListChanged) emit accountsChanged();
-    if (drivesListChanged) emit drivesChanged();
-    if (availableDrivesListChanged) emit availableDrivesChanged();
-    if (syncsListChanged) emit syncsChanged();
-    if (errorsListChanged) emit errorsChanged();
-    if (userSelectionChanged) emit selectedUserDbIdChanged();
-    if (driveSelectionChanged) emit selectedDriveDbIdChanged();
-    if (syncSelectionChanged) emit selectedSyncDbIdChanged();
+    if (hadUsers) emit usersChanged();
+    if (hadAccounts) emit accountsChanged();
+    if (hadDrives) emit drivesChanged();
+    if (hadSyncs) emit syncsChanged();
+    if (hadSyncErrors) emit syncErrorsChanged();
+    if (hadServerErrors) emit serverErrorsChanged();
+    if (hadAvailableDrives) emit allAvailableDrivesChanged();
 }
 
 void AppCache::replaceUsers(const std::vector<UserInfo> &users) {
-    _users = users;
+    _usersByDbId.clear();
+    for (const auto &info: users) {
+        _usersByDbId[info.dbId()].info = info;
+    }
+    pruneConfiguredGraph();
     emit usersChanged();
+    emit accountsChanged();
+    emit drivesChanged();
+    emit syncsChanged();
+    emit syncErrorsChanged();
+    emit allAvailableDrivesChanged();
 }
 
 void AppCache::replaceAccounts(const std::vector<AccountInfo> &accounts) {
-    _accounts = accounts;
+    for (auto &userNode: _usersByDbId | std::views::values) {
+        userNode.accountDbIds.clear();
+    }
+    _accountsByDbId.clear();
+    for (const auto &info: accounts) {
+        if (!_usersByDbId.contains(info.userDbId())) {
+            continue;
+        }
+        _accountsByDbId[info.dbId()] = AccountNode{info, info.userDbId(), {}};
+        linkAccountToUser(info.dbId(), info.userDbId());
+    }
+    pruneConfiguredGraph();
     emit accountsChanged();
+    emit drivesChanged();
+    emit syncsChanged();
+    emit syncErrorsChanged();
 }
 
 void AppCache::replaceDrives(const std::vector<DriveInfo> &drives) {
-    _drives = drives;
+    for (auto &accountNode: _accountsByDbId | std::views::values) {
+        accountNode.driveDbIds.clear();
+    }
+    _drivesByDbId.clear();
+    for (const auto &info: drives) {
+        if (!_accountsByDbId.contains(info.accountDbId())) {
+            continue;
+        }
+        _drivesByDbId[info.dbId()] = DriveNode{info, info.accountDbId(), {}};
+        linkDriveToAccount(info.dbId(), info.accountDbId());
+    }
+    pruneConfiguredGraph();
     emit drivesChanged();
-}
-
-void AppCache::replaceAvailableDrives(const std::vector<DriveAvailableInfo> &availableDrives) {
-    _availableDrives = availableDrives;
-    emit availableDrivesChanged();
+    emit syncsChanged();
+    emit syncErrorsChanged();
 }
 
 void AppCache::replaceSyncs(const std::vector<SyncInfo> &syncs) {
-    _syncs = syncs;
+    for (auto &driveNode: _drivesByDbId | std::views::values) {
+        driveNode.syncDbIds.clear();
+    }
+    _syncsByDbId.clear();
+    for (const auto &info: syncs) {
+        if (!_drivesByDbId.contains(info.driveDbId())) {
+            continue;
+        }
+        _syncsByDbId[info.dbId()] = SyncNode{info, info.driveDbId(), {}};
+        linkSyncToDrive(info.dbId(), info.driveDbId());
+    }
+    pruneConfiguredGraph();
     emit syncsChanged();
+    emit syncErrorsChanged();
 }
 
-void AppCache::replaceErrors(const std::vector<ErrorInfo> &errors) {
-    _errors = errors;
-    emit errorsChanged();
+void AppCache::replaceSyncErrors(const std::vector<ErrorInfo> &errors) {
+    for (auto &syncNode: _syncsByDbId | std::views::values) {
+        syncNode.errorDbIds.clear();
+    }
+    _syncErrorsByDbId.clear();
+    for (const auto &info: errors) {
+        if (!_syncsByDbId.contains(info.syncDbId())) {
+            continue;
+        }
+        _syncErrorsByDbId[info.dbId()] = info;
+        linkErrorToSync(info.dbId(), info.syncDbId());
+    }
+    emit syncErrorsChanged();
+}
+
+void AppCache::replaceServerErrors(const std::vector<ErrorInfo> &errors) {
+    _serverErrorsByDbId.clear();
+    for (const auto &info: errors) {
+        _serverErrorsByDbId[info.dbId()] = info;
+    }
+    emit serverErrorsChanged();
+}
+
+void AppCache::replaceAvailableDrivesForUser(const UserDbId userDbId, const std::vector<DriveAvailableInfo> &availableDrives) {
+    std::vector<DriveAvailableInfo> scopedAvailableDrives;
+    scopedAvailableDrives.reserve(availableDrives.size());
+    for (auto info: availableDrives) {
+        info.setUserDbId(userDbId);
+        scopedAvailableDrives.push_back(info);
+    }
+    _availableDrivesByUserDbId[userDbId] = std::move(scopedAvailableDrives);
+    emit availableDrivesChanged(userDbId);
+}
+
+void AppCache::clearAvailableDrivesForUser(const UserDbId userDbId) {
+    if (_availableDrivesByUserDbId.erase(userDbId) == 0) {
+        return;
+    }
+    emit availableDrivesChanged(userDbId);
+}
+
+void AppCache::clearAllAvailableDrives() {
+    if (_availableDrivesByUserDbId.empty()) {
+        return;
+    }
+    _availableDrivesByUserDbId.clear();
+    emit allAvailableDrivesChanged();
 }
 
 void AppCache::upsertUser(const UserInfo &info) {
-    upsertById(_users, info, info.dbId(), [](const UserInfo &user) { return user.dbId(); });
+    auto &[userInfo, _] = _usersByDbId[info.dbId()];
+    userInfo = info;
     emit usersChanged();
 }
 
 void AppCache::removeUser(const UserDbId userDbId) {
-    if (!removeById(_users, userDbId, [](const UserInfo &user) { return user.dbId(); })) {
+    const auto userIt = _usersByDbId.find(userDbId);
+    if (userIt == _usersByDbId.end()) {
         return;
     }
-    const bool selectionChanged = _selectedUserDbId == userDbId;
-    if (selectionChanged) {
-        _selectedUserDbId = 0;
+
+    for (const auto accountDbIds = userIt->second.accountDbIds; const auto accountDbId: accountDbIds) {
+        removeAccountCascade(accountDbId);
     }
+    _usersByDbId.erase(userIt);
+    const bool hadAvailableDrives = _availableDrivesByUserDbId.erase(userDbId) > 0;
+
     emit usersChanged();
-    if (selectionChanged) {
-        emit selectedUserDbIdChanged();
-    }
+    emit accountsChanged();
+    emit drivesChanged();
+    emit syncsChanged();
+    emit syncErrorsChanged();
+    if (hadAvailableDrives) emit availableDrivesChanged(userDbId);
 }
 
 void AppCache::upsertAccount(const AccountInfo &info) {
-    upsertById(_accounts, info, info.dbId(), [](const AccountInfo &account) { return account.dbId(); });
+    if (!_usersByDbId.contains(info.userDbId())) {
+        return;
+    }
+
+    if (const auto existingIt = _accountsByDbId.find(info.dbId());
+        existingIt != _accountsByDbId.end() && existingIt->second.parentUserDbId != info.userDbId()) {
+        unlinkAccountFromUser(info.dbId(), existingIt->second.parentUserDbId);
+    }
+
+    auto &node = _accountsByDbId[info.dbId()];
+    node.info = info;
+    node.parentUserDbId = info.userDbId();
+    linkAccountToUser(info.dbId(), info.userDbId());
     emit accountsChanged();
 }
 
 void AppCache::removeAccount(const AccountDbId accountDbId) {
-    if (!removeById(_accounts, accountDbId, [](const AccountInfo &account) { return account.dbId(); })) {
+    if (!_accountsByDbId.contains(accountDbId)) {
         return;
     }
+    removeAccountCascade(accountDbId);
     emit accountsChanged();
+    emit drivesChanged();
+    emit syncsChanged();
+    emit syncErrorsChanged();
 }
 
 void AppCache::upsertDrive(const DriveInfo &info) {
-    upsertById(_drives, info, info.dbId(), [](const DriveInfo &drive) { return drive.dbId(); });
+    if (!_accountsByDbId.contains(info.accountDbId())) {
+        return;
+    }
+
+    if (const auto existingIt = _drivesByDbId.find(info.dbId());
+        existingIt != _drivesByDbId.end() && existingIt->second.parentAccountDbId != info.accountDbId()) {
+        unlinkDriveFromAccount(info.dbId(), existingIt->second.parentAccountDbId);
+    }
+
+    auto &node = _drivesByDbId[info.dbId()];
+    node.info = info;
+    node.parentAccountDbId = info.accountDbId();
+    linkDriveToAccount(info.dbId(), info.accountDbId());
     emit drivesChanged();
 }
 
 void AppCache::removeDrive(const DriveDbId driveDbId) {
-    if (!removeById(_drives, driveDbId, [](const DriveInfo &drive) { return drive.dbId(); })) {
+    if (!_drivesByDbId.contains(driveDbId)) {
         return;
     }
-    const bool selectionChanged = _selectedDriveDbId == driveDbId;
-    if (selectionChanged) {
-        _selectedDriveDbId = 0;
-        _selectedSyncDbId = 0;
-    }
+    removeDriveCascade(driveDbId);
     emit drivesChanged();
-    if (selectionChanged) {
-        emit selectedDriveDbIdChanged();
-        emit selectedSyncDbIdChanged();
-    }
+    emit syncsChanged();
+    emit syncErrorsChanged();
 }
 
 void AppCache::upsertSync(const SyncInfo &info) {
-    upsertById(_syncs, info, info.dbId(), [](const SyncInfo &sync) { return sync.dbId(); });
+    if (!_drivesByDbId.contains(info.driveDbId())) {
+        return;
+    }
+
+    if (const auto existingIt = _syncsByDbId.find(info.dbId());
+        existingIt != _syncsByDbId.end() && existingIt->second.parentDriveDbId != info.driveDbId()) {
+        unlinkSyncFromDrive(info.dbId(), existingIt->second.parentDriveDbId);
+    }
+
+    auto &node = _syncsByDbId[info.dbId()];
+    node.info = info;
+    node.parentDriveDbId = info.driveDbId();
+    linkSyncToDrive(info.dbId(), info.driveDbId());
     emit syncsChanged();
 }
 
 void AppCache::removeSync(const SyncDbId syncDbId) {
-    if (!removeById(_syncs, syncDbId, [](const SyncInfo &sync) { return sync.dbId(); })) {
+    if (!_syncsByDbId.contains(syncDbId)) {
         return;
     }
-    const bool selectionChanged = _selectedSyncDbId == syncDbId;
-    if (selectionChanged) {
-        _selectedSyncDbId = 0;
-    }
+    removeSyncCascade(syncDbId);
     emit syncsChanged();
-    if (selectionChanged) {
-        emit selectedSyncDbIdChanged();
-    }
+    emit syncErrorsChanged();
 }
 
-void AppCache::upsertError(const ErrorInfo &info) {
-    upsertById(_errors, info, info.dbId(), [](const ErrorInfo &error) { return error.dbId(); });
-    emit errorsChanged();
-}
-
-void AppCache::removeError(const ErrorDbId errorDbId) {
-    if (!removeById(_errors, errorDbId, [](const ErrorInfo &error) { return error.dbId(); })) {
+void AppCache::upsertSyncError(const ErrorInfo &info) {
+    if (!_syncsByDbId.contains(info.syncDbId())) {
         return;
     }
-    emit errorsChanged();
+
+    if (const auto existingIt = _syncErrorsByDbId.find(info.dbId());
+        existingIt != _syncErrorsByDbId.end() && existingIt->second.syncDbId() != info.syncDbId()) {
+        unlinkErrorFromSync(info.dbId(), existingIt->second.syncDbId());
+    }
+
+    _syncErrorsByDbId[info.dbId()] = info;
+    linkErrorToSync(info.dbId(), info.syncDbId());
+    emit syncErrorsChanged();
+}
+
+void AppCache::removeSyncError(const ErrorDbId errorDbId) {
+    const auto errorIt = _syncErrorsByDbId.find(errorDbId);
+    if (errorIt == _syncErrorsByDbId.end()) {
+        return;
+    }
+    unlinkErrorFromSync(errorDbId, errorIt->second.syncDbId());
+    _syncErrorsByDbId.erase(errorIt);
+    emit syncErrorsChanged();
+}
+
+void AppCache::upsertServerError(const ErrorInfo &info) {
+    _serverErrorsByDbId[info.dbId()] = info;
+    emit serverErrorsChanged();
+}
+
+void AppCache::removeServerError(const ErrorDbId errorDbId) {
+    if (_serverErrorsByDbId.erase(errorDbId) == 0) {
+        return;
+    }
+    emit serverErrorsChanged();
 }
 
 } // namespace KDC

--- a/src/gui4/linux/app/cache/appcache.cpp
+++ b/src/gui4/linux/app/cache/appcache.cpp
@@ -75,7 +75,8 @@ void AppCache::replaceAccounts(const std::vector<AccountInfo> &accounts) {
     _accountsByDbId.clear();
     for (const auto &info: accounts) {
         if (!_usersByDbId.contains(info.userDbId())) {
-            qCWarning(lcAppCache) << "Account dropped during replace | accountDbId:" << info.dbId() << "/ unknown userDbId:" << info.userDbId();
+            qCWarning(lcAppCache) << "Account dropped during replace | accountDbId:" << info.dbId()
+                                  << "/ unknown userDbId:" << info.userDbId();
             continue;
         }
         _accountsByDbId[info.dbId()] = AccountNode{info, info.userDbId(), {}};
@@ -94,7 +95,8 @@ void AppCache::replaceDrives(const std::vector<DriveInfo> &drives) {
     _drivesByDbId.clear();
     for (const auto &info: drives) {
         if (!_accountsByDbId.contains(info.accountDbId())) {
-            qCWarning(lcAppCache) << "Drive dropped during replace | driveDbId:" << info.dbId() << "/ unknown accountDbId:" << info.accountDbId();
+            qCWarning(lcAppCache) << "Drive dropped during replace | driveDbId:" << info.dbId()
+                                  << "/ unknown accountDbId:" << info.accountDbId();
             continue;
         }
         _drivesByDbId[info.dbId()] = DriveNode{info, info.accountDbId(), {}};
@@ -112,7 +114,8 @@ void AppCache::replaceSyncs(const std::vector<SyncInfo> &syncs) {
     _syncsByDbId.clear();
     for (const auto &info: syncs) {
         if (!_drivesByDbId.contains(info.driveDbId())) {
-            qCWarning(lcAppCache) << "Sync dropped during replace | syncDbId:" << info.dbId() << "/ unknown driveDbId:" << info.driveDbId();
+            qCWarning(lcAppCache) << "Sync dropped during replace | syncDbId:" << info.dbId()
+                                  << "/ unknown driveDbId:" << info.driveDbId();
             continue;
         }
         _syncsByDbId[info.dbId()] = SyncNode{info, info.driveDbId(), {}};
@@ -129,7 +132,8 @@ void AppCache::replaceSyncErrors(const std::vector<ErrorInfo> &errors) {
     _syncErrorsByDbId.clear();
     for (const auto &info: errors) {
         if (!_syncsByDbId.contains(info.syncDbId())) {
-            qCWarning(lcAppCache) << "Sync error dropped during replace | errorDbId:" << info.dbId() << "/ unknown syncDbId:" << info.syncDbId();
+            qCWarning(lcAppCache) << "Sync error dropped during replace | errorDbId:" << info.dbId()
+                                  << "/ unknown syncDbId:" << info.syncDbId();
             continue;
         }
         _syncErrorsByDbId[info.dbId()] = info;
@@ -202,7 +206,8 @@ void AppCache::removeUser(const UserDbId userDbId) {
 
 void AppCache::upsertAccount(const AccountInfo &info) {
     if (!_usersByDbId.contains(info.userDbId())) {
-        qCWarning(lcAppCache) << "Account upsert dropped | accountDbId:" << info.dbId() << "/ unknown userDbId:" << info.userDbId();
+        qCWarning(lcAppCache) << "Account upsert dropped | accountDbId:" << info.dbId()
+                              << "/ unknown userDbId:" << info.userDbId();
         return;
     }
 
@@ -233,7 +238,8 @@ void AppCache::removeAccount(const AccountDbId accountDbId) {
 
 void AppCache::upsertDrive(const DriveInfo &info) {
     if (!_accountsByDbId.contains(info.accountDbId())) {
-        qCWarning(lcAppCache) << "Drive upsert dropped | driveDbId:" << info.dbId() << "/ unknown accountDbId:" << info.accountDbId();
+        qCWarning(lcAppCache) << "Drive upsert dropped | driveDbId:" << info.dbId()
+                              << "/ unknown accountDbId:" << info.accountDbId();
         return;
     }
 
@@ -292,7 +298,8 @@ void AppCache::removeSync(const SyncDbId syncDbId) {
 
 void AppCache::upsertSyncError(const ErrorInfo &info) {
     if (!_syncsByDbId.contains(info.syncDbId())) {
-        qCWarning(lcAppCache) << "Sync error upsert dropped | errorDbId:" << info.dbId() << "/ unknown syncDbId:" << info.syncDbId();
+        qCWarning(lcAppCache) << "Sync error upsert dropped | errorDbId:" << info.dbId()
+                              << "/ unknown syncDbId:" << info.syncDbId();
         return;
     }
 

--- a/src/gui4/linux/app/cache/appcache.cpp
+++ b/src/gui4/linux/app/cache/appcache.cpp
@@ -189,7 +189,7 @@ void AppCache::removeUser(const UserDbId userDbId) {
     for (const auto accountDbIds = userIt->second.accountDbIds; const auto accountDbId: accountDbIds) {
         removeAccountCascade(accountDbId);
     }
-    _usersByDbId.erase(userIt);
+    (void) _usersByDbId.erase(userIt);
     const bool hadAvailableDrives = _availableDrivesByUserDbId.erase(userDbId) > 0;
 
     emit usersChanged();
@@ -314,7 +314,7 @@ void AppCache::removeSyncError(const ErrorDbId errorDbId) {
     }
     qCDebug(lcAppCache) << "Sync error removed | dbId:" << errorDbId;
     unlinkErrorFromSync(errorDbId, errorIt->second.syncDbId());
-    _syncErrorsByDbId.erase(errorIt);
+    (void) _syncErrorsByDbId.erase(errorIt);
     emit syncErrorsChanged();
 }
 

--- a/src/gui4/linux/app/cache/appcache.cpp
+++ b/src/gui4/linux/app/cache/appcache.cpp
@@ -77,7 +77,6 @@ void AppCache::replaceAccounts(const std::vector<AccountInfo> &accounts) {
             continue;
         }
         _accountsByDbId[info.dbId()] = AccountNode{info, info.userDbId(), {}};
-        linkAccountToUser(info.dbId(), info.userDbId());
     }
     pruneConfiguredGraph();
     emit accountsChanged();
@@ -96,7 +95,6 @@ void AppCache::replaceDrives(const std::vector<DriveInfo> &drives) {
             continue;
         }
         _drivesByDbId[info.dbId()] = DriveNode{info, info.accountDbId(), {}};
-        linkDriveToAccount(info.dbId(), info.accountDbId());
     }
     pruneConfiguredGraph();
     emit drivesChanged();
@@ -114,7 +112,6 @@ void AppCache::replaceSyncs(const std::vector<SyncInfo> &syncs) {
             continue;
         }
         _syncsByDbId[info.dbId()] = SyncNode{info, info.driveDbId(), {}};
-        linkSyncToDrive(info.dbId(), info.driveDbId());
     }
     pruneConfiguredGraph();
     emit syncsChanged();
@@ -171,8 +168,8 @@ void AppCache::clearAllAvailableDrives() {
 }
 
 void AppCache::upsertUser(const UserInfo &info) {
-    auto &[userInfo, _] = _usersByDbId[info.dbId()];
-    userInfo = info;
+    auto &node = _usersByDbId[info.dbId()];
+    node.info = info;
     emit usersChanged();
 }
 

--- a/src/gui4/linux/app/cache/appcache.h
+++ b/src/gui4/linux/app/cache/appcache.h
@@ -20,7 +20,10 @@
 
 #include "app/cache/cachetypes.h"
 
+#include <QLoggingCategory>
 #include <QObject>
+
+Q_DECLARE_LOGGING_CATEGORY(lcAppCache)
 
 #include <optional>
 #include <unordered_map>

--- a/src/gui4/linux/app/cache/appcache.h
+++ b/src/gui4/linux/app/cache/appcache.h
@@ -23,11 +23,11 @@
 #include <QLoggingCategory>
 #include <QObject>
 
-Q_DECLARE_LOGGING_CATEGORY(lcAppCache)
-
 #include <optional>
 #include <unordered_map>
 #include <vector>
+
+Q_DECLARE_LOGGING_CATEGORY(lcAppCache)
 
 namespace KDC {
 

--- a/src/gui4/linux/app/cache/appcache.h
+++ b/src/gui4/linux/app/cache/appcache.h
@@ -18,67 +18,82 @@
 
 #pragma once
 
-#include "libcommon/utility/types.h"
-#include "libcommon/info/accountinfo.h"
-#include "libcommon/info/driveavailableinfo.h"
-#include "libcommon/info/driveinfo.h"
-#include "libcommon/info/errorinfo.h"
-#include "libcommon/info/syncinfo.h"
-#include "libcommon/info/userinfo.h"
+#include "app/cache/cachetypes.h"
 
 #include <QObject>
 
+#include <optional>
+#include <unordered_map>
 #include <vector>
 
 namespace KDC {
 
 /**
- * Central observable cache for Linux v4 UI-facing state.
+ * Durable graph-backed cache and query layer for Linux v4 product state.
  *
- * The cache stores typed snapshots and incremental updates coming from C++ services.
- * QML-facing services and list models should read from this cache instead of parsing
- * transport payloads directly.
+ * Role: own configured entities, per-user available drives, graph relations, and derived read models.
+ * All mutations must run on the Qt main thread.
  */
 class AppCache : public QObject {
         Q_OBJECT
-        Q_PROPERTY(bool connected READ connected WRITE setConnected NOTIFY connectedChanged)
-        Q_PROPERTY(qint64 selectedUserDbId READ selectedUserDbId NOTIFY selectedUserDbIdChanged)
-        Q_PROPERTY(qint64 selectedDriveDbId READ selectedDriveDbId NOTIFY selectedDriveDbIdChanged)
-        Q_PROPERTY(qint64 selectedSyncDbId READ selectedSyncDbId NOTIFY selectedSyncDbIdChanged)
 
     public:
         explicit AppCache(QObject *parent = nullptr);
 
-        bool connected() const { return _connected; }
-        qint64 selectedUserDbId() const;
-        qint64 selectedDriveDbId() const;
-        qint64 selectedSyncDbId() const;
+        // Flat snapshots rebuilt from the canonical graph for compatibility with list consumers.
+        [[nodiscard]] std::vector<UserInfo> users() const;
+        [[nodiscard]] std::vector<AccountInfo> accounts() const;
+        [[nodiscard]] std::vector<DriveInfo> drives() const;
+        [[nodiscard]] std::vector<SyncInfo> syncs() const;
+        [[nodiscard]] std::vector<ErrorInfo> syncErrors() const;
+        [[nodiscard]] std::vector<ErrorInfo> serverErrors() const;
+        // Returns the addable-drive snapshot scoped to one user. This is not tied to main selection.
+        [[nodiscard]] std::vector<DriveAvailableInfo> availableDrives(UserDbId userDbId) const;
 
-        const std::vector<UserInfo> &users() const { return _users; }
-        const std::vector<AccountInfo> &accounts() const { return _accounts; }
-        const std::vector<DriveInfo> &drives() const { return _drives; }
-        // Available drives for the currently selected user context.
-        const std::vector<DriveAvailableInfo> &availableDrives() const { return _availableDrives; }
-        const std::vector<SyncInfo> &syncs() const { return _syncs; }
-        const std::vector<ErrorInfo> &errors() const { return _errors; }
+        // Direct id-based lookups. Missing or orphaned entities are returned as std::nullopt.
+        [[nodiscard]] std::optional<UserInfo> user(UserDbId userDbId) const;
+        [[nodiscard]] std::optional<AccountInfo> account(AccountDbId accountDbId) const;
+        [[nodiscard]] std::optional<DriveInfo> drive(DriveDbId driveDbId) const;
+        [[nodiscard]] std::optional<SyncInfo> sync(SyncDbId syncDbId) const;
+        [[nodiscard]] std::optional<ErrorInfo> syncError(ErrorDbId errorDbId) const;
+        [[nodiscard]] std::optional<ErrorInfo> serverError(ErrorDbId errorDbId) const;
+        [[nodiscard]] std::optional<DriveAvailableInfo> availableDrive(const AvailableDriveKey &key) const;
 
-        void setConnected(bool connected);
-        // C++-only setters — not exposed via Q_PROPERTY WRITE; QML observes these as read-only properties.
-        void setSelectedUserDbId(qint64 userDbId);
-        void setSelectedDriveDbId(qint64 driveDbId);
-        void setSelectedSyncDbId(qint64 syncDbId);
+        // Parent-to-children graph traversal helpers. Results are stable-sorted by database id.
+        [[nodiscard]] std::vector<AccountInfo> accountsForUser(UserDbId userDbId) const;
+        [[nodiscard]] std::vector<DriveInfo> drivesForAccount(AccountDbId accountDbId) const;
+        [[nodiscard]] std::vector<SyncInfo> syncsForDrive(DriveDbId driveDbId) const;
+        // Sync-scoped errors sorted by error time, oldest first.
+        [[nodiscard]] std::vector<ErrorInfo> errorsForSync(SyncDbId syncDbId) const;
+        [[nodiscard]] std::vector<ErrorInfo> syncErrors(SyncDbId syncDbId) const;
 
+        // Derived read models used by sidebar, settings, and onboarding adapters.
+        // A context is omitted when its full parent chain cannot be resolved.
+        [[nodiscard]] std::optional<SyncContext> syncContext(SyncDbId syncDbId) const;
+        [[nodiscard]] std::vector<SyncContext> syncContexts() const;
+        [[nodiscard]] std::optional<DriveContext> driveContext(DriveDbId driveDbId) const;
+        [[nodiscard]] std::vector<DriveContext> driveContexts() const;
+        // Available-drive contexts reconcile addable drives with configured drives for display/disable decisions.
+        [[nodiscard]] std::vector<AvailableDriveContext> availableDriveContexts(UserDbId userDbId) const;
+        [[nodiscard]] std::vector<AvailableDriveContext> availableDriveContexts() const;
+
+        // Clears all cached product state. Transport/connection state is intentionally not represented here.
         void clearAll();
 
+        // Atomic family snapshot replacements. Orphans are pruned so the graph remains coherent.
         void replaceUsers(const std::vector<UserInfo> &users);
         void replaceAccounts(const std::vector<AccountInfo> &accounts);
         void replaceDrives(const std::vector<DriveInfo> &drives);
-        // Replaces the current selected-user available drives snapshot.
-        void replaceAvailableDrives(const std::vector<DriveAvailableInfo> &availableDrives);
         void replaceSyncs(const std::vector<SyncInfo> &syncs);
-        void replaceErrors(const std::vector<ErrorInfo> &errors);
+        void replaceSyncErrors(const std::vector<ErrorInfo> &errors);
+        void replaceServerErrors(const std::vector<ErrorInfo> &errors);
+        // Replaces only one user's addable-drive snapshot; other users' snapshots are preserved.
+        void replaceAvailableDrivesForUser(UserDbId userDbId, const std::vector<DriveAvailableInfo> &availableDrives);
+        void clearAvailableDrivesForUser(UserDbId userDbId);
+        void clearAllAvailableDrives();
 
     public slots:
+        // Incremental entity mutations used by push-signal wiring. Remove methods own descendant cascade cleanup.
         void upsertUser(const UserInfo &info);
         void removeUser(UserDbId userDbId);
 
@@ -91,34 +106,76 @@ class AppCache : public QObject {
         void upsertSync(const SyncInfo &info);
         void removeSync(SyncDbId syncDbId);
 
-        void upsertError(const ErrorInfo &info);
-        void removeError(ErrorDbId errorDbId);
+        void upsertSyncError(const ErrorInfo &info);
+        void removeSyncError(ErrorDbId errorDbId);
+        void upsertServerError(const ErrorInfo &info);
+        void removeServerError(ErrorDbId errorDbId);
 
     signals:
-        void connectedChanged();
-        void selectedUserDbIdChanged();
-        void selectedDriveDbIdChanged();
-        void selectedSyncDbIdChanged();
-
+        // Coarse invalidation signals. Current QML-facing adapters should rebuild their read models from queries.
         void usersChanged();
         void accountsChanged();
         void drivesChanged();
-        void availableDrivesChanged();
         void syncsChanged();
-        void errorsChanged();
+        void syncErrorsChanged();
+        void serverErrorsChanged();
+        void availableDrivesChanged(UserDbId userDbId);
+        void allAvailableDrivesChanged();
 
     private:
-        bool _connected{false};
-        UserDbId _selectedUserDbId{0};
-        DriveDbId _selectedDriveDbId{0};
-        SyncDbId _selectedSyncDbId{0};
+        struct UserNode {
+                UserInfo info;
+                std::vector<AccountDbId> accountDbIds;
+        };
 
-        std::vector<UserInfo> _users;
-        std::vector<AccountInfo> _accounts;
-        std::vector<DriveInfo> _drives;
-        std::vector<DriveAvailableInfo> _availableDrives;
-        std::vector<SyncInfo> _syncs;
-        std::vector<ErrorInfo> _errors;
+        struct AccountNode {
+                AccountInfo info;
+                UserDbId parentUserDbId{0};
+                std::vector<DriveDbId> driveDbIds;
+        };
+
+        struct DriveNode {
+                DriveInfo info;
+                AccountDbId parentAccountDbId{0};
+                std::vector<SyncDbId> syncDbIds;
+        };
+
+        struct SyncNode {
+                SyncInfo info;
+                DriveDbId parentDriveDbId{0};
+                std::vector<ErrorDbId> errorDbIds;
+        };
+
+        // Maintains canonical parent-child relation lists when entities move or are replaced.
+        void linkAccountToUser(AccountDbId accountDbId, UserDbId userDbId);
+        void unlinkAccountFromUser(AccountDbId accountDbId, UserDbId userDbId);
+        void linkDriveToAccount(DriveDbId driveDbId, AccountDbId accountDbId);
+        void unlinkDriveFromAccount(DriveDbId driveDbId, AccountDbId accountDbId);
+        void linkSyncToDrive(SyncDbId syncDbId, DriveDbId driveDbId);
+        void unlinkSyncFromDrive(SyncDbId syncDbId, DriveDbId driveDbId);
+        void linkErrorToSync(ErrorDbId errorDbId, SyncDbId syncDbId);
+        void unlinkErrorFromSync(ErrorDbId errorDbId, SyncDbId syncDbId);
+
+        // Cascade helpers remove descendants without emitting signals; public removals emit the final invalidations.
+        void removeAccountCascade(AccountDbId accountDbId);
+        void removeDriveCascade(DriveDbId driveDbId);
+        void removeSyncCascade(SyncDbId syncDbId);
+
+        // Prunes orphan entities after snapshot replacement and rebuilds child id lists from canonical maps.
+        void pruneConfiguredGraph();
+        void rebuildGraphRelations();
+
+        // Resolve configured-account/drive matches for addable-drive read models.
+        [[nodiscard]] std::optional<AccountInfo> accountForAvailableDrive(UserDbId userDbId, AccountId accountId) const;
+        [[nodiscard]] std::optional<DriveInfo> configuredDriveForAvailableDrive(AccountDbId accountDbId, DriveId driveId) const;
+
+        std::unordered_map<UserDbId, UserNode> _usersByDbId;
+        std::unordered_map<AccountDbId, AccountNode> _accountsByDbId;
+        std::unordered_map<DriveDbId, DriveNode> _drivesByDbId;
+        std::unordered_map<SyncDbId, SyncNode> _syncsByDbId;
+        std::unordered_map<ErrorDbId, ErrorInfo> _syncErrorsByDbId;
+        std::unordered_map<ErrorDbId, ErrorInfo> _serverErrorsByDbId;
+        std::unordered_map<UserDbId, std::vector<DriveAvailableInfo>> _availableDrivesByUserDbId;
 };
 
 } // namespace KDC

--- a/src/gui4/linux/app/cache/appcache.h
+++ b/src/gui4/linux/app/cache/appcache.h
@@ -68,7 +68,6 @@ class AppCache : public QObject {
         [[nodiscard]] std::vector<SyncInfo> syncsForDrive(DriveDbId driveDbId) const;
         // Sync-scoped errors sorted by error time, oldest first.
         [[nodiscard]] std::vector<ErrorInfo> errorsForSync(SyncDbId syncDbId) const;
-        [[nodiscard]] std::vector<ErrorInfo> syncErrors(SyncDbId syncDbId) const;
 
         // Derived read models used by sidebar, settings, and onboarding adapters.
         // A context is omitted when its full parent chain cannot be resolved.

--- a/src/gui4/linux/app/cache/appcachegraph.cpp
+++ b/src/gui4/linux/app/cache/appcachegraph.cpp
@@ -22,12 +22,14 @@
 #include <algorithm>
 #include <ranges>
 
+Q_LOGGING_CATEGORY(lcAppCache, "gui.v4.appcache", QtInfoMsg)
+
 namespace {
 template<typename IdType>
 void appendUnique(std::vector<IdType> &values, const IdType id) {
     const auto insertIt = std::ranges::lower_bound(values, id);
     if (insertIt == values.end() || *insertIt != id) {
-        values.insert(insertIt, id);
+        (void) values.insert(insertIt, id);
     }
 }
 
@@ -97,7 +99,7 @@ void AppCache::removeAccountCascade(const AccountDbId accountDbId) {
         removeDriveCascade(driveDbId);
     }
     unlinkAccountFromUser(accountDbId, accountIt->second.parentUserDbId);
-    _accountsByDbId.erase(accountIt);
+    (void) _accountsByDbId.erase(accountIt);
 }
 
 void AppCache::removeDriveCascade(const DriveDbId driveDbId) {
@@ -110,7 +112,7 @@ void AppCache::removeDriveCascade(const DriveDbId driveDbId) {
         removeSyncCascade(syncDbId);
     }
     unlinkDriveFromAccount(driveDbId, driveIt->second.parentAccountDbId);
-    _drivesByDbId.erase(driveIt);
+    (void) _drivesByDbId.erase(driveIt);
 }
 
 void AppCache::removeSyncCascade(const SyncDbId syncDbId) {
@@ -120,10 +122,12 @@ void AppCache::removeSyncCascade(const SyncDbId syncDbId) {
     }
 
     for (const auto errorDbId: syncIt->second.errorDbIds) {
-        _syncErrorsByDbId.erase(errorDbId);
+        if (_syncErrorsByDbId.erase(errorDbId) == 0) {
+            qCWarning(lcAppCache) << "Sync error absent during cascade removal | errorDbId:" << errorDbId << "/ syncDbId:" << syncDbId;
+        }
     }
     unlinkSyncFromDrive(syncDbId, syncIt->second.parentDriveDbId);
-    _syncsByDbId.erase(syncIt);
+    (void) _syncsByDbId.erase(syncIt);
 }
 
 void AppCache::pruneConfiguredGraph() {
@@ -157,7 +161,9 @@ void AppCache::pruneConfiguredGraph() {
         removeSyncCascade(syncDbId);
     }
 
-    std::erase_if(_availableDrivesByUserDbId, [this](const auto &entry) { return !_usersByDbId.contains(entry.first); });
+    (void) std::erase_if(_syncErrorsByDbId,
+                         [this](const auto &entry) { return !_syncsByDbId.contains(entry.second.syncDbId()); });
+    (void) std::erase_if(_availableDrivesByUserDbId, [this](const auto &entry) { return !_usersByDbId.contains(entry.first); });
     rebuildGraphRelations();
 }
 

--- a/src/gui4/linux/app/cache/appcachegraph.cpp
+++ b/src/gui4/linux/app/cache/appcachegraph.cpp
@@ -35,7 +35,7 @@ void appendUnique(std::vector<IdType> &values, const IdType id) {
 
 template<typename IdType>
 void removeValue(std::vector<IdType> &values, const IdType id) {
-    std::erase(values, id);
+    (void) std::erase(values, id);
 }
 } // namespace
 

--- a/src/gui4/linux/app/cache/appcachegraph.cpp
+++ b/src/gui4/linux/app/cache/appcachegraph.cpp
@@ -123,7 +123,8 @@ void AppCache::removeSyncCascade(const SyncDbId syncDbId) {
 
     for (const auto errorDbId: syncIt->second.errorDbIds) {
         if (_syncErrorsByDbId.erase(errorDbId) == 0) {
-            qCWarning(lcAppCache) << "Sync error absent during cascade removal | errorDbId:" << errorDbId << "/ syncDbId:" << syncDbId;
+            qCWarning(lcAppCache) << "Sync error absent during cascade removal | errorDbId:" << errorDbId
+                                  << "/ syncDbId:" << syncDbId;
         }
     }
     unlinkSyncFromDrive(syncDbId, syncIt->second.parentDriveDbId);

--- a/src/gui4/linux/app/cache/appcachegraph.cpp
+++ b/src/gui4/linux/app/cache/appcachegraph.cpp
@@ -1,0 +1,192 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include "appcache.h"
+
+#include <algorithm>
+#include <ranges>
+
+namespace {
+template<typename IdType>
+void appendUnique(std::vector<IdType> &values, const IdType id) {
+    if (std::ranges::find(values, id) == values.end()) {
+        values.push_back(id);
+        std::ranges::sort(values);
+    }
+}
+
+template<typename IdType>
+void removeValue(std::vector<IdType> &values, const IdType id) {
+    std::erase(values, id);
+}
+} // namespace
+
+namespace KDC {
+
+void AppCache::linkAccountToUser(const AccountDbId accountDbId, const UserDbId userDbId) {
+    if (const auto userIt = _usersByDbId.find(userDbId); userIt != _usersByDbId.end()) {
+        appendUnique(userIt->second.accountDbIds, accountDbId);
+    }
+}
+
+void AppCache::unlinkAccountFromUser(const AccountDbId accountDbId, const UserDbId userDbId) {
+    if (const auto userIt = _usersByDbId.find(userDbId); userIt != _usersByDbId.end()) {
+        removeValue(userIt->second.accountDbIds, accountDbId);
+    }
+}
+
+void AppCache::linkDriveToAccount(const DriveDbId driveDbId, const AccountDbId accountDbId) {
+    if (const auto accountIt = _accountsByDbId.find(accountDbId); accountIt != _accountsByDbId.end()) {
+        appendUnique(accountIt->second.driveDbIds, driveDbId);
+    }
+}
+
+void AppCache::unlinkDriveFromAccount(const DriveDbId driveDbId, const AccountDbId accountDbId) {
+    if (const auto accountIt = _accountsByDbId.find(accountDbId); accountIt != _accountsByDbId.end()) {
+        removeValue(accountIt->second.driveDbIds, driveDbId);
+    }
+}
+
+void AppCache::linkSyncToDrive(const SyncDbId syncDbId, const DriveDbId driveDbId) {
+    if (const auto driveIt = _drivesByDbId.find(driveDbId); driveIt != _drivesByDbId.end()) {
+        appendUnique(driveIt->second.syncDbIds, syncDbId);
+    }
+}
+
+void AppCache::unlinkSyncFromDrive(const SyncDbId syncDbId, const DriveDbId driveDbId) {
+    if (const auto driveIt = _drivesByDbId.find(driveDbId); driveIt != _drivesByDbId.end()) {
+        removeValue(driveIt->second.syncDbIds, syncDbId);
+    }
+}
+
+void AppCache::linkErrorToSync(const ErrorDbId errorDbId, const SyncDbId syncDbId) {
+    if (const auto syncIt = _syncsByDbId.find(syncDbId); syncIt != _syncsByDbId.end()) {
+        appendUnique(syncIt->second.errorDbIds, errorDbId);
+    }
+}
+
+void AppCache::unlinkErrorFromSync(const ErrorDbId errorDbId, const SyncDbId syncDbId) {
+    if (const auto syncIt = _syncsByDbId.find(syncDbId); syncIt != _syncsByDbId.end()) {
+        removeValue(syncIt->second.errorDbIds, errorDbId);
+    }
+}
+
+void AppCache::removeAccountCascade(const AccountDbId accountDbId) {
+    const auto accountIt = _accountsByDbId.find(accountDbId);
+    if (accountIt == _accountsByDbId.end()) {
+        return;
+    }
+
+    for (const auto driveDbIds = accountIt->second.driveDbIds; const auto driveDbId: driveDbIds) {
+        removeDriveCascade(driveDbId);
+    }
+    unlinkAccountFromUser(accountDbId, accountIt->second.parentUserDbId);
+    _accountsByDbId.erase(accountIt);
+}
+
+void AppCache::removeDriveCascade(const DriveDbId driveDbId) {
+    const auto driveIt = _drivesByDbId.find(driveDbId);
+    if (driveIt == _drivesByDbId.end()) {
+        return;
+    }
+
+    for (const auto syncDbIds = driveIt->second.syncDbIds; const auto syncDbId: syncDbIds) {
+        removeSyncCascade(syncDbId);
+    }
+    unlinkDriveFromAccount(driveDbId, driveIt->second.parentAccountDbId);
+    _drivesByDbId.erase(driveIt);
+}
+
+void AppCache::removeSyncCascade(const SyncDbId syncDbId) {
+    const auto syncIt = _syncsByDbId.find(syncDbId);
+    if (syncIt == _syncsByDbId.end()) {
+        return;
+    }
+
+    for (const auto errorDbId: syncIt->second.errorDbIds) {
+        _syncErrorsByDbId.erase(errorDbId);
+    }
+    unlinkSyncFromDrive(syncDbId, syncIt->second.parentDriveDbId);
+    _syncsByDbId.erase(syncIt);
+}
+
+void AppCache::pruneConfiguredGraph() {
+    std::vector<AccountDbId> orphanAccountIds;
+    for (const auto &[accountDbId, node]: _accountsByDbId) {
+        if (!_usersByDbId.contains(node.parentUserDbId)) {
+            orphanAccountIds.push_back(accountDbId);
+        }
+    }
+    for (const auto accountDbId: orphanAccountIds) {
+        removeAccountCascade(accountDbId);
+    }
+
+    std::vector<DriveDbId> orphanDriveIds;
+    for (const auto &[driveDbId, node]: _drivesByDbId) {
+        if (!_accountsByDbId.contains(node.parentAccountDbId)) {
+            orphanDriveIds.push_back(driveDbId);
+        }
+    }
+    for (const auto driveDbId: orphanDriveIds) {
+        removeDriveCascade(driveDbId);
+    }
+
+    std::vector<SyncDbId> orphanSyncIds;
+    for (const auto &[syncDbId, node]: _syncsByDbId) {
+        if (!_drivesByDbId.contains(node.parentDriveDbId)) {
+            orphanSyncIds.push_back(syncDbId);
+        }
+    }
+    for (const auto syncDbId: orphanSyncIds) {
+        removeSyncCascade(syncDbId);
+    }
+
+    std::erase_if(_availableDrivesByUserDbId, [this](const auto &entry) { return !_usersByDbId.contains(entry.first); });
+    rebuildGraphRelations();
+}
+
+void AppCache::rebuildGraphRelations() {
+    for (auto &[_, accountDbIds]: _usersByDbId | std::views::values) {
+        accountDbIds.clear();
+    }
+    for (auto &accountNode: _accountsByDbId | std::views::values) {
+        accountNode.driveDbIds.clear();
+    }
+    for (auto &driveNode: _drivesByDbId | std::views::values) {
+        driveNode.syncDbIds.clear();
+    }
+    for (auto &syncNode: _syncsByDbId | std::views::values) {
+        syncNode.errorDbIds.clear();
+    }
+
+    for (const auto &[accountDbId, accountNode]: _accountsByDbId) {
+        linkAccountToUser(accountDbId, accountNode.parentUserDbId);
+    }
+    for (const auto &[driveDbId, driveNode]: _drivesByDbId) {
+        linkDriveToAccount(driveDbId, driveNode.parentAccountDbId);
+    }
+    for (const auto &[syncDbId, syncNode]: _syncsByDbId) {
+        linkSyncToDrive(syncDbId, syncNode.parentDriveDbId);
+    }
+    for (const auto &[errorDbId, errorInfo]: _syncErrorsByDbId) {
+        linkErrorToSync(errorDbId, errorInfo.syncDbId());
+    }
+}
+
+} // namespace KDC

--- a/src/gui4/linux/app/cache/appcachegraph.cpp
+++ b/src/gui4/linux/app/cache/appcachegraph.cpp
@@ -25,9 +25,9 @@
 namespace {
 template<typename IdType>
 void appendUnique(std::vector<IdType> &values, const IdType id) {
-    if (std::ranges::find(values, id) == values.end()) {
-        values.push_back(id);
-        std::ranges::sort(values);
+    const auto insertIt = std::ranges::lower_bound(values, id);
+    if (insertIt == values.end() || *insertIt != id) {
+        values.insert(insertIt, id);
     }
 }
 
@@ -162,8 +162,8 @@ void AppCache::pruneConfiguredGraph() {
 }
 
 void AppCache::rebuildGraphRelations() {
-    for (auto &[_, accountDbIds]: _usersByDbId | std::views::values) {
-        accountDbIds.clear();
+    for (auto &userNode: _usersByDbId | std::views::values) {
+        userNode.accountDbIds.clear();
     }
     for (auto &accountNode: _accountsByDbId | std::views::values) {
         accountNode.driveDbIds.clear();

--- a/src/gui4/linux/app/cache/appcachequeries.cpp
+++ b/src/gui4/linux/app/cache/appcachequeries.cpp
@@ -34,8 +34,8 @@ namespace KDC {
 std::vector<UserInfo> AppCache::users() const {
     std::vector<UserInfo> values;
     values.reserve(_usersByDbId.size());
-    for (const auto &[info, _]: _usersByDbId | std::views::values) {
-        values.push_back(info);
+    for (const auto &node: _usersByDbId | std::views::values) {
+        values.push_back(node.info);
     }
     appendSortedById(values, [](const UserInfo &info) { return info.dbId(); });
     return values;

--- a/src/gui4/linux/app/cache/appcachequeries.cpp
+++ b/src/gui4/linux/app/cache/appcachequeries.cpp
@@ -240,10 +240,6 @@ std::vector<ErrorInfo> AppCache::errorsForSync(const SyncDbId syncDbId) const {
     return values;
 }
 
-std::vector<ErrorInfo> AppCache::syncErrors(const SyncDbId syncDbId) const {
-    return errorsForSync(syncDbId);
-}
-
 std::optional<SyncContext> AppCache::syncContext(const SyncDbId syncDbId) const {
     const auto syncIt = _syncsByDbId.find(syncDbId);
     if (syncIt == _syncsByDbId.end()) {

--- a/src/gui4/linux/app/cache/appcachequeries.cpp
+++ b/src/gui4/linux/app/cache/appcachequeries.cpp
@@ -1,0 +1,401 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include "appcache.h"
+
+#include <algorithm>
+#include <ranges>
+
+namespace {
+template<typename T, typename Getter>
+void appendSortedById(std::vector<T> &values, Getter getter) {
+    std::ranges::sort(values, [getter](const T &lhs, const T &rhs) { return getter(lhs) < getter(rhs); });
+}
+} // namespace
+
+namespace KDC {
+
+std::vector<UserInfo> AppCache::users() const {
+    std::vector<UserInfo> values;
+    values.reserve(_usersByDbId.size());
+    for (const auto &[info, _]: _usersByDbId | std::views::values) {
+        values.push_back(info);
+    }
+    appendSortedById(values, [](const UserInfo &info) { return info.dbId(); });
+    return values;
+}
+
+std::vector<AccountInfo> AppCache::accounts() const {
+    std::vector<AccountInfo> values;
+    values.reserve(_accountsByDbId.size());
+    for (const auto &node: _accountsByDbId | std::views::values) {
+        values.push_back(node.info);
+    }
+    appendSortedById(values, [](const AccountInfo &info) { return info.dbId(); });
+    return values;
+}
+
+std::vector<DriveInfo> AppCache::drives() const {
+    std::vector<DriveInfo> values;
+    values.reserve(_drivesByDbId.size());
+    for (const auto &node: _drivesByDbId | std::views::values) {
+        values.push_back(node.info);
+    }
+    appendSortedById(values, [](const DriveInfo &info) { return info.dbId(); });
+    return values;
+}
+
+std::vector<SyncInfo> AppCache::syncs() const {
+    std::vector<SyncInfo> values;
+    values.reserve(_syncsByDbId.size());
+    for (const auto &node: _syncsByDbId | std::views::values) {
+        values.push_back(node.info);
+    }
+    appendSortedById(values, [](const SyncInfo &info) { return info.dbId(); });
+    return values;
+}
+
+std::vector<ErrorInfo> AppCache::syncErrors() const {
+    std::vector<ErrorInfo> values;
+    values.reserve(_syncErrorsByDbId.size());
+    for (const auto &info: _syncErrorsByDbId | std::views::values) {
+        values.push_back(info);
+    }
+    appendSortedById(values, [](const ErrorInfo &info) { return info.dbId(); });
+    return values;
+}
+
+std::vector<ErrorInfo> AppCache::serverErrors() const {
+    std::vector<ErrorInfo> values;
+    values.reserve(_serverErrorsByDbId.size());
+    for (const auto &info: _serverErrorsByDbId | std::views::values) {
+        values.push_back(info);
+    }
+    appendSortedById(values, [](const ErrorInfo &info) { return info.dbId(); });
+    return values;
+}
+
+std::vector<DriveAvailableInfo> AppCache::availableDrives(const UserDbId userDbId) const {
+    const auto it = _availableDrivesByUserDbId.find(userDbId);
+    if (it == _availableDrivesByUserDbId.end()) {
+        return {};
+    }
+    auto values = it->second;
+    std::ranges::sort(values, [](const DriveAvailableInfo &lhs, const DriveAvailableInfo &rhs) {
+        if (lhs.accountId() != rhs.accountId()) {
+            return lhs.accountId() < rhs.accountId();
+        }
+        return lhs.driveId() < rhs.driveId();
+    });
+    return values;
+}
+
+std::optional<UserInfo> AppCache::user(const UserDbId userDbId) const {
+    const auto it = _usersByDbId.find(userDbId);
+    if (it == _usersByDbId.end()) {
+        return std::nullopt;
+    }
+    return it->second.info;
+}
+
+std::optional<AccountInfo> AppCache::account(const AccountDbId accountDbId) const {
+    const auto it = _accountsByDbId.find(accountDbId);
+    if (it == _accountsByDbId.end()) {
+        return std::nullopt;
+    }
+    return it->second.info;
+}
+
+std::optional<DriveInfo> AppCache::drive(const DriveDbId driveDbId) const {
+    const auto it = _drivesByDbId.find(driveDbId);
+    if (it == _drivesByDbId.end()) {
+        return std::nullopt;
+    }
+    return it->second.info;
+}
+
+std::optional<SyncInfo> AppCache::sync(const SyncDbId syncDbId) const {
+    const auto it = _syncsByDbId.find(syncDbId);
+    if (it == _syncsByDbId.end()) {
+        return std::nullopt;
+    }
+    return it->second.info;
+}
+
+std::optional<ErrorInfo> AppCache::syncError(const ErrorDbId errorDbId) const {
+    const auto it = _syncErrorsByDbId.find(errorDbId);
+    if (it == _syncErrorsByDbId.end()) {
+        return std::nullopt;
+    }
+    return it->second;
+}
+
+std::optional<ErrorInfo> AppCache::serverError(const ErrorDbId errorDbId) const {
+    const auto it = _serverErrorsByDbId.find(errorDbId);
+    if (it == _serverErrorsByDbId.end()) {
+        return std::nullopt;
+    }
+    return it->second;
+}
+
+std::optional<DriveAvailableInfo> AppCache::availableDrive(const AvailableDriveKey &key) const {
+    const auto it = _availableDrivesByUserDbId.find(key.userDbId);
+    if (it == _availableDrivesByUserDbId.end()) {
+        return std::nullopt;
+    }
+
+    const auto availableDriveIt = std::ranges::find_if(it->second, [&key](const DriveAvailableInfo &info) {
+        return info.accountId() == key.accountId && info.driveId() == key.driveId;
+    });
+    if (availableDriveIt == it->second.end()) {
+        return std::nullopt;
+    }
+    return *availableDriveIt;
+}
+
+std::vector<AccountInfo> AppCache::accountsForUser(const UserDbId userDbId) const {
+    const auto userIt = _usersByDbId.find(userDbId);
+    if (userIt == _usersByDbId.end()) {
+        return {};
+    }
+
+    std::vector<AccountInfo> values;
+    values.reserve(userIt->second.accountDbIds.size());
+    for (const auto accountDbId: userIt->second.accountDbIds) {
+        if (const auto accountInfo = account(accountDbId)) {
+            values.push_back(*accountInfo);
+        }
+    }
+    appendSortedById(values, [](const AccountInfo &info) { return info.dbId(); });
+    return values;
+}
+
+std::vector<DriveInfo> AppCache::drivesForAccount(const AccountDbId accountDbId) const {
+    const auto accountIt = _accountsByDbId.find(accountDbId);
+    if (accountIt == _accountsByDbId.end()) {
+        return {};
+    }
+
+    std::vector<DriveInfo> values;
+    values.reserve(accountIt->second.driveDbIds.size());
+    for (const auto driveDbId: accountIt->second.driveDbIds) {
+        if (const auto driveInfo = drive(driveDbId)) {
+            values.push_back(*driveInfo);
+        }
+    }
+    appendSortedById(values, [](const DriveInfo &info) { return info.dbId(); });
+    return values;
+}
+
+std::vector<SyncInfo> AppCache::syncsForDrive(const DriveDbId driveDbId) const {
+    const auto driveIt = _drivesByDbId.find(driveDbId);
+    if (driveIt == _drivesByDbId.end()) {
+        return {};
+    }
+
+    std::vector<SyncInfo> values;
+    values.reserve(driveIt->second.syncDbIds.size());
+    for (const auto syncDbId: driveIt->second.syncDbIds) {
+        if (const auto syncInfo = sync(syncDbId)) {
+            values.push_back(*syncInfo);
+        }
+    }
+    appendSortedById(values, [](const SyncInfo &info) { return info.dbId(); });
+    return values;
+}
+
+std::vector<ErrorInfo> AppCache::errorsForSync(const SyncDbId syncDbId) const {
+    const auto syncIt = _syncsByDbId.find(syncDbId);
+    if (syncIt == _syncsByDbId.end()) {
+        return {};
+    }
+
+    std::vector<ErrorInfo> values;
+    values.reserve(syncIt->second.errorDbIds.size());
+    for (const auto errorDbId: syncIt->second.errorDbIds) {
+        if (const auto errorInfo = syncError(errorDbId)) {
+            values.push_back(*errorInfo);
+        }
+    }
+    std::ranges::sort(values, [](const ErrorInfo &lhs, const ErrorInfo &rhs) { return lhs.getTime() < rhs.getTime(); });
+    return values;
+}
+
+std::vector<ErrorInfo> AppCache::syncErrors(const SyncDbId syncDbId) const {
+    return errorsForSync(syncDbId);
+}
+
+std::optional<SyncContext> AppCache::syncContext(const SyncDbId syncDbId) const {
+    const auto syncIt = _syncsByDbId.find(syncDbId);
+    if (syncIt == _syncsByDbId.end()) {
+        return std::nullopt;
+    }
+
+    const auto driveIt = _drivesByDbId.find(syncIt->second.parentDriveDbId);
+    if (driveIt == _drivesByDbId.end()) {
+        return std::nullopt;
+    }
+
+    const auto accountIt = _accountsByDbId.find(driveIt->second.parentAccountDbId);
+    if (accountIt == _accountsByDbId.end()) {
+        return std::nullopt;
+    }
+
+    const auto userIt = _usersByDbId.find(accountIt->second.parentUserDbId);
+    if (userIt == _usersByDbId.end()) {
+        return std::nullopt;
+    }
+
+    SyncContext context;
+    context.user = userIt->second.info;
+    context.account = accountIt->second.info;
+    context.drive = driveIt->second.info;
+    context.sync = syncIt->second.info;
+    context.errors = errorsForSync(syncDbId);
+    if (!context.errors.empty()) {
+        context.latestError = context.errors.back();
+    }
+    return context;
+}
+
+std::vector<SyncContext> AppCache::syncContexts() const {
+    std::vector<SyncContext> contexts;
+    contexts.reserve(_syncsByDbId.size());
+    for (const auto syncDbId: _syncsByDbId | std::views::keys) {
+        if (const auto context = syncContext(syncDbId)) {
+            contexts.push_back(*context);
+        }
+    }
+    std::ranges::sort(contexts, [](const SyncContext &lhs, const SyncContext &rhs) {
+        if (lhs.user.dbId() != rhs.user.dbId()) return lhs.user.dbId() < rhs.user.dbId();
+        if (lhs.account.dbId() != rhs.account.dbId()) return lhs.account.dbId() < rhs.account.dbId();
+        if (lhs.drive.dbId() != rhs.drive.dbId()) return lhs.drive.dbId() < rhs.drive.dbId();
+        return lhs.sync.dbId() < rhs.sync.dbId();
+    });
+    return contexts;
+}
+
+std::optional<DriveContext> AppCache::driveContext(const DriveDbId driveDbId) const {
+    const auto driveIt = _drivesByDbId.find(driveDbId);
+    if (driveIt == _drivesByDbId.end()) {
+        return std::nullopt;
+    }
+
+    const auto accountIt = _accountsByDbId.find(driveIt->second.parentAccountDbId);
+    if (accountIt == _accountsByDbId.end()) {
+        return std::nullopt;
+    }
+
+    const auto userIt = _usersByDbId.find(accountIt->second.parentUserDbId);
+    if (userIt == _usersByDbId.end()) {
+        return std::nullopt;
+    }
+
+    DriveContext context;
+    context.user = userIt->second.info;
+    context.account = accountIt->second.info;
+    context.drive = driveIt->second.info;
+    context.syncs = syncsForDrive(driveDbId);
+    return context;
+}
+
+std::vector<DriveContext> AppCache::driveContexts() const {
+    std::vector<DriveContext> contexts;
+    contexts.reserve(_drivesByDbId.size());
+    for (const auto driveDbId: _drivesByDbId | std::views::keys) {
+        if (const auto context = driveContext(driveDbId)) {
+            contexts.push_back(*context);
+        }
+    }
+    std::ranges::sort(contexts, [](const DriveContext &lhs, const DriveContext &rhs) {
+        if (lhs.user.dbId() != rhs.user.dbId()) return lhs.user.dbId() < rhs.user.dbId();
+        if (lhs.account.dbId() != rhs.account.dbId()) return lhs.account.dbId() < rhs.account.dbId();
+        return lhs.drive.dbId() < rhs.drive.dbId();
+    });
+    return contexts;
+}
+
+std::vector<AvailableDriveContext> AppCache::availableDriveContexts(const UserDbId userDbId) const {
+    const auto userInfo = user(userDbId);
+    if (!userInfo) {
+        return {};
+    }
+
+    std::vector<AvailableDriveContext> contexts;
+    for (const auto &availableDrive: availableDrives(userDbId)) {
+        AvailableDriveContext context;
+        context.user = *userInfo;
+        context.availableDrive = availableDrive;
+        context.account = accountForAvailableDrive(userDbId, availableDrive.accountId());
+        if (context.account) {
+            context.configuredDrive = configuredDriveForAvailableDrive(context.account->dbId(), availableDrive.driveId());
+            context.alreadyConfigured = context.configuredDrive.has_value();
+        }
+        contexts.push_back(context);
+    }
+    return contexts;
+}
+
+std::vector<AvailableDriveContext> AppCache::availableDriveContexts() const {
+    std::vector<AvailableDriveContext> contexts;
+    for (const auto userDbId: _availableDrivesByUserDbId | std::views::keys) {
+        auto userContexts = availableDriveContexts(userDbId);
+        contexts.insert(contexts.end(), userContexts.begin(), userContexts.end());
+    }
+    std::ranges::sort(contexts, [](const AvailableDriveContext &lhs, const AvailableDriveContext &rhs) {
+        if (lhs.user.dbId() != rhs.user.dbId()) return lhs.user.dbId() < rhs.user.dbId();
+        if (lhs.availableDrive.accountId() != rhs.availableDrive.accountId()) {
+            return lhs.availableDrive.accountId() < rhs.availableDrive.accountId();
+        }
+        return lhs.availableDrive.driveId() < rhs.availableDrive.driveId();
+    });
+    return contexts;
+}
+
+std::optional<AccountInfo> AppCache::accountForAvailableDrive(const UserDbId userDbId, const AccountId accountId) const {
+    const auto userIt = _usersByDbId.find(userDbId);
+    if (userIt == _usersByDbId.end()) {
+        return std::nullopt;
+    }
+
+    for (const auto accountDbId: userIt->second.accountDbIds) {
+        if (const auto accountIt = _accountsByDbId.find(accountDbId);
+            accountIt != _accountsByDbId.end() && accountIt->second.info.id() == accountId) {
+            return accountIt->second.info;
+        }
+    }
+    return std::nullopt;
+}
+
+std::optional<DriveInfo> AppCache::configuredDriveForAvailableDrive(const AccountDbId accountDbId, const DriveId driveId) const {
+    const auto accountIt = _accountsByDbId.find(accountDbId);
+    if (accountIt == _accountsByDbId.end()) {
+        return std::nullopt;
+    }
+
+    for (const auto driveDbId: accountIt->second.driveDbIds) {
+        if (const auto driveIt = _drivesByDbId.find(driveDbId);
+            driveIt != _drivesByDbId.end() && driveIt->second.info.id() == driveId) {
+            return driveIt->second.info;
+        }
+    }
+    return std::nullopt;
+}
+
+} // namespace KDC

--- a/src/gui4/linux/app/cache/appcachequeries.cpp
+++ b/src/gui4/linux/app/cache/appcachequeries.cpp
@@ -25,7 +25,7 @@
 namespace {
 template<typename T, typename Getter>
 void appendSortedById(std::vector<T> &values, Getter getter) {
-    std::ranges::sort(values, [getter](const T &lhs, const T &rhs) { return getter(lhs) < getter(rhs); });
+    (void) std::ranges::sort(values, [getter](const T &lhs, const T &rhs) { return getter(lhs) < getter(rhs); });
 }
 } // namespace
 
@@ -97,7 +97,7 @@ std::vector<DriveAvailableInfo> AppCache::availableDrives(const UserDbId userDbI
         return {};
     }
     auto values = it->second;
-    std::ranges::sort(values, [](const DriveAvailableInfo &lhs, const DriveAvailableInfo &rhs) {
+    (void) std::ranges::sort(values, [](const DriveAvailableInfo &lhs, const DriveAvailableInfo &rhs) {
         if (lhs.accountId() != rhs.accountId()) {
             return lhs.accountId() < rhs.accountId();
         }
@@ -141,6 +141,9 @@ std::optional<SyncInfo> AppCache::sync(const SyncDbId syncDbId) const {
 std::optional<ErrorInfo> AppCache::syncError(const ErrorDbId errorDbId) const {
     const auto it = _syncErrorsByDbId.find(errorDbId);
     if (it == _syncErrorsByDbId.end()) {
+        return std::nullopt;
+    }
+    if (!_syncsByDbId.contains(it->second.syncDbId())) {
         return std::nullopt;
     }
     return it->second;
@@ -233,7 +236,7 @@ std::vector<ErrorInfo> AppCache::errorsForSync(const SyncDbId syncDbId) const {
             values.push_back(*errorInfo);
         }
     }
-    std::ranges::sort(values, [](const ErrorInfo &lhs, const ErrorInfo &rhs) { return lhs.getTime() < rhs.getTime(); });
+    (void) std::ranges::sort(values, [](const ErrorInfo &lhs, const ErrorInfo &rhs) { return lhs.getTime() < rhs.getTime(); });
     return values;
 }
 
@@ -282,7 +285,7 @@ std::vector<SyncContext> AppCache::syncContexts() const {
             contexts.push_back(*context);
         }
     }
-    std::ranges::sort(contexts, [](const SyncContext &lhs, const SyncContext &rhs) {
+    (void) std::ranges::sort(contexts, [](const SyncContext &lhs, const SyncContext &rhs) {
         if (lhs.user.dbId() != rhs.user.dbId()) return lhs.user.dbId() < rhs.user.dbId();
         if (lhs.account.dbId() != rhs.account.dbId()) return lhs.account.dbId() < rhs.account.dbId();
         if (lhs.drive.dbId() != rhs.drive.dbId()) return lhs.drive.dbId() < rhs.drive.dbId();
@@ -323,7 +326,7 @@ std::vector<DriveContext> AppCache::driveContexts() const {
             contexts.push_back(*context);
         }
     }
-    std::ranges::sort(contexts, [](const DriveContext &lhs, const DriveContext &rhs) {
+    (void) std::ranges::sort(contexts, [](const DriveContext &lhs, const DriveContext &rhs) {
         if (lhs.user.dbId() != rhs.user.dbId()) return lhs.user.dbId() < rhs.user.dbId();
         if (lhs.account.dbId() != rhs.account.dbId()) return lhs.account.dbId() < rhs.account.dbId();
         return lhs.drive.dbId() < rhs.drive.dbId();
@@ -356,9 +359,9 @@ std::vector<AvailableDriveContext> AppCache::availableDriveContexts() const {
     std::vector<AvailableDriveContext> contexts;
     for (const auto userDbId: _availableDrivesByUserDbId | std::views::keys) {
         auto userContexts = availableDriveContexts(userDbId);
-        contexts.insert(contexts.end(), userContexts.begin(), userContexts.end());
+        (void) contexts.insert(contexts.end(), userContexts.begin(), userContexts.end());
     }
-    std::ranges::sort(contexts, [](const AvailableDriveContext &lhs, const AvailableDriveContext &rhs) {
+    (void) std::ranges::sort(contexts, [](const AvailableDriveContext &lhs, const AvailableDriveContext &rhs) {
         if (lhs.user.dbId() != rhs.user.dbId()) return lhs.user.dbId() < rhs.user.dbId();
         if (lhs.availableDrive.accountId() != rhs.availableDrive.accountId()) {
             return lhs.availableDrive.accountId() < rhs.availableDrive.accountId();

--- a/src/gui4/linux/app/cache/cachetypes.h
+++ b/src/gui4/linux/app/cache/cachetypes.h
@@ -1,0 +1,90 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "libcommon/utility/types.h"
+#include "libcommon/info/accountinfo.h"
+#include "libcommon/info/driveavailableinfo.h"
+#include "libcommon/info/driveinfo.h"
+#include "libcommon/info/errorinfo.h"
+#include "libcommon/info/syncinfo.h"
+#include "libcommon/info/userinfo.h"
+
+#include <QString>
+
+#include <cstddef>
+#include <functional>
+#include <optional>
+#include <vector>
+
+namespace KDC {
+
+struct AvailableDriveKey {
+        UserDbId userDbId{0};
+        AccountId accountId{0};
+        DriveId driveId{0};
+
+        friend bool operator==(const AvailableDriveKey &lhs, const AvailableDriveKey &rhs) {
+            return lhs.userDbId == rhs.userDbId && lhs.accountId == rhs.accountId && lhs.driveId == rhs.driveId;
+        }
+};
+
+struct SyncContext {
+        UserInfo user;
+        AccountInfo account;
+        DriveInfo drive;
+        SyncInfo sync;
+        std::vector<ErrorInfo> errors;
+        std::optional<ErrorInfo> latestError;
+};
+
+struct DriveContext {
+        UserInfo user;
+        AccountInfo account;
+        DriveInfo drive;
+        std::vector<SyncInfo> syncs;
+};
+
+struct AvailableDriveContext {
+        UserInfo user;
+        std::optional<AccountInfo> account;
+        DriveAvailableInfo availableDrive;
+        bool alreadyConfigured{false};
+        std::optional<DriveInfo> configuredDrive;
+};
+
+struct PendingSyncConfig {
+        QString localPath;
+        QString targetPath;
+        QString targetNodeId;
+        bool supportVfs{false};
+        VirtualFileMode virtualFileMode{VirtualFileMode::Off};
+};
+
+} // namespace KDC
+
+template<>
+struct std::hash<KDC::AvailableDriveKey> {
+        std::size_t operator()(const KDC::AvailableDriveKey &key) const noexcept {
+            const auto hashUser = std::hash<KDC::UserDbId>{}(key.userDbId);
+            const auto hashAccount = std::hash<KDC::AccountId>{}(key.accountId);
+            const auto hashDrive = std::hash<KDC::DriveId>{}(key.driveId);
+            return hashUser ^ (hashAccount << 1U) ^ (hashDrive << 2U);
+        }
+};

--- a/src/gui4/linux/app/cache/cachetypes.h
+++ b/src/gui4/linux/app/cache/cachetypes.h
@@ -52,6 +52,8 @@ struct SyncContext {
         SyncInfo sync;
         std::vector<ErrorInfo> errors;
         std::optional<ErrorInfo> latestError;
+
+        friend bool operator==(const SyncContext &lhs, const SyncContext &rhs) = default;
 };
 
 struct DriveContext {
@@ -59,6 +61,8 @@ struct DriveContext {
         AccountInfo account;
         DriveInfo drive;
         std::vector<SyncInfo> syncs;
+
+        friend bool operator==(const DriveContext &lhs, const DriveContext &rhs) = default;
 };
 
 struct AvailableDriveContext {
@@ -67,6 +71,8 @@ struct AvailableDriveContext {
         DriveAvailableInfo availableDrive;
         bool alreadyConfigured{false};
         std::optional<DriveInfo> configuredDrive;
+
+        friend bool operator==(const AvailableDriveContext &lhs, const AvailableDriveContext &rhs) = default;
 };
 
 struct PendingSyncConfig {

--- a/src/gui4/linux/app/cache/cachetypes.h
+++ b/src/gui4/linux/app/cache/cachetypes.h
@@ -40,9 +40,7 @@ struct AvailableDriveKey {
         AccountId accountId{0};
         DriveId driveId{0};
 
-        friend bool operator==(const AvailableDriveKey &lhs, const AvailableDriveKey &rhs) {
-            return lhs.userDbId == rhs.userDbId && lhs.accountId == rhs.accountId && lhs.driveId == rhs.driveId;
-        }
+        friend bool operator==(const AvailableDriveKey &lhs, const AvailableDriveKey &rhs) = default;
 };
 
 struct SyncContext {

--- a/src/gui4/linux/app/cache/mainselectionstore.cpp
+++ b/src/gui4/linux/app/cache/mainselectionstore.cpp
@@ -76,15 +76,21 @@ void MainSelectionStore::ensureValidSelection() {
 }
 
 void MainSelectionStore::handleSyncsChanged() {
+    const auto previousContext = currentSyncContext();
     const auto previousCurrentSyncDbId = _currentSyncDbId;
     ensureValidSelection();
-    if (_currentSyncDbId != 0 && _currentSyncDbId == previousCurrentSyncDbId) {
+    if (_currentSyncDbId != 0 && _currentSyncDbId == previousCurrentSyncDbId && previousContext != currentSyncContext()) {
         emit currentSyncContextChanged();
     }
 }
 
 void MainSelectionStore::handleContextDataChanged() {
+    const auto previousContext = currentSyncContext();
+    const auto previousCurrentSyncDbId = _currentSyncDbId;
     if (_currentSyncDbId != 0) {
+        ensureValidSelection();
+    }
+    if (_currentSyncDbId == previousCurrentSyncDbId && previousContext != currentSyncContext()) {
         emit currentSyncContextChanged();
     }
 }

--- a/src/gui4/linux/app/cache/mainselectionstore.cpp
+++ b/src/gui4/linux/app/cache/mainselectionstore.cpp
@@ -18,15 +18,17 @@
 
 #include "mainselectionstore.h"
 
+Q_LOGGING_CATEGORY(lcMainSelectionStore, "gui.v4.mainselectionstore", QtInfoMsg)
+
 namespace KDC {
 
 MainSelectionStore::MainSelectionStore(AppCache &cache, QObject *const parent) :
     QObject(parent),
     _cache(cache) {
-    (void) connect(&_cache, &AppCache::usersChanged, this, &MainSelectionStore::handleCacheChanged);
-    (void) connect(&_cache, &AppCache::accountsChanged, this, &MainSelectionStore::handleCacheChanged);
-    (void) connect(&_cache, &AppCache::drivesChanged, this, &MainSelectionStore::handleCacheChanged);
-    (void) connect(&_cache, &AppCache::syncsChanged, this, &MainSelectionStore::handleCacheChanged);
+    (void) connect(&_cache, &AppCache::syncsChanged,    this, &MainSelectionStore::handleSyncsChanged);
+    (void) connect(&_cache, &AppCache::usersChanged,    this, &MainSelectionStore::handleContextDataChanged);
+    (void) connect(&_cache, &AppCache::accountsChanged, this, &MainSelectionStore::handleContextDataChanged);
+    (void) connect(&_cache, &AppCache::drivesChanged,   this, &MainSelectionStore::handleContextDataChanged);
 }
 
 qint64 MainSelectionStore::currentSyncDbId() const {
@@ -48,6 +50,7 @@ void MainSelectionStore::selectSync(const qint64 syncDbId) {
     const auto typedSyncDbId = static_cast<SyncDbId>(syncDbId);
     _lastRequestedSyncDbId = typedSyncDbId;
     if (typedSyncDbId != 0 && !_cache.syncContext(typedSyncDbId)) {
+        qCWarning(lcMainSelectionStore) << "Requested sync not in context, falling back | syncDbId:" << typedSyncDbId;
         ensureValidSelection();
         return;
     }
@@ -72,10 +75,16 @@ void MainSelectionStore::ensureValidSelection() {
     setCurrentSyncDbId(firstAvailableSyncDbId());
 }
 
-void MainSelectionStore::handleCacheChanged() {
+void MainSelectionStore::handleSyncsChanged() {
     const auto previousCurrentSyncDbId = _currentSyncDbId;
     ensureValidSelection();
     if (_currentSyncDbId != 0 && _currentSyncDbId == previousCurrentSyncDbId) {
+        emit currentSyncContextChanged();
+    }
+}
+
+void MainSelectionStore::handleContextDataChanged() {
+    if (_currentSyncDbId != 0) {
         emit currentSyncContextChanged();
     }
 }
@@ -84,6 +93,7 @@ void MainSelectionStore::setCurrentSyncDbId(const SyncDbId syncDbId) {
     if (_currentSyncDbId == syncDbId) {
         return;
     }
+    qCDebug(lcMainSelectionStore) << "Current sync changed | from:" << _currentSyncDbId << "/ to:" << syncDbId;
     _currentSyncDbId = syncDbId;
     emit currentSyncDbIdChanged();
     emit currentSyncContextChanged();

--- a/src/gui4/linux/app/cache/mainselectionstore.cpp
+++ b/src/gui4/linux/app/cache/mainselectionstore.cpp
@@ -1,0 +1,92 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "mainselectionstore.h"
+
+namespace KDC {
+
+MainSelectionStore::MainSelectionStore(AppCache &cache, QObject *const parent) :
+    QObject(parent),
+    _cache(cache) {
+    (void) connect(&_cache, &AppCache::usersChanged, this, &MainSelectionStore::ensureValidSelection);
+    (void) connect(&_cache, &AppCache::accountsChanged, this, &MainSelectionStore::ensureValidSelection);
+    (void) connect(&_cache, &AppCache::drivesChanged, this, &MainSelectionStore::ensureValidSelection);
+    (void) connect(&_cache, &AppCache::syncsChanged, this, &MainSelectionStore::ensureValidSelection);
+}
+
+qint64 MainSelectionStore::currentSyncDbId() const {
+    return static_cast<qint64>(_currentSyncDbId);
+}
+
+std::optional<SyncContext> MainSelectionStore::currentSyncContext() const {
+    if (_currentSyncDbId == 0) {
+        return std::nullopt;
+    }
+    return _cache.syncContext(_currentSyncDbId);
+}
+
+std::vector<SyncContext> MainSelectionStore::syncContexts() const {
+    return _cache.syncContexts();
+}
+
+void MainSelectionStore::selectSync(const qint64 syncDbId) {
+    const auto typedSyncDbId = static_cast<SyncDbId>(syncDbId);
+    _lastRequestedSyncDbId = typedSyncDbId;
+    if (typedSyncDbId != 0 && !_cache.syncContext(typedSyncDbId)) {
+        ensureValidSelection();
+        return;
+    }
+    setCurrentSyncDbId(typedSyncDbId);
+}
+
+void MainSelectionStore::clearSelection() {
+    _lastRequestedSyncDbId = 0;
+    setCurrentSyncDbId(0);
+}
+
+void MainSelectionStore::ensureValidSelection() {
+    if (_currentSyncDbId != 0 && _cache.syncContext(_currentSyncDbId)) {
+        return;
+    }
+
+    if (_lastRequestedSyncDbId != 0 && _cache.syncContext(_lastRequestedSyncDbId)) {
+        setCurrentSyncDbId(_lastRequestedSyncDbId);
+        return;
+    }
+
+    setCurrentSyncDbId(firstAvailableSyncDbId());
+}
+
+void MainSelectionStore::setCurrentSyncDbId(const SyncDbId syncDbId) {
+    if (_currentSyncDbId == syncDbId) {
+        return;
+    }
+    _currentSyncDbId = syncDbId;
+    emit currentSyncDbIdChanged();
+    emit currentSyncContextChanged();
+}
+
+SyncDbId MainSelectionStore::firstAvailableSyncDbId() const {
+    const auto contexts = _cache.syncContexts();
+    if (contexts.empty()) {
+        return 0;
+    }
+    return contexts.front().sync.dbId();
+}
+
+} // namespace KDC

--- a/src/gui4/linux/app/cache/mainselectionstore.cpp
+++ b/src/gui4/linux/app/cache/mainselectionstore.cpp
@@ -23,10 +23,10 @@ namespace KDC {
 MainSelectionStore::MainSelectionStore(AppCache &cache, QObject *const parent) :
     QObject(parent),
     _cache(cache) {
-    (void) connect(&_cache, &AppCache::usersChanged, this, &MainSelectionStore::ensureValidSelection);
-    (void) connect(&_cache, &AppCache::accountsChanged, this, &MainSelectionStore::ensureValidSelection);
-    (void) connect(&_cache, &AppCache::drivesChanged, this, &MainSelectionStore::ensureValidSelection);
-    (void) connect(&_cache, &AppCache::syncsChanged, this, &MainSelectionStore::ensureValidSelection);
+    (void) connect(&_cache, &AppCache::usersChanged, this, &MainSelectionStore::handleCacheChanged);
+    (void) connect(&_cache, &AppCache::accountsChanged, this, &MainSelectionStore::handleCacheChanged);
+    (void) connect(&_cache, &AppCache::drivesChanged, this, &MainSelectionStore::handleCacheChanged);
+    (void) connect(&_cache, &AppCache::syncsChanged, this, &MainSelectionStore::handleCacheChanged);
 }
 
 qint64 MainSelectionStore::currentSyncDbId() const {
@@ -70,6 +70,14 @@ void MainSelectionStore::ensureValidSelection() {
     }
 
     setCurrentSyncDbId(firstAvailableSyncDbId());
+}
+
+void MainSelectionStore::handleCacheChanged() {
+    const auto previousCurrentSyncDbId = _currentSyncDbId;
+    ensureValidSelection();
+    if (_currentSyncDbId != 0 && _currentSyncDbId == previousCurrentSyncDbId) {
+        emit currentSyncContextChanged();
+    }
 }
 
 void MainSelectionStore::setCurrentSyncDbId(const SyncDbId syncDbId) {

--- a/src/gui4/linux/app/cache/mainselectionstore.h
+++ b/src/gui4/linux/app/cache/mainselectionstore.h
@@ -55,6 +55,7 @@ class MainSelectionStore : public QObject {
         void currentSyncContextChanged();
 
     private:
+        void handleCacheChanged();
         void setCurrentSyncDbId(SyncDbId syncDbId);
         [[nodiscard]] SyncDbId firstAvailableSyncDbId() const;
 

--- a/src/gui4/linux/app/cache/mainselectionstore.h
+++ b/src/gui4/linux/app/cache/mainselectionstore.h
@@ -1,0 +1,66 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "app/cache/appcache.h"
+#include "app/cache/cachetypes.h"
+
+#include <QObject>
+
+#include <optional>
+#include <vector>
+
+namespace KDC {
+
+/**
+ * Sync-first main-shell selection owner for Linux v4.
+ *
+ * Role: own currentSyncDbId and heal it when cache graph changes.
+ * Non-role: own cached entities or onboarding selections.
+ * All mutations must run on the Qt main thread.
+ */
+class MainSelectionStore : public QObject {
+        Q_OBJECT
+        Q_PROPERTY(qint64 currentSyncDbId READ currentSyncDbId NOTIFY currentSyncDbIdChanged)
+
+    public:
+        explicit MainSelectionStore(AppCache &cache, QObject *parent = nullptr);
+
+        [[nodiscard]] qint64 currentSyncDbId() const;
+        [[nodiscard]] std::optional<SyncContext> currentSyncContext() const;
+        [[nodiscard]] std::vector<SyncContext> syncContexts() const;
+
+        Q_INVOKABLE void selectSync(qint64 syncDbId);
+        Q_INVOKABLE void clearSelection();
+        Q_INVOKABLE void ensureValidSelection();
+
+    signals:
+        void currentSyncDbIdChanged();
+        void currentSyncContextChanged();
+
+    private:
+        void setCurrentSyncDbId(SyncDbId syncDbId);
+        [[nodiscard]] SyncDbId firstAvailableSyncDbId() const;
+
+        AppCache &_cache;
+        SyncDbId _currentSyncDbId{0};
+        SyncDbId _lastRequestedSyncDbId{0};
+};
+
+} // namespace KDC

--- a/src/gui4/linux/app/cache/mainselectionstore.h
+++ b/src/gui4/linux/app/cache/mainselectionstore.h
@@ -24,10 +24,10 @@
 #include <QLoggingCategory>
 #include <QObject>
 
-Q_DECLARE_LOGGING_CATEGORY(lcMainSelectionStore)
-
 #include <optional>
 #include <vector>
+
+Q_DECLARE_LOGGING_CATEGORY(lcMainSelectionStore)
 
 namespace KDC {
 

--- a/src/gui4/linux/app/cache/mainselectionstore.h
+++ b/src/gui4/linux/app/cache/mainselectionstore.h
@@ -21,7 +21,10 @@
 #include "app/cache/appcache.h"
 #include "app/cache/cachetypes.h"
 
+#include <QLoggingCategory>
 #include <QObject>
+
+Q_DECLARE_LOGGING_CATEGORY(lcMainSelectionStore)
 
 #include <optional>
 #include <vector>
@@ -55,7 +58,8 @@ class MainSelectionStore : public QObject {
         void currentSyncContextChanged();
 
     private:
-        void handleCacheChanged();
+        void handleSyncsChanged();
+        void handleContextDataChanged();
         void setCurrentSyncDbId(SyncDbId syncDbId);
         [[nodiscard]] SyncDbId firstAvailableSyncDbId() const;
 

--- a/src/gui4/linux/app/cache/onboardingstate.cpp
+++ b/src/gui4/linux/app/cache/onboardingstate.cpp
@@ -1,0 +1,180 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "onboardingstate.h"
+
+#include <algorithm>
+
+namespace KDC {
+
+OnboardingState::OnboardingState(AppCache &cache, QObject *const parent) :
+    QObject(parent),
+    _cache(cache) {
+    (void) connect(&_cache, &AppCache::usersChanged, this, &OnboardingState::ensureValidState);
+    (void) connect(&_cache, &AppCache::availableDrivesChanged, this, [this](const UserDbId userDbId) {
+        if (userDbId == _selectedUserDbId) {
+            pruneSelectedAvailableDrives();
+        }
+    });
+    (void) connect(&_cache, &AppCache::allAvailableDrivesChanged, this, &OnboardingState::pruneSelectedAvailableDrives);
+}
+
+qint64 OnboardingState::selectedUserDbId() const {
+    return static_cast<qint64>(_selectedUserDbId);
+}
+
+std::vector<AvailableDriveKey> OnboardingState::selectedAvailableDriveKeys() const {
+    std::vector<AvailableDriveKey> keys(_selectedAvailableDriveKeys.begin(), _selectedAvailableDriveKeys.end());
+    std::ranges::sort(keys, [](const AvailableDriveKey &lhs, const AvailableDriveKey &rhs) {
+        if (lhs.userDbId != rhs.userDbId) return lhs.userDbId < rhs.userDbId;
+        if (lhs.accountId != rhs.accountId) return lhs.accountId < rhs.accountId;
+        return lhs.driveId < rhs.driveId;
+    });
+    return keys;
+}
+
+bool OnboardingState::isAvailableDriveSelected(const AvailableDriveKey &key) const {
+    return _selectedAvailableDriveKeys.contains(key);
+}
+
+std::optional<PendingSyncConfig> OnboardingState::pendingSyncConfig(const AvailableDriveKey &key) const {
+    const auto it = _pendingSyncConfigs.find(key);
+    if (it == _pendingSyncConfigs.end()) {
+        return std::nullopt;
+    }
+    return it->second;
+}
+
+void OnboardingState::selectUser(const qint64 userDbId) {
+    const auto typedUserDbId = static_cast<UserDbId>(userDbId);
+    if (_selectedUserDbId == typedUserDbId) {
+        return;
+    }
+
+    const bool hadSelectedDrives = !_selectedAvailableDriveKeys.empty();
+    const bool hadPendingConfigs = !_pendingSyncConfigs.empty();
+    _selectedUserDbId = typedUserDbId;
+    _selectedAvailableDriveKeys.clear();
+    _pendingSyncConfigs.clear();
+
+    emit selectedUserDbIdChanged();
+    if (hadSelectedDrives) emit selectedAvailableDrivesChanged();
+    if (hadPendingConfigs) emit pendingSyncConfigsChanged();
+}
+
+void OnboardingState::clearSelectedUser() {
+    selectUser(0);
+}
+
+void OnboardingState::selectAvailableDrive(const AvailableDriveKey &key) {
+    if (!belongsToSelectedUser(key)) {
+        return;
+    }
+    if (!_selectedAvailableDriveKeys.insert(key).second) {
+        return;
+    }
+    emit selectedAvailableDrivesChanged();
+}
+
+void OnboardingState::unselectAvailableDrive(const AvailableDriveKey &key) {
+    if (_selectedAvailableDriveKeys.erase(key) == 0) {
+        return;
+    }
+    const bool removedConfig = _pendingSyncConfigs.erase(key) > 0;
+    emit selectedAvailableDrivesChanged();
+    if (removedConfig) emit pendingSyncConfigsChanged();
+}
+
+void OnboardingState::toggleAvailableDrive(const AvailableDriveKey &key) {
+    if (isAvailableDriveSelected(key)) {
+        unselectAvailableDrive(key);
+        return;
+    }
+    selectAvailableDrive(key);
+}
+
+void OnboardingState::clearSelectedAvailableDrives() {
+    const bool hadSelectedDrives = !_selectedAvailableDriveKeys.empty();
+    const bool hadPendingConfigs = !_pendingSyncConfigs.empty();
+    _selectedAvailableDriveKeys.clear();
+    _pendingSyncConfigs.clear();
+    if (hadSelectedDrives) emit selectedAvailableDrivesChanged();
+    if (hadPendingConfigs) emit pendingSyncConfigsChanged();
+}
+
+void OnboardingState::setPendingSyncConfig(const AvailableDriveKey &key, const PendingSyncConfig &config) {
+    if (!belongsToSelectedUser(key) || !isAvailableDriveSelected(key)) {
+        return;
+    }
+    _pendingSyncConfigs[key] = config;
+    emit pendingSyncConfigsChanged();
+}
+
+void OnboardingState::clearPendingSyncConfig(const AvailableDriveKey &key) {
+    if (_pendingSyncConfigs.erase(key) == 0) {
+        return;
+    }
+    emit pendingSyncConfigsChanged();
+}
+
+void OnboardingState::reset() {
+    const bool userChanged = _selectedUserDbId != 0;
+    const bool hadSelectedDrives = !_selectedAvailableDriveKeys.empty();
+    const bool hadPendingConfigs = !_pendingSyncConfigs.empty();
+    _selectedUserDbId = 0;
+    _selectedAvailableDriveKeys.clear();
+    _pendingSyncConfigs.clear();
+    if (userChanged) emit selectedUserDbIdChanged();
+    if (hadSelectedDrives) emit selectedAvailableDrivesChanged();
+    if (hadPendingConfigs) emit pendingSyncConfigsChanged();
+}
+
+bool OnboardingState::belongsToSelectedUser(const AvailableDriveKey &key) const {
+    return _selectedUserDbId != 0 && key.userDbId == _selectedUserDbId;
+}
+
+void OnboardingState::ensureValidState() {
+    if (_selectedUserDbId == 0 || _cache.user(_selectedUserDbId)) {
+        pruneSelectedAvailableDrives();
+        return;
+    }
+    reset();
+}
+
+void OnboardingState::pruneSelectedAvailableDrives() {
+    if (_selectedAvailableDriveKeys.empty()) {
+        return;
+    }
+
+    bool selectionChanged = false;
+    bool pendingConfigsChanged = false;
+    for (auto it = _selectedAvailableDriveKeys.begin(); it != _selectedAvailableDriveKeys.end();) {
+        if (_cache.availableDrive(*it)) {
+            ++it;
+            continue;
+        }
+        pendingConfigsChanged = _pendingSyncConfigs.erase(*it) > 0 || pendingConfigsChanged;
+        it = _selectedAvailableDriveKeys.erase(it);
+        selectionChanged = true;
+    }
+
+    if (selectionChanged) emit selectedAvailableDrivesChanged();
+    if (pendingConfigsChanged) emit pendingSyncConfigsChanged();
+}
+
+} // namespace KDC

--- a/src/gui4/linux/app/cache/onboardingstate.cpp
+++ b/src/gui4/linux/app/cache/onboardingstate.cpp
@@ -20,6 +20,8 @@
 
 #include <algorithm>
 
+Q_LOGGING_CATEGORY(lcOnboardingState, "gui.v4.onboardingstate", QtInfoMsg)
+
 namespace KDC {
 
 OnboardingState::OnboardingState(AppCache &cache, QObject *const parent) :
@@ -40,7 +42,7 @@ qint64 OnboardingState::selectedUserDbId() const {
 
 std::vector<AvailableDriveKey> OnboardingState::selectedAvailableDriveKeys() const {
     std::vector<AvailableDriveKey> keys(_selectedAvailableDriveKeys.begin(), _selectedAvailableDriveKeys.end());
-    std::ranges::sort(keys, [](const AvailableDriveKey &lhs, const AvailableDriveKey &rhs) {
+    (void) std::ranges::sort(keys, [](const AvailableDriveKey &lhs, const AvailableDriveKey &rhs) {
         if (lhs.userDbId != rhs.userDbId) return lhs.userDbId < rhs.userDbId;
         if (lhs.accountId != rhs.accountId) return lhs.accountId < rhs.accountId;
         return lhs.driveId < rhs.driveId;
@@ -83,11 +85,13 @@ void OnboardingState::clearSelectedUser() {
 
 void OnboardingState::selectAvailableDrive(const AvailableDriveKey &key) {
     if (!belongsToSelectedUser(key)) {
+        qCWarning(lcOnboardingState) << "Drive select ignored: key does not belong to selected user | userDbId:" << key.userDbId << "/ selectedUserDbId:" << _selectedUserDbId;
         return;
     }
     if (!_selectedAvailableDriveKeys.insert(key).second) {
         return;
     }
+    qCDebug(lcOnboardingState) << "Available drive selected | userDbId:" << key.userDbId << "/ driveId:" << key.driveId;
     emit selectedAvailableDrivesChanged();
 }
 
@@ -95,6 +99,7 @@ void OnboardingState::unselectAvailableDrive(const AvailableDriveKey &key) {
     if (_selectedAvailableDriveKeys.erase(key) == 0) {
         return;
     }
+    qCDebug(lcOnboardingState) << "Available drive unselected | userDbId:" << key.userDbId << "/ driveId:" << key.driveId;
     const bool removedConfig = _pendingSyncConfigs.erase(key) > 0;
     emit selectedAvailableDrivesChanged();
     if (removedConfig) emit pendingSyncConfigsChanged();
@@ -119,6 +124,7 @@ void OnboardingState::clearSelectedAvailableDrives() {
 
 void OnboardingState::setPendingSyncConfig(const AvailableDriveKey &key, const PendingSyncConfig &config) {
     if (!belongsToSelectedUser(key) || !isAvailableDriveSelected(key)) {
+        qCWarning(lcOnboardingState) << "Pending sync config ignored: drive not selected or wrong user | userDbId:" << key.userDbId << "/ driveId:" << key.driveId;
         return;
     }
     _pendingSyncConfigs[key] = config;
@@ -133,6 +139,7 @@ void OnboardingState::clearPendingSyncConfig(const AvailableDriveKey &key) {
 }
 
 void OnboardingState::reset() {
+    qCInfo(lcOnboardingState) << "Onboarding state reset";
     const bool userChanged = _selectedUserDbId != 0;
     const bool hadSelectedDrives = !_selectedAvailableDriveKeys.empty();
     const bool hadPendingConfigs = !_pendingSyncConfigs.empty();
@@ -153,6 +160,7 @@ void OnboardingState::ensureValidState() {
         pruneSelectedAvailableDrives();
         return;
     }
+    qCWarning(lcOnboardingState) << "Selected user removed from cache, resetting | userDbId:" << _selectedUserDbId;
     reset();
 }
 
@@ -168,6 +176,7 @@ void OnboardingState::pruneSelectedAvailableDrives() {
             ++it;
             continue;
         }
+        qCDebug(lcOnboardingState) << "Selected drive pruned (no longer available) | userDbId:" << it->userDbId << "/ driveId:" << it->driveId;
         pendingConfigsChanged = _pendingSyncConfigs.erase(*it) > 0 || pendingConfigsChanged;
         it = _selectedAvailableDriveKeys.erase(it);
         selectionChanged = true;

--- a/src/gui4/linux/app/cache/onboardingstate.h
+++ b/src/gui4/linux/app/cache/onboardingstate.h
@@ -1,0 +1,79 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "app/cache/appcache.h"
+#include "app/cache/cachetypes.h"
+
+#include <QObject>
+
+#include <optional>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace KDC {
+
+/**
+ * Onboarding-only state store for Linux v4.
+ *
+ * Role: own selected onboarding user, selected available drive keys, and pending sync configs.
+ * Non-role: own main-shell current sync or configured cache entities.
+ * All mutations must run on the Qt main thread.
+ */
+class OnboardingState : public QObject {
+        Q_OBJECT
+        Q_PROPERTY(qint64 selectedUserDbId READ selectedUserDbId NOTIFY selectedUserDbIdChanged)
+
+    public:
+        explicit OnboardingState(AppCache &cache, QObject *parent = nullptr);
+
+        [[nodiscard]] qint64 selectedUserDbId() const;
+        [[nodiscard]] UserDbId typedSelectedUserDbId() const { return _selectedUserDbId; }
+        [[nodiscard]] std::vector<AvailableDriveKey> selectedAvailableDriveKeys() const;
+        [[nodiscard]] bool isAvailableDriveSelected(const AvailableDriveKey &key) const;
+        [[nodiscard]] std::optional<PendingSyncConfig> pendingSyncConfig(const AvailableDriveKey &key) const;
+
+        Q_INVOKABLE void selectUser(qint64 userDbId);
+        Q_INVOKABLE void clearSelectedUser();
+        void selectAvailableDrive(const AvailableDriveKey &key);
+        void unselectAvailableDrive(const AvailableDriveKey &key);
+        void toggleAvailableDrive(const AvailableDriveKey &key);
+        void clearSelectedAvailableDrives();
+        void setPendingSyncConfig(const AvailableDriveKey &key, const PendingSyncConfig &config);
+        void clearPendingSyncConfig(const AvailableDriveKey &key);
+        void reset();
+
+    signals:
+        void selectedUserDbIdChanged();
+        void selectedAvailableDrivesChanged();
+        void pendingSyncConfigsChanged();
+
+    private:
+        [[nodiscard]] bool belongsToSelectedUser(const AvailableDriveKey &key) const;
+        void ensureValidState();
+        void pruneSelectedAvailableDrives();
+
+        AppCache &_cache;
+        UserDbId _selectedUserDbId{0};
+        std::unordered_set<AvailableDriveKey> _selectedAvailableDriveKeys;
+        std::unordered_map<AvailableDriveKey, PendingSyncConfig> _pendingSyncConfigs;
+};
+
+} // namespace KDC

--- a/src/gui4/linux/app/cache/onboardingstate.h
+++ b/src/gui4/linux/app/cache/onboardingstate.h
@@ -21,7 +21,10 @@
 #include "app/cache/appcache.h"
 #include "app/cache/cachetypes.h"
 
+#include <QLoggingCategory>
 #include <QObject>
+
+Q_DECLARE_LOGGING_CATEGORY(lcOnboardingState)
 
 #include <optional>
 #include <unordered_map>

--- a/src/gui4/linux/app/cache/onboardingstate.h
+++ b/src/gui4/linux/app/cache/onboardingstate.h
@@ -24,12 +24,12 @@
 #include <QLoggingCategory>
 #include <QObject>
 
-Q_DECLARE_LOGGING_CATEGORY(lcOnboardingState)
-
 #include <optional>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+
+Q_DECLARE_LOGGING_CATEGORY(lcOnboardingState)
 
 namespace KDC {
 

--- a/src/gui4/linux/app/services/userservice.cpp
+++ b/src/gui4/linux/app/services/userservice.cpp
@@ -66,12 +66,15 @@ void UserService::loadUsers() {
 }
 
 void UserService::loadAvailableDrives(const qint64 userDbId) {
-    beginAction(actionLoadAvailableDrives, userDbId);
+    const auto scopedUserDbId = static_cast<UserDbId>(userDbId);
+    beginAction(actionLoadAvailableDrives, scopedUserDbId);
+    const auto generation = ++_availableDriveLoadGenerations[scopedUserDbId];
 
     _commService.requestUserAvailableDrives(
-            userDbId, [this, userDbId](const ExitInfo &exitInfo, const std::vector<DriveAvailableInfo> &list) {
-                endAction(actionLoadAvailableDrives, userDbId);
-                if (_appCache.selectedUserDbId() != userDbId) {
+            scopedUserDbId,
+            [this, scopedUserDbId, generation](const ExitInfo &exitInfo, const std::vector<DriveAvailableInfo> &list) {
+                endAction(actionLoadAvailableDrives, scopedUserDbId);
+                if (_availableDriveLoadGenerations[scopedUserDbId] != generation) {
                     return;
                 }
 
@@ -80,7 +83,7 @@ void UserService::loadAvailableDrives(const qint64 userDbId) {
                     return;
                 }
 
-                _appCache.replaceAvailableDrives(list);
+                _appCache.replaceAvailableDrivesForUser(scopedUserDbId, list);
             });
 }
 

--- a/src/gui4/linux/app/services/userservice.h
+++ b/src/gui4/linux/app/services/userservice.h
@@ -26,6 +26,9 @@
 #include <QObject>
 #include <QString>
 
+#include <cstdint>
+#include <unordered_map>
+
 namespace KDC {
 
 /**
@@ -73,6 +76,7 @@ class UserService : public QObject {
         AppCache &_appCache;
         ServiceActionTracker &_serviceActionTracker;
         ServiceEventBus &_serviceEventBus;
+        std::unordered_map<UserDbId, uint64_t> _availableDriveLoadGenerations;
         bool _loading{false};
 };
 

--- a/src/gui4/linux/appclientlinux.h
+++ b/src/gui4/linux/appclientlinux.h
@@ -18,6 +18,9 @@
 
 #pragma once
 
+#include "app/cache/appcache.h"
+#include "app/cache/mainselectionstore.h"
+#include "app/cache/onboardingstate.h"
 #include "app/services/commservice.h"
 #include "app/services/serviceactiontracker.h"
 #include "app/services/serviceeventbus.h"
@@ -55,6 +58,9 @@ class AppClientLinux : public QApplication {
          */
         SignalDispatcher &signalDispatcher() { return _signalDispatcher; }
         CommService &serverCommService() { return _serverCommService; }
+        AppCache &appCache() { return _appCache; }
+        MainSelectionStore &mainSelectionStore() { return _mainSelectionStore; }
+        OnboardingState &onboardingState() { return _onboardingState; }
         ServiceActionTracker &serviceActionTracker() { return _serviceActionTracker; }
         ServiceEventBus &serviceEventBus() { return _serviceEventBus; }
 
@@ -70,6 +76,9 @@ class AppClientLinux : public QApplication {
         IpcClient _ipcClient{this};
         SignalDispatcher _signalDispatcher{this};
         CommService _serverCommService{_ipcClient, _signalDispatcher, this};
+        AppCache _appCache{this};
+        MainSelectionStore _mainSelectionStore{_appCache, this};
+        OnboardingState _onboardingState{_appCache, this};
         ServiceActionTracker _serviceActionTracker{this};
         ServiceEventBus _serviceEventBus{this};
 };

--- a/src/gui4/linux/communicationlayer/ipcclient.cpp
+++ b/src/gui4/linux/communicationlayer/ipcclient.cpp
@@ -321,7 +321,7 @@ void IpcClient::handleServerSignal(const Poco::DynamicStruct &ipcMessage, const 
     }
     const Poco::DynamicStruct params = ipcMessage[msgRequestParams].extract<Poco::DynamicStruct>();
 
-    qCDebug(lcIpcClient) << "Signal emitted | SignalNum:" << num << "/ id:" << id;
+    qCDebug(lcIpcClient) << "Signal received | SignalNum:" << num << "/ id:" << id;
     emit serverSignalReceived(num, params);
 }
 /**

--- a/src/libcommon/info/driveavailableinfo.h
+++ b/src/libcommon/info/driveavailableinfo.h
@@ -54,6 +54,8 @@ class DriveAvailableInfo {
         friend QDataStream &operator>>(QDataStream &in, DriveAvailableInfo &info);
         friend QDataStream &operator<<(QDataStream &out, const DriveAvailableInfo &info);
 
+        friend bool operator==(const DriveAvailableInfo &lhs, const DriveAvailableInfo &rhs) = default;
+
         friend QDataStream &operator>>(QDataStream &in, QList<DriveAvailableInfo> &list);
         friend QDataStream &operator<<(QDataStream &out, const QList<DriveAvailableInfo> &list);
 

--- a/src/libcommon/info/errorinfo.h
+++ b/src/libcommon/info/errorinfo.h
@@ -81,6 +81,8 @@ class ErrorInfo {
         friend QDataStream &operator>>(QDataStream &in, ErrorInfo &errorInfo);
         friend QDataStream &operator<<(QDataStream &out, const ErrorInfo &errorInfo);
 
+        friend bool operator==(const ErrorInfo &lhs, const ErrorInfo &rhs) = default;
+
         friend QDataStream &operator>>(QDataStream &in, QList<ErrorInfo> &list);
         friend QDataStream &operator<<(QDataStream &out, const QList<ErrorInfo> &list);
 

--- a/src/libcommon/info/syncinfo.h
+++ b/src/libcommon/info/syncinfo.h
@@ -59,6 +59,8 @@ class SyncInfo {
         friend QDataStream &operator>>(QDataStream &in, SyncInfo &info);
         friend QDataStream &operator<<(QDataStream &out, const SyncInfo &info);
 
+        friend bool operator==(const SyncInfo &lhs, const SyncInfo &rhs) = default;
+
         friend QDataStream &operator>>(QDataStream &in, QList<SyncInfo> &list);
         friend QDataStream &operator<<(QDataStream &out, const QList<SyncInfo> &list);
 


### PR DESCRIPTION
## Summary

Replaces the flat, vector-based `AppCache` with a normalized graph model (`User -> Account -> Drive -> Sync -> Error`) and introduces two dedicated state stores: `MainSelectionStore` (owns `currentSyncDbId`) and `OnboardingState` (owns onboarding user, drive key selections, and pending sync configs). This is the Linux v4 cache foundation branch. No `CachePipeline` real wiring is included; that belongs to the follow-up `linux-v4/cache/services` branch.

## Changes

### AppCache (`appcache.h/cpp`, `appcachegraph.cpp`, `appcachequeries.cpp`)
- Internal storage replaced from `std::vector<*Info>` to `std::unordered_map<*DbId, *Node>` keyed by database id. Each node (`UserNode`, `AccountNode`, `DriveNode`, `SyncNode`) carries its entity info plus sorted child id lists, forming an explicit adjacency graph.
- Cascade removal: `removeUser` walks and deletes all descendant accounts, drives, syncs, and errors; the silent cascade helpers (`removeAccountCascade`, `removeDriveCascade`, `removeSyncCascade`) do not emit signals and are called by the public remove methods which emit the appropriate coarse signals after cleanup.
- Snapshot replacement methods (`replaceUsers`, `replaceAccounts`, etc.) prune orphans via `pruneConfiguredGraph()` and rebuild child id lists via `rebuildGraphRelations()` after each bulk load.
- `availableDrives` is now per-user: `replaceAvailableDrivesForUser(UserDbId, ...)` replaces one user's snapshot without touching others; `availableDrivesChanged(UserDbId)` signal carries the user scope.
- Sync errors and server errors are tracked in separate maps (`_syncErrorsByDbId`, `_serverErrorsByDbId`) with their own upsert/remove/replace/signal pairs (`syncErrorsChanged`, `serverErrorsChanged`).
- Selection state (`selectedUserDbId`, `selectedDriveDbId`, `selectedSyncDbId`) and connection state are removed from `AppCache`; these responsibilities are now owned by `MainSelectionStore` and callers respectively.
- New id-based point lookups return `std::optional<*Info>` (e.g. `user(UserDbId)`, `drive(DriveDbId)`, `sync(SyncDbId)`).
- New graph traversal helpers: `accountsForUser`, `drivesForAccount`, `syncsForDrive`, `errorsForSync`; results are stable-sorted by database id.
- New derived read models (`appcachequeries.cpp`): `syncContext(SyncDbId)`, `syncContexts()`, `driveContext(DriveDbId)`, `driveContexts()`, `availableDriveContexts(UserDbId)`, `availableDriveContexts()`; a context is `nullopt` when any node in its parent chain is missing.
- Flat snapshot accessors (`users()`, `accounts()`, etc.) now reconstruct sorted `std::vector` from the maps on each call (copy-out, not reference return).

### Cache types (`cachetypes.h`)
- New header consolidating all cache-layer value types.
- `SyncContext`: bundles `UserInfo`, `AccountInfo`, `DriveInfo`, `SyncInfo`, errors list, and `latestError`.
- `DriveContext`: bundles user, account, drive, and syncs list.
- `AvailableDriveContext`: bundles user, optional account, `DriveAvailableInfo`, `alreadyConfigured` flag, and optional configured `DriveInfo`.
- `AvailableDriveKey`: composite key `(userDbId, accountId, driveId)` with `operator==` and `std::hash` specialization for use in `unordered_set` and `unordered_map`.
- `PendingSyncConfig`: captures local path, target path, target node id, and VFS mode; used by `OnboardingState`.
- `SyncContext`, `DriveContext`, and `AvailableDriveContext` now define `operator== = default`, which lets the main-selection store compare derived contexts directly.

### MainSelectionStore (`mainselectionstore.h/cpp`)
- New `QObject` subclass, sole owner of `currentSyncDbId`; exposed as a read-only `Q_PROPERTY` to QML.
- `selectSync(qint64)` validates that the id exists in the cache before committing; `ensureValidSelection()` re-pins to the first available sync when the graph changes.
- `_lastRequestedSyncDbId` is kept separately so a sync temporarily absent from the cache can be restored if it reappears.
- `currentSyncContext()` delegates to `AppCache::syncContext`; no duplicate entity storage.
- `handleSyncsChanged()` and `handleContextDataChanged()` are fine-grained: `currentSyncContextChanged()` is emitted only when the derived context actually differs, not on every cache signal.

### OnboardingState (`onboardingstate.h/cpp`)
- New `QObject` subclass owning onboarding-flow-specific state only: selected user, a set of selected `AvailableDriveKey` values, and a map of `PendingSyncConfig` keyed by `AvailableDriveKey`.
- `pruneSelectedAvailableDrives()` drops keys that no longer belong to the selected user when the available drives snapshot changes.
- `reset()` clears all three fields and emits all three change signals.
- Holds a `AppCache &` reference; reads entities from the cache but owns none.

### UserService (`userservice.h/cpp`)
- `loadAvailableDrives` uses a per-user generation counter (`_availableDriveLoadGenerations: unordered_map<UserDbId, uint64_t>`) to discard stale async responses when a newer request has been issued for the same user.
- Replaces the old `selectedUserDbId()` guard (which coupled the service to selection state) with the generation check, which is correct regardless of current selection.
- Calls `replaceAvailableDrivesForUser` instead of the removed global `replaceAvailableDrives`.
- Uses a single casted `UserDbId` local inside `loadAvailableDrives()` instead of carrying both raw and casted ids through the method.

### AppClientLinux (`appclientlinux.h`)
- `AppCache _appCache`, `MainSelectionStore _mainSelectionStore`, and `OnboardingState _onboardingState` are owned members of `AppClientLinux`, constructed in declaration order with proper `AppCache &` references.
- Public accessors `appCache()`, `mainSelectionStore()`, `onboardingState()` added for downstream service and adapter wiring.

## Architecture notes

- All cache, selection, and onboarding mutations must run on the Qt main thread. No internal locking exists; callers must not invoke mutating methods from worker threads.
- `AppCache` emits coarse invalidation signals only. Consumers must re-query the full read model on each signal rather than diffing. This matches the macOS pattern.
- Cascade removes do not emit intermediate signals; only the top-level public remove methods emit, preventing observer storms on multi-level deletions.
- `MainSelectionStore` and `OnboardingState` hold `AppCache &` references and are declared after `_appCache` in `AppClientLinux`, guaranteeing correct construction and destruction order.
- `availableDrives` is intentionally scoped per-user and never global. The `AvailableDriveContext` query reconciles addable drives with configured drives (already-configured flag) for display decisions.
- `CachePipeline` service adapter wiring is deferred to `linux-v4/cache/services`.
- `MainSelectionStore` emits `currentSyncContextChanged()` only when the selected sync context actually changes, while still healing selection on cache changes.