### PR TITLE
fix(extended-tests): Adds missing certificate thumbrint as a CI build parameter

### DIFF
--- a/.github/actions/build_windows/action.yml
+++ b/.github/actions/build_windows/action.yml
@@ -34,7 +34,7 @@ inputs:
     description: 'If true, build the Windows app with the new client'
     required: false
     default: 'false'
-    
+
 outputs:
   kDrive_version:
     description: 'The version of the kDrive app built'
@@ -43,7 +43,7 @@ outputs:
 runs:
     using: "composite"
     steps:
-      
+
       - name: Load system Path into Github environment
         run : echo Path=%Path%>> %GITHUB_ENV%
         shell: cmd
@@ -124,7 +124,6 @@ runs:
             )
 
           ) ELSE (
-            $thumbprint = "${{ inputs.debug_cert_thumbprint }}"
             powershell -File "./infomaniak-build-tools/windows/build-drive.ps1" -thumbprint ${{ inputs.debug_cert_thumbprint }} -ci -unitTests
           )
         shell: cmd
@@ -169,7 +168,7 @@ runs:
             Write-Host "No conanrun.ps1 found, skipping Conan dependencies fetch."
             exit 0
           }
-          
+
           New-Item -ItemType Directory -Path "./dependencies/platforms" -Force *> $null
           $patterns = @(
               "xxhash*.dll",

--- a/.github/actions/build_windows/action.yml
+++ b/.github/actions/build_windows/action.yml
@@ -62,14 +62,14 @@ runs:
             Set-Content -Path certificate/tempCert.txt -Value $env:WINDOWS_KSP_CLIENT_CERT
             certutil -decode certificate/tempCert.txt certificate/ksp_client_certificate.pfx
             Remove-Item -path certificate -include tempCert.txt
-            Import-PfxCertificate -FilePath certificate/ksp_client_certificate.pfx -CertStoreLocation Cert:\LocalMachine\My -Password (ConvertTo-SecureString -String "${{ inputs.ksp_client_cert }}" -Force -AsPlainText)
+            Import-PfxCertificate -FilePath certificate/ksp_client_certificate.pfx -CertStoreLocation Cert:\LocalMachine\My -Password (ConvertTo-SecureString -String "${{ inputs.ksp_client_cert_pass }}" -Force -AsPlainText)
             Write-Host "KSP client certificate imported successfully."
           } else {
             New-Item -ItemType directory -Path certificate
             Set-Content -Path certificate/tempCert.txt -Value $env:WINDOWS_DEBUG_CERT
             certutil -decode certificate/tempCert.txt certificate/debug_certificate.pfx
             Remove-Item -path certificate -include tempCert.txt
-            Import-PfxCertificate -FilePath certificate/debug_certificate.pfx -CertStoreLocation Cert:\LocalMachine\My -Password (ConvertTo-SecureString -String "${{ inputs.debug_cert }}" -Force -AsPlainText)
+            Import-PfxCertificate -FilePath certificate/debug_certificate.pfx -CertStoreLocation Cert:\LocalMachine\My -Password (ConvertTo-SecureString -String "${{ inputs.debug_cert_pass }}" -Force -AsPlainText)
             Write-Host "Debug certificate imported successfully."
           }
         shell: powershell

--- a/.github/actions/build_windows/action.yml
+++ b/.github/actions/build_windows/action.yml
@@ -62,14 +62,14 @@ runs:
             Set-Content -Path certificate/tempCert.txt -Value $env:WINDOWS_KSP_CLIENT_CERT
             certutil -decode certificate/tempCert.txt certificate/ksp_client_certificate.pfx
             Remove-Item -path certificate -include tempCert.txt
