### PR TITLE
fix(winui): various bug fix

### DIFF
--- a/src/gui4/windows/kDrive client/kDrive client/App.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/App.xaml.cs
@@ -19,6 +19,7 @@
 using CodeArt.MatomoTracking;
 using DynamicData;
 using Infomaniak.kDrive.Analytics;
+using Infomaniak.kDrive.OnBoarding;
 using Infomaniak.kDrive.ServerCommunication.Interfaces;
 using Infomaniak.kDrive.ServerCommunication.Services;
 using Infomaniak.kDrive.TrayIcon;
@@ -164,21 +165,32 @@ namespace Infomaniak.kDrive
         public enum CreateWindowOptions
         {
             Foreground = 1,
-            CancelOnboarding = 2
+            CancelOnboarding = 2,
+            OpenSettings = 4
         }
         public void CreateWindow(CreateWindowOptions options)
         {
+            if (CurrentWindow is OnBoardingWindow && options.HasFlag(CreateWindowOptions.CancelOnboarding))
+            {
+                CurrentWindow.Close();
+                CurrentWindow = null;
+            }
+
             if (CurrentWindow is null)
             {
                 var appModel = ServiceProvider.GetRequiredService<AppModel>();
                 if (options.HasFlag(CreateWindowOptions.CancelOnboarding) || !StartOnboardingIfNeeded())
                 {
-                    CurrentWindow = new MainWindow();
+                    CurrentWindow = new MainWindow(options.HasFlag(CreateWindowOptions.OpenSettings) ? typeof(Pages.Settings.SettingsPage) : null);
                 }
                 else
                 {
                     options &= ~CreateWindowOptions.Foreground; // StartOnboarding will handle bringing the window to the front, so we can skip it here to avoid unnecessary calls.
                 }
+            }
+            else if (CurrentWindow is MainWindow mainWindow && options.HasFlag(CreateWindowOptions.OpenSettings))
+            {
+                mainWindow?.AppNavView?.Frame?.Navigate(typeof(Pages.Settings.SettingsPage));
             }
 
             if (options.HasFlag(CreateWindowOptions.Foreground))

--- a/src/gui4/windows/kDrive client/kDrive client/App.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/App.xaml.cs
@@ -253,11 +253,15 @@ namespace Infomaniak.kDrive
             return false;
         }
 
-        public static void RestartApplication()
+        public static void RestartApplicationWindows()
         {
-            Logger.Log(Logger.Level.Info, $"Restarting client app");
-            Windows.ApplicationModel.Core.AppRestartFailureReason failureReason = Microsoft.Windows.AppLifecycle.AppInstance.Restart(string.Join(" ", Environment.GetCommandLineArgs()));
-            Logger.Log(Logger.Level.Warning, $"Restarting application fail with reason: {failureReason}");
+            Logger.Log(Logger.Level.Info, $"Restarting all application windows.");
+            App app = (App)Current;
+            app.CloseUpdateWindow();
+            var previousWindow = app.CurrentWindow;
+            app.CurrentWindow = new OnBoarding.OnBoardingWindow();
+            previousWindow?.Close();
+            app.CreateWindow(CreateWindowOptions.Foreground);
         }
         public static void ExitApplication()
         {

--- a/src/gui4/windows/kDrive client/kDrive client/App.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/App.xaml.cs
@@ -259,7 +259,7 @@ namespace Infomaniak.kDrive
             App app = (App)Current;
             app.CloseUpdateWindow();
             var previousWindow = app.CurrentWindow;
-            app.CurrentWindow = new OnBoarding.OnBoardingWindow();
+            app.CurrentWindow = null;
             previousWindow?.Close();
             app.CreateWindow(CreateWindowOptions.Foreground);
         }

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/AppNavigationView.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/AppNavigationView.xaml.cs
@@ -73,10 +73,22 @@ namespace Infomaniak.kDrive.CustomControls
             InitializeComponent();
         }
 
