### PR TITLE
feat: adding check hash match job

### DIFF
--- a/src/libsyncengine/CMakeLists.txt
+++ b/src/libsyncengine/CMakeLists.txt
@@ -60,6 +60,7 @@ set(syncengine_SRCS
     jobs/network/kDrive_API/getfileinfojobV3.h jobs/network/kDrive_API/getfileinfojobV3.cpp
     jobs/network/kDrive_API/deletejob.h jobs/network/kDrive_API/deletejob.cpp
     jobs/network/kDrive_API/createdirjob.h jobs/network/kDrive_API/createdirjob.cpp
+    jobs/network/kDrive_API/createdirjob.h jobs/network/kDrive_API/checkhashmatchjob.cpp
     jobs/network/kDrive_API/movejob.h jobs/network/kDrive_API/movejob.cpp
     jobs/network/kDrive_API/renamejob.h jobs/network/kDrive_API/renamejob.cpp
     jobs/network/kDrive_API/duplicatejob.h jobs/network/kDrive_API/duplicatejob.cpp

--- a/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.cpp
@@ -16,96 +16,52 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "createdirjob.h"
-#include "libcommonserver/utility/utility.h"
+#include "checkhashmatchjob.h"
 #include "libcommonserver/utility/jsonparserutility.h"
 
 #include <Poco/Net/HTTPRequest.h>
 
 namespace KDC {
 
-CreateDirJob::CreateDirJob(const std::shared_ptr<Vfs> vfs, const DriveDbId driveDbId, const SyncPath &filepath,
-                           const NodeId &parentId, const SyncName &name, const std::string &color /*= ""*/) :
+CheckHashMatchJob::CheckHashMatchJob(const DriveDbId driveDbId, const SyncPath &filepath, const NodeId &nodeId, int localsize,
+                                     int remotesize) :
     AbstractTokenNetworkJob(ApiType::Drive, 0, 0, driveDbId, 0),
     _filePath(filepath),
-    _parentDirId(parentId),
-    _name(name),
-    _color(color),
-    _vfs(vfs) {
-    _httpMethod = Poco::Net::HTTPRequest::HTTP_POST;
+    _nodeId(nodeId) {
+    if (localsize != remotesize) abort();
+
+    _httpMethod = Poco::Net::HTTPRequest::HTTP_GET;
 }
 
-CreateDirJob::CreateDirJob(const std::shared_ptr<Vfs> vfs, const DriveDbId driveDbId, const NodeId &parentId,
-                           const SyncName &name) :
-    CreateDirJob(vfs, driveDbId, "", parentId, name) {}
+CheckHashMatchJob::~CheckHashMatchJob() {}
 
-CreateDirJob::CreateDirJob(const std::shared_ptr<Vfs> vfs, const UserDbId userDbId, const DriveId driveId, const NodeId &parentId,
-                           const SyncName &name) :
-    AbstractTokenNetworkJob(ApiType::Drive, userDbId, 0, 0, driveId),
-    _parentDirId(parentId),
-    _name(name),
-    _vfs(vfs) {
-    _httpMethod = Poco::Net::HTTPRequest::HTTP_POST;
-}
-
-CreateDirJob::~CreateDirJob() {
-    if (_filePath.empty() || !_vfs) return;
-    if (const ExitInfo exitInfo = _vfs->setPinState(_filePath, PinState::AlwaysLocal); !exitInfo) {
-        LOGW_WARN(_logger,
-                  L"Error in CreateDirJob::vfsSetPinState for " << Utility::formatSyncPath(_filePath) << L" : " << exitInfo);
-    }
-
-    if (const ExitInfo exitInfo =
-                _vfs->forceStatus(_filePath, VfsStatus({.isHydrated = true, .isSyncing = false, .progress = 0}));
-        !exitInfo) {
-        LOGW_WARN(_logger,
-                  L"Error in CreateDirJob::vfsForceStatus for " << Utility::formatSyncPath(_filePath) << L" : " << exitInfo);
-    }
-}
-std::string CreateDirJob::getSpecificUrl() {
+std::string CheckHashMatchJob::getSpecificUrl() {
     std::string str = AbstractTokenNetworkJob::getSpecificUrl();
     str += "/files/";
-    str += _parentDirId;
-    str += "/directory";
+    str += _nodeId;
+    str += "/hash";
     return str;
 }
 
-ExitInfo CreateDirJob::setData() {
-    Poco::JSON::Object json;
-    json.set("name", _name);
-    if (!_color.empty()) {
-        json.set("color", _color);
-    }
-
-    std::stringstream ss;
-    json.stringify(ss);
-    _data = ss.str();
-    return ExitCode::Ok;
-}
-
-ExitInfo CreateDirJob::handleResponse(std::istream &is) {
+ExitInfo CheckHashMatchJob::handleResponse(std::istream &is) {
     if (const auto exitInfo = AbstractTokenNetworkJob::handleResponse(is); !exitInfo) {
         return exitInfo;
     }
 
     if (jsonRes()) {
         if (const auto dataObj = jsonRes()->getObject(dataKey); dataObj) {
-            if (!JsonParserUtility::extractValue(dataObj, idKey, _nodeId)) {
-                return {};
-            }
-            if (!JsonParserUtility::extractValue(dataObj, lastModifiedAtKey, _modtime)) {
-                return {};
-            }
-        }
-
-        if (!_filePath.empty() && _vfs) {
-            constexpr VfsStatus vfsStatus({.isHydrated = true, .isSyncing = false, .progress = 0});
-            if (const auto exitInfo = _vfs->forceStatus(_filePath, vfsStatus); !exitInfo) {
-                LOGW_WARN(_logger, L"Error in CreateDirJob::_vfsForceStatus for " << Utility::formatSyncPath(_filePath) << L" : "
-                                                                                  << exitInfo);
+            if (!JsonParserUtility::extractValue(dataObj, hashKey, _distantHash)) {
+                return {ExitCode::BackError, ExitCause::MissingReplyData};
             }
         }
     }
+
+    std::ifstream ifs;
+    IoError ioError = IoError::Unknown;
+    _localHash = "xxh3:" + IoHelper::getFileChecksum(_filePath, ifs, ioError);
+
+    if (_localHash != _distantHash) return ExitCode::Ok;
+    _shouldDownload = false;
 
     return ExitCode::Ok;
 }

--- a/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.cpp
@@ -1,0 +1,113 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "createdirjob.h"
+#include "libcommonserver/utility/utility.h"
+#include "libcommonserver/utility/jsonparserutility.h"
+
+#include <Poco/Net/HTTPRequest.h>
+
+namespace KDC {
+
+CreateDirJob::CreateDirJob(const std::shared_ptr<Vfs> vfs, const DriveDbId driveDbId, const SyncPath &filepath,
+                           const NodeId &parentId, const SyncName &name, const std::string &color /*= ""*/) :
+    AbstractTokenNetworkJob(ApiType::Drive, 0, 0, driveDbId, 0),
+    _filePath(filepath),
+    _parentDirId(parentId),
+    _name(name),
+    _color(color),
+    _vfs(vfs) {
+    _httpMethod = Poco::Net::HTTPRequest::HTTP_POST;
+}
+
+CreateDirJob::CreateDirJob(const std::shared_ptr<Vfs> vfs, const DriveDbId driveDbId, const NodeId &parentId,
+                           const SyncName &name) :
+    CreateDirJob(vfs, driveDbId, "", parentId, name) {}
+
+CreateDirJob::CreateDirJob(const std::shared_ptr<Vfs> vfs, const UserDbId userDbId, const DriveId driveId, const NodeId &parentId,
+                           const SyncName &name) :
+    AbstractTokenNetworkJob(ApiType::Drive, userDbId, 0, 0, driveId),
+    _parentDirId(parentId),
+    _name(name),
+    _vfs(vfs) {
+    _httpMethod = Poco::Net::HTTPRequest::HTTP_POST;
+}
+
+CreateDirJob::~CreateDirJob() {
+    if (_filePath.empty() || !_vfs) return;
+    if (const ExitInfo exitInfo = _vfs->setPinState(_filePath, PinState::AlwaysLocal); !exitInfo) {
+        LOGW_WARN(_logger,
+                  L"Error in CreateDirJob::vfsSetPinState for " << Utility::formatSyncPath(_filePath) << L" : " << exitInfo);
+    }
+
+    if (const ExitInfo exitInfo =
+                _vfs->forceStatus(_filePath, VfsStatus({.isHydrated = true, .isSyncing = false, .progress = 0}));
+        !exitInfo) {
+        LOGW_WARN(_logger,
+                  L"Error in CreateDirJob::vfsForceStatus for " << Utility::formatSyncPath(_filePath) << L" : " << exitInfo);
+    }
+}
+std::string CreateDirJob::getSpecificUrl() {
+    std::string str = AbstractTokenNetworkJob::getSpecificUrl();
+    str += "/files/";
+    str += _parentDirId;
+    str += "/directory";
+    return str;
+}
+
+ExitInfo CreateDirJob::setData() {
+    Poco::JSON::Object json;
+    json.set("name", _name);
+    if (!_color.empty()) {
+        json.set("color", _color);
+    }
+
+    std::stringstream ss;
+    json.stringify(ss);
+    _data = ss.str();
+    return ExitCode::Ok;
+}
+
+ExitInfo CreateDirJob::handleResponse(std::istream &is) {
+    if (const auto exitInfo = AbstractTokenNetworkJob::handleResponse(is); !exitInfo) {
+        return exitInfo;
+    }
+
+    if (jsonRes()) {
+        if (const auto dataObj = jsonRes()->getObject(dataKey); dataObj) {
+            if (!JsonParserUtility::extractValue(dataObj, idKey, _nodeId)) {
+                return {};
+            }
+            if (!JsonParserUtility::extractValue(dataObj, lastModifiedAtKey, _modtime)) {
+                return {};
+            }
+        }
+
+        if (!_filePath.empty() && _vfs) {
+            constexpr VfsStatus vfsStatus({.isHydrated = true, .isSyncing = false, .progress = 0});
+            if (const auto exitInfo = _vfs->forceStatus(_filePath, vfsStatus); !exitInfo) {
+                LOGW_WARN(_logger, L"Error in CreateDirJob::_vfsForceStatus for " << Utility::formatSyncPath(_filePath) << L" : "
+                                                                                  << exitInfo);
+            }
+        }
+    }
+
+    return ExitCode::Ok;
+}
+
+} // namespace KDC

--- a/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.cpp
@@ -23,17 +23,31 @@
 
 namespace KDC {
 
-CheckHashMatchJob::CheckHashMatchJob(const DriveDbId driveDbId, const SyncPath &filepath, const NodeId &nodeId, int localsize,
-                                     int remotesize) :
+CheckHashMatchJob::CheckHashMatchJob(const DriveDbId driveDbId, const SyncPath &filepath, const NodeId &nodeId, int64_t localsize,
+                                     int64_t remotesize) :
     AbstractTokenNetworkJob(ApiType::Drive, 0, 0, driveDbId, 0),
     _filePath(filepath),
-    _nodeId(nodeId) {
-    if (localsize != remotesize) abort();
-
+    _nodeId(nodeId),
+    _localSize(localsize),
+    _remoteSize(remotesize) {
     _httpMethod = Poco::Net::HTTPRequest::HTTP_GET;
 }
 
-CheckHashMatchJob::~CheckHashMatchJob() {}
+ExitInfo CheckHashMatchJob::runJob() noexcept {
+    if (_localSize != _remoteSize) return ExitCode::Ok;
+
+    if (const ExitInfo exitInfo = AbstractTokenNetworkJob::runJob(); !exitInfo) {
+        return exitInfo;
+    }
+
+    std::ifstream ifs;
+    IoError ioError = IoError::Unknown;
+    _localHash = "xxh3:" + IoHelper::getFileChecksum(_filePath, ifs, ioError);
+
+    if (_localHash != _remoteHash) return ExitCode::Ok;
+    _shouldDownload = false;
+    return ExitCode::Ok;
+}
 
 std::string CheckHashMatchJob::getSpecificUrl() {
     std::string str = AbstractTokenNetworkJob::getSpecificUrl();
@@ -50,18 +64,11 @@ ExitInfo CheckHashMatchJob::handleResponse(std::istream &is) {
 
     if (jsonRes()) {
         if (const auto dataObj = jsonRes()->getObject(dataKey); dataObj) {
-            if (!JsonParserUtility::extractValue(dataObj, hashKey, _distantHash)) {
+            if (!JsonParserUtility::extractValue(dataObj, hashKey, _remoteHash)) {
                 return {ExitCode::BackError, ExitCause::MissingReplyData};
             }
         }
     }
-
-    std::ifstream ifs;
-    IoError ioError = IoError::Unknown;
-    _localHash = "xxh3:" + IoHelper::getFileChecksum(_filePath, ifs, ioError);
-
-    if (_localHash != _distantHash) return ExitCode::Ok;
-    _shouldDownload = false;
 
     return ExitCode::Ok;
 }

--- a/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.h
+++ b/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.h
@@ -19,23 +19,15 @@
 #pragma once
 
 #include "jobs/network/abstracttokennetworkjob.h"
-#include "libcommonserver/vfs/vfs.h"
 
 namespace KDC {
 
-class CreateDirJob : public AbstractTokenNetworkJob {
+class CheckHashMatchJob : public AbstractTokenNetworkJob {
     public:
-        CreateDirJob(const std::shared_ptr<Vfs> vfs, DriveDbId driveDbId, const SyncPath &filepath, const NodeId &parentId,
-                     const SyncName &name, const std::string &color = "");
-        CreateDirJob(const std::shared_ptr<Vfs> vfs, DriveDbId driveDbId, const NodeId &parentId, const SyncName &name);
-        CreateDirJob(const std::shared_ptr<Vfs> vfs, UserDbId userDbId, DriveId driveId, const NodeId &parentId,
-                     const SyncName &name);
-        ~CreateDirJob() override;
+        CheckHashMatchJob(DriveDbId driveDbId, const SyncPath &filepath, const NodeId &nodeId, int localsize, int remotesize);
 
-        [[nodiscard]] inline const NodeId &parentDirId() const { return _parentDirId; }
-
-        [[nodiscard]] inline const NodeId &nodeId() const { return _nodeId; }
-        [[nodiscard]] inline SyncTime modtime() const { return _modtime; }
+        [[nodiscard]] const NodeId &nodeId() const { return _nodeId; }
+        [[nodiscard]] bool shouldDownload() const { return _shouldDownload; }
 
     protected:
         ExitInfo handleResponse(std::istream &is) override;
@@ -45,13 +37,13 @@ class CreateDirJob : public AbstractTokenNetworkJob {
         ExitInfo setData() override;
 
         SyncPath _filePath;
-        NodeId _parentDirId;
         SyncName _name;
-        std::string _color;
 
         NodeId _nodeId;
-        SyncTime _modtime = 0;
-        const std::shared_ptr<Vfs> _vfs;
+        std::string _distantHash;
+        std::string _localHash;
+
+        bool _shouldDownload = true;
 };
 
 } // namespace KDC

--- a/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.h
+++ b/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.h
@@ -1,0 +1,57 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "jobs/network/abstracttokennetworkjob.h"
+#include "libcommonserver/vfs/vfs.h"
+
+namespace KDC {
+
+class CreateDirJob : public AbstractTokenNetworkJob {
+    public:
+        CreateDirJob(const std::shared_ptr<Vfs> vfs, DriveDbId driveDbId, const SyncPath &filepath, const NodeId &parentId,
+                     const SyncName &name, const std::string &color = "");
+        CreateDirJob(const std::shared_ptr<Vfs> vfs, DriveDbId driveDbId, const NodeId &parentId, const SyncName &name);
+        CreateDirJob(const std::shared_ptr<Vfs> vfs, UserDbId userDbId, DriveId driveId, const NodeId &parentId,
+                     const SyncName &name);
+        ~CreateDirJob() override;
+
+        [[nodiscard]] inline const NodeId &parentDirId() const { return _parentDirId; }
+
+        [[nodiscard]] inline const NodeId &nodeId() const { return _nodeId; }
+        [[nodiscard]] inline SyncTime modtime() const { return _modtime; }
+
+    protected:
+        ExitInfo handleResponse(std::istream &is) override;
+
+    private:
+        std::string getSpecificUrl() override;
+        ExitInfo setData() override;
+
+        SyncPath _filePath;
+        NodeId _parentDirId;
+        SyncName _name;
+        std::string _color;
+
+        NodeId _nodeId;
+        SyncTime _modtime = 0;
+        const std::shared_ptr<Vfs> _vfs;
+};
+
+} // namespace KDC

--- a/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.h
+++ b/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.h
@@ -24,7 +24,7 @@ namespace KDC {
 
 class CheckHashMatchJob : public AbstractTokenNetworkJob {
     public:
-        CheckHashMatchJob(DriveDbId driveDbId, const SyncPath &filepath, const NodeId &nodeId, int localsize, int remotesize);
+        CheckHashMatchJob(DriveDbId driveDbId, const SyncPath &filepath, const NodeId &nodeId, int64_t localsize, int64_t remotesize);
 
         [[nodiscard]] const NodeId &nodeId() const { return _nodeId; }
         [[nodiscard]] bool shouldDownload() const { return _shouldDownload; }
@@ -34,14 +34,17 @@ class CheckHashMatchJob : public AbstractTokenNetworkJob {
 
     private:
         std::string getSpecificUrl() override;
-        ExitInfo setData() override;
+        ExitInfo runJob() noexcept override;
 
         SyncPath _filePath;
         SyncName _name;
 
         NodeId _nodeId;
-        std::string _distantHash;
+        std::string _remoteHash;
         std::string _localHash;
+
+        int64_t _localSize = 0;
+        int64_t _remoteSize = 0;
 
         bool _shouldDownload = true;
 };

--- a/src/libsyncengine/jobs/network/networkjobsparams.h
+++ b/src/libsyncengine/jobs/network/networkjobsparams.h
@@ -110,6 +110,7 @@ static const std::string avatarKey = "avatar";
 static const std::string isStaffKey = "is_staff";
 static const std::string updatedAtKey = "updated_at";
 static const std::string versionsKey = "versions";
+static const std::string hashKey = "hash";
 
 static const std::string totalNbItemKey = "total";
 static const std::string pageKey = "page";

--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -826,32 +826,6 @@ ExitInfo ExecutorWorker::generateEditJob(SyncOpPtr syncOp, std::shared_ptr<SyncJ
         SyncPath relativeLocalFilePath = syncOp->nodePath(ReplicaSide::Local);
         SyncPath absoluteLocalFilePath = _syncPal->localPath() / relativeLocalFilePath;
 
-        // If both checksums are available and identical, the file content is already up-to-date locally.
-        // Skip the download and only update the local metadata (dates).
-        const std::string remoteChecksum =
-                _syncPal->snapshot(ReplicaSide::Remote)->contentChecksum(syncOp->affectedNode()->id().value_or(""));
-        const std::string localChecksum =
-                syncOp->correspondingNode()
-                        ? _syncPal->snapshot(ReplicaSide::Local)->contentChecksum(syncOp->correspondingNode()->id().value_or(""))
-                        : std::string{};
-        const int64_t remoteSize = _syncPal->snapshot(ReplicaSide::Remote)->size(syncOp->affectedNode()->id().value_or(""));
-        const int64_t localSize = _syncPal->snapshot(ReplicaSide::Local)->size(syncOp->correspondingNode()->id().value_or(""));
-        if (ParametersCache::isExtendedLogEnabled())
-            LOG_SYNCPAL_DEBUG(_logger, "Edit checksum comparison - remote: \"" << remoteChecksum << "\" local: \""
-                                                                               << localChecksum << "\"");
-        if (!remoteChecksum.empty() && remoteChecksum == localChecksum && localSize != remoteSize) {
-            LOGW_SYNCPAL_DEBUG(_logger, L"Checksums match, skipping download and updating metadata only: "
-                                                << Utility::formatSyncPath(absoluteLocalFilePath));
-            const SyncTime creationTime = syncOp->affectedNode()->createdAt().value_or(0);
-            const SyncTime modificationTime = syncOp->affectedNode()->modificationTime().value_or(0);
-            if (const IoError ioError = IoHelper::setFileDates(absoluteLocalFilePath, creationTime, modificationTime, false);
-                ioError != IoError::Success) {
-                LOGW_SYNCPAL_WARN(_logger,
-                                  L"Error in IoHelper::setFileDates for " << Utility::formatSyncPath(absoluteLocalFilePath));
-            }
-            return ExitCode::Ok;
-        }
-
         try {
             job = std::make_shared<DownloadJob>(
                     _syncPal->vfs(), _syncPal->cacheDirectory(),
@@ -870,24 +844,6 @@ ExitInfo ExecutorWorker::generateEditJob(SyncOpPtr syncOp, std::shared_ptr<SyncJ
     } else {
         SyncPath relativeLocalFilePath = syncOp->nodePath(ReplicaSide::Local);
         SyncPath absoluteLocalFilePath = _syncPal->localPath() / relativeLocalFilePath;
-
-        // If both checksums are available and identical, the remote already has the same content.
-        // Skip the upload entirely.
-        const std::string localChecksum =
-                _syncPal->snapshot(ReplicaSide::Local)->contentChecksum(syncOp->affectedNode()->id().value_or(""));
-        const std::string remoteChecksum =
-                syncOp->correspondingNode()
-                        ? _syncPal->snapshot(ReplicaSide::Remote)->contentChecksum(syncOp->correspondingNode()->id().value_or(""))
-                        : std::string{};
-        const int64_t remoteSize = _syncPal->snapshot(ReplicaSide::Remote)->size(syncOp->affectedNode()->id().value_or(""));
-        const int64_t localSize = _syncPal->snapshot(ReplicaSide::Local)->size(syncOp->correspondingNode()->id().value_or(""));
-        if (ParametersCache::isExtendedLogEnabled())
-            LOG_SYNCPAL_DEBUG(_logger, "Edit upload checksum comparison - local: \"" << localChecksum << "\" remote: \""
-                                                                                     << remoteChecksum << "\"");
-        if (!localChecksum.empty() && localChecksum == remoteChecksum && localSize == remoteSize) {
-            LOGW_SYNCPAL_DEBUG(_logger, L"Checksums match, skipping upload: " << Utility::formatSyncPath(absoluteLocalFilePath));
-            return ExitCode::Ok;
-        }
 
         uint64_t filesize;
         if (ExitInfo exitInfo = getFileSize(absoluteLocalFilePath, filesize); !exitInfo) {

--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -834,17 +834,20 @@ ExitInfo ExecutorWorker::generateEditJob(SyncOpPtr syncOp, std::shared_ptr<SyncJ
                 syncOp->correspondingNode()
                         ? _syncPal->snapshot(ReplicaSide::Local)->contentChecksum(syncOp->correspondingNode()->id().value_or(""))
                         : std::string{};
-        LOG_SYNCPAL_DEBUG(_logger, "Edit checksum comparison - remote: \"" << remoteChecksum << "\" local: \""
-                                                                           << localChecksum << "\"");
-        if (!remoteChecksum.empty() && remoteChecksum == localChecksum) {
+        const int64_t remoteSize = _syncPal->snapshot(ReplicaSide::Remote)->size(syncOp->affectedNode()->id().value_or(""));
+        const int64_t localSize = _syncPal->snapshot(ReplicaSide::Local)->size(syncOp->correspondingNode()->id().value_or(""));
+        if (ParametersCache::isExtendedLogEnabled())
+            LOG_SYNCPAL_DEBUG(_logger, "Edit checksum comparison - remote: \"" << remoteChecksum << "\" local: \""
+                                                                               << localChecksum << "\"");
+        if (!remoteChecksum.empty() && remoteChecksum == localChecksum && localSize != remoteSize) {
             LOGW_SYNCPAL_DEBUG(_logger, L"Checksums match, skipping download and updating metadata only: "
                                                 << Utility::formatSyncPath(absoluteLocalFilePath));
             const SyncTime creationTime = syncOp->affectedNode()->createdAt().value_or(0);
             const SyncTime modificationTime = syncOp->affectedNode()->modificationTime().value_or(0);
             if (const IoError ioError = IoHelper::setFileDates(absoluteLocalFilePath, creationTime, modificationTime, false);
                 ioError != IoError::Success) {
-                LOGW_SYNCPAL_WARN(_logger, L"Error in IoHelper::setFileDates for "
-                                                   << Utility::formatSyncPath(absoluteLocalFilePath));
+                LOGW_SYNCPAL_WARN(_logger,
+                                  L"Error in IoHelper::setFileDates for " << Utility::formatSyncPath(absoluteLocalFilePath));
             }
             return ExitCode::Ok;
         }
@@ -876,11 +879,13 @@ ExitInfo ExecutorWorker::generateEditJob(SyncOpPtr syncOp, std::shared_ptr<SyncJ
                 syncOp->correspondingNode()
                         ? _syncPal->snapshot(ReplicaSide::Remote)->contentChecksum(syncOp->correspondingNode()->id().value_or(""))
                         : std::string{};
-        LOG_SYNCPAL_DEBUG(_logger, "Edit upload checksum comparison - local: \"" << localChecksum << "\" remote: \""
-                                                                                 << remoteChecksum << "\"");
-        if (!localChecksum.empty() && localChecksum == remoteChecksum) {
-            LOGW_SYNCPAL_DEBUG(_logger, L"Checksums match, skipping upload: "
-                                                << Utility::formatSyncPath(absoluteLocalFilePath));
+        const int64_t remoteSize = _syncPal->snapshot(ReplicaSide::Remote)->size(syncOp->affectedNode()->id().value_or(""));
+        const int64_t localSize = _syncPal->snapshot(ReplicaSide::Local)->size(syncOp->correspondingNode()->id().value_or(""));
+        if (ParametersCache::isExtendedLogEnabled())
+            LOG_SYNCPAL_DEBUG(_logger, "Edit upload checksum comparison - local: \"" << localChecksum << "\" remote: \""
+                                                                                     << remoteChecksum << "\"");
+        if (!localChecksum.empty() && localChecksum == remoteChecksum && localSize == remoteSize) {
+            LOGW_SYNCPAL_DEBUG(_logger, L"Checksums match, skipping upload: " << Utility::formatSyncPath(absoluteLocalFilePath));
             return ExitCode::Ok;
         }
 

--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -826,6 +826,29 @@ ExitInfo ExecutorWorker::generateEditJob(SyncOpPtr syncOp, std::shared_ptr<SyncJ
         SyncPath relativeLocalFilePath = syncOp->nodePath(ReplicaSide::Local);
         SyncPath absoluteLocalFilePath = _syncPal->localPath() / relativeLocalFilePath;
 
+        // If both checksums are available and identical, the file content is already up-to-date locally.
+        // Skip the download and only update the local metadata (dates).
+        const std::string remoteChecksum =
+                _syncPal->snapshot(ReplicaSide::Remote)->contentChecksum(syncOp->affectedNode()->id().value_or(""));
+        const std::string localChecksum =
+                syncOp->correspondingNode()
+                        ? _syncPal->snapshot(ReplicaSide::Local)->contentChecksum(syncOp->correspondingNode()->id().value_or(""))
+                        : std::string{};
+        LOG_SYNCPAL_DEBUG(_logger, "Edit checksum comparison - remote: \"" << remoteChecksum << "\" local: \""
+                                                                           << localChecksum << "\"");
+        if (!remoteChecksum.empty() && remoteChecksum == localChecksum) {
+            LOGW_SYNCPAL_DEBUG(_logger, L"Checksums match, skipping download and updating metadata only: "
+                                                << Utility::formatSyncPath(absoluteLocalFilePath));
+            const SyncTime creationTime = syncOp->affectedNode()->createdAt().value_or(0);
+            const SyncTime modificationTime = syncOp->affectedNode()->modificationTime().value_or(0);
+            if (const IoError ioError = IoHelper::setFileDates(absoluteLocalFilePath, creationTime, modificationTime, false);
+                ioError != IoError::Success) {
+                LOGW_SYNCPAL_WARN(_logger, L"Error in IoHelper::setFileDates for "
+                                                   << Utility::formatSyncPath(absoluteLocalFilePath));
+            }
+            return ExitCode::Ok;
+        }
+
         try {
             job = std::make_shared<DownloadJob>(
                     _syncPal->vfs(), _syncPal->cacheDirectory(),
@@ -844,6 +867,22 @@ ExitInfo ExecutorWorker::generateEditJob(SyncOpPtr syncOp, std::shared_ptr<SyncJ
     } else {
         SyncPath relativeLocalFilePath = syncOp->nodePath(ReplicaSide::Local);
         SyncPath absoluteLocalFilePath = _syncPal->localPath() / relativeLocalFilePath;
+
+        // If both checksums are available and identical, the remote already has the same content.
+        // Skip the upload entirely.
+        const std::string localChecksum =
+                _syncPal->snapshot(ReplicaSide::Local)->contentChecksum(syncOp->affectedNode()->id().value_or(""));
+        const std::string remoteChecksum =
+                syncOp->correspondingNode()
+                        ? _syncPal->snapshot(ReplicaSide::Remote)->contentChecksum(syncOp->correspondingNode()->id().value_or(""))
+                        : std::string{};
+        LOG_SYNCPAL_DEBUG(_logger, "Edit upload checksum comparison - local: \"" << localChecksum << "\" remote: \""
+                                                                                 << remoteChecksum << "\"");
+        if (!localChecksum.empty() && localChecksum == remoteChecksum) {
+            LOGW_SYNCPAL_DEBUG(_logger, L"Checksums match, skipping upload: "
+                                                << Utility::formatSyncPath(absoluteLocalFilePath));
+            return ExitCode::Ok;
+        }
 
         uint64_t filesize;
         if (ExitInfo exitInfo = getFileSize(absoluteLocalFilePath, filesize); !exitInfo) {

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -38,6 +38,7 @@
 #include "jobs/network/infomaniak_API/getappversionjob.h"
 #include "jobs/network/directdownloadjob.h"
 #include "jobs/network/kDrive_API/createdirjob.h"
+#include "jobs/network/kDrive_API/checkhashmatchjob.h"
 #include "jobs/network/kDrive_API/itemsexistjob.h"
 #include "jobs/network/kDrive_API/searchjob.h"
 #include "jobs/network/kDrive_API/listing/csvfullfilelistwithcursorjob.h"
@@ -961,6 +962,79 @@ void TestNetworkJobs::testGetFileList() {
                 CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(1), dataArray->size());
             }
         }
+    }
+}
+
+void TestNetworkJobs::testGetFileHashMatch() {
+    // Download picture-1.jpg once to use as a valid local reference file
+    const LocalTemporaryDirectory tmpDir("testGetFileHashMatch");
+    const SyncPath validLocalFile = tmpDir.path() / "picture-1.jpg";
+    {
+        DownloadJob downloadJob(nullptr, _cacheDirectory,
+                                DownloadJob::FileDownloadInfo{_driveDbId, picture1RemoteId, validLocalFile, 0, 0, 0, false},
+                                DownloadJob::DateTimePolicy::ApplyDateTime);
+        CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, downloadJob.runSynchronously().code());
+    }
+    CPPUNIT_ASSERT(std::filesystem::exists(validLocalFile));
+
+    FileStat validFileStat;
+    IoError ioError = IoError::Success;
+    IoHelper::getFileStat(validLocalFile, &validFileStat, ioError, IoHelper::PathCheckOption::Insensitive);
+    CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+    const int64_t validSize = validFileStat.size;
+
+    // Create a tampered copy (wrong local content, same remote node)
+    const SyncPath tamperedLocalFile = tmpDir.path() / "picture-1-tampered.jpg";
+    std::filesystem::copy_file(validLocalFile, tamperedLocalFile);
+    {
+        std::ofstream ofs(tamperedLocalFile, std::ios::binary | std::ios::app);
+        ofs << "corrupted";
+    }
+
+    // Create a dummy file that has the same size as the valid file (to bypass size check but fail hash)
+    const SyncPath sameSizeDifferentContentFile = tmpDir.path() / "picture-1-same-size.jpg";
+    {
+        std::ofstream ofs(sameSizeDifferentContentFile, std::ios::binary);
+        ofs << std::string(static_cast<size_t>(validSize), 'X');
+    }
+
+    // Create an empty file (wrong size → should skip API call and trigger download)
+    const SyncPath emptyLocalFile = tmpDir.path() / "picture-1-empty.jpg";
+    std::ofstream(emptyLocalFile).close();
+
+    struct TestCase {
+            std::string name;
+            SyncPath localFile;
+            NodeId remoteNodeId;
+            int64_t localSize;
+            int64_t remoteSize;
+            bool expectedShouldDownload;
+            ExitCode expectedExitCode;
+    };
+
+    const std::vector<TestCase> testCases = {
+            // Both hash and size match → file is in sync
+            {"MatchingHashAndSize", validLocalFile, picture1RemoteId, validSize, validSize, false, ExitCode::Ok},
+
+            // Local file is corrupted but size is provided as matching → hash mismatch detected
+            {"LocalFileTampered_SizeForcedMatch", tamperedLocalFile, picture1RemoteId, validSize, validSize, true, ExitCode::Ok},
+
+            // Wrong remote node ID → API returns a different hash → mismatch
+            {"WrongRemoteNodeId", validLocalFile, testFileRemoteId, validSize, validSize, true, ExitCode::Ok},
+
+            // Sizes differ → job aborts immediately, no API call, shouldDownload stays true
+            {"SizeMismatch_EmptyLocal", emptyLocalFile, picture1RemoteId, 0, validSize, true, ExitCode::Ok},
+
+            // Same size, different content → passes size check, hash mismatch detected
+            {"SameSizeDifferentContent", sameSizeDifferentContentFile, picture1RemoteId, validSize, validSize, true,
+             ExitCode::Ok},
+    };
+
+    for (const auto &tc: testCases) {
+        CheckHashMatchJob job(_driveDbId, tc.localFile, tc.remoteNodeId, tc.localSize, tc.remoteSize);
+        job.runSynchronously();
+        CPPUNIT_ASSERT_EQUAL_MESSAGE(tc.name + ": unexpected exit code", tc.expectedExitCode, job.exitInfo().code());
+        CPPUNIT_ASSERT_EQUAL_MESSAGE(tc.name + ": unexpected shouldDownload", tc.expectedShouldDownload, job.shouldDownload());
     }
 }
 

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -965,7 +965,7 @@ void TestNetworkJobs::testGetFileList() {
     }
 }
 
-void TestNetworkJobs::testGetFileHashMatch() {
+void TestNetworkJobs::testCheckHashMatch() {
     // Download picture-1.jpg once to use as a valid local reference file
     const LocalTemporaryDirectory tmpDir("testGetFileHashMatch");
     const SyncPath validLocalFile = tmpDir.path() / "picture-1.jpg";

--- a/test/libsyncengine/jobs/network/testnetworkjobs.h
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.h
@@ -43,6 +43,7 @@ class TestNetworkJobs : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST(testGetFileInfo);
         CPPUNIT_TEST(testGetFileList);
         CPPUNIT_TEST(testCheckHashMatch);
+        CPPUNIT_TEST(testGetFileListWithCursor);
         CPPUNIT_TEST(testFullFileListWithCursorCsv);
         CPPUNIT_TEST(testFullFileListWithCursorCsvZip);
         CPPUNIT_TEST(testFullFileListWithCursorCsvBlacklist);

--- a/test/libsyncengine/jobs/network/testnetworkjobs.h
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.h
@@ -42,7 +42,7 @@ class TestNetworkJobs : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST(testGetDriveList);
         CPPUNIT_TEST(testGetFileInfo);
         CPPUNIT_TEST(testGetFileList);
-        CPPUNIT_TEST(testGetFileHashMatch);
+        CPPUNIT_TEST(testCheckHashMatch);
         CPPUNIT_TEST(testFullFileListWithCursorCsv);
         CPPUNIT_TEST(testFullFileListWithCursorCsvZip);
         CPPUNIT_TEST(testFullFileListWithCursorCsvBlacklist);
@@ -87,7 +87,7 @@ class TestNetworkJobs : public CppUnit::TestFixture, public TestBase {
         void testGetDriveList();
         void testGetFileInfo();
         void testGetFileList();
-        void testGetFileHashMatch();
+        void testCheckHashMatch();
         void testGetFileListWithCursor();
         void testFullFileListWithCursorCsv();
         void testFullFileListWithCursorCsvZip();

--- a/test/libsyncengine/jobs/network/testnetworkjobs.h
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.h
@@ -42,7 +42,7 @@ class TestNetworkJobs : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST(testGetDriveList);
         CPPUNIT_TEST(testGetFileInfo);
         CPPUNIT_TEST(testGetFileList);
-        CPPUNIT_TEST(testGetFileListWithCursor);
+        CPPUNIT_TEST(testGetFileHashMatch);
         CPPUNIT_TEST(testFullFileListWithCursorCsv);
         CPPUNIT_TEST(testFullFileListWithCursorCsvZip);
         CPPUNIT_TEST(testFullFileListWithCursorCsvBlacklist);
@@ -87,6 +87,7 @@ class TestNetworkJobs : public CppUnit::TestFixture, public TestBase {
         void testGetDriveList();
         void testGetFileInfo();
         void testGetFileList();
+        void testGetFileHashMatch();
         void testGetFileListWithCursor();
         void testFullFileListWithCursorCsv();
         void testFullFileListWithCursorCsvZip();


### PR DESCRIPTION
This pull request introduces a new job for verifying file integrity between local and remote files in the kDrive API, along with comprehensive unit tests to ensure its correctness. The main focus is on adding the `CheckHashMatchJob` class, which compares file hashes and sizes to determine if a download is necessary.

**New file integrity checking job:**

* Added the `CheckHashMatchJob` class in `jobs/network/kDrive_API/checkhashmatchjob.h` and its implementation in `checkhashmatchjob.cpp`. This job compares the local and remote file hashes (using the xxh3 algorithm) and file sizes to decide if the file should be downloaded. It also handles the API request/response for retrieving the remote hash. [[1]](diffhunk://#diff-f0df3dba286f0b2426ee319f60fc0b9a8904980ef761db5ad0b715b6045dde2bR1-R52) [[2]](diffhunk://#diff-70ec71f86a41cad2be15ebadd9a5683169ff5e10b69c5e7e51e233a122346711R1-R76)
* Registered the new job source file in the build system by updating `src/libsyncengine/CMakeLists.txt`.
* Added the `hashKey` constant to `networkjobsparams.h` for parsing the remote hash from API responses.

**Testing enhancements:**

* Introduced a comprehensive unit test `testCheckHashMatch` in `testnetworkjobs.cpp` to cover various scenarios (matching files, tampered files, size mismatches, and hash mismatches).
* Registered the new test in the test suite (`testnetworkjobs.h` and `testnetworkjobs.cpp`). [[1]](diffhunk://#diff-7cb4981dbd48c6446082f1f1058fe4f92be59b6f6ef5d9dfe5dda249e0618330R45) [[2]](diffhunk://#diff-7cb4981dbd48c6446082f1f1058fe4f92be59b6f6ef5d9dfe5dda249e0618330R91) [[3]](diffhunk://#diff-a44011b4b2142730cdb600b754fc9df3f32479959030cd13cf167fda5bfc52ebR41)

These changes improve the reliability of file synchronization by ensuring that files are only downloaded when necessary, based on both size and hash comparisons.