### PR TITLE
fix: distinguish access denied from invalid token

### DIFF
--- a/src/libsyncengine/jobs/network/abstracttokennetworkjob.cpp
+++ b/src/libsyncengine/jobs/network/abstracttokennetworkjob.cpp
@@ -142,6 +142,7 @@ ExitInfo AbstractTokenNetworkJob::handleUnauthorizedResponse() {
     switch (_apiType) {
         case ApiType::Drive:
         case ApiType::NotifyDrive:
+            disableRetry();
             return {ExitCode::BackError, ExitCause::DriveAccessError};
         case ApiType::DriveByUser:
         case ApiType::Desktop:

--- a/src/libsyncengine/jobs/network/abstracttokennetworkjob.cpp
+++ b/src/libsyncengine/jobs/network/abstracttokennetworkjob.cpp
@@ -139,6 +139,14 @@ std::string AbstractTokenNetworkJob::getSpecificUrl() {
 }
 
 ExitInfo AbstractTokenNetworkJob::handleUnauthorizedResponse() {
+    if (_apiType == ApiType::Profile || _apiType == ApiType::DriveByUser) {
+        return handleUserUnauthorizedResponse();
+    } else {
+        return handleDriveUnauthorizedResponse();
+    }
+}
+
+ExitInfo AbstractTokenNetworkJob::handleUserUnauthorizedResponse() {
     // There is no longer any refresh of the token since v3.5.6
     // This code is only used when updating from a version < v3.5.6
     if (const auto apiToken = loadApiToken(); apiToken != _apiToken) {
@@ -164,6 +172,10 @@ ExitInfo AbstractTokenNetworkJob::handleUnauthorizedResponse() {
     if (_trials > 2) disableRetry();
 
     return ExitCode::InvalidToken;
+}
+
+ExitInfo AbstractTokenNetworkJob::handleDriveUnauthorizedResponse() {
+    return {ExitCode::BackError, ExitCause::DriveAccessError};
 }
 
 void AbstractTokenNetworkJob::defaultBackErrorHandling(const NetworkErrorCode errorCode, const Poco::URI &uri,

--- a/src/libsyncengine/jobs/network/abstracttokennetworkjob.cpp
+++ b/src/libsyncengine/jobs/network/abstracttokennetworkjob.cpp
@@ -139,10 +139,18 @@ std::string AbstractTokenNetworkJob::getSpecificUrl() {
 }
 
 ExitInfo AbstractTokenNetworkJob::handleUnauthorizedResponse() {
-    if (_apiType == ApiType::Profile || _apiType == ApiType::DriveByUser) {
-        return handleUserUnauthorizedResponse();
-    } else {
-        return handleDriveUnauthorizedResponse();
+    switch (_apiType) {
+        case ApiType::Drive:
+        case ApiType::NotifyDrive:
+            return {ExitCode::BackError, ExitCause::DriveAccessError};
+        case ApiType::DriveByUser:
+        case ApiType::Desktop:
+        case ApiType::Profile:
+            return handleUserUnauthorizedResponse();
+        default: {
+            LOG_WARN(_logger, "Unauthorized response received for unknown API type");
+            return ExitInfo{ExitCode::BackError, ExitCause::Unknown};
+        }
     }
 }
 
@@ -172,10 +180,6 @@ ExitInfo AbstractTokenNetworkJob::handleUserUnauthorizedResponse() {
     if (_trials > 2) disableRetry();
 
     return ExitCode::InvalidToken;
-}
-
-ExitInfo AbstractTokenNetworkJob::handleDriveUnauthorizedResponse() {
-    return {ExitCode::BackError, ExitCause::DriveAccessError};
 }
 
 void AbstractTokenNetworkJob::defaultBackErrorHandling(const NetworkErrorCode errorCode, const Poco::URI &uri,

--- a/src/libsyncengine/jobs/network/abstracttokennetworkjob.h
+++ b/src/libsyncengine/jobs/network/abstracttokennetworkjob.h
@@ -107,7 +107,6 @@ class AbstractTokenNetworkJob : public AbstractNetworkJob {
         std::string getUrl() override;
         ExitInfo handleUnauthorizedResponse();
         ExitInfo handleUserUnauthorizedResponse();
-        ExitInfo handleDriveUnauthorizedResponse();
         void defaultBackErrorHandling(NetworkErrorCode errorCode, const Poco::URI &uri, ExitCause &exitCause);
 
         // Load user information, including the API token, based on the record associated `_driveDbId`, provided it does exist.

--- a/src/libsyncengine/jobs/network/abstracttokennetworkjob.h
+++ b/src/libsyncengine/jobs/network/abstracttokennetworkjob.h
@@ -106,6 +106,8 @@ class AbstractTokenNetworkJob : public AbstractNetworkJob {
 
         std::string getUrl() override;
         ExitInfo handleUnauthorizedResponse();
+        ExitInfo handleUserUnauthorizedResponse();
+        ExitInfo handleDriveUnauthorizedResponse();
         void defaultBackErrorHandling(NetworkErrorCode errorCode, const Poco::URI &uri, ExitCause &exitCause);
 
         // Load user information, including the API token, based on the record associated `_driveDbId`, provided it does exist.

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -4418,6 +4418,7 @@ void AppServer::addError(const Error &error) const {
         LOG_WARN(Log::instance()->getLogger(), "Error in ParmsDb::insertError");
         return;
     }
+    if (!errorAlreadyExists) errorList.push_back(errorCopy);
 
     manageError(errorCopy, errorList, errorAlreadyExists);
 

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -4418,14 +4418,8 @@ void AppServer::addError(const Error &error) const {
         LOG_WARN(Log::instance()->getLogger(), "Error in ParmsDb::insertError");
         return;
     }
-    if (!errorAlreadyExists) errorList.push_back(errorCopy);
 
-
-    User user;
-    if (errorCopy.syncDbId() && ServerRequests::getUserFromSyncDbId(errorCopy.syncDbId(), user) != ExitCode::Ok) {
-        LOG_WARN(Log::instance()->getLogger(), "Error in ServerRequests::getUserFromSyncDbId");
-        return;
-    }
+    manageError(errorCopy, errorList, errorAlreadyExists);
 
     if (ServerRequests::isDisplayableError(errorCopy)) {
         // Notify the client
@@ -4438,75 +4432,132 @@ void AppServer::addError(const Error &error) const {
         ServerRequests::errorToErrorInfo(errorCopy, errorInfo);
         sendErrorAdded(errorInfo);
     }
+}
 
-    if (errorCopy.exitCode() == ExitCode::InvalidToken) {
-        // Manage invalid token error
-        LOG_DEBUG(Log::instance()->getLogger(), "Manage invalid token error");
-
-        if (!user.dbId()) {
-            LOG_WARN(Log::instance()->getLogger(), "Invalid error");
-            return;
-        }
-
-        // Update user
-        user.setKeychainKey(std::string());
-        bool found = false;
-        if (!ParmsDb::instance()->updateUser(user, found)) {
-            LOG_WARN(Log::instance()->getLogger(), "Error in ParmsDb::updateUser");
-            return;
-        }
-        if (!found) {
-            LOG_WARN(Log::instance()->getLogger(), "User not found with dbId=" << user.dbId());
-            return;
-        }
-
-        UserInfo userInfo;
-        ServerRequests::userToUserInfo(user, userInfo);
-        sendUserUpdated(userInfo);
-    } else if (errorCopy.exitCode() == ExitCode::NetworkError && errorCopy.exitCause() == ExitCause::SocketsDefuncted) {
-        // Manage sockets defuncted error
-        LOG_WARN(Log::instance()->getLogger(), "Manage sockets defuncted error");
-
-        sentry::Handler::captureMessage(sentry::Level::Warning, "AppServer::addError", "Sockets defuncted error");
-
-        // Decrease upload session max parallel jobs
-        ParametersCache::instance()->decreaseUploadSessionParallelThreads();
-
-        // Decrease JobManager pool capacity
-        SyncJobManagerSingleton::instance()->decreasePoolCapacity();
-    } else if (errorCopy.exitCode() == ExitCode::SystemError && errorCopy.exitCause() == ExitCause::FileAccessError) {
-        // Remove child errors
-        std::unordered_set<int64_t> toBeRemovedErrorIds;
-        for (const Error &parentError: errorList) {
-            for (const Error &childError: errorList) {
-                if (CommonUtility::isDescendantOrEqual(childError.path(), parentError.path()) &&
-                    childError.dbId() != parentError.dbId()) {
-                    toBeRemovedErrorIds.insert(childError.dbId());
-                }
-            }
-        }
-        for (auto errorId: toBeRemovedErrorIds) {
-            bool found = false;
-            if (!ParmsDb::instance()->deleteError(errorId, found)) {
-                LOG_WARN(Log::instance()->getLogger(), "Error in ParmsDb::deleteError");
-                return;
-            }
-            if (!found) {
-                LOG_WARN(Log::instance()->getLogger(), "Error not found in Error table for dbId=" << errorId);
-                return;
-            }
-            sendErrorRemoved(errorId);
-        }
-        if (!toBeRemovedErrorIds.empty()) sendErrorsCleared(errorCopy.syncDbId());
-    } else if (_updateManager && errorCopy.exitCode() == ExitCode::UpdateRequired) {
-        _updateManager->updater()->unskipVersion();
+void AppServer::manageError(const Error &error, std::vector<Error> &errorList, bool errorAlreadyExists) const {
+    User user;
+    Account account;
+    Drive drive;
+    Sync sync;
+    if (error.syncDbId() &&
+        ServerRequests::getDbStructsFromSyncDbId(error.syncDbId(), user, account, drive, sync) != ExitCode::Ok) {
+        LOG_WARN(Log::instance()->getLogger(), "Error in ServerRequests::getDbStructsFromSyncDbId");
+        return;
     }
 
-    if (!ServerRequests::isAutoResolvedError(errorCopy) && !errorAlreadyExists) {
+    if (error.exitCode() == ExitCode::InvalidToken) {
+        manageInvalidTokenError(user);
+    } else if (error.exitCode() == ExitCode::BackError && error.exitCause() == ExitCause::DriveAccessError) {
+        manageDriveAccessError(drive);
+    } else if (error.exitCode() == ExitCode::NetworkError && error.exitCause() == ExitCause::SocketsDefuncted) {
+        manageSocketsDefunctedError();
+    } else if (error.exitCode() == ExitCode::SystemError && error.exitCause() == ExitCause::FileAccessError) {
+        manageFileAccessErrorError(errorList);
+    } else if (_updateManager && error.exitCode() == ExitCode::UpdateRequired) {
+        manageUpdateRequiredErrorError();
+    }
+
+    if (!ServerRequests::isAutoResolvedError(error) && !errorAlreadyExists) {
         // Send error to sentry only for technical errors
         SentryUser sentryUser(user.email(), user.name(), std::to_string(user.userId()));
         sentry::Handler::captureMessage(sentry::Level::Warning, "AppServer::addError", error.errorString(), sentryUser);
     }
+}
+
+void AppServer::manageDriveAccessError(Drive &drive) const {
+    // Manage drive access error
+    LOG_DEBUG(Log::instance()->getLogger(), "Manage drive access error");
+
+    if (!drive.dbId()) {
+        LOG_WARN(Log::instance()->getLogger(), "Invalid error");
+        return;
+    }
+
+    // Update drive
+    drive.setAccessDenied(true);
+    bool found = false;
+    if (!ParmsDb::instance()->updateDrive(drive, found)) {
+        LOG_WARN(Log::instance()->getLogger(), "Error in ParmsDb::updateDrive");
+        return;
+    }
+    if (!found) {
+        LOG_WARN(Log::instance()->getLogger(), "Drive not found with dbId=" << drive.dbId());
+        return;
+    }
+
+    DriveInfo driveInfo;
+    ServerRequests::driveToDriveInfo(drive, driveInfo);
+    sendDriveUpdated(driveInfo);
+}
+
+void AppServer::manageInvalidTokenError(User &user) const {
+    // Manage invalid token error
+    LOG_DEBUG(Log::instance()->getLogger(), "Manage invalid token error");
+
+    if (!user.dbId()) {
+        LOG_WARN(Log::instance()->getLogger(), "Invalid error");
+        return;
+    }
+
+    // Update user
+    user.setKeychainKey(std::string());
+    bool found = false;
+    if (!ParmsDb::instance()->updateUser(user, found)) {
+        LOG_WARN(Log::instance()->getLogger(), "Error in ParmsDb::updateUser");
+        return;
+    }
+    if (!found) {
+        LOG_WARN(Log::instance()->getLogger(), "User not found with dbId=" << user.dbId());
+        return;
+    }
+
+    UserInfo userInfo;
+    ServerRequests::userToUserInfo(user, userInfo);
+    sendUserUpdated(userInfo);
+}
+
+void AppServer::manageSocketsDefunctedError() const {
+    // Manage sockets defuncted error
+    LOG_WARN(Log::instance()->getLogger(), "Manage sockets defuncted error");
+
+    sentry::Handler::captureMessage(sentry::Level::Warning, "AppServer::addError", "Sockets defuncted error");
+
+    // Decrease upload session max parallel jobs
+    ParametersCache::instance()->decreaseUploadSessionParallelThreads();
+
+    // Decrease JobManager pool capacity
+    SyncJobManagerSingleton::instance()->decreasePoolCapacity();
+}
+
+void AppServer::manageFileAccessErrorError(const std::vector<Error> &errorList) const {
+    // Remove child errors
+    std::unordered_set<int64_t> toBeRemovedErrorIds;
+    for (const Error &parentError: errorList) {
+        for (const Error &childError: errorList) {
+            if (CommonUtility::isDescendantOrEqual(childError.path(), parentError.path()) &&
+                childError.dbId() != parentError.dbId()) {
+                toBeRemovedErrorIds.insert(childError.dbId());
+            }
+        }
+    }
+    for (auto errorId: toBeRemovedErrorIds) {
+        bool found = false;
+        if (!ParmsDb::instance()->deleteError(errorId, found)) {
+            LOG_WARN(Log::instance()->getLogger(), "Error in ParmsDb::deleteError");
+            return;
+        }
+        if (!found) {
+            LOG_WARN(Log::instance()->getLogger(), "Error not found in Error table for dbId=" << errorId);
+            return;
+        }
+        sendErrorRemoved(errorId);
+    }
+
+    if (!toBeRemovedErrorIds.empty()) sendErrorsCleared(errorList[0].syncDbId());
+}
+
+void AppServer::manageUpdateRequiredErrorError() const {
+    _updateManager->updater()->unskipVersion();
 }
 
 void AppServer::resolveItemErrors(const SyncDbId syncDbId, const SyncFileItem &item) const {

--- a/src/server/appserver.h
+++ b/src/server/appserver.h
@@ -149,8 +149,16 @@ class AppServer : public SharedTools::QtSingleApplication {
                               const SyncPal::DbBehaviorAfterStop behavior = SyncPal::DbBehaviorAfterStop::Keep);
 
         void addError(const Error &error) const;
+        void manageError(const Error &error, std::vector<Error> &errorList, bool errorAlreadyExists) const;
+        void manageDriveAccessError(Drive &drive) const;
+        void manageInvalidTokenError(User& user) const;
+        void manageSocketsDefunctedError() const;
+        void manageFileAccessErrorError(const std::vector<Error> &errorList) const;
+        void manageUpdateRequiredErrorError() const;
+
         void resolveItemErrors(SyncDbId syncDbId, const SyncFileItem &item) const;
         void resolveSyncErrorsByExitCause(SyncDbId syncDbId, ExitCause cause) const;
+
         void updateSentryUser();
         void deleteDrive(DriveDbId driveDbId);
         void deleteSync(SyncDbId syncDbId);

--- a/src/server/requests/serverrequests.cpp
+++ b/src/server/requests/serverrequests.cpp
@@ -1275,10 +1275,10 @@ bool ServerRequests::isAutoResolvedError(const Error &error) {
     return autoResolved;
 }
 
-ExitCode ServerRequests::getUserFromSyncDbId(const SyncDbId syncDbId, User &user) {
+ExitCode ServerRequests::getDbStructsFromSyncDbId(SyncDbId syncDbId, User &user, Account &account, Drive &drive, Sync &sync) {
     // Get User
     bool found = false;
-    Sync sync;
+
     if (!ParmsDb::instance()->selectSync(syncDbId, sync, found)) {
         LOG_WARN(Log::instance()->getLogger(), "Error in ParmsDb::selectSync");
         return ExitCode::DbError;
@@ -1288,7 +1288,6 @@ ExitCode ServerRequests::getUserFromSyncDbId(const SyncDbId syncDbId, User &user
         return ExitCode::DataError;
     }
 
-    Drive drive;
     if (!ParmsDb::instance()->selectDrive(sync.driveDbId(), drive, found)) {
         LOG_WARN(Log::instance()->getLogger(), "Error in ParmsDb::selectDrive");
         return ExitCode::DbError;
@@ -1298,8 +1297,7 @@ ExitCode ServerRequests::getUserFromSyncDbId(const SyncDbId syncDbId, User &user
         return ExitCode::DataError;
     }
 
-    Account acc;
-    if (!ParmsDb::instance()->selectAccount(drive.accountDbId(), acc, found)) {
+    if (!ParmsDb::instance()->selectAccount(drive.accountDbId(), account, found)) {
         LOG_WARN(Log::instance()->getLogger(), "Error in ParmsDb::selectAccount");
         return ExitCode::DbError;
     }
@@ -1308,12 +1306,12 @@ ExitCode ServerRequests::getUserFromSyncDbId(const SyncDbId syncDbId, User &user
         return ExitCode::DataError;
     }
 
-    if (!ParmsDb::instance()->selectUser(acc.userDbId(), user, found)) {
+    if (!ParmsDb::instance()->selectUser(account.userDbId(), user, found)) {
         LOG_WARN(Log::instance()->getLogger(), "Error in ParmsDb::selectUser");
         return ExitCode::DbError;
     }
     if (!found) {
-        LOG_WARN(Log::instance()->getLogger(), "User not found with dbId=" << acc.userDbId());
+        LOG_WARN(Log::instance()->getLogger(), "User not found with dbId=" << account.userDbId());
         return ExitCode::DataError;
     }
 

--- a/src/server/requests/serverrequests.h
+++ b/src/server/requests/serverrequests.h
@@ -173,7 +173,7 @@ struct SYNCENGINE_EXPORT ServerRequests {
         static void exclusionAppInfoToExclusionApp(const ExclusionAppInfo &exclusionAppInfo, ExclusionApp &exclusionApp);
         static bool isDisplayableError(const Error &error);
         static bool isAutoResolvedError(const Error &error);
-        static ExitCode getUserFromSyncDbId(SyncDbId syncDbId, User &user);
+        static ExitCode getDbStructsFromSyncDbId(SyncDbId syncDbId, User &user, Account &account, Drive &drive, Sync &sync);
         static ExitCode fixProxyConfig();
 
     private:

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -1698,6 +1698,29 @@ void TestNetworkJobs::testGetInfoUserTrialsOn401Error() {
     }
 }
 
+void TestNetworkJobs::testGetInfoDriveOn401Error() {
+    class GetInfoDriveJobMock final : public GetInfoDriveJob {
+        public:
+            explicit GetInfoDriveJobMock(const DriveDbId driveDbId, const ApiToken &apiToken) :
+                GetInfoDriveJob(driveDbId),
+                _apiToken(apiToken) {}
+
+            [[nodiscard]] Poco::Net::HTTPResponse httpResponse() const override {
+                return Poco::Net::HTTPResponse(Poco::Net::HTTPResponse::HTTP_UNAUTHORIZED);
+            }
+            ApiToken loadApiToken() override { return _apiToken; }
+
+        private:
+            ApiToken _apiToken;
+    };
+
+    GetInfoDriveJobMock job(_driveDbId, _apiToken);
+    const auto exitInfo = job.runSynchronously();
+    CPPUNIT_ASSERT_EQUAL(ExitCode::BackError, exitInfo.code());
+    CPPUNIT_ASSERT_EQUAL(ExitCause::DriveAccessError, exitInfo.cause());
+    CPPUNIT_ASSERT_EQUAL(0, job.trials());
+}
+
 void TestNetworkJobs::testExists() {
     const NodeId dummyId("1234567890");
     const auto ids = {pictureDirRemoteId, picture1RemoteId, dummyId};

--- a/test/libsyncengine/jobs/network/testnetworkjobs.h
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.h
@@ -68,6 +68,7 @@ class TestNetworkJobs : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST(testDownloadHasEnoughSpace);
         CPPUNIT_TEST(testSearch);
         CPPUNIT_TEST(testGetInfoUserTrialsOn401Error);
+        CPPUNIT_TEST(testGetInfoDriveOn401Error);
         CPPUNIT_TEST(testExists);
         CPPUNIT_TEST(testGetAllFilesInDirectory);
         CPPUNIT_TEST_SUITE_END();
@@ -112,6 +113,7 @@ class TestNetworkJobs : public CppUnit::TestFixture, public TestBase {
         void testDownloadHasEnoughSpace();
         void testSearch();
         void testGetInfoUserTrialsOn401Error();
+        void testGetInfoDriveOn401Error();
         void testExists();
         void testGetAllFilesInDirectory();
 


### PR DESCRIPTION
This pull request refactors how unauthorized API responses are handled in `AbstractTokenNetworkJob`, introducing clearer separation between user and drive-specific unauthorized cases. The main changes involve splitting the handling logic into two dedicated methods for improved maintainability and clarity.

**Unauthorized response handling improvements:**

* The `handleUnauthorizedResponse()` method now delegates to either `handleUserUnauthorizedResponse()` or `handleDriveUnauthorizedResponse()` based on the `_apiType`, ensuring the correct logic is applied for different API types.
* Added `handleUserUnauthorizedResponse()` and `handleDriveUnauthorizedResponse()` methods to encapsulate the logic for handling unauthorized responses for user and drive APIs, respectively. [[1]](diffhunk://#diff-44d54fbf5a0fdb8990e89ae9ff4b9c555be529e20538d84943437912b6b4b468R109-R110) [[2]](diffhunk://#diff-d6d751d72f794f1ff6b86c39ce823610a741b72ef54260c8e1b441a1a291d1faR177-R180)Refactor AbstractTokenNetworkJob to distinguish between user and drive unauthorized responses. Introduce handleDriveUnauthorizedResponse returning a specific ExitInfo. Declare new methods in the header. Also includes minor formatting changes in the csproj file.