+        public Type? LandingPageType
+        {
+            get { return (Type?)GetValue(LandingPageTypeProperty); }
+            set { SetValue(LandingPageTypeProperty, value); }
+        }
+
+        public static readonly DependencyProperty LandingPageTypeProperty =
+           DependencyProperty.Register(nameof(LandingPageType), typeof(Type), typeof(AppNavigationView), new PropertyMetadata(null));
+
         private void AppNavigationView_Loaded(object sender, RoutedEventArgs e)
         {
             Frame.Navigated += Frame_Navigated;
-            Frame.Navigate(typeof(Pages.HomePage));
+            if (LandingPageType is not null && LandingPageType.IsSubclassOf(typeof(Page)))
+                Frame.Navigate(LandingPageType);
+            else 
+                Frame.Navigate(typeof(Pages.HomePage));
 
             // Add an infobadge to SettingsItem
             var infoBadge = new InfoBadge()

--- a/src/gui4/windows/kDrive client/kDrive client/MainWindow.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/MainWindow.xaml.cs
@@ -30,8 +30,8 @@ namespace Infomaniak.kDrive
 {
     public sealed partial class MainWindow : Window
     {
-        private const int _defaultWidth = 900;
-        private const int _defaultHeight = 600;
+        private const int _defaultWidth = 1025;
+        private const int _defaultHeight = 683;
         private const int _minimumWidth = 900;
         private const int _minimumHeight = 600;
         public AppNavigationView AppNavView { get { return NavView; } }
@@ -44,6 +44,7 @@ namespace Infomaniak.kDrive
             this.SetTitleBar(AppTitleBar);
             Utility.SetWindowProperties(this, _minimumWidth, _minimumHeight, Utility.WindowResizeOptions.AllowMinimize | Utility.WindowResizeOptions.AllowResize); // Set initial size and allow resizing
             Utility.SetWindowCurrentSize(this, _defaultWidth, _defaultHeight); // Set to the minimum size keeping the nav bar panel open by default
+            Utility.CenterWindow(this);
             AppModel.UIThreadDispatcher = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread(); // Save the UI thread dispatcher for later use in view models
             AppWindow.TitleBar.PreferredTheme = Microsoft.UI.Windowing.TitleBarTheme.UseDefaultAppMode;
             ViewModel.PropertyChanged += ViewModel_PropertyChanged;

--- a/src/gui4/windows/kDrive client/kDrive client/MainWindow.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/MainWindow.xaml.cs
@@ -43,8 +43,8 @@ namespace Infomaniak.kDrive
             AppNavView.LandingPageType = landingPageType;
             this.ExtendsContentIntoTitleBar = true;  // enable custom titlebar
             this.SetTitleBar(AppTitleBar);
-            Utility.SetWindowProperties(this, _minimumWidth, _minimumHeight, Utility.WindowResizeOptions.AllowMinimize | Utility.WindowResizeOptions.AllowResize); // Set initial size and allow resizing
-            Utility.SetWindowCurrentSize(this, _defaultWidth, _defaultHeight); // Set to the minimum size keeping the nav bar panel open by default
+            Utility.SetWindowProperties(this, _minimumWidth, _minimumHeight, Utility.WindowResizeOptions.AllowMinimize | Utility.WindowResizeOptions.AllowResize); // Set the minimum size and allow resizing
+            Utility.SetWindowCurrentSize(this, _defaultWidth, _defaultHeight); // Default size sized for the navigation pane expanded state
             Utility.CenterWindow(this);
             AppModel.UIThreadDispatcher = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread(); // Save the UI thread dispatcher for later use in view models
             AppWindow.TitleBar.PreferredTheme = Microsoft.UI.Windowing.TitleBarTheme.UseDefaultAppMode;

--- a/src/gui4/windows/kDrive client/kDrive client/MainWindow.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/MainWindow.xaml.cs
@@ -37,9 +37,10 @@ namespace Infomaniak.kDrive
         public AppNavigationView AppNavView { get { return NavView; } }
         public AppModel ViewModel { get; } = App.ServiceProvider.GetRequiredService<AppModel>();
 
-        public MainWindow()
+        public MainWindow(Type? landingPageType = null)
         {
             InitializeComponent();
+            AppNavView.LandingPageType = landingPageType;
             this.ExtendsContentIntoTitleBar = true;  // enable custom titlebar
             this.SetTitleBar(AppTitleBar);
             Utility.SetWindowProperties(this, _minimumWidth, _minimumHeight, Utility.WindowResizeOptions.AllowMinimize | Utility.WindowResizeOptions.AllowResize); // Set initial size and allow resizing

--- a/src/gui4/windows/kDrive client/kDrive client/OnBoardingWindow.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/OnBoardingWindow.xaml
@@ -48,8 +48,7 @@
         <TitleBar x:Name="AppTitleBar"
                   Grid.Row="0"
                   Grid.ColumnSpan="2"
-                  Title="kDrive"
-                  Subtitle="Beta">
+                  Title="kDrive">
             <TitleBar.IconSource>
                 <ImageIconSource>
                     <ImageIconSource.ImageSource>

--- a/src/gui4/windows/kDrive client/kDrive client/OnBoardingWindow.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/OnBoardingWindow.xaml.cs
@@ -50,6 +50,7 @@ namespace Infomaniak.kDrive.OnBoarding
 
             this.SetTitleBar(AppTitleBar);
             Utility.SetWindowProperties(this, _minimumWidth, _minimumHeight, Utility.WindowResizeOptions.AllowMinimize | Utility.WindowResizeOptions.AllowResize); // Set initial size and allow resizing
+            Utility.CenterWindow(this);
             LottiePlayer.ActualThemeChanged += LottiePlayer_ActualThemeChanged;
             UpdateLottieSource(_lottieRessourceKey, 130, 1);
             Closed += OnBoardingWindow_Closed;

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/SettingsPage.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/SettingsPage.xaml
@@ -267,6 +267,7 @@
                     <ListView x:Name="UsersListView"
                               ItemsSource="{x:Bind ViewModel.Users, Mode=OneWay}"
                               SelectionMode="None"
+                              ScrollViewer.VerticalScrollMode="Disabled"
                               Visibility="{x:Bind ViewModel.Users.Count, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}">
                         <ListView.ItemContainerStyle>
                             <Style TargetType="ListViewItem">

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/SettingsPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/SettingsPage.xaml.cs
@@ -528,10 +528,7 @@ namespace Infomaniak.kDrive.Pages.Settings
             }
 
             if (!control.IsEnabled)
-            {
-                Logger.Log(Logger.Level.Error, "control is disabled");
                 return;
-            }
 
             control.IsEnabled = false;
 
@@ -572,10 +569,8 @@ namespace Infomaniak.kDrive.Pages.Settings
             }
 
             if (!control.IsEnabled)
-            {
-                Logger.Log(Logger.Level.Error, "control is disabled");
                 return;
-            }
+
             _analyticsService.TrackClick(Analytics.Keys.Category.GeneralSettingsPage, Analytics.Keys.EventName.ChangeLanguage);
 
             control.IsEnabled = false;

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/SettingsPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/SettingsPage.xaml.cs
@@ -662,7 +662,7 @@ namespace Infomaniak.kDrive.Pages.Settings
             }
         }
 
-        private void RestartAppHyperlinkButton_Click(object sender, RoutedEventArgs e) => App.RestartApplication();
+        private void RestartAppHyperlinkButton_Click(object sender, RoutedEventArgs e) => App.RestartApplicationWindows();
     }
     // templateSelector for the drives listview
     public partial class DriveDataTemplateSelector : DataTemplateSelector

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/SettingsPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/SettingsPage.xaml.cs
@@ -662,7 +662,11 @@ namespace Infomaniak.kDrive.Pages.Settings
             }
         }
 
