### PR TITLE
fix: fix stream reading resilience on HTTP 500 responses

### DIFF
--- a/src/libcommonserver/utility/utility.cpp
+++ b/src/libcommonserver/utility/utility.cpp
@@ -342,10 +342,10 @@ std::string Utility::xxHashToStr(XXH64_hash_t hash) {
 }
 
 void Utility::unzipStream(std::istream &inputStream, std::stringstream &ss,
-                          Poco::InflatingStreamBuf::StreamType type /*= Poco::InflatingStreamBuf::STREAM_GZIP*/) {
+                          const Poco::InflatingStreamBuf::StreamType type /*= Poco::InflatingStreamBuf::STREAM_GZIP*/) {
     Poco::InflatingInputStream inflater(inputStream, type);
     while (inputStream) {
-        Poco::StreamCopier::copyStream(inflater, ss);
+        (void) Poco::StreamCopier::copyStream(inflater, ss);
     }
 }
 

--- a/src/libcommonserver/utility/utility.cpp
+++ b/src/libcommonserver/utility/utility.cpp
@@ -25,6 +25,8 @@
 
 #include "libcommon/utility/utility.h"
 
+#include <Poco/StreamCopier.h>
+
 #if defined(KD_MACOS)
 #include <sys/statvfs.h>
 #include <sys/mount.h>
@@ -337,6 +339,14 @@ std::string Utility::xxHashToStr(XXH64_hash_t hash) {
         output.append(buf);
     }
     return output;
+}
+
+void Utility::unzipStream(std::istream &inputStream, std::stringstream &ss,
+                          Poco::InflatingStreamBuf::StreamType type /*= Poco::InflatingStreamBuf::STREAM_GZIP*/) {
+    Poco::InflatingInputStream inflater(inputStream, type);
+    while (inputStream) {
+        Poco::StreamCopier::copyStream(inflater, ss);
+    }
 }
 
 #if defined(KD_MACOS)

--- a/src/libcommonserver/utility/utility.h
+++ b/src/libcommonserver/utility/utility.h
@@ -122,7 +122,7 @@ struct COMMONSERVER_EXPORT Utility {
         static std::string xxHashToStr(XXH64_hash_t hash);
 
         static void unzipStream(std::istream &inputStream, std::stringstream &ss,
-                                Poco::InflatingStreamBuf::StreamType type = Poco::InflatingStreamBuf::STREAM_GZIP);
+                                const Poco::InflatingStreamBuf::StreamType type = Poco::InflatingStreamBuf::STREAM_GZIP);
 
 #if defined(KD_MACOS)
         static SyncPath getExcludedAppFilePath(bool test = false);

--- a/src/libcommonserver/utility/utility.h
+++ b/src/libcommonserver/utility/utility.h
@@ -33,6 +33,7 @@
 #include <filesystem>
 #include <unordered_set>
 #include <list>
+#include <Poco/InflatingStream.h>
 
 #include <Poco/DOM/Document.h>
 #include <Poco/Net/HTTPResponse.h>
