### PR TITLE
chore(update): rename enum to DistributionChannel

### DIFF
--- a/src/gui4/macOS/kDrive/UI/Views/PreferencesWindow/General/Components/VersionManagementView.swift
+++ b/src/gui4/macOS/kDrive/UI/Views/PreferencesWindow/General/Components/VersionManagementView.swift
@@ -105,7 +105,7 @@ struct VersionManagementView: View {
 
         versionTask?.cancel()
         versionTask = Task { @MainActor in
-            let channel: KDC.VersionChannel = repository.parametersInfo.distributionChannel.toKDCVersionChannel()
+            let channel: KDC.DistributionChannel = repository.parametersInfo.distributionChannel.toKDCDistributionChannel()
             guard let newVersion = try? await UpdaterJobs().versionInfo(channel: channel) else {
                 return
             }

--- a/src/gui4/macOS/kDrive/UI/Views/PreferencesWindow/General/Sections/GeneralPreferencesVersionSection.swift
+++ b/src/gui4/macOS/kDrive/UI/Views/PreferencesWindow/General/Sections/GeneralPreferencesVersionSection.swift
@@ -64,6 +64,8 @@ enum BetaOption: String, Identifiable, CaseIterable, PreferenceOption {
             self = .internal
         case .legacy:
             self = .doNotJoin
+        case .test:
+            self = .doNotJoin
         }
     }
 }