-        private void RestartAppHyperlinkButton_Click(object sender, RoutedEventArgs e) => App.RestartApplicationWindows();
+        private void RestartAppHyperlinkButton_Click(object sender, RoutedEventArgs e)
+        {
+            App.RestartApplicationWindows();
+            ViewModel.Settings.RestartRequiredForLanguageChange = false;
+        }
     }
     // templateSelector for the drives listview
     public partial class DriveDataTemplateSelector : DataTemplateSelector

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/da-DK/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/da-DK/Resources.resw
@@ -6,7 +6,7 @@
   Locale: da, Danish
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Mon, 11 May 2026 09:31:50 +0200 
+  Exported at: Tue, 19 May 2026 14:16:33 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -1614,6 +1614,9 @@ Synkronisering er sat på pause. Kontrollér venligst dine filer og prøv igen.<
     <value>Åbn kDrive</value> 
     <comment>This translation is used for the taskbar icon menu, which requires the x:Uid format (i.e., suffixed with .Label).</comment> 
   </data> 
+  <data name="trayIconButtonOpenSettings.Label" xml:space="preserve"> 
+    <value>Indstillinger</value> 
+  </data> 
   <data name="unableToCreateRemoteFolderTeachingTipContent" xml:space="preserve"> 
     <value>Kontrollér, at din internetforbindelse er aktiv, at dette navn ikke allerede er i brug, og at det ikke indeholder ugyldige tegn.</value> 
   </data> 
@@ -1682,6 +1685,9 @@ Opdater programmet for at få adgang til dine filer og genoptage synkronisering.
   </data> 
   <data name="userExclusionFileListHeader" xml:space="preserve"> 
     <value>Brugerdefinerede udelukkelsesregler</value> 
+  </data> 
+  <data name="userExclusionFileListHeaderDescription" xml:space="preserve"> 
+    <value>Udeluk bestemte filtyper fra synkronisering.</value> 
   </data> 
   <data name="viewSourceCode" xml:space="preserve"> 
     <value>Se kildekode</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/de-DE/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/de-DE/Resources.resw
@@ -6,7 +6,7 @@
   Locale: de, German
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Mon, 11 May 2026 09:31:50 +0200 
+  Exported at: Tue, 19 May 2026 14:16:33 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -1455,7 +1455,7 @@ Diese Daten ermöglichen es unserem Team, die Anwendung schnell zu beheben und z
     <value>Einstellungen</value> 
   </data> 
   <data name="sidebarItemAccounts" xml:space="preserve"> 
-    <value>Konten</value> 
+    <value>Konten &amp; Synchronisierungen</value> 
   </data> 
   <data name="sidebarItemAdvanced" xml:space="preserve"> 
     <value>Erweitert</value> 
@@ -1613,6 +1613,9 @@ Die Synchronisierung wurde pausiert. Bitte überprüfen Sie Ihre Dateien und ver
     <value>kDrive öffnen</value> 
     <comment>This translation is used for the taskbar icon menu, which requires the x:Uid format (i.e., suffixed with .Label).</comment> 
   </data> 
+  <data name="trayIconButtonOpenSettings.Label" xml:space="preserve"> 
+    <value>Einstellungen</value> 
+  </data> 
   <data name="unableToCreateRemoteFolderTeachingTipContent" xml:space="preserve"> 
     <value>Stellen Sie sicher, dass Ihre Internetverbindung aktiv ist, dass dieser Name nicht bereits verwendet wird und dass er keine ungültigen Zeichen enthält.</value> 
   </data> 
@@ -1681,6 +1684,9 @@ Bitte aktualisieren Sie die Anwendung, um auf Ihre Dateien zuzugreifen und die S
   </data> 
   <data name="userExclusionFileListHeader" xml:space="preserve"> 
     <value>Benutzerdefinierte Ausschlussregeln</value> 
+  </data> 
+  <data name="userExclusionFileListHeaderDescription" xml:space="preserve"> 
+    <value>Schliessen Sie bestimmte Dateitypen von der Synchronisierung aus.</value> 
   </data> 
   <data name="viewSourceCode" xml:space="preserve"> 
     <value>Quellcode anzeigen</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/el-GR/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/el-GR/Resources.resw
@@ -6,7 +6,7 @@
   Locale: el, Greek
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Mon, 11 May 2026 09:31:50 +0200 
+  Exported at: Tue, 19 May 2026 14:16:33 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -73,7 +73,7 @@
     <value>Greek</value>
   </metadata> 
   <data name="aboutAppVersionCopyright" xml:space="preserve"> 
-    <value>Έκδοση %@.%@
+    <value>Version %@.%@
 © 2019-%@ Infomaniak Network SA -</value> 
   </data> 
   <data name="aboutKDrive" xml:space="preserve"> 
@@ -1456,7 +1456,7 @@
     <value>Ρυθμίσεις</value> 
   </data> 
   <data name="sidebarItemAccounts" xml:space="preserve"> 
-    <value>Λογαριασμοί</value> 
+    <value>Λογαριασμοί &amp; Συγχρονισμοί</value> 
   </data> 
   <data name="sidebarItemAdvanced" xml:space="preserve"> 
     <value>Προηγμένα</value> 
@@ -1614,6 +1614,9 @@
     <value>Άνοιγμα kDrive</value> 
     <comment>This translation is used for the taskbar icon menu, which requires the x:Uid format (i.e., suffixed with .Label).</comment> 
   </data> 
+  <data name="trayIconButtonOpenSettings.Label" xml:space="preserve"> 
+    <value>Ρυθμίσεις</value> 
+  </data> 
   <data name="unableToCreateRemoteFolderTeachingTipContent" xml:space="preserve"> 
     <value>Ελέγξτε ότι η σύνδεσή σας στο διαδίκτυο είναι ενεργή, ότι αυτό το όνομα δεν χρησιμοποιείται ήδη και ότι δεν περιέχει μη έγκυρους χαρακτήρες.</value> 
   </data> 
