### PR TITLE
fix(icons): improve SvgIconSource usage and sizing

### DIFF
--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/HomeErrorInfoBar.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/HomeErrorInfoBar.xaml
@@ -38,7 +38,7 @@
                  IsClosable="True"
                  Closed="kDriveFullInfoBar_Closed">
             <InfoBar.IconSource>
-                <controls:SvgIconSource UriString="{StaticResource Infomaniak.DS.Icons.Products.kDrive-outline}"
+                <controls:SvgIconSource UriSource="{StaticResource Infomaniak.DS.Icons.Products.kDrive-outline}"
                                         Foreground="{ThemeResource SystemAccentColor}" />
             </InfoBar.IconSource>
             <InfoBar.ActionButton>
@@ -56,7 +56,7 @@
                  IsClosable="True"
                  Closed="TmpDirAccessError_Closed">
             <InfoBar.IconSource>
-                <controls:SvgIconSource UriString="{StaticResource Infomaniak.DS.Icons.Network.cloud-offline}"
+                <controls:SvgIconSource UriSource="{StaticResource Infomaniak.DS.Icons.Network.cloud-offline}"
                                         Foreground="{ThemeResource SystemAccentColor}" />
             </InfoBar.IconSource>
             <InfoBar.ActionButton>

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/SvgIcon.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/SvgIcon.cs
@@ -32,16 +32,13 @@ namespace Infomaniak.kDrive.CustomControls
     {
         private bool _isLoaded;
         private CancellationTokenSource? _refreshCts;
-        private List<KeyValuePair<DependencyProperty, long>> subscribptionTokens = new List<KeyValuePair<DependencyProperty, long>>();
+        private List<KeyValuePair<DependencyProperty, long>> _subscriptionTokens = new List<KeyValuePair<DependencyProperty, long>>();
 
         public SvgIcon()
         {
             // Register property change callbacks
             Foreground = null;
-            subscribptionTokens.Add(new KeyValuePair<DependencyProperty, long>(ForegroundProperty, RegisterPropertyChangedCallback(ForegroundProperty, OnDependencyPropertyChanged)));
-            subscribptionTokens.Add(new KeyValuePair<DependencyProperty, long>(WidthProperty, RegisterPropertyChangedCallback(WidthProperty, OnDependencyPropertyChanged)));
-            subscribptionTokens.Add(new KeyValuePair<DependencyProperty, long>(HeightProperty, RegisterPropertyChangedCallback(HeightProperty, OnDependencyPropertyChanged)));
-
+           
             // Track Loaded state
             Loaded += OnLoaded;
             Unloaded += OnUnloaded;
@@ -115,6 +112,11 @@ namespace Infomaniak.kDrive.CustomControls
 
         private void OnLoaded(object sender, RoutedEventArgs e)
         {
+            _subscriptionTokens.Add(new KeyValuePair<DependencyProperty, long>(ForegroundProperty, RegisterPropertyChangedCallback(ForegroundProperty, OnDependencyPropertyChanged)));
+            _subscriptionTokens.Add(new KeyValuePair<DependencyProperty, long>(WidthProperty, RegisterPropertyChangedCallback(WidthProperty, OnDependencyPropertyChanged)));
+            _subscriptionTokens.Add(new KeyValuePair<DependencyProperty, long>(HeightProperty, RegisterPropertyChangedCallback(HeightProperty, OnDependencyPropertyChanged)));
+
+
             _isLoaded = true;
             ScheduleRefresh();
 
@@ -128,11 +130,11 @@ namespace Infomaniak.kDrive.CustomControls
             ActualThemeChanged -= OnThemeChanged;
 
             // Unregister property change callbacks
-            foreach (var token in subscribptionTokens)
+            foreach (var token in _subscriptionTokens)
             {
                 UnregisterPropertyChangedCallback(token.Key, token.Value);
             }
-            subscribptionTokens.Clear();
+            _subscriptionTokens.Clear();
         }
 
         private void OnThemeChanged(FrameworkElement sender, object args)

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/SvgIcon.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/SvgIcon.cs
@@ -15,13 +15,13 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Svg;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -32,14 +32,15 @@ namespace Infomaniak.kDrive.CustomControls
     {
         private bool _isLoaded;
         private CancellationTokenSource? _refreshCts;
+        private List<KeyValuePair<DependencyProperty, long>> subscribptionTokens = new List<KeyValuePair<DependencyProperty, long>>();
 
         public SvgIcon()
         {
             // Register property change callbacks
             Foreground = null;
-            RegisterPropertyChangedCallback(ForegroundProperty, OnDependencyPropertyChanged);
-            RegisterPropertyChangedCallback(WidthProperty, OnDependencyPropertyChanged);
-            RegisterPropertyChangedCallback(HeightProperty, OnDependencyPropertyChanged);
+            subscribptionTokens.Add(new KeyValuePair<DependencyProperty, long>(ForegroundProperty, RegisterPropertyChangedCallback(ForegroundProperty, OnDependencyPropertyChanged)));
+            subscribptionTokens.Add(new KeyValuePair<DependencyProperty, long>(WidthProperty, RegisterPropertyChangedCallback(WidthProperty, OnDependencyPropertyChanged)));
+            subscribptionTokens.Add(new KeyValuePair<DependencyProperty, long>(HeightProperty, RegisterPropertyChangedCallback(HeightProperty, OnDependencyPropertyChanged)));
 
             // Track Loaded state
             Loaded += OnLoaded;
@@ -125,6 +126,13 @@ namespace Infomaniak.kDrive.CustomControls
         {
             _isLoaded = false;
             ActualThemeChanged -= OnThemeChanged;
+
+            // Unregister property change callbacks
+            foreach (var token in subscribptionTokens)
+            {
+                UnregisterPropertyChangedCallback(token.Key, token.Value);
+            }
+            subscribptionTokens.Clear();
         }
 
         private void OnThemeChanged(FrameworkElement sender, object args)

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/SvgIconSource.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/SvgIconSource.cs
@@ -23,7 +23,6 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Windows.Media.Media3D;
 
 namespace Infomaniak.kDrive.CustomControls
 {
@@ -107,17 +106,17 @@ namespace Infomaniak.kDrive.CustomControls
 
         private (double Width, double Height) ComputeRasterSize(SvgDocument svgDoc)
         {
-            var scale = Utility.DpiHelper.GetScaleForWindow(
-                WinRT.Interop.WindowNative.GetWindowHandle((Application.Current as App)?.CurrentWindow));
+            Window? window = (Application.Current as App)?.CurrentWindow;
 
-            var ratio = svgDoc.Height.Value / svgDoc.Width.Value;
-            if (double.IsNaN(ratio) || double.IsInfinity(ratio))
-                ratio = 1.0F;
+            if (window is null)
+            {
+                Logger.Log(Logger.Level.Warning, "Unable to get current window for DPI scaling, defaulting to 1.0");
+                return (svgDoc.Width.Value, svgDoc.Height.Value);
+            }
 
-            double targetHeight = svgDoc.Height.Value;
-            double targetWidth = targetHeight / ratio;
-
-            return (targetWidth * scale, targetHeight * scale);
+            var scale = Utility.DpiHelper.GetScaleForWindow(WinRT.Interop.WindowNative.GetWindowHandle(window));
+            scale = scale == 0 ? 1.0 : scale; // Fallback to 1.0 if DPI scaling is unavailable
+            return (svgDoc.Height.Value * scale, svgDoc.Width.Value * scale);
         }
 
         private void TryFallback()

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/SvgIconSource.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/SvgIconSource.cs
@@ -17,12 +17,13 @@
  */
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Imaging;
+using Svg;
 using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows.Media.Media3D;
 
 namespace Infomaniak.kDrive.CustomControls
 {
@@ -33,7 +34,6 @@ namespace Infomaniak.kDrive.CustomControls
         public SvgIconSource()
         {
             RegisterPropertyChangedCallback(ForegroundProperty, OnDependencyPropertyChanged);
-            ImageSource = new SvgImageSource();
         }
 
         public Uri? UriSource
@@ -48,17 +48,6 @@ namespace Infomaniak.kDrive.CustomControls
                 typeof(SvgIconSource),
                 new PropertyMetadata(null, OnDependencyPropertyChanged));
 
-        public string UriString
-        {
-            get => (string)GetValue(UriSourceStringProperty);
-            set => SetValue(UriSourceStringProperty, value);
-        }
-        public static readonly DependencyProperty UriSourceStringProperty =
-            DependencyProperty.Register(
-                nameof(UriString),
-                typeof(string),
-                typeof(SvgIconSource),
-                new PropertyMetadata(string.Empty, OnDependencyPropertyChanged));
 
         private static void OnDependencyPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
@@ -75,19 +64,6 @@ namespace Infomaniak.kDrive.CustomControls
 
         private void ScheduleRefresh()
         {
-            if (UriString != UriSource?.ToString())
-            {
-                try
-                {
-                    UriSource = new Uri(UriString);
-                }
-                catch
-                {
-                    UriSource = null;
-                }
-                return; // UriSource changed will trigger Refresh
-            }
-
             _refreshCts = SvgHelper.ScheduleOnDispatcher(_refreshCts, DispatcherQueue, RefreshSource, "SvgIconSource");
         }
 
@@ -99,20 +75,20 @@ namespace Infomaniak.kDrive.CustomControls
                 if (UriSource is null)
                     return;
 
-                var svgImageSource = ImageSource as SvgImageSource;
-                if (svgImageSource is null)
-                {
-                    Logger.Log(Logger.Level.Error, $"ImageSource is not SvgImageSource");
-                    TryFallback();
-                    return;
-                }
-
                 var result = SvgHelper.TryLoad(UriSource, Foreground, token);
                 if (result is null)
                 {
                     TryFallback();
                     return;
                 }
+                var (pixelWidth, pixelHeight) = ComputeRasterSize(result.Value.Doc);
+
+                ImageSource = new SvgImageSource
+                {
+                    RasterizePixelWidth = pixelWidth,
+                    RasterizePixelHeight = pixelHeight
+                };
+                var svgImageSource = (SvgImageSource)ImageSource;
 
                 using var memoryStream = result.Value.Stream;
                 await svgImageSource.SetSourceAsync(memoryStream.AsRandomAccessStream()).AsTask(token);
@@ -127,7 +103,23 @@ namespace Infomaniak.kDrive.CustomControls
                 TryFallback();
             }
         }
-     
+
+
+        private (double Width, double Height) ComputeRasterSize(SvgDocument svgDoc)
+        {
+            var scale = Utility.DpiHelper.GetScaleForWindow(
+                WinRT.Interop.WindowNative.GetWindowHandle((Application.Current as App)?.CurrentWindow));
+
+            var ratio = svgDoc.Height.Value / svgDoc.Width.Value;
+            if (double.IsNaN(ratio) || double.IsInfinity(ratio))
+                ratio = 1.0F;
+
+            double targetHeight = svgDoc.Height.Value;
+            double targetWidth = targetHeight / ratio;
+
+            return (targetWidth * scale, targetHeight * scale);
+        }
+
         private void TryFallback()
         {
             try

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/SyncActivityTable.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/SyncActivityTable.xaml.cs
@@ -46,7 +46,7 @@ namespace Infomaniak.kDrive.CustomControls
         {
             InitializeComponent();
 
-            ViewModel.PropertyChanged += ViewModel_PropertyChanged;
+            ViewModel.SelectedSyncChanged += ViewModel_SelectedSyncChanged;
 
             if (ViewModel.SelectedSync != null)
             {
@@ -54,18 +54,17 @@ namespace Infomaniak.kDrive.CustomControls
             }
             RefreshFilteredActivities();
         }
+
         private void UserControl_Unloaded(object sender, RoutedEventArgs e)
         {
             _activitySubscription?.Dispose();
-            ViewModel.PropertyChanged -= ViewModel_PropertyChanged;
+            _outGoingActivities.Clear();
+            ViewModel.SelectedSyncChanged -= ViewModel_SelectedSyncChanged;
         }
 
-        private void ViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+        private void ViewModel_SelectedSyncChanged(object? sender, AppModel.SelectedSyncChangedEventArgs e)
         {
-            if (e.PropertyName == nameof(ViewModel.SelectedSync) && ViewModel.SelectedSync is not null)
-            {
-                RefreshFilteredActivities();
-            }
+            RefreshFilteredActivities();
         }
 
         private void SubscribeToActivities(Sync sync)
@@ -76,7 +75,14 @@ namespace Infomaniak.kDrive.CustomControls
                 .ToObservableChangeSet()
                 .Filter(a => a.Direction == SyncDirection.Up)
                 .Sort(SortExpressionComparer<SyncFileItem>.Ascending(a => a.Timestamp))
-                .OnItemAdded(a => _outGoingActivities.Insert(0, a))
+                .OnItemAdded(a =>
+                {
+                    _outGoingActivities.Insert(0, a);
+                    const int MaxActivities = 200;
+                    while (_outGoingActivities.Count > MaxActivities)
+                        _outGoingActivities.RemoveAt(_outGoingActivities.Count - 1);
+                })
+                .OnItemRemoved(a => _outGoingActivities.Remove(a))
                 .Subscribe();
         }
 
@@ -109,8 +115,11 @@ namespace Infomaniak.kDrive.CustomControls
         {
             if (ActivityList == null)
                 return;
+
             if (ShowIncomingActivity == null || ShowIncomingActivity == true)
             {
+                _activitySubscription?.Dispose();
+                _outGoingActivities.Clear();
                 ActivityList.ItemsSource = ViewModel.SelectedSync?.SyncActivities;
             }
             else if (ViewModel.SelectedSync is not null)

--- a/src/gui4/windows/kDrive client/kDrive client/MainWindow.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/MainWindow.xaml.cs
@@ -45,7 +45,11 @@ namespace Infomaniak.kDrive
             ViewModel.PropertyChanged += ViewModel_PropertyChanged;
             Closed += MainWindow_Closed;
             this.Content.PointerPressed += OnPointerPressed;
+            Activated += OnActivated;
+        }
 
+        private void OnActivated(object sender, WindowActivatedEventArgs args)
+        {
             UpdateControlsVisibility();
         }
 

--- a/src/gui4/windows/kDrive client/kDrive client/MainWindow.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/MainWindow.xaml.cs
@@ -44,13 +44,8 @@ namespace Infomaniak.kDrive
             AppWindow.TitleBar.PreferredTheme = Microsoft.UI.Windowing.TitleBarTheme.UseDefaultAppMode;
             ViewModel.PropertyChanged += ViewModel_PropertyChanged;
             Closed += MainWindow_Closed;
+            Activated += MainWindow_Activated;
             this.Content.PointerPressed += OnPointerPressed;
-            Activated += OnActivated;
-        }
-
-        private void OnActivated(object sender, WindowActivatedEventArgs args)
-        {
-            UpdateControlsVisibility();
         }
 
         private void OnPointerPressed(object sender, PointerRoutedEventArgs e)
@@ -75,6 +70,11 @@ namespace Infomaniak.kDrive
             }
         }
 
+        private void MainWindow_Activated(object sender, WindowActivatedEventArgs args)
+        {
+            UpdateControlsVisibility();
+        }
+
         private void MainWindow_Closed(object sender, WindowEventArgs args)
         {
             if ((App.Current as App)?.CurrentWindow == this)
@@ -86,6 +86,7 @@ namespace Infomaniak.kDrive
 
             ViewModel.PropertyChanged -= ViewModel_PropertyChanged;
             Closed -= MainWindow_Closed;
+            Activated -= MainWindow_Activated;
             this.Content.PointerPressed -= OnPointerPressed;
         }
 


### PR DESCRIPTION
Replaced UriString with UriSource in XAML for SVG icons. Removed UriString property and related logic from SvgIconSource.cs. Added dynamic raster size calculation based on window DPI. ImageSource is now re-initialized with computed dimensions on refresh. Cleaned up unused dependencies.