### PR TITLE
feat(gui): add Test distribution channel to beta program

### DIFF
--- a/src/gui/betaprogramdialog.cpp
+++ b/src/gui/betaprogramdialog.cpp
@@ -34,6 +34,7 @@ static constexpr auto iconColor = QColor(239, 139, 52);
 static constexpr int indexNo = 0;
 static constexpr int indexBeta = 1;
 static constexpr int indexInternal = 2;
+static constexpr int indexTest = 3;
 
 namespace KDC {
 
@@ -91,6 +92,7 @@ BetaProgramDialog::BetaProgramDialog(const bool isQuit, const bool isStaff, QWid
         _staffSelectionBox->insertItem(indexNo, tr("No"));
         _staffSelectionBox->insertItem(indexBeta, tr("Public beta version"));
         _staffSelectionBox->insertItem(indexInternal, tr("Internal beta version"));
+        _staffSelectionBox->insertItem(indexTest, tr("Test version"));
 
         switch (ParametersCache::instance()->parametersInfo().distributionChannel()) {
             case DistributionChannel::Prod:
@@ -101,6 +103,9 @@ BetaProgramDialog::BetaProgramDialog(const bool isQuit, const bool isStaff, QWid
                 break;
             case DistributionChannel::Internal:
                 _initialIndex = indexInternal;
+                break;
+            case DistributionChannel::Test:
+                _initialIndex = indexTest;
                 break;
             default:
                 break;
@@ -188,6 +193,8 @@ DistributionChannel indexToDistributionChannel(const int index) {
             return DistributionChannel::Beta;
         case indexInternal:
             return DistributionChannel::Internal;
+        case indexTest:
+            return DistributionChannel::Test;
         default:
             break;
     }
@@ -217,7 +224,7 @@ void BetaProgramDialog::onChannelChange(const int index) {
     }
 
     _acknowledgmentFrame->setVisible(true);
-    if (index > _initialIndex)
+    if (_initialIndex == indexNo)
         setInstabilityMessage();
     else
         setTooRecentMessage();

--- a/src/gui/versionwidget.cpp
+++ b/src/gui/versionwidget.cpp
@@ -45,6 +45,7 @@ static const QString downloadPageLink = "downloadPageLink";
 static constexpr int statusLayoutSpacing = 8;
 static constexpr auto betaTagColor = QColor(214, 56, 100);
 static constexpr auto internalTagColor = QColor(120, 116, 176);
+static constexpr auto testTagColor = QColor(62, 160, 146);
 
 Q_LOGGING_CATEGORY(lcVersionWidget, "gui.versionwidget", QtInfoMsg)
 
@@ -258,8 +259,26 @@ void VersionWidget::refresh(UpdateState state /*= UpdateState::Unknown*/) const 
         } else {
             _joinBetaButton->setText(_isStaff ? tr("Modify") : tr("Quit"));
             _betaTag->setVisible(true);
-            _betaTag->setBackgroundColor(channel == DistributionChannel::Beta ? betaTagColor : internalTagColor);
-            _betaTag->setText(channel == DistributionChannel::Beta ? "BETA" : "INTERNAL");
+            auto tagColor = betaTagColor;
+            auto tagText = "BETA";
+            switch (channel) {
+                case DistributionChannel::Beta:
+                    tagColor = betaTagColor;
+                    tagText = "BETA";
+                    break;
+                case DistributionChannel::Internal:
+                    tagColor = internalTagColor;
+                    tagText = "INTERNAL";
+                    break;
+                case DistributionChannel::Test:
+                    tagColor = testTagColor;
+                    tagText = "TEST";
+                    break;
+                default:
+                    break;
+            }
+            _betaTag->setBackgroundColor(tagColor);
+            _betaTag->setText(tagText);
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds support for the **Test** distribution channel in the beta program UI.

## Changes

- `src/gui/betaprogramdialog.cpp`:
  - Introduced `indexTest` and a new "Test version" option in the staff channel selector.
  - Added mapping for `DistributionChannel::Test` when setting the initial index.
  - Fixed instability message logic: the warning now shows when the user switches **from** "No" channel, rather than relying on `index > _initialIndex`.

- `src/gui/versionwidget.cpp`:
  - Added a dedicated `testTagColor` constant.
  - Replaced the hard-coded Beta/Internal tag logic with a `switch` covering Beta, Internal, and Test channels.

## Notes

- This branch was created from `develop` and targets `develop`.
- Please ensure the `DistributionChannel::Test` enum value is already defined in the backend/parameters layer before merging.