@@ -1682,6 +1685,9 @@
   </data> 
   <data name="userExclusionFileListHeader" xml:space="preserve"> 
     <value>Προσαρμοσμένοι κανόνες εξαίρεσης</value> 
+  </data> 
+  <data name="userExclusionFileListHeaderDescription" xml:space="preserve"> 
+    <value>Εξαιρέστε ορισμένους τύπους αρχείων από τον συγχρονισμό.</value> 
   </data> 
   <data name="viewSourceCode" xml:space="preserve"> 
     <value>Προβολή πηγαίου κώδικα</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/en-US/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/en-US/Resources.resw
@@ -6,7 +6,7 @@
   Locale: en, English
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Mon, 11 May 2026 09:31:50 +0200 
+  Exported at: Tue, 19 May 2026 14:16:32 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -1456,7 +1456,7 @@ This data allows our team to quickly fix and optimize the application, resulting
     <value>Settings</value> 
   </data> 
   <data name="sidebarItemAccounts" xml:space="preserve"> 
-    <value>Accounts</value> 
+    <value>Accounts &amp; Sync</value> 
   </data> 
   <data name="sidebarItemAdvanced" xml:space="preserve"> 
     <value>Advanced</value> 
@@ -1614,6 +1614,9 @@ Sync has been paused. Please check your files and try again.</value>
     <value>Open kDrive</value> 
     <comment>This translation is used for the taskbar icon menu, which requires the x:Uid format (i.e., suffixed with .Label).</comment> 
   </data> 
+  <data name="trayIconButtonOpenSettings.Label" xml:space="preserve"> 
+    <value>Settings</value> 
+  </data> 
   <data name="unableToCreateRemoteFolderTeachingTipContent" xml:space="preserve"> 
     <value>Check that your internet connection is active, that this name is not already in use, and that it does not contain invalid characters.</value> 
   </data> 
@@ -1682,6 +1685,9 @@ Please update the application to access your files and resume synchronization.</
   </data> 
   <data name="userExclusionFileListHeader" xml:space="preserve"> 
     <value>Custom exclusion rules</value> 
+  </data> 
+  <data name="userExclusionFileListHeaderDescription" xml:space="preserve"> 
+    <value>Exclude certain file types from synchronization.</value> 
   </data> 
   <data name="viewSourceCode" xml:space="preserve"> 
     <value>View source code</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/es-ES/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/es-ES/Resources.resw
@@ -6,7 +6,7 @@
   Locale: es, Spanish
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Mon, 11 May 2026 09:31:50 +0200 
+  Exported at: Tue, 19 May 2026 14:16:33 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -1456,7 +1456,7 @@ Estos datos permiten a nuestro equipo corregir y optimizar rápidamente la aplic
     <value>Ajustes</value> 
   </data> 
   <data name="sidebarItemAccounts" xml:space="preserve"> 
-    <value>Cuentas</value> 
+    <value>Cuentas y sincronizaciones</value> 
   </data> 
   <data name="sidebarItemAdvanced" xml:space="preserve"> 
     <value>Avanzado</value> 
@@ -1614,6 +1614,9 @@ La sincronización ha sido pausada. Verifique sus archivos e inténtelo de nuevo
     <value>Abrir kDrive</value> 
     <comment>This translation is used for the taskbar icon menu, which requires the x:Uid format (i.e., suffixed with .Label).</comment> 
   </data> 
+  <data name="trayIconButtonOpenSettings.Label" xml:space="preserve"> 
+    <value>Ajustes</value> 
+  </data> 
   <data name="unableToCreateRemoteFolderTeachingTipContent" xml:space="preserve"> 
     <value>Verifique que su conexión a Internet esté activa, que este nombre no esté ya en uso y que no contenga caracteres no válidos.</value> 
   </data> 
@@ -1682,6 +1685,9 @@ Actualice la aplicación para acceder a sus archivos y reanudar la sincronizaci�
   </data> 
   <data name="userExclusionFileListHeader" xml:space="preserve"> 
     <value>Reglas de exclusión personalizadas</value> 
+  </data> 
+  <data name="userExclusionFileListHeaderDescription" xml:space="preserve"> 
+    <value>Excluya ciertos tipos de archivos de la sincronización.</value> 
   </data> 
   <data name="viewSourceCode" xml:space="preserve"> 
     <value>Ver código fuente</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/fi-FI/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/fi-FI/Resources.resw
@@ -6,7 +6,7 @@
   Locale: fi, Finnish
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Mon, 11 May 2026 09:31:50 +0200 
+  Exported at: Tue, 19 May 2026 14:16:33 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -1456,7 +1456,7 @@ Näiden tietojen avulla tiimimme voi nopeasti korjata ja optimoida sovellusta, m
     <value>Asetukset</value> 
   </data> 
   <data name="sidebarItemAccounts" xml:space="preserve"> 
-    <value>Tilit</value> 
+    <value>Tilit ja synkronoinnit</value> 
   </data> 
   <data name="sidebarItemAdvanced" xml:space="preserve"> 
     <value>Lisäasetukset</value> 
@@ -1614,6 +1614,9 @@ Synkronointi on keskeytetty. Tarkista tiedostosi ja yritä uudelleen.</value>
     <value>Avaa kDrive</value> 
     <comment>This translation is used for the taskbar icon menu, which requires the x:Uid format (i.e., suffixed with .Label).</comment> 
   </data> 
+  <data name="trayIconButtonOpenSettings.Label" xml:space="preserve"> 
+    <value>Asetukset</value> 
+  </data> 
   <data name="unableToCreateRemoteFolderTeachingTipContent" xml:space="preserve"> 
     <value>Tarkista, että internet-yhteysi on aktiivinen, että tätä nimeä ei ole jo käytössä ja ettei se sisällä virheellisiä merkkejä.</value> 
   </data> 
@@ -1682,6 +1685,9 @@ Päivitä sovellus päästäksesi tiedostoihisi ja jatkaaksesi synkronointia.</v
   </data> 
   <data name="userExclusionFileListHeader" xml:space="preserve"> 
     <value>Mukautetut poissulkemissäännöt</value> 
