### PR TITLE
feat(server): improve callback thread management

### DIFF
--- a/src/server/comm/socketcommserver.cpp
+++ b/src/server/comm/socketcommserver.cpp
@@ -334,9 +334,9 @@ void SocketCommServer::execute() {
     }
     _isListening = false;
 }
-void SocketCommServer::joinAndClearPostponedLostConnectionCbks() {
+void SocketCommServer::joinAndClearPostponedLostConnectionCbks() noexcept {
     // Join and remove all postponed lost-connection callback threads
-    for (const auto thread: _postponedLostConnectionCbks) {
+    for (const auto& thread: _postponedLostConnectionCbks) {
         if (thread->joinable()) {
             thread->join();
         }

--- a/src/server/comm/socketcommserver.cpp
+++ b/src/server/comm/socketcommserver.cpp
@@ -160,9 +160,13 @@ void SocketCommChannel::close() {
 }
 
 bool SocketCommChannel::joinCallbackThread() {
-    if (_callbackThread && _callbackThread->joinable()) {
-        _callbackThread->join();
-        return true;
+    try {
+        if (_callbackThread && _callbackThread->joinable()) {
+            _callbackThread->join();
+            return true;
+        }
+    } catch (std::exception &ex) {
+        LOG_ERROR(Log::instance()->getLogger(), "Exception in StdLoggingThread::join: " << ex.what());
     }
     return false;
 }
@@ -292,9 +296,9 @@ void SocketCommServer::execute() {
 
         const auto channel = makeCommChannel(socket);
         channel->setLostConnectionCbk([this](std::shared_ptr<AbstractCommChannel> ch) {
-            std::function<void()> postPonnedLostConnectionCbk = [this, ch]() {
+            std::function<void()> postponedLostConnectionCbk = [this, ch]() {
                 auto channelPtr = std::dynamic_pointer_cast<SocketCommChannel>(ch);
-                if (channelPtr->joinCallbackThread()) {
+                if (channelPtr && channelPtr->joinCallbackThread()) {
                     const std::scoped_lock lock(_channelsMutex);
                     (void) _channels.remove(ch);
                     lostConnectionCbk(ch);
@@ -307,7 +311,7 @@ void SocketCommServer::execute() {
             // Postpone _channels.remove(ch), as it may destroy the channel and its
             // SocketCommChannel::callbackHandler thread while the current code
             // (SocketCommChannel::lostConnectionCbk) is executing from this same callbackHandler thread.
-            StdLoggingThread(postPonnedLostConnectionCbk).detach();
+            StdLoggingThread(postponedLostConnectionCbk).detach();
         });
 
         {

--- a/src/server/comm/socketcommserver.cpp
+++ b/src/server/comm/socketcommserver.cpp
@@ -42,8 +42,10 @@ SocketCommChannel::~SocketCommChannel() {
         LOG_ERROR(Log::instance()->getLogger(), "Exception in SocketCommChannel::close: " << ex.what());
     }
 
-    if (_callbackThread && _callbackThread->joinable()) {
-        _callbackThread->join();
+    if (joinCallbackThread()) {
+        LOG_DEBUG(Log::instance()->getLogger(), "Callback thread joined successfully");
+    } else {
+        LOG_ERROR(Log::instance()->getLogger(), "Failed to join callback thread");
     }
 }
 
@@ -313,7 +315,7 @@ void SocketCommServer::execute() {
             // Postpone _channels.remove(ch), as it may destroy the channel and its
             // SocketCommChannel::callbackHandler thread while the current code
             // (SocketCommChannel::lostConnectionCbk) is executing from this same callbackHandler thread.
-            _postponedLostConnectionCbks.emplace_back(std::make_shared<StdLoggingThread>(postponedLostConnectionCbk));
+            (void) _postponedLostConnectionCbks.emplace_back(std::make_shared<StdLoggingThread>(postponedLostConnectionCbk));
         });
 
         {
@@ -332,7 +334,7 @@ void SocketCommServer::execute() {
 }
 void SocketCommServer::joinAndClearPostponedLostConnectionCbks() {
     // Join and remove all postponed lost-connection callback threads
-    for (auto &thread: _postponedLostConnectionCbks) {
+    for (auto thread: _postponedLostConnectionCbks) {
         if (thread->joinable()) {
             thread->join();
         }

--- a/src/server/comm/socketcommserver.cpp
+++ b/src/server/comm/socketcommserver.cpp
@@ -30,17 +30,8 @@ SocketCommChannel::SocketCommChannel(const Poco::Net::StreamSocket &socket) :
     _socket(socket) {}
 
 void SocketCommChannel::startCallbackThread() {
-    const std::weak_ptr<SocketCommChannel> weakChannel = std::static_pointer_cast<SocketCommChannel>(shared_from_this());
-    auto callbackHandlerFunc = std::function<void()>([weakChannel]() {
-        const auto channel = weakChannel.lock();
-        if (!channel) {
-            LOG_WARN(Log::instance()->getLogger(),
-                     "Unable to lock SocketCommChannel in callbackHandlerFunc, channel might have been destroyed");
-            return;
-        }
-        channel->callbackHandler();
-    });
-    _callbackThread = std::make_unique<StdLoggingThread>(callbackHandlerFunc);
+    auto callbackHandlerFct = std::function<void()>([this]() { callbackHandler(); });
+    _callbackThread = std::make_unique<StdLoggingThread>(callbackHandlerFct);
 }
 
 SocketCommChannel::~SocketCommChannel() {
@@ -52,11 +43,7 @@ SocketCommChannel::~SocketCommChannel() {
     }
 
     if (_callbackThread && _callbackThread->joinable()) {
-        if (_callbackThread->get_id() == std::this_thread::get_id()) {
-            _callbackThread->detach();
-        } else {
-            _callbackThread->join();
-        }
+        _callbackThread->join();
     }
 }
 
@@ -170,6 +157,14 @@ void SocketCommChannel::close() {
     } catch (Poco::Exception &ex) {
         LOG_ERROR(Log::instance()->getLogger(), "Exception in StreamSocket::shutdown: " << ex.displayText());
     }
+}
+
+bool SocketCommChannel::joinCallbackThread() {
+    if (_callbackThread && _callbackThread->joinable()) {
+        _callbackThread->join();
+        return true;
+    }
+    return false;
 }
 
 SocketCommServer::SocketCommServer(const std::string &name) :
@@ -297,11 +292,21 @@ void SocketCommServer::execute() {
 
         const auto channel = makeCommChannel(socket);
         channel->setLostConnectionCbk([this](std::shared_ptr<AbstractCommChannel> ch) {
-            {
-                const std::scoped_lock lock(_channelsMutex);
-                (void) _channels.remove(ch);
-            }
-            lostConnectionCbk(ch);
+            std::function<void()> postPonnedLostConnectionCbk = [this, ch]() {
+                auto channelPtr = std::dynamic_pointer_cast<SocketCommChannel>(ch);
+                if (channelPtr->joinCallbackThread()) {
+                    const std::scoped_lock lock(_channelsMutex);
+                    (void) _channels.remove(ch);
+                    lostConnectionCbk(ch);
+                } else {
+                    LOG_WARN(Log::instance()->getLogger(),
+                             "Failed to join callback thread for channel " << ch->id() << " on lost connection");
+                }
+            };
+
+            // Postpone the lost connection callback to avoid potential deadlocks if the callback is called from the callback
+            // thread itself
+            StdLoggingThread(postPonnedLostConnectionCbk).detach();
         });
 
         {

--- a/src/server/comm/socketcommserver.cpp
+++ b/src/server/comm/socketcommserver.cpp
@@ -161,7 +161,7 @@ void SocketCommChannel::close() {
     }
 }
 
-bool SocketCommChannel::joinCallbackThread() {
+bool SocketCommChannel::joinCallbackThread() noexcept {
     try {
         if (_callbackThread && _callbackThread->joinable()) {
             _callbackThread->join();
@@ -334,7 +334,7 @@ void SocketCommServer::execute() {
     }
     _isListening = false;
 }
-void SocketCommServer::joinAndClearPostponedLostConnectionCbks() noexcept {
+void SocketCommServer::joinAndClearPostponedLostConnectionCbks() {
     // Join and remove all postponed lost-connection callback threads
     for (const auto& thread: _postponedLostConnectionCbks) {
         if (thread->joinable()) {

--- a/src/server/comm/socketcommserver.cpp
+++ b/src/server/comm/socketcommserver.cpp
@@ -169,6 +169,8 @@ bool SocketCommChannel::joinCallbackThread() {
         }
     } catch (std::exception &ex) {
         LOG_ERROR(Log::instance()->getLogger(), "Exception in StdLoggingThread::join: " << ex.what());
+    } catch (...) {
+        LOG_ERROR(Log::instance()->getLogger(), "Unknown exception in StdLoggingThread::join");
     }
     return false;
 }
@@ -334,7 +336,7 @@ void SocketCommServer::execute() {
 }
 void SocketCommServer::joinAndClearPostponedLostConnectionCbks() {
     // Join and remove all postponed lost-connection callback threads
-    for (auto thread: _postponedLostConnectionCbks) {
+    for (const auto thread: _postponedLostConnectionCbks) {
         if (thread->joinable()) {
             thread->join();
         }

--- a/src/server/comm/socketcommserver.cpp
+++ b/src/server/comm/socketcommserver.cpp
@@ -339,4 +339,5 @@ void SocketCommServer::joinAndClearPostponedLostConnectionCbks() {
     }
 
     _postponedLostConnectionCbks.clear();
+}
 } // namespace KDC

--- a/src/server/comm/socketcommserver.cpp
+++ b/src/server/comm/socketcommserver.cpp
@@ -180,6 +180,8 @@ SocketCommServer::~SocketCommServer() {
     } catch (std::exception &ex) {
         LOG_ERROR(Log::instance()->getLogger(), "Exception in SocketCommChannel::close: " << ex.what());
     }
+
+    joinAndClearPostponedLostConnectionCbks();
 }
 
 std::string SocketCommServer::getHost() {
@@ -311,7 +313,7 @@ void SocketCommServer::execute() {
             // Postpone _channels.remove(ch), as it may destroy the channel and its
             // SocketCommChannel::callbackHandler thread while the current code
             // (SocketCommChannel::lostConnectionCbk) is executing from this same callbackHandler thread.
-            StdLoggingThread(postponedLostConnectionCbk).detach();
+            _postponedLostConnectionCbks.emplace_back(std::make_shared<StdLoggingThread>(postponedLostConnectionCbk));
         });
 
         {
@@ -320,7 +322,21 @@ void SocketCommServer::execute() {
         }
         newConnectionCbk();
         channel->startCallbackThread();
+
+        // Clear terminated postponed lost-connection callback threads to avoid accumulating too many threads in case of many
+        // connections/disconnections (edge case as the application is not expected to handle more than one connection at a time,
+        // but better be safe)
+        joinAndClearPostponedLostConnectionCbks();
     }
     _isListening = false;
 }
+void SocketCommServer::joinAndClearPostponedLostConnectionCbks() {
+    // Join and remove all postponed lost-connection callback threads
+    for (auto &thread: _postponedLostConnectionCbks) {
+        if (thread->joinable()) {
+            thread->join();
+        }
+    }
+
+    _postponedLostConnectionCbks.clear();
 } // namespace KDC

--- a/src/server/comm/socketcommserver.cpp
+++ b/src/server/comm/socketcommserver.cpp
@@ -304,8 +304,9 @@ void SocketCommServer::execute() {
                 }
             };
 
-            // Postpone the lost connection callback to avoid potential deadlocks if the callback is called from the callback
-            // thread itself
+            // Postpone _channels.remove(ch), as it may destroy the channel and its
+            // SocketCommChannel::callbackHandler thread while the current code
+            // (SocketCommChannel::lostConnectionCbk) is executing from this same callbackHandler thread.
             StdLoggingThread(postPonnedLostConnectionCbk).detach();
         });
 

--- a/src/server/comm/socketcommserver.h
+++ b/src/server/comm/socketcommserver.h
@@ -76,6 +76,8 @@ class SocketCommServer : public AbstractCommServer {
         bool _stopAsked = false;
         std::unique_ptr<StdLoggingThread> _serverSocketThread{nullptr};
         void execute();
+
+        std::vector<std::shared_ptr<StdLoggingThread>> _postponedLostConnectionCbks;
 };
 
 } // namespace KDC

--- a/src/server/comm/socketcommserver.h
+++ b/src/server/comm/socketcommserver.h
@@ -76,7 +76,7 @@ class SocketCommServer : public AbstractCommServer {
         bool _stopAsked = false;
         std::unique_ptr<StdLoggingThread> _serverSocketThread{nullptr};
         void execute();
-
+        void joinAndClearPostponedLostConnectionCbks();
         std::vector<std::shared_ptr<StdLoggingThread>> _postponedLostConnectionCbks;
 };
 

--- a/src/server/comm/socketcommserver.h
+++ b/src/server/comm/socketcommserver.h
@@ -36,6 +36,8 @@ class SocketCommChannel : public AbstractCommChannel {
         uint64_t bytesAvailable() const override;
         void close() override;
 
+        bool joinCallbackThread();
+
     protected:
         // Return number of CommChar (/!\ not always equal the number of bytes) read or 0 on error or closed connection
         uint64_t readData(CommChar *data, uint64_t maxlen) override;

--- a/src/server/comm/socketcommserver.h
+++ b/src/server/comm/socketcommserver.h
@@ -36,7 +36,7 @@ class SocketCommChannel : public AbstractCommChannel {
         uint64_t bytesAvailable() const override;
         void close() override;
 
-        bool joinCallbackThread();
+        bool joinCallbackThread() noexcept;
 
     protected:
         // Return number of CommChar (/!\ not always equal the number of bytes) read or 0 on error or closed connection


### PR DESCRIPTION
feat(server): improve callback thread management

Refactor callback thread handling in SocketCommChannel to use direct method reference and add joinCallbackThread() for controlled joining. In SocketCommServer, defer lost connection handling to a separate thread to prevent deadlocks and log a warning if the callback thread cannot be joined.