--- a/src/gui4/macOS/kDriveCore/Models/DTOs/VersionInfo.swift
+++ b/src/gui4/macOS/kDriveCore/Models/DTOs/VersionInfo.swift
@@ -19,7 +19,14 @@
 import CppInterop
 
 public struct VersionInfo: Codable, Sendable {
-    public init(channel: KDC.DistributionChannel, tag: String, buildVersion: UInt64, buildMinOsVersion: String, downloadUrl: String, checksum: String) {
+    public init(
+        channel: KDC.DistributionChannel,
+        tag: String,
+        buildVersion: UInt64,
+        buildMinOsVersion: String,
+        downloadUrl: String,
+        checksum: String
+    ) {
         self.channel = channel
         self.tag = tag
         self.buildVersion = buildVersion

--- a/src/gui4/macOS/kDriveCore/Models/DTOs/VersionInfo.swift
+++ b/src/gui4/macOS/kDriveCore/Models/DTOs/VersionInfo.swift
@@ -19,17 +19,19 @@
 import CppInterop
 
 public struct VersionInfo: Codable, Sendable {
-    public init(channel: KDC.VersionChannel, tag: String, buildVersion: UInt64, buildMinOsVersion: String, downloadUrl: String) {
+    public init(channel: KDC.DistributionChannel, tag: String, buildVersion: UInt64, buildMinOsVersion: String, downloadUrl: String, checksum: String) {
         self.channel = channel
         self.tag = tag
         self.buildVersion = buildVersion
         self.buildMinOsVersion = buildMinOsVersion
         self.downloadUrl = downloadUrl
+        self.checksum = checksum
     }
 
-    public let channel: KDC.VersionChannel
+    public let channel: KDC.DistributionChannel
     public let tag: String
     public let buildVersion: UInt64
     public let buildMinOsVersion: String
     public let downloadUrl: String
+    public let checksum: String
 }

--- a/src/gui4/macOS/kDriveCore/ServerBridge/Jobs/DTOs/ParametersResponse.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/Jobs/DTOs/ParametersResponse.swift
@@ -36,7 +36,7 @@ public struct ParametersInfo: Codable, Sendable {
     public let proxyConfigInfo: ProxyConfigInfo
     public let darkTheme: Bool
     public let maxAllowedCpu: Int32
-    public let distributionChannel: KDC.VersionChannel
+    public let distributionChannel: KDC.DistributionChannel
     public let sentryEnabled: Bool
     public let matomoEnabled: Bool
 
@@ -53,7 +53,7 @@ public struct ParametersInfo: Codable, Sendable {
         proxyConfigInfo: ProxyConfigInfo,
         darkTheme: Bool,
         maxAllowedCpu: Int32,
-        distributionChannel: KDC.VersionChannel,
+        distributionChannel: KDC.DistributionChannel,
         sentryEnabled: Bool,
         matomoEnabled: Bool
     ) {

--- a/src/gui4/macOS/kDriveCore/ServerBridge/Jobs/DTOs/UpdaterQuery.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/Jobs/DTOs/UpdaterQuery.swift
@@ -20,7 +20,7 @@ import CppInterop
 import Foundation
 
 struct UpdaterVersionInfoQuery: Codable, Sendable {
-    let channel: KDC.VersionChannel
+    let channel: KDC.DistributionChannel
 }
 
 struct UpdaterSkipVersionQuery: Codable, Sendable {

--- a/src/gui4/macOS/kDriveCore/ServerBridge/Jobs/DTOs/UpdaterResponse.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/Jobs/DTOs/UpdaterResponse.swift
@@ -20,11 +20,12 @@ import CppInterop
 import Foundation
 
 struct VersionInfoResponse: Codable, Sendable {
-    let channel: KDC.VersionChannel
+    let channel: KDC.DistributionChannel
     @Base64CodedString var tag: String
     let buildVersion: UInt64
     @Base64CodedString var buildMinOsVersion: String
     @Base64CodedString var downloadUrl: String
+    @Base64CodedString var checksum: String
 }
 
 struct UpdaterVersionInfoResponse: Codable, Sendable {

--- a/src/gui4/macOS/kDriveCore/ServerBridge/Jobs/UpdaterJobs.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/Jobs/UpdaterJobs.swift
@@ -25,7 +25,7 @@ public struct UpdaterJobs: Sendable {
 
     public init() {}
 
-    public func versionInfo(channel: KDC.VersionChannel) async throws -> VersionInfo {
+    public func versionInfo(channel: KDC.DistributionChannel) async throws -> VersionInfo {
         IKLogger.data.log("Query for version info")
         let query = UpdaterVersionInfoQuery(channel: channel)
         let request = await RequestMessage<UpdaterVersionInfoQuery>(num: RequestNum.UPDATER_VERSION_INFO, body: query)
@@ -41,7 +41,8 @@ public struct UpdaterJobs: Sendable {
             tag: versionInfoResponse.tag,
             buildVersion: versionInfoResponse.buildVersion,
             buildMinOsVersion: versionInfoResponse.buildMinOsVersion,
-            downloadUrl: versionInfoResponse.downloadUrl
+            downloadUrl: versionInfoResponse.downloadUrl,
+            checksum: versionInfoResponse.checksum
         )
     }
 

--- a/src/gui4/macOS/kDriveCore/ServerBridge/XPC/Extensions/EnumInterop+Codable.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/XPC/Extensions/EnumInterop+Codable.swift
@@ -35,7 +35,7 @@ extension KDC.Language: Codable {}
 extension KDC.LogLevel: Codable {}
 extension KDC.NotificationsDisabled: Codable {}
 extension KDC.ProxyType: Codable {}
-extension KDC.VersionChannel: Codable {}
+extension KDC.DistributionChannel: Codable {}
 extension KDC.UpdateState: Codable {}
 extension KDC.ReplicaSide: Codable {}
 extension KDC.SyncConfiguration: Codable {}

--- a/src/gui4/macOS/kDriveCore/ServerBridge/XPC/Extensions/EnumInterop+Hashable.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/XPC/Extensions/EnumInterop+Hashable.swift
@@ -35,7 +35,7 @@ extension KDC.Language: Hashable {}
 extension KDC.LogLevel: Hashable {}
 extension KDC.NotificationsDisabled: Hashable {}
 extension KDC.ProxyType: Hashable {}
-extension KDC.VersionChannel: Hashable {}
+extension KDC.DistributionChannel: Hashable {}
 extension KDC.UpdateState: Hashable {}
 extension KDC.SyncConfiguration: Hashable {}
 extension MsgType: @retroactive Hashable {}

--- a/src/gui4/macOS/kDriveCoreUI/Models/UIs/Mappers/UIParametersInfo+Mappers.swift
+++ b/src/gui4/macOS/kDriveCoreUI/Models/UIs/Mappers/UIParametersInfo+Mappers.swift
@@ -141,8 +141,8 @@ public extension UILogLevel {
 }
 
 public extension UIDistributionChannel {
-    init(versionChannel: KDC.DistributionChannel) {
-        switch versionChannel {
+    init(distributionChannel: KDC.DistributionChannel) {
+        switch distributionChannel {
         case .Prod:
             self = .prod
         case .Next:
@@ -156,10 +156,10 @@ public extension UIDistributionChannel {
         case .Test:
             self = .test
         case .Unknown:
-            ReportHelper.reportToSentryIfProd(message: "UIDistributionChannel init received KDC.VersionChannel.Unknown case")
+            ReportHelper.reportToSentryIfProd(message: "UIDistributionChannel init received KDC.DistributionChannel.Unknown case")
             self = .prod
         case .EnumEnd:
-            ReportHelper.reportToSentryIfProd(message: "UIDistributionChannel init received KDC.VersionChannel.EnumEnd case")
+            ReportHelper.reportToSentryIfProd(message: "UIDistributionChannel init received KDC.DistributionChannel.EnumEnd case")
             self = .prod
         @unknown default:
             ReportHelper.reportToSentryIfProd(message: "UIDistributionChannel init received @unknown case")
@@ -197,7 +197,7 @@ public extension UIParametersInfo {
             isExtendedLogEnabled: parametersInfo.extendedLog,
             shouldPurgeOldLogs: parametersInfo.purgeOldLogs,
             proxyConfiguration: UIProxyConfiguration(proxyConfigInfo: parametersInfo.proxyConfigInfo),
-            distributionChannel: UIDistributionChannel(versionChannel: parametersInfo.distributionChannel),
+            distributionChannel: UIDistributionChannel(distributionChannel: parametersInfo.distributionChannel),
             isSentryEnabled: parametersInfo.sentryEnabled,
             isMatomoEnabled: parametersInfo.matomoEnabled
         )

--- a/src/gui4/macOS/kDriveCoreUI/Models/UIs/Mappers/UIParametersInfo+Mappers.swift
+++ b/src/gui4/macOS/kDriveCoreUI/Models/UIs/Mappers/UIParametersInfo+Mappers.swift
@@ -141,7 +141,7 @@ public extension UILogLevel {
 }
 
 public extension UIDistributionChannel {
-    init(versionChannel: KDC.VersionChannel) {
+    init(versionChannel: KDC.DistributionChannel) {
         switch versionChannel {
         case .Prod:
             self = .prod
@@ -153,6 +153,8 @@ public extension UIDistributionChannel {
             self = .internal
         case .Legacy:
             self = .legacy
+        case .Test:
+            self = .test
         case .Unknown:
             ReportHelper.reportToSentryIfProd(message: "UIDistributionChannel init received KDC.VersionChannel.Unknown case")
             self = .prod
@@ -165,7 +167,7 @@ public extension UIDistributionChannel {
         }
     }
 
-    func toKDCVersionChannel() -> KDC.VersionChannel {
+    func toKDCDistributionChannel() -> KDC.DistributionChannel {
         switch self {
         case .prod:
             return .Prod
@@ -177,6 +179,8 @@ public extension UIDistributionChannel {
             return .Internal
         case .legacy:
             return .Legacy
+        case .test:
+            return .Test
         }
     }
 }
@@ -213,7 +217,7 @@ public extension UIParametersInfo {
             proxyConfigInfo: proxyConfiguration.toProxyConfigInfo(),
             darkTheme: parametersInfo.darkTheme,
             maxAllowedCpu: parametersInfo.maxAllowedCpu,
-            distributionChannel: distributionChannel.toKDCVersionChannel(),
+            distributionChannel: distributionChannel.toKDCDistributionChannel(),
             sentryEnabled: isSentryEnabled,
             matomoEnabled: isMatomoEnabled
         )

--- a/src/gui4/macOS/kDriveCoreUI/Models/UIs/Mappers/UIUpdateState+Mappers.swift
+++ b/src/gui4/macOS/kDriveCoreUI/Models/UIs/Mappers/UIUpdateState+Mappers.swift
@@ -53,7 +53,7 @@ public extension UIUpdateState {
 public extension UIVersionInfo {
     init(versionInfo: VersionInfo) {
         self.init(
-            channel: UIDistributionChannel(versionChannel: versionInfo.channel),
+            channel: UIDistributionChannel(distributionChannel: versionInfo.channel),
             tag: versionInfo.tag,
             buildVersion: Int(versionInfo.buildVersion)
         )

--- a/src/gui4/macOS/kDriveCoreUI/Models/UIs/Parameters/UIParametersInfo.swift
+++ b/src/gui4/macOS/kDriveCoreUI/Models/UIs/Parameters/UIParametersInfo.swift
@@ -120,6 +120,7 @@ public enum UIDistributionChannel: String, CaseIterable, Sendable, Equatable {
     case beta
     case `internal`
     case legacy
+    case test
 }
 
 public struct UIParametersInfo: Sendable, Equatable {

--- a/src/gui4/macOS/kDriveTests/Parsing/Jobs/JSON/UPDATER_VERSION_INFO.json
+++ b/src/gui4/macOS/kDriveTests/Parsing/Jobs/JSON/UPDATER_VERSION_INFO.json
@@ -8,7 +8,8 @@
       "buildVersion": 5,
       "channel": 3,
       "downloadUrl": "aHR0cHM6Ly9kb3dubG9hZC5zdG9yYWdlLmluZm9tYW5pYWsuY29tL2RyaXZlL2Rlc2t0b3BjbGllbnQvdXBkYXRlLW1hY29zLTMuOC4yLjUueG1s",
-      "tag": "My44LjI="
+      "tag": "My44LjI=",
+      "checksum": "MTIzNDU="
     }
   }
 }

--- a/src/gui4/macOS/kDriveTests/Parsing/Jobs/UpdaterVersionInfoTest.swift
+++ b/src/gui4/macOS/kDriveTests/Parsing/Jobs/UpdaterVersionInfoTest.swift
@@ -58,5 +58,6 @@ struct UpdaterVersionInfoTest {
         #expect(response.body.versionInfo.buildMinOsVersion == "10.15")
         #expect(response.body.versionInfo
             .downloadUrl == "https://download.storage.infomaniak.com/drive/desktopclient/update-macos-3.8.2.5.xml")
+        #expect(response.body.versionInfo.checksum == "12345")
     }
 }


### PR DESCRIPTION
`VersionChannel` enum has been renamed to `DistributionChannel`. This PR aims to propagate this change in the macOS GUI project.
Other changes:
- The new distribution channel `Test` has also been added to the `DistributionChannel` enum.
- Checksum has been added to the `VersionInfo` struct.