+  </data> 
+  <data name="userExclusionFileListHeaderDescription" xml:space="preserve"> 
+    <value>Sulje tietyt tiedostotyypit synkronoinnin ulkopuolelle.</value> 
   </data> 
   <data name="viewSourceCode" xml:space="preserve"> 
     <value>Näytä lähdekoodi</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/fr-FR/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/fr-FR/Resources.resw
@@ -6,7 +6,7 @@
   Locale: fr, French
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Mon, 11 May 2026 12:40:23 +0200 
+  Exported at: Tue, 19 May 2026 14:16:33 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -1614,6 +1614,9 @@ La synchronisation a été interrompue. Veuillez vérifier vos fichiers et rées
     <value>Ouvrir kDrive</value> 
     <comment>This translation is used for the taskbar icon menu, which requires the x:Uid format (i.e., suffixed with .Label).</comment> 
   </data> 
+  <data name="trayIconButtonOpenSettings.Label" xml:space="preserve"> 
+    <value>Paramètres</value> 
+  </data> 
   <data name="unableToCreateRemoteFolderTeachingTipContent" xml:space="preserve"> 
     <value>Vérifiez que votre connexion internet est active, que ce nom n’est pas déjà utilisé et qu’il ne contient pas de caractères invalides.</value> 
   </data> 
@@ -1683,6 +1686,9 @@ Mettez à jour l’application pour accéder à vos fichiers et relancer la sync
   <data name="userExclusionFileListHeader" xml:space="preserve"> 
     <value>Règles d’exclusion personnalisées</value> 
   </data> 
+  <data name="userExclusionFileListHeaderDescription" xml:space="preserve"> 
+    <value>Excluez certains types de fichiers de la synchronisation.</value> 
+  </data> 
   <data name="viewSourceCode" xml:space="preserve"> 
     <value>Voir le code source</value> 
   </data> 
@@ -1705,7 +1711,7 @@ déverrouillé et accessible depuis votre ordinateur.</value>
     <comment>Title shown when a storage disk is not accessible; %@ is the disk name or drive letter.</comment> 
   </data> 
   <data name="winbuttonRemoveFileExclusionRule" xml:space="preserve"> 
-    <value>Retirer</value> 
+    <value>Supprimer</value> 
     <comment>Button to remove a single selected file exclusion rule from the exclusion list.</comment> 
   </data> 
   <data name="winbuttonRemoveFileExclusionRule-plural" xml:space="preserve"> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/it-IT/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/it-IT/Resources.resw
@@ -6,7 +6,7 @@
   Locale: it, Italian
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Mon, 11 May 2026 09:31:50 +0200 
+  Exported at: Tue, 19 May 2026 14:16:33 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -1456,7 +1456,7 @@ Questi dati consentono al nostro team di correggere e ottimizzare rapidamente l�
     <value>Impostazioni</value> 
   </data> 
   <data name="sidebarItemAccounts" xml:space="preserve"> 
-    <value>Account</value> 
+    <value>Account e sincronizzazioni</value> 
   </data> 
   <data name="sidebarItemAdvanced" xml:space="preserve"> 
     <value>Avanzate</value> 
@@ -1614,6 +1614,9 @@ La sincronizzazione è stata sospesa. Verifica i tuoi file e riprova.</value>
     <value>Apri kDrive</value> 
     <comment>This translation is used for the taskbar icon menu, which requires the x:Uid format (i.e., suffixed with .Label).</comment> 
   </data> 
+  <data name="trayIconButtonOpenSettings.Label" xml:space="preserve"> 
+    <value>Impostazioni</value> 
+  </data> 
   <data name="unableToCreateRemoteFolderTeachingTipContent" xml:space="preserve"> 
     <value>Verifica che la tua connessione internet sia attiva, che questo nome non sia già in uso e che non contenga caratteri non validi.</value> 
   </data> 
@@ -1682,6 +1685,9 @@ Aggiorna l’applicazione per accedere ai tuoi file e riprendere la sincronizzaz
   </data> 
   <data name="userExclusionFileListHeader" xml:space="preserve"> 
     <value>Regole di esclusione personalizzate</value> 
+  </data> 
+  <data name="userExclusionFileListHeaderDescription" xml:space="preserve"> 
+    <value>Escludi alcuni tipi di file dalla sincronizzazione.</value> 
   </data> 
   <data name="viewSourceCode" xml:space="preserve"> 
     <value>Visualizza codice sorgente</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/nb-NO/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/nb-NO/Resources.resw
@@ -6,7 +6,7 @@
   Locale: nb, Norwegian Bokmål
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Mon, 11 May 2026 09:31:50 +0200 
+  Exported at: Tue, 19 May 2026 14:16:33 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -1456,7 +1456,7 @@ Disse dataene lar teamet vårt raskt rette og optimalisere programmet, noe som g
     <value>Innstillinger</value> 
   </data> 
   <data name="sidebarItemAccounts" xml:space="preserve"> 
-    <value>Kontoer</value> 
+    <value>Kontoer og synkroniseringer</value> 
   </data> 
   <data name="sidebarItemAdvanced" xml:space="preserve"> 
     <value>Avansert</value> 
@@ -1614,6 +1614,9 @@ Synkronisering er stoppet midlertidig. Kontroller filene dine og prøv igjen.</v
     <value>Åpne kDrive</value> 
     <comment>This translation is used for the taskbar icon menu, which requires the x:Uid format (i.e., suffixed with .Label).</comment> 
   </data> 
+  <data name="trayIconButtonOpenSettings.Label" xml:space="preserve"> 
+    <value>Innstillinger</value> 
+  </data> 
   <data name="unableToCreateRemoteFolderTeachingTipContent" xml:space="preserve"> 
     <value>Kontroller at internettforbindelsen er aktiv, at dette navnet ikke allerede er i bruk, og at det ikke inneholder ugyldige tegn.</value> 
   </data> 
