### PR TITLE
chore(gui): remove dual clien packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,8 +166,11 @@ option(BUILD_DOCS "BUILD_DOCS" OFF)
 # this option needs to be refactored out BUILD_CLIENT needs to be ON.
 option(BUILD_LIBRARIES_ONLY "BUILD_LIBRARIES_ONLY" OFF)
 
-# this option adds src/gui to the subdirectories when building the src folder 
+# this option adds src/gui4 to the subdirectories when building the src folder 
 option(BUILD_GUI "BUILD_GUI" ON)
+
+# this option adds src/gui to the subdirectories when building the src folder 
+option(BUILD_GUI_LEGACY "BUILD_GUI_LEGACY" OFF)
 
 # build the tests
 option(BUILD_UNIT_TESTS "BUILD_UNIT_TESTS" OFF)
@@ -295,6 +298,7 @@ elseif(BUILD_CLIENT)
         set(CMAKE_FIND_LIBRARY_SUFFIXES .dll)
         find_library(VFS_SHARED_LIBRARY NAMES vfs PATHS ${VFS_DIRECTORY} NO_DEFAULT_PATH NO_CACHE)
         message(STATUS "vfs dll found in ${VFS_SHARED_LIBRARY}")
+        file(COPY ${VFS_SHARED_LIBRARY} DESTINATION ${BIN_OUTPUT_DIRECTORY})  
         install(FILES ${VFS_SHARED_LIBRARY} DESTINATION ${CMAKE_INSTALL_BINDIR})
 
         # Sentry
@@ -304,6 +308,7 @@ elseif(BUILD_CLIENT)
                 NO_DEFAULT_PATH NO_CACHE
         )
         message(STATUS "sentry dll found in ${SENTRY_SHARED_LIBRARY}")
+        file(COPY ${SENTRY_SHARED_LIBRARY} DESTINATION ${BIN_OUTPUT_DIRECTORY})  
         install(FILES ${SENTRY_SHARED_LIBRARY} DESTINATION ${CMAKE_INSTALL_BINDIR})
 
         # Crashpad_handler
@@ -313,11 +318,8 @@ elseif(BUILD_CLIENT)
                 NO_DEFAULT_PATH NO_CACHE
         )
         message(STATUS "crashpad_handler found in ${CRASHPAD_HANDLER_PROGRAM}")
+        file(COPY ${CRASHPAD_HANDLER_PROGRAM} DESTINATION ${BIN_OUTPUT_DIRECTORY})  
         install(PROGRAMS ${CRASHPAD_HANDLER_PROGRAM} DESTINATION ${CMAKE_INSTALL_BINDIR})
