### PR TITLE
fix(server): avoid restarting client when a connection is already active

### DIFF
--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -2649,7 +2649,7 @@ void AppServer::onMessageReceivedFromAnotherProcess(const QString &message, QObj
         const auto oldCommServerHasActiveConnection = useOldCommServer() && OldCommServer::instance()->hasActiveConnexion();
         const auto newCommServerHasActiveConnection = useCommManager() && _commManager->hasActiveClientConnexion();
         if (oldCommServerHasActiveConnection || newCommServerHasActiveConnection) {
-            LOG_INFO(_logger, "An active connexion with a client already exist, showing synthesis!");
+            LOG_INFO(_logger, "An active connexion with a client already exists, showing synthesis!");
             showSynthesis();
             return;
         }

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -2647,7 +2647,7 @@ void AppServer::onMessageReceivedFromAnotherProcess(const QString &message, QObj
         showSettings();
     } else if (message == restartClientMsg) {
         const auto oldCommServerHasActiveConnection = useOldCommServer() && OldCommServer::instance()->hasActiveConnexion();
-        const auto newCommServerHasActiveConnection = useCommManager() && _commManager->hasActiveClientConnexion();
+        const auto newCommServerHasActiveConnection = useCommManager() && _commManager->hasActiveGuiConnection();
         if (oldCommServerHasActiveConnection || newCommServerHasActiveConnection) {
             LOG_INFO(_logger, "An active connexion with a client already exists, showing synthesis!");
             showSynthesis();

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -389,7 +389,8 @@ void AppServer::init() {
         }
 
         connect(OldCommServer::instance().get(), &OldCommServer::requestReceived, this, &AppServer::onRequestReceived);
-        connect(OldCommServer::instance().get(), &OldCommServer::clientDisconnected, this, &AppServer::onClientDisconnectedReceived);
+        connect(OldCommServer::instance().get(), &OldCommServer::clientDisconnected, this,
+                &AppServer::onClientDisconnectedReceived);
     }
 
     // Update users/accounts/drives info
@@ -2645,13 +2646,18 @@ void AppServer::onMessageReceivedFromAnotherProcess(const QString &message, QObj
     } else if (message == showSettingsMsg) {
         showSettings();
     } else if (message == restartClientMsg) {
+        const auto oldCommServerHasActiveConnection = useOldCommServer() && OldCommServer::instance()->hasActiveConnexion();
+        const auto newCommServerHasActiveConnection = useCommManager() && _commManager->hasActiveClientConnexion();
+        if (oldCommServerHasActiveConnection || newCommServerHasActiveConnection) {
+            LOG_INFO(_logger, "An active connexion with a client already exist, showing synthesis!");
+            showSynthesis();
+            return;
+        }
         _clientManuallyRestarted = true;
         if (!_clientProcess || _clientProcess->state() == QProcess::ProcessState::NotRunning) {
             if (!startClient()) {
                 LOG_ERROR(_logger, "Failed to start the client");
             }
-        } else if (_clientProcess->state() == QProcess::ProcessState::Running) {
-            showSynthesis();
         }
     } else {
         LOG_WARN(_logger, "Unknown message received from another kDrive process: '" << message.toStdString() << "'");

--- a/src/server/comm/abstractcommserver.h
+++ b/src/server/comm/abstractcommserver.h
@@ -41,6 +41,7 @@ class AbstractCommServer {
         virtual bool listen() = 0;
         virtual std::shared_ptr<AbstractCommChannel> nextPendingConnection() = 0;
         virtual std::list<std::shared_ptr<AbstractCommChannel>> connections() = 0;
+        bool hasActiveConnexion() { return !connections().empty(); }
 
         void setNewConnectionCbk(const std::function<void()> &cbk) { _onNewConnectionCbk = cbk; }
         void newConnectionCbk() {

--- a/src/server/comm/commmanager.cpp
+++ b/src/server/comm/commmanager.cpp
@@ -298,7 +298,7 @@ void CommManager::sendGuiSignal(const std::shared_ptr<AbstractGuiJob> signal) {
     GuiJobManagerSingleton::instance()->queueAsyncJob(signal);
 }
 
-bool CommManager::hasActiveClientConnexion() {
+bool CommManager::hasActiveGuiConnection() {
     const std::scoped_lock lock(_mutex);
     return _guiCommServer && _guiCommServer->hasActiveConnexion();
 }

--- a/src/server/comm/commmanager.cpp
+++ b/src/server/comm/commmanager.cpp
@@ -298,6 +298,11 @@ void CommManager::sendGuiSignal(const std::shared_ptr<AbstractGuiJob> signal) {
     GuiJobManagerSingleton::instance()->queueAsyncJob(signal);
 }
 
+bool CommManager::hasActiveClientConnexion() {
+    const std::scoped_lock lock(_mutex);
+    return _guiCommServer && _guiCommServer->hasActiveConnexion();
+}
+
 void CommManager::onNewGuiConnection() {
     const std::scoped_lock lock(_mutex);
     if (!_guiCommServer) return;

--- a/src/server/comm/commmanager.h
+++ b/src/server/comm/commmanager.h
@@ -56,7 +56,7 @@ class CommManager : public std::enable_shared_from_this<CommManager> {
 
         // Broadcast a signal to all the gui channels
         void sendGuiSignal(const std::shared_ptr<AbstractGuiJob> signal);
-        bool hasActiveClientConnexion();
+        bool hasActiveGuiConnection();
 
     private:
         // AppServer maps

--- a/src/server/comm/commmanager.h
+++ b/src/server/comm/commmanager.h
@@ -56,6 +56,7 @@ class CommManager : public std::enable_shared_from_this<CommManager> {
 
         // Broadcast a signal to all the gui channels
         void sendGuiSignal(const std::shared_ptr<AbstractGuiJob> signal);
+        bool hasActiveClientConnexion();
 
     private:
         // AppServer maps

--- a/src/server/comm/oldcommserver.h
+++ b/src/server/comm/oldcommserver.h
@@ -54,6 +54,9 @@ class OldCommServer : public QObject {
 
         void start();
         inline bool isListening() { return _tcpServer.isListening(); }
+        bool hasActiveConnexion() {
+            return _tcpSocket != nullptr && _tcpSocket->state() == QAbstractSocket::ConnectedState && _tcpSocket->isValid();
+        }
 
     signals:
         void requestReceived(int id, RequestNum num, const QByteArray &params);

--- a/src/server/comm/oldcommserver.h
+++ b/src/server/comm/oldcommserver.h
@@ -54,7 +54,7 @@ class OldCommServer : public QObject {
 
         void start();
         inline bool isListening() { return _tcpServer.isListening(); }
-        bool hasActiveConnexion() {
+        bool hasActiveConnexion() const {
             return _tcpSocket != nullptr && _tcpSocket->state() == QAbstractSocket::ConnectedState && _tcpSocket->isValid();
         }
 


### PR DESCRIPTION
## Summary
- avoid restarting the client when a restart message is received while a GUI connection is already active
- expose active connection checks in both the legacy communication server and the new communication manager
- show the synthesis window instead of starting a second client instance in that case