@@ -1682,6 +1685,9 @@ Oppdater programmet for å få tilgang til filene dine og gjenoppta synkroniseri
   </data> 
   <data name="userExclusionFileListHeader" xml:space="preserve"> 
     <value>Tilpassede ekskluderingsregler</value> 
+  </data> 
+  <data name="userExclusionFileListHeaderDescription" xml:space="preserve"> 
+    <value>Utelukk bestemte filtyper fra synkronisering.</value> 
   </data> 
   <data name="viewSourceCode" xml:space="preserve"> 
     <value>Vis kildekode</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/nl-NL/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/nl-NL/Resources.resw
@@ -6,7 +6,7 @@
   Locale: nl, Dutch; Flemish
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Mon, 11 May 2026 09:31:50 +0200 
+  Exported at: Tue, 19 May 2026 14:16:33 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -1456,7 +1456,7 @@ Deze gegevens stellen ons team in staat de applicatie snel te corrigeren en te o
     <value>Instellingen</value> 
   </data> 
   <data name="sidebarItemAccounts" xml:space="preserve"> 
-    <value>Accounts</value> 
+    <value>Accounts &amp; synchronisatiess</value> 
   </data> 
   <data name="sidebarItemAdvanced" xml:space="preserve"> 
     <value>Geavanceerd</value> 
@@ -1614,6 +1614,9 @@ De synchronisatie is onderbroken. Controleer uw bestanden en probeer het opnieuw
     <value>kDrive openen</value> 
     <comment>This translation is used for the taskbar icon menu, which requires the x:Uid format (i.e., suffixed with .Label).</comment> 
   </data> 
+  <data name="trayIconButtonOpenSettings.Label" xml:space="preserve"> 
+    <value>Instellingen</value> 
+  </data> 
   <data name="unableToCreateRemoteFolderTeachingTipContent" xml:space="preserve"> 
     <value>Controleer of uw internetverbinding actief is, of deze naam nog niet in gebruik is en of het geen ongeldige tekens bevat.</value> 
   </data> 
@@ -1682,6 +1685,9 @@ Werk de applicatie bij om toegang te krijgen tot uw bestanden en de synchronisat
   </data> 
   <data name="userExclusionFileListHeader" xml:space="preserve"> 
     <value>Aangepaste uitsluitingsregels</value> 
+  </data> 
+  <data name="userExclusionFileListHeaderDescription" xml:space="preserve"> 
+    <value>Sluit bepaalde bestandstypen uit van synchronisatie.</value> 
   </data> 
   <data name="viewSourceCode" xml:space="preserve"> 
     <value>Broncode bekijken</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/pl-PL/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/pl-PL/Resources.resw
@@ -6,7 +6,7 @@
   Locale: pl, Polish
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Mon, 11 May 2026 09:31:50 +0200 
+  Exported at: Tue, 19 May 2026 14:16:33 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -1456,7 +1456,7 @@ Dane te pozwalają naszemu zespołowi na szybkie naprawianie i optymalizację ap
     <value>Ustawienia</value> 
   </data> 
   <data name="sidebarItemAccounts" xml:space="preserve"> 
-    <value>Konta</value> 
+    <value>Konta i synchronizacje</value> 
   </data> 
   <data name="sidebarItemAdvanced" xml:space="preserve"> 
     <value>Zaawansowane</value> 
@@ -1614,6 +1614,9 @@ Synchronizacja została wstrzymana. Sprawdź pliki i spróbuj ponownie.</value>
     <value>Otwórz kDrive</value> 
     <comment>This translation is used for the taskbar icon menu, which requires the x:Uid format (i.e., suffixed with .Label).</comment> 
   </data> 
+  <data name="trayIconButtonOpenSettings.Label" xml:space="preserve"> 
+    <value>Ustawienia</value> 
+  </data> 
   <data name="unableToCreateRemoteFolderTeachingTipContent" xml:space="preserve"> 
     <value>Sprawdź, czy Twoje połączenie z Internetem jest aktywne, czy ta nazwa nie jest już używana i czy nie zawiera nieprawidłowych znaków.</value> 
   </data> 
@@ -1682,6 +1685,9 @@ Zaktualizuj aplikację, aby uzyskać dostęp do plików i wznowić synchronizacj
   </data> 
   <data name="userExclusionFileListHeader" xml:space="preserve"> 
     <value>Niestandardowe reguły wykluczenia</value> 
+  </data> 
+  <data name="userExclusionFileListHeaderDescription" xml:space="preserve"> 
+    <value>Wyklucz niektóre typy plików z synchronizacji.</value> 
   </data> 
   <data name="viewSourceCode" xml:space="preserve"> 
     <value>Wyświetl kod źródłowy</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/pt-PT/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/pt-PT/Resources.resw
@@ -6,7 +6,7 @@
   Locale: pt, Portuguese
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Mon, 11 May 2026 09:31:50 +0200 
+  Exported at: Tue, 19 May 2026 14:16:33 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -1456,7 +1456,7 @@ Estes dados permitem à nossa equipa corrigir e otimizar rapidamente a aplicaç�
     <value>Definições</value> 
   </data> 
   <data name="sidebarItemAccounts" xml:space="preserve"> 
-    <value>Contas</value> 
+    <value>Contas e sincronizações</value> 
   </data> 
   <data name="sidebarItemAdvanced" xml:space="preserve"> 
     <value>Avançadas</value> 
@@ -1614,6 +1614,9 @@ A sincronização foi interrompida. Verifique os seus ficheiros e tente novament
     <value>Abrir o kDrive</value> 
     <comment>This translation is used for the taskbar icon menu, which requires the x:Uid format (i.e., suffixed with .Label).</comment> 
   </data> 
