### PR TITLE
test: exclude tests from from code duplication analysis

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,1 +1,1 @@
-sonar.cpd.exclusions=src/gui4/macOS/CppInterop/**/*,src/gui4/macOS/kDriveCore/ServerBridge/XPC/**/*
+sonar.cpd.exclusions=src/gui4/macOS/CppInterop/**/*,src/gui4/macOS/kDriveCore/ServerBridge/XPC/**/*,test/**/*


### PR DESCRIPTION
Subfolders in `test` folder should be ignored during code duplication analysis