@@ -119,6 +120,9 @@ struct COMMONSERVER_EXPORT Utility {
         static std::string computeXxHash(const std::string &in);
         static std::string computeXxHash(const char *in, std::size_t length);
         static std::string xxHashToStr(XXH64_hash_t hash);
+
+        static void unzipStream(std::istream &inputStream, std::stringstream &ss,
+                                Poco::InflatingStreamBuf::StreamType type = Poco::InflatingStreamBuf::STREAM_GZIP);
 
 #if defined(KD_MACOS)
         static SyncPath getExcludedAppFilePath(bool test = false);

--- a/src/libsyncengine/jobs/network/abstractnetworkjob.cpp
+++ b/src/libsyncengine/jobs/network/abstractnetworkjob.cpp
@@ -39,6 +39,7 @@
 #include <iostream> // std::ios, std::istream, std::cout, std::cerr
 #include <atomic>
 #include <functional>
+#include <thread>
 #include <Poco/JSON/Parser.h>
 #include <Poco/Net/HTTPRequest.h>
 

--- a/src/libsyncengine/jobs/network/abstractnetworkjob.cpp
+++ b/src/libsyncengine/jobs/network/abstractnetworkjob.cpp
@@ -569,7 +569,7 @@ ExitInfo AbstractNetworkJob::handleError(std::istream &inputStream, const Poco::
     return handleError(replyBody, uri);
 }
 
-void readStream(std::istream &inputStream, const Poco::Net::HTTPResponse &httpResponse, std::string &res,
+void readStream(const Poco::Net::HTTPResponse &httpResponse, std::istream &inputStream, std::string &res,
                 std::atomic_bool &finished, std::exception_ptr &threadException) {
     res = {};
     try {
@@ -591,7 +591,7 @@ void readStream(std::istream &inputStream, const Poco::Net::HTTPResponse &httpRe
 void AbstractNetworkJob::getStringFromStream(std::istream &inputStream, std::string &res) {
     std::atomic_bool finished = false;
     std::exception_ptr threadException = nullptr;
-    std::thread t(readStream, std::ref(inputStream), httpResponse(), std::ref(res), std::ref(finished),
+    std::thread t(readStream, httpResponse(), std::ref(inputStream), std::ref(res), std::ref(finished),
                   std::ref(threadException));
 
     // Wait

--- a/src/libsyncengine/jobs/network/abstractnetworkjob.cpp
+++ b/src/libsyncengine/jobs/network/abstractnetworkjob.cpp
@@ -324,13 +324,6 @@ void AbstractNetworkJob::abort() {
     abortSession();
 }
 
-void AbstractNetworkJob::unzip(std::istream &is, std::stringstream &ss) {
-    Poco::InflatingInputStream inflater(is, Poco::InflatingStreamBuf::STREAM_GZIP);
-    while (is) {
-        Poco::StreamCopier::copyStream(inflater, ss);
-    }
-}
-
 void AbstractNetworkJob::createSession(const Poco::URI &uri) {
     const std::scoped_lock lock(_mutexSession);
 
@@ -580,11 +573,7 @@ void readStream(std::istream &inputStream, const Poco::Net::HTTPResponse &httpRe
     try {
         if (const std::string encoding = httpResponse.get("content-encoding", ""); encoding == "gzip") {
             std::stringstream ss;
-            // unzip(inputStream, ss);
-            Poco::InflatingInputStream inflater(inputStream, Poco::InflatingStreamBuf::STREAM_GZIP);
-            while (inputStream) {
-                Poco::StreamCopier::copyStream(inflater, ss);
-            }
+            Utility::unzipStream(inputStream, ss);
             res = ss.str();
         } else {
             std::string tmp(std::istreambuf_iterator<char>(inputStream), (std::istreambuf_iterator<char>()));
@@ -605,7 +594,7 @@ void AbstractNetworkJob::getStringFromStream(std::istream &inputStream, std::str
 
     // Wait
     TimerUtility timer;
-    while (timer.elapsed<std::chrono::seconds>() < std::chrono::seconds(sleepDurationThreshold) && !finished.load()) {
+    while (timer.elapsed<std::chrono::milliseconds>() < std::chrono::milliseconds(sleepDurationThreshold) && !finished.load()) {
         Utility::msleep(100);
     }
 

--- a/src/libsyncengine/jobs/network/abstractnetworkjob.cpp
+++ b/src/libsyncengine/jobs/network/abstractnetworkjob.cpp
@@ -571,6 +571,7 @@ ExitInfo AbstractNetworkJob::handleError(std::istream &inputStream, const Poco::
 
 void readStream(std::istream &inputStream, const Poco::Net::HTTPResponse &httpResponse, std::string &res,
                 std::atomic_bool &finished, std::exception_ptr &threadException) {
+    res = {};
     try {
         if (const std::string encoding = httpResponse.get("content-encoding", ""); encoding == "gzip") {
             std::stringstream ss;
@@ -614,7 +615,7 @@ void AbstractNetworkJob::getStringFromStream(std::istream &inputStream, std::str
         } catch (const std::exception &e) {
             LOG_WARN(_logger, "Failed to read response stream for job " << jobId() << ": " << e.what());
         } catch (...) {
-            LOG_WARN(_logger, "Failed to read response stream for job " << jobId() << ": unknown error");
+            LOG_WARN(_logger, "Failed to read response stream for job " << jobId() << ": unknown exception.");
         }
     }
 }

--- a/src/libsyncengine/jobs/network/abstractnetworkjob.cpp
+++ b/src/libsyncengine/jobs/network/abstractnetworkjob.cpp
@@ -24,6 +24,7 @@
 #include "libcommon/utility/utility.h"
 #include "libcommonserver/utility/utility.h"
 #include "libcommonserver/utility/jsonparserutility.h"
+#include "utility/timerutility.h"
 
 #include <log4cplus/loggingmacros.h>
 
@@ -36,6 +37,7 @@
 #include <Poco/Error.h>
 
 #include <iostream> // std::ios, std::istream, std::cout, std::cerr
+#include <atomic>
 #include <functional>
 #include <Poco/JSON/Parser.h>
 #include <Poco/Net/HTTPRequest.h>
@@ -573,14 +575,57 @@ ExitInfo AbstractNetworkJob::handleError(std::istream &inputStream, const Poco::
     return handleError(replyBody, uri);
 }
 
+void readStream(std::istream &inputStream, const Poco::Net::HTTPResponse &httpResponse, std::string &res,
+                std::atomic_bool &finished, std::exception_ptr &threadException) {
+    try {
+        if (const std::string encoding = httpResponse.get("content-encoding", ""); encoding == "gzip") {
+            std::stringstream ss;
+            // unzip(inputStream, ss);
+            Poco::InflatingInputStream inflater(inputStream, Poco::InflatingStreamBuf::STREAM_GZIP);
+            while (inputStream) {
+                Poco::StreamCopier::copyStream(inflater, ss);
+            }
+            res = ss.str();
+        } else {
+            std::string tmp(std::istreambuf_iterator<char>(inputStream), (std::istreambuf_iterator<char>()));
+            res = std::move(tmp);
+        }
+    } catch (...) {
+        threadException = std::current_exception();
+    }
+
+    finished.store(true);
+}
+
 void AbstractNetworkJob::getStringFromStream(std::istream &inputStream, std::string &res) {
-    if (const std::string encoding = httpResponse().get("content-encoding", ""); encoding == "gzip") {
-        std::stringstream ss;
-        unzip(inputStream, ss);
-        res = ss.str();
-    } else {
-        std::string tmp(std::istreambuf_iterator<char>(inputStream), (std::istreambuf_iterator<char>()));
-        res = std::move(tmp);
+    std::atomic_bool finished = false;
+    std::exception_ptr threadException = nullptr;
+    std::thread t(readStream, std::ref(inputStream), httpResponse(), std::ref(res), std::ref(finished),
+                  std::ref(threadException));
+
+    // Wait
+    TimerUtility timer;
+    while (timer.elapsed<std::chrono::seconds>() < std::chrono::seconds(sleepDurationThreshold) && !finished.load()) {
+        Utility::msleep(100);
+    }
+
+    if (!finished.load()) {
+        LOG_WARN(_logger, "Timed out while reading response stream for job " << jobId() << ", aborting session");
+        abortSession();
+    }
+
+    if (t.joinable()) {
+        t.join();
+    }
+
+    if (threadException) {
+        try {
+            std::rethrow_exception(threadException);
+        } catch (const std::exception &e) {
+            LOG_WARN(_logger, "Failed to read response stream for job " << jobId() << ": " << e.what());
+        } catch (...) {
+            LOG_WARN(_logger, "Failed to read response stream for job " << jobId() << ": unknown error");
+        }
     }
 }
 

--- a/src/libsyncengine/jobs/network/abstractnetworkjob.h
+++ b/src/libsyncengine/jobs/network/abstractnetworkjob.h
@@ -67,8 +67,6 @@ class AbstractNetworkJob : public SyncJob {
         virtual std::string getSpecificUrl() = 0;
         virtual std::string getUrl() = 0;
 
-        void unzip(std::istream &inputStream, std::stringstream &ss);
-
         [[nodiscard]] std::string errorText(Poco::Exception const &e) const;
         [[nodiscard]] std::string errorText(std::exception const &e) const;
 

--- a/src/libsyncengine/jobs/network/kDrive_API/listing/csvfullfilelistwithcursorjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/listing/csvfullfilelistwithcursorjob.cpp
@@ -73,7 +73,7 @@ void CsvFullFileListWithCursorJob::setQueryParameters(Poco::URI &uri) {
 
 ExitInfo CsvFullFileListWithCursorJob::handleResponse(std::istream &is) {
     if (_zip) {
-        unzip(is, _ss);
+        Utility::unzipStream(is, _ss);
     } else {
         _ss << is.rdbuf();
     }


### PR DESCRIPTION
## What changed
- Hardened response body reading in `AbstractNetworkJob::getStringFromStream`.
- Replaced detached reader behavior with a joinable worker thread and explicit completion signaling.
- Added timeout handling that aborts the HTTP session when body reading stalls.
- Added exception propagation/logging from the reader thread to avoid silent failures.
## Why
When backend listing requests return HTTP 500, response-body decoding/reading could get stuck in the error path and make higher-level workers appear blocked.
This change makes the read path deterministic and resilient, so jobs complete and propagate `ExitCode::BackError` / `ExitCause::Http5xx` correctly.
## Scope
- `src/libsyncengine/jobs/network/abstractnetworkjob.cpp`