+  <data name="trayIconButtonOpenSettings.Label" xml:space="preserve"> 
+    <value>Definições</value> 
+  </data> 
   <data name="unableToCreateRemoteFolderTeachingTipContent" xml:space="preserve"> 
     <value>Verifique se a sua ligação à Internet está ativa, se este nome ainda não está em uso e se não contém caracteres inválidos.</value> 
   </data> 
@@ -1682,6 +1685,9 @@ Atualize a aplicação para aceder aos seus ficheiros e retomar a sincronizaçã
   </data> 
   <data name="userExclusionFileListHeader" xml:space="preserve"> 
     <value>Regras de exclusão personalizadas</value> 
+  </data> 
+  <data name="userExclusionFileListHeaderDescription" xml:space="preserve"> 
+    <value>Exclua determinados tipos de ficheiros da sincronização.</value> 
   </data> 
   <data name="viewSourceCode" xml:space="preserve"> 
     <value>Ver código-fonte</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/sv-SE/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/sv-SE/Resources.resw
@@ -6,7 +6,7 @@
   Locale: sv, Swedish
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Mon, 11 May 2026 09:31:50 +0200 
+  Exported at: Tue, 19 May 2026 14:16:33 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -1456,7 +1456,7 @@ Dessa data gör det möjligt för vårt team att snabbt åtgärda och optimera p
     <value>Inställningar</value> 
   </data> 
   <data name="sidebarItemAccounts" xml:space="preserve"> 
-    <value>Konton</value> 
+    <value>Konton och synkroniseringar</value> 
   </data> 
   <data name="sidebarItemAdvanced" xml:space="preserve"> 
     <value>Avancerat</value> 
@@ -1614,6 +1614,9 @@ Synkroniseringen har pausats. Kontrollera dina filer och försök igen.</value>
     <value>Öppna kDrive</value> 
     <comment>This translation is used for the taskbar icon menu, which requires the x:Uid format (i.e., suffixed with .Label).</comment> 
   </data> 
+  <data name="trayIconButtonOpenSettings.Label" xml:space="preserve"> 
+    <value>Inställningar</value> 
+  </data> 
   <data name="unableToCreateRemoteFolderTeachingTipContent" xml:space="preserve"> 
     <value>Kontrollera att din internetanslutning är aktiv, att det här namnet inte redan används och att det inte innehåller ogiltiga tecken.</value> 
   </data> 
@@ -1682,6 +1685,9 @@ Uppdatera programmet för att komma åt dina filer och återuppta synkronisering
   </data> 
   <data name="userExclusionFileListHeader" xml:space="preserve"> 
     <value>Anpassade undantagsregler</value> 
+  </data> 
+  <data name="userExclusionFileListHeaderDescription" xml:space="preserve"> 
+    <value>Undanta vissa filtyper från synkronisering.</value> 
   </data> 
   <data name="viewSourceCode" xml:space="preserve"> 
     <value>Visa källkod</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/TrayIcon/TrayIconManager.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/TrayIcon/TrayIconManager.cs
@@ -61,6 +61,17 @@ namespace Infomaniak.kDrive.TrayIcon
                 Logger.Log(Logger.Level.Error, "ShowWindowCommand not found in application resources.");
             }
 
+
+            if (Application.Current.Resources["OpenSettingsCommand"] is XamlUICommand settingsCommand)
+            {
+                settingsCommand.ExecuteRequested -= OpenSettingsCommand_ExecuteRequested;
+                settingsCommand.ExecuteRequested += OpenSettingsCommand_ExecuteRequested;
+            }
+            else
+            {
+                Logger.Log(Logger.Level.Error, "OpenSettingsCommand not found in application resources.");
+            }
+
             if (Application.Current.Resources["ExitApplicationCommand"] is XamlUICommand exitCommand)
             {
                 exitCommand.ExecuteRequested -= ExitApplicationCommand_ExecuteRequested;
@@ -187,6 +198,15 @@ namespace Infomaniak.kDrive.TrayIcon
             Logger.Log(Logger.Level.Info, "ExitApplicationCommand executed - exiting application");
             _trayIcon?.Dispose();
             App.ExitApplicationAndShutdownServer();
+        }
+
+        private void OpenSettingsCommand_ExecuteRequested(XamlUICommand sender, ExecuteRequestedEventArgs args)
+        {
+            Logger.Log(Logger.Level.Info, "OpenSettingsCommand executed");
+            if (Application.Current is App app)
+            {
+                app.CreateWindow(CreateWindowOptions.Foreground | CreateWindowOptions.CancelOnboarding | CreateWindowOptions.OpenSettings);
+            }
         }
 
         [System.Runtime.InteropServices.DllImport("user32.dll", CharSet = CharSet.Auto)]

--- a/src/gui4/windows/kDrive client/kDrive client/TrayIcon/TrayIconResources.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/TrayIcon/TrayIconResources.xaml
@@ -23,6 +23,9 @@
     <XamlUICommand x:Key="ShowWindowCommand"
                    x:Uid="trayIconButtonOpenKDrive">
     </XamlUICommand>
+    <XamlUICommand x:Key="OpenSettingsCommand"
+                   x:Uid="trayIconButtonOpenSettings">
+    </XamlUICommand>
     <XamlUICommand x:Key="ExitApplicationCommand"
                    x:Uid="trayIconButtonCloseKDrive">
     </XamlUICommand>
@@ -35,6 +38,7 @@
         <tb:TaskbarIcon.ContextFlyout>
             <MenuFlyout>
                 <MenuFlyoutItem Command="{StaticResource ShowWindowCommand}" />
+                <MenuFlyoutItem Command="{StaticResource OpenSettingsCommand}" />
                 <MenuFlyoutSeparator />
                 <MenuFlyoutItem Command="{StaticResource ExitApplicationCommand}" />
             </MenuFlyout>

--- a/src/gui4/windows/kDrive client/kDrive client/Utility/Utility.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Utility/Utility.cs
@@ -66,33 +66,29 @@ namespace Infomaniak.kDrive
             return await tcs.Task.ConfigureAwait(false);
         }
 