-
-        # Client
-        install(DIRECTORY ${BIN_OUTPUT_DIRECTORY}/client DESTINATION ${CMAKE_INSTALL_BINDIR} OPTIONAL)
-
     else()
         # Default sync exclude list
         if(CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/infomaniak-build-tools/windows/Readme.md
+++ b/infomaniak-build-tools/windows/Readme.md
@@ -230,6 +230,8 @@ The project requires additional CMake variables for a correct build. To inject t
    set(APPLICATION_CLIENT_EXECUTABLE "kdrive_client")
    set(KDRIVE_THEME_DIR "F:/Projects/desktop-kDrive/infomaniak")
    set(BUILD_UNIT_TESTS "ON")      # Set to "OFF" to skip tests
+   set(BUILD_GUI "ON")      	   # Set to "OFF" to not build the GUI v4
+   set(BUILD_GUI_LEGACY "OFF")     # Set to "OFF" to not build the legacy GUI
    set(CMAKE_BUILD_TYPE "Debug")
    set(CMAKE_INSTALL_PREFIX "F:/Projects/cmake-build-release_CLion")
    set(ZLIB_INCLUDE_DIR "C:/Program Files (x86)/zlib-1.2.11/include")

--- a/infomaniak-build-tools/windows/build-drive.ps1
+++ b/infomaniak-build-tools/windows/build-drive.ps1
@@ -276,7 +276,8 @@ function CMake-Build-And-Install {
         [string] $path,
         [string] $installPath,
         [string] $vfsDir,
-        [bool] $ci
+        [bool] $ci,
+        [bool] $newGui
     )
     Write-Host "1) Installing Conan dependencies…"
     $conanFolder = Join-Path $buildPath "conan"
@@ -346,6 +347,14 @@ function CMake-Build-And-Install {
         $flags += ("'-DKD_COVERAGE:BOOL=TRUE'")
     }
 
+    if($newGui) {
+        $flags += ("'-DBUILD_GUI:BOOL=TRUE'")
+        $flags += ("'-DBUILD_GUI_LEGACY:BOOL=FALSE'")
+    }else{
+        $flags += ("'-DBUILD_GUI:BOOL=FALSE'")
+        $flags += ("'-DBUILD_GUI_LEGACY:BOOL=TRUE'")
+    }
+
     $args += $flags
 
     $args += ("'-B$buildPath'")
@@ -373,11 +382,16 @@ function CMake-Build-And-Install {
 
 function Get-Icon-Path {
     param (
-        [string] $buildPath
+        [string] $buildPath,
+        [bool] $newGui
     )
 
     # NSIS needs the path to use backslash
-    $iconPath = "$buildPath\src\gui\kdrive-win.ico".Replace('/', '\')
+    if(-not $newGui) {
+        $iconPath = "$buildPath\src\gui\kdrive-win.ico".Replace('/', '\')
+    }else {
+        $iconPath = "$buildPath\bin\client\Assets\kdrive.ico".Replace('/', '\')
+    }
 
     return $iconPath
 }
@@ -391,13 +405,14 @@ function Set-Up-NSIS {
         [string] $archiveName,
         [string] $archivePath,
         [string] $archiveDataPath,
-        [bool] $upload
+        [bool] $upload,
+        [bool] $newGui
     )
 
     Write-Host "Setting up NSIS."
 
     # NSIS needs the path to use backslash
-    $iconPath = Get-Icon-Path $buildpath
+    $iconPath = Get-Icon-Path $buildpath -newGui $newGui
     $appName = Get-Package-Name -exe
    
     $installerPath = Get-Installer-Path -ContentPath $contentPath
@@ -514,9 +529,12 @@ function Prepare-Archive {
 
     $binaries = @(
         "$crashpad_folder/crashpad_handler.exe",
-        "kDrive.exe",
-        "kDrive_client.exe"
+        "kDrive.exe"
     )
+
+    if(-not $newGui) {
+        $binaries += "kDrive_client.exe"
+    }
 
     # Move each executable to the bin folder and sign them
     foreach ($file in $binaries) {
@@ -543,7 +561,7 @@ function Prepare-Archive {
         Copy-Item -Path "$newGuiDir/." -Destination "$archivePath/client" -Recurse -ErrorAction Stop
 
         # Sign all the .exe, .dll and .xbf that have no signature yet
-        $filesToSign = Get-ChildItem -Path "$archivePath/client" -Recurse -Include *.exe, *.dll, *.xbf | Where-Object {
+        $filesToSign = Get-ChildItem -Path "$archivePath/client" -Recurse -Include *.exe, *.dll | Where-Object {
             $signature = Get-AuthenticodeSignature $_.FullName
             $signature.Status -eq 'NotSigned'
         }
@@ -799,7 +817,7 @@ if (!(Test-Path "$vfsDir\vfs.dll") -or $ext) {
 #                                                                                               #
 #################################################################################################
 
-CMake-Build-And-Install -Path $path -InstallPath $installPath -VfsDir $vfsDir -Ci $ci
+CMake-Build-And-Install -Path $path -InstallPath $installPath -VfsDir $vfsDir -Ci $ci -NewGui $newGui
 
 if ($LASTEXITCODE -ne 0) {
     Write-Host "CMake build failed. Aborting." -f Red
@@ -812,7 +830,7 @@ if ($LASTEXITCODE -ne 0) {
 #                                                                                               #
 #################################################################################################
 
-Set-Up-NSIS -BuildPath $buildPath -ContentPath $contentPath -ExtPath $extPath -VfsDir $vfsDir -ArchiveName $archiveName -ArchivePath $archivePath -ArchiveDataPath $archiveDataPath -Upload $upload
+Set-Up-NSIS -BuildPath $buildPath -ContentPath $contentPath -ExtPath $extPath -VfsDir $vfsDir -ArchiveName $archiveName -ArchivePath $archivePath -ArchiveDataPath $archiveDataPath -Upload $upload -NewGui $newGui
 
 if ($LASTEXITCODE -ne 0) {
     Write-Host "NSIS setup failed. Aborting." -f Red

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,20 +33,29 @@ add_subdirectory(libsyncengine)
 add_subdirectory(libparms)
 
 if(NOT BUILD_LIBRARIES_ONLY)
-    if(BUILD_GUI)
-        add_subdirectory(gui)
-        add_subdirectory(gui4)
-    endif()
     add_subdirectory(server)
 
-endif(NOT BUILD_LIBRARIES_ONLY)
+    # At most one GUI type can be built, fail if both are enabled
+    if(BUILD_GUI AND BUILD_GUI_LEGACY)
+        message(FATAL_ERROR "Both BUILD_GUI and BUILD_GUI_LEGACY are enabled. Please choose only one.")
+    endif()
 
-find_program(KRAZY2_EXECUTABLE krazy2)
-if(KRAZY2_EXECUTABLE)
-    # s/y k/y ALL k/ for building this target always
-    add_custom_target( krazy krazy2 --check-sets c++,qt4,foss
-                       ${PROJECT_SOURCE_DIR}/src/gui/*.ui
-                       ${PROJECT_SOURCE_DIR}/src/gui/*.h
-                       ${PROJECT_SOURCE_DIR}/src/gui/*.cpp)
-endif()
+    set(CLIENT_DEST "${BIN_OUTPUT_DIRECTORY}/client")
+    if(WIN32)
+        if(BUILD_GUI)
+            add_subdirectory(gui4)
+        else()
+            # delete the client build directory if GUI is disabled to avoid confusion
+            file(REMOVE_RECURSE "${CLIENT_DEST}")
+        endif()
+
+        if(BUILD_GUI_LEGACY)
+            add_subdirectory(gui)
+        endif()
+    else()
+        if(BUILD_GUI)
+            add_subdirectory(gui)
+        endif()
+    endif()
+endif(NOT BUILD_LIBRARIES_ONLY)
 

--- a/src/gui4/CMakeLists.txt
+++ b/src/gui4/CMakeLists.txt
@@ -4,12 +4,13 @@ if(WIN32)
     set(CLIENT_PROJECT "${CLIENT_PATH}/kDrive client/kDrive client.csproj")
     set(CLIENT_BOOTSTRAP_PROJECT "${CLIENT_PATH}/Bootstrapper/Bootstrapper.csproj")
     set(CLIENT_OUTPUT_DIRECTORY "${CLIENT_PATH}/kDrive client/bin/x64/${CMAKE_BUILD_TYPE}/net9.0-windows10.0.19041/win-x64")
-    set(CLIENT_DEST "${BIN_OUTPUT_DIRECTORY}/client")
-    set(CLIENT_STAMP "${CMAKE_BINARY_DIR}/client_build.stamp")
+    set(CLIENT_STAMP_NAME "client_build.stamp")
+    set(CLIENT_STAMP "${CLIENT_DEST}/${CLIENT_STAMP_NAME}")
 
     set(CLIENT_SOURCES
         ${CLIENT_PATH}/*.cs
         ${CLIENT_PATH}/*.xaml
+        ${CMAKE_SOURCE_DIR}/version.json
     )
     file(GLOB_RECURSE CLIENT_SOURCES ${CLIENT_SOURCES})
     list(FILTER CLIENT_SOURCES EXCLUDE REGEX "/kDrive client/bin/")
@@ -24,9 +25,17 @@ if(WIN32)
         COMMAND ${CMAKE_COMMAND} -E copy_directory "${CLIENT_OUTPUT_DIRECTORY}" "${CLIENT_DEST}"
         COMMAND ${CMAKE_COMMAND} -E touch "${CLIENT_STAMP}"
         DEPENDS "${CLIENT_PROJECT}" ${CLIENT_SOURCES}
+        USES_TERMINAL  
     )
 
     add_custom_target(build_kDrive_client ALL
         DEPENDS "${CLIENT_STAMP}"
+    )
+
+    # Ensure the main executable always triggers the client build
+    add_dependencies(${APPLICATION_EXECUTABLE} build_kDrive_client)
+
+    install(DIRECTORY ${CLIENT_DEST}/ DESTINATION ${CMAKE_INSTALL_BINDIR}/client
+        PATTERN "${CLIENT_STAMP_NAME}" EXCLUDE
     )
 endif()


### PR DESCRIPTION
Introduce `BUILD_GUI` and `BUILD_GUI_LEGACY` options in CMake
to manage the construction of two GUI versions, ensuring only
one can be enabled at a time. Update `build-drive.ps1` to
handle GUI-specific parameters and behaviors.