### PR TITLE
feat: env variable for stdout logs

### DIFF
--- a/src/libcommon/utility/utility.cpp
+++ b/src/libcommon/utility/utility.cpp
@@ -1169,7 +1169,10 @@ std::string CommonUtility::envVarValue(const std::string &name, bool &isSet) {
 }
 
 #ifndef NDEBUG
-const bool CommonUtility::logToConsole = CommonUtility::envVarValue("KDRIVE_ENABLE_LOG_TO_CONSOLE") == "1";
+bool CommonUtility::logToConsoleEnabled() {
+    static const bool value = CommonUtility::envVarValue("KDRIVE_ENABLE_LOG_TO_CONSOLE") == "1";
+    return value;
+}
 #endif
 
 int CommonUtility::setenv(const char *const name, const char *const value, const int overwrite) {

--- a/src/libcommon/utility/utility.cpp
+++ b/src/libcommon/utility/utility.cpp
@@ -1168,12 +1168,14 @@ std::string CommonUtility::envVarValue(const std::string &name, bool &isSet) {
     return std::string();
 }
 
-#ifndef NDEBUG
 bool CommonUtility::logToConsoleEnabled() {
+#ifndef NDEBUG
     static const bool value = CommonUtility::envVarValue("KDRIVE_ENABLE_LOG_TO_CONSOLE") == "1";
     return value;
-}
+#else
+    return false;
 #endif
+}
 
 int CommonUtility::setenv(const char *const name, const char *const value, const int overwrite) {
 #if defined(KD_WINDOWS)

--- a/src/libcommon/utility/utility.cpp
+++ b/src/libcommon/utility/utility.cpp
@@ -1168,6 +1168,10 @@ std::string CommonUtility::envVarValue(const std::string &name, bool &isSet) {
     return std::string();
 }
 
+#ifndef NDEBUG
+const bool CommonUtility::logToConsole = CommonUtility::envVarValue("KDRIVE_ENABLE_LOG_TO_CONSOLE") == "1";
+#endif
+
 int CommonUtility::setenv(const char *const name, const char *const value, const int overwrite) {
 #if defined(KD_WINDOWS)
     // https://stackoverflow.com/a/23616164/4675396

--- a/src/libcommon/utility/utility.h
+++ b/src/libcommon/utility/utility.h
@@ -175,7 +175,7 @@ struct COMMON_EXPORT CommonUtility {
         static int setenv(const char *const name, const char *const value, const int overwrite);
 
 #ifndef NDEBUG
-        static const bool logToConsole;
+        static bool logToConsoleEnabled();
 #endif
 
 #if defined(KD_LINUX)

--- a/src/libcommon/utility/utility.h
+++ b/src/libcommon/utility/utility.h
@@ -174,6 +174,10 @@ struct COMMON_EXPORT CommonUtility {
         static std::string envVarValue(const std::string &name, bool &isSet);
         static int setenv(const char *const name, const char *const value, const int overwrite);
 
+#ifndef NDEBUG
+        static const bool logToConsole;
+#endif
+
 #if defined(KD_LINUX)
         // Sets the working directory path and configures GIO_MODULE_DIR to prevent loading incompatible system GIO modules.
         static void initAppImageEnvironment();

--- a/src/libcommon/utility/utility.h
+++ b/src/libcommon/utility/utility.h
@@ -174,9 +174,7 @@ struct COMMON_EXPORT CommonUtility {
         static std::string envVarValue(const std::string &name, bool &isSet);
         static int setenv(const char *const name, const char *const value, const int overwrite);
 
-#ifndef NDEBUG
         static bool logToConsoleEnabled();
-#endif
 
 #if defined(KD_LINUX)
         // Sets the working directory path and configures GIO_MODULE_DIR to prevent loading incompatible system GIO modules.

--- a/src/libcommongui/logger.cpp
+++ b/src/libcommongui/logger.cpp
@@ -90,7 +90,7 @@ Logger::Logger(QObject *parent) :
     _doFileFlush(false),
     _logExpire(0),
     _logDebug(false) {
-#if defined(KD_WINDOWS) && !defined(NDEBUG) && defined(ENABLE_LOG_TO_CONSOLE)
+#if defined(Q_OS_WIN) && !defined(NDEBUG)
     if (AllocConsole()) {
         FILE *fp = nullptr;
         (void) freopen_s(&fp, "CONOUT$", "w", stdout);
@@ -171,8 +171,10 @@ void Logger::doLog(const QString &msg) {
             if (_doFileFlush) _logstream->flush();
         }
     }
-#if !defined(NDEBUG) && defined(ENABLE_LOG_TO_CONSOLE)
-    std::cout << qPrintable(msg) << std::endl;
+#ifndef NDEBUG
+    if (CommonUtility::envVarValue("ENABLE_LOG_TO_CONSOLE") != "0") {
+        std::cout << qPrintable(msg) << std::endl;
+    }
 #endif
     emit logWindowLog(msg);
 }

--- a/src/libcommongui/logger.cpp
+++ b/src/libcommongui/logger.cpp
@@ -90,16 +90,18 @@ Logger::Logger(QObject *parent) :
     _doFileFlush(false),
     _logExpire(0),
     _logDebug(false) {
-#if defined(Q_OS_WIN) && !defined(NDEBUG)
-    if (AllocConsole()) {
-        FILE *fp = nullptr;
-        (void) freopen_s(&fp, "CONOUT$", "w", stdout);
-        (void) freopen_s(&fp, "CONOUT$", "w", stderr);
+#if defined(Q_OS_WIN)
+    if (CommonUtility::logToConsoleEnabled()) {
+        if (AllocConsole()) {
+            FILE *fp = nullptr;
+            (void) freopen_s(&fp, "CONOUT$", "w", stdout);
+            (void) freopen_s(&fp, "CONOUT$", "w", stderr);
 
-        // freopen_s may leave the stream in an error state on failure.
-        // Clear C++ stream flags to ensure std::cout/std::cerr remain usable.
-        std::cout.clear();
-        std::cerr.clear();
+            // freopen_s may leave the stream in an error state on failure.
+            // Clear C++ stream flags to ensure std::cout/std::cerr remain usable.
+            std::cout.clear();
+            std::cerr.clear();
+        }
     }
 #endif
     qSetMessagePattern(

--- a/src/libcommongui/logger.cpp
+++ b/src/libcommongui/logger.cpp
@@ -91,17 +91,15 @@ Logger::Logger(QObject *parent) :
     _logExpire(0),
     _logDebug(false) {
 #if defined(Q_OS_WIN)
-    if (CommonUtility::logToConsoleEnabled()) {
-        if (AllocConsole()) {
-            FILE *fp = nullptr;
-            (void) freopen_s(&fp, "CONOUT$", "w", stdout);
-            (void) freopen_s(&fp, "CONOUT$", "w", stderr);
+    if (CommonUtility::logToConsoleEnabled() && AllocConsole()) {
+        FILE *fp = nullptr;
+        (void) freopen_s(&fp, "CONOUT$", "w", stdout);
+        (void) freopen_s(&fp, "CONOUT$", "w", stderr);
 
-            // freopen_s may leave the stream in an error state on failure.
-            // Clear C++ stream flags to ensure std::cout/std::cerr remain usable.
-            std::cout.clear();
-            std::cerr.clear();
-        }
+        // freopen_s may leave the stream in an error state on failure.
+        // Clear C++ stream flags to ensure std::cout/std::cerr remain usable.
+        std::cout.clear();
+        std::cerr.clear();
     }
 #endif
     qSetMessagePattern(

--- a/src/libcommongui/logger.cpp
+++ b/src/libcommongui/logger.cpp
@@ -172,7 +172,7 @@ void Logger::doLog(const QString &msg) {
         }
     }
 #ifndef NDEBUG
-    if (CommonUtility::envVarValue("ENABLE_LOG_TO_CONSOLE") != "0") {
+    if (CommonUtility::envVarValue("ENABLE_LOG_TO_CONSOLE") == "1") {
         std::cout << qPrintable(msg) << std::endl;
     }
 #endif

--- a/src/libcommongui/logger.cpp
+++ b/src/libcommongui/logger.cpp
@@ -172,7 +172,7 @@ void Logger::doLog(const QString &msg) {
         }
     }
 #ifndef NDEBUG
-    if (CommonUtility::envVarValue("ENABLE_LOG_TO_CONSOLE") == "1") {
+    if (CommonUtility::logToConsole) {
         std::cout << qPrintable(msg) << std::endl;
     }
 #endif

--- a/src/libcommongui/logger.cpp
+++ b/src/libcommongui/logger.cpp
@@ -90,7 +90,7 @@ Logger::Logger(QObject *parent) :
     _doFileFlush(false),
     _logExpire(0),
     _logDebug(false) {
-#if defined(Q_OS_WIN) && !defined(NDEBUG)
+#if defined(KD_WINDOWS) && !defined(NDEBUG) && defined(ENABLE_LOG_TO_CONSOLE)
     if (AllocConsole()) {
         FILE *fp = nullptr;
         (void) freopen_s(&fp, "CONOUT$", "w", stdout);
@@ -171,7 +171,7 @@ void Logger::doLog(const QString &msg) {
             if (_doFileFlush) _logstream->flush();
         }
     }
-#ifndef NDEBUG
+#if !defined(NDEBUG) && defined(ENABLE_LOG_TO_CONSOLE)
     std::cout << qPrintable(msg) << std::endl;
 #endif
     emit logWindowLog(msg);

--- a/src/libcommongui/logger.cpp
+++ b/src/libcommongui/logger.cpp
@@ -172,7 +172,7 @@ void Logger::doLog(const QString &msg) {
         }
     }
 #ifndef NDEBUG
-    if (CommonUtility::logToConsole) {
+    if (CommonUtility::logToConsoleEnabled()) {
         std::cout << qPrintable(msg) << std::endl;
     }
 #endif

--- a/src/libcommonserver/log/customrollingfileappender.cpp
+++ b/src/libcommonserver/log/customrollingfileappender.cpp
@@ -192,7 +192,7 @@ void CustomRollingFileAppender::append(const log4cplus::spi::InternalLoggingEven
     try {
         RollingFileAppender::append(event);
 #ifndef NDEBUG
-        if (CommonUtility::logToConsole) {
+        if (CommonUtility::logToConsoleEnabled()) {
             log4cplus::tostringstream oss;
 
             // layout is optional in log4cplus, fall back to raw message if not set

--- a/src/libcommonserver/log/customrollingfileappender.cpp
+++ b/src/libcommonserver/log/customrollingfileappender.cpp
@@ -192,7 +192,7 @@ void CustomRollingFileAppender::append(const log4cplus::spi::InternalLoggingEven
     try {
         RollingFileAppender::append(event);
 #ifndef NDEBUG
-        if (CommonUtility::envVarValue("ENABLE_LOG_TO_CONSOLE") == "1") {
+        if (CommonUtility::logToConsole) {
             log4cplus::tostringstream oss;
 
             // layout is optional in log4cplus, fall back to raw message if not set

--- a/src/libcommonserver/log/customrollingfileappender.cpp
+++ b/src/libcommonserver/log/customrollingfileappender.cpp
@@ -191,7 +191,6 @@ void CustomRollingFileAppender::append(const log4cplus::spi::InternalLoggingEven
 
     try {
         RollingFileAppender::append(event);
-#ifndef NDEBUG
         if (CommonUtility::logToConsoleEnabled()) {
             log4cplus::tostringstream oss;
 
@@ -203,7 +202,6 @@ void CustomRollingFileAppender::append(const log4cplus::spi::InternalLoggingEven
 
             std::cout << LOG4CPLUS_TSTRING_TO_STRING(oss.str()) << std::flush;
         }
-#endif
     } catch (...) {
         // Bug in gcc => std::filesystem::path wstring is crashing with non ASCII characters
         // Fixed in next gcc-12 version

--- a/src/libcommonserver/log/customrollingfileappender.cpp
+++ b/src/libcommonserver/log/customrollingfileappender.cpp
@@ -191,16 +191,18 @@ void CustomRollingFileAppender::append(const log4cplus::spi::InternalLoggingEven
 
     try {
         RollingFileAppender::append(event);
-#if !defined(NDEBUG) && defined(ENABLE_LOG_TO_CONSOLE)
-        log4cplus::tostringstream oss;
+#ifndef NDEBUG
+        if (CommonUtility::envVarValue("ENABLE_LOG_TO_CONSOLE") != "0") {
+            log4cplus::tostringstream oss;
 
-        // layout is optional in log4cplus, fall back to raw message if not set
-        if (layout)
-            layout->formatAndAppend(oss, event);
-        else
-            oss << event.getMessage();
+            // layout is optional in log4cplus, fall back to raw message if not set
+            if (layout)
+                layout->formatAndAppend(oss, event);
+            else
+                oss << event.getMessage();
 
-        std::cout << LOG4CPLUS_TSTRING_TO_STRING(oss.str()) << std::flush;
+            std::cout << LOG4CPLUS_TSTRING_TO_STRING(oss.str()) << std::flush;
+        }
 #endif
     } catch (...) {
         // Bug in gcc => std::filesystem::path wstring is crashing with non ASCII characters

--- a/src/libcommonserver/log/customrollingfileappender.cpp
+++ b/src/libcommonserver/log/customrollingfileappender.cpp
@@ -192,7 +192,7 @@ void CustomRollingFileAppender::append(const log4cplus::spi::InternalLoggingEven
     try {
         RollingFileAppender::append(event);
 #ifndef NDEBUG
-        if (CommonUtility::envVarValue("ENABLE_LOG_TO_CONSOLE") != "0") {
+        if (CommonUtility::envVarValue("ENABLE_LOG_TO_CONSOLE") == "1") {
             log4cplus::tostringstream oss;
 
             // layout is optional in log4cplus, fall back to raw message if not set

--- a/src/libcommonserver/log/customrollingfileappender.cpp
+++ b/src/libcommonserver/log/customrollingfileappender.cpp
@@ -191,7 +191,7 @@ void CustomRollingFileAppender::append(const log4cplus::spi::InternalLoggingEven
 
     try {
         RollingFileAppender::append(event);
-#ifndef NDEBUG
+#if !defined(NDEBUG) && defined(ENABLE_LOG_TO_CONSOLE)
         log4cplus::tostringstream oss;
 
         // layout is optional in log4cplus, fall back to raw message if not set

--- a/src/libcommonserver/log/log.cpp
+++ b/src/libcommonserver/log/log.cpp
@@ -26,7 +26,7 @@
 
 #include <codecvt>
 
-#if defined(KD_WINDOWS) && !defined(NDEBUG) && defined(ENABLE_LOG_TO_CONSOLE)
+#if defined(KD_WINDOWS) && !defined(NDEBUG)
 #include <windows.h>
 #include <iostream>
 #endif
@@ -47,17 +47,18 @@ Log::~Log() {
 
 std::shared_ptr<Log> Log::instance(const log4cplus::tstring &filePath) {
     if (_instance == nullptr) {
-        //add there a environement variable, which, if defined, print logs)
-#if defined(KD_WINDOWS) && !defined(NDEBUG) && defined(ENABLE_LOG_TO_CONSOLE)
-        if (AllocConsole()) {
-            FILE *fp = nullptr;
-            (void) freopen_s(&fp, "CONOUT$", "w", stdout);
-            (void) freopen_s(&fp, "CONOUT$", "w", stderr);
-
-            // freopen_s may leave the stream in an error state on failure.
-            // Clear C++ stream flags to ensure std::cout/std::cerr remain usable.
-            std::cout.clear();
-            std::cerr.clear();
+        // add there a environement variable, which, if defined, print logs)
+#if defined(KD_WINDOWS) && !defined(NDEBUG)
+        if (CommonUtility::envVarValue("ENABLE_LOG_TO_CONSOLE") != "0") {
+            if (AllocConsole()) {
+                FILE *fp = nullptr;
+                (void) freopen_s(&fp, "CONOUT$", "w", stdout);
+                (void) freopen_s(&fp, "CONOUT$", "w", stderr);
+                // freopen_s may leave the stream in an error state on failure.
+                // Clear C++ stream flags to ensure std::cout/std::cerr remain usable.
+                std::cout.clear();
+                std::cerr.clear();
+            }
         }
 #endif
         if (filePath.empty()) {

--- a/src/libcommonserver/log/log.cpp
+++ b/src/libcommonserver/log/log.cpp
@@ -48,7 +48,7 @@ Log::~Log() {
 std::shared_ptr<Log> Log::instance(const log4cplus::tstring &filePath) {
     if (_instance == nullptr) {
 #if defined(KD_WINDOWS) && !defined(NDEBUG)
-        if (CommonUtility::logToConsole) {
+        if (CommonUtility::logToConsoleEnabled()) {
             if (AllocConsole()) {
                 FILE *fp = nullptr;
                 (void) freopen_s(&fp, "CONOUT$", "w", stdout);

--- a/src/libcommonserver/log/log.cpp
+++ b/src/libcommonserver/log/log.cpp
@@ -47,9 +47,8 @@ Log::~Log() {
 
 std::shared_ptr<Log> Log::instance(const log4cplus::tstring &filePath) {
     if (_instance == nullptr) {
-        // add there a environement variable, which, if defined, print logs)
 #if defined(KD_WINDOWS) && !defined(NDEBUG)
-        if (CommonUtility::envVarValue("ENABLE_LOG_TO_CONSOLE") == "1") {
+        if (CommonUtility::logToConsole) {
             if (AllocConsole()) {
                 FILE *fp = nullptr;
                 (void) freopen_s(&fp, "CONOUT$", "w", stdout);

--- a/src/libcommonserver/log/log.cpp
+++ b/src/libcommonserver/log/log.cpp
@@ -26,7 +26,7 @@
 
 #include <codecvt>
 
-#if defined(KD_WINDOWS) && !defined(NDEBUG)
+#if defined(KD_WINDOWS) && !defined(NDEBUG) && defined(ENABLE_LOG_TO_CONSOLE)
 #include <windows.h>
 #include <iostream>
 #endif
@@ -47,7 +47,8 @@ Log::~Log() {
 
 std::shared_ptr<Log> Log::instance(const log4cplus::tstring &filePath) {
     if (_instance == nullptr) {
-#if defined(KD_WINDOWS) && !defined(NDEBUG)
+        //add there a environement variable, which, if defined, print logs)
+#if defined(KD_WINDOWS) && !defined(NDEBUG) && defined(ENABLE_LOG_TO_CONSOLE)
         if (AllocConsole()) {
             FILE *fp = nullptr;
             (void) freopen_s(&fp, "CONOUT$", "w", stdout);

--- a/src/libcommonserver/log/log.cpp
+++ b/src/libcommonserver/log/log.cpp
@@ -47,7 +47,7 @@ Log::~Log() {
 
 std::shared_ptr<Log> Log::instance(const log4cplus::tstring &filePath) {
     if (_instance == nullptr) {
-#if defined(KD_WINDOWS) && !defined(NDEBUG)
+#if defined(KD_WINDOWS)
         if (CommonUtility::logToConsoleEnabled()) {
             if (AllocConsole()) {
                 FILE *fp = nullptr;

--- a/src/libcommonserver/log/log.cpp
+++ b/src/libcommonserver/log/log.cpp
@@ -48,16 +48,14 @@ Log::~Log() {
 std::shared_ptr<Log> Log::instance(const log4cplus::tstring &filePath) {
     if (_instance == nullptr) {
 #if defined(KD_WINDOWS)
-        if (CommonUtility::logToConsoleEnabled()) {
-            if (AllocConsole()) {
-                FILE *fp = nullptr;
-                (void) freopen_s(&fp, "CONOUT$", "w", stdout);
-                (void) freopen_s(&fp, "CONOUT$", "w", stderr);
-                // freopen_s may leave the stream in an error state on failure.
-                // Clear C++ stream flags to ensure std::cout/std::cerr remain usable.
-                std::cout.clear();
-                std::cerr.clear();
-            }
+        if (CommonUtility::logToConsoleEnabled() && AllocConsole()) {
+            FILE *fp = nullptr;
+            (void) freopen_s(&fp, "CONOUT$", "w", stdout);
+            (void) freopen_s(&fp, "CONOUT$", "w", stderr);
+            // freopen_s may leave the stream in an error state on failure.
+            // Clear C++ stream flags to ensure std::cout/std::cerr remain usable.
+            std::cout.clear();
+            std::cerr.clear();
         }
 #endif
         if (filePath.empty()) {

--- a/src/libcommonserver/log/log.cpp
+++ b/src/libcommonserver/log/log.cpp
@@ -49,7 +49,7 @@ std::shared_ptr<Log> Log::instance(const log4cplus::tstring &filePath) {
     if (_instance == nullptr) {
         // add there a environement variable, which, if defined, print logs)
 #if defined(KD_WINDOWS) && !defined(NDEBUG)
-        if (CommonUtility::envVarValue("ENABLE_LOG_TO_CONSOLE") != "0") {
+        if (CommonUtility::envVarValue("ENABLE_LOG_TO_CONSOLE") == "1") {
             if (AllocConsole()) {
                 FILE *fp = nullptr;
                 (void) freopen_s(&fp, "CONOUT$", "w", stdout);


### PR DESCRIPTION
This pull request introduces an environment variable, `ENABLE_LOG_TO_CONSOLE`, to control whether logs are printed to the console in debug builds. This provides developers with a convenient way to enable or disable console logging without modifying code, making debugging easier and less intrusive. The changes are applied consistently across both client and server logging components.

**Logging improvements:**

* Added checks for the `ENABLE_LOG_TO_CONSOLE` environment variable in `Logger::doLog` and `CustomRollingFileAppender::append` to conditionally print logs to the console in debug builds. [[1]](diffhunk://#diff-68c0e0c740cd097f516198e208d0e4f540343bfaadc0134ce9a7a365933472bbR175-R177) [[2]](diffhunk://#diff-5c3887eff30b60981a0abdd0af69f5f7d77ac4ef5e70a1f3061d4b071272547fR195) [[3]](diffhunk://#diff-5c3887eff30b60981a0abdd0af69f5f7d77ac4ef5e70a1f3061d4b071272547fR205)
* Updated the singleton initialization in `Log::instance` (Windows, debug builds) to only allocate a console and redirect output streams if `ENABLE_LOG_TO_CONSOLE` is set.