-        public static async Task RunOnUIThread(Action action)
+        public static async Task RunOnUIThread(Func<Task> action)
         {
             var dispatcher = AppModel.UIThreadDispatcher;
 
             if (dispatcher.HasThreadAccess)
             {
-                action();
+                await action();
+                return;
             }
-            else
+
+            await dispatcher.EnqueueAsync(async () =>
             {
-                TaskCompletionSource tcs = new();
+                await action();
+            });
+        }
 
-                await dispatcher.EnqueueAsync(() =>
-                {
-                    try
-                    {
-                        action();
-                        tcs.SetResult();
-                    }
-                    catch (Exception ex)
-                    {
-                        tcs.SetException(ex);
-                    }
-                });
-
-                await tcs.Task;
-            }
+        public static Task RunOnUIThread(Action action)
+        {
+            return RunOnUIThread(() =>
+            {
+                action();
+                return Task.CompletedTask;
+            });
         }
 
         public static async Task OpenFileAsync(string filePath)

--- a/src/gui4/windows/kDrive client/kDrive client/Utility/Utility.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Utility/Utility.cs
@@ -407,7 +407,6 @@ namespace Infomaniak.kDrive
         public static void BringWindowToFront(Window window)
         {
             Logger.Log(Logger.Level.Info, "Bringing current window to front");
-
             if (!window.Visible)
             {
                 window.Activate();

--- a/src/gui4/windows/kDrive client/kDrive client/kDrive client.csproj
+++ b/src/gui4/windows/kDrive client/kDrive client/kDrive client.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyVersion>3.8.4.1</AssemblyVersion>
     <OutputType>WinExe</OutputType>
@@ -361,6 +361,6 @@
     <!-- Debug: keep original PRI and copy to avoid rebuild -->
     <Exec Condition="'$(Configuration)' == 'Debug'" Command="powershell -ExecutionPolicy Bypass -NoProfile -Command &quot;Copy-Item '$(OutDir)$(AssemblyName).pri' '$(OutDir)Resources.pri' -Force&quot;" />
     <!-- Release: rename PRI -->
-    <Exec Condition="'$(Configuration)' == 'Release'" Command="powershell -ExecutionPolicy Bypass -NoProfile -Command &quot;$src='$(OutDir)$(AssemblyName).pri'; $dst='$(OutDir)Resources.pri'; if (Test-Path $dst) { Remove-Item $dst -Force }; Rename-Item $src 'Resources.pri'&quot;" />
+    <Exec Condition="'$(Configuration)' != 'Debug'" Command="powershell -ExecutionPolicy Bypass -NoProfile -Command &quot;$src='$(OutDir)$(AssemblyName).pri'; $dst='$(OutDir)Resources.pri'; if (Test-Path $dst) { Remove-Item $dst -Force }; Rename-Item $src 'Resources.pri'&quot;" />
   </Target>
 </Project>

--- a/src/gui4/windows/kDrive client/kDrive client/kDrive client.csproj
+++ b/src/gui4/windows/kDrive client/kDrive client/kDrive client.csproj
@@ -4,7 +4,7 @@
     <OutputType>WinExe</OutputType>
     <FileVersion>$(AssemblyVersion)</FileVersion>
     <Version>$(AssemblyVersion)</Version>
-    <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net9.0-windows10.0.19041</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>Infomaniak.kDrive</RootNamespace>
     <SupportedLocales>da-DK;de-DE;el-GR;en-US;es-ES;fi-FI;fr-FR;it-It;nb-NO;nl-NL;pl-PL;pt-PT;sv-SE</SupportedLocales>

--- a/src/gui4/windows/kDrive client/kDrive client/kDrive client.csproj
+++ b/src/gui4/windows/kDrive client/kDrive client/kDrive client.csproj
@@ -4,7 +4,7 @@
     <OutputType>WinExe</OutputType>
     <FileVersion>$(AssemblyVersion)</FileVersion>
     <Version>$(AssemblyVersion)</Version>
-    <TargetFramework>net9.0-windows10.0.19041</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>Infomaniak.kDrive</RootNamespace>
     <SupportedLocales>da-DK;de-DE;el-GR;en-US;es-ES;fi-FI;fr-FR;it-It;nb-NO;nl-NL;pl-PL;pt-PT;sv-SE</SupportedLocales>
@@ -42,7 +42,7 @@
     <PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.2.251219" />
     <PackageReference Include="CommunityToolkit.WinUI.Lottie" Version="8.2.250604" />
     <PackageReference Include="DynamicData" Version="9.4.31" />
-    <PackageReference Include="H.NotifyIcon.WinUI" Version="2.3.1" />
+    <PackageReference Include="H.NotifyIcon.WinUI" Version="2.3.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.5" />
     <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.4.0" />

--- a/version.json
+++ b/version.json
@@ -1,9 +1,9 @@
 {
   "Version": {
-    "major": 4,
-    "minor": 0,
-    "patch": 0,
-    "build": 4,
+    "major": 3,
+    "minor": 8,
+    "patch": 4,
+    "build": 1,
     "year": 2026
   }
 }

--- a/version.json
+++ b/version.json
@@ -1,9 +1,9 @@
 {
   "Version": {
-    "major": 3,
-    "minor": 8,
-    "patch": 4,
-    "build": 1,
+    "major": 4,
+    "minor": 0,
+    "patch": 0,
+    "build": 4,
     "year": 2026
   }
 }


### PR DESCRIPTION
* Only restart the entire window; fully restarting the app leads to socket disconnection and causes the server to shut down.
* The default main window size was accidentally set to the minimum size; this has been reverted.
* Remove the beta tag from window title bars.
* Center the main window by default.
* Fix a bug causing an unpleasant UI effect in the user list in settings.
* Fix an issue with renaming PRI files in `releaseWithDebugInfo`.
* Fix an issue with an overload of `RunOnUIThread` which returned without awaiting the completion of the task.
