### PR TITLE
fix: New mac interop flag fix

### DIFF
--- a/src/gui4/macOS/CppInterop/interop/kd_macos_defines.h
+++ b/src/gui4/macOS/CppInterop/interop/kd_macos_defines.h
@@ -1,0 +1,3 @@
+// Required flag to correctly compile shared types
+#pragma once
+#define KD_MACOS 1

--- a/src/gui4/macOS/CppInterop/interop/kd_macos_defines.h
+++ b/src/gui4/macOS/CppInterop/interop/kd_macos_defines.h
@@ -1,3 +1,21 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 // Required flag to correctly compile shared types
 #pragma once
 #define KD_MACOS 1

--- a/src/gui4/macOS/CppInterop/module.modulemap
+++ b/src/gui4/macOS/CppInterop/module.modulemap
@@ -1,4 +1,5 @@
 module CppInterop {
+    header "interop/kd_macos_defines.h"
     header "interop/cstypes.h"
     header "interop/comm.h"
     requires cplusplus

--- a/src/gui4/macOS/kDriveCore/kDriveCore-Bridging-Header.h
+++ b/src/gui4/macOS/kDriveCore/kDriveCore-Bridging-Header.h
@@ -16,9 +16,6 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// Required flag to correctly compile shared types
-#define KD_MACOS 1
-
 // Bridging-Header.h
 #import "ServerBridge/XPC/xpcGuiProtocol.h"
 #import "ServerBridge/XPC/xpcLoginItemProtocol.h"


### PR DESCRIPTION
To correctly build the shared CPP type a mac flag needs to be defined.
This flag was missing to the new way of importing the shared CPP types.