### PR TITLE
chore(deps): migrate keychain from git submodule to Conan package

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "src/3rdparty/keychain"]
-	path = src/3rdparty/keychain
-	url = https://github.com/hrantzsch/keychain.git
 [submodule "src/3rdparty/qt-piwik-tracker"]
 	path = src/3rdparty/qt-piwik-tracker
 	url = https://github.com/pbek/qt-piwik-tracker.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,12 +41,6 @@ if(UNIX)
     add_subdirectory(src/3rdparty/utf8proc)
 endif()
 
-# keychain
-add_subdirectory(src/3rdparty/keychain)
-if (UNIX AND NOT APPLE) # Add this on linux to fix keychain problems with gcc 15
-    target_compile_options(keychain PRIVATE -Wno-uninitialized)
-endif()
-
 #####
 
 # Create an alias for the Qt6::Core target, used by the sentry recipe

--- a/conanfile.py
+++ b/conanfile.py
@@ -156,6 +156,7 @@ class KDriveDesktop(ConanFile):
             "shared": False,
             "build_executable": False
         })
+        self.requires("keychain/1.3.0")
         # log4cplus
         self.requires("log4cplus/2.1.2", options={
             "shared": True,

--- a/src/libcommon/CMakeLists.txt
+++ b/src/libcommon/CMakeLists.txt
@@ -111,14 +111,12 @@ if(WIN32)
     target_include_directories(${libcommon_NAME} PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}
         ${CMAKE_CURRENT_BINARY_DIR}
-        "C:/Program Files (x86)/libzip/include"
-        ${CMAKE_SOURCE_DIR}/src/3rdparty/keychain/include)
+        "C:/Program Files (x86)/libzip/include")
 else()
     target_include_directories(${libcommon_NAME} PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}
         ${CMAKE_CURRENT_BINARY_DIR}
-        "/usr/local/include"
-        ${CMAKE_SOURCE_DIR}/src/3rdparty/keychain/include)
+        "/usr/local/include")
 endif()
 
 # Link
@@ -127,7 +125,6 @@ target_link_libraries(${libcommon_NAME}
     Poco::Foundation Poco::JSON Poco::Util
     log4cplus::log4cplus
     sentry::sentry
-    keychain
     libzip::zip)
 
 if(UNIX)

--- a/src/libcommonserver/CMakeLists.txt
+++ b/src/libcommonserver/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(SQLite3 3.53.0 REQUIRED)
 find_package(Poco 1.13.3 REQUIRED Foundation Net JSON Util)
 find_package(OpenSSL 3.1.0 REQUIRED SSL Crypto)
 find_package(xxHash 0.8.2 REQUIRED)
+find_package(keychain REQUIRED)
 
 if(UNIX AND CMAKE_BUILD_TYPE MATCHES "RelWithDebInfo")
     # Use fallback library types for imported dependencies
@@ -138,6 +139,7 @@ target_link_libraries(${libcommonserver_NAME}
     Poco::Foundation Poco::Net Poco::JSON Poco::Util
     OpenSSL::SSL OpenSSL::Crypto
     xxHash::xxhash
+    keychain::keychain
     libzip::zip)
 
 if(WIN32)

--- a/src/libcommonserver/keychainmanager/keychainmanager.cpp
+++ b/src/libcommonserver/keychainmanager/keychainmanager.cpp
@@ -17,8 +17,9 @@
  */
 
 #include "keychainmanager.h"
-#include "keychain/keychain.h"
 #include "log/log.h"
+
+#include "keychain/keychain.h"
 
 #include <log4cplus/loggingmacros.h>
 


### PR DESCRIPTION
## Summary

Replace the `hrantzsch/keychain` git submodule with the `keychain/1.3.0` package from Conan Center.

## Motivation

Managing keychain as a submodule required manual tracking of the Git dependency and injecting a hand-rolled `include_directories` path into every consuming target. Using the Conan package:

- unifies all C++ dependency management through Conan
- propagates include dirs and link via proper CMake usage requirements (`keychain::keychain` target)
- removes the ad-hoc `-Wno-uninitialized` workaround that was needed for GCC 15 on Linux

## Changes

| File | What changed |
|---|---|
| `.gitmodules` | Remove `src/3rdparty/keychain` submodule entry |
| `src/3rdparty/keychain` | Deleted (was tracked as submodule) |
| `CMakeLists.txt` | Remove `add_subdirectory(src/3rdparty/keychain)` block |
| `conanfile.py` | Add `self.requires("keychain/1.3.0")` |
| `src/libcommon/CMakeLists.txt` | Drop manual keychain include dir and old `keychain` link target |
| `src/libcommonserver/CMakeLists.txt` | Add `find_package(keychain REQUIRED)` and link `keychain::keychain` — the correct Conan exported target, on the library that actually owns `keychainmanager.cpp` |
| `src/libcommonserver/keychainmanager/keychainmanager.cpp` | Move `keychain/keychain.h` include below project headers (Google style) |