### PR TITLE
fix(server): handle server-level errors specifically

### DIFF
--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -1862,6 +1862,17 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 return;
             }
 
+            if (errorInfo.Level == ErrorLevel.Server)
+            {
+                lock (_errorLock)
+                {
+                    ++_errorCount;
+                }
+                Error error = new(errorInfo);
+                await _viewModel.AddErrorAsync(error).ConfigureAwait(false);
+                return;
+            }
+
             var sync = App.ServiceProvider.GetRequiredService<AppModel>().AllSyncs.FirstOrDefault(s => s.DbId == errorInfo.SyncDbId);
             if (sync is not null)
             {

--- a/version.json
+++ b/version.json
@@ -1,8 +1,8 @@
 {
   "Version": {
     "major": 3,
-    "minor": 7,
-    "patch": 2,
+    "minor": 8,
+    "patch": 4,
     "build": 1,
     "year": 2026
   }

--- a/version.json
+++ b/version.json
@@ -1,8 +1,8 @@
 {
   "Version": {
     "major": 3,
-    "minor": 8,
-    "patch": 4,
+    "minor": 7,
+    "patch": 2,
     "build": 1,
     "year": 2026
   }


### PR DESCRIPTION
fix(server): handle server-level errors specifically

Introduce specific handling for `ErrorLevel.Server` errors:
- Increment a thread-safe error counter (`_errorLock`).
- Create an `Error` object from `errorInfo`.
- Asynchronously add the error to the `ViewModel` using `AddErrorAsync`.
- Return immediately after processing server-level errors.