### PR TITLE
feat(sync): improve SyncPath serialization handling

### DIFF
--- a/src/libcommon/info/searchinfo.cpp
+++ b/src/libcommon/info/searchinfo.cpp
@@ -43,7 +43,7 @@ void SearchInfo::toDynamicStruct(Poco::DynamicStruct &dstruct) const {
     CommonUtility::writeValueToStruct(dstruct, searchInfoId, _id);
     CommonUtility::writeValueToStruct(dstruct, searchInfoName, _name);
     CommonUtility::writeValueToStruct(dstruct, searchInfoType, _type);
-    CommonUtility::writeValueToStruct(dstruct, searchInfoPath, Path2Str(_path));
+    CommonUtility::writeValueToStruct(dstruct, searchInfoPath, CommonUtility::syncPath2CommString(_path));
     CommonUtility::writeValueToStruct(dstruct, searchInfoModifiedTime, _modifiedTime);
     CommonUtility::writeValueToStruct(dstruct, searchInfoSize, _size);
     CommonUtility::writeValueToStruct(dstruct, searchInfoIsAvailableLocally, _isAvailableLocally);
@@ -53,9 +53,9 @@ void SearchInfo::fromDynamicStruct(const Poco::DynamicStruct &dstruct) {
     CommonUtility::readValueFromStruct(dstruct, searchInfoId, _id);
     CommonUtility::readValueFromStruct(dstruct, searchInfoName, _name);
     CommonUtility::readValueFromStruct(dstruct, searchInfoType, _type);
-    std::string pathStr;
+    CommString pathStr;
     CommonUtility::readValueFromStruct(dstruct, searchInfoPath, pathStr);
-    _path = Str2Path(pathStr);
+    _path = CommonUtility::commString2SyncPath(pathStr);
     CommonUtility::readValueFromStruct(dstruct, searchInfoModifiedTime, _modifiedTime);
     CommonUtility::readValueFromStruct(dstruct, searchInfoSize, _size);
     CommonUtility::readValueFromStruct(dstruct, searchInfoIsAvailableLocally, _isAvailableLocally);

--- a/src/libcommon/utility/utility.h
+++ b/src/libcommon/utility/utility.h
@@ -284,6 +284,7 @@ struct COMMON_EXPORT CommonUtility {
 
         // CommString conversion functions
         static CommString syncPath2CommString(const SyncPath &s) { return s.native(); }
+        static SyncPath commString2SyncPath(const CommString &s) { return SyncPath(s); }
 
 #if defined(KD_WINDOWS)
         static CommString str2CommString(const std::string &s) { return KDC::CommonUtility::s2ws(s); }

--- a/src/libsyncengine/jobs/network/kDrive_API/searchjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/searchjob.cpp
@@ -126,11 +126,11 @@ ExitInfo SearchJob::handleResponse(std::istream &is) {
             return {ExitCode::BackError, ExitCause::MissingReplyData};
         }
 
-        SyncName path_;
-        if (!JsonParserUtility::extractValue(obj, pathKey, path_)) {
+        SyncName pathStr;
+        if (!JsonParserUtility::extractValue(obj, pathKey, pathStr)) {
             return {ExitCode::BackError, ExitCause::MissingReplyData};
         }
-        SyncPath path(path_);
+        SyncPath path(pathStr);
 
         SyncTime modifiedTime = 0;
         if (!JsonParserUtility::extractValue(obj, lastModifiedAtKey, modifiedTime, false)) {
@@ -149,6 +149,10 @@ ExitInfo SearchJob::handleResponse(std::istream &is) {
                 path = path.string().substr(std::char_traits<char>::length(privateFolder));
             } else if (path.string().starts_with(sharedFolder)) {
                 path = path.string().substr(std::char_traits<char>::length(sharedFolder));
+            }
+
+            if (path.string().starts_with("/") || path.string().starts_with("\\")) {
+                path = path.relative_path();
             }
 
             SyncPath absolutePath = _syncRootPath / path;

--- a/src/libsyncengine/jobs/network/kDrive_API/searchjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/searchjob.cpp
@@ -27,8 +27,8 @@
 
 namespace KDC {
 
-static constexpr auto privateFolder = "/Private/";
-static constexpr auto sharedFolder = "/Shared/";
+static constexpr auto privateFolder = Str("/Private/");
+static constexpr auto sharedFolder = Str("/Shared/");
 
 SearchJob::SearchJob(const DriveDbId driveDbId, const SyncDbId syncDbId, const std::string &searchString,
                      const std::string &cursorInput /*= {}*/) :
@@ -145,13 +145,14 @@ ExitInfo SearchJob::handleResponse(std::istream &is) {
         bool isAvailableLocally = false;
 
         if (!_syncRootPath.empty()) {
-            if (path.string().starts_with(privateFolder)) {
-                path = path.string().substr(std::char_traits<char>::length(privateFolder));
-            } else if (path.string().starts_with(sharedFolder)) {
-                path = path.string().substr(std::char_traits<char>::length(sharedFolder));
+            if (path.native().starts_with(privateFolder)) {
+                path = path.native().substr(
+                        std::char_traits<std::remove_cvref_t<decltype(*privateFolder)>>::length(privateFolder));
+            } else if (path.native().starts_with(sharedFolder)) {
+                path = path.native().substr(std::char_traits<std::remove_cvref_t<decltype(*sharedFolder)>>::length(sharedFolder));
             }
 
-            if (path.string().starts_with("/") || path.string().starts_with("\\")) {
+            if (path.native().starts_with(Str("/")) || path.native().starts_with(Str("\\"))) {
                 path = path.relative_path();
             }
 

--- a/src/libsyncengine/jobs/network/kDrive_API/searchjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/searchjob.cpp
@@ -146,9 +146,10 @@ ExitInfo SearchJob::handleResponse(std::istream &is) {
 
         if (!_syncRootPath.empty()) {
             if (path.native().starts_with(privateFolder)) {
-                path = path.native().substr(std::size(privateFolder) - 1);
+                path = path.native().substr(
+                        std::char_traits<std::remove_cvref_t<decltype(*privateFolder)>>::length(privateFolder));
             } else if (path.native().starts_with(sharedFolder)) {
-                path = path.native().substr(std::size(sharedFolder) - 1);
+                path = path.native().substr(std::char_traits<std::remove_cvref_t<decltype(*sharedFolder)>>::length(sharedFolder));
             }
 
             if (path.native().starts_with(Str("/")) || path.native().starts_with(Str("\\"))) {

--- a/src/libsyncengine/jobs/network/kDrive_API/searchjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/searchjob.cpp
@@ -146,10 +146,9 @@ ExitInfo SearchJob::handleResponse(std::istream &is) {
 
         if (!_syncRootPath.empty()) {
             if (path.native().starts_with(privateFolder)) {
-                path = path.native().substr(
-                        std::char_traits<std::remove_cvref_t<decltype(*privateFolder)>>::length(privateFolder));
+                path = path.native().substr(std::size(privateFolder) - 1);
             } else if (path.native().starts_with(sharedFolder)) {
-                path = path.native().substr(std::char_traits<std::remove_cvref_t<decltype(*sharedFolder)>>::length(sharedFolder));
+                path = path.native().substr(std::size(sharedFolder) - 1);
             }
 
             if (path.native().starts_with(Str("/")) || path.native().starts_with(Str("\\"))) {

--- a/src/libsyncengine/jobs/network/kDrive_API/searchjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/searchjob.cpp
@@ -27,8 +27,8 @@
 
 namespace KDC {
 
-static constexpr auto privateFolder = "Private/";
-static constexpr auto sharedFolder = "Shared/";
+static constexpr auto privateFolder = "/Private/";
+static constexpr auto sharedFolder = "/Shared/";
 
 SearchJob::SearchJob(const DriveDbId driveDbId, const SyncDbId syncDbId, const std::string &searchString,
                      const std::string &cursorInput /*= {}*/) :
@@ -126,10 +126,11 @@ ExitInfo SearchJob::handleResponse(std::istream &is) {
             return {ExitCode::BackError, ExitCause::MissingReplyData};
         }
 
-        std::string path;
-        if (!JsonParserUtility::extractValue(obj, pathKey, path)) {
+        SyncName path_;
+        if (!JsonParserUtility::extractValue(obj, pathKey, path_)) {
             return {ExitCode::BackError, ExitCause::MissingReplyData};
         }
+        SyncPath path(path_);
 
         SyncTime modifiedTime = 0;
         if (!JsonParserUtility::extractValue(obj, lastModifiedAtKey, modifiedTime, false)) {
@@ -144,14 +145,10 @@ ExitInfo SearchJob::handleResponse(std::istream &is) {
         bool isAvailableLocally = false;
 
         if (!_syncRootPath.empty()) {
-            if (path.starts_with('/') || path.starts_with('\\')) {
-                path.erase(0, 1);
-            }
-
-            if (path.starts_with(privateFolder)) {
-                path.erase(0, std::char_traits<char>::length(privateFolder));
-            } else if (path.starts_with(sharedFolder)) {
-                path.erase(0, std::char_traits<char>::length(sharedFolder));
+            if (path.string().starts_with(privateFolder)) {
+                path = path.string().substr(std::char_traits<char>::length(privateFolder));
+            } else if (path.string().starts_with(sharedFolder)) {
+                path = path.string().substr(std::char_traits<char>::length(sharedFolder));
             }
 
             SyncPath absolutePath = _syncRootPath / path;

--- a/src/libsyncengine/jobs/network/kDrive_API/searchjob.h
+++ b/src/libsyncengine/jobs/network/kDrive_API/searchjob.h
@@ -36,6 +36,8 @@ class SearchJob : public AbstractTokenNetworkJob {
         [[nodiscard]] bool hasMore() const { return _hasMore; }
 
     private:
+        friend class TestSearchJob;
+
         std::string getSpecificUrl() override;
         void setQueryParameters(Poco::URI &uri) override;
         ExitInfo handleResponse(std::istream &is) override;

--- a/test/libsyncengine/CMakeLists.txt
+++ b/test/libsyncengine/CMakeLists.txt
@@ -36,6 +36,7 @@ set(testsyncengine_SRCS
         jobs/network/testnetworkjobs.h jobs/network/testnetworkjobs.cpp
         jobs/network/kDrive_API/testapitranslator.h jobs/network/kDrive_API/testapitranslator.cpp
         jobs/network/kDrive_API/testloguploadjob.h jobs/network/kDrive_API/testloguploadjob.cpp
+        jobs/network/kDrive_API/testsearchjob.h jobs/network/kDrive_API/testsearchjob.cpp
         ## Local jobs
         jobs/local/testlocaljobs.h jobs/local/testlocaljobs.cpp
         # Update Detection

--- a/test/libsyncengine/jobs/network/kDrive_API/testsearchjob.cpp
+++ b/test/libsyncengine/jobs/network/kDrive_API/testsearchjob.cpp
@@ -1,0 +1,166 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "testsearchjob.h"
+
+#include "jobs/network/kDrive_API/searchjob.h"
+#include "jobs/network/abstracttokennetworkjob.h"
+#include "requests/parameterscache.h"
+#include "libcommonserver/utility/utility.h"
+
+#include "libcommonserver/keychainmanager/keychainmanager.h"
+#include "keychainmanager/apitoken.h"
+#include "libparms/db/parmsdb.h"
+#include "mocks/libcommonserver/db/mockdb.h"
+
+#include <filesystem>
+#include <sstream>
+
+using namespace CppUnit;
+
+namespace KDC {
+
+namespace {
+
+// Builds a minimal valid search API JSON response with a single file result
+// whose remote path is pathValue (UTF-8 encoded).
+std::string makeSearchResponseJson(const std::string &pathValue) {
+    return R"({"cursor":"c1","has_more":false,"data":[{"id":"1","name":"doc.txt","type":"file","path":")" + pathValue +
+           R"(","last_modified_at":1700000000,"size":100}]})";
+}
+
+} // anonymous namespace
+
+void TestSearchJob::setUp() {
+    TestBase::start();
+    LOGW_DEBUG(Log::instance()->getLogger(), L"$$$$$ Set Up TestSearchJob");
+
+    // Init in-memory keychain (testing mode, no real OS keychain used)
+    (void) KeyChainManager::instance(true);
+
+    ApiToken apiToken;
+    apiToken.setAccessToken("dummy_access_token");
+    const std::string keychainKey("test_search_job_key");
+    (void) KeyChainManager::instance()->writeToken(keychainKey, apiToken.reconstructJsonString());
+
+    // Init ParmsDb
+    (void) ParmsDb::instance(_localTempDir.path() / MockDb::makeDbMockFileName(), KDRIVE_VERSION_STRING, true, true);
+
+    // Insert the minimal User / Account / Drive so SearchJob construction succeeds
+    User user(1, 12345, keychainKey);
+    (void) ParmsDb::instance()->insertUser(user);
+
+    Account account(1, 67890, user.dbId(), "test_account");
+    (void) ParmsDb::instance()->insertAccount(account);
+
+    Drive drive(static_cast<int>(_driveDbId), 99999, account.dbId(), "test_drive", 0, std::string());
+    (void) ParmsDb::instance()->insertDrive(drive);
+}
+
+void TestSearchJob::tearDown() {
+    LOGW_DEBUG(Log::instance()->getLogger(), L"$$$$$ Tear Down TestSearchJob");
+
+    AbstractTokenNetworkJob::clearCache();
+    ParmsDb::instance()->close();
+    ParmsDb::reset();
+    ParametersCache::reset();
+    TestBase::stop();
+}
+
+void TestSearchJob::testHandleResponsePrivatePath() {
+    // Paths returned by the API for "Private" files are prefixed with "/Private/".
+    // handleResponse() should strip this prefix so SearchInfo::path() is relative.
+    SearchJob job(_driveDbId, "doc");
+    job._syncRootPath = _localTempDir.path();
+
+    const std::string json = makeSearchResponseJson("/Private/testdir");
+    std::istringstream is(json);
+    const ExitInfo exitInfo = job.handleResponse(is);
+
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), exitInfo);
+    const auto results = job.searchResults();
+    CPPUNIT_ASSERT_EQUAL(size_t{1}, results.size());
+    CPPUNIT_ASSERT_EQUAL(SyncPath(Str("testdir")), results.front().path());
+}
+
+void TestSearchJob::testHandleResponseSharedPath() {
+    // Paths returned by the API for "Shared" files are prefixed with "/Shared/".
+    // handleResponse() should strip this prefix so SearchInfo::path() is relative.
+    SearchJob job(_driveDbId, "doc");
+    job._syncRootPath = _localTempDir.path();
+
+    const std::string json = makeSearchResponseJson("/Shared/testdir");
+    std::istringstream is(json);
+    const ExitInfo exitInfo = job.handleResponse(is);
+
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), exitInfo);
+    const auto results = job.searchResults();
+    CPPUNIT_ASSERT_EQUAL(size_t{1}, results.size());
+    CPPUNIT_ASSERT_EQUAL(SyncPath(Str("testdir")), results.front().path());
+}
+
+void TestSearchJob::testHandleResponseLeadingSlash() {
+    // When a path has no recognized prefix but begins with '/', handleResponse()
+    // should strip the root component so the result is a relative path.
+    SearchJob job(_driveDbId, "doc");
+    job._syncRootPath = _localTempDir.path();
+
+    const std::string json = makeSearchResponseJson("/testdir");
+    std::istringstream is(json);
+    const ExitInfo exitInfo = job.handleResponse(is);
+
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), exitInfo);
+    const auto results = job.searchResults();
+    CPPUNIT_ASSERT_EQUAL(size_t{1}, results.size());
+    CPPUNIT_ASSERT_EQUAL(SyncPath(Str("testdir")), results.front().path());
+}
+
+void TestSearchJob::testHandleResponseIsAvailableLocally() {
+    // Create an actual directory under the sync root so that
+    // SearchInfo::isAvailableLocally() returns true for it.
+    const SyncPath existingDir = _localTempDir.path() / "existing_dir";
+    std::error_code ec;
+    std::filesystem::create_directory(existingDir, ec);
+    CPPUNIT_ASSERT_MESSAGE("Failed to create test directory", !ec);
+
+    {
+        // A Private path that resolves to an existing local directory
+        SearchJob job(_driveDbId, "doc");
+        job._syncRootPath = _localTempDir.path();
+        const std::string json = makeSearchResponseJson("/Private/existing_dir");
+        std::istringstream is(json);
+        CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), job.handleResponse(is));
+        const auto results = job.searchResults();
+        CPPUNIT_ASSERT_EQUAL(size_t{1}, results.size());
+        CPPUNIT_ASSERT_EQUAL(true, results.front().isAvailableLocally());
+    }
+
+    {
+        // A Private path that does NOT exist locally
+        SearchJob job(_driveDbId, "doc");
+        job._syncRootPath = _localTempDir.path();
+        const std::string json = makeSearchResponseJson("/Private/missing_dir");
+        std::istringstream is(json);
+        CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), job.handleResponse(is));
+        const auto results = job.searchResults();
+        CPPUNIT_ASSERT_EQUAL(size_t{1}, results.size());
+        CPPUNIT_ASSERT_EQUAL(false, results.front().isAvailableLocally());
+    }
+}
+
+} // namespace KDC

--- a/test/libsyncengine/jobs/network/kDrive_API/testsearchjob.cpp
+++ b/test/libsyncengine/jobs/network/kDrive_API/testsearchjob.cpp
@@ -18,6 +18,7 @@
 
 #include "testsearchjob.h"
 
+#include "config.h"
 #include "jobs/network/kDrive_API/searchjob.h"
 #include "jobs/network/abstracttokennetworkjob.h"
 #include "requests/parameterscache.h"

--- a/test/libsyncengine/jobs/network/kDrive_API/testsearchjob.cpp
+++ b/test/libsyncengine/jobs/network/kDrive_API/testsearchjob.cpp
@@ -18,7 +18,7 @@
 
 #include "testsearchjob.h"
 
-#include "config.h"
+#include "version.h"
 #include "jobs/network/kDrive_API/searchjob.h"
 #include "jobs/network/abstracttokennetworkjob.h"
 #include "requests/parameterscache.h"

--- a/test/libsyncengine/jobs/network/kDrive_API/testsearchjob.h
+++ b/test/libsyncengine/jobs/network/kDrive_API/testsearchjob.h
@@ -1,0 +1,54 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "testincludes.h"
+#include "test_utility/localtemporarydirectory.h"
+
+#include "utility/types.h"
+
+using namespace CppUnit;
+
+namespace KDC {
+
+class TestSearchJob : public CppUnit::TestFixture, public TestBase {
+    public:
+        CPPUNIT_TEST_SUITE(TestSearchJob);
+        CPPUNIT_TEST(testHandleResponsePrivatePath);
+        CPPUNIT_TEST(testHandleResponseSharedPath);
+        CPPUNIT_TEST(testHandleResponseLeadingSlash);
+        CPPUNIT_TEST(testHandleResponseIsAvailableLocally);
+        CPPUNIT_TEST_SUITE_END();
+
+    public:
+        void setUp() override;
+        void tearDown() override;
+
+    protected:
+        void testHandleResponsePrivatePath();
+        void testHandleResponseSharedPath();
+        void testHandleResponseLeadingSlash();
+        void testHandleResponseIsAvailableLocally();
+
+    private:
+        DriveDbId _driveDbId = 1;
+        LocalTemporaryDirectory _localTempDir{"testSearchJob"};
+};
+
+} // namespace KDC

--- a/test/libsyncengine/test.cpp
+++ b/test/libsyncengine/test.cpp
@@ -42,6 +42,7 @@
 #include "jobs/network/testnetworkjobs.h"
 #include "jobs/network/kDrive_API/testapitranslator.h"
 #include "jobs/network/kDrive_API/testloguploadjob.h"
+#include "jobs/network/kDrive_API/testsearchjob.h"
 #include "jobs/network/testsnapshotitemhandler.h"
 #include "jobs/local/testlocaljobs.h"
 #include "jobs/testabstractjob.h"
@@ -64,6 +65,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION(TestExclusionTemplateCache);
 CPPUNIT_TEST_SUITE_REGISTRATION(TestNetworkJobs);
 CPPUNIT_TEST_SUITE_REGISTRATION(TestApiTranslator);
 CPPUNIT_TEST_SUITE_REGISTRATION(TestLogUploadJob);
+CPPUNIT_TEST_SUITE_REGISTRATION(TestSearchJob);
 
 CPPUNIT_TEST_SUITE_REGISTRATION(TestSyncDb);
 CPPUNIT_TEST_SUITE_REGISTRATION(TestSyncNodeCache);


### PR DESCRIPTION
Refactor path serialization/deserialization in SearchInfo to use utility functions for SyncPath and CommString conversion. Add commString2SyncPath to CommonUtility. Update SearchJob to handle path extraction and prefix removal using SyncPath instead of std::string. Adjust folder constants to match expected path format.