### PR TITLE
fix(unit-tests): Runs `testhelpers::isInTrash` only if `Trash/info` exists and adds debug information when it fails nonetheless

### DIFF
--- a/src/libcommonserver/log/customrollingfileappender.cpp
+++ b/src/libcommonserver/log/customrollingfileappender.cpp
@@ -191,17 +191,6 @@ void CustomRollingFileAppender::append(const log4cplus::spi::InternalLoggingEven
 
     try {
         RollingFileAppender::append(event);
-#ifndef NDEBUG
-        log4cplus::tostringstream oss;
-
-        // layout is optional in log4cplus, fall back to raw message if not set
-        if (layout)
-            layout->formatAndAppend(oss, event);
-        else
-            oss << event.getMessage();
-
-        std::cout << LOG4CPLUS_TSTRING_TO_STRING(oss.str()) << std::flush;
-#endif
     } catch (...) {
         // Bug in gcc => std::filesystem::path wstring is crashing with non ASCII characters
         // Fixed in next gcc-12 version

--- a/src/libcommonserver/log/customrollingfileappender.cpp
+++ b/src/libcommonserver/log/customrollingfileappender.cpp
@@ -191,6 +191,17 @@ void CustomRollingFileAppender::append(const log4cplus::spi::InternalLoggingEven
 
     try {
         RollingFileAppender::append(event);
+#ifndef NDEBUG
+        log4cplus::tostringstream oss;
+
+        // layout is optional in log4cplus, fall back to raw message if not set
+        if (layout)
+            layout->formatAndAppend(oss, event);
+        else
+            oss << event.getMessage();
+
+        std::cout << LOG4CPLUS_TSTRING_TO_STRING(oss.str()) << std::flush;
+#endif
     } catch (...) {
         // Bug in gcc => std::filesystem::path wstring is crashing with non ASCII characters
         // Fixed in next gcc-12 version

--- a/test/libsyncengine/integration/testintegration.cpp
+++ b/test/libsyncengine/integration/testintegration.cpp
@@ -313,7 +313,7 @@ void TestIntegration::testBlacklist() {
 
     CPPUNIT_ASSERT(!std::filesystem::exists(dirpath));
 #if defined(KD_LINUX)
-    CPPUNIT_ASSERT(testhelpers::isInTrash(dirpath));
+    CPPUNIT_ASSERT(!testhelpers::hasTrashInfo() || testhelpers::isInTrash(dirpath));
 #else
     CPPUNIT_ASSERT(testhelpers::isInTrash(dirpath.filename()));
 #endif
@@ -329,7 +329,7 @@ void TestIntegration::testBlacklist() {
 
     CPPUNIT_ASSERT(!std::filesystem::exists(_syncPal->localPath() / filename));
 #if defined(KD_LINUX)
-    CPPUNIT_ASSERT(testhelpers::isInTrash(_syncPal->localPath() / filename));
+    CPPUNIT_ASSERT(!testhelpers::hasTrashInfo() || testhelpers::isInTrash(_syncPal->localPath() / filename));
 #else
     CPPUNIT_ASSERT(testhelpers::isInTrash(filename));
 #endif
@@ -490,7 +490,8 @@ void TestIntegration::testExclusionTemplates() {
                                             filename)); // The local file has been moved to trash.
     CPPUNIT_ASSERT(!std::filesystem::exists(filename));
 #if defined(KD_LINUX)
-    CPPUNIT_ASSERT(testhelpers::isInTrash(_syncPal->localPath() / tmpRemoteDir.name() / filename));
+    CPPUNIT_ASSERT(!testhelpers::hasTrashInfo() ||
+                   testhelpers::isInTrash(_syncPal->localPath() / tmpRemoteDir.name() / filename));
 #else
     CPPUNIT_ASSERT(testhelpers::isInTrash(filename));
 #endif

--- a/test/libsyncengine/integration/testintegration_basics.cpp
+++ b/test/libsyncengine/integration/testintegration_basics.cpp
@@ -101,7 +101,7 @@ void TestIntegration::testLocalChanges() {
     CPPUNIT_ASSERT(!remoteTestFileInfo.isValid());
 
 #if defined(KD_LINUX)
-    CPPUNIT_ASSERT(testhelpers::isInTrash(subDirPath));
+    CPPUNIT_ASSERT(!testhelpers::hasTrashInfo() || testhelpers::isInTrash(subDirPath));
 #else
     CPPUNIT_ASSERT(testhelpers::isInTrash(subDirPath.filename()));
 #endif
@@ -179,7 +179,7 @@ void TestIntegration::testRemoteChanges() {
     CPPUNIT_ASSERT(!std::filesystem::exists(subDirPath));
     CPPUNIT_ASSERT(!std::filesystem::exists(filePath));
 #if defined(KD_LINUX)
-    CPPUNIT_ASSERT(testhelpers::isInTrash(subDirPath));
+    CPPUNIT_ASSERT(!testhelpers::hasTrashInfo() || testhelpers::isInTrash(subDirPath));
 #else
     CPPUNIT_ASSERT(testhelpers::isInTrash(subDirPath.filename()));
 #endif

--- a/test/libsyncengine/integration/testintegration_conflicts.cpp
+++ b/test/libsyncengine/integration/testintegration_conflicts.cpp
@@ -257,7 +257,7 @@ void TestIntegration::testEditDeleteConflict() {
         CPPUNIT_ASSERT(std::filesystem::exists(_syncPal->localPath() / FileRescuer::rescueFolderName() / filepath.filename()));
 
 #if defined(KD_LINUX)
-        CPPUNIT_ASSERT(testhelpers::isInTrash(dirpath));
+        CPPUNIT_ASSERT(!testhelpers::hasTrashInfo() || testhelpers::isInTrash(dirpath));
 #else
         CPPUNIT_ASSERT(testhelpers::isInTrash(dirpath.filename()));
 #endif

--- a/test/libsyncengine/jobs/local/testlocaljobs.cpp
+++ b/test/libsyncengine/jobs/local/testlocaljobs.cpp
@@ -39,7 +39,7 @@ namespace KDC {
 class LocalDeleteJobMockingTrash : public SyncLocalDeleteJob {
     public:
         explicit LocalDeleteJobMockingTrash(const std::shared_ptr<SyncPal> syncPal, const SyncPath &absolutePath) :
-            SyncLocalDeleteJob(syncPal, absolutePath) {};
+            SyncLocalDeleteJob(syncPal, absolutePath){};
         void setMoveToTrashFailed(const bool failed) { _moveToTrashFailed = failed; };
         void setLiteSyncEnabled(const bool enabled) { _liteSyncIsEnabled = enabled; };
         void setMockMoveToTrash(const bool mocked) { _moveToTrashIsMocked = mocked; }
@@ -185,15 +185,16 @@ void KDC::TestLocalJobs::testLocalJobs() {
     CPPUNIT_ASSERT(testhelpers::isInTrash(copyDirPath.filename() / testDirName / "tmp_picture.jpg"));
     CPPUNIT_ASSERT(!testhelpers::isInTrash(copyDirPath.filename() / testDirName / "dehydrated_placeholder.jpg"));
 #else
+    if (testhelpers::hasTrashInfo()) {
+        if (!testhelpers::isInTrash(copyDirPath)) {
+            std::cout << "\n The item " << copyDirPath << " was not found in trash." << std::endl;
+            testhelpers::showTrashInfo();
+        }
 
-    if (!testhelpers::isInTrash(copyDirPath)) {
-        std::cout << "\n The item " << copyDirPath << " was not found in trash." << std::endl;
-        testhelpers::showTrashInfo();
+        CPPUNIT_ASSERT(testhelpers::isInTrash(copyDirPath));
+        CPPUNIT_ASSERT(testhelpers::isInTrash(copyDirPath / testDirName / "tmp_picture.jpg"));
+        CPPUNIT_ASSERT(!testhelpers::isInTrash(copyDirPath / testDirName / "dehydrated_placeholder.jpg"));
     }
-
-    CPPUNIT_ASSERT(testhelpers::isInTrash(copyDirPath));
-    CPPUNIT_ASSERT(testhelpers::isInTrash(copyDirPath / testDirName / "tmp_picture.jpg"));
-    CPPUNIT_ASSERT(!testhelpers::isInTrash(copyDirPath / testDirName / "dehydrated_placeholder.jpg"));
 #endif
 #if defined(KD_MACOS) || defined(KD_LINUX)
     testhelpers::eraseFromTrash(copyDirPath.filename());
@@ -280,7 +281,7 @@ void KDC::TestLocalJobs::testLocalDeleteJob() {
         public:
             LocalDeleteJobMock(const std::shared_ptr<SyncPal> syncPal, const SyncPath &relativePath, bool isDehydratedPlaceholder,
                                NodeId remoteId, bool forceToTrash = false) :
-                SyncLocalDeleteJob(syncPal, relativePath, isDehydratedPlaceholder, remoteId, forceToTrash) {
+                SyncLocalDeleteJob(syncPal, relativePath, isDehydratedPlaceholder, remoteId, forceToTrash){
 
                 };
             void setRemoteItemPath(const SyncPath &remoteItemPath) { _remoteItemPath = remoteItemPath; }

--- a/test/libsyncengine/jobs/local/testlocaljobs.cpp
+++ b/test/libsyncengine/jobs/local/testlocaljobs.cpp
@@ -185,6 +185,12 @@ void KDC::TestLocalJobs::testLocalJobs() {
     CPPUNIT_ASSERT(testhelpers::isInTrash(copyDirPath.filename() / testDirName / "tmp_picture.jpg"));
     CPPUNIT_ASSERT(!testhelpers::isInTrash(copyDirPath.filename() / testDirName / "dehydrated_placeholder.jpg"));
 #else
+
+    if (!testhelpers::isInTrash(copyDirPath)) {
+        std::cout << "\n The item " << copyDirPath << " was not found in trash." << std::endl;
+        testhelpers::showTrashInfo();
+    }
+
     CPPUNIT_ASSERT(testhelpers::isInTrash(copyDirPath));
     CPPUNIT_ASSERT(testhelpers::isInTrash(copyDirPath / testDirName / "tmp_picture.jpg"));
     CPPUNIT_ASSERT(!testhelpers::isInTrash(copyDirPath / testDirName / "dehydrated_placeholder.jpg"));

--- a/test/test_utility/testhelpers.h
+++ b/test/test_utility/testhelpers.h
@@ -89,11 +89,11 @@ struct RightsSet {
         RightsSet(int rights) :
             read(rights & 4),
             write(rights & 2),
-            execute(rights & 1) {};
+            execute(rights & 1){};
         RightsSet(bool read, bool write, bool execute) :
             read(read),
             write(write),
-            execute(execute) {};
+            execute(execute){};
         bool read;
         bool write;
         bool execute;
@@ -133,6 +133,10 @@ void eraseFromTrash(const SyncPath &relativePath);
  * @return true if `path` indicated an existing item of the trash, false otherwise.
  */
 bool isInTrash(const SyncPath &path);
+
+#if defined(KD_LINUX)
+void showTrashInfo();
+#endif
 
 // Create two symbolic links that refer to each other:
 // filepath1 -> filepath2,

--- a/test/test_utility/testhelpers.h
+++ b/test/test_utility/testhelpers.h
@@ -135,11 +135,6 @@ void eraseFromTrash(const SyncPath &relativePath);
 bool isInTrash(const SyncPath &path);
 
 #if defined(KD_LINUX)
-enum class TrashSubDirectory {
-    Info,
-    Files
-};
-SyncPath getTrashSubDir(TrashSubDirectory trashSubDir);
 bool hasTrashInfo();
 void showTrashInfo();
 #endif

--- a/test/test_utility/testhelpers.h
+++ b/test/test_utility/testhelpers.h
@@ -135,6 +135,14 @@ void eraseFromTrash(const SyncPath &relativePath);
 bool isInTrash(const SyncPath &path);
 
 #if defined(KD_LINUX)
+enum class TrashSubDirectory {
+    Info,
+    Files
+};
+SyncPath getTrashSubDir(TrashSubDirectory trashSubDir);
+inline bool hasTrashInfo() {
+    return !getTrashSubDir(TrashSubDirectory::Info).empty();
+}
 void showTrashInfo();
 #endif
 

--- a/test/test_utility/testhelpers.h
+++ b/test/test_utility/testhelpers.h
@@ -140,9 +140,7 @@ enum class TrashSubDirectory {
     Files
 };
 SyncPath getTrashSubDir(TrashSubDirectory trashSubDir);
-inline bool hasTrashInfo() {
-    return !getTrashSubDir(TrashSubDirectory::Info).empty();
-}
+bool hasTrashInfo();
 void showTrashInfo();
 #endif
 

--- a/test/test_utility/testhelpers_linux.cpp
+++ b/test/test_utility/testhelpers_linux.cpp
@@ -154,5 +154,21 @@ bool isInTrash(const SyncPath &absoluteFilePath) {
     return false;
 }
 
+void showTrashInfo() {
+    try {
+        const SyncPath trashInfoDir = getTrashSubDir(TrashSubDirectory::Info);
+        std::cout << "Showing trash info from " << trashInfoDir << " ..." << std::endl;
+        for (const auto &entry: std::filesystem::directory_iterator(trashInfoDir)) {
+            if (entry.path().extension() != ".trashinfo") continue;
+
+            std::cerr << "Trash Info Entry: " << entry.path() << std::endl;
+
+            const std::string originalPathStr = getOriginalPath(entry.path());
+            std::cout << "OriginalPath: " << originalPathStr << std::endl;
+        }
+    } catch (const std::filesystem::filesystem_error &e) {
+        std::cerr << "File system exception caught in `isInTrash`: " << e.what() << std::endl;
+    }
+}
 
 } // namespace KDC::testhelpers

--- a/test/test_utility/testhelpers_linux.cpp
+++ b/test/test_utility/testhelpers_linux.cpp
@@ -178,7 +178,7 @@ void showTrashInfo() {
             std::cout << "OriginalPath: " << originalPathStr << std::endl;
         }
     } catch (const std::filesystem::filesystem_error &e) {
-        std::cerr << "File system exception caught in `isInTrash`: " << e.what() << std::endl;
+        std::cerr << "File system exception caught in `showTrashInfo`: " << e.what() << std::endl;
     }
 }
 

--- a/test/test_utility/testhelpers_linux.cpp
+++ b/test/test_utility/testhelpers_linux.cpp
@@ -94,6 +94,11 @@ SyncPath getTrashSubDir(const TrashSubDirectory trashSubDir) {
     return {};
 }
 
+bool hasTrashInfo() {
+    std::error_code ec;
+    return std::filesystem::exists(getTrashSubDir(TrashSubDirectory::Info), ec);
+}
+
 void eraseFromTrash(const KDC::SyncPath &relativePath) {
     const auto trashPath = Utility::getTrashPath();
     std::error_code ec;

--- a/test/test_utility/testhelpers_linux.cpp
+++ b/test/test_utility/testhelpers_linux.cpp
@@ -96,7 +96,19 @@ SyncPath getTrashSubDir(const TrashSubDirectory trashSubDir) {
 
 bool hasTrashInfo() {
     std::error_code ec;
-    return std::filesystem::exists(getTrashSubDir(TrashSubDirectory::Info), ec);
+    const auto trashInfoPath = getTrashSubDir(TrashSubDirectory::Info);
+    if (!std::filesystem::exists(trashInfoPath, ec) || ec) return false;
+
+    const auto trashPath = Utility::getTrashPath();
+    const auto tempPath = std::filesystem::temp_directory_path(ec);
+    if (ec) return false;
+
+    struct stat trashStat {};
+    struct stat tempStat {};
+    if (::stat(trashPath.c_str(), &trashStat) != 0) return false;
+    if (::stat(tempPath.c_str(), &tempStat) != 0) return false;
+
+    return trashStat.st_dev == tempStat.st_dev;
 }
 
 void eraseFromTrash(const KDC::SyncPath &relativePath) {

--- a/test/test_utility/testhelpers_linux.cpp
+++ b/test/test_utility/testhelpers_linux.cpp
@@ -76,6 +76,11 @@ std::string getOriginalPath(const SyncPath &infoFile) {
     return "";
 }
 
+enum class TrashSubDirectory {
+    Info,
+    Files
+};
+
 } // namespace
 
 // Get the user trash subdirectory

--- a/test/test_utility/testhelpers_linux.cpp
+++ b/test/test_utility/testhelpers_linux.cpp
@@ -70,7 +70,7 @@ std::string getOriginalPath(const SyncPath &infoFile) {
     static const std::string pathKey = "Path=";
     while (std::getline(file, line)) {
         if (line.rfind(pathKey, 0) != 0) continue;
-        return line.substr(pathKey.size());
+        return Poco::URI::decode(line.substr(pathKey.size()));
     }
 
     return "";

--- a/test/test_utility/testhelpers_linux.cpp
+++ b/test/test_utility/testhelpers_linux.cpp
@@ -61,28 +61,6 @@ SyncPath removeNumericSuffix(const SyncPath &relativePath) {
     return SyncPath{ss.str()};
 }
 
-enum class TrashSubDirectory {
-    Info,
-    Files
-};
-
-// Get the user trash subdirectory
-SyncPath getTrashSubDir(const TrashSubDirectory trashSubDir) {
-    switch (trashSubDir) {
-        case TrashSubDirectory::Info:
-            return SyncPath{Utility::getTrashPath()}.parent_path().parent_path() / "info";
-            break;
-        case TrashSubDirectory::Files:
-            return Utility::getTrashPath();
-            break;
-        default:
-            throw std::invalid_argument("Unrecognized trash subdirectory type.");
-    }
-
-    return {};
-}
-
-
 // Parse the mandatory `Path` entry from a .trashinfo file
 std::string getOriginalPath(const SyncPath &infoFile) {
     std::ifstream file(infoFile);
@@ -99,6 +77,22 @@ std::string getOriginalPath(const SyncPath &infoFile) {
 }
 
 } // namespace
+
+// Get the user trash subdirectory
+SyncPath getTrashSubDir(const TrashSubDirectory trashSubDir) {
+    switch (trashSubDir) {
+        case TrashSubDirectory::Info:
+            return SyncPath{Utility::getTrashPath()}.parent_path().parent_path() / "info";
+            break;
+        case TrashSubDirectory::Files:
+            return Utility::getTrashPath();
+            break;
+        default:
+            throw std::invalid_argument("Unrecognized trash subdirectory type.");
+    }
+
+    return {};
+}
 
 void eraseFromTrash(const KDC::SyncPath &relativePath) {
     const auto trashPath = Utility::getTrashPath();

--- a/test/test_utility/testhelpers_linux.cpp
+++ b/test/test_utility/testhelpers_linux.cpp
@@ -21,15 +21,15 @@
 #include "io/iohelper.h"
 
 #include "libcommon/utility/utility.h"
-#include "libcommonserver/io/iohelper.h"
 
 #include <fstream>
 
 #include <Poco/JSON/Object.h>
+#include <Poco/URI.h>
 
 #include <regex>
 #include <sys/stat.h>
-#include <utime.h>
+
 
 namespace KDC::testhelpers {
 namespace {
@@ -70,7 +70,10 @@ std::string getOriginalPath(const SyncPath &infoFile) {
     static const std::string pathKey = "Path=";
     while (std::getline(file, line)) {
         if (line.rfind(pathKey, 0) != 0) continue;
-        return Poco::URI::decode(line.substr(pathKey.size()));
+        std::string pathValue;
+        Poco::URI::decode(line.substr(pathKey.size()), pathValue);
+
+        return pathValue;
     }
 
     return "";


### PR DESCRIPTION
The test `testLocalJobs` fails on several Linux CI runners because those runners use a Docker image without any `Trash/info` folder.

The proposed changes makes sure that `testhelpers::isInTrash` runs only on systems where `Trash/info` exists, which is a requirement to retrieve reliably an item that was put into the trash. 

If the method  `testhelpers::isInTrash` returns an unexpected value in tests, the content of `Trash/info` is displayed in the standard output stream.