-            Import-PfxCertificate -FilePath certificate/ksp_client_certificate.pfx -CertStoreLocation Cert:\LocalMachine\My -Password (ConvertTo-SecureString -String $env:WINDOWS_KSP_CLIENT_CERT -Force -AsPlainText)
+            Import-PfxCertificate -FilePath certificate/ksp_client_certificate.pfx -CertStoreLocation Cert:\LocalMachine\My -Password (ConvertTo-SecureString -String "${{ inputs.ksp_client_cert }}" -Force -AsPlainText)
             Write-Host "KSP client certificate imported successfully."
           } else {
             New-Item -ItemType directory -Path certificate
             Set-Content -Path certificate/tempCert.txt -Value $env:WINDOWS_DEBUG_CERT
             certutil -decode certificate/tempCert.txt certificate/debug_certificate.pfx
             Remove-Item -path certificate -include tempCert.txt
-            Import-PfxCertificate -FilePath certificate/debug_certificate.pfx -CertStoreLocation Cert:\LocalMachine\My -Password (ConvertTo-SecureString -String $env:WINDOWS_DEBUG_CERT -Force -AsPlainText)
+            Import-PfxCertificate -FilePath certificate/debug_certificate.pfx -CertStoreLocation Cert:\LocalMachine\My -Password (ConvertTo-SecureString -String "${{ inputs.debug_cert }}" -Force -AsPlainText)
             Write-Host "Debug certificate imported successfully."
           }
         shell: powershell

--- a/.github/actions/build_windows/action.yml
+++ b/.github/actions/build_windows/action.yml
@@ -62,14 +62,14 @@ runs:
             Set-Content -Path certificate/tempCert.txt -Value $env:WINDOWS_KSP_CLIENT_CERT
             certutil -decode certificate/tempCert.txt certificate/ksp_client_certificate.pfx
             Remove-Item -path certificate -include tempCert.txt
-            Import-PfxCertificate -FilePath certificate/ksp_client_certificate.pfx -CertStoreLocation Cert:\LocalMachine\My -Password (ConvertTo-SecureString -String "$env:WINDOWS_KSP_CLIENT_CERT" -Force -AsPlainText)
+            Import-PfxCertificate -FilePath certificate/ksp_client_certificate.pfx -CertStoreLocation Cert:\LocalMachine\My -Password (ConvertTo-SecureString -String $env:WINDOWS_KSP_CLIENT_CERT -Force -AsPlainText)
             Write-Host "KSP client certificate imported successfully."
           } else {
             New-Item -ItemType directory -Path certificate
             Set-Content -Path certificate/tempCert.txt -Value $env:WINDOWS_DEBUG_CERT
             certutil -decode certificate/tempCert.txt certificate/debug_certificate.pfx
             Remove-Item -path certificate -include tempCert.txt
-            Import-PfxCertificate -FilePath certificate/debug_certificate.pfx -CertStoreLocation Cert:\LocalMachine\My -Password (ConvertTo-SecureString -String "$env:WINDOWS_DEBUG_CERT" -Force -AsPlainText)
+            Import-PfxCertificate -FilePath certificate/debug_certificate.pfx -CertStoreLocation Cert:\LocalMachine\My -Password (ConvertTo-SecureString -String $env:WINDOWS_DEBUG_CERT -Force -AsPlainText)
             Write-Host "Debug certificate imported successfully."
           }
         shell: powershell

--- a/.github/actions/build_windows/action.yml
+++ b/.github/actions/build_windows/action.yml
@@ -57,19 +57,19 @@ runs:
           WINDOWS_KSP_CLIENT_CERT: ${{ inputs.ksp_client_cert }}
           WINDOWS_DEBUG_CERT: ${{ inputs.debug_cert }}
         run: |
