### PR TITLE
fix(unsupported-characters): Detects `exFAT` file system on Linux and handles unsupported characters accordingly

### DIFF
--- a/src/libcommon/utility/utility.cpp
+++ b/src/libcommon/utility/utility.cpp
@@ -220,20 +220,21 @@ const std::string &CommonUtility::versionTag() {
 uint64_t CommonUtility::versionBuild() {
     return KDRIVE_VERSION_BUILD;
 }
-
-static std::unordered_map<std::string, std::string> rootFsTypeMap;
+namespace {
 std::string getRootFsType(const SyncPath &targetPath) {
+    static std::unordered_map<std::string, std::string> rootFsTypeMap;
+
     auto it = rootFsTypeMap.find(targetPath.root_name().string());
     if (it == rootFsTypeMap.end()) {
         const std::string fsType = CommonUtility::fileSystemName(targetPath);
         const auto [it2, inserted] = rootFsTypeMap.try_emplace(targetPath.root_name().string(), CommonUtility::toUpper(fsType));
-        if (!inserted) {
-            return {};
-        }
+        if (!inserted) return {};
+
         it = it2;
     }
     return it->second;
 }
+} // namespace
 
 bool CommonUtility::isNTFS(const SyncPath &targetPath) {
     static const std::string ntfs("NTFS");
@@ -275,6 +276,32 @@ bool CommonUtility::isLiteSyncCompatible([[maybe_unused]] const SyncPath &target
 #endif
 }
 
+#if defined(KD_LINUX)
+namespace {
+#ifndef EXFAT_SUPER_MAGIC
+#define EXFAT_SUPER_MAGIC 0x2011BAB0
+#endif
+
+constexpr auto exFat = "exFAT";
+constexpr auto ext234 = "EXT2/3/4";
+
+std::string formatFsName(const std::string &prettyName, const long fType) {
+    std::stringstream stream;
+    stream << std::hex << fType;
+    return prettyName + " | 0x" + stream.str();
+}
+} // namespace
+
+bool CommonUtility::isEXT234(const SyncPath &targetPath) {
+    return contains(getRootFsType(targetPath), ext234);
+}
+
+std::string CommonUtility::exFAT() {
+    return formatFsName(exFat, EXFAT_SUPER_MAGIC);
+}
+
+#endif
+
 std::string CommonUtility::fileSystemName(const SyncPath &targetPath) {
 #if defined(KD_MACOS)
     struct statfs stat;
@@ -287,7 +314,7 @@ std::string CommonUtility::fileSystemName(const SyncPath &targetPath) {
     DWORD dwFileSystemFlags = 0;
 
     if (GetVolumeInformation(targetPath.root_path().c_str(), NULL, 0, NULL, &dwMaxFileNameLength, &dwFileSystemFlags,
-                             szFileSystemName, sizeof(szFileSystemName)) == TRUE) {
+                             szFileSystemName, sizeof(szf)) == TRUE) {
         return ws2s(szFileSystemName);
     } else {
         // Not all the requested information is retrieved
@@ -303,18 +330,16 @@ std::string CommonUtility::fileSystemName(const SyncPath &targetPath) {
 #elif defined(KD_LINUX)
     struct statfs stat;
     if (statfs(targetPath.root_path().native().c_str(), &stat) == 0) {
-        const auto formatFsName = [](const std::string &prettyName, long fsCode) {
-            std::stringstream stream;
-            stream << std::hex << fsCode;
-            return prettyName + " | 0x" + stream.str();
-        };
         switch (stat.f_type) {
+            case EXFAT_SUPER_MAGIC:
+                return exFAT();
             case 0x137d:
                 return formatFsName("EXT(1)", stat.f_type);
             case 0xef51:
                 return formatFsName("EXT2", stat.f_type);
-            case 0xef53:
-                return formatFsName("EXT2/3/4", stat.f_type);
+            case 0xef53: // EXT_SUPER_MAGIC
+                return formatFsName(ext234, stat.f_type);
+                ;
             case 0xbad1dea:
             case 0xa501fcf5:
             case 0x58465342:

--- a/src/libcommon/utility/utility.cpp
+++ b/src/libcommon/utility/utility.cpp
@@ -285,7 +285,7 @@ namespace {
 constexpr auto exFat = "exFAT";
 constexpr auto ext234 = "EXT2/3/4";
 
-std::string formatFsName(const std::string &prettyName, const long fType) {
+std::string formatFsName(const std::string &prettyName, const int64_t fType) {
     std::stringstream stream;
     stream << std::hex << fType;
     return prettyName + " | 0x" + stream.str();

--- a/src/libcommon/utility/utility.cpp
+++ b/src/libcommon/utility/utility.cpp
@@ -220,8 +220,8 @@ const std::string &CommonUtility::versionTag() {
 uint64_t CommonUtility::versionBuild() {
     return KDRIVE_VERSION_BUILD;
 }
-namespace {
-std::string getRootFsType(const SyncPath &targetPath) {
+
+std::string CommonUtility::getRootFsType(const SyncPath &targetPath) {
     static std::unordered_map<std::string, std::string> rootFsTypeMap;
 
     auto it = rootFsTypeMap.find(targetPath.root_name().string());
@@ -234,7 +234,7 @@ std::string getRootFsType(const SyncPath &targetPath) {
     }
     return it->second;
 }
-} // namespace
+
 
 bool CommonUtility::isNTFS(const SyncPath &targetPath) {
     static const std::string ntfs("NTFS");
@@ -274,94 +274,6 @@ bool CommonUtility::isLiteSyncCompatible([[maybe_unused]] const SyncPath &target
 #else
     return false;
 #endif
-}
-
-#if defined(KD_LINUX)
-namespace {
-#ifndef EXFAT_SUPER_MAGIC
-#define EXFAT_SUPER_MAGIC 0x2011BAB0
-#endif
-
-constexpr auto exFat = "exFAT";
-constexpr auto ext234 = "EXT2/3/4";
-
-std::string formatFsName(const std::string &prettyName, const int64_t fType) {
-    std::stringstream stream;
-    stream << std::hex << fType;
-    return prettyName + " | 0x" + stream.str();
-}
-} // namespace
-
-bool CommonUtility::isEXT234(const SyncPath &targetPath) {
-    return contains(getRootFsType(targetPath), ext234);
-}
-
-std::string CommonUtility::exFAT() {
-    return formatFsName(exFat, EXFAT_SUPER_MAGIC);
-}
-
-#endif
-
-std::string CommonUtility::fileSystemName(const SyncPath &targetPath) {
-#if defined(KD_MACOS)
-    struct statfs stat;
-    if (statfs(targetPath.root_path().native().c_str(), &stat) == 0) {
-        return stat.f_fstypename;
-    }
-#elif defined(KD_WINDOWS)
-    TCHAR szFileSystemName[MAX_PATH + 1];
-    DWORD dwMaxFileNameLength = 0;
-    DWORD dwFileSystemFlags = 0;
-
-    if (GetVolumeInformation(targetPath.root_path().c_str(), NULL, 0, NULL, &dwMaxFileNameLength, &dwFileSystemFlags,
-                             szFileSystemName, sizeof(szFileSystemName)) == TRUE) {
-        return ws2s(szFileSystemName);
-    } else {
-        // Not all the requested information is retrieved
-        DWORD dwError = GetLastError();
-        std::wstringstream message;
-        message << L"Error in GetVolumeInformation for " << Path2WStr(targetPath.root_name()) << L" ("
-                << utility_base::getErrorMessage(dwError) << L")";
-        sentry::Handler::captureMessage(sentry::Level::Warning, "CommonUtility::fileSystemName", ws2s(message.str()));
-
-        // !!! File system name can be OK or not !!!
-        return ws2s(szFileSystemName);
-    }
-#elif defined(KD_LINUX)
-    struct statfs stat;
-    if (statfs(targetPath.root_path().native().c_str(), &stat) == 0) {
-        switch (stat.f_type) {
-            case EXFAT_SUPER_MAGIC:
-                return exFAT();
-            case 0x137d:
-                return formatFsName("EXT(1)", stat.f_type);
-            case 0xef51:
-                return formatFsName("EXT2", stat.f_type);
-            case 0xef53: // EXT_SUPER_MAGIC
-                return formatFsName(ext234, stat.f_type);
-            case 0xbad1dea:
-            case 0xa501fcf5:
-            case 0x58465342:
-                return formatFsName("XFS", stat.f_type);
-            case 0x9123683e:
-            case 0x73727279:
-                return formatFsName("BTRFS", stat.f_type);
-            case 0xf15f:
-                return formatFsName("ECRYPTFS", stat.f_type);
-            case 0x4244:
-                return formatFsName("HFS", stat.f_type);
-            case 0x5346544e:
-                return formatFsName("NTFS", stat.f_type);
-            case 0x858458f6:
-                return formatFsName("RAMFS", stat.f_type);
-            default:
-                return formatFsName("Unknown-see corresponding entry at https://man7.org/linux/man-pages/man2/statfs.2.html",
-                                    stat.f_type);
-        }
-    }
-#endif
-
-    return "UNIDENTIFIED";
 }
 
 void CommonUtility::resetTranslations() {

--- a/src/libcommon/utility/utility.cpp
+++ b/src/libcommon/utility/utility.cpp
@@ -314,7 +314,7 @@ std::string CommonUtility::fileSystemName(const SyncPath &targetPath) {
     DWORD dwFileSystemFlags = 0;
 
     if (GetVolumeInformation(targetPath.root_path().c_str(), NULL, 0, NULL, &dwMaxFileNameLength, &dwFileSystemFlags,
-                             szFileSystemName, sizeof(szf)) == TRUE) {
+                             szFileSystemName, sizeof(szFileSystemName)) == TRUE) {
         return ws2s(szFileSystemName);
     } else {
         // Not all the requested information is retrieved
@@ -339,7 +339,6 @@ std::string CommonUtility::fileSystemName(const SyncPath &targetPath) {
                 return formatFsName("EXT2", stat.f_type);
             case 0xef53: // EXT_SUPER_MAGIC
                 return formatFsName(ext234, stat.f_type);
-                ;
             case 0xbad1dea:
             case 0xa501fcf5:
             case 0x58465342:
@@ -739,7 +738,7 @@ bool CommonUtility::compressFile(const QString &originalName, const QString &tar
 #endif
 }
 
-Language CommonUtility::strToLanguage(const QString& lang) {
+Language CommonUtility::strToLanguage(const QString &lang) {
     if (lang == "en") {
         return Language::English;
     } else if (lang == "fr") {
@@ -869,9 +868,9 @@ bool CommonUtility::languageCodeIsEnglish(const QString &languageCode) {
 }
 
 bool CommonUtility::isSupportedLanguage(const QString &languageCode) {
-    static const std::unordered_set<QString> supportedLanguages = {englishCode,   frenchCode,  germanCode,     italianCode,
-                                                                   spanishCode,   dutchCode,   swedishCode,    portugueseCode, 
-                                                                   polishCode,    norwegianCode, finnishCode, danishCode,     greekCode};
+    static const std::unordered_set<QString> supportedLanguages = {
+            englishCode,    frenchCode, germanCode,    italianCode, spanishCode, dutchCode, swedishCode,
+            portugueseCode, polishCode, norwegianCode, finnishCode, danishCode,  greekCode};
     return supportedLanguages.contains(languageCode);
 }
 

--- a/src/libcommon/utility/utility.h
+++ b/src/libcommon/utility/utility.h
@@ -82,6 +82,8 @@ struct COMMON_EXPORT CommonUtility {
         static std::string osVersion();
 #ifdef KD_LINUX
         static std::string distributionName();
+        static bool isEXT234(const SyncPath &targetPath);
+        static std::string exFAT();
 #endif
         static Platform platform();
         static QString platformArch();

--- a/src/libcommon/utility/utility.h
+++ b/src/libcommon/utility/utility.h
@@ -533,6 +533,7 @@ struct COMMON_EXPORT CommonUtility {
 
         static SyncPath getGenericAppSupportDir();
 
+        static std::string getRootFsType(const SyncPath &targetPath);
 
         friend class TestUtility;
 };

--- a/src/libcommon/utility/utility.h
+++ b/src/libcommon/utility/utility.h
@@ -80,7 +80,7 @@ struct COMMON_EXPORT CommonUtility {
         static void crash();
         static QString platformName();
         static std::string osVersion();
-#ifdef KD_LINUX
+#if defined(KD_LINUX)
         static std::string distributionName();
         static bool isEXT234(const SyncPath &targetPath);
         static std::string exFAT();
@@ -120,7 +120,7 @@ struct COMMON_EXPORT CommonUtility {
         static const QString norwegianCode;
         static const QString finnishCode;
         static const QString danishCode;
-        static const QString greekCode;      
+        static const QString greekCode;
         static Language strToLanguage(const QString &lang);
         static QString languageCode(Language language);
         static QStringList languageCodeList(Language enforcedLocale);

--- a/src/libcommon/utility/utility_linux.cpp
+++ b/src/libcommon/utility/utility_linux.cpp
@@ -118,7 +118,7 @@ namespace {
 constexpr auto exFat = "exFAT";
 constexpr auto ext234 = "EXT2/3/4";
 
-std::string formatFsName(const std::string &prettyName, const int64_t fType) {
+std::string formatFsName(const std::string &prettyName, const uint64_t fType) {
     std::stringstream stream;
     stream << std::hex << fType;
     return prettyName + " | 0x" + stream.str();
@@ -140,26 +140,26 @@ std::string CommonUtility::fileSystemName(const SyncPath &targetPath) {
         switch (stat.f_type) {
             case EXFAT_SUPER_MAGIC:
                 return exFAT();
-            case 0x137d:
+            case 0x137du:
                 return formatFsName("EXT(1)", stat.f_type);
-            case 0xef51:
+            case 0xef51u:
                 return formatFsName("EXT2", stat.f_type);
-            case 0xef53: // EXT_SUPER_MAGIC
+            case 0xef53u: // EXT_SUPER_MAGIC
                 return formatFsName(ext234, stat.f_type);
-            case 0xbad1dea:
-            case 0xa501fcf5:
-            case 0x58465342:
+            case 0xbad1deau:
+            case 0xa501fcf5u:
+            case 0x58465342u:
                 return formatFsName("XFS", stat.f_type);
-            case 0x9123683e:
-            case 0x73727279:
+            case 0x9123683eu:
+            case 0x73727279u:
                 return formatFsName("BTRFS", stat.f_type);
-            case 0xf15f:
+            case 0xf15fu:
                 return formatFsName("ECRYPTFS", stat.f_type);
-            case 0x4244:
+            case 0x4244u:
                 return formatFsName("HFS", stat.f_type);
-            case 0x5346544e:
+            case 0x5346544eu:
                 return formatFsName("NTFS", stat.f_type);
-            case 0x858458f6:
+            case 0x858458f6u:
                 return formatFsName("RAMFS", stat.f_type);
             default:
                 return formatFsName("Unknown-see corresponding entry at https://man7.org/linux/man-pages/man2/statfs.2.html",

--- a/src/libcommon/utility/utility_linux.cpp
+++ b/src/libcommon/utility/utility_linux.cpp
@@ -18,21 +18,14 @@
 
 #include "utility.h"
 
-#include <QStandardPaths>
-
 #include <filesystem>
 #include <fstream>
 #include <unistd.h>
 #include <sys/types.h>
+#include <sys/vfs.h>
 #include <pwd.h>
 
 #include "utility/types.h"
-
-#include <log4cplus/logger.h>
-#include <log4cplus/loggingmacros.h>
-
-#include <Poco/File.h>
-#include <Poco/Exception.h>
 
 namespace KDC {
 
@@ -114,6 +107,67 @@ std::string CommonUtility::osVersion() {
 
 std::string CommonUtility::distributionName() {
     return extractOSInfo("NAME");
+}
+
+
+namespace {
+#ifndef EXFAT_SUPER_MAGIC
+#define EXFAT_SUPER_MAGIC 0x2011BAB0
+#endif
+
+constexpr auto exFat = "exFAT";
+constexpr auto ext234 = "EXT2/3/4";
+
+std::string formatFsName(const std::string &prettyName, const int64_t fType) {
+    std::stringstream stream;
+    stream << std::hex << fType;
+    return prettyName + " | 0x" + stream.str();
+}
+} // namespace
+
+bool CommonUtility::isEXT234(const SyncPath &targetPath) {
+    return contains(getRootFsType(targetPath), ext234);
+}
+
+std::string CommonUtility::exFAT() {
+    return formatFsName(exFat, EXFAT_SUPER_MAGIC);
+}
+
+std::string CommonUtility::fileSystemName(const SyncPath &targetPath) {
+    struct statfs stat;
+
+    if (statfs(targetPath.root_path().native().c_str(), &stat) == 0) {
+        switch (stat.f_type) {
+            case EXFAT_SUPER_MAGIC:
+                return exFAT();
+            case 0x137d:
+                return formatFsName("EXT(1)", stat.f_type);
+            case 0xef51:
+                return formatFsName("EXT2", stat.f_type);
+            case 0xef53: // EXT_SUPER_MAGIC
+                return formatFsName(ext234, stat.f_type);
+            case 0xbad1dea:
+            case 0xa501fcf5:
+            case 0x58465342:
+                return formatFsName("XFS", stat.f_type);
+            case 0x9123683e:
+            case 0x73727279:
+                return formatFsName("BTRFS", stat.f_type);
+            case 0xf15f:
+                return formatFsName("ECRYPTFS", stat.f_type);
+            case 0x4244:
+                return formatFsName("HFS", stat.f_type);
+            case 0x5346544e:
+                return formatFsName("NTFS", stat.f_type);
+            case 0x858458f6:
+                return formatFsName("RAMFS", stat.f_type);
+            default:
+                return formatFsName("Unknown-see corresponding entry at https://man7.org/linux/man-pages/man2/statfs.2.html",
+                                    stat.f_type);
+        }
+    }
+
+    return "UNIDENTIFIED";
 }
 
 } // namespace KDC

--- a/src/libcommon/utility/utility_mac.mm
+++ b/src/libcommon/utility/utility_mac.mm
@@ -18,9 +18,9 @@
 
 #include "utility.h"
 
-#include "types.h"
-
-#include <QString>
+#include <system_error>
+#include <fstream>
+#include <sys/mount.h>
 
 #import <AppKit/NSApplication.h>
 #import <AppKit/NSImage.h>

--- a/src/libcommon/utility/utility_mac.mm
+++ b/src/libcommon/utility/utility_mac.mm
@@ -98,4 +98,14 @@ std::string CommonUtility::osVersion() {
            [@(osVersion.patchVersion) stringValue].UTF8String;
 }
 
+std::string CommonUtility::fileSystemName(const SyncPath &targetPath) {
+    struct statfs stat;
+
+    if (statfs(targetPath.root_path().native().c_str(), &stat) == 0) {
+        return stat.f_fstypename;
+    }
+
+    return "UNIDENTIFIED";
+}
+
 } // namespace KDC

--- a/src/libcommon/utility/utility_win.cpp
+++ b/src/libcommon/utility/utility_win.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "utility.h"
+#include "utility_base.h"
 #include "log/sentry/handler.h"
 
 #include <shlobj.h>

--- a/src/libcommon/utility/utility_win.cpp
+++ b/src/libcommon/utility/utility_win.cpp
@@ -157,4 +157,28 @@ std::string CommonUtility::osVersion() {
     return std::string(versionStr);
 }
 
+std::string CommonUtility::fileSystemName(const SyncPath &targetPath) {
+    TCHAR szFileSystemName[MAX_PATH + 1];
+    DWORD dwMaxFileNameLength = 0;
+    DWORD dwFileSystemFlags = 0;
+
+    if (GetVolumeInformation(targetPath.root_path().c_str(), NULL, 0, NULL, &dwMaxFileNameLength, &dwFileSystemFlags,
+                             szFileSystemName, sizeof(szFileSystemName)) == TRUE) {
+        return ws2s(szFileSystemName);
+    } else {
+        // Not all the requested information is retrieved
+        DWORD dwError = GetLastError();
+        std::wstringstream message;
+        message << L"Error in GetVolumeInformation for " << Path2WStr(targetPath.root_name()) << L" ("
+                << utility_base::getErrorMessage(dwError) << L")";
+        sentry::Handler::captureMessage(sentry::Level::Warning, "CommonUtility::fileSystemName", ws2s(message.str()));
+
+        // !!! File system name can be OK or not !!!
+        return ws2s(szFileSystemName);
+    }
+
+
+    return "UNIDENTIFIED";
+}
+
 } // namespace KDC

--- a/src/libcommonserver/utility/utility.cpp
+++ b/src/libcommonserver/utility/utility.cpp
@@ -726,7 +726,7 @@ ExitInfo Utility::getFileSystemName(const std::shared_ptr<CacheDirectory> cacheD
                   "File names containing a colon character are not valid for the filesystem in use. We shall assume that "
                   "this file system is exFAT.");
         fileSystemName = CommonUtility::exFAT();
-        cacheDirectoryToFileSystemName[cacheDirectory->path()] = fileSystemName;
+        cacheDirectoryToFileSystemName[localSyncPath] = fileSystemName;
 
         return ExitCode::Ok;
     }

--- a/src/libcommonserver/utility/utility.cpp
+++ b/src/libcommonserver/utility/utility.cpp
@@ -651,7 +651,7 @@ ExitInfo Utility::tryCreateTmpFile(const std::shared_ptr<CacheDirectory> cacheDi
     Count retries = 0;
     bool exists = false;
 
-    const auto createPathInCacheWithRandomSuffix = [&]() {
+    const auto createPathInCacheWithRandomSuffix = [&cacheDirectoryPath, &name]() {
         return cacheDirectoryPath / (name + Str2SyncName(CommonUtility::generateRandomStringAlphaNum()));
     };
 

--- a/src/libcommonserver/utility/utility.cpp
+++ b/src/libcommonserver/utility/utility.cpp
@@ -687,11 +687,12 @@ ExitInfo Utility::tryCreateTmpFile(const std::shared_ptr<CacheDirectory> cacheDi
 
 #if defined(KD_LINUX)
 ExitInfo Utility::getFileSystemName(const std::shared_ptr<CacheDirectory> cacheDirectory, std::string &fileSystemName) {
+    fileSystemName = {};
+
     if (!cacheDirectory) {
         LOG_WARN(logger(), "Cache directory not provided!");
         return {ExitCode::SystemError, ExitCause::InvalidArgument};
     }
-
 
     SyncPath localSyncPath;
     if (const auto exitInfo = cacheDirectory->path(localSyncPath); !exitInfo) return exitInfo;

--- a/src/libcommonserver/utility/utility.cpp
+++ b/src/libcommonserver/utility/utility.cpp
@@ -686,56 +686,6 @@ ExitInfo Utility::tryCreateTmpFile(const std::shared_ptr<CacheDirectory> cacheDi
     return ExitCode::Ok;
 }
 
-#if defined(KD_LINUX)
-ExitInfo Utility::getFileSystemName(const std::shared_ptr<CacheDirectory> cacheDirectory, std::string &fileSystemName) {
-    fileSystemName = {};
-
-    if (!cacheDirectory) {
-        LOG_WARN(logger(), "Cache directory not provided!");
-        return {ExitCode::SystemError, ExitCause::InvalidArgument};
-    }
-
-    SyncPath localSyncPath;
-    if (const auto exitInfo = cacheDirectory->path(localSyncPath); !exitInfo) return exitInfo;
-
-    static std::unordered_map<SyncPath, std::string> cacheDirectoryToFileSystemName;
-
-    const auto it = cacheDirectoryToFileSystemName.find(localSyncPath);
-    if (it != cacheDirectoryToFileSystemName.end()) {
-        fileSystemName = it->second;
-        return ExitCode::Ok;
-    }
-
-    fileSystemName = CommonUtility::fileSystemName(localSyncPath);
-    cacheDirectoryToFileSystemName[localSyncPath] = fileSystemName;
-
-    if (!CommonUtility::isEXT234(localSyncPath)) return ExitCode::Ok;
-
-    // `statfs` can confuse more restrictive systems with `EXT2/3/4 when a USB stick is used.
-    constexpr auto invalidExFatFileName = "a:b";
-
-    const auto exitInfo = tryCreateTmpFile(cacheDirectory, invalidExFatFileName);
-    if (exitInfo.cause() == ExitCause::TmpDirAccessError) {
-        LOG_WARN(logger(), "Cannot access tmp directory.");
-
-        return exitInfo;
-    }
-
-    if (exitInfo.cause() == ExitCause::InvalidName) {
-        LOG_DEBUG(logger(),
-                  "File names containing a colon character are not valid for the filesystem in use. We shall assume that "
-                  "this file system is exFAT.");
-        fileSystemName = CommonUtility::exFAT();
-        cacheDirectoryToFileSystemName[localSyncPath] = fileSystemName;
-
-        return ExitCode::Ok;
-    }
-
-    return exitInfo;
-}
-#endif
-
-
 ExitInfo Utility::checkIfFileNamesCanEndWithSpace([[maybe_unused]] const std::shared_ptr<CacheDirectory> cacheDirectory,
                                                   bool &canEndWithSpace) {
     canEndWithSpace = true;

--- a/src/libcommonserver/utility/utility.cpp
+++ b/src/libcommonserver/utility/utility.cpp
@@ -690,14 +690,6 @@ ExitInfo Utility::tryCreateTmpFile(const std::shared_ptr<CacheDirectory> cacheDi
 ExitInfo Utility::getFileSystemName(const std::shared_ptr<CacheDirectory> cacheDirectory, std::string &fileSystemName) {
     fileSystemName = {};
 
-    static std::unordered_map<SyncPath, std::string> cacheDirectoryToFileSystemName;
-
-    const auto it = cacheDirectoryToFileSystemName.find(cacheDirectory->path());
-    if (it != cacheDirectoryToFileSystemName.end()) {
-        fileSystemName = it->second;
-        return ExitCode::Ok;
-    }
-
     if (!cacheDirectory) {
         LOG_WARN(logger(), "Cache directory not provided!");
         return {ExitCode::SystemError, ExitCause::InvalidArgument};
@@ -706,8 +698,16 @@ ExitInfo Utility::getFileSystemName(const std::shared_ptr<CacheDirectory> cacheD
     SyncPath localSyncPath;
     if (const auto exitInfo = cacheDirectory->path(localSyncPath); !exitInfo) return exitInfo;
 
+    static std::unordered_map<SyncPath, std::string> cacheDirectoryToFileSystemName;
+
+    const auto it = cacheDirectoryToFileSystemName.find(localSyncPath);
+    if (it != cacheDirectoryToFileSystemName.end()) {
+        fileSystemName = it->second;
+        return ExitCode::Ok;
+    }
+
     fileSystemName = CommonUtility::fileSystemName(localSyncPath);
-    cacheDirectoryToFileSystemName[cacheDirectory->path()] = fileSystemName;
+    cacheDirectoryToFileSystemName[localSyncPath] = fileSystemName;
 
     if (!CommonUtility::isEXT234(localSyncPath)) return ExitCode::Ok;
 

--- a/src/libcommonserver/utility/utility.cpp
+++ b/src/libcommonserver/utility/utility.cpp
@@ -684,6 +684,75 @@ ExitInfo Utility::tryCreateTmpFile(const std::shared_ptr<CacheDirectory> cacheDi
     return ok ? ExitCode::Ok : ExitCode::SystemError;
 }
 
+#if defined(KD_LINUX)
+ExitInfo Utility::getFileSystemName(const std::shared_ptr<CacheDirectory> cacheDirectory, std::string &fileSystemName) {
+    if (!cacheDirectory) {
+        LOG_WARN(logger(), "Cache directory not provided!");
+        return {ExitCode::SystemError, ExitCause::InvalidArgument};
+    }
+
+
+    SyncPath localSyncPath;
+    if (const auto exitInfo = cacheDirectory->path(localSyncPath); !exitInfo) return exitInfo;
+
+    fileSystemName = CommonUtility::fileSystemName(localSyncPath);
+
+    if (CommonUtility::isEXT234(localSyncPath)) {
+        // `statfs` can confuse more restrictive systems with `EXT2/3/4 when a USB stick is used.
+        constexpr auto invalidExFatFileName = "a:b";
+
+        const auto exitInfo = tryCreateTmpFile(cacheDirectory, invalidExFatFileName);
+        if (exitInfo.cause() == ExitCause::TmpDirAccessError) {
+            LOG_WARN(logger(), "Cannot access tmp directory.");
+
+            return exitInfo;
+        }
+
+        if (!exitInfo) {
+            LOG_DEBUG(logger(),
+                      "File names containing a colon character are not valid for the filesystem in use. We shall assume that "
+                      "this file system is exFAT.");
+            fileSystemName = CommonUtility::exFAT();
+        }
+    }
+#endif
+
+    return ExitCode::Ok;
+}
+
+ExitInfo Utility::checkIfFileNamesCanEndWithSpace([[maybe_unused]] const std::shared_ptr<CacheDirectory> cacheDirectory,
+                                                  bool &canEndWithSpace) {
+    canEndWithSpace = true;
+
+#if defined(KD_LINUX)
+    SyncPath localSyncPath;
+    if (const auto exitInfo = cacheDirectory->path(localSyncPath); !exitInfo) {
+        if (exitInfo.cause() == ExitCause::TmpDirAccessError) {
+            LOG_WARN(logger(), "Cannot access tmp directory.");
+
+            return exitInfo;
+        }
+    }
+    if (CommonUtility::isEXT234(localSyncPath)) {
+        constexpr auto fileNameWithEndingSpace = "a ";
+
+        const auto exitInfo = tryCreateTmpFile(cacheDirectory, fileNameWithEndingSpace);
+        if (exitInfo.cause() == ExitCause::TmpDirAccessError) {
+            LOG_WARN(logger(), "Cannot access tmp directory.");
+
+            return exitInfo;
+        }
+
+        if (!exitInfo) {
+            LOG_DEBUG(logger(), "The file system in use does not support file names with an ending space.");
+            canEndWithSpace = false;
+        }
+    }
+#endif
+
+    return ExitCode::Ok;
+}
+
 void Utility::msleep(const int64_t msec) {
     const std::chrono::milliseconds dura(msec);
     std::this_thread::sleep_for(dura);

--- a/src/libcommonserver/utility/utility.cpp
+++ b/src/libcommonserver/utility/utility.cpp
@@ -645,24 +645,26 @@ ExitInfo Utility::tryCreateTmpFile(const std::shared_ptr<CacheDirectory> cacheDi
     }
 
     SyncPath cacheDirectoryPath;
-    if (const auto exitInfo = cacheDirectory->path(cacheDirectoryPath); !exitInfo) {
-        return exitInfo;
-    }
+    if (const auto exitInfo = cacheDirectory->path(cacheDirectoryPath); !exitInfo) return exitInfo;
+
     SyncPath tmpPath = cacheDirectoryPath / name;
-    uint64_t retries = 0;
-    bool ok = false;
+    Count retries = 0;
+    bool exists = false;
+
+    const auto createPathInCacheWithRandomSuffix = [&]() {
+        return cacheDirectoryPath / (name + Str2SyncName(CommonUtility::generateRandomStringAlphaNum()));
+    };
+
     do {
-        bool exists = false;
-        auto output = std::ofstream(tmpPath.native().c_str(), std::ios::binary);
-        if (!output) {
+        if (auto output = std::ofstream(tmpPath.native().c_str(), std::ios::binary); !output) {
             if (const auto exitInfo = checkTmpDirectoryRights(cacheDirectoryPath); !exitInfo) return exitInfo;
 
-            retries++;
-            // Retry with a random suffix added to item name
-            tmpPath = cacheDirectoryPath / (name + Str2SyncName(CommonUtility::generateRandomStringAlphaNum()));
+            ++retries;
+            tmpPath = createPathInCacheWithRandomSuffix();
+
             continue;
-        }
-        output.close();
+        } else
+            output.close();
 
         // Check if item already exist (it should exist at this point)
         if (auto ioError = IoError::Unknown;
@@ -670,24 +672,31 @@ ExitInfo Utility::tryCreateTmpFile(const std::shared_ptr<CacheDirectory> cacheDi
             LOGW_WARN(logger(), L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(tmpPath, ioError));
             return {ExitCode::SystemError, ioError == IoError::AccessDenied ? ExitCause::TmpDirAccessError : ExitCause::Unknown};
         }
+
         if (!exists) {
-            retries++;
-            // Retry with a random suffix added to item name
-            tmpPath = cacheDirectoryPath / (name + Str2SyncName(CommonUtility::generateRandomStringAlphaNum()));
-            continue;
+            ++retries;
+            tmpPath = createPathInCacheWithRandomSuffix();
         }
-        ok = true;
-    } while (!ok && retries < maxNbCreationTmpFolderRetries);
+    } while (!exists && retries < maxNbCreationTmpFolderRetries);
 
-    auto ioError = IoError::Unknown;
-    (void) IoHelper::deleteItem(tmpPath, ioError);
+    if (!exists) return {ExitCode::SystemError, ExitCause::InvalidName};
 
-    return ok ? ExitCode::Ok : ExitCode::SystemError;
+    (void) IoHelper::deleteItem(tmpPath);
+
+    return ExitCode::Ok;
 }
 
 #if defined(KD_LINUX)
 ExitInfo Utility::getFileSystemName(const std::shared_ptr<CacheDirectory> cacheDirectory, std::string &fileSystemName) {
     fileSystemName = {};
+
+    static std::unordered_map<SyncPath, std::string> cacheDirectoryToFileSystemName;
+
+    const auto it = cacheDirectoryToFileSystemName.find(cacheDirectory->path());
+    if (it != cacheDirectoryToFileSystemName.end()) {
+        fileSystemName = it->second;
+        return ExitCode::Ok;
+    }
 
     if (!cacheDirectory) {
         LOG_WARN(logger(), "Cache directory not provided!");
@@ -698,27 +707,31 @@ ExitInfo Utility::getFileSystemName(const std::shared_ptr<CacheDirectory> cacheD
     if (const auto exitInfo = cacheDirectory->path(localSyncPath); !exitInfo) return exitInfo;
 
     fileSystemName = CommonUtility::fileSystemName(localSyncPath);
+    cacheDirectoryToFileSystemName[cacheDirectory->path()] = fileSystemName;
 
-    if (CommonUtility::isEXT234(localSyncPath)) {
-        // `statfs` can confuse more restrictive systems with `EXT2/3/4 when a USB stick is used.
-        constexpr auto invalidExFatFileName = "a:b";
+    if (!CommonUtility::isEXT234(localSyncPath)) return ExitCode::Ok;
 
-        const auto exitInfo = tryCreateTmpFile(cacheDirectory, invalidExFatFileName);
-        if (exitInfo.cause() == ExitCause::TmpDirAccessError) {
-            LOG_WARN(logger(), "Cannot access tmp directory.");
+    // `statfs` can confuse more restrictive systems with `EXT2/3/4 when a USB stick is used.
+    constexpr auto invalidExFatFileName = "a:b";
 
-            return exitInfo;
-        }
+    const auto exitInfo = tryCreateTmpFile(cacheDirectory, invalidExFatFileName);
+    if (exitInfo.cause() == ExitCause::TmpDirAccessError) {
+        LOG_WARN(logger(), "Cannot access tmp directory.");
 
-        if (!exitInfo) {
-            LOG_DEBUG(logger(),
-                      "File names containing a colon character are not valid for the filesystem in use. We shall assume that "
-                      "this file system is exFAT.");
-            fileSystemName = CommonUtility::exFAT();
-        }
+        return exitInfo;
     }
 
-    return ExitCode::Ok;
+    if (exitInfo.cause() == ExitCause::InvalidName) {
+        LOG_DEBUG(logger(),
+                  "File names containing a colon character are not valid for the filesystem in use. We shall assume that "
+                  "this file system is exFAT.");
+        fileSystemName = CommonUtility::exFAT();
+        cacheDirectoryToFileSystemName[cacheDirectory->path()] = fileSystemName;
+
+        return ExitCode::Ok;
+    }
+
+    return exitInfo;
 }
 #endif
 
@@ -732,9 +745,9 @@ ExitInfo Utility::checkIfFileNamesCanEndWithSpace([[maybe_unused]] const std::sh
     if (const auto exitInfo = cacheDirectory->path(localSyncPath); !exitInfo) {
         if (exitInfo.cause() == ExitCause::TmpDirAccessError) {
             LOG_WARN(logger(), "Cannot access tmp directory.");
-
-            return exitInfo;
         }
+
+        return exitInfo;
     }
     if (CommonUtility::isEXT234(localSyncPath)) {
         constexpr auto fileNameWithEndingSpace = "a ";

--- a/src/libcommonserver/utility/utility.cpp
+++ b/src/libcommonserver/utility/utility.cpp
@@ -717,6 +717,8 @@ ExitInfo Utility::getFileSystemName(const std::shared_ptr<CacheDirectory> cacheD
             fileSystemName = CommonUtility::exFAT();
         }
     }
+
+    return ExitCode::Ok;
 }
 #endif
 

--- a/src/libcommonserver/utility/utility.cpp
+++ b/src/libcommonserver/utility/utility.cpp
@@ -681,6 +681,7 @@ ExitInfo Utility::tryCreateTmpFile(const std::shared_ptr<CacheDirectory> cacheDi
 
     auto ioError = IoError::Unknown;
     (void) IoHelper::deleteItem(tmpPath, ioError);
+
     return ok ? ExitCode::Ok : ExitCode::SystemError;
 }
 
@@ -715,10 +716,9 @@ ExitInfo Utility::getFileSystemName(const std::shared_ptr<CacheDirectory> cacheD
             fileSystemName = CommonUtility::exFAT();
         }
     }
+}
 #endif
 
-    return ExitCode::Ok;
-}
 
 ExitInfo Utility::checkIfFileNamesCanEndWithSpace([[maybe_unused]] const std::shared_ptr<CacheDirectory> cacheDirectory,
                                                   bool &canEndWithSpace) {

--- a/src/libcommonserver/utility/utility.h
+++ b/src/libcommonserver/utility/utility.h
@@ -200,6 +200,10 @@ struct COMMONSERVER_EXPORT Utility {
         static ExitInfo tryCreateTmpFile(std::shared_ptr<CacheDirectory> cacheDirectory, const SyncName &name = Str("testFile"));
 
 #if defined(KD_LINUX)
+        // This method makes a more accurate detection of the file system type on Linux, correcting the possibly wrong guess
+        // of `Utility::fileSystemName` when it returns "EXT2/3/4". In this case, it tries to create a file in the cache
+        // directory. This method circumvents the fact that `statfs` can mistake "exFAT" with the more permissive "EXT2/3/4" when
+        // a USB stick is used.
         static ExitInfo getFileSystemName(std::shared_ptr<CacheDirectory> cacheDirectory, std::string &fileSystemName);
 #endif
         static ExitInfo checkIfFileNamesCanEndWithSpace([[maybe_unused]] std::shared_ptr<CacheDirectory> cacheDirectory,

--- a/src/libcommonserver/utility/utility.h
+++ b/src/libcommonserver/utility/utility.h
@@ -56,7 +56,7 @@ class URI;
 
 namespace KDC {
 struct COMMONSERVER_EXPORT Utility {
-        inline static void setLogger(const log4cplus::Logger &logger) { _logger = logger; }
+        static void setLogger(const log4cplus::Logger &logger) { _logger = logger; }
 
         static bool init();
         static void free();
@@ -200,10 +200,12 @@ struct COMMONSERVER_EXPORT Utility {
         static ExitInfo tryCreateTmpFile(std::shared_ptr<CacheDirectory> cacheDirectory, const SyncName &name = Str("testFile"));
 
 #if defined(KD_LINUX)
-        // This method makes a more accurate detection of the file system type on Linux, correcting the possibly wrong guess
-        // of `Utility::fileSystemName` when it returns "EXT2/3/4". In this case, it tries to create a file in the cache
-        // directory. This method circumvents the fact that `statfs` can mistake "exFAT" with the more permissive "EXT2/3/4" when
-        // a USB stick is used.
+        /*
+         This method makes a more accurate detection of the file system type on Linux, correcting the possibly wrong guess
+         of `Utility::fileSystemName` when it returns "EXT2/3/4". In this case, the method tries to create a file in the cache
+         directory. This method circumvents the fact that `statfs` can mistake "exFAT" with the more permissive "EXT2/3/4" when
+         a USB stick is used.
+        */
         static ExitInfo getFileSystemName(std::shared_ptr<CacheDirectory> cacheDirectory, std::string &fileSystemName);
 #endif
         static ExitInfo checkIfFileNamesCanEndWithSpace([[maybe_unused]] std::shared_ptr<CacheDirectory> cacheDirectory,

--- a/src/libcommonserver/utility/utility.h
+++ b/src/libcommonserver/utility/utility.h
@@ -199,6 +199,12 @@ struct COMMONSERVER_EXPORT Utility {
          */
         static ExitInfo tryCreateTmpFile(std::shared_ptr<CacheDirectory> cacheDirectory, const SyncName &name = Str("testFile"));
 
+#if defined(KD_LINUX)
+        static ExitInfo getFileSystemName(std::shared_ptr<CacheDirectory> cacheDirectory, std::string &fileSystemName);
+#endif
+        static ExitInfo checkIfFileNamesCanEndWithSpace([[maybe_unused]] std::shared_ptr<CacheDirectory> cacheDirectory,
+                                                        bool &canEndWithSpace);
+
         static void msleep(int64_t msec);
 
         static bool getLinuxDesktopType(std::string &currentDesktop);

--- a/src/libcommonserver/utility/utility_linux.cpp
+++ b/src/libcommonserver/utility/utility_linux.cpp
@@ -327,4 +327,52 @@ bool Utility::registerLoginRedirection() {
     return res;
 }
 
+ExitInfo Utility::getFileSystemName(const std::shared_ptr<CacheDirectory> cacheDirectory, std::string &fileSystemName) {
+    fileSystemName = {};
+
+    if (!cacheDirectory) {
+        LOG_WARN(logger(), "Cache directory not provided!");
+        return {ExitCode::SystemError, ExitCause::InvalidArgument};
+    }
+
+    SyncPath localSyncPath;
+    if (const auto exitInfo = cacheDirectory->path(localSyncPath); !exitInfo) return exitInfo;
+
+    static std::unordered_map<SyncPath, std::string> cacheDirectoryToFileSystemName;
+
+    const auto it = cacheDirectoryToFileSystemName.find(localSyncPath);
+    if (it != cacheDirectoryToFileSystemName.end()) {
+        fileSystemName = it->second;
+        return ExitCode::Ok;
+    }
+
+    fileSystemName = CommonUtility::fileSystemName(localSyncPath);
+    cacheDirectoryToFileSystemName[localSyncPath] = fileSystemName;
+
+    if (!CommonUtility::isEXT234(localSyncPath)) return ExitCode::Ok;
+
+    // `statfs` can confuse more restrictive systems with `EXT2/3/4 when a USB stick is used.
+    constexpr auto invalidExFatFileName = "a:b";
+
+    const auto exitInfo = tryCreateTmpFile(cacheDirectory, invalidExFatFileName);
+    if (exitInfo.cause() == ExitCause::TmpDirAccessError) {
+        LOG_WARN(logger(), "Cannot access tmp directory.");
+
+        return exitInfo;
+    }
+
+    if (exitInfo.cause() == ExitCause::InvalidName) {
+        LOG_DEBUG(logger(),
+                  "File names containing a colon character are not valid for the filesystem in use. We shall assume that "
+                  "this file system is exFAT.");
+        fileSystemName = CommonUtility::exFAT();
+        cacheDirectoryToFileSystemName[localSyncPath] = fileSystemName;
+
+        return ExitCode::Ok;
+    }
+
+    return exitInfo;
+}
+
+
 } // namespace KDC

--- a/src/libcommonserver/utility/utility_win.cpp
+++ b/src/libcommonserver/utility/utility_win.cpp
@@ -19,7 +19,6 @@
 #include "utility.h"
 
 #include "libcommon/utility/utility.h"
-#include "libcommon/utility/utility_base.h"
 
 #include "log/log.h"
 

--- a/src/libcommonserver/utility/utility_win.cpp
+++ b/src/libcommonserver/utility/utility_win.cpp
@@ -19,6 +19,8 @@
 #include "utility.h"
 
 #include "libcommon/utility/utility.h"
+#include "libcommon/utility/utility_base.h"
+
 #include "log/log.h"
 
 #include <filesystem>

--- a/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerutility.cpp
+++ b/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerutility.cpp
@@ -31,15 +31,15 @@
 #endif
 
 namespace forbidden_filename_characters {
-static const char fat32[] = {'\\', '/', ':', '*', '?', '"', '<', '>', '|', '\n', '\r', '\t', '\0'};
+static const std::vector<char> fat32 = {'\\', '/', ':', '*', '?', '"', '<', '>', '|', '\n', '\r', '\t', '\0'};
 
 #if defined(KD_WINDOWS)
-static const chars[] = {'\\', '/', ':', '*', '?', '"', '<', '>', '|', '\n'};
+static const std::vector<char> chars = {'\\', '/', ':', '*', '?', '"', '<', '>', '|', '\n'};
 #else
 #if defined(KD_MACOS)
-static const char chars[] = {'/'};
+static const std::vector<char> chars = {'/'};
 #else
-static const char chars[] = {'/', '\0'};
+static const std::vector<char> chars = {'/', '\0'};
 #endif
 #endif
 } // namespace forbidden_filename_characters
@@ -99,12 +99,12 @@ ExitInfo PlatformInconsistencyCheckerUtility::renameLocalFile(const SyncPath &ab
     return moveJob.exitInfo();
 }
 
-ExitInfo PlatformInconsistencyCheckerUtility::nameHasForbiddenChars(
+ExitInfo PlatformInconsistencyCheckerUtility::checkIfNameHasForbiddenChars(
         const SyncName &name, [[maybe_unused]] std::shared_ptr<CacheDirectory> cacheDirectory, bool &hasForbiddenChars) {
     hasForbiddenChars = false;
-    std::string forbiddenChars;
+    std::vector<char> forbiddenChars;
 
-    const auto exitInfo = forbiddenFilenameChars(cacheDirectory, forbiddenChars);
+    const auto exitInfo = getForbiddenFilenameChars(cacheDirectory, forbiddenChars);
     if (!exitInfo) return exitInfo;
 
     for (auto c: forbiddenChars) {
@@ -124,6 +124,7 @@ ExitInfo PlatformInconsistencyCheckerUtility::nameHasForbiddenChars(
             LOGW_INFO(Log::instance()->getLogger(),
                       L"Name '" << SyncName2WStr(name) << L"' contains forbidden character: '" << std::wstring(1, c) << L"'");
             forbiddenChars = true;
+            return ExitCode::Ok;
         }
     }
 #endif
@@ -135,7 +136,7 @@ bool PlatformInconsistencyCheckerUtility::isNameOnlySpaces(const SyncName &name)
     return CommonUtility::ltrim(name).empty();
 }
 
-ExitInfo PlatformInconsistencyCheckerUtility::checkIfNameEndWithForbiddenSpace(
+ExitInfo PlatformInconsistencyCheckerUtility::checkIfNameEndsWithForbiddenSpace(
         [[maybe_unused]] const SyncName &name, [[maybe_unused]] const std::shared_ptr<CacheDirectory> cacheDirectory,
         bool &endsWithForbiddenSpace) {
     endsWithForbiddenSpace = false;
@@ -155,9 +156,10 @@ ExitInfo PlatformInconsistencyCheckerUtility::checkIfNameEndWithForbiddenSpace(
     if (const auto exitInfo = Utility::checkIfFileNamesCanEndWithSpace(cacheDirectory, fileNamesCanEndWithSpace); !exitInfo)
         return exitInfo;
 
-    endsWithForbiddenSpace = name.back() == ' ';
+    endsWithForbiddenSpace = !fileNamesCanEndWithSpace && name.back() == ' ';
 #endif
-    return ExitCode::Ok; // Name ending with a space is only forbidden on Windows.
+    return ExitCode::Ok; // Name ending with a space is only forbidden on Windows or on a Linux when a USB stick with exFAT is
+                         // used.
 }
 
 #if defined(KD_WINDOWS)
@@ -258,8 +260,8 @@ SyncName PlatformInconsistencyCheckerUtility::generateSuffix(SuffixType suffixTy
     return suffix + ss.str() + Str("_") + Str2SyncName(CommonUtility::generateRandomStringAlphaNum(10));
 }
 
-ExitInfo PlatformInconsistencyCheckerUtility::forbiddenFilenameChars(
-        [[maybe_unused]] const std::shared_ptr<CacheDirectory> cacheDirectory, std::string &forbiddenChars) {
+ExitInfo PlatformInconsistencyCheckerUtility::getForbiddenFilenameChars(
+        [[maybe_unused]] const std::shared_ptr<CacheDirectory> cacheDirectory, std::vector<char> &forbiddenChars) {
     forbiddenChars = forbidden_filename_characters::chars;
 #if defined(KD_LINUX)
     std::string fileSystemName;

--- a/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerutility.cpp
+++ b/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerutility.cpp
@@ -112,6 +112,7 @@ ExitInfo PlatformInconsistencyCheckerUtility::checkIfNameHasForbiddenChars(
             LOGW_INFO(Log::instance()->getLogger(),
                       L"Name '" << SyncName2WStr(name) << L"' contains forbidden character: '" << std::wstring(1, c) << L"'");
             hasForbiddenChars = true;
+
             return ExitCode::Ok;
         }
     }
@@ -122,8 +123,9 @@ ExitInfo PlatformInconsistencyCheckerUtility::checkIfNameHasForbiddenChars(
         const int64_t asciiCode(c);
         if (asciiCode <= 31) {
             LOGW_INFO(Log::instance()->getLogger(),
-                      L"Name '" << SyncName2WStr(name) << L"' contains forbidden character: '" << std::wstring(1, c) << L"'");
-            forbiddenChars = true;
+                      L"Name '" << SyncName2WStr(name) << L"' contains a forbidden character: '" << std::wstring(1, c) << L"'");
+            hasForbiddenChars = true;
+
             return ExitCode::Ok;
         }
     }

--- a/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerutility.cpp
+++ b/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerutility.cpp
@@ -30,8 +30,8 @@
 #include <Poco/Util/WinRegistryKey.h>
 #endif
 
-namespace forbidden_filename_characters {
-static const std::vector<char> fat32 = {'\\', '/', ':', '*', '?', '"', '<', '>', '|', '\n', '\r', '\t', '\0'};
+namespace ForbiddenFilenameCharacters {
+static const std::vector<char> fat32Chars = {'\\', '/', ':', '*', '?', '"', '<', '>', '|', '\n', '\r', '\t', '\0'};
 
 #if defined(KD_WINDOWS)
 static const std::vector<char> chars = {'\\', '/', ':', '*', '?', '"', '<', '>', '|', '\n'};
@@ -42,7 +42,7 @@ static const std::vector<char> chars = {'/'};
 static const std::vector<char> chars = {'/', '\0'};
 #endif
 #endif
-} // namespace forbidden_filename_characters
+} // namespace ForbiddenFilenameCharacters
 
 static const int maxNameLengh = 255; // Max filename length is uniformized to 255 characters for all platforms and backends
 
@@ -264,12 +264,12 @@ SyncName PlatformInconsistencyCheckerUtility::generateSuffix(SuffixType suffixTy
 
 ExitInfo PlatformInconsistencyCheckerUtility::getForbiddenFilenameChars(
         [[maybe_unused]] const std::shared_ptr<CacheDirectory> cacheDirectory, std::vector<char> &forbiddenChars) {
-    forbiddenChars = forbidden_filename_characters::chars;
+    forbiddenChars = ForbiddenFilenameCharacters::chars;
 #if defined(KD_LINUX)
     std::string fileSystemName;
     const auto exitInfo = Utility::getFileSystemName(cacheDirectory, fileSystemName);
     if (!exitInfo) return exitInfo;
-    if (fileSystemName == CommonUtility::exFAT()) forbiddenChars = forbidden_filename_characters::fat32;
+    if (fileSystemName == CommonUtility::exFAT()) forbiddenChars = ForbiddenFilenameCharacters::fat32Chars;
 #endif
     return ExitCode::Ok;
 }

--- a/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerutility.cpp
+++ b/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerutility.cpp
@@ -30,15 +30,19 @@
 #include <Poco/Util/WinRegistryKey.h>
 #endif
 
+namespace forbidden_filename_characters {
+static const char fat32[] = {'\\', '/', ':', '*', '?', '"', '<', '>', '|', '\n', '\r', '\t', '\0'};
+
 #if defined(KD_WINDOWS)
-static const char forbiddenFilenameChars[] = {'\\', '/', ':', '*', '?', '"', '<', '>', '|', '\n'};
+static const chars[] = {'\\', '/', ':', '*', '?', '"', '<', '>', '|', '\n'};
 #else
 #if defined(KD_MACOS)
-static const char forbiddenFilenameChars[] = {'/'};
+static const char chars[] = {'/'};
 #else
-static const char forbiddenFilenameChars[] = {'/', '\0'};
+static const char chars[] = {'/', '\0'};
 #endif
 #endif
+} // namespace forbidden_filename_characters
 
 static const int maxNameLengh = 255; // Max filename length is uniformized to 255 characters for all platforms and backends
 
@@ -95,12 +99,20 @@ ExitInfo PlatformInconsistencyCheckerUtility::renameLocalFile(const SyncPath &ab
     return moveJob.exitInfo();
 }
 
-bool PlatformInconsistencyCheckerUtility::nameHasForbiddenChars(const SyncName &name) {
-    for (auto c: forbiddenFilenameChars) {
+ExitInfo PlatformInconsistencyCheckerUtility::nameHasForbiddenChars(
+        const SyncName &name, [[maybe_unused]] std::shared_ptr<CacheDirectory> cacheDirectory, bool &hasForbiddenChars) {
+    hasForbiddenChars = false;
+    std::string forbiddenChars;
+
+    const auto exitInfo = forbiddenFilenameChars(cacheDirectory, forbiddenChars);
+    if (!exitInfo) return exitInfo;
+
+    for (auto c: forbiddenChars) {
         if (name.find(c) != std::string::npos) {
             LOGW_INFO(Log::instance()->getLogger(),
                       L"Name '" << SyncName2WStr(name) << L"' contains forbidden character: '" << std::wstring(1, c) << L"'");
-            return true;
+            hasForbiddenChars = true;
+            return ExitCode::Ok;
         }
     }
 
@@ -111,26 +123,41 @@ bool PlatformInconsistencyCheckerUtility::nameHasForbiddenChars(const SyncName &
         if (asciiCode <= 31) {
             LOGW_INFO(Log::instance()->getLogger(),
                       L"Name '" << SyncName2WStr(name) << L"' contains forbidden character: '" << std::wstring(1, c) << L"'");
-            return true;
+            forbiddenChars = true;
         }
     }
 #endif
 
-    return false;
+    return ExitCode::Ok;
 }
 
 bool PlatformInconsistencyCheckerUtility::isNameOnlySpaces(const SyncName &name) {
     return CommonUtility::ltrim(name).empty();
 }
 
-bool PlatformInconsistencyCheckerUtility::nameEndWithForbiddenSpace([[maybe_unused]] const SyncName &name) {
+ExitInfo PlatformInconsistencyCheckerUtility::checkIfNameEndWithForbiddenSpace(
+        [[maybe_unused]] const SyncName &name, [[maybe_unused]] const std::shared_ptr<CacheDirectory> cacheDirectory,
+        bool &endsWithForbiddenSpace) {
+    endsWithForbiddenSpace = false;
 #if defined(KD_WINDOWS)
     // Can't finish with a space
     if (SyncName nameStr(name); nameStr[nameStr.size() - 1] == ' ') {
-        return true;
+        endsWithForbiddenSpace = true;
     }
+#elif defined(KD_LINUX)
+    SyncPath localSyncPath;
+    if (const auto exitInfo = cacheDirectory->path(localSyncPath); !exitInfo) return exitInfo;
+
+    if (!CommonUtility::isEXT234(localSyncPath)) return ExitCode::Ok;
+
+    // `statfs` can confuse more restrictive systems with EXT2/3/4 when a USB stick is used.
+    bool fileNamesCanEndWithSpace = true;
+    if (const auto exitInfo = Utility::checkIfFileNamesCanEndWithSpace(cacheDirectory, fileNamesCanEndWithSpace); !exitInfo)
+        return exitInfo;
+
+    endsWithForbiddenSpace = name.back() == ' ';
 #endif
-    return false; // Name ending with a space is only forbidden on Windows.
+    return ExitCode::Ok; // Name ending with a space is only forbidden on Windows.
 }
 
 #if defined(KD_WINDOWS)
@@ -229,6 +256,18 @@ SyncName PlatformInconsistencyCheckerUtility::generateSuffix(SuffixType suffixTy
     }
 
     return suffix + ss.str() + Str("_") + Str2SyncName(CommonUtility::generateRandomStringAlphaNum(10));
+}
+
+ExitInfo PlatformInconsistencyCheckerUtility::forbiddenFilenameChars(
+        [[maybe_unused]] const std::shared_ptr<CacheDirectory> cacheDirectory, std::string &forbiddenChars) {
+    forbiddenChars = forbidden_filename_characters::chars;
+#if defined(KD_LINUX)
+    std::string fileSystemName;
+    const auto exitInfo = Utility::getFileSystemName(cacheDirectory, fileSystemName);
+    if (!exitInfo) return exitInfo;
+    if (fileSystemName == CommonUtility::exFAT()) forbiddenChars = forbidden_filename_characters::fat32;
+#endif
+    return ExitCode::Ok;
 }
 
 } // namespace KDC

--- a/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerutility.h
+++ b/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerutility.h
@@ -38,15 +38,15 @@ class PlatformInconsistencyCheckerUtility {
 
         bool isNameTooLong(const SyncName &name) const;
         bool isPathTooLong(size_t pathSize);
-        static ExitInfo nameHasForbiddenChars(const SyncName &name,
-                                              [[maybe_unused]] std::shared_ptr<CacheDirectory> cacheDirectory,
-                                              bool &hasForbiddenChars);
+        static ExitInfo checkIfNameHasForbiddenChars(const SyncName &name,
+                                                     [[maybe_unused]] std::shared_ptr<CacheDirectory> cacheDirectory,
+                                                     bool &hasForbiddenChars);
         static bool isNameOnlySpaces(const SyncName &name);
-        static ExitInfo checkIfNameEndWithForbiddenSpace([[maybe_unused]] const SyncName &name,
-                                                         [[maybe_unused]] std::shared_ptr<CacheDirectory> cacheDirectory,
-                                                         bool &endsWithForbiddenSpace);
-        static ExitInfo forbiddenFilenameChars([[maybe_unused]] std::shared_ptr<CacheDirectory> cacheDirectory,
-                                               std::string &forbiddenChars);
+        static ExitInfo checkIfNameEndsWithForbiddenSpace([[maybe_unused]] const SyncName &name,
+                                                          [[maybe_unused]] std::shared_ptr<CacheDirectory> cacheDirectory,
+                                                          bool &endsWithForbiddenSpace);
+        static ExitInfo getForbiddenFilenameChars([[maybe_unused]] std::shared_ptr<CacheDirectory> cacheDirectory,
+                                                  std::vector<char> &forbiddenChars);
 
 #if defined(KD_WINDOWS)
         bool fixNameWithBackslash(const SyncName &name, SyncName &newName);

--- a/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerutility.h
+++ b/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerutility.h
@@ -38,9 +38,15 @@ class PlatformInconsistencyCheckerUtility {
 
         bool isNameTooLong(const SyncName &name) const;
         bool isPathTooLong(size_t pathSize);
-        bool nameHasForbiddenChars(const SyncName &name);
+        static ExitInfo nameHasForbiddenChars(const SyncName &name,
+                                              [[maybe_unused]] std::shared_ptr<CacheDirectory> cacheDirectory,
+                                              bool &hasForbiddenChars);
         static bool isNameOnlySpaces(const SyncName &name);
-        static bool nameEndWithForbiddenSpace(const SyncName &name);
+        static ExitInfo checkIfNameEndWithForbiddenSpace([[maybe_unused]] const SyncName &name,
+                                                         [[maybe_unused]] std::shared_ptr<CacheDirectory> cacheDirectory,
+                                                         bool &endsWithForbiddenSpace);
+        static ExitInfo forbiddenFilenameChars([[maybe_unused]] std::shared_ptr<CacheDirectory> cacheDirectory,
+                                               std::string &forbiddenChars);
 
 #if defined(KD_WINDOWS)
         bool fixNameWithBackslash(const SyncName &name, SyncName &newName);

--- a/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerworker.cpp
+++ b/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerworker.cpp
@@ -191,9 +191,16 @@ bool PlatformInconsistencyCheckerWorker::checkPathAndName(std::shared_ptr<Node> 
     if (const auto exitInfo = PlatformInconsistencyCheckerUtility::checkIfNameEndsWithForbiddenSpace(
                 remoteNode->name(), _syncPal->cacheDirectory(), endsWithForbiddenSpace);
         !exitInfo) {
+        LOGW_SYNCPAL_INFO(_logger, L"Error in PlatformInconsistencyCheckerUtility::checkIfNameEndsWithForbiddenSpace: exitInfo="
+                                           << exitInfo);
+        _syncPal->addError(Error(ERR_ID, exitInfo));
+        return false;
+    }
+    if (endsWithForbiddenSpace) {
         blacklistNode(remoteNode, InconsistencyType::ForbiddenCharEndWithSpace);
         return false;
     }
+
     if (PlatformInconsistencyCheckerUtility::instance()->checkReservedNames(remoteNode->name())) {
         blacklistNode(remoteNode, InconsistencyType::ReservedName);
         return false;

--- a/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerworker.cpp
+++ b/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerworker.cpp
@@ -87,9 +87,14 @@ ExitCode PlatformInconsistencyCheckerWorker::checkRemoteTree(std::shared_ptr<Nod
         return ExitCode::Ok;
     }
 
-    if (pathChanged(remoteNode) && !checkPathAndName(remoteNode)) {
-        // Item has been blacklisted
-        return ExitCode::Ok;
+    if (pathChanged(remoteNode)) {
+        bool pathAndNameAreValid = true;
+        const auto exitInfo = checkIfPathAndNameAreValid(remoteNode, pathAndNameAreValid);
+
+        if (!exitInfo) return exitInfo;
+
+        // The item has been blacklisted.
+        if (!pathAndNameAreValid) return ExitCode::Ok;
     }
 
     bool checkAgainstSiblings = false;
@@ -171,20 +176,26 @@ void PlatformInconsistencyCheckerWorker::blacklistNode(std::shared_ptr<Node> nod
     _idsToBeRemoved.emplace_back(nodeIDs);
 }
 
-bool PlatformInconsistencyCheckerWorker::checkPathAndName(std::shared_ptr<Node> remoteNode) {
+ExitInfo PlatformInconsistencyCheckerWorker::checkIfPathAndNameAreValid(std::shared_ptr<Node> remoteNode,
+                                                                        bool &pathAndNameAreValid) {
+    pathAndNameAreValid = true;
+
     const SyncPath relativePath = remoteNode->getPath();
     bool hasForbiddenCharacters = false;
     if (const auto exitInfo = PlatformInconsistencyCheckerUtility::checkIfNameHasForbiddenChars(
                 remoteNode->name(), _syncPal->cacheDirectory(), hasForbiddenCharacters);
         !exitInfo) {
+        pathAndNameAreValid = false;
         LOGW_SYNCPAL_INFO(_logger,
                           L"Error in PlatformInconsistencyCheckerUtility::checkIfNameHasForbiddenChars: exitInfo=" << exitInfo);
-        _syncPal->addError(Error(ERR_ID, exitInfo));
+        return exitInfo;
     }
 
     if (hasForbiddenCharacters) {
         blacklistNode(remoteNode, InconsistencyType::ForbiddenChar);
-        return false;
+        pathAndNameAreValid = false;
+
+        return ExitCode::Ok;
     }
 
     bool endsWithForbiddenSpace = false;
@@ -193,25 +204,33 @@ bool PlatformInconsistencyCheckerWorker::checkPathAndName(std::shared_ptr<Node> 
         !exitInfo) {
         LOGW_SYNCPAL_INFO(_logger, L"Error in PlatformInconsistencyCheckerUtility::checkIfNameEndsWithForbiddenSpace: exitInfo="
                                            << exitInfo);
-        _syncPal->addError(Error(ERR_ID, exitInfo));
-        return false;
+        pathAndNameAreValid = false;
+
+        return exitInfo;
     }
+
     if (endsWithForbiddenSpace) {
         blacklistNode(remoteNode, InconsistencyType::ForbiddenCharEndWithSpace);
-        return false;
+        pathAndNameAreValid = false;
+
+        return ExitCode::Ok;
     }
 
     if (PlatformInconsistencyCheckerUtility::instance()->checkReservedNames(remoteNode->name())) {
         blacklistNode(remoteNode, InconsistencyType::ReservedName);
-        return false;
+        pathAndNameAreValid = false;
+
+        return ExitCode::Ok;
     }
 
     if (PlatformInconsistencyCheckerUtility::instance()->isNameTooLong(remoteNode->name())) {
         blacklistNode(remoteNode, InconsistencyType::NameLength);
-        return false;
+        pathAndNameAreValid = false;
+
+        return ExitCode::Ok;
     }
 
-    return true;
+    return ExitCode::Ok;
 }
 
 void PlatformInconsistencyCheckerWorker::checkNameClashAgainstSiblings(const std::shared_ptr<Node> remoteParentNode) {

--- a/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerworker.cpp
+++ b/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerworker.cpp
@@ -173,12 +173,23 @@ void PlatformInconsistencyCheckerWorker::blacklistNode(std::shared_ptr<Node> nod
 
 bool PlatformInconsistencyCheckerWorker::checkPathAndName(std::shared_ptr<Node> remoteNode) {
     const SyncPath relativePath = remoteNode->getPath();
-    if (PlatformInconsistencyCheckerUtility::instance()->nameHasForbiddenChars(remoteNode->name())) {
+    bool hasForbiddenCharacters = false;
+    if (const auto exitInfo = PlatformInconsistencyCheckerUtility::nameHasForbiddenChars(
+                remoteNode->name(), _syncPal->cacheDirectory(), hasForbiddenCharacters);
+        !exitInfo) {
+        LOGW_SYNCPAL_INFO(_logger, L"Error in PlatformInconsistencyCheckerUtility::nameHasForbiddenChars: exitInfo=" << exitInfo);
+        _syncPal->addError(Error(ERR_ID, exitInfo));
+    }
+
+    if (hasForbiddenCharacters) {
         blacklistNode(remoteNode, InconsistencyType::ForbiddenChar);
         return false;
     }
 
-    if (PlatformInconsistencyCheckerUtility::nameEndWithForbiddenSpace(remoteNode->name())) {
+    bool endsWithForbiddenSpace = false;
+    if (const auto exitInfo = PlatformInconsistencyCheckerUtility::checkIfNameEndWithForbiddenSpace(
+                remoteNode->name(), _syncPal->cacheDirectory(), endsWithForbiddenSpace);
+        !exitInfo) {
         blacklistNode(remoteNode, InconsistencyType::ForbiddenCharEndWithSpace);
         return false;
     }

--- a/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerworker.cpp
+++ b/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerworker.cpp
@@ -174,10 +174,11 @@ void PlatformInconsistencyCheckerWorker::blacklistNode(std::shared_ptr<Node> nod
 bool PlatformInconsistencyCheckerWorker::checkPathAndName(std::shared_ptr<Node> remoteNode) {
     const SyncPath relativePath = remoteNode->getPath();
     bool hasForbiddenCharacters = false;
-    if (const auto exitInfo = PlatformInconsistencyCheckerUtility::nameHasForbiddenChars(
+    if (const auto exitInfo = PlatformInconsistencyCheckerUtility::checkIfNameHasForbiddenChars(
                 remoteNode->name(), _syncPal->cacheDirectory(), hasForbiddenCharacters);
         !exitInfo) {
-        LOGW_SYNCPAL_INFO(_logger, L"Error in PlatformInconsistencyCheckerUtility::nameHasForbiddenChars: exitInfo=" << exitInfo);
+        LOGW_SYNCPAL_INFO(_logger,
+                          L"Error in PlatformInconsistencyCheckerUtility::checkIfNameHasForbiddenChars: exitInfo=" << exitInfo);
         _syncPal->addError(Error(ERR_ID, exitInfo));
     }
 
@@ -187,7 +188,7 @@ bool PlatformInconsistencyCheckerWorker::checkPathAndName(std::shared_ptr<Node> 
     }
 
     bool endsWithForbiddenSpace = false;
-    if (const auto exitInfo = PlatformInconsistencyCheckerUtility::checkIfNameEndWithForbiddenSpace(
+    if (const auto exitInfo = PlatformInconsistencyCheckerUtility::checkIfNameEndsWithForbiddenSpace(
                 remoteNode->name(), _syncPal->cacheDirectory(), endsWithForbiddenSpace);
         !exitInfo) {
         blacklistNode(remoteNode, InconsistencyType::ForbiddenCharEndWithSpace);

--- a/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerworker.h
+++ b/src/libsyncengine/reconciliation/platform_inconsistency_checker/platforminconsistencycheckerworker.h
@@ -36,7 +36,7 @@ class PlatformInconsistencyCheckerWorker : public OperationProcessor {
         ExitCode checkLocalTree(std::shared_ptr<Node> localNode, const SyncPath &parentPath);
 
         void blacklistNode(std::shared_ptr<Node> node, const InconsistencyType inconsistencyType);
-        bool checkPathAndName(std::shared_ptr<Node> remoteNode);
+        ExitInfo checkIfPathAndNameAreValid(std::shared_ptr<Node> remoteNode, bool &pathAndNameAreValid);
         void checkNameClashAgainstSiblings(const std::shared_ptr<Node> remoteParentNode);
 
         bool pathChanged(std::shared_ptr<Node> node) const;

--- a/src/libsyncengine/syncpal/isyncworker.h
+++ b/src/libsyncengine/syncpal/isyncworker.h
@@ -43,13 +43,13 @@ class ISyncWorker {
         // Will not return until the internal thread has exited
         void waitForExit();
 
-        inline std::string name() const { return _name; }
-        inline std::string shortName() const { return _shortName; }
+        std::string name() const { return _name; }
+        std::string shortName() const { return _shortName; }
 
-        inline bool isRunning() const { return _isRunning; }
-        inline bool stopAsked() const { return _stopAsked; }
-        inline ExitCode exitCode() const { return _exitCode; }
-        inline ExitCause exitCause() const { return _exitCause; }
+        bool isRunning() const { return _isRunning; }
+        bool stopAsked() const { return _stopAsked; }
+        ExitCode exitCode() const { return _exitCode; }
+        ExitCause exitCause() const { return _exitCause; }
 
         [[nodiscard]] const int64_t &pauseDuration() const { return _pauseDuration; }
         void setPauseDuration(const int64_t &pauseDuration) {
@@ -57,7 +57,8 @@ class ISyncWorker {
         } // Minimum pause duration is 1 min
         void resetPauseDuration() { _pauseDuration = defaultPauseDuration; }
 
-        inline void setTesting(bool testing) { _testing = testing; }
+        void setTesting(bool testing) { _testing = testing; }
+        [[nodiscard]] std::shared_ptr<CacheDirectory> cacheDirectory() const { return _syncPal->cacheDirectory(); }
 
     protected:
         log4cplus::Logger _logger;

--- a/src/libsyncengine/update_detection/file_system_observer/folderwatcher_linux.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/folderwatcher_linux.cpp
@@ -44,7 +44,15 @@ SyncPath FolderWatcher_linux::makeSyncPath(const SyncPath &watchedFolderPath, co
 
 void FolderWatcher_linux::startWatching() {
     LOGW_DEBUG(_logger, L"Start watching folder " << Utility::formatSyncPath(_folder));
-    LOG_DEBUG(_logger, "File system format: " << CommonUtility::fileSystemName(_folder));
+
+    std::string fileSystemName;
+    if (const auto exitInfo = Utility::getFileSystemName(_parent->cacheDirectory(), fileSystemName); !exitInfo) {
+        LOGW_WARN(_logger, L"Error in Utility::getFileSystemName: exitInfo=" << exitInfo);
+        setExitInfo(exitInfo);
+        return;
+    }
+
+    LOG_DEBUG(_logger, "File system format: " << fileSystemName);
     LOG_DEBUG(_logger, "Free space on disk: " << Utility::getFreeDiskSpace(_folder) << " bytes.");
 
     _fileDescriptor = inotify_init();
@@ -53,8 +61,8 @@ void FolderWatcher_linux::startWatching() {
         return;
     }
 
-    if (const auto &exitInfo = addFolderRecursive(_folder); !exitInfo) {
-        setExitInfo(exitInfo);
+    if (const auto &addFolderRecursiveExitInfo = addFolderRecursive(_folder); !addFolderRecursiveExitInfo) {
+        setExitInfo(addFolderRecursiveExitInfo);
         return;
     }
 

--- a/src/libsyncengine/update_detection/file_system_observer/folderwatcher_linux.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/folderwatcher_linux.cpp
@@ -61,7 +61,7 @@ void FolderWatcher_linux::startWatching() {
         return;
     }
 
-    if (const auto &addFolderRecursiveExitInfo = addFolderRecursive(_folder); !addFolderRecursiveExitInfo) {
+    if (const auto addFolderRecursiveExitInfo = addFolderRecursive(_folder); !addFolderRecursiveExitInfo) {
         setExitInfo(addFolderRecursiveExitInfo);
         return;
     }

--- a/src/libsyncengine/update_detection/file_system_observer/remotefilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/remotefilesystemobserverworker.cpp
@@ -404,7 +404,7 @@ ExitInfo RemoteFileSystemObserverWorker::getItemsInDir(const NodeId &dirId, cons
                 return ExitCode::DataError;
             }
         }
-        nodeIdIt++;
+        ++nodeIdIt;
     }
 
     LOG_SYNCPAL_DEBUG(_logger,

--- a/src/libsyncengine/update_detection/file_system_observer/remotefilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/remotefilesystemobserverworker.cpp
@@ -810,8 +810,9 @@ ExitInfo RemoteFileSystemObserverWorker::checkRightsAndUpdateItem(const NodeId &
 ExitInfo RemoteFileSystemObserverWorker::checkForUnsupportedCharacters([[maybe_unused]] const SyncName &name,
                                                                        [[maybe_unused]] const NodeId &nodeId,
                                                                        [[maybe_unused]] const NodeType type) {
-#if defined(KD_MACOS)
     ExitInfo exitInfo = ExitCode::Ok;
+
+#if defined(KD_MACOS)
     // Check that the name doesn't contain a character not yet supported by the filesystem (ex: U+1FA77 on pre macOS 13.4)
     if (type == NodeType::File) {
         exitInfo = Utility::tryCreateTmpFile(_syncPal->cacheDirectory(), name);
@@ -831,7 +832,7 @@ ExitInfo RemoteFileSystemObserverWorker::checkForUnsupportedCharacters([[maybe_u
     }
 #endif
 
-    return ExitCode::Ok;
+    return exitInfo;
 }
 
 void RemoteFileSystemObserverWorker::countListingRequests() {

--- a/src/libsyncengine/update_detection/file_system_observer/remotefilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/remotefilesystemobserverworker.cpp
@@ -807,10 +807,11 @@ ExitInfo RemoteFileSystemObserverWorker::checkRightsAndUpdateItem(const NodeId &
     return ExitCode::Ok;
 }
 
-ExitInfo RemoteFileSystemObserverWorker::checkForUnsupportedCharacters(const SyncName &name, const NodeId &nodeId,
-                                                                       const NodeType type) {
-    ExitInfo exitInfo = ExitCode::Ok;
+ExitInfo RemoteFileSystemObserverWorker::checkForUnsupportedCharacters([[maybe_unused]] const SyncName &name,
+                                                                       [[maybe_unused]] const NodeId &nodeId,
+                                                                       [[maybe_unused]] const NodeType type) {
 #if defined(KD_MACOS)
+    ExitInfo exitInfo = ExitCode::Ok;
     // Check that the name doesn't contain a character not yet supported by the filesystem (ex: U+1FA77 on pre macOS 13.4)
     if (type == NodeType::File) {
         exitInfo = Utility::tryCreateTmpFile(_syncPal->cacheDirectory(), name);
@@ -828,12 +829,9 @@ ExitInfo RemoteFileSystemObserverWorker::checkForUnsupportedCharacters(const Syn
                 Error(_syncPal->syncDbId(), "", nodeId, type, name, ConflictType::None, InconsistencyType::NotYetSupportedChar));
         exitInfo = {ExitCode::SystemError, ExitCause::InvalidName};
     }
-#else
-    (void) name;
-    (void) nodeId;
-    (void) type;
 #endif
-    return exitInfo;
+
+    return ExitCode::Ok;
 }
 
 void RemoteFileSystemObserverWorker::countListingRequests() {

--- a/test/libcommon/utility/testutility.cpp
+++ b/test/libcommon/utility/testutility.cpp
@@ -476,7 +476,7 @@ void TestUtility::testGenerateRandomNumber() {
     bool allValuesAreTheSame = true;
     for (auto i = 0; i < 100; i++) {
         const auto val = CommonUtility::generateRandomNumber(1, 100);
-        if (val != sequence[i]) {
+        if (val != sequence[static_cast<size_t>(i)]) {
             allValuesAreTheSame = false;
             break;
         }

--- a/test/libsyncengine/reconciliation/platform_inconsistency_checker/testplatforminconsistencycheckerworker.cpp
+++ b/test/libsyncengine/reconciliation/platform_inconsistency_checker/testplatforminconsistencycheckerworker.cpp
@@ -163,7 +163,7 @@ void TestPlatformInconsistencyCheckerWorker::testCheckNameForbiddenChars() {
     CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), PlatformInconsistencyCheckerUtility::checkIfNameEndsWithForbiddenSpace(
                                                          forbiddenName, _syncPal->cacheDirectory(), endsWithForbiddenSpace));
     CPPUNIT_ASSERT(endsWithForbiddenSpace);
-#elif defined(KD_LINUX) && !defined(KD_MACOS)
+#elif defined(KD_LINUX)
     forbiddenName = std::string("test");
     forbiddenName.append(1, '\0');
     hasForbiddenChars = false;

--- a/test/libsyncengine/reconciliation/platform_inconsistency_checker/testplatforminconsistencycheckerworker.cpp
+++ b/test/libsyncengine/reconciliation/platform_inconsistency_checker/testplatforminconsistencycheckerworker.cpp
@@ -96,37 +96,86 @@ void TestPlatformInconsistencyCheckerWorker::testIsNameTooLong() {
 
 void TestPlatformInconsistencyCheckerWorker::testCheckNameForbiddenChars() {
     SyncName allowedName = Str("test-test");
-    CPPUNIT_ASSERT(!PlatformInconsistencyCheckerUtility::instance()->nameHasForbiddenChars(allowedName));
+    bool hasForbiddenChars = false;
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), PlatformInconsistencyCheckerUtility::instance()->checkIfNameHasForbiddenChars(
+                                                         allowedName, _syncPal->cacheDirectory(), hasForbiddenChars));
+    CPPUNIT_ASSERT(!hasForbiddenChars);
 
     SyncName forbiddenName = Str("test/test");
-    CPPUNIT_ASSERT(PlatformInconsistencyCheckerUtility::instance()->nameHasForbiddenChars(forbiddenName));
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), PlatformInconsistencyCheckerUtility::instance()->checkIfNameHasForbiddenChars(
+                                                         forbiddenName, _syncPal->cacheDirectory(), hasForbiddenChars));
+    CPPUNIT_ASSERT(hasForbiddenChars);
+
+    hasForbiddenChars = false;
 
 #if defined(KD_WINDOWS)
     forbiddenName = Str("test\\test");
-    CPPUNIT_ASSERT(PlatformInconsistencyCheckerUtility::instance()->nameHasForbiddenChars(forbiddenName));
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), PlatformInconsistencyCheckerUtility::instance()->checkIfNameHasForbiddenChars(
+                                                         forbiddenName, _syncPal->cacheDirectory(), hasForbiddenChars));
+    CPPUNIT_ASSERT(hasForbiddenChars);
+
     forbiddenName = Str("test:test");
-    CPPUNIT_ASSERT(PlatformInconsistencyCheckerUtility::instance()->nameHasForbiddenChars(forbiddenName));
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), PlatformInconsistencyCheckerUtility::instance()->checkIfNameHasForbiddenChars(
+                                                         forbiddenName, _syncPal->cacheDirectory(), hasForbiddenChars));
+    CPPUNIT_ASSERT(hasForbiddenChars);
+
     forbiddenName = Str("test*test");
-    CPPUNIT_ASSERT(PlatformInconsistencyCheckerUtility::instance()->nameHasForbiddenChars(forbiddenName));
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), PlatformInconsistencyCheckerUtility::instance()->checkIfNameHasForbiddenChars(
+                                                         forbiddenName, _syncPal->cacheDirectory(), hasForbiddenChars));
+    CPPUNIT_ASSERT(hasForbiddenChars);
+
     forbiddenName = Str("test?test");
-    CPPUNIT_ASSERT(PlatformInconsistencyCheckerUtility::instance()->nameHasForbiddenChars(forbiddenName));
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), PlatformInconsistencyCheckerUtility::instance()->checkIfNameHasForbiddenChars(
+                                                         forbiddenName, _syncPal->cacheDirectory(), hasForbiddenChars));
+    CPPUNIT_ASSERT(hasForbiddenChars);
+
     forbiddenName = Str("test\"test");
-    CPPUNIT_ASSERT(PlatformInconsistencyCheckerUtility::instance()->nameHasForbiddenChars(forbiddenName));
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), PlatformInconsistencyCheckerUtility::instance()->checkIfNameHasForbiddenChars(
+                                                         forbiddenName, _syncPal->cacheDirectory(), hasForbiddenChars));
+    CPPUNIT_ASSERT(hasForbiddenChars);
+
     forbiddenName = Str("test<test");
-    CPPUNIT_ASSERT(PlatformInconsistencyCheckerUtility::instance()->nameHasForbiddenChars(forbiddenName));
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), PlatformInconsistencyCheckerUtility::instance()->checkIfNameHasForbiddenChars(
+                                                         forbiddenName, _syncPal->cacheDirectory(), hasForbiddenChars));
+    CPPUNIT_ASSERT(hasForbiddenChars);
+
     forbiddenName = Str("test>test");
-    CPPUNIT_ASSERT(PlatformInconsistencyCheckerUtility::instance()->nameHasForbiddenChars(forbiddenName));
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), PlatformInconsistencyCheckerUtility::instance()->checkIfNameHasForbiddenChars(
+                                                         forbiddenName, _syncPal->cacheDirectory(), hasForbiddenChars));
+    CPPUNIT_ASSERT(hasForbiddenChars);
+
     forbiddenName = Str("test|test");
-    CPPUNIT_ASSERT(PlatformInconsistencyCheckerUtility::instance()->nameHasForbiddenChars(forbiddenName));
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), PlatformInconsistencyCheckerUtility::instance()->checkIfNameHasForbiddenChars(
+                                                         forbiddenName, _syncPal->cacheDirectory(), hasForbiddenChars));
+    CPPUNIT_ASSERT(hasForbiddenChars);
+
     forbiddenName = Str("test\ntest");
-    CPPUNIT_ASSERT(PlatformInconsistencyCheckerUtility::instance()->nameHasForbiddenChars(forbiddenName));
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), PlatformInconsistencyCheckerUtility::instance()->checkIfNameHasForbiddenChars(
+                                                         forbiddenName, _syncPal->cacheDirectory(), hasForbiddenChars));
+    CPPUNIT_ASSERT(hasForbiddenChars);
+
     forbiddenName = Str("test ");
-    CPPUNIT_ASSERT(!PlatformInconsistencyCheckerUtility::instance()->nameHasForbiddenChars(forbiddenName));
-    CPPUNIT_ASSERT(PlatformInconsistencyCheckerUtility::nameEndWithForbiddenSpace(forbiddenName));
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok),
+                         PlatformInconsistencyCheckerUtility::instance()->checkIfNameHasForbiddenChars(forbiddenName));
+    CPPUNIT_ASSERT(!hasForbiddenChars);
+
+    bool endsWithForbiddenSpace = false;
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), PlatformInconsistencyCheckerUtility::checkIfNameEndsWithForbiddenSpace(
+                                                         forbiddenName, _syncPal->cacheDirectory(), endsWithForbiddenSpace));
+    CPPUNIT_ASSERT(endsWithForbiddenSpace);
 #elif defined(KD_LINUX) && !defined(KD_MACOS)
     forbiddenName = std::string("test");
     forbiddenName.append(1, '\0');
-    CPPUNIT_ASSERT(PlatformInconsistencyCheckerUtility::instance()->nameHasForbiddenChars(forbiddenName));
+    hasForbiddenChars = false;
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), PlatformInconsistencyCheckerUtility::instance()->checkIfNameHasForbiddenChars(
+                                                         forbiddenName, _syncPal->cacheDirectory(), hasForbiddenChars));
+    CPPUNIT_ASSERT(hasForbiddenChars);
+
+    forbiddenName = Str("test ");
+    bool endsWithForbiddenSpace = false;
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), PlatformInconsistencyCheckerUtility::checkIfNameEndsWithForbiddenSpace(
+                                                         forbiddenName, _syncPal->cacheDirectory(), endsWithForbiddenSpace));
+    CPPUNIT_ASSERT(!endsWithForbiddenSpace);
 #endif
 }
 

--- a/test/libsyncengine/reconciliation/platform_inconsistency_checker/testplatforminconsistencycheckerworker.cpp
+++ b/test/libsyncengine/reconciliation/platform_inconsistency_checker/testplatforminconsistencycheckerworker.cpp
@@ -156,7 +156,7 @@ void TestPlatformInconsistencyCheckerWorker::testCheckNameForbiddenChars() {
 
     forbiddenName = Str("test ");
     CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), PlatformInconsistencyCheckerUtility::checkIfNameHasForbiddenChars(
-                                                         forbiddenName, _syncPal->cacheDirectory(), endsWithForbiddenSpace));
+                                                         forbiddenName, _syncPal->cacheDirectory(), hasForbiddenChars));
     CPPUNIT_ASSERT(!hasForbiddenChars);
 
     bool endsWithForbiddenSpace = false;

--- a/test/libsyncengine/reconciliation/platform_inconsistency_checker/testplatforminconsistencycheckerworker.cpp
+++ b/test/libsyncengine/reconciliation/platform_inconsistency_checker/testplatforminconsistencycheckerworker.cpp
@@ -97,12 +97,12 @@ void TestPlatformInconsistencyCheckerWorker::testIsNameTooLong() {
 void TestPlatformInconsistencyCheckerWorker::testCheckNameForbiddenChars() {
     SyncName allowedName = Str("test-test");
     bool hasForbiddenChars = false;
-    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), PlatformInconsistencyCheckerUtility::instance()->checkIfNameHasForbiddenChars(
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), PlatformInconsistencyCheckerUtility::checkIfNameHasForbiddenChars(
                                                          allowedName, _syncPal->cacheDirectory(), hasForbiddenChars));
     CPPUNIT_ASSERT(!hasForbiddenChars);
 
     SyncName forbiddenName = Str("test/test");
-    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), PlatformInconsistencyCheckerUtility::instance()->checkIfNameHasForbiddenChars(
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), PlatformInconsistencyCheckerUtility::checkIfNameHasForbiddenChars(
                                                          forbiddenName, _syncPal->cacheDirectory(), hasForbiddenChars));
     CPPUNIT_ASSERT(hasForbiddenChars);
 
@@ -110,53 +110,53 @@ void TestPlatformInconsistencyCheckerWorker::testCheckNameForbiddenChars() {
 
 #if defined(KD_WINDOWS)
     forbiddenName = Str("test\\test");
-    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), PlatformInconsistencyCheckerUtility::instance()->checkIfNameHasForbiddenChars(
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), PlatformInconsistencyCheckerUtility::checkIfNameHasForbiddenChars(
                                                          forbiddenName, _syncPal->cacheDirectory(), hasForbiddenChars));
     CPPUNIT_ASSERT(hasForbiddenChars);
 
     forbiddenName = Str("test:test");
-    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), PlatformInconsistencyCheckerUtility::instance()->checkIfNameHasForbiddenChars(
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), PlatformInconsistencyCheckerUtility::checkIfNameHasForbiddenChars(
                                                          forbiddenName, _syncPal->cacheDirectory(), hasForbiddenChars));
     CPPUNIT_ASSERT(hasForbiddenChars);
 
     forbiddenName = Str("test*test");
-    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), PlatformInconsistencyCheckerUtility::instance()->checkIfNameHasForbiddenChars(
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), PlatformInconsistencyCheckerUtility::checkIfNameHasForbiddenChars(
                                                          forbiddenName, _syncPal->cacheDirectory(), hasForbiddenChars));
     CPPUNIT_ASSERT(hasForbiddenChars);
 
     forbiddenName = Str("test?test");
-    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), PlatformInconsistencyCheckerUtility::instance()->checkIfNameHasForbiddenChars(
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), PlatformInconsistencyCheckerUtility::checkIfNameHasForbiddenChars(
                                                          forbiddenName, _syncPal->cacheDirectory(), hasForbiddenChars));
     CPPUNIT_ASSERT(hasForbiddenChars);
 
     forbiddenName = Str("test\"test");
-    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), PlatformInconsistencyCheckerUtility::instance()->checkIfNameHasForbiddenChars(
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), PlatformInconsistencyCheckerUtility::checkIfNameHasForbiddenChars(
                                                          forbiddenName, _syncPal->cacheDirectory(), hasForbiddenChars));
     CPPUNIT_ASSERT(hasForbiddenChars);
 
     forbiddenName = Str("test<test");
-    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), PlatformInconsistencyCheckerUtility::instance()->checkIfNameHasForbiddenChars(
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), PlatformInconsistencyCheckerUtility::checkIfNameHasForbiddenChars(
                                                          forbiddenName, _syncPal->cacheDirectory(), hasForbiddenChars));
     CPPUNIT_ASSERT(hasForbiddenChars);
 
     forbiddenName = Str("test>test");
-    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), PlatformInconsistencyCheckerUtility::instance()->checkIfNameHasForbiddenChars(
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), PlatformInconsistencyCheckerUtility::checkIfNameHasForbiddenChars(
                                                          forbiddenName, _syncPal->cacheDirectory(), hasForbiddenChars));
     CPPUNIT_ASSERT(hasForbiddenChars);
 
     forbiddenName = Str("test|test");
-    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), PlatformInconsistencyCheckerUtility::instance()->checkIfNameHasForbiddenChars(
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), PlatformInconsistencyCheckerUtility::checkIfNameHasForbiddenChars(
                                                          forbiddenName, _syncPal->cacheDirectory(), hasForbiddenChars));
     CPPUNIT_ASSERT(hasForbiddenChars);
 
     forbiddenName = Str("test\ntest");
-    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), PlatformInconsistencyCheckerUtility::instance()->checkIfNameHasForbiddenChars(
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), PlatformInconsistencyCheckerUtility::checkIfNameHasForbiddenChars(
                                                          forbiddenName, _syncPal->cacheDirectory(), hasForbiddenChars));
     CPPUNIT_ASSERT(hasForbiddenChars);
 
     forbiddenName = Str("test ");
-    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok),
-                         PlatformInconsistencyCheckerUtility::instance()->checkIfNameHasForbiddenChars(forbiddenName));
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), PlatformInconsistencyCheckerUtility::checkIfNameHasForbiddenChars(
+                                                         forbiddenName, _syncPal->cacheDirectory(), endsWithForbiddenSpace));
     CPPUNIT_ASSERT(!hasForbiddenChars);
 
     bool endsWithForbiddenSpace = false;
@@ -167,7 +167,7 @@ void TestPlatformInconsistencyCheckerWorker::testCheckNameForbiddenChars() {
     forbiddenName = std::string("test");
     forbiddenName.append(1, '\0');
     hasForbiddenChars = false;
-    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), PlatformInconsistencyCheckerUtility::instance()->checkIfNameHasForbiddenChars(
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), PlatformInconsistencyCheckerUtility::checkIfNameHasForbiddenChars(
                                                          forbiddenName, _syncPal->cacheDirectory(), hasForbiddenChars));
     CPPUNIT_ASSERT(hasForbiddenChars);
 


### PR DESCRIPTION
These changes circumvent the fact that `statfs` can fail to correctly detect the type of file system in use on Linux, specially if it is the file system of a USB stick. For instance, it can mistakenly identify the file system used for synchronizing as `EXT2/3/4`, whereas the file system is actually a much more restrictive file system such as `exFAT` (which is as restrictive as `FAT32` regarding allowed characters used in file names).

If `stafs` claims that the file system used by the synchronization on a Linux system is `EXT2/3/4`, then we also check whether the file system supports some specific characters to confirm or reject this claim. In case of rejection, we assume that the file system is `exFAT`, the most restrictive one.

The changes have been tested on a USB stick with `exFAT` format on Linux.
Only the Linux specific code is affected by these changes. 

 