### PR TITLE
fix(server): remove sync DB file during delete flows

### DIFF
--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -585,9 +585,10 @@ void AppServer::reset() {
 }
 
 // This task can be long and block the GUI
-void AppServer::stopSyncTask(const SyncDbId syncDbId) {
+void AppServer::stopSyncTask(const SyncDbId syncDbId,
+                             const SyncPal::DbBehaviorAfterStop behavior /*= SyncPal::DbBehaviorAfterStop::Keep*/) {
     // Stop sync and remove it from syncPalMap
-    if (const auto exitInfo = stopSyncPal(syncDbId, SyncPal::PauseCaller::Sync, SyncPal::DbBehaviorAfterStop::Keep); !exitInfo) {
+    if (const auto exitInfo = stopSyncPal(syncDbId, SyncPal::PauseCaller::Sync, behavior); !exitInfo) {
         LOG_WARN(_logger, "Error in stopSyncPal for syncDbId=" << syncDbId << " : " << exitInfo);
     }
 
@@ -639,9 +640,10 @@ void AppServer::stopAllVfs() {
     LOG_DEBUG(_logger, "Vfs(s) stopped");
 }
 
-void AppServer::stopAllSyncsTask(const std::vector<SyncDbId> &syncDbIdList) {
+void AppServer::stopAllSyncsTask(const std::vector<SyncDbId> &syncDbIdList,
+                                 const SyncPal::DbBehaviorAfterStop behavior /*= SyncPal::DbBehaviorAfterStop::Keep*/) {
     for (const auto syncDbId: syncDbIdList) {
-        stopSyncTask(syncDbId);
+        stopSyncTask(syncDbId, behavior);
     }
 }
 
@@ -1095,7 +1097,7 @@ void AppServer::onRequestReceived(int id, RequestNum num, const QByteArray &para
 
             // Stop syncs for this user and remove them from syncPalMap.
             QTimer::singleShot(100, [this, userDbId, syncDbIdList]() {
-                AppServer::stopAllSyncsTask(syncDbIdList);
+                AppServer::stopAllSyncsTask(syncDbIdList, SyncPal::DbBehaviorAfterStop::Remove);
 
                 // Delete user from DB
                 const ExitCode exitCode = ServerRequests::deleteUser(userDbId);
@@ -1348,7 +1350,7 @@ void AppServer::onRequestReceived(int id, RequestNum num, const QByteArray &para
 
             // Stop syncs for this drive and remove them from syncPalMap
             QTimer::singleShot(100, [this, driveDbId, syncDbIdList]() {
-                AppServer::stopAllSyncsTask(syncDbIdList);
+                AppServer::stopAllSyncsTask(syncDbIdList, SyncPal::DbBehaviorAfterStop::Remove);
                 AppServer::deleteDrive(driveDbId);
             });
 #if defined(KD_MACOS)
@@ -1653,7 +1655,8 @@ void AppServer::onRequestReceived(int id, RequestNum num, const QByteArray &para
 
             const auto syncDbId = static_cast<SyncDbId>(tmpSyncDbId);
             QTimer::singleShot(100, [this, syncDbId]() {
-                AppServer::stopSyncTask(syncDbId); // This task can be long, hence blocking, on Windows.
+                AppServer::stopSyncTask(
+                        syncDbId, SyncPal::DbBehaviorAfterStop::Remove); // This task can be long, hence blocking, on Windows.
 
                 // Delete sync from DB
                 deleteSync(syncDbId);
@@ -3865,8 +3868,7 @@ bool AppServer::startClient() {
 
         IoError ioError = IoError::Success;
         bool exists = false;
-        if (!IoHelper::checkIfPathExists(QStr2Path(pathToExecutable), exists, ioError,
-                                         IoHelper::PathCheckOption::Insensitive) ||
+        if (!IoHelper::checkIfPathExists(QStr2Path(pathToExecutable), exists, ioError, IoHelper::PathCheckOption::Insensitive) ||
             !exists || ioError != IoError::Success) {
             pathToExecutable.clear();
         }
@@ -3956,7 +3958,8 @@ ExitInfo AppServer::initSyncPal(const Sync &sync, const NodeSet &blackList, bool
         // Set callbacks
         syncPalMapIt = syncPalMap.find(sync.dbId());
         syncPalMapIt->second->setAddErrorCallback(std::bind_front(&AppServer::addError, this));
-        syncPalMapIt->second->setResolveSyncErrorsByExitCauseCallback(std::bind_front(&AppServer::resolveSyncErrorsByExitCause, this));
+        syncPalMapIt->second->setResolveSyncErrorsByExitCauseCallback(
+                std::bind_front(&AppServer::resolveSyncErrorsByExitCause, this));
         syncPalMapIt->second->setAddCompletedItemCallback(std::bind_front(&AppServer::addCompletedItem, this));
         syncPalMapIt->second->setFixConflictedFilesCompletedCallback(
                 std::bind_front(&AppServer::sendNodeFixConflictedFilesCompleted, this));

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -1600,7 +1600,7 @@ void AppServer::onRequestReceived(int id, RequestNum num, const QByteArray &para
                 // Create and start SyncPal
                 if (const auto exitInfo = initSyncPal(sync, blackList, !startPostponed, std::chrono::seconds(0), false, true);
                     !exitInfo) {
-                    stopSyncTask(syncInfo.dbId());
+                    stopSyncTask(syncInfo.dbId(), SyncPal::DbBehaviorAfterStop::Remove);
 
                     // Delete sync from DB
                     if (const ExitInfo exitInfo2 = ServerRequests::deleteSync(syncInfo.dbId()); !exitInfo2) {

--- a/src/server/appserver.h
+++ b/src/server/appserver.h
@@ -144,7 +144,8 @@ class AppServer : public SharedTools::QtSingleApplication {
         void stopAllSyncPals();
         void stopAllVfs();
 
-        void stopAllSyncsTask(const std::vector<SyncDbId> &syncDbIdList);
+        void stopAllSyncsTask(const std::vector<SyncDbId> &syncDbIdList,
+                              const SyncPal::DbBehaviorAfterStop behavior = SyncPal::DbBehaviorAfterStop::Keep);
 
         void addError(const Error &error) const;
         void resolveItemErrors(SyncDbId syncDbId, const SyncFileItem &item) const;
@@ -176,7 +177,7 @@ class AppServer : public SharedTools::QtSingleApplication {
 
         [[nodiscard]] ExitInfo stopVfs(SyncDbId syncDbId, bool unregister);
         [[nodiscard]] ExitInfo startSyncs(User &user);
-        void stopSyncTask(SyncDbId syncDbId);
+        void stopSyncTask(SyncDbId syncDbId, const SyncPal::DbBehaviorAfterStop behavior = SyncPal::DbBehaviorAfterStop::Keep);
         [[nodiscard]] ExitInfo setSupportsVirtualFilesAsync(SyncDbId syncDbId, bool value);
         [[nodiscard]] ExitInfo setSupportsVirtualFiles(SyncDbId syncDbId, bool value);
         void setDistributionChannel(VersionChannel versionChannel);

--- a/src/server/comm/guijobs/drivedeletejob.cpp
+++ b/src/server/comm/guijobs/drivedeletejob.cpp
@@ -61,7 +61,7 @@ ExitInfo DriveDeleteJob::process() {
     }
 
     // Stop syncs for this user and remove them from syncPalMap.
-    _commManager->appServer().stopAllSyncsTask(syncDbIdList);
+    _commManager->appServer().stopAllSyncsTask(syncDbIdList, SyncPal::DbBehaviorAfterStop::Remove);
     _commManager->appServer().deleteDrive(_driveDbId);
 #if defined(KD_MACOS)
     Utility::restartFinderExtension();

--- a/src/server/comm/guijobs/syncdeletejob.cpp
+++ b/src/server/comm/guijobs/syncdeletejob.cpp
@@ -50,7 +50,7 @@ ExitInfo SyncDeleteJob::serializeOutputParms() {
 }
 
 ExitInfo SyncDeleteJob::process() {
-    _commManager->appServer().stopSyncTask(_syncDbId);
+    _commManager->appServer().stopSyncTask(_syncDbId, SyncPal::DbBehaviorAfterStop::Remove);
 
     // Delete sync from DB
     _commManager->appServer().deleteSync(_syncDbId);

--- a/src/server/comm/guijobs/userdeletejob.cpp
+++ b/src/server/comm/guijobs/userdeletejob.cpp
@@ -63,7 +63,7 @@ ExitInfo UserDeleteJob::process() {
     }
 
     // Stop syncs for this user and remove them from syncPalMap.
-    _commManager->appServer().stopAllSyncsTask(syncDbIdList);
+    _commManager->appServer().stopAllSyncsTask(syncDbIdList, SyncPal::DbBehaviorAfterStop::Remove);
 
     // Delete user from DB
     const ExitInfo exitInfo = ServerRequests::deleteUser(_userDbId);

--- a/test/server/appserver/testappserver.cpp
+++ b/test/server/appserver/testappserver.cpp
@@ -149,6 +149,8 @@ void TestAppServer::testStartAndStopSync() {
     CPPUNIT_ASSERT(_appPtr->syncPalMap[syncDbId]->isRunning());
     CPPUNIT_ASSERT(syncIsActive(syncDbId));
 
+    const auto syncDbPath = _appPtr->syncPalMap[syncDbId]->syncDb()->dbPath();
+
     // Stop sync & clear maps
     _appPtr->stopSyncTask(syncDbId);
     CPPUNIT_ASSERT(_appPtr->syncPalMap.empty());
@@ -164,6 +166,10 @@ void TestAppServer::testStartAndStopSync() {
     _appPtr->stopAllSyncsTask({syncDbId});
     CPPUNIT_ASSERT(_appPtr->syncPalMap.empty());
     CPPUNIT_ASSERT(_appPtr->vfsMap.empty());
+    auto exists = false;
+    auto ioError = IoError::Unknown;
+    CPPUNIT_ASSERT(IoHelper::checkIfPathExists(syncDbPath, exists, ioError, IoHelper::PathCheckOption::Insensitive));
+    CPPUNIT_ASSERT(exists);
 
     // Update sync local folder with a dummy value
     Sync sync;
@@ -188,6 +194,13 @@ void TestAppServer::testStartAndStopSync() {
     // Update sync local folder with the good value
     CPPUNIT_ASSERT(ParmsDb::instance()->updateSync(sync, found) && found);
     sync.setLocalPath(_localPath);
+
+    // Stop syncs & clear maps for all users
+    _appPtr->stopAllSyncsTask({syncDbId}, SyncPal::DbBehaviorAfterStop::Remove);
+    CPPUNIT_ASSERT(_appPtr->syncPalMap.empty());
+    CPPUNIT_ASSERT(_appPtr->vfsMap.empty());
+    CPPUNIT_ASSERT(IoHelper::checkIfPathExists(syncDbPath, exists, ioError, IoHelper::PathCheckOption::Insensitive));
+    CPPUNIT_ASSERT(exists);
 }
 
 void TestAppServer::testCleanup() {

--- a/test/server/appserver/testappserver.cpp
+++ b/test/server/appserver/testappserver.cpp
@@ -66,11 +66,10 @@ void TestAppServer::setUp() {
     const Drive drive(1, driveId, account.dbId(), std::string(), 0, std::string());
     (void) ParmsDb::instance()->insertDrive(drive);
 
-    const auto localPath = _localTempDir.path().string() + "/local_sync_directory";
+    const auto localPath = _localTempDir.path() / "local_sync_directory";
     std::filesystem::create_directories(localPath);
 
-    const auto remotePath = testVariables.remotePath;
-    Sync sync(1, drive.dbId(), localPath, "", remotePath);
+    Sync sync(1, drive.dbId(), localPath, "", testVariables.remotePath);
     (void) ParmsDb::instance()->insertSync(sync);
 
     // Create AppServer

--- a/test/server/appserver/testappserver.cpp
+++ b/test/server/appserver/testappserver.cpp
@@ -40,12 +40,6 @@ void TestAppServer::setUp() {
 
     if (QCoreApplication::instance()) {
         _appPtr = dynamic_cast<MockAppServer *>(QCoreApplication::instance());
-
-        Sync sync;
-        bool found = false;
-        if (ParmsDb::instance()->selectSync(1, sync, found) && found) {
-            _localPath = sync.localPath();
-        }
         return;
     }
 
@@ -72,11 +66,11 @@ void TestAppServer::setUp() {
     const Drive drive(1, driveId, account.dbId(), std::string(), 0, std::string());
     (void) ParmsDb::instance()->insertDrive(drive);
 
-    _localPath = _localTempDir.path().string() + "/local_sync_directory";
-    std::filesystem::create_directories(_localPath);
+    const auto localPath = _localTempDir.path().string() + "/local_sync_directory";
+    std::filesystem::create_directories(localPath);
 
-    _remotePath = testVariables.remotePath;
-    Sync sync(1, drive.dbId(), _localPath, "", _remotePath);
+    const auto remotePath = testVariables.remotePath;
+    Sync sync(1, drive.dbId(), localPath, "", remotePath);
     (void) ParmsDb::instance()->insertSync(sync);
 
     // Create AppServer

--- a/test/server/appserver/testappserver.cpp
+++ b/test/server/appserver/testappserver.cpp
@@ -40,6 +40,12 @@ void TestAppServer::setUp() {
 
     if (QCoreApplication::instance()) {
         _appPtr = dynamic_cast<MockAppServer *>(QCoreApplication::instance());
+
+        Sync sync;
+        bool found = false;
+        if (ParmsDb::instance()->selectSync(1, sync, found) && found) {
+            _localPath = sync.localPath();
+        }
         return;
     }
 
@@ -175,6 +181,8 @@ void TestAppServer::testStartAndStopSync() {
     Sync sync;
     found = false;
     CPPUNIT_ASSERT(ParmsDb::instance()->selectSync(syncDbId, sync, found) && found);
+    const auto originalLocalPath = sync.localPath();
+    CPPUNIT_ASSERT(!originalLocalPath.empty());
 
 #ifdef KD_WINDOWS
     sync.setLocalPath("Y:\\dummy");
@@ -192,15 +200,16 @@ void TestAppServer::testStartAndStopSync() {
     CPPUNIT_ASSERT(exitInfo.cause() == ExitCause::SyncDirDiskMissing);
 
     // Update sync local folder with the good value
+    sync.setLocalPath(originalLocalPath);
     CPPUNIT_ASSERT(ParmsDb::instance()->updateSync(sync, found) && found);
-    sync.setLocalPath(_localPath);
 
-    // Stop syncs & clear maps for all users
+    // Check that DB file is removed when sync is deleted
+    CPPUNIT_ASSERT(_appPtr->startSyncs());
     _appPtr->stopAllSyncsTask({syncDbId}, SyncPal::DbBehaviorAfterStop::Remove);
     CPPUNIT_ASSERT(_appPtr->syncPalMap.empty());
     CPPUNIT_ASSERT(_appPtr->vfsMap.empty());
     CPPUNIT_ASSERT(IoHelper::checkIfPathExists(syncDbPath, exists, ioError, IoHelper::PathCheckOption::Insensitive));
-    CPPUNIT_ASSERT(exists);
+    CPPUNIT_ASSERT(!exists);
 }
 
 void TestAppServer::testCleanup() {

--- a/test/server/appserver/testappserver.h
+++ b/test/server/appserver/testappserver.h
@@ -72,8 +72,6 @@ class TestAppServer : public CppUnit::TestFixture, public TestBase {
     private:
         MockAppServer *_appPtr;
         LocalTemporaryDirectory _localTempDir = LocalTemporaryDirectory("TestAppServer");
-        SyncPath _localPath;
-        SyncPath _remotePath;
 
         bool waitForSyncStatus(int syncDbId, SyncStatus targetStatus) const;
         bool syncIsActive(int syncDbId) const;


### PR DESCRIPTION
## Summary
- Add a database cleanup behavior parameter to the methods `stopSyncTask` and `stopAllSyncsTask`.
- Use the remove behavior in sync, drive, and user deletion flows so deleted syncs are stopped with cleanup.
- Keep the default stop behavior unchanged for non-deletion paths.