### PR TITLE
fix(fso): Reports the file path of any problematic item when LFSO directory exploration fails

### DIFF
--- a/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
@@ -626,8 +626,6 @@ void LocalFileSystemObserverWorker::sendAccessDeniedError(const SyncPath &absolu
 
 ExitInfo LocalFileSystemObserverWorker::exploreDir(const SyncPath &absoluteParentDirPath, bool fromChangeDetected) {
     // Check if root dir exists
-    auto ioError = IoError::Success;
-
     ItemType itemType;
     if (!IoHelper::getItemType(absoluteParentDirPath, itemType)) {
         LOGW_WARN(_logger,
@@ -650,6 +648,8 @@ ExitInfo LocalFileSystemObserverWorker::exploreDir(const SyncPath &absoluteParen
     }
 
     // Process all files
+    auto ioError = IoError::Success;
+    DirectoryEntry entry;
     try {
         IoHelper::DirectoryIterator dirIt;
         if (!IoHelper::getRecursiveDirectoryIterator(absoluteParentDirPath, ioError, dirIt, false)) {
@@ -662,11 +662,9 @@ ExitInfo LocalFileSystemObserverWorker::exploreDir(const SyncPath &absoluteParen
             return {ExitCode::SystemError, Utility::exitCauseFromInaccessibleSyncDirectory(absoluteParentDirPath)};
         }
 
-        DirectoryEntry entry;
         bool endOfDirectory = false;
         sentry::pTraces::counterScoped::LFSOExploreItem perfMonitor(fromChangeDetected, syncDbId());
         while (dirIt.next(entry, endOfDirectory, ioError) && !endOfDirectory) {
-            auto entryIoError = IoError::Success;
             perfMonitor.start();
 
             if (ParametersCache::isExtendedLogEnabled()) {
@@ -698,6 +696,7 @@ ExitInfo LocalFileSystemObserverWorker::exploreDir(const SyncPath &absoluteParen
 
             // Check if the directory entry is managed
             bool isManaged = false;
+            auto entryIoError = IoError::Success;
             if (!Utility::checkIfDirEntryIsManaged(entry, isManaged, entryIoError, itemType)) {
                 LOGW_SYNCPAL_WARN(_logger, L"Error in Utility::checkIfDirEntryIsManaged: "
                                                    << Utility::formatIoError(absoluteParentDirPath, entryIoError));
@@ -732,8 +731,8 @@ ExitInfo LocalFileSystemObserverWorker::exploreDir(const SyncPath &absoluteParen
                 }
             }
 
-            FileStat fileStat;
             NodeId nodeId;
+            FileStat fileStat;
             if (!toExclude) {
                 if (!IoHelper::getFileStat(absolutePath, &fileStat, entryIoError, IoHelper::PathCheckOption::Insensitive)) {
                     LOGW_SYNCPAL_DEBUG(_logger,
@@ -790,6 +789,9 @@ ExitInfo LocalFileSystemObserverWorker::exploreDir(const SyncPath &absoluteParen
                         }
                         parentNodeId = std::to_string(parentFileStat.inode);
                     } else {
+                        LOGW_SYNCPAL_DEBUG(_logger, L"Error in local LiveSnapshot::getItemId for item with "
+                                                            << Utility::formatSyncPath(absolutePath.parent_path())
+                                                            << L" ExitInfo: " << exitInfo);
                         return exitInfo;
                     }
                 }
@@ -819,6 +821,10 @@ ExitInfo LocalFileSystemObserverWorker::exploreDir(const SyncPath &absoluteParen
     } catch (...) {
         LOG_SYNCPAL_WARN(Log::instance()->getLogger(), "Exception caught in LocalFileSystemObserverWorker::exploreDir");
         return ExitCode::SystemError;
+    }
+
+    if (ioError != IoError::Success) {
+        LOGW_SYNCPAL_WARN(_logger, L"Error in directory iteration at " << Utility::formatIoError(entry.path(), ioError));
     }
 
     ExitInfo res = ExitCode::Ok;

--- a/src/libsyncengine/update_detection/file_system_observer/remotefilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/remotefilesystemobserverworker.cpp
@@ -105,9 +105,12 @@ ExitInfo RemoteFileSystemObserverWorker::generateInitialSnapshot() {
     _updating = true;
     countListingRequests();
 
+    exitInfo = initWithCursor();
+
     const auto end = std::chrono::steady_clock::now();
     const std::chrono::duration<double> elapsedSeconds = end - start;
-    if (exitInfo = initWithCursor(); exitInfo && !stopAsked()) {
+
+    if (exitInfo && !stopAsked()) {
         _liveSnapshot.setValid(true);
         LOG_SYNCPAL_INFO(_logger, "Remote snapshot generated in: " << elapsedSeconds.count() << "s for "
                                                                    << _liveSnapshot.nbItems() << " items");


### PR DESCRIPTION
The changes are two-fold:
- The estimate of time needed to create the remote snapshot is corrected (RFSO).
- The log message of any failure of the directory exploration made by the Local File System Observer (LFSO) contains the path of the problematic item.