### PR TITLE
feat(auth): add debug environment variable to bypass keychain access

### DIFF
--- a/src/libsyncengine/jobs/network/abstracttokennetworkjob.cpp
+++ b/src/libsyncengine/jobs/network/abstracttokennetworkjob.cpp
@@ -395,7 +395,7 @@ void AbstractTokenNetworkJob::loadUserInfoFromUserDbId() {
             throw TokenError(err);
         }
 
-        // Read token form keystore
+        // Read token from keystore
         auto login = std::make_shared<Login>(user.keychainKey());
         if (!login->hasToken()) {
             const std::string err{"Failed to retrieve access token"};

--- a/src/libsyncengine/jobs/network/abstracttokennetworkjob.cpp
+++ b/src/libsyncengine/jobs/network/abstracttokennetworkjob.cpp
@@ -345,16 +345,16 @@ ExitInfo AbstractTokenNetworkJob::handleJsonResponse(const std::string &replyBod
 
 #ifndef NDEBUG
 namespace {
-std::string hasDebugApiToken(const UserId &userId) {
+std::string getAccessTokenFromEnv(const UserId &userId) {
     std::string str = CommonUtility::envVarValue("KDRIVE_DEBUG_API_TOKEN");
     if (str.empty()) return {};
 
     const auto strList = Utility::splitStr(str, ';');
     if (strList.size() != 2) return {};
 
-    const auto debugUserDbId = strList[0];
+    const auto debugUserId = strList[0];
     const auto debugAccessToken = strList[1];
-    if (debugUserDbId != std::to_string(userId)) return {};
+    if (debugUserId != std::to_string(userId)) return {};
 
     return debugAccessToken;
 }
@@ -386,7 +386,7 @@ void AbstractTokenNetworkJob::loadUserInfoFromUserDbId() {
 
 
 #ifndef NDEBUG
-    const auto debugAccessToken = hasDebugApiToken(user.userId());
+    const auto debugAccessToken = getAccessTokenFromEnv(user.userId());
     if (debugAccessToken.empty()) {
 #endif
         if (user.keychainKey().empty()) {

--- a/src/libsyncengine/jobs/network/abstracttokennetworkjob.cpp
+++ b/src/libsyncengine/jobs/network/abstracttokennetworkjob.cpp
@@ -343,6 +343,24 @@ ExitInfo AbstractTokenNetworkJob::handleJsonResponse(const std::string &replyBod
     return ExitCode::Ok;
 }
 
+#ifndef NDEBUG
+namespace {
+std::string hasDebugApiToken(const UserId &userId) {
+    std::string str = CommonUtility::envVarValue("KDRIVE_DEBUG_API_TOKEN");
+    if (str.empty()) return {};
+
+    const auto strList = Utility::splitStr(str, ';');
+    if (strList.size() != 2) return {};
+
+    const auto debugUserDbId = strList[0];
+    const auto debugAccessToken = strList[1];
+    if (debugUserDbId != std::to_string(userId)) return {};
+
+    return debugAccessToken;
+}
+} // namespace
+#endif
+
 void AbstractTokenNetworkJob::loadUserInfoFromUserDbId() {
     assert(_userDbId && "Invalid user DB ID.");
 
@@ -366,21 +384,35 @@ void AbstractTokenNetworkJob::loadUserInfoFromUserDbId() {
         throw DataError(err);
     }
 
-    if (user.keychainKey().empty()) {
-        const std::string err{"Access token is empty"};
-        LOG_DEBUG(_logger, err);
-        throw TokenError(err);
-    }
 
-    // Read token form keystore
-    auto login = std::make_shared<Login>(user.keychainKey());
-    if (!login->hasToken()) {
-        const std::string err{"Failed to retrieve access token"};
-        LOG_WARN(_logger, err);
-        throw TokenError(err);
-    }
+#ifndef NDEBUG
+    const auto debugAccessToken = hasDebugApiToken(user.userId());
+    if (debugAccessToken.empty()) {
+#endif
+        if (user.keychainKey().empty()) {
+            const std::string err{"Access token is empty"};
+            LOG_DEBUG(_logger, err);
+            throw TokenError(err);
+        }
 
-    _userToApiKeyMap[_userDbId] = {login, user.userId()};
+        // Read token form keystore
+        auto login = std::make_shared<Login>(user.keychainKey());
+        if (!login->hasToken()) {
+            const std::string err{"Failed to retrieve access token"};
+            LOG_WARN(_logger, err);
+            throw TokenError(err);
+        }
+        _userToApiKeyMap[_userDbId] = {login, user.userId()};
+#ifndef NDEBUG
+    } else {
+        ApiToken apiToken;
+        apiToken.setAccessToken(debugAccessToken);
+        auto login = std::make_shared<Login>();
+        login->setApiToken(apiToken);
+        LOG_INFO(_logger, "Using API token from environment variable KDRIVE_DEBUG_API_TOKEN for userDbId=" << _userDbId);
+        _userToApiKeyMap[_userDbId] = {login, user.userId()};
+    }
+#endif
 }
 
 Drive AbstractTokenNetworkJob::getDrive(const DriveDbId driveDbId) const {


### PR DESCRIPTION
## Summary
In debug builds, this PR introduces support for providing an API token via the `KDRIVE_DEBUG_API_TOKEN` environment variable, allowing developers to bypass keychain/keystore access during development and testing.

## Changes
- Added `hasDebugApiToken()` helper (debug builds only) that parses `KDRIVE_DEBUG_API_TOKEN` in the format `userId;accessToken`
- Modified `loadUserInfoFromUserDbId()` to check for debug token before falling back to keychain retrieval
- **This is strictly for debug/development use** — the new code path is guarded by `#ifndef NDEBUG` and does not affect release builds

## Motivation
This simplifies development workflows where authenticating through the system keychain is inconvenient or unnecessary, such as automated testing or local debugging.