-          if("${{ inputs.release_build }}" -eq "true") {
+          if ("${{ inputs.release_build }}" -eq "true") {
             New-Item -ItemType directory -Path certificate
             Set-Content -Path certificate/tempCert.txt -Value $env:WINDOWS_KSP_CLIENT_CERT
             certutil -decode certificate/tempCert.txt certificate/ksp_client_certificate.pfx
             Remove-Item -path certificate -include tempCert.txt
-            Import-PfxCertificate -FilePath certificate/ksp_client_certificate.pfx -CertStoreLocation Cert:\LocalMachine\My -Password (ConvertTo-SecureString -String "${{ inputs.ksp_client_cert_pass }}" -Force -AsPlainText)
+            Import-PfxCertificate -FilePath certificate/ksp_client_certificate.pfx -CertStoreLocation Cert:\LocalMachine\My -Password (ConvertTo-SecureString -String "$env:WINDOWS_KSP_CLIENT_CERT" -Force -AsPlainText)
             Write-Host "KSP client certificate imported successfully."
           } else {
             New-Item -ItemType directory -Path certificate
             Set-Content -Path certificate/tempCert.txt -Value $env:WINDOWS_DEBUG_CERT
             certutil -decode certificate/tempCert.txt certificate/debug_certificate.pfx
             Remove-Item -path certificate -include tempCert.txt
-            Import-PfxCertificate -FilePath certificate/debug_certificate.pfx -CertStoreLocation Cert:\LocalMachine\My -Password (ConvertTo-SecureString -String "${{ inputs.debug_cert_pass }}" -Force -AsPlainText)
+            Import-PfxCertificate -FilePath certificate/debug_certificate.pfx -CertStoreLocation Cert:\LocalMachine\My -Password (ConvertTo-SecureString -String "$env:WINDOWS_DEBUG_CERT" -Force -AsPlainText)
             Write-Host "Debug certificate imported successfully."
           }
         shell: powershell

--- a/.github/workflows/build-and-run-extended-tests.yml
+++ b/.github/workflows/build-and-run-extended-tests.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Import Windows certificate
         env:
-          WINDOWS_DEBUG_CERT: ${{ secrets.WINDOWS_DEBUG_CERT_THUMBPRINT }}
+          WINDOWS_DEBUG_CERT: ${{ secrets.WINDOWS_DEBUG_CERT }}
         run: |
             New-Item -ItemType directory -Path certificate
             Set-Content -Path certificate/tempCert.txt -Value $env:WINDOWS_DEBUG_CERT
@@ -70,10 +70,10 @@ jobs:
 
       - name: Build kDrive desktop
         env:
-          WINDOWS_DEBUG_CERT: ${{ secrets.WINDOWS_DEBUG_CERT_THUMBPRINT }}
+          WINDOWS_DEBUG_CERT_THUMBPRINT: ${{ secrets.WINDOWS_DEBUG_CERT_THUMBPRINT }}
         run: |
           call "C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Auxiliary/Build/vcvars64.bat"
-          powershell ./infomaniak-build-tools/windows/build-drive.ps1 -thumbprint $env:WINDOWS_DEBUG_CERT -ci -coverage -unitTests
+          powershell ./infomaniak-build-tools/windows/build-drive.ps1 -thumbprint $env:WINDOWS_DEBUG_CERT_THUMBPRINT -ci -coverage -unitTests
         shell: cmd
 
       - name: Execute tests

--- a/.github/workflows/build-and-run-extended-tests.yml
+++ b/.github/workflows/build-and-run-extended-tests.yml
@@ -63,7 +63,7 @@ jobs:
             Set-Content -Path certificate/tempCert.txt -Value $env:WINDOWS_DEBUG_CERT
             certutil -decode certificate/tempCert.txt certificate/debug_certificate.pfx
             Remove-Item -path certificate -include tempCert.txt
-            Import-PfxCertificate -FilePath certificate/debug_certificate.pfx -CertStoreLocation Cert:\LocalMachine\My -Password (ConvertTo-SecureString -String "${{ secrets.WINDOWS_DEBUG_CERT_THUMBPRINT }}" -Force -AsPlainText)
+            Import-PfxCertificate -FilePath certificate/debug_certificate.pfx -CertStoreLocation Cert:\LocalMachine\My -Password (ConvertTo-SecureString -String "${{ secrets.WINDOWS_DEBUG_CERT_PASSWORD }}" -Force -AsPlainText)
             Write-Host "Debug certificate imported successfully."
 
         shell: powershell

--- a/.github/workflows/build-and-run-extended-tests.yml
+++ b/.github/workflows/build-and-run-extended-tests.yml
@@ -57,10 +57,10 @@ jobs:
 
       - name: Import Windows certificate
         env:
-          WINDOWS_DEBUG_CERT: ${{ secrets.WINDOWS_DEBUG_CERT }}
+          WINDOWS_DEBUG_CERT_FILE_B64: ${{ secrets.WINDOWS_DEBUG_CERT_FILE_B64 }}
         run: |
             New-Item -ItemType directory -Path certificate
-            Set-Content -Path certificate/tempCert.txt -Value $env:WINDOWS_DEBUG_CERT
+            Set-Content -Path certificate/tempCert.txt -Value $env:WINDOWS_DEBUG_CERT_FILE_B64
             certutil -decode certificate/tempCert.txt certificate/debug_certificate.pfx
             Remove-Item -path certificate -include tempCert.txt
             Import-PfxCertificate -FilePath certificate/debug_certificate.pfx -CertStoreLocation Cert:\CurrentUser\My -Password (ConvertTo-SecureString -String "${{ secrets.WINDOWS_DEBUG_CERT_PASSWORD }}" -Force -AsPlainText)

--- a/.github/workflows/build-and-run-extended-tests.yml
+++ b/.github/workflows/build-and-run-extended-tests.yml
@@ -63,7 +63,7 @@ jobs:
             Set-Content -Path certificate/tempCert.txt -Value $env:WINDOWS_DEBUG_CERT
             certutil -decode certificate/tempCert.txt certificate/debug_certificate.pfx
             Remove-Item -path certificate -include tempCert.txt
-            Import-PfxCertificate -FilePath certificate/debug_certificate.pfx -CertStoreLocation Cert:\LocalMachine\My -Password (ConvertTo-SecureString -String $env:WINDOWS_DEBUG_CERT -Force -AsPlainText)
+            Import-PfxCertificate -FilePath certificate/debug_certificate.pfx -CertStoreLocation Cert:\LocalMachine\My -Password (ConvertTo-SecureString -String "${{ secrets.WINDOWS_DEBUG_CERT_THUMBPRINT }}" -Force -AsPlainText)
             Write-Host "Debug certificate imported successfully."
 
         shell: powershell

--- a/.github/workflows/build-and-run-extended-tests.yml
+++ b/.github/workflows/build-and-run-extended-tests.yml
@@ -63,7 +63,7 @@ jobs:
             Set-Content -Path certificate/tempCert.txt -Value $env:WINDOWS_DEBUG_CERT
             certutil -decode certificate/tempCert.txt certificate/debug_certificate.pfx
             Remove-Item -path certificate -include tempCert.txt
-            Import-PfxCertificate -FilePath certificate/debug_certificate.pfx -CertStoreLocation Cert:\LocalMachine\My -Password (ConvertTo-SecureString -String "${{ secrets.WINDOWS_DEBUG_CERT_PASSWORD }}" -Force -AsPlainText)
+            Import-PfxCertificate -FilePath certificate/debug_certificate.pfx -CertStoreLocation Cert:\CurrentUser\My -Password (ConvertTo-SecureString -String "${{ secrets.WINDOWS_DEBUG_CERT_PASSWORD }}" -Force -AsPlainText)
             Write-Host "Debug certificate imported successfully."
 
         shell: powershell

--- a/.github/workflows/build-and-run-extended-tests.yml
+++ b/.github/workflows/build-and-run-extended-tests.yml
@@ -55,21 +55,25 @@ jobs:
       - name: Restore extension packages
         run : nuget restore extensions/windows/cfapi/kDriveExt.sln
 
-      - name: Import Windows virtual certificate
+      - name: Import Windows certificate
         env:
-          WINDOWS_VIRTUAL_CERT: ${{ secrets.WINDOWS_VIRTUAL_CERT }}
-          WINDOWS_VIRTUAL_CERT_PASSWORD: ${{ secrets.WINDOWS_VIRTUAL_CERT_PASSWORD }}
+          WINDOWS_DEBUG_CERT: ${{ secrets.WINDOWS_DEBUG_CERT_THUMBPRINT }}
         run: |
-          New-Item -ItemType directory -Path certificate
-          Set-Content -Path certificate/tempCert.txt -Value $env:WINDOWS_VIRTUAL_CERT
-          certutil -decode certificate/tempCert.txt certificate/certificate.pfx
-          Remove-Item -path certificate -include tempCert.txt
-          Import-PfxCertificate -FilePath certificate/certificate.pfx -CertStoreLocation Cert:\CurrentUser\My -Password (ConvertTo-SecureString -String $env:WINDOWS_VIRTUAL_CERT_PASSWORD -Force -AsPlainText)
+            New-Item -ItemType directory -Path certificate
+            Set-Content -Path certificate/tempCert.txt -Value $env:WINDOWS_DEBUG_CERT
+            certutil -decode certificate/tempCert.txt certificate/debug_certificate.pfx
+            Remove-Item -path certificate -include tempCert.txt
+            Import-PfxCertificate -FilePath certificate/debug_certificate.pfx -CertStoreLocation Cert:\LocalMachine\My -Password (ConvertTo-SecureString -String "$env:WINDOWS_DEBUG_CERT" -Force -AsPlainText)
+            Write-Host "Debug certificate imported successfully."
+
+        shell: powershell
 
       - name: Build kDrive desktop
+        env:
+          WINDOWS_DEBUG_CERT: ${{ secrets.WINDOWS_DEBUG_CERT_THUMBPRINT }}
         run: |
           call "C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Auxiliary/Build/vcvars64.bat"
-          powershell ./infomaniak-build-tools/windows/build-drive.ps1 -thumbprint ${{ secrets.WINDOWS_DEBUG_CERT_THUMBPRINT }} -ci -coverage -unitTests
+          powershell ./infomaniak-build-tools/windows/build-drive.ps1 -thumbprint $env:WINDOWS_DEBUG_CERT -ci -coverage -unitTests
         shell: cmd
 
       - name: Execute tests

--- a/.github/workflows/build-and-run-extended-tests.yml
+++ b/.github/workflows/build-and-run-extended-tests.yml
@@ -1,17 +1,17 @@
 name: Build and run extended tests
 on:
     # Allows manual execution
-    workflow_dispatch:  
+    workflow_dispatch:
     # Runs every day at midnight
     schedule:
         - cron: '0 0 * * *'
     # Runs on PR to a release branch
-    pull_request: 
+    pull_request:
       types: [synchronize, opened]
       branches:
         - 'release/**'
         - 'main'
- 
+
 concurrency:
   group: extended-tests-${{ github.event.pull_request.number || github.ref_name || github.run_id }}
   cancel-in-progress: true
@@ -48,7 +48,7 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || (github.event_name == 'workflow_dispatch' && github.ref_name || 'develop') }}
           submodules: recursive
