### PR TITLE
fix(snapshot): handle removeItem failures and guard against empty ID or root folder

### DIFF
--- a/src/libsyncengine/syncpal/syncpal.cpp
+++ b/src/libsyncengine/syncpal/syncpal.cpp
@@ -993,39 +993,47 @@ ExitCode SyncPal::fileRemoteIdFromLocalPath(const SyncPath &path, NodeId &nodeId
     return ExitCode::Ok;
 }
 
-bool SyncPal::checkIfExistsOnServer(const SyncPath &path, bool &exists) const {
+ExitInfo SyncPal::checkIfExistsOnServer(const SyncPath &path, bool &exists) const {
     exists = false;
 
-    if (!_remoteFSObserverWorker) return false;
+    if (!_remoteFSObserverWorker) return {ExitCode::LogicError};
 
     // Path is normalized on server side
     SyncPath normalizedPath;
     if (!Utility::normalizedSyncPath(path, normalizedPath)) {
         LOGW_SYNCPAL_WARN(_logger, L"Error in Utility::normalizedSyncPath: " << Utility::formatSyncPath(path));
-        return false;
+        return ExitCode::SystemError;
     }
-    const NodeId nodeId = liveSnapshot(ReplicaSide::Remote).itemId(normalizedPath);
-    exists = !nodeId.empty();
-    return true;
+
+    NodeId nodeId;
+    if (const auto exitInfo = liveSnapshot(ReplicaSide::Remote).getItemId(normalizedPath, nodeId); !exitInfo) {
+        if (exitInfo.cause() == ExitCause::NotFound) {
+            exists = false;
+        } else {
+            return exitInfo;
+        }
+    }
+
+    exists = true;
+    return ExitCode::Ok;
 }
 
-bool SyncPal::checkIfCanShareItem(const SyncPath &path, bool &canShare) const {
+ExitInfo SyncPal::checkIfCanShareItem(const SyncPath &path, bool &canShare) const {
     canShare = false;
 
-    if (!_remoteFSObserverWorker) return false;
+    if (!_remoteFSObserverWorker) ExitCode::LogicError;
 
     // Path is normalized on server side
     SyncPath normalizedPath;
     if (!Utility::normalizedSyncPath(path, normalizedPath)) {
         LOGW_SYNCPAL_WARN(_logger, L"Error in Utility::normalizedSyncPath: " << Utility::formatSyncPath(path));
-        return false;
+        return ExitCode::SystemError;
     }
 
-    if (const NodeId nodeId = liveSnapshot(ReplicaSide::Remote).itemId(normalizedPath); !nodeId.empty()) {
-        canShare = liveSnapshot(ReplicaSide::Remote).canShare(nodeId);
-    }
-
-    return true;
+    NodeId nodeId;
+    if (const auto exitInfo = liveSnapshot(ReplicaSide::Remote).getItemId(normalizedPath, nodeId); !exitInfo) return exitInfo;
+    canShare = liveSnapshot(ReplicaSide::Remote).canShare(nodeId);
+    return ExitCode::Ok;
 }
 
 ExitCode SyncPal::syncIdSet(SyncNodeType type, NodeSet &nodeIdSet) {
@@ -1472,8 +1480,16 @@ ExitInfo SyncPal::handleAccessDeniedItem(const SyncPath &relativeLocalPath, bool
     LOG_IF_FAIL(_remoteFSObserverWorker)
     if (!_localFSObserverWorker || !_remoteFSObserverWorker) return ExitCode::LogicError;
 
-    NodeId localNodeId = liveSnapshot(ReplicaSide::Local).itemId(relativeLocalPath);
-    NodeId remoteNodeId = liveSnapshot(ReplicaSide::Remote).itemId(relativeLocalPath);
+    NodeId localNodeId;
+    if (const auto exitInfo = liveSnapshot(ReplicaSide::Local).getItemId(relativeLocalPath, localNodeId);
+        !exitInfo && exitInfo.cause() != ExitCause::NotFound) {
+        return exitInfo;
+    }
+    NodeId remoteNodeId;
+    if (const auto exitInfo = liveSnapshot(ReplicaSide::Remote).getItemId(relativeLocalPath, localNodeId);
+        !exitInfo && exitInfo.cause() != ExitCause::NotFound) {
+        return exitInfo;
+    }
 
     // File type cannot be fetched for an access denied item, using File as default.
     Error error(syncDbId(), localNodeId, remoteNodeId, NodeType::File, relativeLocalPath, ConflictType::None,

--- a/src/libsyncengine/syncpal/syncpal.cpp
+++ b/src/libsyncengine/syncpal/syncpal.cpp
@@ -1487,7 +1487,7 @@ ExitInfo SyncPal::handleAccessDeniedItem(const SyncPath &relativeLocalPath, bool
         return exitInfo;
     }
     NodeId remoteNodeId;
-    if (const auto exitInfo = liveSnapshot(ReplicaSide::Remote).getItemId(relativeLocalPath, localNodeId);
+    if (const auto exitInfo = liveSnapshot(ReplicaSide::Remote).getItemId(relativeLocalPath, remoteNodeId);
         !exitInfo && exitInfo.cause() != ExitCause::NotFound) {
         return exitInfo;
     }

--- a/src/libsyncengine/syncpal/syncpal.cpp
+++ b/src/libsyncengine/syncpal/syncpal.cpp
@@ -1009,6 +1009,7 @@ ExitInfo SyncPal::checkIfExistsOnServer(const SyncPath &path, bool &exists) cons
     if (const auto exitInfo = liveSnapshot(ReplicaSide::Remote).getItemId(normalizedPath, nodeId); !exitInfo) {
         if (exitInfo.cause() == ExitCause::NotFound) {
             exists = false;
+            return ExitCode::Ok;
         } else {
             return exitInfo;
         }

--- a/src/libsyncengine/syncpal/syncpal.cpp
+++ b/src/libsyncengine/syncpal/syncpal.cpp
@@ -1022,7 +1022,7 @@ ExitInfo SyncPal::checkIfExistsOnServer(const SyncPath &path, bool &exists) cons
 ExitInfo SyncPal::checkIfCanShareItem(const SyncPath &path, bool &canShare) const {
     canShare = false;
 
-    if (!_remoteFSObserverWorker) ExitCode::LogicError;
+    if (!_remoteFSObserverWorker) return ExitCode::LogicError;
 
     // Path is normalized on server side
     SyncPath normalizedPath;

--- a/src/libsyncengine/syncpal/syncpal.h
+++ b/src/libsyncengine/syncpal/syncpal.h
@@ -147,7 +147,8 @@ class SYNCENGINE_EXPORT SyncPal : public std::enable_shared_from_this<SyncPal> {
         virtual ~SyncPal();
 
         inline void setAddErrorCallback(const std::function<void(const Error &)> &addError) { _addError = addError; }
-        inline void setResolveSyncErrorsByExitCauseCallback(const std::function<void(SyncDbId syncDbId, ExitCause cause)> &resolveSyncErrors) {
+        inline void setResolveSyncErrorsByExitCauseCallback(
+                const std::function<void(SyncDbId syncDbId, ExitCause cause)> &resolveSyncErrors) {
             _resolveSyncErrors = resolveSyncErrors;
         }
 
@@ -193,8 +194,8 @@ class SYNCENGINE_EXPORT SyncPal : public std::enable_shared_from_this<SyncPal> {
         [[nodiscard]] std::shared_ptr<ConflictQueue> conflictQueue() const { return _conflictQueue; }
 
         // TODO : not ideal, to be refactored
-        bool checkIfExistsOnServer(const SyncPath &path, bool &exists) const;
-        bool checkIfCanShareItem(const SyncPath &path, bool &canShare) const;
+        ExitInfo checkIfExistsOnServer(const SyncPath &path, bool &exists) const;
+        ExitInfo checkIfCanShareItem(const SyncPath &path, bool &canShare) const;
 
         ExitCode fileRemoteIdFromLocalPath(const SyncPath &path, NodeId &nodeId) const;
         ExitCode syncIdSet(SyncNodeType type, NodeSet &nodeIdSet);

--- a/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/computefsoperationworker.cpp
@@ -31,8 +31,7 @@ namespace KDC {
 ComputeFSOperationWorker::ComputeFSOperationWorker(std::shared_ptr<SyncPal> syncPal, const std::string &name,
                                                    const std::string &shortName) :
     ISyncWorker(syncPal, name, shortName),
-    _syncDbReadOnlyCache(syncPal->syncDb()->cache()) {
-}
+    _syncDbReadOnlyCache(syncPal->syncDb()->cache()) {}
 
 ComputeFSOperationWorker::ComputeFSOperationWorker(SyncDbReadOnlyCache &testSyncDbReadOnlyCache, const std::string &name,
                                                    const std::string &shortName) :
@@ -801,7 +800,7 @@ ExitInfo ComputeFSOperationWorker::checkIfOkToDelete(const ReplicaSide side, con
                                                      bool &isExcluded) {
     if (side != ReplicaSide::Local) return ExitCode::Ok;
 
-    if (!_syncPal->snapshot(ReplicaSide::Local)->itemId(relativePath).empty()) {
+    if (NodeId existingId; _syncPal->snapshot(ReplicaSide::Local)->getItemId(relativePath, existingId) && !existingId.empty()) {
         // Item with the same path but different ID exist
         // This is an Edit operation (Delete-Create)
         return ExitCode::Ok;

--- a/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
@@ -209,6 +209,9 @@ ExitInfo LocalFileSystemObserverWorker::changesDetected(
                     // The file does not exist anymore, ignore it
                     continue;
                 }
+                LOGW_SYNCPAL_WARN(_logger, L"Error in Snapshot::getItemId: " << Utility::formatSyncPath(absolutePath) << L" ("
+                                                                             << CommonUtility::s2ws(itemId) << L")");
+                invalidateSnapshot();
                 return exitInfo;
             }
 

--- a/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
@@ -82,6 +82,12 @@ ExitInfo LocalFileSystemObserverWorker::changesDetected(
             _pendingFileEvents.clear();
             break;
         }
+
+        if (path == _syncPal->localPath()) {
+            // Ignore events on the sync folder
+            continue;
+        }
+
         sentry::pTraces::scoped::LFSOChangeDetected perfMonitor(syncDbId());
         // Raise flag _updating in order to wait 1sec without local changes before starting the sync
         _updating = true;

--- a/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
@@ -176,17 +176,19 @@ ExitInfo LocalFileSystemObserverWorker::changesDetected(
 
                 // Check if item still exist in liveSnapshot
                 NodeId itemId;
-                if (const auto exitInfo = _liveSnapshot.getItemId(relativePath, itemId); !exitInfo) {
+                if (const auto exitInfo = _liveSnapshot.getItemId(relativePath, itemId); exitInfo) {
+                    // Remove it from liveSnapshot
+                    if (!_liveSnapshot.removeItem(itemId)) {
+                        LOGW_SYNCPAL_WARN(_logger, L"Fail to remove item: " << Utility::formatSyncPath(absolutePath) << L" ("
+                                                                            << CommonUtility::s2ws(itemId) << L")");
+                        invalidateSnapshot();
+                        return ExitCode::DataError;
+                    }
+                } else {
                     if (exitInfo.cause() == ExitCause::NotFound) {
-                        // Remove it from liveSnapshot
-                        if (!_liveSnapshot.removeItem(itemId)) {
-                            LOGW_SYNCPAL_WARN(_logger, L"Fail to remove item: " << Utility::formatSyncPath(absolutePath) << L" ("
-                                                                                << CommonUtility::s2ws(itemId) << L")");
-                            invalidateSnapshot();
-                            return ExitCode::DataError;
-                        }
+                        // OK, just continue
                     } else {
-                        tryToInvalidateSnapshot();
+                        invalidateSnapshot();
                         return exitInfo;
                     }
                 }

--- a/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
@@ -336,6 +336,13 @@ ExitInfo LocalFileSystemObserverWorker::changesDetected(
                     invalidateSnapshot();
                     return ExitCode::DataError;
                 }
+            } else {
+                if (exitInfo.cause() == ExitCause::NotFound) {
+                    // OK, just continue
+                } else {
+                    invalidateSnapshot();
+                    return exitInfo;
+                }
             }
 
             // This can be either Create, Move or Edit operation
@@ -773,6 +780,8 @@ ExitInfo LocalFileSystemObserverWorker::exploreDir(const SyncPath &absoluteParen
                             continue;
                         }
                         parentNodeId = std::to_string(parentFileStat.inode);
+                    } else {
+                        return exitInfo;
                     }
                 }
             }

--- a/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
@@ -94,30 +94,33 @@ ExitInfo LocalFileSystemObserverWorker::changesDetected(
         if (opTypeFromOS == OperationType::Delete) {
             // Check if exists with same nodeId
             NodeId prevNodeId;
-            if (const auto exitInfo = _liveSnapshot.getItemId(relativePath, prevNodeId); !exitInfo) {
-                if (exitInfo.cause() == ExitCause::NotFound) {
-                    bool existsWithSameId = false;
-                    NodeId otherNodeId;
-                    if (auto checkError = IoError::Success;
-                        IoHelper::checkIfPathExistsWithSameNodeId(absolutePath, prevNodeId, existsWithSameId, otherNodeId,
-                                                                  checkError, IoHelper::PathCheckOption::Insensitive) &&
-                        !existsWithSameId) {
-                        if (_liveSnapshot.removeItem(prevNodeId)) {
-                            LOGW_SYNCPAL_DEBUG(_logger, L"Item removed from local snapshot: "
-                                                                << Utility::formatSyncPath(absolutePath) << L" ("
-                                                                << CommonUtility::s2ws(prevNodeId) << L")");
-                        } else {
-                            LOGW_SYNCPAL_WARN(_logger, L"Fail to remove item: " << Utility::formatSyncPath(absolutePath) << L" ("
-                                                                                << CommonUtility::s2ws(prevNodeId) << L")");
-                            invalidateSnapshot();
-                            return ExitCode::DataError;
-                        }
-                        continue;
+            if (const auto exitInfo = _liveSnapshot.getItemId(relativePath, prevNodeId); exitInfo) {
+                // An item has been found with the same path
+                bool existsWithSameId = false;
+                NodeId otherNodeId;
+                if (auto checkError = IoError::Success;
+                    IoHelper::checkIfPathExistsWithSameNodeId(absolutePath, prevNodeId, existsWithSameId, otherNodeId, checkError,
+                                                              IoHelper::PathCheckOption::Insensitive) &&
+                    !existsWithSameId) {
+                    if (_liveSnapshot.removeItem(prevNodeId)) {
+                        LOGW_SYNCPAL_DEBUG(_logger, L"Item removed from local snapshot: "
+                                                            << Utility::formatSyncPath(absolutePath) << L" ("
+                                                            << CommonUtility::s2ws(prevNodeId) << L")");
+                    } else {
+                        LOGW_SYNCPAL_WARN(_logger, L"Fail to remove item: " << Utility::formatSyncPath(absolutePath) << L" ("
+                                                                            << CommonUtility::s2ws(prevNodeId) << L")");
+                        invalidateSnapshot();
+                        return ExitCode::DataError;
                     }
+                    continue;
                 }
-
-                tryToInvalidateSnapshot();
-                return exitInfo;
+            } else {
+                if (exitInfo.cause() == ExitCause::NotFound) {
+                    // OK, just continue
+                } else {
+                    invalidateSnapshot();
+                    return exitInfo;
+                }
             }
         }
 

--- a/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
@@ -91,24 +91,28 @@ ExitInfo LocalFileSystemObserverWorker::changesDetected(
         const SyncPath relativePath = CommonUtility::relativePath(_syncPal->localPath(), absolutePath);
         _syncPal->removeItemFromTmpBlacklist(relativePath);
 
-
         if (opTypeFromOS == OperationType::Delete) {
             // Check if exists with same nodeId
-            NodeId prevNodeId = _liveSnapshot.itemId(relativePath);
-            if (!prevNodeId.empty()) {
-                bool existsWithSameId = false;
-                NodeId otherNodeId;
-                if (auto checkError = IoError::Success;
-                    IoHelper::checkIfPathExistsWithSameNodeId(absolutePath, prevNodeId, existsWithSameId, otherNodeId, checkError,
-                                                              IoHelper::PathCheckOption::Insensitive) &&
-                    !existsWithSameId) {
-                    if (_liveSnapshot.removeItem(prevNodeId)) {
-                        LOGW_SYNCPAL_DEBUG(_logger, L"Item removed from local snapshot: "
-                                                            << Utility::formatSyncPath(absolutePath) << L" ("
-                                                            << CommonUtility::s2ws(prevNodeId) << L")");
+            NodeId prevNodeId;
+            if (const auto exitInfo = _liveSnapshot.getItemId(relativePath, prevNodeId); !exitInfo) {
+                if (exitInfo.cause() == ExitCause::NotFound) {
+                    bool existsWithSameId = false;
+                    NodeId otherNodeId;
+                    if (auto checkError = IoError::Success;
+                        IoHelper::checkIfPathExistsWithSameNodeId(absolutePath, prevNodeId, existsWithSameId, otherNodeId,
+                                                                  checkError, IoHelper::PathCheckOption::Insensitive) &&
+                        !existsWithSameId) {
+                        if (_liveSnapshot.removeItem(prevNodeId)) {
+                            LOGW_SYNCPAL_DEBUG(_logger, L"Item removed from local snapshot: "
+                                                                << Utility::formatSyncPath(absolutePath) << L" ("
+                                                                << CommonUtility::s2ws(prevNodeId) << L")");
+                        }
+                        continue;
                     }
-                    continue;
                 }
+
+                tryToInvalidateSnapshot();
+                return exitInfo;
             }
         }
 
@@ -163,15 +167,18 @@ ExitInfo LocalFileSystemObserverWorker::changesDetected(
                 }
 
                 // Check if item still exist in liveSnapshot
-                if (const auto itemId = _liveSnapshot.itemId(relativePath); !itemId.empty()) {
-                    // Remove it from liveSnapshot
-                    (void) _liveSnapshot.removeItem(itemId);
-                    LOGW_SYNCPAL_DEBUG(_logger,
-                                       L"Item removed from sync because it is hidden: " << Utility::formatSyncPath(absolutePath));
-                } else {
-                    LOGW_SYNCPAL_DEBUG(_logger,
-                                       L"Item not processed because it is excluded: " << Utility::formatSyncPath(absolutePath));
+                NodeId itemId;
+                if (const auto exitInfo = _liveSnapshot.getItemId(relativePath, itemId); !exitInfo) {
+                    if (exitInfo.cause() == ExitCause::NotFound) {
+                        // Remove it from liveSnapshot
+                        (void) _liveSnapshot.removeItem(itemId);
+                    } else {
+                        tryToInvalidateSnapshot();
+                        return exitInfo;
+                    }
                 }
+                LOGW_SYNCPAL_DEBUG(_logger,
+                                   L"Item not processed because it is excluded: " << Utility::formatSyncPath(absolutePath));
 
                 _syncPal->vfs()->exclude(absolutePath);
                 continue;
@@ -181,10 +188,13 @@ ExitInfo LocalFileSystemObserverWorker::changesDetected(
         if (!exists) {
             // This is a delete operation
             // Get the ID from the liveSnapshot
-            const auto itemId = _liveSnapshot.itemId(relativePath);
-            if (itemId.empty()) {
-                // The file does not exist anymore, ignore it
-                continue;
+            NodeId itemId;
+            if (const auto exitInfo = _liveSnapshot.getItemId(relativePath, itemId); !exitInfo) {
+                if (exitInfo.cause() == ExitCause::NotFound) {
+                    // The file does not exist anymore, ignore it
+                    continue;
+                }
+                return exitInfo;
             }
 
             if (_liveSnapshot.removeItem(itemId)) {
@@ -273,8 +283,16 @@ ExitInfo LocalFileSystemObserverWorker::changesDetected(
                 // happens for instance if a file is deleted while another file with the same path is created shortly
                 // afterward. Typically, editors of the MS suite (xlsx, docx) or Adobe suite (pdf) perform a
                 // Delete-followed-by-Create operation during a single edit.
-                const NodeId itemId = _liveSnapshot.itemId(relativePath);
-                if (itemId.empty()) continue;
+                NodeId itemId;
+                if (const auto exitInfo = _liveSnapshot.getItemId(relativePath, itemId); !exitInfo) {
+                    if (exitInfo.cause() == ExitCause::NotFound) {
+                        // The file does not exist anymore, ignore it
+                        continue;
+                    }
+                    tryToInvalidateSnapshot();
+                    return exitInfo;
+                }
+
                 if (_liveSnapshot.removeItem(itemId)) {
                     LOGW_SYNCPAL_DEBUG(_logger, L"Item removed from local snapshot: " << Utility::formatSyncPath(absolutePath)
                                                                                       << L" (" << CommonUtility::s2ws(itemId)
@@ -288,8 +306,8 @@ ExitInfo LocalFileSystemObserverWorker::changesDetected(
                 continue;
             }
 
-            if (_liveSnapshot.pathExists(relativePath)) {
-                NodeId previousItemId = _liveSnapshot.itemId(relativePath);
+            NodeId previousItemId;
+            if (const auto exitInfo = _liveSnapshot.getItemId(relativePath, previousItemId); exitInfo) {
                 // If an item with the same path already exists, remove it from snapshot because its ID might have changed (i.e.
                 // the file has been downloaded in the tmp folder then moved to override the existing one). The item will be
                 // inserted below anyway.
@@ -717,29 +735,30 @@ ExitInfo LocalFileSystemObserverWorker::exploreDir(const SyncPath &absoluteParen
             if (absolutePath.parent_path() == _rootFolder) {
                 parentNodeId = *_syncPal->syncDb()->rootNode().nodeIdLocal();
             } else {
-                parentNodeId = _liveSnapshot.itemId(relativePath.parent_path());
-                if (parentNodeId.empty()) {
-                    FileStat parentFileStat;
-                    if (!IoHelper::getFileStat(absolutePath.parent_path(), &parentFileStat, entryIoError,
-                                               IoHelper::PathCheckOption::Insensitive)) {
-                        LOGW_WARN(_logger, L"Error in IoHelper::getFileStat: "
-                                                   << Utility::formatIoError(absolutePath.parent_path(), entryIoError));
-                        return {ExitCode::SystemError, ExitCause::FileAccessError};
-                    }
+                if (const auto exitInfo = _liveSnapshot.getItemId(relativePath.parent_path(), parentNodeId); !exitInfo) {
+                    if (exitInfo.cause() == ExitCause::NotFound) {
+                        FileStat parentFileStat;
+                        if (!IoHelper::getFileStat(absolutePath.parent_path(), &parentFileStat, entryIoError,
+                                                   IoHelper::PathCheckOption::Insensitive)) {
+                            LOGW_WARN(_logger, L"Error in IoHelper::getFileStat: "
+                                                       << Utility::formatIoError(absolutePath.parent_path(), entryIoError));
+                            return {ExitCode::SystemError, ExitCause::FileAccessError};
+                        }
 
-                    if (entryIoError == IoError::NoSuchFileOrDirectory) {
-                        LOGW_SYNCPAL_DEBUG(_logger, L"Directory doesn't exist anymore: "
-                                                            << Utility::formatSyncPath(absolutePath.parent_path()));
-                        dirIt.disableRecursionPending();
-                        continue;
-                    } else if (entryIoError == IoError::AccessDenied) {
-                        LOGW_SYNCPAL_DEBUG(_logger, L"Directory misses search permission: "
-                                                            << Utility::formatSyncPath(absolutePath.parent_path()));
-                        dirIt.disableRecursionPending();
-                        sendAccessDeniedError(absolutePath);
-                        continue;
+                        if (entryIoError == IoError::NoSuchFileOrDirectory) {
+                            LOGW_SYNCPAL_DEBUG(_logger, L"Directory doesn't exist anymore: "
+                                                                << Utility::formatSyncPath(absolutePath.parent_path()));
+                            dirIt.disableRecursionPending();
+                            continue;
+                        } else if (entryIoError == IoError::AccessDenied) {
+                            LOGW_SYNCPAL_DEBUG(_logger, L"Directory misses search permission: "
+                                                                << Utility::formatSyncPath(absolutePath.parent_path()));
+                            dirIt.disableRecursionPending();
+                            sendAccessDeniedError(absolutePath);
+                            continue;
+                        }
+                        parentNodeId = std::to_string(parentFileStat.inode);
                     }
-                    parentNodeId = std::to_string(parentFileStat.inode);
                 }
             }
 

--- a/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
@@ -107,8 +107,8 @@ ExitInfo LocalFileSystemObserverWorker::changesDetected(
                                                             << Utility::formatSyncPath(absolutePath) << L" ("
                                                             << CommonUtility::s2ws(prevNodeId) << L")");
                     } else {
-                        LOGW_SYNCPAL_WARN(_logger, L"Fail to remove item: " << Utility::formatSyncPath(absolutePath) << L" ("
-                                                                            << CommonUtility::s2ws(prevNodeId) << L")");
+                        LOGW_SYNCPAL_WARN(_logger, L"Failed to remove item: " << Utility::formatSyncPath(absolutePath) << L" ("
+                                                                              << CommonUtility::s2ws(prevNodeId) << L")");
                         invalidateSnapshot();
                         return ExitCode::DataError;
                     }
@@ -179,8 +179,8 @@ ExitInfo LocalFileSystemObserverWorker::changesDetected(
                 if (const auto exitInfo = _liveSnapshot.getItemId(relativePath, itemId); exitInfo) {
                     // Remove it from liveSnapshot
                     if (!_liveSnapshot.removeItem(itemId)) {
-                        LOGW_SYNCPAL_WARN(_logger, L"Fail to remove item: " << Utility::formatSyncPath(absolutePath) << L" ("
-                                                                            << CommonUtility::s2ws(itemId) << L")");
+                        LOGW_SYNCPAL_WARN(_logger, L"Failed to remove item: " << Utility::formatSyncPath(absolutePath) << L" ("
+                                                                              << CommonUtility::s2ws(itemId) << L")");
                         invalidateSnapshot();
                         return ExitCode::DataError;
                     }
@@ -220,8 +220,8 @@ ExitInfo LocalFileSystemObserverWorker::changesDetected(
                                                                                   << L" (" << CommonUtility::s2ws(itemId)
                                                                                   << L")");
             } else {
-                LOGW_SYNCPAL_WARN(_logger, L"Fail to remove item: " << Utility::formatSyncPath(absolutePath) << L" ("
-                                                                    << CommonUtility::s2ws(itemId) << L")");
+                LOGW_SYNCPAL_WARN(_logger, L"Failed to remove item: " << Utility::formatSyncPath(absolutePath) << L" ("
+                                                                      << CommonUtility::s2ws(itemId) << L")");
                 invalidateSnapshot();
                 return ExitCode::DataError;
             }

--- a/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
@@ -106,6 +106,11 @@ ExitInfo LocalFileSystemObserverWorker::changesDetected(
                             LOGW_SYNCPAL_DEBUG(_logger, L"Item removed from local snapshot: "
                                                                 << Utility::formatSyncPath(absolutePath) << L" ("
                                                                 << CommonUtility::s2ws(prevNodeId) << L")");
+                        } else {
+                            LOGW_SYNCPAL_WARN(_logger, L"Fail to remove item: " << Utility::formatSyncPath(absolutePath) << L" ("
+                                                                                << CommonUtility::s2ws(prevNodeId) << L")");
+                            invalidateSnapshot();
+                            return ExitCode::DataError;
                         }
                         continue;
                     }
@@ -171,7 +176,12 @@ ExitInfo LocalFileSystemObserverWorker::changesDetected(
                 if (const auto exitInfo = _liveSnapshot.getItemId(relativePath, itemId); !exitInfo) {
                     if (exitInfo.cause() == ExitCause::NotFound) {
                         // Remove it from liveSnapshot
-                        (void) _liveSnapshot.removeItem(itemId);
+                        if (!_liveSnapshot.removeItem(itemId)) {
+                            LOGW_SYNCPAL_WARN(_logger, L"Fail to remove item: " << Utility::formatSyncPath(absolutePath) << L" ("
+                                                                                << CommonUtility::s2ws(itemId) << L")");
+                            invalidateSnapshot();
+                            return ExitCode::DataError;
+                        }
                     } else {
                         tryToInvalidateSnapshot();
                         return exitInfo;
@@ -204,7 +214,7 @@ ExitInfo LocalFileSystemObserverWorker::changesDetected(
             } else {
                 LOGW_SYNCPAL_WARN(_logger, L"Fail to remove item: " << Utility::formatSyncPath(absolutePath) << L" ("
                                                                     << CommonUtility::s2ws(itemId) << L")");
-                tryToInvalidateSnapshot();
+                invalidateSnapshot();
                 return ExitCode::DataError;
             }
 
@@ -300,7 +310,7 @@ ExitInfo LocalFileSystemObserverWorker::changesDetected(
                 } else {
                     LOGW_SYNCPAL_WARN(_logger, L"Failed to remove item: " << Utility::formatSyncPath(absolutePath) << L" ("
                                                                           << CommonUtility::s2ws(itemId) << L")");
-                    tryToInvalidateSnapshot();
+                    invalidateSnapshot();
                     return ExitCode::DataError;
                 }
                 continue;
@@ -318,7 +328,7 @@ ExitInfo LocalFileSystemObserverWorker::changesDetected(
                 } else {
                     LOGW_SYNCPAL_WARN(_logger, L"Failed to delete item: " << Utility::formatSyncPath(absolutePath) << L" ("
                                                                           << CommonUtility::s2ws(previousItemId) << L")");
-                    tryToInvalidateSnapshot();
+                    invalidateSnapshot();
                     return ExitCode::DataError;
                 }
             }

--- a/src/libsyncengine/update_detection/file_system_observer/remotefilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/remotefilesystemobserverworker.cpp
@@ -394,10 +394,15 @@ ExitInfo RemoteFileSystemObserverWorker::getItemsInDir(const NodeId &dirId, cons
     auto nodeIdIt = nodeIds.begin();
     while (nodeIdIt != nodeIds.end()) {
         if (_liveSnapshot.isOrphan(*nodeIdIt)) {
-            LOGW_SYNCPAL_DEBUG(_logger, L"Node '" << SyncName2WStr(_liveSnapshot.name(*nodeIdIt)) << L"' ("
-                                                  << CommonUtility::s2ws(*nodeIdIt) << L") is orphan. Removing it from "
-                                                  << _liveSnapshot.side() << L" snapshot.");
-            _liveSnapshot.removeItem(*nodeIdIt);
+            const auto itemName = _liveSnapshot.name(*nodeIdIt);
+            LOGW_SYNCPAL_DEBUG(_logger, L"Node '" << SyncName2WStr(itemName) << L"' (" << CommonUtility::s2ws(*nodeIdIt)
+                                                  << L") is orphan. Removing it from " << _liveSnapshot.side() << L" snapshot.");
+            if (!_liveSnapshot.removeItem(*nodeIdIt)) {
+                LOGW_SYNCPAL_WARN(_logger, L"Fail to remove item: " << SyncName2WStr(itemName) << L" ("
+                                                                    << CommonUtility::s2ws(*nodeIdIt) << L")");
+                invalidateSnapshot();
+                return ExitCode::DataError;
+            }
         }
         nodeIdIt++;
     }
@@ -505,7 +510,12 @@ ExitInfo RemoteFileSystemObserverWorker::processActions(Poco::JSON::Array::Ptr a
                 _syncPal->addError(error);
             }
             // Remove it from liveSnapshot
-            _liveSnapshot.removeItem(actionInfo.snapshotItem.id());
+            if (!_liveSnapshot.removeItem(actionInfo.snapshotItem.id())) {
+                LOGW_SYNCPAL_WARN(_logger, L"Fail to remove item: " << SyncName2WStr(actionInfo.snapshotItem.name()) << L" ("
+                                                                    << CommonUtility::s2ws(actionInfo.snapshotItem.id()) << L")");
+                invalidateSnapshot();
+                return ExitCode::DataError;
+            }
             continue;
         }
 
@@ -754,7 +764,7 @@ ExitInfo RemoteFileSystemObserverWorker::removeItemFromSnapshot(const NodeId &id
     if (_liveSnapshot.removeItem(id)) return ExitCode::Ok;
 
     LOG_SYNCPAL_WARN(_logger, "Fail to remove item for ID: " << id);
-    tryToInvalidateSnapshot();
+    invalidateSnapshot();
     return ExitCode::BackError;
 }
 

--- a/src/libsyncengine/update_detection/file_system_observer/snapshot/livesnapshot.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/snapshot/livesnapshot.cpp
@@ -129,6 +129,15 @@ bool LiveSnapshot::updateItem(const SnapshotItem &newItem) {
 }
 
 bool LiveSnapshot::removeItem(const NodeId itemId) {
+    if (itemId.empty()) {
+        LOG_WARN(Log::instance()->getLogger(), "Error in LiveSnapshot::removeItem: empty item ID argument.");
+        return false;
+    }
+    if (itemId == rootFolderId()) {
+        LOG_WARN(Log::instance()->getLogger(), "Error in LiveSnapshot::removeItem: cannot remove root folder.");
+        return false;
+    }
+
     if (auto item = findItem(itemId); item) {
         return removeItem(item);
     }

--- a/src/libsyncengine/update_detection/file_system_observer/snapshot/snapshot.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/snapshot/snapshot.cpp
@@ -236,8 +236,16 @@ bool Snapshot::exists(const NodeId &itemId) const {
 
 ExitInfo Snapshot::checkIfPathExists(const SyncPath &path, bool &exists) const {
     const std::scoped_lock lock(_mutex);
+    exists = false;
+
     NodeId id;
-    if (const auto exitInfo = getItemId(path, id); !exitInfo) return exitInfo;
+    if (const auto exitInfo = getItemId(path, id); !exitInfo) {
+        if (exitInfo.exitCause() == ExitCause::NotFound) {
+            return ExitCode::Ok;
+        }
+        return exitInfo;
+    }
+
     exists = !id.empty();
     return ExitCode::Ok;
 }

--- a/src/libsyncengine/update_detection/file_system_observer/snapshot/snapshot.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/snapshot/snapshot.cpp
@@ -66,13 +66,15 @@ Snapshot::Snapshot(Snapshot const &other) {
     }
 }
 
-NodeId Snapshot::itemId(const SyncPath &path) const {
+ExitInfo Snapshot::getItemId(const SyncPath &path, NodeId &id) const {
     const std::scoped_lock lock(_mutex);
-
+    id = {};
     const auto rootItemIt = _items.find(rootFolderId());
     if (rootItemIt == _items.end()) {
         LOG_WARN(Log::instance()->getLogger(), "Root folder id not found in snapshot");
-        return "";
+        sentry::Handler::captureMessage(sentry::Level::Error, "Root folder id not found in snapshot",
+                                        "Snapshot::getItemId failed because the root node ID was not found in snapshot.");
+        return {ExitCode::DataError, ExitCause::InvalidSnapshot};
     }
 
     auto item = rootItemIt->second;
@@ -93,11 +95,12 @@ NodeId Snapshot::itemId(const SyncPath &path) const {
         }
 
         if (!idFound) {
-            return "";
+            return {ExitCode::DataError, ExitCause::NotFound};
         }
     }
 
-    return item->id();
+    id = item->id();
+    return ExitCode::Ok;
 }
 
 NodeId Snapshot::parentId(const NodeId &itemId) const {
@@ -231,9 +234,12 @@ bool Snapshot::exists(const NodeId &itemId) const {
     return findItem(itemId) && !isOrphan(itemId);
 }
 
-bool Snapshot::pathExists(const SyncPath &path) const {
+ExitInfo Snapshot::checkIfPathExists(const SyncPath &path, bool &exists) const {
     const std::scoped_lock lock(_mutex);
-    return !itemId(path).empty();
+    NodeId id;
+    if (const auto exitInfo = getItemId(path, id); !exitInfo) return exitInfo;
+    exists = !id.empty();
+    return ExitCode::Ok;
 }
 
 bool Snapshot::isLink(const NodeId &itemId) const {

--- a/src/libsyncengine/update_detection/file_system_observer/snapshot/snapshot.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/snapshot/snapshot.cpp
@@ -240,7 +240,7 @@ ExitInfo Snapshot::checkIfPathExists(const SyncPath &path, bool &exists) const {
 
     NodeId id;
     if (const auto exitInfo = getItemId(path, id); !exitInfo) {
-        if (exitInfo.exitCause() == ExitCause::NotFound) {
+        if (exitInfo.cause() == ExitCause::NotFound) {
             return ExitCode::Ok;
         }
         return exitInfo;

--- a/src/libsyncengine/update_detection/file_system_observer/snapshot/snapshot.h
+++ b/src/libsyncengine/update_detection/file_system_observer/snapshot/snapshot.h
@@ -33,7 +33,7 @@ class Snapshot {
     public:
         Snapshot(const Snapshot &);
         virtual ~Snapshot() = default;
-        NodeId itemId(const SyncPath &path) const;
+
         NodeId parentId(const NodeId &itemId) const;
         virtual bool path(const NodeId &itemId, SyncPath &path, bool &ignore) const noexcept;
         SyncName name(const NodeId &itemId) const;
@@ -45,11 +45,13 @@ class Snapshot {
         bool canWrite(const NodeId &itemId) const;
         bool canShare(const NodeId &itemId) const;
         bool exists(const NodeId &itemId) const;
-        bool pathExists(const SyncPath &path) const;
         bool isLink(const NodeId &itemId) const;
         SnapshotRevision lastChangeRevision(const NodeId &itemId) const;
         bool getChildrenIds(const NodeId &itemId, NodeSet &childrenIds) const;
         NodeSet getDescendantIds(const NodeId &itemId) const;
+
+        ExitInfo getItemId(const SyncPath &path, NodeId &id) const;
+        ExitInfo checkIfPathExists(const SyncPath &path, bool &exists) const;
 
         void ids(NodeSet &ids) const;
         /** Checks if ancestorItem is an ancestor of item.

--- a/test/libsyncengine/integration/testintegration_nodeid_reuse.cpp
+++ b/test/libsyncengine/integration/testintegration_nodeid_reuse.cpp
@@ -1,18 +1,20 @@
-// Infomaniak kDrive - Desktop
-// Copyright (C) 2023-2026 Infomaniak Network SA
-//
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #include "testintegration.h"
 #include "test_utility/testhelpers.h"
@@ -119,7 +121,7 @@ void TestIntegration::testNodeIdReuseFile2File() {
     NodeId nodeId;
     CPPUNIT_ASSERT(_syncPal->liveSnapshot(ReplicaSide::Local).getItemId(relativeWorkingDirPath, nodeId));
     CPPUNIT_ASSERT(!nodeId.empty());
-    CPPUNIT_ASSERT(!_syncPal->liveSnapshot(ReplicaSide::Remote).getItemId(relativeWorkingDirPath, nodeId));
+    CPPUNIT_ASSERT(_syncPal->liveSnapshot(ReplicaSide::Remote).getItemId(relativeWorkingDirPath, nodeId));
     CPPUNIT_ASSERT(!nodeId.empty());
 
     MockIoHelperFileStat mockIoHelper;

--- a/test/libsyncengine/integration/testintegration_nodeid_reuse.cpp
+++ b/test/libsyncengine/integration/testintegration_nodeid_reuse.cpp
@@ -1,20 +1,18 @@
-/*
- * Infomaniak kDrive - Desktop
- * Copyright (C) 2023-2026 Infomaniak Network SA
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Infomaniak kDrive - Desktop
+// Copyright (C) 2023-2026 Infomaniak Network SA
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "testintegration.h"
 #include "test_utility/testhelpers.h"
@@ -32,19 +30,22 @@ void TestIntegration::testNodeIdReuseFile2DirAndDir2File() {
     _syncPal->start();
     waitForSyncToBeIdle(SourceLocation::currentLoc());
 
-    CPPUNIT_ASSERT(!_syncPal->liveSnapshot(ReplicaSide::Local).itemId(relativeWorkingDirPath).empty());
-    CPPUNIT_ASSERT(!_syncPal->liveSnapshot(ReplicaSide::Remote).itemId(relativeWorkingDirPath).empty());
+    NodeId nodeId;
+    CPPUNIT_ASSERT(_syncPal->liveSnapshot(ReplicaSide::Local).getItemId(relativeWorkingDirPath, nodeId));
+    CPPUNIT_ASSERT(!nodeId.empty());
+    CPPUNIT_ASSERT(_syncPal->liveSnapshot(ReplicaSide::Remote).getItemId(relativeWorkingDirPath, nodeId));
+    CPPUNIT_ASSERT(!nodeId.empty());
 
     MockIoHelperFileStat mockIoHelper;
     // Create a file with a custom inode on the local side
     mockIoHelper.setPathWithFakeInode(absoluteLocalWorkingDir / "testNodeIdReuseFile", 2);
     { const std::ofstream file(absoluteLocalWorkingDir / "testNodeIdReuseFile"); }
     waitForSyncToBeIdle(SourceLocation::currentLoc());
-    CPPUNIT_ASSERT_EQUAL(NodeId("2"),
-                         _syncPal->liveSnapshot(ReplicaSide::Local).itemId(relativeWorkingDirPath / "testNodeIdReuseFile"));
-    const NodeId remoteFileId =
-            _syncPal->liveSnapshot(ReplicaSide::Remote).itemId(relativeWorkingDirPath / "testNodeIdReuseFile");
-    CPPUNIT_ASSERT(!remoteFileId.empty());
+    CPPUNIT_ASSERT(_syncPal->liveSnapshot(ReplicaSide::Local).getItemId(relativeWorkingDirPath / "testNodeIdReuseFile", nodeId));
+    CPPUNIT_ASSERT_EQUAL(NodeId("2"), nodeId);
+    NodeId remoteFileId;
+    CPPUNIT_ASSERT(
+            _syncPal->liveSnapshot(ReplicaSide::Remote).getItemId(relativeWorkingDirPath / "testNodeIdReuseFile", remoteFileId));
     CPPUNIT_ASSERT_EQUAL(NodeType::File, _syncPal->liveSnapshot(ReplicaSide::Remote).type(remoteFileId));
 
     // Replace the file with a directory on the local side (with the same id)
@@ -66,17 +67,17 @@ void TestIntegration::testNodeIdReuseFile2DirAndDir2File() {
     waitForSyncToBeIdle(SourceLocation::currentLoc());
 
     // Check that the file has been replaced by a directory on the remote replica with a different ID.
-    const NodeId newRemoteDirId =
-            _syncPal->liveSnapshot(ReplicaSide::Remote).itemId(relativeWorkingDirPath / "testNodeIdReuseDir");
-    CPPUNIT_ASSERT(!newRemoteDirId.empty());
+    NodeId newRemoteDirId;
+    CPPUNIT_ASSERT(
+            _syncPal->liveSnapshot(ReplicaSide::Remote).getItemId(relativeWorkingDirPath / "testNodeIdReuseDir", newRemoteDirId));
     CPPUNIT_ASSERT(newRemoteDirId != remoteFileId);
     CPPUNIT_ASSERT_EQUAL(NodeType::Directory, _syncPal->liveSnapshot(ReplicaSide::Remote).type(newRemoteDirId));
     CPPUNIT_ASSERT(!_syncPal->liveSnapshot(ReplicaSide::Remote).exists(remoteFileId));
 
     // Check that the new directory contains the file "childFile.txt" that was created locally.
-    const NodeId newRemoteChildFileId =
-            _syncPal->liveSnapshot(ReplicaSide::Remote).itemId(relativeWorkingDirPath / "testNodeIdReuseDir" / "childFile.txt");
-    CPPUNIT_ASSERT(!newRemoteChildFileId.empty());
+    NodeId newRemoteChildFileId;
+    CPPUNIT_ASSERT(_syncPal->liveSnapshot(ReplicaSide::Remote)
+                           .getItemId(relativeWorkingDirPath / "testNodeIdReuseDir" / "childFile.txt", newRemoteChildFileId));
     CPPUNIT_ASSERT_EQUAL(NodeType::File, _syncPal->liveSnapshot(ReplicaSide::Remote).type(newRemoteChildFileId));
 
     // Replace the directory with a file on the local side with the same ID.
@@ -93,8 +94,9 @@ void TestIntegration::testNodeIdReuseFile2DirAndDir2File() {
     waitForSyncToBeIdle(SourceLocation::currentLoc());
 
     // Check that the directory has been replaced by a file on the remote with a different ID.
-    const NodeId newRemoteFileId =
-            _syncPal->liveSnapshot(ReplicaSide::Remote).itemId(relativeWorkingDirPath / "testNodeIdReuseFile");
+    NodeId newRemoteFileId;
+    CPPUNIT_ASSERT(_syncPal->liveSnapshot(ReplicaSide::Remote)
+                           .getItemId(relativeWorkingDirPath / "testNodeIdReuseFile", newRemoteFileId));
     CPPUNIT_ASSERT(newRemoteFileId != "");
     CPPUNIT_ASSERT(newRemoteFileId != newRemoteDirId);
     CPPUNIT_ASSERT(newRemoteFileId != remoteFileId);
@@ -114,17 +116,21 @@ void TestIntegration::testNodeIdReuseFile2File() {
     _syncPal->start();
     waitForSyncToBeIdle(SourceLocation::currentLoc());
 
-    CPPUNIT_ASSERT(!_syncPal->liveSnapshot(ReplicaSide::Local).itemId(relativeWorkingDirPath).empty());
-    CPPUNIT_ASSERT(!_syncPal->liveSnapshot(ReplicaSide::Remote).itemId(relativeWorkingDirPath).empty());
+    NodeId nodeId;
+    CPPUNIT_ASSERT(_syncPal->liveSnapshot(ReplicaSide::Local).getItemId(relativeWorkingDirPath, nodeId));
+    CPPUNIT_ASSERT(!nodeId.empty());
+    CPPUNIT_ASSERT(!_syncPal->liveSnapshot(ReplicaSide::Remote).getItemId(relativeWorkingDirPath, nodeId));
+    CPPUNIT_ASSERT(!nodeId.empty());
 
     MockIoHelperFileStat mockIoHelper;
     mockIoHelper.setPathWithFakeInode(absoluteLocalWorkingDir / "testNodeIdReuseFile", 2);
     { const std::ofstream file(absoluteLocalWorkingDir / "testNodeIdReuseFile"); }
     waitForSyncToBeIdle(SourceLocation::currentLoc());
-    CPPUNIT_ASSERT_EQUAL(NodeId("2"),
-                         _syncPal->liveSnapshot(ReplicaSide::Local).itemId(relativeWorkingDirPath / "testNodeIdReuseFile"));
-    const NodeId remoteFileId =
-            _syncPal->liveSnapshot(ReplicaSide::Remote).itemId(relativeWorkingDirPath / "testNodeIdReuseFile");
+    CPPUNIT_ASSERT(_syncPal->liveSnapshot(ReplicaSide::Local).getItemId(relativeWorkingDirPath / "testNodeIdReuseFile", nodeId));
+    CPPUNIT_ASSERT_EQUAL(NodeId("2"), nodeId);
+    NodeId remoteFileId;
+    CPPUNIT_ASSERT(
+            _syncPal->liveSnapshot(ReplicaSide::Remote).getItemId(relativeWorkingDirPath / "testNodeIdReuseFile", remoteFileId));
     CPPUNIT_ASSERT(!remoteFileId.empty());
     CPPUNIT_ASSERT_EQUAL(NodeType::File, _syncPal->liveSnapshot(ReplicaSide::Remote).type(remoteFileId));
 
@@ -155,9 +161,9 @@ void TestIntegration::testNodeIdReuseFile2File() {
     _syncPal->unpause();
     waitForSyncToBeIdle(SourceLocation::currentLoc());
     _syncPal->pause();
-    const NodeId newRemoteFileId =
-            _syncPal->liveSnapshot(ReplicaSide::Remote).itemId(relativeWorkingDirPath / "testNodeIdReuseFile2");
-    CPPUNIT_ASSERT(!newRemoteFileId.empty());
+    NodeId newRemoteFileId;
+    CPPUNIT_ASSERT(_syncPal->liveSnapshot(ReplicaSide::Remote)
+                           .getItemId(relativeWorkingDirPath / "testNodeIdReuseFile2", newRemoteFileId));
     CPPUNIT_ASSERT(remoteFileId != newRemoteFileId);
     CPPUNIT_ASSERT(!_syncPal->liveSnapshot(ReplicaSide::Remote).exists(remoteFileId));
 
@@ -175,10 +181,11 @@ void TestIntegration::testNodeIdReuseFile2File() {
 
     _syncPal->unpause();
     waitForSyncToBeIdle(SourceLocation::currentLoc());
-    CPPUNIT_ASSERT(_syncPal->liveSnapshot(ReplicaSide::Remote).itemId(relativeWorkingDirPath / "testNodeIdReuseFile2").empty());
-    const NodeId newRemoteFileId2 =
-            _syncPal->liveSnapshot(ReplicaSide::Remote).itemId(relativeWorkingDirPath / "testNodeIdReuseFile3");
-    CPPUNIT_ASSERT(!newRemoteFileId2.empty());
+    CPPUNIT_ASSERT(_syncPal->liveSnapshot(ReplicaSide::Remote)
+                           .getItemId(relativeWorkingDirPath / "testNodeIdReuseFile2", newRemoteFileId));
+    NodeId newRemoteFileId2;
+    CPPUNIT_ASSERT(_syncPal->liveSnapshot(ReplicaSide::Remote)
+                           .getItemId(relativeWorkingDirPath / "testNodeIdReuseFile3", newRemoteFileId2));
     CPPUNIT_ASSERT_EQUAL(newRemoteFileId, newRemoteFileId2);
     CPPUNIT_ASSERT_EQUAL(_syncPal->liveSnapshot(ReplicaSide::Remote).size(newRemoteFileId2),
                          _syncPal->liveSnapshot(ReplicaSide::Local).size("2"));

--- a/test/libsyncengine/update_detection/file_system_observer/testcomputefsoperationworker.cpp
+++ b/test/libsyncengine/update_detection/file_system_observer/testcomputefsoperationworker.cpp
@@ -187,7 +187,7 @@ void TestComputeFSOperationWorker::testAccessDenied() {
         // AA (child of A) is deleted and recreated with the same node ID after the snapshots are copied
         // A access is denied
         // Causes an Access Denied in checkIfOkToDelete
-        _syncPal->_localFSObserverWorker->_liveSnapshot.removeItem("l_aa");
+        (void) _syncPal->_localFSObserverWorker->_liveSnapshot.removeItem("l_aa");
 
         SyncPath aNodePath = "A";
         std::error_code ec;

--- a/test/libsyncengine/update_detection/file_system_observer/testsnapshot.cpp
+++ b/test/libsyncengine/update_detection/file_system_observer/testsnapshot.cpp
@@ -159,12 +159,15 @@ void TestSnapshot::testSnapshot() {
     CPPUNIT_ASSERT(childrenIds.empty());
 
     // Remove node B
-    _liveSnapshot->removeItem("b");
+    CPPUNIT_ASSERT(_liveSnapshot->removeItem("b"));
     _liveSnapshot->getChildrenIds(_rootNodeId, childrenIds);
     CPPUNIT_ASSERT(!_liveSnapshot->exists("aaa"));
     CPPUNIT_ASSERT(!_liveSnapshot->exists("aa"));
     CPPUNIT_ASSERT(!_liveSnapshot->exists("b"));
     CPPUNIT_ASSERT(!childrenIds.contains("b"));
+
+    CPPUNIT_ASSERT(!_liveSnapshot->removeItem(""));
+    CPPUNIT_ASSERT(!_liveSnapshot->removeItem(_liveSnapshot->rootFolderId()));
 
     // Reset liveSnapshot
     _liveSnapshot->init();

--- a/test/libsyncengine/update_detection/file_system_observer/testsnapshot.cpp
+++ b/test/libsyncengine/update_detection/file_system_observer/testsnapshot.cpp
@@ -73,7 +73,7 @@ void TestSnapshot::tearDown() {
     TestBase::stop();
 }
 
-void TestSnapshot::testItemId() {
+void TestSnapshot::testGetItemId() {
     const NodeId rootNodeId = SyncDb::driveRootNode().nodeIdLocal().value();
 
     const DbNode dummyRootNode(0, std::nullopt, SyncName(), SyncName(), "1", "1", std::nullopt, std::nullopt, std::nullopt,
@@ -88,7 +88,9 @@ void TestSnapshot::testItemId() {
     liveSnapshot.updateItem(
             SnapshotItem("6", "4", Str("aba"), 1640995202, 1640995202, NodeType::Directory, 0, false, true, true));
     liveSnapshot.updateItem(SnapshotItem("7", "6", Str("abaa"), 1640995202, 1640995202, NodeType::File, 10, false, true, true));
-    CPPUNIT_ASSERT_EQUAL(NodeId("7"), liveSnapshot.itemId(SyncPath("a/ab/aba/abaa")));
+    NodeId nodeId;
+    CPPUNIT_ASSERT(liveSnapshot.getItemId(SyncPath("a/ab/aba/abaa"), nodeId));
+    CPPUNIT_ASSERT_EQUAL(NodeId("7"), nodeId);
 
     SyncName nfcNormalized;
     Utility::normalizedSyncName(Str("abà"), nfcNormalized);
@@ -98,13 +100,17 @@ void TestSnapshot::testItemId() {
 
     liveSnapshot.updateItem(
             SnapshotItem("6", "4", nfcNormalized, 1640995202, 1640995202, NodeType::Directory, 0, false, true, true));
-    CPPUNIT_ASSERT_EQUAL(NodeId("7"), liveSnapshot.itemId(SyncPath("a/ab") / nfcNormalized / Str("abaa")));
-    CPPUNIT_ASSERT_EQUAL(NodeId(""), liveSnapshot.itemId(SyncPath("a/ab") / nfdNormalized / Str("abaa")));
+    CPPUNIT_ASSERT(liveSnapshot.getItemId(SyncPath("a/ab") / nfcNormalized / Str("abaa"), nodeId));
+    CPPUNIT_ASSERT_EQUAL(NodeId("7"), nodeId);
+    CPPUNIT_ASSERT(!liveSnapshot.getItemId(SyncPath("a/ab") / nfdNormalized / Str("abaa"), nodeId));
+    CPPUNIT_ASSERT_EQUAL(NodeId(""), nodeId);
 
     liveSnapshot.updateItem(
             SnapshotItem("6", "4", nfdNormalized, 1640995202, 1640995202, NodeType::Directory, 0, false, true, true));
-    CPPUNIT_ASSERT_EQUAL(NodeId("7"), liveSnapshot.itemId(SyncPath("a/ab") / nfdNormalized / Str("abaa")));
-    CPPUNIT_ASSERT_EQUAL(NodeId(""), liveSnapshot.itemId(SyncPath("a/ab") / nfcNormalized / Str("abaa")));
+    CPPUNIT_ASSERT(liveSnapshot.getItemId(SyncPath("a/ab") / nfdNormalized / Str("abaa"), nodeId));
+    CPPUNIT_ASSERT_EQUAL(NodeId("7"), nodeId);
+    CPPUNIT_ASSERT(!liveSnapshot.getItemId(SyncPath("a/ab") / nfcNormalized / Str("abaa"), nodeId));
+    CPPUNIT_ASSERT_EQUAL(NodeId(""), nodeId);
 }
 
 void TestSnapshot::testSnapshot() {
@@ -139,7 +145,9 @@ void TestSnapshot::testSnapshot() {
     CPPUNIT_ASSERT_EQUAL(static_cast<SyncTime>(testhelpers::defaultTime), _liveSnapshot->lastModified("aaa"));
     CPPUNIT_ASSERT_EQUAL(NodeType::File, _liveSnapshot->type("aaa"));
     CPPUNIT_ASSERT(_liveSnapshot->contentChecksum("aaa").empty()); // Checksum never computed for now
-    CPPUNIT_ASSERT_EQUAL(NodeId("aaa"), _liveSnapshot->itemId(std::filesystem::path("A*/AA/AAA")));
+    NodeId nodeId;
+    CPPUNIT_ASSERT(_liveSnapshot->getItemId(SyncPath("A*/AA/AAA"), nodeId));
+    CPPUNIT_ASSERT_EQUAL(NodeId("aaa"), nodeId);
 
     // Move node AA under B
     _liveSnapshot->updateItem(SnapshotItem("aa", "b", Str("AA"), testhelpers::defaultTime, testhelpers::defaultTime,

--- a/test/libsyncengine/update_detection/file_system_observer/testsnapshot.h
+++ b/test/libsyncengine/update_detection/file_system_observer/testsnapshot.h
@@ -27,7 +27,7 @@ namespace KDC {
 
 class TestSnapshot : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST_SUITE(TestSnapshot);
-        CPPUNIT_TEST(testItemId);
+        CPPUNIT_TEST(testGetItemId);
         CPPUNIT_TEST(testSnapshot);
         CPPUNIT_TEST(testSize);
         CPPUNIT_TEST(testDuplicatedItem);
@@ -42,7 +42,7 @@ class TestSnapshot : public CppUnit::TestFixture, public TestBase {
         void tearDown() override;
 
     private:
-        void testItemId();
+        void testGetItemId();
         void testSnapshot();
         void testSize();
         void testDuplicatedItem();


### PR DESCRIPTION
## Summary

This PR addresses cases where `LiveSnapshot::removeItem` was called without checking its return value, potentially masking silent failures.

### Changes

- **`livesnapshot.cpp`**: Added early-return guards in `removeItem` for:
  - Empty item ID argument
  - Attempt to remove the root folder node

- **`localfilesystemobserverworker.cpp`**: 
  - Check return value of `removeItem` calls and handle failures explicitly
  - Replace `tryToInvalidateSnapshot()` with `invalidateSnapshot()` on `DataError` paths

- **`remotefilesystemobserverworker.cpp`**:
  - Check return value of `removeItem` calls and handle failures explicitly
  - Replace `tryToInvalidateSnapshot()` with `invalidateSnapshot()` on error paths

### Tests

- Updated `testsnapshot.cpp` to assert `removeItem` return values and cover the new guard cases (empty ID, root folder ID)
- Updated `testcomputefsoperationworker.cpp` to silence the unused-return-value warning with `(void)`