### PR TITLE
feat: xxhash iohelper

### DIFF
--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -762,8 +762,30 @@ void IoHelper::getFileStat(const SyncPath &path, FileStat *buf, bool &exists, Pa
     }
 }
 
-std::string IoHelper::getFileChecksum(const SyncPath &path, std::ifstream &ifs, IoError &ioError) {
+std::string IoHelper::getFileChecksum(const SyncPath &path, std::ifstream &ifs, IoError &ioError) noexcept {
     ioError = IoError::Success;
+
+    std::error_code ec;
+    auto status = std::filesystem::symlink_status(path, ec);
+    ioError = stdError2ioError(ec);
+
+    if (ioError != IoError::Success) return "";
+
+    if (std::filesystem::is_symlink(status)) {
+        ioError = IoError::InvalidArgument;
+        return "";
+    }
+
+#if defined(KD_MACOS)
+    bool isAlias = false;
+    if (!IoHelper::checkIfIsAlias(path, isAlias, ioError)) {
+        return "";
+    }
+    if (isAlias) {
+        ioError = IoError::InvalidArgument;
+        return "";
+    }
+#endif
 
     IoHelper::openFile(path, ifs, ioError);
 
@@ -779,12 +801,11 @@ std::string IoHelper::getFileChecksum(const SyncPath &path, std::ifstream &ifs, 
     XXH3_64bits_reset(state);
 
     size_t readBytes;
-    while ((readBytes = fread(buffer.data(), 1, buffer.size(), f)) > 0) {
+    while ((readBytes = ifs.read(buffer.data(), buffer.size()).gcount()) > 0) {
         XXH3_64bits_update(state, buffer.data(), readBytes);
     }
 
-    fclose(f);
-
+    ifs.close();
     XXH64_hash_t hash = XXH3_64bits_digest(state);
     XXH3_freeState(state);
 

--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -31,6 +31,9 @@
 #include <fstream>
 #include <log4cplus/loggingmacros.h> // LOGW_WARN
 
+#include <vector>
+#include <xxhash.h>
+
 namespace KDC {
 
 // Default `std::filesytem` implementation. This can be changed in unit tests.

--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -794,6 +794,7 @@ std::string IoHelper::getFileChecksum(const SyncPath &path, std::ifstream &ifs, 
         const bool isOpen = IoHelper::openFile(path, ifs, ioError);
 
         if (!isOpen || !ifs) {
+            ioError = IoError::InvalidArgument;
             return "";
         }
 

--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -778,7 +778,7 @@ std::string IoHelper::getFileChecksum(const SyncPath &path, std::ifstream &ifs, 
 
 #if defined(KD_MACOS)
     bool isAlias = false;
-    if (!IoHelper::checkIfIsAlias(path, isAlias, ioError)) {
+    if (!IoHelper::_checkIfAlias(path, isAlias, ioError)) {
         return "";
     }
     if (isAlias) {
@@ -800,7 +800,7 @@ std::string IoHelper::getFileChecksum(const SyncPath &path, std::ifstream &ifs, 
     XXH3_state_t *state = XXH3_createState();
     XXH3_64bits_reset(state);
 
-    size_t readBytes(0);
+    std::streamsize readBytes(0);
     while ((readBytes = ifs.read(buffer.data(), buffer.size()).gcount()) > 0) {
         XXH3_64bits_update(state, buffer.data(), readBytes);
     }

--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -768,50 +768,64 @@ void IoHelper::getFileStat(const SyncPath &path, FileStat *buf, bool &exists, Pa
 std::string IoHelper::getFileChecksum(const SyncPath &path, std::ifstream &ifs, IoError &ioError) noexcept {
     ioError = IoError::Success;
 
-    std::error_code ec;
-    auto status = std::filesystem::symlink_status(path, ec);
-    ioError = stdError2ioError(ec);
+    try {
+        std::error_code ec;
+        auto status = std::filesystem::symlink_status(path, ec);
+        ioError = stdError2ioError(ec);
 
-    if (ioError != IoError::Success) return "";
+        if (ioError != IoError::Success) return "";
 
-    if (std::filesystem::is_symlink(status)) {
-        ioError = IoError::InvalidArgument;
-        return "";
-    }
+        if (std::filesystem::is_symlink(status)) {
+            ioError = IoError::InvalidArgument;
+            return "";
+        }
 
 #if defined(KD_MACOS)
-    bool isAlias = false;
-    if (!IoHelper::_checkIfAlias(path, isAlias, ioError)) {
-        return "";
-    }
-    if (isAlias) {
-        ioError = IoError::InvalidArgument;
-        return "";
-    }
+        bool isAlias = false;
+        if (!IoHelper::_checkIfAlias(path, isAlias, ioError)) {
+            return "";
+        }
+        if (isAlias) {
+            ioError = IoError::InvalidArgument;
+            return "";
+        }
 #endif
 
-    const bool isOpen = IoHelper::openFile(path, ifs, ioError);
+        const bool isOpen = IoHelper::openFile(path, ifs, ioError);
 
-    if (!isOpen || !ifs) {
+        if (!isOpen || !ifs) {
+            return "";
+        }
+
+        constexpr size_t CHUNK_SIZE = 8 * 1024 * 1024; // 8 MB
+        std::vector<char> buffer(CHUNK_SIZE);
+
+        XXH3_state_t *state = XXH3_createState();
+        XXH3_64bits_reset(state);
+
+        std::streamsize readBytes(0);
+        while ((readBytes = ifs.read(buffer.data(), buffer.size()).gcount()) > 0) {
+            XXH3_64bits_update(state, buffer.data(), readBytes);
+        }
+
+        ifs.close();
+        XXH64_hash_t hash = XXH3_64bits_digest(state);
+        XXH3_freeState(state);
+
+        return Utility::xxHashToStr(hash);
+    } catch (const std::bad_alloc &e) {
+        LOGW_WARN(logger(), L"Memory allocation failed in getFileChecksum");
+        ioError = IoError::Unknown;
+        return "";
+    } catch (const std::exception &e) {
+        LOGW_WARN(logger(), L"Exception in getFileChecksum: " << CommonUtility::s2ws(e.what()));
+        ioError = IoError::Unknown;
+        return "";
+    } catch (...) {
+        LOGW_WARN(logger(), L"Unknown exception in getFileChecksum");
+        ioError = IoError::Unknown;
         return "";
     }
-
-    constexpr size_t CHUNK_SIZE = 8 * 1024 * 1024; // 8 MB
-    std::vector<char> buffer(CHUNK_SIZE);
-
-    XXH3_state_t *state = XXH3_createState();
-    XXH3_64bits_reset(state);
-
-    std::streamsize readBytes(0);
-    while ((readBytes = ifs.read(buffer.data(), buffer.size()).gcount()) > 0) {
-        XXH3_64bits_update(state, buffer.data(), readBytes);
-    }
-
-    ifs.close();
-    XXH64_hash_t hash = XXH3_64bits_digest(state);
-    XXH3_freeState(state);
-
-    return Utility::xxHashToStr(hash);
 }
 
 bool IoHelper::checkIfFileChanged(const SyncPath &path, int64_t previousSize, SyncTime previousMtime,

--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -787,7 +787,7 @@ std::string IoHelper::getFileChecksum(const SyncPath &path, std::ifstream &ifs, 
     }
 #endif
 
-    IoHelper::openFile(path, ifs, ioError);
+    (void) IoHelper::openFile(path, ifs, ioError);
 
     if (!ifs) {
         ioError = IoError::NoSuchFileOrDirectory;
@@ -800,7 +800,7 @@ std::string IoHelper::getFileChecksum(const SyncPath &path, std::ifstream &ifs, 
     XXH3_state_t *state = XXH3_createState();
     XXH3_64bits_reset(state);
 
-    size_t readBytes;
+    size_t readBytes(0);
     while ((readBytes = ifs.read(buffer.data(), buffer.size()).gcount()) > 0) {
         XXH3_64bits_update(state, buffer.data(), readBytes);
     }

--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -766,33 +766,34 @@ void IoHelper::getFileStat(const SyncPath &path, FileStat *buf, bool &exists, Pa
 }
 
 IoError IoHelper::getFileChecksum(const SyncPath &path, std::ifstream &ifs, std::string &checksum) noexcept {
+    using enum IoError;
     checksum.clear();
 
     try {
         std::error_code ec;
         const bool isSymlink = _isSymlink(path, ec);
-        if (const IoError ioError = stdError2ioError(ec); ioError != IoError::Success) return ioError;
-        if (isSymlink) return IoError::InvalidArgument;
+        if (const IoError ioError = stdError2ioError(ec); ioError != Success) return ioError;
+        if (isSymlink) return InvalidArgument;
 
 #if defined(KD_MACOS)
         bool isAlias = false;
-        IoError aliasError = IoError::Success;
+        IoError aliasError = Success;
         if (!IoHelper::_checkIfAlias(path, isAlias, aliasError)) return aliasError;
-        if (isAlias) return IoError::InvalidArgument;
+        if (isAlias) return InvalidArgument;
 #endif
 
-        IoError openError = IoError::Success;
+        IoError openError = Success;
         if (!IoHelper::openFile(path, ifs, openError) || !ifs) return openError;
 
         constexpr size_t chunkSize = 8 * 1024 * 1024; // 8 MB
         std::vector<char> buffer(chunkSize);
 
         XXH3_state_t *state = XXH3_createState();
-        if (state == nullptr) return IoError::Unknown;
+        if (state == nullptr) return Unknown;
 
         if (XXH3_64bits_reset(state) == XXH_ERROR) {
             XXH3_freeState(state);
-            return IoError::Unknown;
+            return Unknown;
         }
 
         std::streamsize readBytes(0);
@@ -800,7 +801,7 @@ IoError IoHelper::getFileChecksum(const SyncPath &path, std::ifstream &ifs, std:
             if (XXH3_64bits_update(state, buffer.data(), readBytes) == XXH_ERROR) {
                 ifs.close();
                 XXH3_freeState(state);
-                return IoError::Unknown;
+                return Unknown;
             }
         }
 
@@ -809,16 +810,16 @@ IoError IoHelper::getFileChecksum(const SyncPath &path, std::ifstream &ifs, std:
         XXH3_freeState(state);
 
         checksum = Utility::xxHashToStr(hash);
-        return IoError::Success;
+        return Success;
     } catch (const std::bad_alloc &) {
         LOGW_WARN(logger(), L"Memory allocation failed in getFileChecksum");
-        return IoError::Unknown;
+        return Unknown;
     } catch (const std::exception &e) {
         LOGW_WARN(logger(), L"Exception in getFileChecksum: " << CommonUtility::s2ws(e.what()));
-        return IoError::Unknown;
+        return Unknown;
     } catch (...) {
         LOGW_WARN(logger(), L"Unknown exception in getFileChecksum");
-        return IoError::Unknown;
+        return Unknown;
     }
 }
 

--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -767,53 +767,32 @@ void IoHelper::getFileStat(const SyncPath &path, FileStat *buf, bool &exists, Pa
 
 IoError IoHelper::getFileChecksum(const SyncPath &path, std::ifstream &ifs, std::string &checksum) noexcept {
     checksum.clear();
-    IoError ioError = IoError::Success;
 
     try {
         std::error_code ec;
-        auto status = std::filesystem::symlink_status(path, ec);
-        ioError = stdError2ioError(ec);
-
-        if (ioError != IoError::Success) return ioError;
-
-        if (std::filesystem::is_symlink(status)) {
-            ioError = IoError::InvalidArgument;
-            return ioError;
-        }
+        const bool isSymlink = _isSymlink(path, ec);
+        if (const IoError ioError = stdError2ioError(ec); ioError != IoError::Success) return ioError;
+        if (isSymlink) return IoError::InvalidArgument;
 
 #if defined(KD_MACOS)
         bool isAlias = false;
-        if (!IoHelper::_checkIfAlias(path, isAlias, ioError)) {
-            return ioError;
-        }
-        if (isAlias) {
-            ioError = IoError::InvalidArgument;
-            return ioError;
-        }
+        IoError aliasError = IoError::Success;
+        if (!IoHelper::_checkIfAlias(path, isAlias, aliasError)) return aliasError;
+        if (isAlias) return IoError::InvalidArgument;
 #endif
 
-        const bool isOpen = IoHelper::openFile(path, ifs, ioError);
-
-        if (!isOpen || !ifs) {
-            ioError = IoError::InvalidArgument;
-            return ioError;
-        }
+        IoError openError = IoError::Success;
+        if (!IoHelper::openFile(path, ifs, openError) || !ifs) return openError;
 
         constexpr size_t chunkSize = 8 * 1024 * 1024; // 8 MB
         std::vector<char> buffer(chunkSize);
 
         XXH3_state_t *state = XXH3_createState();
+        if (state == nullptr) return IoError::Unknown;
 
-        if (state == nullptr) {
-            ifs.close();
-            ioError = IoError::Unknown;
-            return ioError;
-        }
         if (XXH3_64bits_reset(state) == XXH_ERROR) {
-            ifs.close();
             XXH3_freeState(state);
-            ioError = IoError::Unknown;
-            return ioError;
+            return IoError::Unknown;
         }
 
         std::streamsize readBytes(0);
@@ -821,8 +800,7 @@ IoError IoHelper::getFileChecksum(const SyncPath &path, std::ifstream &ifs, std:
             if (XXH3_64bits_update(state, buffer.data(), readBytes) == XXH_ERROR) {
                 ifs.close();
                 XXH3_freeState(state);
-                ioError = IoError::Unknown;
-                return ioError;
+                return IoError::Unknown;
             }
         }
 
@@ -832,18 +810,15 @@ IoError IoHelper::getFileChecksum(const SyncPath &path, std::ifstream &ifs, std:
 
         checksum = Utility::xxHashToStr(hash);
         return IoError::Success;
-    } catch (const std::bad_alloc &e) {
+    } catch (const std::bad_alloc &) {
         LOGW_WARN(logger(), L"Memory allocation failed in getFileChecksum");
-        ioError = IoError::Unknown;
-        return ioError;
+        return IoError::Unknown;
     } catch (const std::exception &e) {
         LOGW_WARN(logger(), L"Exception in getFileChecksum: " << CommonUtility::s2ws(e.what()));
-        ioError = IoError::Unknown;
-        return ioError;
+        return IoError::Unknown;
     } catch (...) {
         LOGW_WARN(logger(), L"Unknown exception in getFileChecksum");
-        ioError = IoError::Unknown;
-        return ioError;
+        return IoError::Unknown;
     }
 }
 

--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -765,29 +765,30 @@ void IoHelper::getFileStat(const SyncPath &path, FileStat *buf, bool &exists, Pa
     }
 }
 
-std::string IoHelper::getFileChecksum(const SyncPath &path, std::ifstream &ifs, IoError &ioError) noexcept {
-    ioError = IoError::Success;
+IoError IoHelper::getFileChecksum(const SyncPath &path, std::ifstream &ifs, std::string &checksum) noexcept {
+    checksum.clear();
+    IoError ioError = IoError::Success;
 
     try {
         std::error_code ec;
         auto status = std::filesystem::symlink_status(path, ec);
         ioError = stdError2ioError(ec);
 
-        if (ioError != IoError::Success) return "";
+        if (ioError != IoError::Success) return ioError;
 
         if (std::filesystem::is_symlink(status)) {
             ioError = IoError::InvalidArgument;
-            return "";
+            return ioError;
         }
 
 #if defined(KD_MACOS)
         bool isAlias = false;
         if (!IoHelper::_checkIfAlias(path, isAlias, ioError)) {
-            return "";
+            return ioError;
         }
         if (isAlias) {
             ioError = IoError::InvalidArgument;
-            return "";
+            return ioError;
         }
 #endif
 
@@ -795,7 +796,7 @@ std::string IoHelper::getFileChecksum(const SyncPath &path, std::ifstream &ifs, 
 
         if (!isOpen || !ifs) {
             ioError = IoError::InvalidArgument;
-            return "";
+            return ioError;
         }
 
         constexpr size_t chunkSize = 8 * 1024 * 1024; // 8 MB
@@ -806,13 +807,13 @@ std::string IoHelper::getFileChecksum(const SyncPath &path, std::ifstream &ifs, 
         if (state == nullptr) {
             ifs.close();
             ioError = IoError::Unknown;
-            return "";
+            return ioError;
         }
         if (XXH3_64bits_reset(state) == XXH_ERROR) {
             ifs.close();
             XXH3_freeState(state);
             ioError = IoError::Unknown;
-            return "";
+            return ioError;
         }
 
         std::streamsize readBytes(0);
@@ -821,7 +822,7 @@ std::string IoHelper::getFileChecksum(const SyncPath &path, std::ifstream &ifs, 
                 ifs.close();
                 XXH3_freeState(state);
                 ioError = IoError::Unknown;
-                return "";
+                return ioError;
             }
         }
 
@@ -829,19 +830,20 @@ std::string IoHelper::getFileChecksum(const SyncPath &path, std::ifstream &ifs, 
         XXH64_hash_t hash = XXH3_64bits_digest(state);
         XXH3_freeState(state);
 
-        return Utility::xxHashToStr(hash);
+        checksum = Utility::xxHashToStr(hash);
+        return IoError::Success;
     } catch (const std::bad_alloc &e) {
         LOGW_WARN(logger(), L"Memory allocation failed in getFileChecksum");
         ioError = IoError::Unknown;
-        return "";
+        return ioError;
     } catch (const std::exception &e) {
         LOGW_WARN(logger(), L"Exception in getFileChecksum: " << CommonUtility::s2ws(e.what()));
         ioError = IoError::Unknown;
-        return "";
+        return ioError;
     } catch (...) {
         LOGW_WARN(logger(), L"Unknown exception in getFileChecksum");
         ioError = IoError::Unknown;
-        return "";
+        return ioError;
     }
 }
 

--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -798,8 +798,8 @@ std::string IoHelper::getFileChecksum(const SyncPath &path, std::ifstream &ifs, 
             return "";
         }
 
-        constexpr size_t CHUNK_SIZE = 8 * 1024 * 1024; // 8 MB
-        std::vector<char> buffer(CHUNK_SIZE);
+        constexpr size_t chunkSize = 8 * 1024 * 1024; // 8 MB
+        std::vector<char> buffer(chunkSize);
 
         XXH3_state_t *state = XXH3_createState();
 

--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -762,6 +762,35 @@ void IoHelper::getFileStat(const SyncPath &path, FileStat *buf, bool &exists, Pa
     }
 }
 
+std::string IoHelper::getFileChecksum(const SyncPath &path, std::ifstream &ifs, IoError &ioError) {
+    ioError = IoError::Success;
+
+    IoHelper::openFile(path, ifs, ioError);
+
+    if (!ifs) {
+        ioError = IoError::NoSuchFileOrDirectory;
+        return "";
+    }
+
+    constexpr size_t CHUNK_SIZE = 8 * 1024 * 1024; // 8 MB
+    std::vector<char> buffer(CHUNK_SIZE);
+
+    XXH3_state_t *state = XXH3_createState();
+    XXH3_64bits_reset(state);
+
+    size_t readBytes;
+    while ((readBytes = fread(buffer.data(), 1, buffer.size(), f)) > 0) {
+        XXH3_64bits_update(state, buffer.data(), readBytes);
+    }
+
+    fclose(f);
+
+    XXH64_hash_t hash = XXH3_64bits_digest(state);
+    XXH3_freeState(state);
+
+    return Utility::xxHashToStr(hash);
+}
+
 bool IoHelper::checkIfFileChanged(const SyncPath &path, int64_t previousSize, SyncTime previousMtime,
                                   SyncTime previousCreationTime, bool &changed, IoError &ioError) noexcept {
     changed = false;

--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -801,11 +801,27 @@ std::string IoHelper::getFileChecksum(const SyncPath &path, std::ifstream &ifs, 
         std::vector<char> buffer(CHUNK_SIZE);
 
         XXH3_state_t *state = XXH3_createState();
-        XXH3_64bits_reset(state);
+
+        if (state == nullptr) {
+            ifs.close();
+            ioError = IoError::Unknown;
+            return "";
+        }
+        if (XXH3_64bits_reset(state) == XXH_ERROR) {
+            ifs.close();
+            XXH3_freeState(state);
+            ioError = IoError::Unknown;
+            return "";
+        }
 
         std::streamsize readBytes(0);
         while ((readBytes = ifs.read(buffer.data(), buffer.size()).gcount()) > 0) {
-            XXH3_64bits_update(state, buffer.data(), readBytes);
+            if (XXH3_64bits_update(state, buffer.data(), readBytes) == XXH_ERROR) {
+                ifs.close();
+                XXH3_freeState(state);
+                ioError = IoError::Unknown;
+                return "";
+            }
         }
 
         ifs.close();

--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -790,10 +790,9 @@ std::string IoHelper::getFileChecksum(const SyncPath &path, std::ifstream &ifs, 
     }
 #endif
 
-    (void) IoHelper::openFile(path, ifs, ioError);
+    const bool isOpen = IoHelper::openFile(path, ifs, ioError);
 
-    if (!ifs) {
-        ioError = IoError::NoSuchFileOrDirectory;
+    if (!isOpen || !ifs) {
         return "";
     }
 

--- a/src/libcommonserver/io/iohelper.h
+++ b/src/libcommonserver/io/iohelper.h
@@ -161,6 +161,7 @@ struct IoHelper {
         //! Get the checksum of the file indicated by `path`.
         /*!
          \param path is a file system path to a directory entry (we also call it an item).
+         \param ifs is an input file stream used to read the file contents.
          \param ioError holds the error returned when an underlying OS API call fails.
          \return the checksum of the file indicated by `path`.
          */

--- a/src/libcommonserver/io/iohelper.h
+++ b/src/libcommonserver/io/iohelper.h
@@ -158,6 +158,14 @@ struct IoHelper {
         // file status. This is a convenience function to be used in tests only.
         static void getFileStat(const SyncPath &path, FileStat *filestat, bool &exists, PathCheckOption option);
 
+        //! Get the checksum of the file indicated by `path`.
+        /*!
+         \param path is a file system path to a directory entry (we also call it an item).
+         \param ioError holds the error returned when an underlying OS API call fails.
+         \return the checksum of the file indicated by `path`.
+         */
+        static std::string getFileChecksum(const SyncPath &path, std::ifstream &ifs, IoError &ioError) noexcept;
+
         //! Check if the item indicated by path has a size or a modification date different from the specified ones.
         /*!
          \param path is a file system path to a directory entry (we also call it an item).

--- a/src/libcommonserver/io/iohelper.h
+++ b/src/libcommonserver/io/iohelper.h
@@ -162,10 +162,10 @@ struct IoHelper {
         /*!
          \param path is a file system path to a directory entry (we also call it an item).
          \param ifs is an input file stream used to read the file contents.
-         \param ioError holds the error returned when an underlying OS API call fails.
-         \return the checksum of the file indicated by `path`.
+         \param checksum is set with the checksum of the file indicated by `path`, or empty on error.
+         \return the IoError representing the success or failure of the operation.
          */
-        static std::string getFileChecksum(const SyncPath &path, std::ifstream &ifs, IoError &ioError) noexcept;
+        static IoError getFileChecksum(const SyncPath &path, std::ifstream &ifs, std::string &checksum) noexcept;
 
         //! Check if the item indicated by path has a size or a modification date different from the specified ones.
         /*!

--- a/test/libcommon/CMakeLists.txt
+++ b/test/libcommon/CMakeLists.txt
@@ -30,8 +30,7 @@ set(testcommon_SRCS
         io/testio.h io/testio.cpp io/testgetitemtype.cpp io/testgetfilesize.cpp io/testcheckifpathexists.cpp io/testgetnodeid.cpp io/testgetfilestat.cpp io/testgetrights.cpp io/testisfileaccessible.cpp io/testfilechanged.cpp
         io/testcheckifisdirectory.cpp io/testcreatesymlink.cpp io/testcheckifdehydrated.cpp io/testcheckdirectoryiterator.cpp io/testrights.cpp io/testopenfile.cpp io/testgetdirectorysize.cpp
         io/testmoveitemtotrash.cpp io/testispathonmounteddisk.cpp
-        io/testcachedirectory.h io/testcachedirectory.cpp
-)
+        io/testcachedirectory.h io/testcachedirectory.cpp io/testgetfilechecksum.cpp)
 
 if(APPLE)
     list(APPEND testcommon_SRCS ../test_utility/testhelpers_mac.cpp io/testcreatealias.cpp io/testreadalias.cpp io/testgetxattrvalue.cpp io/testsetxattrvalue.cpp io/testremovexattr.cpp)
@@ -46,8 +45,6 @@ if(WIN32)
 else()
     include_directories("/usr/local/include")
 endif()
-
-add_executable(${testcommon_NAME} ${testcommon_SRCS})
 
 # Precompiled headers
 set(PC_HEADER_FILES

--- a/test/libcommon/CMakeLists.txt
+++ b/test/libcommon/CMakeLists.txt
@@ -46,6 +46,8 @@ else()
     include_directories("/usr/local/include")
 endif()
 
+add_executable(${testcommon_NAME} ${testcommon_SRCS})
+
 # Precompiled headers
 set(PC_HEADER_FILES
     # std c++

--- a/test/libcommon/io/testgetfilechecksum.cpp
+++ b/test/libcommon/io/testgetfilechecksum.cpp
@@ -192,7 +192,7 @@ void TestIo::testGetFileChecksum() {
         std::ifstream ifs;
 
         auto checksum = IoHelper::getFileChecksum(path, ifs, ioError);
-        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+        CPPUNIT_ASSERT_EQUAL(IoError::InvalidArgument, ioError);
         CPPUNIT_ASSERT(checksum.empty());
         CPPUNIT_ASSERT_EQUAL(std::string(""), checksum);
     }
@@ -240,53 +240,6 @@ void TestIo::testGetFileChecksum() {
         auto checksum = IoHelper::getFileChecksum(path, ifs, ioError);
         CPPUNIT_ASSERT_EQUAL(IoError::InvalidArgument, ioError);
         CPPUNIT_ASSERT(checksum.empty());
-    } /*
-#elif defined(KD_WINDOWS)
-    // A junction on a regular directory.
-    {
-        const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath targetPath = temporaryDirectory.path() / "regular_dir";
-        const SyncPath path = temporaryDirectory.path() / "regular_dir_alias";
-
-        std::error_code ec;
-        CPPUNIT_ASSERT(std::filesystem::create_directory(targetPath, ec) && ec.value() == 0);
-
-        IoError junctionError{IoError::Unknown};
-        IoHelper::createJunctionFromPath(targetPath, path, junctionError);
-        CPPUNIT_ASSERT(junctionError == IoError::Success);
-
-        FileStat fileStat;
-        IoError ioError = IoError::Unknown;
-
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
-        CPPUNIT_ASSERT(!fileStat.isHidden);
-        CPPUNIT_ASSERT_EQUAL(int64_t{0},
-                             fileStat.size); // `fileStat.size` is 0 for a junction`
-        CPPUNIT_ASSERT_GREATEREQUAL(fileStat.creationTime, fileStat.modificationTime);
-        CPPUNIT_ASSERT_EQUAL(NodeType::Directory, fileStat.nodeType);
-        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
-    }
-
-    // A dangling junction on a non-existing directory.
-    {
-        const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath targetPath = _localTestDirPath / "dummy"; // Non existing directory
-        const SyncPath path = temporaryDirectory.path() / "regular_dir_alias";
-
-        IoError junctionError{IoError::Unknown};
-        IoHelper::createJunctionFromPath(targetPath, path, junctionError);
-        CPPUNIT_ASSERT(junctionError == IoError::Success);
-
-        FileStat fileStat;
-        IoError ioError = IoError::Unknown;
-
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
-        CPPUNIT_ASSERT(!fileStat.isHidden);
-        CPPUNIT_ASSERT_EQUAL(int64_t{0},
-                             fileStat.size); // `fileStat.size` is 0 for a junction`
-        CPPUNIT_ASSERT_GREATEREQUAL(fileStat.creationTime, fileStat.modificationTime);
-        CPPUNIT_ASSERT_EQUAL(NodeType::Directory, fileStat.nodeType);
-        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
     }
 #endif
 
@@ -301,46 +254,20 @@ void TestIo::testGetFileChecksum() {
 
         std::filesystem::permissions(path, std::filesystem::perms::all, std::filesystem::perm_options::remove);
 
-        FileStat fileStat;
         IoError ioError = IoError::Unknown;
+        std::ifstream ifs;
 
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
+        auto checksum = IoHelper::getFileChecksum(path, ifs, ioError);
+        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+        CPPUNIT_ASSERT(!checksum.empty());
+        CPPUNIT_ASSERT_EQUAL(std::string("3d48b0e057db6f01"), checksum);
 
         std::filesystem::permissions(path, std::filesystem::perms::all, std::filesystem::perm_options::add);
 
-        CPPUNIT_ASSERT(!fileStat.isHidden);
-        CPPUNIT_ASSERT_GREATER(int64_t{0}, fileStat.size);
-        CPPUNIT_ASSERT_GREATER(SyncTime{0}, fileStat.creationTime);
-        CPPUNIT_ASSERT_GREATEREQUAL(fileStat.creationTime, fileStat.modificationTime);
-        CPPUNIT_ASSERT_EQUAL(NodeType::File, fileStat.nodeType);
+        checksum = IoHelper::getFileChecksum(path, ifs, ioError);
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
-    }
-
-    // A regular directory missing all permissions (no error expected)
-    {
-        const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path() / "permission_less_directory";
-        std::filesystem::create_directory(path);
-
-        std::filesystem::permissions(path, std::filesystem::perms::all, std::filesystem::perm_options::remove);
-
-        FileStat fileStat;
-        IoError ioError = IoError::Unknown;
-
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
-
-        std::filesystem::permissions(path, std::filesystem::perms::all, std::filesystem::perm_options::add);
-
-        CPPUNIT_ASSERT(!fileStat.isHidden);
-#if defined(KD_WINDOWS)
-        CPPUNIT_ASSERT_EQUAL(int64_t{0}, fileStat.size);
-#else
-        CPPUNIT_ASSERT(fileStat.size > 0u);
-#endif
-        CPPUNIT_ASSERT_GREATER(SyncTime{0}, fileStat.creationTime);
-        CPPUNIT_ASSERT_GREATEREQUAL(fileStat.creationTime, fileStat.modificationTime);
-        CPPUNIT_ASSERT_EQUAL(NodeType::Directory, fileStat.nodeType);
-        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+        CPPUNIT_ASSERT(!checksum.empty());
+        CPPUNIT_ASSERT_EQUAL(std::string("3d48b0e057db6f01"), checksum);
     }
 
     // A regular file within a subdirectory that misses owner read permission (no error expected)
@@ -355,20 +282,23 @@ void TestIo::testGetFileChecksum() {
         }
         std::filesystem::permissions(subdir, std::filesystem::perms::owner_read, std::filesystem::perm_options::remove);
 
-        FileStat fileStat;
         IoError ioError = IoError::Unknown;
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
+        std::ifstream ifs;
+
+        auto checksum = IoHelper::getFileChecksum(path, ifs, ioError);
+        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+        CPPUNIT_ASSERT(!checksum.empty());
+        CPPUNIT_ASSERT_EQUAL(std::string("3d48b0e057db6f01"), checksum);
 
         // Restore permission to allow subdir removal
         std::filesystem::permissions(subdir, std::filesystem::perms::owner_read, std::filesystem::perm_options::add);
 
-        CPPUNIT_ASSERT(!fileStat.isHidden);
-        CPPUNIT_ASSERT_GREATER(int64_t{0}, fileStat.size);
-        CPPUNIT_ASSERT_GREATER(SyncTime{0}, fileStat.creationTime);
-        CPPUNIT_ASSERT_GREATEREQUAL(fileStat.creationTime, fileStat.modificationTime);
-        CPPUNIT_ASSERT_EQUAL(NodeType::File, fileStat.nodeType);
+        checksum = IoHelper::getFileChecksum(path, ifs, ioError);
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+        CPPUNIT_ASSERT(!checksum.empty());
+        CPPUNIT_ASSERT_EQUAL(std::string("3d48b0e057db6f01"), checksum);
     }
+    /*
 
     // A regular file within a subdirectory that misses owner search/exec permission:
     // - access denied expected on MacOSX
@@ -404,8 +334,8 @@ void TestIo::testGetFileChecksum() {
         CPPUNIT_ASSERT_EQUAL(SyncTime{0}, fileStat.creationTime);
         CPPUNIT_ASSERT_EQUAL(NodeType::Unknown, fileStat.nodeType);
         CPPUNIT_ASSERT_EQUAL(IoError::AccessDenied, ioError);
-    }*/
-#endif
+    }
+#endif*/
 }
 
 } // namespace KDC

--- a/test/libcommon/io/testgetfilechecksum.cpp
+++ b/test/libcommon/io/testgetfilechecksum.cpp
@@ -270,7 +270,7 @@ void TestIo::testGetFileChecksum() {
         CPPUNIT_ASSERT(!checksum.empty());
         CPPUNIT_ASSERT_EQUAL(std::string("91f9d1732ca53515"), checksum);
 #else
-        CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
+        CPPUNIT_ASSERT_EQUAL(IoError::AccessDenied, ioError);
         CPPUNIT_ASSERT(checksum.empty());
         CPPUNIT_ASSERT_EQUAL(std::string(""), checksum);
 #endif

--- a/test/libcommon/io/testgetfilechecksum.cpp
+++ b/test/libcommon/io/testgetfilechecksum.cpp
@@ -1,0 +1,582 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "testio.h"
+
+#include <filesystem>
+#include <fstream>
+
+using namespace CppUnit;
+
+namespace KDC {
+
+void TestIo::testGetFileStat() {
+    // A regular file
+    {
+        const SyncPath path = _localTestDirPath / "test_pictures/picture-1.jpg";
+        IoError ioError = IoError::Unknown;
+        std::ifstream ifs;
+
+        CPPUNIT_ASSERT_EQUAL(IoHelper::getFileChecksum(path, ifs, ioError), std::string(""));
+        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+    }
+    /*
+    // A regular file whose name exists with a different capitalization
+    {
+        const SyncPath path = _localTestDirPath / "test_pictures/Picture-1.jpg";
+        std::ifstream ifs;
+        IoError ioError = IoError::Unknown;
+
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
+#if defined(KD_MACOS) || defined(KD_WINDOWS)
+        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+#else
+        CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
+#endif
+
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Sensitive));
+        CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
+    }
+
+    // A regular directory
+    {
+        const SyncPath path = _localTestDirPath / "test_pictures";
+        FileStat fileStat;
+        IoError ioError = IoError::Unknown;
+
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
+        CPPUNIT_ASSERT(!fileStat.isHidden);
+#if defined(KD_WINDOWS)
+        CPPUNIT_ASSERT_EQUAL(int64_t{0}, fileStat.size);
+#else
+        CPPUNIT_ASSERT(fileStat.size > 0);
+#endif
+        CPPUNIT_ASSERT_GREATER(SyncTime{0}, fileStat.creationTime);
+        CPPUNIT_ASSERT_GREATEREQUAL(fileStat.creationTime, fileStat.modificationTime);
+        CPPUNIT_ASSERT_GREATER(SyncTime{0}, fileStat.creationTime);
+        CPPUNIT_ASSERT_EQUAL(NodeType::Directory, fileStat.nodeType);
+        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+
+        NodeId nodeId;
+        CPPUNIT_ASSERT(IoHelper::getNodeId(path, nodeId));
+        CPPUNIT_ASSERT_EQUAL(nodeId, std::to_string(fileStat.inode));
+    }
+
+    // A regular symbolic link on a file
+    {
+        const SyncPath targetPath = _localTestDirPath / "test_pictures/picture-1.jpg";
+        const LocalTemporaryDirectory temporaryDirectory;
+        const SyncPath path = temporaryDirectory.path() / "regular_file_symbolic_link";
+        std::filesystem::create_symlink(targetPath, path);
+
+        FileStat fileStat;
+        IoError ioError = IoError::Unknown;
+
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
+        CPPUNIT_ASSERT(!fileStat.isHidden);
+#if defined(KD_WINDOWS)
+        CPPUNIT_ASSERT_EQUAL(int64_t{0}, fileStat.size);
+#else
+        CPPUNIT_ASSERT(fileStat.size == static_cast<int64_t>(targetPath.native().length()));
+#endif
+        CPPUNIT_ASSERT_GREATEREQUAL(fileStat.creationTime, fileStat.modificationTime);
+        CPPUNIT_ASSERT_EQUAL(NodeType::File, fileStat.nodeType);
+        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+
+        NodeId nodeId;
+        CPPUNIT_ASSERT(IoHelper::getNodeId(path, nodeId));
+        CPPUNIT_ASSERT_EQUAL(nodeId, std::to_string(fileStat.inode));
+    }
+
+    // A regular symbolic link on a folder
+    {
+        const SyncPath targetPath = _localTestDirPath / "test_pictures";
+        const LocalTemporaryDirectory temporaryDirectory;
+        const SyncPath path = temporaryDirectory.path() / "regular_dir_symbolic_link";
+        std::filesystem::create_directory_symlink(targetPath, path);
+
+        FileStat fileStat;
+        IoError ioError = IoError::Unknown;
+
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
+        CPPUNIT_ASSERT(!fileStat.isHidden);
+#if defined(KD_WINDOWS)
+        CPPUNIT_ASSERT_EQUAL(int64_t{0}, fileStat.size);
+#else
+        CPPUNIT_ASSERT(fileStat.size == static_cast<int64_t>(targetPath.native().length()));
+#endif
+        CPPUNIT_ASSERT_EQUAL(NodeType::Directory, fileStat.nodeType);
+        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+    }
+
+    // A non-existing file
+    {
+        const SyncPath path = _localTestDirPath / "non-existing.jpg"; // This file does not exist.
+        FileStat fileStat;
+        IoError ioError = IoError::Success;
+
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
+        CPPUNIT_ASSERT(!fileStat.isHidden);
+        CPPUNIT_ASSERT_EQUAL(int64_t{0}, fileStat.size);
+        CPPUNIT_ASSERT_EQUAL(SyncTime{0}, fileStat.modificationTime);
+        CPPUNIT_ASSERT_EQUAL(SyncTime{0}, fileStat.creationTime);
+        CPPUNIT_ASSERT_EQUAL(uint64_t{0}, fileStat.inode);
+        CPPUNIT_ASSERT_EQUAL(NodeType::Unknown, fileStat.nodeType);
+        CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
+    }
+
+    // A non-existing file with a very long name
+    {
+        const std::string veryLongfileName(1000, 'a'); // Exceeds the max allowed name length on every file system of interest.
+        const SyncPath path = _localTestDirPath / veryLongfileName; // This file doesn't exist.
+        FileStat fileStat;
+        IoError ioError = IoError::Success;
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
+        CPPUNIT_ASSERT(!fileStat.isHidden);
+        CPPUNIT_ASSERT_EQUAL(int64_t{0}, fileStat.size);
+        CPPUNIT_ASSERT_EQUAL(uint64_t{0}, fileStat.inode);
+        CPPUNIT_ASSERT_EQUAL(SyncTime{0}, fileStat.modificationTime);
+        CPPUNIT_ASSERT_EQUAL(SyncTime{0}, fileStat.creationTime);
+        CPPUNIT_ASSERT_EQUAL(NodeType::Unknown, fileStat.nodeType);
+#if defined(KD_WINDOWS)
+        CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
+#else
+        CPPUNIT_ASSERT_EQUAL(IoError::FileNameTooLong, ioError);
+#endif
+    }
+
+    // A non-existing file with a very long path
+    {
+        const std::string pathSegment(50, 'a');
+        SyncPath path = _localTestDirPath;
+        for (auto i = 0; i < 1000; ++i) {
+            path /= pathSegment; // Eventually exceeds the max allowed path length on every file system of interest.
+        }
+        FileStat fileStat;
+        IoError ioError = IoError::Success;
+
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
+        CPPUNIT_ASSERT(!fileStat.isHidden);
+        CPPUNIT_ASSERT_EQUAL(int64_t{0}, fileStat.size);
+        CPPUNIT_ASSERT_EQUAL(uint64_t{0}, fileStat.inode);
+        CPPUNIT_ASSERT_EQUAL(SyncTime{0}, fileStat.modificationTime);
+        CPPUNIT_ASSERT_EQUAL(SyncTime{0}, fileStat.creationTime);
+        CPPUNIT_ASSERT_EQUAL(NodeType::Unknown, fileStat.nodeType);
+#if defined(KD_WINDOWS)
+        CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
+#else
+        CPPUNIT_ASSERT_EQUAL(IoError::FileNameTooLong, ioError);
+#endif
+    }
+
+    // A hidden file
+    {
+        const LocalTemporaryDirectory temporaryDirectory;
+#if defined(KD_MACOS) || defined(KD_WINDOWS)
+        const SyncPath path = temporaryDirectory.path() / "hidden_file.txt";
+#else
+        const SyncPath path = temporaryDirectory.path() / ".hidden_file.txt";
+#endif
+        {
+            std::ofstream ofs(path);
+            ofs << "Some content.\n";
+        }
+
+#if defined(KD_MACOS) || defined(KD_WINDOWS)
+        IoHelper::setFileHidden(path, true);
+#endif
+
+        FileStat fileStat;
+        IoError ioError = IoError::Unknown;
+
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
+
+        CPPUNIT_ASSERT(fileStat.isHidden);
+        CPPUNIT_ASSERT_GREATER(int64_t{0}, fileStat.size);
+        CPPUNIT_ASSERT_GREATER(SyncTime{0}, fileStat.creationTime);
+        CPPUNIT_ASSERT_GREATEREQUAL(fileStat.creationTime, fileStat.modificationTime);
+        CPPUNIT_ASSERT_EQUAL(NodeType::File, fileStat.nodeType);
+        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+    }
+
+    // A hidden directory
+    {
+        const LocalTemporaryDirectory temporaryDirectory;
+#if defined(KD_MACOS) || defined(KD_WINDOWS)
+        const SyncPath &path = temporaryDirectory.path();
+#else
+        const SyncPath path = temporaryDirectory.path() / ".hidden_directory";
+        std::filesystem::create_directory(path);
+#endif
+
+#if defined(KD_MACOS) || defined(KD_WINDOWS)
+        IoHelper::setFileHidden(path, true);
+#endif
+        FileStat fileStat;
+        IoError ioError = IoError::Unknown;
+
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
+        CPPUNIT_ASSERT(fileStat.isHidden);
+        CPPUNIT_ASSERT_GREATER(SyncTime{0}, fileStat.creationTime);
+        CPPUNIT_ASSERT_GREATEREQUAL(fileStat.creationTime, fileStat.modificationTime);
+        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+        CPPUNIT_ASSERT_EQUAL(NodeType::Directory, fileStat.nodeType);
+    }
+
+    // A file with dots and colons in its name
+    {
+        const LocalTemporaryDirectory temporaryDirectory;
+        const SyncPath path = temporaryDirectory.path() / ":.file.::.name.:";
+        {
+            std::ofstream ofs(path);
+            ofs << "Some content.\n";
+        }
+
+        FileStat fileStat;
+        IoError ioError = IoError::Unknown;
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
+
+#if defined(KD_WINDOWS)
+        CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
+        CPPUNIT_ASSERT(!fileStat.isHidden);
+        CPPUNIT_ASSERT_EQUAL(int64_t{0}, fileStat.size);
+        CPPUNIT_ASSERT_EQUAL(uint64_t{0}, fileStat.inode);
+        CPPUNIT_ASSERT_EQUAL(SyncTime{0}, fileStat.modificationTime);
+        CPPUNIT_ASSERT_EQUAL(SyncTime{0}, fileStat.creationTime);
+        CPPUNIT_ASSERT_EQUAL(NodeType::Unknown, fileStat.nodeType);
+#else
+        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+        CPPUNIT_ASSERT(!fileStat.isHidden);
+        CPPUNIT_ASSERT_GREATER(int64_t{0}, fileStat.size);
+        CPPUNIT_ASSERT_GREATER(SyncTime{0}, fileStat.creationTime);
+        CPPUNIT_ASSERT_EQUAL(fileStat.modificationTime, fileStat.creationTime);
+        CPPUNIT_ASSERT_EQUAL(NodeType::File, fileStat.nodeType);
+#endif
+    }
+
+    // An existing file with emojis in its name
+    {
+        const LocalTemporaryDirectory temporaryDirectory;
+        const SyncPath path = temporaryDirectory.path() / makeFileNameWithEmojis();
+        {
+            std::ofstream ofs(path);
+            ofs << "Some content.\n";
+            ofs.close();
+        }
+
+        FileStat fileStat;
+        IoError ioError = IoError::Unknown;
+
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
+        CPPUNIT_ASSERT(!fileStat.isHidden);
+        CPPUNIT_ASSERT_GREATER(int64_t{0}, fileStat.size);
+        CPPUNIT_ASSERT_GREATER(SyncTime{0}, fileStat.creationTime);
+        CPPUNIT_ASSERT_GREATEREQUAL(fileStat.creationTime, fileStat.modificationTime);
+        CPPUNIT_ASSERT_EQUAL(NodeType::File, fileStat.nodeType);
+        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+    }
+
+    // A dangling symbolic link
+    {
+        const LocalTemporaryDirectory temporaryDirectory;
+        const SyncPath targetPath = temporaryDirectory.path() / "non_existing_test_file.txt"; // This file does not exist.
+        const SyncPath path = temporaryDirectory.path() / "dangling_symbolic_link";
+        std::filesystem::create_symlink(targetPath, path);
+
+        FileStat fileStat;
+        IoError ioError = IoError::Unknown;
+
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
+        CPPUNIT_ASSERT_GREATER(SyncTime{0}, fileStat.creationTime);
+        CPPUNIT_ASSERT(!fileStat.isHidden);
+#if defined(KD_WINDOWS)
+        CPPUNIT_ASSERT_EQUAL(int64_t{0}, fileStat.size);
+#else
+        CPPUNIT_ASSERT_EQUAL(static_cast<int64_t>(targetPath.native().length()), fileStat.size);
+#endif
+        CPPUNIT_ASSERT_GREATER(SyncTime{0}, fileStat.creationTime);
+        CPPUNIT_ASSERT_GREATEREQUAL(fileStat.creationTime, fileStat.modificationTime);
+#if defined(KD_WINDOWS)
+        CPPUNIT_ASSERT_EQUAL(NodeType::File, fileStat.nodeType);
+#else
+        CPPUNIT_ASSERT_EQUAL(NodeType::Unknown, fileStat.nodeType);
+#endif
+        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+    }
+#if defined(KD_MACOS)
+    // A MacOSX Finder alias on a regular file.
+    {
+        const LocalTemporaryDirectory temporaryDirectory;
+        const SyncPath targetPath = _localTestDirPath / "test_pictures/picture-1.jpg";
+        const SyncPath path = temporaryDirectory.path() / "regular_file_alias";
+
+        IoError aliasError;
+        IoHelper::createAliasFromPath(targetPath, path, aliasError);
+
+        FileStat fileStat;
+        IoError ioError = IoError::Unknown;
+
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
+        CPPUNIT_ASSERT(!fileStat.isHidden);
+        CPPUNIT_ASSERT_GREATER(int64_t{0},
+                               fileStat.size); // `fileStat.size` is greater than `static_cast<int64_t>(path.native().length())`
+
+        CPPUNIT_ASSERT_GREATER(SyncTime{0}, fileStat.creationTime);
+        CPPUNIT_ASSERT_GREATEREQUAL(fileStat.creationTime, fileStat.modificationTime);
+        CPPUNIT_ASSERT_EQUAL(NodeType::File, fileStat.nodeType);
+        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+    }
+
+    // A MacOSX Finder alias on a regular directory.
+    {
+        const LocalTemporaryDirectory temporaryDirectory;
+        const SyncPath targetPath = _localTestDirPath / "test_pictures";
+        const SyncPath path = temporaryDirectory.path() / "regular_dir_alias";
+
+        IoError aliasError;
+        IoHelper::createAliasFromPath(targetPath, path, aliasError);
+
+        FileStat fileStat;
+        IoError ioError = IoError::Unknown;
+
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
+        CPPUNIT_ASSERT(!fileStat.isHidden);
+        CPPUNIT_ASSERT_GREATER(int64_t{0}, fileStat.size);
+        CPPUNIT_ASSERT_GREATER(SyncTime{0}, fileStat.creationTime);
+        CPPUNIT_ASSERT_GREATEREQUAL(fileStat.creationTime, fileStat.modificationTime);
+        CPPUNIT_ASSERT_EQUAL(NodeType::File, fileStat.nodeType);
+        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+    }
+
+    // A dangling MacOSX Finder alias on a non-existing file.
+    {
+        const LocalTemporaryDirectory temporaryDirectory;
+        const SyncPath targetPath = temporaryDirectory.path() / "file_to_be_deleted.png"; // This file will be deleted.
+        const SyncPath path = temporaryDirectory.path() / "dangling_file_alias";
+        {
+            std::ofstream ofs(targetPath);
+            ofs << "Some content.\n";
+        }
+
+        IoError aliasError;
+        IoHelper::createAliasFromPath(targetPath, path, aliasError);
+        (void) IoHelper::deleteItem(targetPath);
+
+        FileStat fileStat;
+        IoError ioError = IoError::Unknown;
+
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
+        CPPUNIT_ASSERT(!fileStat.isHidden);
+        CPPUNIT_ASSERT_GREATER(int64_t{0},
+                               fileStat.size); // `fileStat.size` is greater than `static_cast<int64_t>(path.native().length())`
+        CPPUNIT_ASSERT_GREATEREQUAL(fileStat.creationTime, fileStat.modificationTime);
+        CPPUNIT_ASSERT_EQUAL(NodeType::File, fileStat.nodeType);
+        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+    }
+
+    // A dangling MacOSX Finder alias on a non-existing directory.
+    {
+        const LocalTemporaryDirectory temporaryDirectory;
+        const SyncPath targetPath = temporaryDirectory.path() / "directory_to_be_deleted"; // This directory will be deleted.
+        std::filesystem::create_directory(targetPath);
+
+        const SyncPath path = temporaryDirectory.path() / "dangling_directory_alias";
+
+        auto aliasError = IoError::Unknown;
+        CPPUNIT_ASSERT_MESSAGE(toString(aliasError), IoHelper::createAliasFromPath(targetPath, path, aliasError));
+        (void) IoHelper::deleteItem(targetPath);
+
+        FileStat fileStat;
+        IoError ioError = IoError::Unknown;
+
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
+        CPPUNIT_ASSERT(!fileStat.isHidden);
+        CPPUNIT_ASSERT_GREATER(int64_t{0},
+                               fileStat.size); // `fileStat.size` is greater than `static_cast<int64_t>(path.native().length())`
+        CPPUNIT_ASSERT_GREATEREQUAL(fileStat.creationTime, fileStat.modificationTime);
+        CPPUNIT_ASSERT_EQUAL(NodeType::File, fileStat.nodeType);
+        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+    }
+#elif defined(KD_WINDOWS)
+    // A junction on a regular directory.
+    {
+        const LocalTemporaryDirectory temporaryDirectory;
+        const SyncPath targetPath = temporaryDirectory.path() / "regular_dir";
+        const SyncPath path = temporaryDirectory.path() / "regular_dir_alias";
+
+        std::error_code ec;
+        CPPUNIT_ASSERT(std::filesystem::create_directory(targetPath, ec) && ec.value() == 0);
+
+        IoError junctionError{IoError::Unknown};
+        IoHelper::createJunctionFromPath(targetPath, path, junctionError);
+        CPPUNIT_ASSERT(junctionError == IoError::Success);
+
+        FileStat fileStat;
+        IoError ioError = IoError::Unknown;
+
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
+        CPPUNIT_ASSERT(!fileStat.isHidden);
+        CPPUNIT_ASSERT_EQUAL(int64_t{0},
+                             fileStat.size); // `fileStat.size` is 0 for a junction`
+        CPPUNIT_ASSERT_GREATEREQUAL(fileStat.creationTime, fileStat.modificationTime);
+        CPPUNIT_ASSERT_EQUAL(NodeType::Directory, fileStat.nodeType);
+        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+    }
+
+    // A dangling junction on a non-existing directory.
+    {
+        const LocalTemporaryDirectory temporaryDirectory;
+        const SyncPath targetPath = _localTestDirPath / "dummy"; // Non existing directory
+        const SyncPath path = temporaryDirectory.path() / "regular_dir_alias";
+
+        IoError junctionError{IoError::Unknown};
+        IoHelper::createJunctionFromPath(targetPath, path, junctionError);
+        CPPUNIT_ASSERT(junctionError == IoError::Success);
+
+        FileStat fileStat;
+        IoError ioError = IoError::Unknown;
+
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
+        CPPUNIT_ASSERT(!fileStat.isHidden);
+        CPPUNIT_ASSERT_EQUAL(int64_t{0},
+                             fileStat.size); // `fileStat.size` is 0 for a junction`
+        CPPUNIT_ASSERT_GREATEREQUAL(fileStat.creationTime, fileStat.modificationTime);
+        CPPUNIT_ASSERT_EQUAL(NodeType::Directory, fileStat.nodeType);
+        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+    }
+#endif
+
+    // A regular file missing all permissions (no error expected)
+    {
+        const LocalTemporaryDirectory temporaryDirectory;
+        const SyncPath path = temporaryDirectory.path() / "permission_less_file.txt";
+        {
+            std::ofstream ofs(path);
+            ofs << "Some content.\n";
+        }
+
+        std::filesystem::permissions(path, std::filesystem::perms::all, std::filesystem::perm_options::remove);
+
+        FileStat fileStat;
+        IoError ioError = IoError::Unknown;
+
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
+
+        std::filesystem::permissions(path, std::filesystem::perms::all, std::filesystem::perm_options::add);
+
+        CPPUNIT_ASSERT(!fileStat.isHidden);
+        CPPUNIT_ASSERT_GREATER(int64_t{0}, fileStat.size);
+        CPPUNIT_ASSERT_GREATER(SyncTime{0}, fileStat.creationTime);
+        CPPUNIT_ASSERT_GREATEREQUAL(fileStat.creationTime, fileStat.modificationTime);
+        CPPUNIT_ASSERT_EQUAL(NodeType::File, fileStat.nodeType);
+        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+    }
+
+    // A regular directory missing all permissions (no error expected)
+    {
+        const LocalTemporaryDirectory temporaryDirectory;
+        const SyncPath path = temporaryDirectory.path() / "permission_less_directory";
+        std::filesystem::create_directory(path);
+
+        std::filesystem::permissions(path, std::filesystem::perms::all, std::filesystem::perm_options::remove);
+
+        FileStat fileStat;
+        IoError ioError = IoError::Unknown;
+
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
+
+        std::filesystem::permissions(path, std::filesystem::perms::all, std::filesystem::perm_options::add);
+
+        CPPUNIT_ASSERT(!fileStat.isHidden);
+#if defined(KD_WINDOWS)
+        CPPUNIT_ASSERT_EQUAL(int64_t{0}, fileStat.size);
+#else
+        CPPUNIT_ASSERT(fileStat.size > 0u);
+#endif
+        CPPUNIT_ASSERT_GREATER(SyncTime{0}, fileStat.creationTime);
+        CPPUNIT_ASSERT_GREATEREQUAL(fileStat.creationTime, fileStat.modificationTime);
+        CPPUNIT_ASSERT_EQUAL(NodeType::Directory, fileStat.nodeType);
+        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+    }
+
+    // A regular file within a subdirectory that misses owner read permission (no error expected)
+    {
+        const LocalTemporaryDirectory temporaryDirectory;
+        const SyncPath subdir = temporaryDirectory.path() / "permission_less_subdirectory";
+        std::filesystem::create_directory(subdir);
+        const SyncPath path = subdir / "file.txt";
+        {
+            std::ofstream ofs(path);
+            ofs << "Some content.\n";
+        }
+        std::filesystem::permissions(subdir, std::filesystem::perms::owner_read, std::filesystem::perm_options::remove);
+
+        FileStat fileStat;
+        IoError ioError = IoError::Unknown;
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
+
+        // Restore permission to allow subdir removal
+        std::filesystem::permissions(subdir, std::filesystem::perms::owner_read, std::filesystem::perm_options::add);
+
+        CPPUNIT_ASSERT(!fileStat.isHidden);
+        CPPUNIT_ASSERT_GREATER(int64_t{0}, fileStat.size);
+        CPPUNIT_ASSERT_GREATER(SyncTime{0}, fileStat.creationTime);
+        CPPUNIT_ASSERT_GREATEREQUAL(fileStat.creationTime, fileStat.modificationTime);
+        CPPUNIT_ASSERT_EQUAL(NodeType::File, fileStat.nodeType);
+        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+    }
+
+    // A regular file within a subdirectory that misses owner search/exec permission:
+    // - access denied expected on MacOSX
+    // - no error expected on Windows
+    {
+        const LocalTemporaryDirectory temporaryDirectory;
+        const SyncPath subdir = temporaryDirectory.path() / "permission_less_subdirectory";
+        std::filesystem::create_directory(subdir);
+        const SyncPath path = subdir / "file.txt";
+        {
+            std::ofstream ofs(path);
+            ofs << "Some content.\n";
+        }
+        std::filesystem::permissions(subdir, std::filesystem::perms::owner_exec, std::filesystem::perm_options::remove);
+
+        FileStat fileStat;
+        IoError ioError = IoError::Unknown;
+        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
+
+        // Restore permission to allow subdir removal
+        std::filesystem::permissions(subdir, std::filesystem::perms::owner_exec, std::filesystem::perm_options::add);
+
+        CPPUNIT_ASSERT(!fileStat.isHidden);
+#if defined(KD_WINDOWS)
+        CPPUNIT_ASSERT_GREATER(int64_t{0}, fileStat.size);
+        CPPUNIT_ASSERT_GREATER(SyncTime{0}, fileStat.modificationTime);
+        CPPUNIT_ASSERT_GREATEREQUAL(fileStat.creationTime, fileStat.modificationTime);
+        CPPUNIT_ASSERT_EQUAL(NodeType::File, fileStat.nodeType);
+        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+#else
+        CPPUNIT_ASSERT_EQUAL(int64_t{0}, fileStat.size);
+        CPPUNIT_ASSERT_EQUAL(SyncTime{0}, fileStat.modificationTime);
+        CPPUNIT_ASSERT_EQUAL(SyncTime{0}, fileStat.creationTime);
+        CPPUNIT_ASSERT_EQUAL(NodeType::Unknown, fileStat.nodeType);
+        CPPUNIT_ASSERT_EQUAL(IoError::AccessDenied, ioError);
+#endif
+    }*/
+}
+
+} // namespace KDC

--- a/test/libcommon/io/testgetfilechecksum.cpp
+++ b/test/libcommon/io/testgetfilechecksum.cpp
@@ -25,56 +25,33 @@ using namespace CppUnit;
 
 namespace KDC {
 
-void TestIo::testGetFileStat() {
+void TestIo::testGetFileChecksum() {
     // A regular file
     {
         const SyncPath path = _localTestDirPath / "test_pictures/picture-1.jpg";
         IoError ioError = IoError::Unknown;
         std::ifstream ifs;
 
-        CPPUNIT_ASSERT_EQUAL(IoHelper::getFileChecksum(path, ifs, ioError), std::string(""));
+        auto checksum = IoHelper::getFileChecksum(path, ifs, ioError);
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+        CPPUNIT_ASSERT(!checksum.empty());
+        CPPUNIT_ASSERT_EQUAL(std::string("5dcc477e35136516"), checksum);
     }
-    /*
+
     // A regular file whose name exists with a different capitalization
     {
         const SyncPath path = _localTestDirPath / "test_pictures/Picture-1.jpg";
-        std::ifstream ifs;
         IoError ioError = IoError::Unknown;
+        std::ifstream ifs;
 
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
+        auto checksum = IoHelper::getFileChecksum(path, ifs, ioError);
 #if defined(KD_MACOS) || defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
 #else
         CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
 #endif
-
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Sensitive));
-        CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
-    }
-
-    // A regular directory
-    {
-        const SyncPath path = _localTestDirPath / "test_pictures";
-        FileStat fileStat;
-        IoError ioError = IoError::Unknown;
-
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
-        CPPUNIT_ASSERT(!fileStat.isHidden);
-#if defined(KD_WINDOWS)
-        CPPUNIT_ASSERT_EQUAL(int64_t{0}, fileStat.size);
-#else
-        CPPUNIT_ASSERT(fileStat.size > 0);
-#endif
-        CPPUNIT_ASSERT_GREATER(SyncTime{0}, fileStat.creationTime);
-        CPPUNIT_ASSERT_GREATEREQUAL(fileStat.creationTime, fileStat.modificationTime);
-        CPPUNIT_ASSERT_GREATER(SyncTime{0}, fileStat.creationTime);
-        CPPUNIT_ASSERT_EQUAL(NodeType::Directory, fileStat.nodeType);
-        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
-
-        NodeId nodeId;
-        CPPUNIT_ASSERT(IoHelper::getNodeId(path, nodeId));
-        CPPUNIT_ASSERT_EQUAL(nodeId, std::to_string(fileStat.inode));
+        CPPUNIT_ASSERT(!checksum.empty());
+        CPPUNIT_ASSERT_EQUAL(std::string("5dcc477e35136516"), checksum);
     }
 
     // A regular symbolic link on a file
@@ -83,60 +60,24 @@ void TestIo::testGetFileStat() {
         const LocalTemporaryDirectory temporaryDirectory;
         const SyncPath path = temporaryDirectory.path() / "regular_file_symbolic_link";
         std::filesystem::create_symlink(targetPath, path);
-
-        FileStat fileStat;
         IoError ioError = IoError::Unknown;
+        std::ifstream ifs;
 
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
-        CPPUNIT_ASSERT(!fileStat.isHidden);
-#if defined(KD_WINDOWS)
-        CPPUNIT_ASSERT_EQUAL(int64_t{0}, fileStat.size);
-#else
-        CPPUNIT_ASSERT(fileStat.size == static_cast<int64_t>(targetPath.native().length()));
-#endif
-        CPPUNIT_ASSERT_GREATEREQUAL(fileStat.creationTime, fileStat.modificationTime);
-        CPPUNIT_ASSERT_EQUAL(NodeType::File, fileStat.nodeType);
-        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
-
-        NodeId nodeId;
-        CPPUNIT_ASSERT(IoHelper::getNodeId(path, nodeId));
-        CPPUNIT_ASSERT_EQUAL(nodeId, std::to_string(fileStat.inode));
-    }
-
-    // A regular symbolic link on a folder
-    {
-        const SyncPath targetPath = _localTestDirPath / "test_pictures";
-        const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath path = temporaryDirectory.path() / "regular_dir_symbolic_link";
-        std::filesystem::create_directory_symlink(targetPath, path);
-
-        FileStat fileStat;
-        IoError ioError = IoError::Unknown;
-
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
-        CPPUNIT_ASSERT(!fileStat.isHidden);
-#if defined(KD_WINDOWS)
-        CPPUNIT_ASSERT_EQUAL(int64_t{0}, fileStat.size);
-#else
-        CPPUNIT_ASSERT(fileStat.size == static_cast<int64_t>(targetPath.native().length()));
-#endif
-        CPPUNIT_ASSERT_EQUAL(NodeType::Directory, fileStat.nodeType);
-        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+        auto checksum = IoHelper::getFileChecksum(path, ifs, ioError);
+        CPPUNIT_ASSERT(checksum.empty());
+        CPPUNIT_ASSERT_EQUAL(std::string(""), checksum);
+        CPPUNIT_ASSERT_EQUAL(IoError::InvalidArgument, ioError);
     }
 
     // A non-existing file
     {
         const SyncPath path = _localTestDirPath / "non-existing.jpg"; // This file does not exist.
-        FileStat fileStat;
         IoError ioError = IoError::Success;
+        std::ifstream ifs;
 
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
-        CPPUNIT_ASSERT(!fileStat.isHidden);
-        CPPUNIT_ASSERT_EQUAL(int64_t{0}, fileStat.size);
-        CPPUNIT_ASSERT_EQUAL(SyncTime{0}, fileStat.modificationTime);
-        CPPUNIT_ASSERT_EQUAL(SyncTime{0}, fileStat.creationTime);
-        CPPUNIT_ASSERT_EQUAL(uint64_t{0}, fileStat.inode);
-        CPPUNIT_ASSERT_EQUAL(NodeType::Unknown, fileStat.nodeType);
+        auto checksum = IoHelper::getFileChecksum(path, ifs, ioError);
+        CPPUNIT_ASSERT(checksum.empty());
+        CPPUNIT_ASSERT_EQUAL(std::string(""), checksum);
         CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
     }
 
@@ -144,22 +85,14 @@ void TestIo::testGetFileStat() {
     {
         const std::string veryLongfileName(1000, 'a'); // Exceeds the max allowed name length on every file system of interest.
         const SyncPath path = _localTestDirPath / veryLongfileName; // This file doesn't exist.
-        FileStat fileStat;
         IoError ioError = IoError::Success;
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
-        CPPUNIT_ASSERT(!fileStat.isHidden);
-        CPPUNIT_ASSERT_EQUAL(int64_t{0}, fileStat.size);
-        CPPUNIT_ASSERT_EQUAL(uint64_t{0}, fileStat.inode);
-        CPPUNIT_ASSERT_EQUAL(SyncTime{0}, fileStat.modificationTime);
-        CPPUNIT_ASSERT_EQUAL(SyncTime{0}, fileStat.creationTime);
-        CPPUNIT_ASSERT_EQUAL(NodeType::Unknown, fileStat.nodeType);
-#if defined(KD_WINDOWS)
-        CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
-#else
-        CPPUNIT_ASSERT_EQUAL(IoError::FileNameTooLong, ioError);
-#endif
-    }
+        std::ifstream ifs;
 
+        auto checksum = IoHelper::getFileChecksum(path, ifs, ioError);
+        CPPUNIT_ASSERT(checksum.empty());
+        CPPUNIT_ASSERT_EQUAL(std::string(""), checksum);
+        CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
+    }
     // A non-existing file with a very long path
     {
         const std::string pathSegment(50, 'a');
@@ -167,16 +100,13 @@ void TestIo::testGetFileStat() {
         for (auto i = 0; i < 1000; ++i) {
             path /= pathSegment; // Eventually exceeds the max allowed path length on every file system of interest.
         }
-        FileStat fileStat;
         IoError ioError = IoError::Success;
+        std::ifstream ifs;
 
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
-        CPPUNIT_ASSERT(!fileStat.isHidden);
-        CPPUNIT_ASSERT_EQUAL(int64_t{0}, fileStat.size);
-        CPPUNIT_ASSERT_EQUAL(uint64_t{0}, fileStat.inode);
-        CPPUNIT_ASSERT_EQUAL(SyncTime{0}, fileStat.modificationTime);
-        CPPUNIT_ASSERT_EQUAL(SyncTime{0}, fileStat.creationTime);
-        CPPUNIT_ASSERT_EQUAL(NodeType::Unknown, fileStat.nodeType);
+        auto checksum = IoHelper::getFileChecksum(path, ifs, ioError);
+        CPPUNIT_ASSERT(checksum.empty());
+        CPPUNIT_ASSERT_EQUAL(std::string(""), checksum);
+
 #if defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
 #else
@@ -201,41 +131,13 @@ void TestIo::testGetFileStat() {
         IoHelper::setFileHidden(path, true);
 #endif
 
-        FileStat fileStat;
         IoError ioError = IoError::Unknown;
+        std::ifstream ifs;
 
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
-
-        CPPUNIT_ASSERT(fileStat.isHidden);
-        CPPUNIT_ASSERT_GREATER(int64_t{0}, fileStat.size);
-        CPPUNIT_ASSERT_GREATER(SyncTime{0}, fileStat.creationTime);
-        CPPUNIT_ASSERT_GREATEREQUAL(fileStat.creationTime, fileStat.modificationTime);
-        CPPUNIT_ASSERT_EQUAL(NodeType::File, fileStat.nodeType);
+        auto checksum = IoHelper::getFileChecksum(path, ifs, ioError);
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
-    }
-
-    // A hidden directory
-    {
-        const LocalTemporaryDirectory temporaryDirectory;
-#if defined(KD_MACOS) || defined(KD_WINDOWS)
-        const SyncPath &path = temporaryDirectory.path();
-#else
-        const SyncPath path = temporaryDirectory.path() / ".hidden_directory";
-        std::filesystem::create_directory(path);
-#endif
-
-#if defined(KD_MACOS) || defined(KD_WINDOWS)
-        IoHelper::setFileHidden(path, true);
-#endif
-        FileStat fileStat;
-        IoError ioError = IoError::Unknown;
-
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
-        CPPUNIT_ASSERT(fileStat.isHidden);
-        CPPUNIT_ASSERT_GREATER(SyncTime{0}, fileStat.creationTime);
-        CPPUNIT_ASSERT_GREATEREQUAL(fileStat.creationTime, fileStat.modificationTime);
-        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
-        CPPUNIT_ASSERT_EQUAL(NodeType::Directory, fileStat.nodeType);
+        CPPUNIT_ASSERT(!checksum.empty());
+        CPPUNIT_ASSERT_EQUAL(std::string("3d48b0e057db6f01"), checksum);
     }
 
     // A file with dots and colons in its name
@@ -247,25 +149,16 @@ void TestIo::testGetFileStat() {
             ofs << "Some content.\n";
         }
 
-        FileStat fileStat;
         IoError ioError = IoError::Unknown;
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
+        std::ifstream ifs;
 
+        auto checksum = IoHelper::getFileChecksum(path, ifs, ioError);
 #if defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
-        CPPUNIT_ASSERT(!fileStat.isHidden);
-        CPPUNIT_ASSERT_EQUAL(int64_t{0}, fileStat.size);
-        CPPUNIT_ASSERT_EQUAL(uint64_t{0}, fileStat.inode);
-        CPPUNIT_ASSERT_EQUAL(SyncTime{0}, fileStat.modificationTime);
-        CPPUNIT_ASSERT_EQUAL(SyncTime{0}, fileStat.creationTime);
-        CPPUNIT_ASSERT_EQUAL(NodeType::Unknown, fileStat.nodeType);
+        CPPUNIT_ASSERT(checksum.empty());
 #else
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
-        CPPUNIT_ASSERT(!fileStat.isHidden);
-        CPPUNIT_ASSERT_GREATER(int64_t{0}, fileStat.size);
-        CPPUNIT_ASSERT_GREATER(SyncTime{0}, fileStat.creationTime);
-        CPPUNIT_ASSERT_EQUAL(fileStat.modificationTime, fileStat.creationTime);
-        CPPUNIT_ASSERT_EQUAL(NodeType::File, fileStat.nodeType);
+        CPPUNIT_ASSERT_EQUAL(std::string("3d48b0e057db6f01"), checksum);
 #endif
     }
 
@@ -279,16 +172,13 @@ void TestIo::testGetFileStat() {
             ofs.close();
         }
 
-        FileStat fileStat;
         IoError ioError = IoError::Unknown;
+        std::ifstream ifs;
 
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
-        CPPUNIT_ASSERT(!fileStat.isHidden);
-        CPPUNIT_ASSERT_GREATER(int64_t{0}, fileStat.size);
-        CPPUNIT_ASSERT_GREATER(SyncTime{0}, fileStat.creationTime);
-        CPPUNIT_ASSERT_GREATEREQUAL(fileStat.creationTime, fileStat.modificationTime);
-        CPPUNIT_ASSERT_EQUAL(NodeType::File, fileStat.nodeType);
+        auto checksum = IoHelper::getFileChecksum(path, ifs, ioError);
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+        CPPUNIT_ASSERT(!checksum.empty());
+        CPPUNIT_ASSERT_EQUAL(std::string("3d48b0e057db6f01"), checksum);
     }
 
     // A dangling symbolic link
@@ -298,72 +188,35 @@ void TestIo::testGetFileStat() {
         const SyncPath path = temporaryDirectory.path() / "dangling_symbolic_link";
         std::filesystem::create_symlink(targetPath, path);
 
-        FileStat fileStat;
         IoError ioError = IoError::Unknown;
+        std::ifstream ifs;
 
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
-        CPPUNIT_ASSERT_GREATER(SyncTime{0}, fileStat.creationTime);
-        CPPUNIT_ASSERT(!fileStat.isHidden);
-#if defined(KD_WINDOWS)
-        CPPUNIT_ASSERT_EQUAL(int64_t{0}, fileStat.size);
-#else
-        CPPUNIT_ASSERT_EQUAL(static_cast<int64_t>(targetPath.native().length()), fileStat.size);
-#endif
-        CPPUNIT_ASSERT_GREATER(SyncTime{0}, fileStat.creationTime);
-        CPPUNIT_ASSERT_GREATEREQUAL(fileStat.creationTime, fileStat.modificationTime);
-#if defined(KD_WINDOWS)
-        CPPUNIT_ASSERT_EQUAL(NodeType::File, fileStat.nodeType);
-#else
-        CPPUNIT_ASSERT_EQUAL(NodeType::Unknown, fileStat.nodeType);
-#endif
+        auto checksum = IoHelper::getFileChecksum(path, ifs, ioError);
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+        CPPUNIT_ASSERT(checksum.empty());
+        CPPUNIT_ASSERT_EQUAL(std::string(""), checksum);
     }
 #if defined(KD_MACOS)
-    // A MacOSX Finder alias on a regular file.
+    // A macOS Finder alias on a regular file: not computed, returns empty checksum.
     {
         const LocalTemporaryDirectory temporaryDirectory;
         const SyncPath targetPath = _localTestDirPath / "test_pictures/picture-1.jpg";
         const SyncPath path = temporaryDirectory.path() / "regular_file_alias";
 
-        IoError aliasError;
-        IoHelper::createAliasFromPath(targetPath, path, aliasError);
+        IoError aliasError = IoError::Unknown;
+        CPPUNIT_ASSERT(IoHelper::createAliasFromPath(targetPath, path, aliasError));
+        CPPUNIT_ASSERT_EQUAL(IoError::Success, aliasError);
 
-        FileStat fileStat;
         IoError ioError = IoError::Unknown;
+        std::ifstream ifs;
 
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
-        CPPUNIT_ASSERT(!fileStat.isHidden);
-        CPPUNIT_ASSERT_GREATER(int64_t{0},
-                               fileStat.size); // `fileStat.size` is greater than `static_cast<int64_t>(path.native().length())`
-
-        CPPUNIT_ASSERT_GREATER(SyncTime{0}, fileStat.creationTime);
-        CPPUNIT_ASSERT_GREATEREQUAL(fileStat.creationTime, fileStat.modificationTime);
-        CPPUNIT_ASSERT_EQUAL(NodeType::File, fileStat.nodeType);
-        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+        auto checksum = IoHelper::getFileChecksum(path, ifs, ioError);
+        CPPUNIT_ASSERT_EQUAL(IoError::InvalidArgument, ioError);
+        CPPUNIT_ASSERT(checksum.empty());
+        CPPUNIT_ASSERT_EQUAL(std::string(""), checksum);
     }
 
-    // A MacOSX Finder alias on a regular directory.
-    {
-        const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath targetPath = _localTestDirPath / "test_pictures";
-        const SyncPath path = temporaryDirectory.path() / "regular_dir_alias";
-
-        IoError aliasError;
-        IoHelper::createAliasFromPath(targetPath, path, aliasError);
-
-        FileStat fileStat;
-        IoError ioError = IoError::Unknown;
-
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
-        CPPUNIT_ASSERT(!fileStat.isHidden);
-        CPPUNIT_ASSERT_GREATER(int64_t{0}, fileStat.size);
-        CPPUNIT_ASSERT_GREATER(SyncTime{0}, fileStat.creationTime);
-        CPPUNIT_ASSERT_GREATEREQUAL(fileStat.creationTime, fileStat.modificationTime);
-        CPPUNIT_ASSERT_EQUAL(NodeType::File, fileStat.nodeType);
-        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
-    }
-
-    // A dangling MacOSX Finder alias on a non-existing file.
+    // A dangling macOS Finder alias (target deleted): not computed, returns empty checksum.
     {
         const LocalTemporaryDirectory temporaryDirectory;
         const SyncPath targetPath = temporaryDirectory.path() / "file_to_be_deleted.png"; // This file will be deleted.
@@ -373,45 +226,21 @@ void TestIo::testGetFileStat() {
             ofs << "Some content.\n";
         }
 
-        IoError aliasError;
-        IoHelper::createAliasFromPath(targetPath, path, aliasError);
-        (void) IoHelper::deleteItem(targetPath);
+        IoError aliasError = IoError::Unknown;
+        CPPUNIT_ASSERT(IoHelper::createAliasFromPath(targetPath, path, aliasError));
+        CPPUNIT_ASSERT_EQUAL(IoError::Success, aliasError);
 
-        FileStat fileStat;
+        auto ioErr = IoError::Unknown;
+        CPPUNIT_ASSERT(IoHelper::deleteItem(targetPath, ioErr));
+        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioErr);
+
         IoError ioError = IoError::Unknown;
+        std::ifstream ifs;
 
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
-        CPPUNIT_ASSERT(!fileStat.isHidden);
-        CPPUNIT_ASSERT_GREATER(int64_t{0},
-                               fileStat.size); // `fileStat.size` is greater than `static_cast<int64_t>(path.native().length())`
-        CPPUNIT_ASSERT_GREATEREQUAL(fileStat.creationTime, fileStat.modificationTime);
-        CPPUNIT_ASSERT_EQUAL(NodeType::File, fileStat.nodeType);
-        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
-    }
-
-    // A dangling MacOSX Finder alias on a non-existing directory.
-    {
-        const LocalTemporaryDirectory temporaryDirectory;
-        const SyncPath targetPath = temporaryDirectory.path() / "directory_to_be_deleted"; // This directory will be deleted.
-        std::filesystem::create_directory(targetPath);
-
-        const SyncPath path = temporaryDirectory.path() / "dangling_directory_alias";
-
-        auto aliasError = IoError::Unknown;
-        CPPUNIT_ASSERT_MESSAGE(toString(aliasError), IoHelper::createAliasFromPath(targetPath, path, aliasError));
-        (void) IoHelper::deleteItem(targetPath);
-
-        FileStat fileStat;
-        IoError ioError = IoError::Unknown;
-
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
-        CPPUNIT_ASSERT(!fileStat.isHidden);
-        CPPUNIT_ASSERT_GREATER(int64_t{0},
-                               fileStat.size); // `fileStat.size` is greater than `static_cast<int64_t>(path.native().length())`
-        CPPUNIT_ASSERT_GREATEREQUAL(fileStat.creationTime, fileStat.modificationTime);
-        CPPUNIT_ASSERT_EQUAL(NodeType::File, fileStat.nodeType);
-        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
-    }
+        auto checksum = IoHelper::getFileChecksum(path, ifs, ioError);
+        CPPUNIT_ASSERT_EQUAL(IoError::InvalidArgument, ioError);
+        CPPUNIT_ASSERT(checksum.empty());
+    } /*
 #elif defined(KD_WINDOWS)
     // A junction on a regular directory.
     {
@@ -575,8 +404,8 @@ void TestIo::testGetFileStat() {
         CPPUNIT_ASSERT_EQUAL(SyncTime{0}, fileStat.creationTime);
         CPPUNIT_ASSERT_EQUAL(NodeType::Unknown, fileStat.nodeType);
         CPPUNIT_ASSERT_EQUAL(IoError::AccessDenied, ioError);
-#endif
     }*/
+#endif
 }
 
 } // namespace KDC

--- a/test/libcommon/io/testgetfilechecksum.cpp
+++ b/test/libcommon/io/testgetfilechecksum.cpp
@@ -29,10 +29,9 @@ void TestIo::testGetFileChecksum() {
     // A regular file
     {
         const SyncPath path = _localTestDirPath / "test_pictures/picture-1.jpg";
-        IoError ioError = IoError::Unknown;
         std::ifstream ifs;
-
-        auto checksum = IoHelper::getFileChecksum(path, ifs, ioError);
+        std::string checksum;
+        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
         CPPUNIT_ASSERT(!checksum.empty());
         CPPUNIT_ASSERT_EQUAL(std::string("5dcc477e35136516"), checksum);
@@ -41,10 +40,9 @@ void TestIo::testGetFileChecksum() {
     // A regular file whose name exists with a different capitalization
     {
         const SyncPath path = _localTestDirPath / "test_pictures/Picture-1.jpg";
-        IoError ioError = IoError::Unknown;
         std::ifstream ifs;
-
-        auto checksum = IoHelper::getFileChecksum(path, ifs, ioError);
+        std::string checksum;
+        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
 #if defined(KD_MACOS) || defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
         CPPUNIT_ASSERT(!checksum.empty());
@@ -61,43 +59,38 @@ void TestIo::testGetFileChecksum() {
         const LocalTemporaryDirectory temporaryDirectory;
         const SyncPath path = temporaryDirectory.path() / "regular_file_symbolic_link";
         std::filesystem::create_symlink(targetPath, path);
-        IoError ioError = IoError::Unknown;
         std::ifstream ifs;
-
-        auto checksum = IoHelper::getFileChecksum(path, ifs, ioError);
-        CPPUNIT_ASSERT(checksum.empty());
-        CPPUNIT_ASSERT_EQUAL(std::string(""), checksum);
+        std::string checksum;
+        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
         CPPUNIT_ASSERT_EQUAL(IoError::InvalidArgument, ioError);
+        CPPUNIT_ASSERT(checksum.empty());
     }
 
     // A non-existing file
     {
         const SyncPath path = _localTestDirPath / "non-existing.jpg"; // This file does not exist.
-        IoError ioError = IoError::Success;
         std::ifstream ifs;
-
-        auto checksum = IoHelper::getFileChecksum(path, ifs, ioError);
-        CPPUNIT_ASSERT(checksum.empty());
-        CPPUNIT_ASSERT_EQUAL(std::string(""), checksum);
+        std::string checksum;
+        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
         CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
+        CPPUNIT_ASSERT(checksum.empty());
     }
 
     // A non-existing file with a very long name
     {
         const std::string veryLongfileName(1000, 'a'); // Exceeds the max allowed name length on every file system of interest.
         const SyncPath path = _localTestDirPath / veryLongfileName; // This file doesn't exist.
-        IoError ioError = IoError::Success;
         std::ifstream ifs;
-
-        auto checksum = IoHelper::getFileChecksum(path, ifs, ioError);
+        std::string checksum;
+        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
         CPPUNIT_ASSERT(checksum.empty());
-        CPPUNIT_ASSERT_EQUAL(std::string(""), checksum);
 #if defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
 #else
         CPPUNIT_ASSERT_EQUAL(IoError::FileNameTooLong, ioError);
 #endif
     }
+
     // A non-existing file with a very long path
     {
         const std::string pathSegment(50, 'a');
@@ -105,13 +98,10 @@ void TestIo::testGetFileChecksum() {
         for (auto i = 0; i < 1000; ++i) {
             path /= pathSegment; // Eventually exceeds the max allowed path length on every file system of interest.
         }
-        IoError ioError = IoError::Success;
         std::ifstream ifs;
-
-        auto checksum = IoHelper::getFileChecksum(path, ifs, ioError);
+        std::string checksum;
+        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
         CPPUNIT_ASSERT(checksum.empty());
-        CPPUNIT_ASSERT_EQUAL(std::string(""), checksum);
-
 #if defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
 #else
@@ -131,15 +121,12 @@ void TestIo::testGetFileChecksum() {
             std::ofstream ofs(path);
             ofs << "Some content.";
         }
-
 #if defined(KD_MACOS) || defined(KD_WINDOWS)
         IoHelper::setFileHidden(path, true);
 #endif
-
-        IoError ioError = IoError::Unknown;
         std::ifstream ifs;
-
-        auto checksum = IoHelper::getFileChecksum(path, ifs, ioError);
+        std::string checksum;
+        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
         CPPUNIT_ASSERT(!checksum.empty());
         CPPUNIT_ASSERT_EQUAL(std::string("91f9d1732ca53515"), checksum);
@@ -153,11 +140,9 @@ void TestIo::testGetFileChecksum() {
             std::ofstream ofs(path);
             ofs << "Some content.";
         }
-
-        IoError ioError = IoError::Unknown;
         std::ifstream ifs;
-
-        auto checksum = IoHelper::getFileChecksum(path, ifs, ioError);
+        std::string checksum;
+        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
 #if defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
         CPPUNIT_ASSERT(checksum.empty());
@@ -174,13 +159,10 @@ void TestIo::testGetFileChecksum() {
         {
             std::ofstream ofs(path);
             ofs << "Some content.";
-            ofs.close();
         }
-
-        IoError ioError = IoError::Unknown;
         std::ifstream ifs;
-
-        auto checksum = IoHelper::getFileChecksum(path, ifs, ioError);
+        std::string checksum;
+        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
         CPPUNIT_ASSERT(!checksum.empty());
         CPPUNIT_ASSERT_EQUAL(std::string("91f9d1732ca53515"), checksum);
@@ -192,15 +174,13 @@ void TestIo::testGetFileChecksum() {
         const SyncPath targetPath = temporaryDirectory.path() / "non_existing_test_file.txt"; // This file does not exist.
         const SyncPath path = temporaryDirectory.path() / "dangling_symbolic_link";
         std::filesystem::create_symlink(targetPath, path);
-
-        IoError ioError = IoError::Unknown;
         std::ifstream ifs;
-
-        auto checksum = IoHelper::getFileChecksum(path, ifs, ioError);
+        std::string checksum;
+        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
         CPPUNIT_ASSERT_EQUAL(IoError::InvalidArgument, ioError);
         CPPUNIT_ASSERT(checksum.empty());
-        CPPUNIT_ASSERT_EQUAL(std::string(""), checksum);
     }
+
 #if defined(KD_MACOS)
     // A macOS Finder alias on a regular file: not computed, returns empty checksum.
     {
@@ -208,18 +188,14 @@ void TestIo::testGetFileChecksum() {
         const LocalTemporaryDirectory temporaryDirectory;
         const SyncPath targetPath = _localTestDirPath / "test_pictures/picture-1.jpg";
         const SyncPath path = temporaryDirectory.path() / "regular_file_alias";
-
         IoError aliasError = Unknown;
         CPPUNIT_ASSERT(IoHelper::createAliasFromPath(targetPath, path, aliasError));
         CPPUNIT_ASSERT_EQUAL(Success, aliasError);
-
-        IoError ioError = Unknown;
         std::ifstream ifs;
-
-        auto checksum = IoHelper::getFileChecksum(path, ifs, ioError);
+        std::string checksum;
+        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
         CPPUNIT_ASSERT_EQUAL(InvalidArgument, ioError);
         CPPUNIT_ASSERT(checksum.empty());
-        CPPUNIT_ASSERT_EQUAL(std::string(""), checksum);
     }
 
     // A dangling macOS Finder alias (target deleted): not computed, returns empty checksum.
@@ -232,25 +208,21 @@ void TestIo::testGetFileChecksum() {
             std::ofstream ofs(targetPath);
             ofs << "Some content.";
         }
-
         IoError aliasError = Unknown;
         CPPUNIT_ASSERT(IoHelper::createAliasFromPath(targetPath, path, aliasError));
         CPPUNIT_ASSERT_EQUAL(Success, aliasError);
-
-        auto ioErr = Unknown;
-        CPPUNIT_ASSERT(IoHelper::deleteItem(targetPath, ioErr));
-        CPPUNIT_ASSERT_EQUAL(Success, ioErr);
-
-        IoError ioError = Unknown;
+        IoError deleteError = Unknown;
+        CPPUNIT_ASSERT(IoHelper::deleteItem(targetPath, deleteError));
+        CPPUNIT_ASSERT_EQUAL(Success, deleteError);
         std::ifstream ifs;
-
-        auto checksum = IoHelper::getFileChecksum(path, ifs, ioError);
+        std::string checksum;
+        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
         CPPUNIT_ASSERT_EQUAL(InvalidArgument, ioError);
         CPPUNIT_ASSERT(checksum.empty());
     }
 #endif
 
-    // A regular file missing all permissions (no error expected on Windows ,error expected on Unix)
+    // A regular file missing all permissions (no error expected on Windows, error expected on Unix)
     {
         const LocalTemporaryDirectory temporaryDirectory;
         const SyncPath path = temporaryDirectory.path() / "permission_less_file.txt";
@@ -258,29 +230,29 @@ void TestIo::testGetFileChecksum() {
             std::ofstream ofs(path);
             ofs << "Some content.";
         }
-
         std::filesystem::permissions(path, std::filesystem::perms::all, std::filesystem::perm_options::remove);
-
-        IoError ioError = IoError::Unknown;
-        std::ifstream ifs;
-
-        auto checksum = IoHelper::getFileChecksum(path, ifs, ioError);
+        {
+            std::ifstream ifs;
+            std::string checksum;
+            const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
 #if defined(KD_WINDOWS)
-        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
-        CPPUNIT_ASSERT(!checksum.empty());
-        CPPUNIT_ASSERT_EQUAL(std::string("91f9d1732ca53515"), checksum);
+            CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+            CPPUNIT_ASSERT(!checksum.empty());
+            CPPUNIT_ASSERT_EQUAL(std::string("91f9d1732ca53515"), checksum);
 #else
-        CPPUNIT_ASSERT_EQUAL(IoError::AccessDenied, ioError);
-        CPPUNIT_ASSERT(checksum.empty());
-        CPPUNIT_ASSERT_EQUAL(std::string(""), checksum);
+            CPPUNIT_ASSERT_EQUAL(IoError::AccessDenied, ioError);
+            CPPUNIT_ASSERT(checksum.empty());
 #endif
-
+        }
         std::filesystem::permissions(path, std::filesystem::perms::all, std::filesystem::perm_options::add);
-
-        checksum = IoHelper::getFileChecksum(path, ifs, ioError);
-        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
-        CPPUNIT_ASSERT(!checksum.empty());
-        CPPUNIT_ASSERT_EQUAL(std::string("91f9d1732ca53515"), checksum);
+        {
+            std::ifstream ifs;
+            std::string checksum;
+            const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
+            CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+            CPPUNIT_ASSERT(!checksum.empty());
+            CPPUNIT_ASSERT_EQUAL(std::string("91f9d1732ca53515"), checksum);
+        }
     }
 
     // A regular file within a subdirectory that misses owner read permission (no error expected)
@@ -294,22 +266,24 @@ void TestIo::testGetFileChecksum() {
             ofs << "Some content.";
         }
         std::filesystem::permissions(subdir, std::filesystem::perms::owner_read, std::filesystem::perm_options::remove);
-
-        IoError ioError = IoError::Unknown;
-        std::ifstream ifs;
-
-        auto checksum = IoHelper::getFileChecksum(path, ifs, ioError);
-        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
-        CPPUNIT_ASSERT(!checksum.empty());
-        CPPUNIT_ASSERT_EQUAL(std::string("91f9d1732ca53515"), checksum);
-
+        {
+            std::ifstream ifs;
+            std::string checksum;
+            const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
+            CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+            CPPUNIT_ASSERT(!checksum.empty());
+            CPPUNIT_ASSERT_EQUAL(std::string("91f9d1732ca53515"), checksum);
+        }
         // Restore permission to allow subdir removal
         std::filesystem::permissions(subdir, std::filesystem::perms::owner_read, std::filesystem::perm_options::add);
-
-        checksum = IoHelper::getFileChecksum(path, ifs, ioError);
-        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
-        CPPUNIT_ASSERT(!checksum.empty());
-        CPPUNIT_ASSERT_EQUAL(std::string("91f9d1732ca53515"), checksum);
+        {
+            std::ifstream ifs;
+            std::string checksum;
+            const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
+            CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+            CPPUNIT_ASSERT(!checksum.empty());
+            CPPUNIT_ASSERT_EQUAL(std::string("91f9d1732ca53515"), checksum);
+        }
     }
 
     // A regular file within a subdirectory that misses owner search/exec permission:
@@ -325,15 +299,11 @@ void TestIo::testGetFileChecksum() {
             ofs << "Some content.";
         }
         std::filesystem::permissions(subdir, std::filesystem::perms::owner_exec, std::filesystem::perm_options::remove);
-
-        IoError ioError = IoError::Unknown;
         std::ifstream ifs;
-
-        auto checksum = IoHelper::getFileChecksum(path, ifs, ioError);
-
+        std::string checksum;
+        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
         // Restore permission to allow subdir removal
         std::filesystem::permissions(subdir, std::filesystem::perms::owner_exec, std::filesystem::perm_options::add);
-
 #if defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
         CPPUNIT_ASSERT(!checksum.empty());

--- a/test/libcommon/io/testgetfilechecksum.cpp
+++ b/test/libcommon/io/testgetfilechecksum.cpp
@@ -265,9 +265,15 @@ void TestIo::testGetFileChecksum() {
         std::ifstream ifs;
 
         auto checksum = IoHelper::getFileChecksum(path, ifs, ioError);
+#if defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
         CPPUNIT_ASSERT(!checksum.empty());
         CPPUNIT_ASSERT_EQUAL(std::string("91f9d1732ca53515"), checksum);
+#else
+        CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
+#endif
+        CPPUNIT_ASSERT(checksum.empty());
+        CPPUNIT_ASSERT_EQUAL(std::string(""), checksum);
 
         std::filesystem::permissions(path, std::filesystem::perms::all, std::filesystem::perm_options::add);
 

--- a/test/libcommon/io/testgetfilechecksum.cpp
+++ b/test/libcommon/io/testgetfilechecksum.cpp
@@ -271,9 +271,9 @@ void TestIo::testGetFileChecksum() {
         CPPUNIT_ASSERT_EQUAL(std::string("91f9d1732ca53515"), checksum);
 #else
         CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
-#endif
         CPPUNIT_ASSERT(checksum.empty());
         CPPUNIT_ASSERT_EQUAL(std::string(""), checksum);
+#endif
 
         std::filesystem::permissions(path, std::filesystem::perms::all, std::filesystem::perm_options::add);
 

--- a/test/libcommon/io/testgetfilechecksum.cpp
+++ b/test/libcommon/io/testgetfilechecksum.cpp
@@ -92,7 +92,11 @@ void TestIo::testGetFileChecksum() {
         auto checksum = IoHelper::getFileChecksum(path, ifs, ioError);
         CPPUNIT_ASSERT(checksum.empty());
         CPPUNIT_ASSERT_EQUAL(std::string(""), checksum);
+#if defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
+#else
+        CPPUNIT_ASSERT_EQUAL(IoError::FileNameTooLong, ioError);
+#endif
     }
     // A non-existing file with a very long path
     {

--- a/test/libcommon/io/testgetfilechecksum.cpp
+++ b/test/libcommon/io/testgetfilechecksum.cpp
@@ -129,7 +129,7 @@ void TestIo::testGetFileChecksum() {
 #endif
         {
             std::ofstream ofs(path);
-            ofs << "Some content.\n";
+            ofs << "Some content.";
         }
 
 #if defined(KD_MACOS) || defined(KD_WINDOWS)
@@ -142,7 +142,7 @@ void TestIo::testGetFileChecksum() {
         auto checksum = IoHelper::getFileChecksum(path, ifs, ioError);
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
         CPPUNIT_ASSERT(!checksum.empty());
-        CPPUNIT_ASSERT_EQUAL(std::string("3d48b0e057db6f01"), checksum);
+        CPPUNIT_ASSERT_EQUAL(std::string("91f9d1732ca53515"), checksum);
     }
 
     // A file with dots and colons in its name
@@ -151,7 +151,7 @@ void TestIo::testGetFileChecksum() {
         const SyncPath path = temporaryDirectory.path() / ":.file.::.name.:";
         {
             std::ofstream ofs(path);
-            ofs << "Some content.\n";
+            ofs << "Some content.";
         }
 
         IoError ioError = IoError::Unknown;
@@ -163,7 +163,7 @@ void TestIo::testGetFileChecksum() {
         CPPUNIT_ASSERT(checksum.empty());
 #else
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
-        CPPUNIT_ASSERT_EQUAL(std::string("3d48b0e057db6f01"), checksum);
+        CPPUNIT_ASSERT_EQUAL(std::string("91f9d1732ca53515"), checksum);
 #endif
     }
 
@@ -173,7 +173,7 @@ void TestIo::testGetFileChecksum() {
         const SyncPath path = temporaryDirectory.path() / makeFileNameWithEmojis();
         {
             std::ofstream ofs(path);
-            ofs << "Some content.\n";
+            ofs << "Some content.";
             ofs.close();
         }
 
@@ -183,7 +183,7 @@ void TestIo::testGetFileChecksum() {
         auto checksum = IoHelper::getFileChecksum(path, ifs, ioError);
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
         CPPUNIT_ASSERT(!checksum.empty());
-        CPPUNIT_ASSERT_EQUAL(std::string("3d48b0e057db6f01"), checksum);
+        CPPUNIT_ASSERT_EQUAL(std::string("91f9d1732ca53515"), checksum);
     }
 
     // A dangling symbolic link
@@ -230,7 +230,7 @@ void TestIo::testGetFileChecksum() {
         const SyncPath path = temporaryDirectory.path() / "dangling_file_alias";
         {
             std::ofstream ofs(targetPath);
-            ofs << "Some content.\n";
+            ofs << "Some content.";
         }
 
         IoError aliasError = Unknown;
@@ -256,7 +256,7 @@ void TestIo::testGetFileChecksum() {
         const SyncPath path = temporaryDirectory.path() / "permission_less_file.txt";
         {
             std::ofstream ofs(path);
-            ofs << "Some content.\n";
+            ofs << "Some content.";
         }
 
         std::filesystem::permissions(path, std::filesystem::perms::all, std::filesystem::perm_options::remove);
@@ -267,14 +267,14 @@ void TestIo::testGetFileChecksum() {
         auto checksum = IoHelper::getFileChecksum(path, ifs, ioError);
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
         CPPUNIT_ASSERT(!checksum.empty());
-        CPPUNIT_ASSERT_EQUAL(std::string("3d48b0e057db6f01"), checksum);
+        CPPUNIT_ASSERT_EQUAL(std::string("91f9d1732ca53515"), checksum);
 
         std::filesystem::permissions(path, std::filesystem::perms::all, std::filesystem::perm_options::add);
 
         checksum = IoHelper::getFileChecksum(path, ifs, ioError);
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
         CPPUNIT_ASSERT(!checksum.empty());
-        CPPUNIT_ASSERT_EQUAL(std::string("3d48b0e057db6f01"), checksum);
+        CPPUNIT_ASSERT_EQUAL(std::string("91f9d1732ca53515"), checksum);
     }
 
     // A regular file within a subdirectory that misses owner read permission (no error expected)
@@ -285,7 +285,7 @@ void TestIo::testGetFileChecksum() {
         const SyncPath path = subdir / "file.txt";
         {
             std::ofstream ofs(path);
-            ofs << "Some content.\n";
+            ofs << "Some content.";
         }
         std::filesystem::permissions(subdir, std::filesystem::perms::owner_read, std::filesystem::perm_options::remove);
 
@@ -295,7 +295,7 @@ void TestIo::testGetFileChecksum() {
         auto checksum = IoHelper::getFileChecksum(path, ifs, ioError);
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
         CPPUNIT_ASSERT(!checksum.empty());
-        CPPUNIT_ASSERT_EQUAL(std::string("3d48b0e057db6f01"), checksum);
+        CPPUNIT_ASSERT_EQUAL(std::string("91f9d1732ca53515"), checksum);
 
         // Restore permission to allow subdir removal
         std::filesystem::permissions(subdir, std::filesystem::perms::owner_read, std::filesystem::perm_options::add);
@@ -303,7 +303,7 @@ void TestIo::testGetFileChecksum() {
         checksum = IoHelper::getFileChecksum(path, ifs, ioError);
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
         CPPUNIT_ASSERT(!checksum.empty());
-        CPPUNIT_ASSERT_EQUAL(std::string("3d48b0e057db6f01"), checksum);
+        CPPUNIT_ASSERT_EQUAL(std::string("91f9d1732ca53515"), checksum);
     }
 
     // A regular file within a subdirectory that misses owner search/exec permission:
@@ -316,7 +316,7 @@ void TestIo::testGetFileChecksum() {
         const SyncPath path = subdir / "file.txt";
         {
             std::ofstream ofs(path);
-            ofs << "Some content.\n";
+            ofs << "Some content.";
         }
         std::filesystem::permissions(subdir, std::filesystem::perms::owner_exec, std::filesystem::perm_options::remove);
 
@@ -331,7 +331,7 @@ void TestIo::testGetFileChecksum() {
 #if defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
         CPPUNIT_ASSERT(!checksum.empty());
-        CPPUNIT_ASSERT_EQUAL(std::string("3d48b0e057db6f01"), checksum);
+        CPPUNIT_ASSERT_EQUAL(std::string("91f9d1732ca53515"), checksum);
 #else
         CPPUNIT_ASSERT_EQUAL(IoError::AccessDenied, ioError);
         CPPUNIT_ASSERT(checksum.empty());

--- a/test/libcommon/io/testgetfilechecksum.cpp
+++ b/test/libcommon/io/testgetfilechecksum.cpp
@@ -307,7 +307,7 @@ void TestIo::testGetFileChecksum() {
     {
         const LocalTemporaryDirectory temporaryDirectory;
         const SyncPath subdir = temporaryDirectory.path() / "permission_less_subdirectory";
-        std::filesystem::create_directory(subdir);
+        CPPUNIT_ASSERT(std::filesystem::create_directory(subdir));
         const SyncPath path = subdir / "file.txt";
         {
             std::ofstream ofs(path);

--- a/test/libcommon/io/testgetfilechecksum.cpp
+++ b/test/libcommon/io/testgetfilechecksum.cpp
@@ -250,7 +250,7 @@ void TestIo::testGetFileChecksum() {
     }
 #endif
 
-    // A regular file missing all permissions (no error expected)
+    // A regular file missing all permissions (no error expected on Windows ,error expected on Unix)
     {
         const LocalTemporaryDirectory temporaryDirectory;
         const SyncPath path = temporaryDirectory.path() / "permission_less_file.txt";

--- a/test/libcommon/io/testgetfilechecksum.cpp
+++ b/test/libcommon/io/testgetfilechecksum.cpp
@@ -199,25 +199,27 @@ void TestIo::testGetFileChecksum() {
 #if defined(KD_MACOS)
     // A macOS Finder alias on a regular file: not computed, returns empty checksum.
     {
+        using enum IoError;
         const LocalTemporaryDirectory temporaryDirectory;
         const SyncPath targetPath = _localTestDirPath / "test_pictures/picture-1.jpg";
         const SyncPath path = temporaryDirectory.path() / "regular_file_alias";
 
-        IoError aliasError = IoError::Unknown;
+        IoError aliasError = Unknown;
         CPPUNIT_ASSERT(IoHelper::createAliasFromPath(targetPath, path, aliasError));
-        CPPUNIT_ASSERT_EQUAL(IoError::Success, aliasError);
+        CPPUNIT_ASSERT_EQUAL(Success, aliasError);
 
-        IoError ioError = IoError::Unknown;
+        IoError ioError = Unknown;
         std::ifstream ifs;
 
         auto checksum = IoHelper::getFileChecksum(path, ifs, ioError);
-        CPPUNIT_ASSERT_EQUAL(IoError::InvalidArgument, ioError);
+        CPPUNIT_ASSERT_EQUAL(InvalidArgument, ioError);
         CPPUNIT_ASSERT(checksum.empty());
         CPPUNIT_ASSERT_EQUAL(std::string(""), checksum);
     }
 
     // A dangling macOS Finder alias (target deleted): not computed, returns empty checksum.
     {
+        using enum IoError;
         const LocalTemporaryDirectory temporaryDirectory;
         const SyncPath targetPath = temporaryDirectory.path() / "file_to_be_deleted.png"; // This file will be deleted.
         const SyncPath path = temporaryDirectory.path() / "dangling_file_alias";
@@ -226,19 +228,19 @@ void TestIo::testGetFileChecksum() {
             ofs << "Some content.\n";
         }
 
-        IoError aliasError = IoError::Unknown;
+        IoError aliasError = Unknown;
         CPPUNIT_ASSERT(IoHelper::createAliasFromPath(targetPath, path, aliasError));
-        CPPUNIT_ASSERT_EQUAL(IoError::Success, aliasError);
+        CPPUNIT_ASSERT_EQUAL(Success, aliasError);
 
-        auto ioErr = IoError::Unknown;
+        auto ioErr = Unknown;
         CPPUNIT_ASSERT(IoHelper::deleteItem(targetPath, ioErr));
-        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioErr);
+        CPPUNIT_ASSERT_EQUAL(Success, ioErr);
 
-        IoError ioError = IoError::Unknown;
+        IoError ioError = Unknown;
         std::ifstream ifs;
 
         auto checksum = IoHelper::getFileChecksum(path, ifs, ioError);
-        CPPUNIT_ASSERT_EQUAL(IoError::InvalidArgument, ioError);
+        CPPUNIT_ASSERT_EQUAL(InvalidArgument, ioError);
         CPPUNIT_ASSERT(checksum.empty());
     }
 #endif
@@ -274,7 +276,7 @@ void TestIo::testGetFileChecksum() {
     {
         const LocalTemporaryDirectory temporaryDirectory;
         const SyncPath subdir = temporaryDirectory.path() / "permission_less_subdirectory";
-        std::filesystem::create_directory(subdir);
+        CPPUNIT_ASSERT(std::filesystem::create_directory(subdir));
         const SyncPath path = subdir / "file.txt";
         {
             std::ofstream ofs(path);
@@ -298,10 +300,9 @@ void TestIo::testGetFileChecksum() {
         CPPUNIT_ASSERT(!checksum.empty());
         CPPUNIT_ASSERT_EQUAL(std::string("3d48b0e057db6f01"), checksum);
     }
-    /*
 
     // A regular file within a subdirectory that misses owner search/exec permission:
-    // - access denied expected on MacOSX
+    // - access denied expected on macOS/Linux
     // - no error expected on Windows
     {
         const LocalTemporaryDirectory temporaryDirectory;
@@ -314,28 +315,23 @@ void TestIo::testGetFileChecksum() {
         }
         std::filesystem::permissions(subdir, std::filesystem::perms::owner_exec, std::filesystem::perm_options::remove);
 
-        FileStat fileStat;
         IoError ioError = IoError::Unknown;
-        CPPUNIT_ASSERT(IoHelper::getFileStat(path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
+        std::ifstream ifs;
+
+        auto checksum = IoHelper::getFileChecksum(path, ifs, ioError);
 
         // Restore permission to allow subdir removal
         std::filesystem::permissions(subdir, std::filesystem::perms::owner_exec, std::filesystem::perm_options::add);
 
-        CPPUNIT_ASSERT(!fileStat.isHidden);
 #if defined(KD_WINDOWS)
-        CPPUNIT_ASSERT_GREATER(int64_t{0}, fileStat.size);
-        CPPUNIT_ASSERT_GREATER(SyncTime{0}, fileStat.modificationTime);
-        CPPUNIT_ASSERT_GREATEREQUAL(fileStat.creationTime, fileStat.modificationTime);
-        CPPUNIT_ASSERT_EQUAL(NodeType::File, fileStat.nodeType);
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+        CPPUNIT_ASSERT(!checksum.empty());
+        CPPUNIT_ASSERT_EQUAL(std::string("3d48b0e057db6f01"), checksum);
 #else
-        CPPUNIT_ASSERT_EQUAL(int64_t{0}, fileStat.size);
-        CPPUNIT_ASSERT_EQUAL(SyncTime{0}, fileStat.modificationTime);
-        CPPUNIT_ASSERT_EQUAL(SyncTime{0}, fileStat.creationTime);
-        CPPUNIT_ASSERT_EQUAL(NodeType::Unknown, fileStat.nodeType);
         CPPUNIT_ASSERT_EQUAL(IoError::AccessDenied, ioError);
+        CPPUNIT_ASSERT(checksum.empty());
+#endif
     }
-#endif*/
 }
 
 } // namespace KDC

--- a/test/libcommon/io/testgetfilechecksum.cpp
+++ b/test/libcommon/io/testgetfilechecksum.cpp
@@ -47,11 +47,12 @@ void TestIo::testGetFileChecksum() {
         auto checksum = IoHelper::getFileChecksum(path, ifs, ioError);
 #if defined(KD_MACOS) || defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
-#else
-        CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
-#endif
         CPPUNIT_ASSERT(!checksum.empty());
         CPPUNIT_ASSERT_EQUAL(std::string("5dcc477e35136516"), checksum);
+#else
+        CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
+        CPPUNIT_ASSERT(checksum.empty());
+#endif
     }
 
     // A regular symbolic link on a file

--- a/test/libcommon/io/testio.h
+++ b/test/libcommon/io/testio.h
@@ -44,6 +44,7 @@ class TestIo : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST(testCreateSymlink);
         CPPUNIT_TEST(testGetNodeId);
         CPPUNIT_TEST(testGetFileStat);
+        CPPUNIT_TEST(testGetFileChecksum);
         CPPUNIT_TEST(testGetRights);
         // CPPUNIT_TEST(testIsFileAccessible); // Temporary disabled: Infinite loop on Linux CI
         CPPUNIT_TEST(testFileChanged);
@@ -94,6 +95,7 @@ class TestIo : public CppUnit::TestFixture, public TestBase {
         void testCreateDirectory(void);
         void testCreateSymlink(void);
         void testGetFileStat(void);
+        void testGetFileChecksum(void);
         void testGetRights(void);
         void testIsFileAccessible(void);
         void testFileChanged(void);


### PR DESCRIPTION
This pull request introduces a new utility function to compute file checksums and integrates corresponding unit tests. The main changes include adding the `getFileChecksum` method to `IoHelper`, updating headers and CMake configuration, and expanding the test suite.

**New file checksum functionality:**

* Added a new static method `getFileChecksum` to the `IoHelper` class in `iohelper.cpp` and declared it in `iohelper.h`. This method computes the checksum of a file using the XXH3 hash algorithm and returns it as a string. [[1]](diffhunk://#diff-5b5469306d0a47b23f79d639d928ff9b0cd51d4686ff4b04f23ec084c2f3d92dR764-R792) [[2]](diffhunk://#diff-ca22a05fec24f50cb9d1c8659f67491a20fbc454f02e4f4ff10b33010d6343c2R161-R168)

**Testing and build system updates:**

* Registered a new test case `testGetFileChecksum` in the `TestIo` test fixture and declared its implementation. [[1]](diffhunk://#diff-1ac40624c592f2b9db55ff7078ea9f40d3fe51f4f014f69c2cb931e80681a921R47) [[2]](diffhunk://#diff-1ac40624c592f2b9db55ff7078ea9f40d3fe51f4f014f69c2cb931e80681a921R98)
* Added the new test source file `testgetfilechecksum.cpp` to the test suite in `CMakeLists.txt`.