-        
+
       - name: Clean the log directory
         run : rm -r -force C:/Windows/Temp/kDrive-logdir/*
 
@@ -69,7 +69,7 @@ jobs:
       - name: Build kDrive desktop
         run: |
           call "C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Auxiliary/Build/vcvars64.bat"
-          powershell ./infomaniak-build-tools/windows/build-drive.ps1 -ci -coverage -unitTests
+          powershell ./infomaniak-build-tools/windows/build-drive.ps1 -thumbprint ${{ secrets.WINDOWS_DEBUG_CERT_THUMBPRINT }} -ci -coverage -unitTests
         shell: cmd
 
       - name: Execute tests
@@ -80,7 +80,7 @@ jobs:
           ./infomaniak-build-tools/run-tests.ps1
 
       - name: Compute code coverage
-        run : |          
+        run : |
           & "covselect.exe" "--add" 'exclude folder c:/'
           & "covselect.exe" "--add" 'exclude folder ../'
           & "covselect.exe" "--add" 'exclude folder 3rdparty/'
@@ -120,7 +120,7 @@ jobs:
     steps:
       - name: Clean-up XCode DerivedData
         run : rm -rf /Users/runner/Library/Developer/Xcode/DerivedData
-        
+
       - name: Checkout the code
         uses: actions/checkout@v6.0.2
         with:
@@ -202,7 +202,7 @@ jobs:
 
       - name: Clean-up generated code
         run : rm -rf build-linux
-  
+
   kChat_notification:
     if: ((github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && always())
     needs: [ Windows-extended-tests, MacOS-extended-tests, Linux-extended-tests ]

--- a/.github/workflows/build-and-run-extended-tests.yml
+++ b/.github/workflows/build-and-run-extended-tests.yml
@@ -63,7 +63,7 @@ jobs:
             Set-Content -Path certificate/tempCert.txt -Value $env:WINDOWS_DEBUG_CERT
             certutil -decode certificate/tempCert.txt certificate/debug_certificate.pfx
             Remove-Item -path certificate -include tempCert.txt
-            Import-PfxCertificate -FilePath certificate/debug_certificate.pfx -CertStoreLocation Cert:\LocalMachine\My -Password (ConvertTo-SecureString -String "$env:WINDOWS_DEBUG_CERT" -Force -AsPlainText)
+            Import-PfxCertificate -FilePath certificate/debug_certificate.pfx -CertStoreLocation Cert:\LocalMachine\My -Password (ConvertTo-SecureString -String $env:WINDOWS_DEBUG_CERT -Force -AsPlainText)
             Write-Host "Debug certificate imported successfully."
 
         shell: powershell


### PR DESCRIPTION
This PR fixes the extended test build failure on the Windows CI runners. 
The issue stems from a missing certificate thumbprint parameter required by the build script.