### PR TITLE
feat: adding new check hash match job

### DIFF
--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -815,8 +815,8 @@ std::string IoHelper::getFileChecksum(const SyncPath &path, std::ifstream &ifs, 
         }
 
         std::streamsize readBytes(0);
-        while ((readBytes = ifs.read(buffer.data(), buffer.size()).gcount()) > 0) {
-            if (XXH3_64bits_update(state, buffer.data(), readBytes) == XXH_ERROR) {
+        while ((readBytes = ifs.read(buffer.data(), static_cast<std::streamsize>(buffer.size())).gcount()) > 0) {
+            if (XXH3_64bits_update(state, buffer.data(), static_cast<size_t>(readBytes)) == XXH_ERROR) {
                 ifs.close();
                 XXH3_freeState(state);
                 ioError = IoError::Unknown;

--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -829,7 +829,7 @@ std::string IoHelper::getFileChecksum(const SyncPath &path, std::ifstream &ifs, 
         XXH3_freeState(state);
 
         return Utility::xxHashToStr(hash);
-    } catch (const std::bad_alloc &e) {
+    } catch (const std::bad_alloc &) {
         LOGW_WARN(logger(), L"Memory allocation failed in getFileChecksum");
         ioError = IoError::Unknown;
         return "";

--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -765,43 +765,62 @@ void IoHelper::getFileStat(const SyncPath &path, FileStat *buf, bool &exists, Pa
     }
 }
 
-IoError IoHelper::getFileChecksum(const SyncPath &path, std::ifstream &ifs, std::string &checksum) noexcept {
-    using enum IoError;
-    checksum.clear();
+std::string IoHelper::getFileChecksum(const SyncPath &path, std::ifstream &ifs, IoError &ioError) noexcept {
+    ioError = IoError::Success;
 
     try {
         std::error_code ec;
-        const bool isSymlink = _isSymlink(path, ec);
-        if (const IoError ioError = stdError2ioError(ec); ioError != Success) return ioError;
-        if (isSymlink) return InvalidArgument;
+        auto status = std::filesystem::symlink_status(path, ec);
+        ioError = stdError2ioError(ec);
+
+        if (ioError != IoError::Success) return "";
+
+        if (std::filesystem::is_symlink(status)) {
+            ioError = IoError::InvalidArgument;
+            return "";
+        }
 
 #if defined(KD_MACOS)
         bool isAlias = false;
-        IoError aliasError = Success;
-        if (!IoHelper::_checkIfAlias(path, isAlias, aliasError)) return aliasError;
-        if (isAlias) return InvalidArgument;
+        if (!IoHelper::_checkIfAlias(path, isAlias, ioError)) {
+            return "";
+        }
+        if (isAlias) {
+            ioError = IoError::InvalidArgument;
+            return "";
+        }
 #endif
 
-        IoError openError = Success;
-        if (!IoHelper::openFile(path, ifs, openError) || !ifs) return openError;
+        const bool isOpen = IoHelper::openFile(path, ifs, ioError);
 
-        constexpr size_t chunkSize = 8 * 1024 * 1024; // 8 MB
-        std::vector<char> buffer(chunkSize);
+        if (!isOpen || !ifs) {
+            return "";
+        }
+
+        constexpr size_t CHUNK_SIZE = 8 * 1024 * 1024; // 8 MB
+        std::vector<char> buffer(CHUNK_SIZE);
 
         XXH3_state_t *state = XXH3_createState();
-        if (state == nullptr) return Unknown;
 
+        if (state == nullptr) {
+            ifs.close();
+            ioError = IoError::Unknown;
+            return "";
+        }
         if (XXH3_64bits_reset(state) == XXH_ERROR) {
+            ifs.close();
             XXH3_freeState(state);
-            return Unknown;
+            ioError = IoError::Unknown;
+            return "";
         }
 
         std::streamsize readBytes(0);
-        while ((readBytes = ifs.read(buffer.data(), static_cast<std::streamsize>(buffer.size())).gcount()) > 0) {
-            if (XXH3_64bits_update(state, buffer.data(), static_cast<size_t>(readBytes)) == XXH_ERROR) {
+        while ((readBytes = ifs.read(buffer.data(), buffer.size()).gcount()) > 0) {
+            if (XXH3_64bits_update(state, buffer.data(), readBytes) == XXH_ERROR) {
                 ifs.close();
                 XXH3_freeState(state);
-                return Unknown;
+                ioError = IoError::Unknown;
+                return "";
             }
         }
 
@@ -809,17 +828,19 @@ IoError IoHelper::getFileChecksum(const SyncPath &path, std::ifstream &ifs, std:
         XXH64_hash_t hash = XXH3_64bits_digest(state);
         XXH3_freeState(state);
 
-        checksum = Utility::xxHashToStr(hash);
-        return Success;
-    } catch (const std::bad_alloc &) {
+        return Utility::xxHashToStr(hash);
+    } catch (const std::bad_alloc &e) {
         LOGW_WARN(logger(), L"Memory allocation failed in getFileChecksum");
-        return Unknown;
+        ioError = IoError::Unknown;
+        return "";
     } catch (const std::exception &e) {
         LOGW_WARN(logger(), L"Exception in getFileChecksum: " << CommonUtility::s2ws(e.what()));
-        return Unknown;
+        ioError = IoError::Unknown;
+        return "";
     } catch (...) {
         LOGW_WARN(logger(), L"Unknown exception in getFileChecksum");
-        return Unknown;
+        ioError = IoError::Unknown;
+        return "";
     }
 }
 

--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -785,6 +785,13 @@ IoError IoHelper::getFileChecksum(const SyncPath &path, std::ifstream &ifs, std:
         IoError openError = Success;
         if (!IoHelper::openFile(path, ifs, openError) || !ifs) return openError;
 
+        struct IfstreamCloser {
+            std::ifstream &stream;
+            ~IfstreamCloser() {
+                if (stream.is_open()) stream.close();
+            }
+        } ifstreamCloser{ifs};
+
         constexpr size_t chunkSize = 8 * 1024 * 1024; // 8 MB
         std::vector<char> buffer(chunkSize);
 
@@ -799,13 +806,11 @@ IoError IoHelper::getFileChecksum(const SyncPath &path, std::ifstream &ifs, std:
         std::streamsize readBytes(0);
         while ((readBytes = ifs.read(buffer.data(), static_cast<std::streamsize>(buffer.size())).gcount()) > 0) {
             if (XXH3_64bits_update(state, buffer.data(), static_cast<size_t>(readBytes)) == XXH_ERROR) {
-                ifs.close();
                 XXH3_freeState(state);
                 return Unknown;
             }
         }
 
-        ifs.close();
         XXH64_hash_t hash = XXH3_64bits_digest(state);
         XXH3_freeState(state);
 

--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -787,10 +787,16 @@ IoError IoHelper::getFileChecksum(const SyncPath &path, std::ifstream &ifs, std:
 
         struct IfstreamCloser {
             std::ifstream &stream;
-            ~IfstreamCloser() {
-                if (stream.is_open()) stream.close();
+            explicit IfstreamCloser(std::ifstream &s) : stream(s) {}
+            IfstreamCloser(const IfstreamCloser &) = delete;
+            IfstreamCloser &operator=(const IfstreamCloser &) = delete;
+            ~IfstreamCloser() noexcept {
+                try {
+                    if (stream.is_open()) stream.close();
+                } catch (...) {}
             }
-        } ifstreamCloser{ifs};
+        };
+        IfstreamCloser ifstreamCloser(ifs);
 
         constexpr size_t chunkSize = 8 * 1024 * 1024; // 8 MB
         std::vector<char> buffer(chunkSize);

--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -811,6 +811,11 @@ IoError IoHelper::getFileChecksum(const SyncPath &path, std::ifstream &ifs, std:
             }
         }
 
+        if (ifs.bad()) {
+            XXH3_freeState(state);
+            return Unknown;
+        }
+
         XXH64_hash_t hash = XXH3_64bits_digest(state);
         XXH3_freeState(state);
 

--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -791,9 +791,7 @@ IoError IoHelper::getFileChecksum(const SyncPath &path, std::ifstream &ifs, std:
             IfstreamCloser(const IfstreamCloser &) = delete;
             IfstreamCloser &operator=(const IfstreamCloser &) = delete;
             ~IfstreamCloser() noexcept {
-                try {
-                    if (stream.is_open()) stream.close();
-                } catch (...) {}
+                if (stream.is_open()) stream.close();
             }
         };
         IfstreamCloser ifstreamCloser(ifs);

--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -765,53 +765,35 @@ void IoHelper::getFileStat(const SyncPath &path, FileStat *buf, bool &exists, Pa
     }
 }
 
-std::string IoHelper::getFileChecksum(const SyncPath &path, std::ifstream &ifs, IoError &ioError) noexcept {
-    ioError = IoError::Success;
+IoError IoHelper::getFileChecksum(const SyncPath &path, std::ifstream &ifs, std::string &checksum) noexcept {
+    using enum IoError;
+    checksum.clear();
 
     try {
         std::error_code ec;
-        auto status = std::filesystem::symlink_status(path, ec);
-        ioError = stdError2ioError(ec);
-
-        if (ioError != IoError::Success) return "";
-
-        if (std::filesystem::is_symlink(status)) {
-            ioError = IoError::InvalidArgument;
-            return "";
-        }
+        const bool isSymlink = _isSymlink(path, ec);
+        if (const IoError ioError = stdError2ioError(ec); ioError != Success) return ioError;
+        if (isSymlink) return InvalidArgument;
 
 #if defined(KD_MACOS)
         bool isAlias = false;
-        if (!IoHelper::_checkIfAlias(path, isAlias, ioError)) {
-            return "";
-        }
-        if (isAlias) {
-            ioError = IoError::InvalidArgument;
-            return "";
-        }
+        IoError aliasError = Success;
+        if (!IoHelper::_checkIfAlias(path, isAlias, aliasError)) return aliasError;
+        if (isAlias) return InvalidArgument;
 #endif
 
-        const bool isOpen = IoHelper::openFile(path, ifs, ioError);
+        IoError openError = Success;
+        if (!IoHelper::openFile(path, ifs, openError) || !ifs) return openError;
 
-        if (!isOpen || !ifs) {
-            return "";
-        }
-
-        constexpr size_t CHUNK_SIZE = 8 * 1024 * 1024; // 8 MB
-        std::vector<char> buffer(CHUNK_SIZE);
+        constexpr size_t chunkSize = 8 * 1024 * 1024; // 8 MB
+        std::vector<char> buffer(chunkSize);
 
         XXH3_state_t *state = XXH3_createState();
+        if (state == nullptr) return Unknown;
 
-        if (state == nullptr) {
-            ifs.close();
-            ioError = IoError::Unknown;
-            return "";
-        }
         if (XXH3_64bits_reset(state) == XXH_ERROR) {
-            ifs.close();
             XXH3_freeState(state);
-            ioError = IoError::Unknown;
-            return "";
+            return Unknown;
         }
 
         std::streamsize readBytes(0);
@@ -819,8 +801,7 @@ std::string IoHelper::getFileChecksum(const SyncPath &path, std::ifstream &ifs, 
             if (XXH3_64bits_update(state, buffer.data(), static_cast<size_t>(readBytes)) == XXH_ERROR) {
                 ifs.close();
                 XXH3_freeState(state);
-                ioError = IoError::Unknown;
-                return "";
+                return Unknown;
             }
         }
 
@@ -828,19 +809,17 @@ std::string IoHelper::getFileChecksum(const SyncPath &path, std::ifstream &ifs, 
         XXH64_hash_t hash = XXH3_64bits_digest(state);
         XXH3_freeState(state);
 
-        return Utility::xxHashToStr(hash);
+        checksum = "xxh3:" + Utility::xxHashToStr(hash);
+        return Success;
     } catch (const std::bad_alloc &) {
         LOGW_WARN(logger(), L"Memory allocation failed in getFileChecksum");
-        ioError = IoError::Unknown;
-        return "";
+        return Unknown;
     } catch (const std::exception &e) {
         LOGW_WARN(logger(), L"Exception in getFileChecksum: " << CommonUtility::s2ws(e.what()));
-        ioError = IoError::Unknown;
-        return "";
+        return Unknown;
     } catch (...) {
         LOGW_WARN(logger(), L"Unknown exception in getFileChecksum");
-        ioError = IoError::Unknown;
-        return "";
+        return Unknown;
     }
 }
 

--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -765,7 +765,7 @@ void IoHelper::getFileStat(const SyncPath &path, FileStat *buf, bool &exists, Pa
     }
 }
 
-IoError IoHelper::getFileChecksum(const SyncPath &path, std::ifstream &ifs, std::string &checksum) noexcept {
+IoError IoHelper::getFileChecksum(const SyncPath &path, std::string &checksum) noexcept {
     using enum IoError;
     checksum.clear();
 
@@ -783,6 +783,7 @@ IoError IoHelper::getFileChecksum(const SyncPath &path, std::ifstream &ifs, std:
 #endif
 
         IoError openError = Success;
+        std::ifstream ifs;
         if (!IoHelper::openFile(path, ifs, openError) || !ifs) return openError;
 
         constexpr size_t chunkSize = 8 * 1024 * 1024; // 8 MB
@@ -790,12 +791,10 @@ IoError IoHelper::getFileChecksum(const SyncPath &path, std::ifstream &ifs, std:
 
         XXH3_state_t *state = XXH3_createState();
         if (state == nullptr) {
-            ifs.close();
             return Unknown;
         }
 
         if (XXH3_64bits_reset(state) == XXH_ERROR) {
-            ifs.close();
             XXH3_freeState(state);
             return Unknown;
         }
@@ -803,19 +802,16 @@ IoError IoHelper::getFileChecksum(const SyncPath &path, std::ifstream &ifs, std:
         std::streamsize readBytes(0);
         while ((readBytes = ifs.read(buffer.data(), static_cast<std::streamsize>(buffer.size())).gcount()) > 0) {
             if (XXH3_64bits_update(state, buffer.data(), static_cast<size_t>(readBytes)) == XXH_ERROR) {
-                ifs.close();
                 XXH3_freeState(state);
                 return Unknown;
             }
         }
 
         if (ifs.bad()) {
-            ifs.close();
             XXH3_freeState(state);
             return Unknown;
         }
 
-        ifs.close();
         XXH64_hash_t hash = XXH3_64bits_digest(state);
         XXH3_freeState(state);
 

--- a/src/libcommonserver/io/iohelper.cpp
+++ b/src/libcommonserver/io/iohelper.cpp
@@ -785,24 +785,17 @@ IoError IoHelper::getFileChecksum(const SyncPath &path, std::ifstream &ifs, std:
         IoError openError = Success;
         if (!IoHelper::openFile(path, ifs, openError) || !ifs) return openError;
 
-        struct IfstreamCloser {
-            std::ifstream &stream;
-            explicit IfstreamCloser(std::ifstream &s) : stream(s) {}
-            IfstreamCloser(const IfstreamCloser &) = delete;
-            IfstreamCloser &operator=(const IfstreamCloser &) = delete;
-            ~IfstreamCloser() noexcept {
-                if (stream.is_open()) stream.close();
-            }
-        };
-        IfstreamCloser ifstreamCloser(ifs);
-
         constexpr size_t chunkSize = 8 * 1024 * 1024; // 8 MB
         std::vector<char> buffer(chunkSize);
 
         XXH3_state_t *state = XXH3_createState();
-        if (state == nullptr) return Unknown;
+        if (state == nullptr) {
+            ifs.close();
+            return Unknown;
+        }
 
         if (XXH3_64bits_reset(state) == XXH_ERROR) {
+            ifs.close();
             XXH3_freeState(state);
             return Unknown;
         }
@@ -810,16 +803,19 @@ IoError IoHelper::getFileChecksum(const SyncPath &path, std::ifstream &ifs, std:
         std::streamsize readBytes(0);
         while ((readBytes = ifs.read(buffer.data(), static_cast<std::streamsize>(buffer.size())).gcount()) > 0) {
             if (XXH3_64bits_update(state, buffer.data(), static_cast<size_t>(readBytes)) == XXH_ERROR) {
+                ifs.close();
                 XXH3_freeState(state);
                 return Unknown;
             }
         }
 
         if (ifs.bad()) {
+            ifs.close();
             XXH3_freeState(state);
             return Unknown;
         }
 
+        ifs.close();
         XXH64_hash_t hash = XXH3_64bits_digest(state);
         XXH3_freeState(state);
 

--- a/src/libcommonserver/io/iohelper.h
+++ b/src/libcommonserver/io/iohelper.h
@@ -162,10 +162,10 @@ struct IoHelper {
         /*!
          \param path is a file system path to a directory entry (we also call it an item).
          \param ifs is an input file stream used to read the file contents.
-         \param checksum is set with the checksum of the file indicated by `path`, or empty on error.
-         \return the IoError representing the success or failure of the operation.
+         \param ioError holds the error returned when an underlying OS API call fails.
+         \return the checksum of the file indicated by `path`.
          */
-        static IoError getFileChecksum(const SyncPath &path, std::ifstream &ifs, std::string &checksum) noexcept;
+        static std::string getFileChecksum(const SyncPath &path, std::ifstream &ifs, IoError &ioError) noexcept;
 
         //! Check if the item indicated by path has a size or a modification date different from the specified ones.
         /*!

--- a/src/libcommonserver/io/iohelper.h
+++ b/src/libcommonserver/io/iohelper.h
@@ -165,7 +165,7 @@ struct IoHelper {
          \param checksum is set with the checksum of the file indicated by `path`, or empty on error.
          \return the IoError representing the success or failure of the operation.
          */
-        static IoError getFileChecksum(const SyncPath &path, std::ifstream &ifs, std::string &checksum) noexcept;
+        static IoError getFileChecksum(const SyncPath &path, std::string &checksum) noexcept;
 
         //! Check if the item indicated by path has a size or a modification date different from the specified ones.
         /*!

--- a/src/libcommonserver/io/iohelper.h
+++ b/src/libcommonserver/io/iohelper.h
@@ -162,8 +162,8 @@ struct IoHelper {
         /*!
          \param path is a file system path to a directory entry (we also call it an item).
          \param ifs is an input file stream used to read the file contents.
-         \param ioError holds the error returned when an underlying OS API call fails.
-         \return the checksum of the file indicated by `path`.
+         \param ioError holds the error when an underlying OS API call fails or when an internal hashing failure occurs.
+         \return the checksum of the file indicated by `path`, or an empty string if an error occurs.
          */
         static std::string getFileChecksum(const SyncPath &path, std::ifstream &ifs, IoError &ioError) noexcept;
 

--- a/src/libcommonserver/io/iohelper.h
+++ b/src/libcommonserver/io/iohelper.h
@@ -162,10 +162,10 @@ struct IoHelper {
         /*!
          \param path is a file system path to a directory entry (we also call it an item).
          \param ifs is an input file stream used to read the file contents.
-         \param ioError holds the error when an underlying OS API call fails or when an internal hashing failure occurs.
-         \return the checksum of the file indicated by `path`, or an empty string if an error occurs.
+         \param checksum is set with the checksum of the file indicated by `path`, or empty on error.
+         \return the IoError representing the success or failure of the operation.
          */
-        static std::string getFileChecksum(const SyncPath &path, std::ifstream &ifs, IoError &ioError) noexcept;
+        static IoError getFileChecksum(const SyncPath &path, std::ifstream &ifs, std::string &checksum) noexcept;
 
         //! Check if the item indicated by path has a size or a modification date different from the specified ones.
         /*!

--- a/src/libsyncengine/CMakeLists.txt
+++ b/src/libsyncengine/CMakeLists.txt
@@ -60,7 +60,7 @@ set(syncengine_SRCS
     jobs/network/kDrive_API/getfileinfojobV3.h jobs/network/kDrive_API/getfileinfojobV3.cpp
     jobs/network/kDrive_API/deletejob.h jobs/network/kDrive_API/deletejob.cpp
     jobs/network/kDrive_API/createdirjob.h jobs/network/kDrive_API/createdirjob.cpp
-    jobs/network/kDrive_API/createdirjob.h jobs/network/kDrive_API/checkhashmatchjob.cpp
+    jobs/network/kDrive_API/checkhashmatchjob.h jobs/network/kDrive_API/checkhashmatchjob.cpp
     jobs/network/kDrive_API/movejob.h jobs/network/kDrive_API/movejob.cpp
     jobs/network/kDrive_API/renamejob.h jobs/network/kDrive_API/renamejob.cpp
     jobs/network/kDrive_API/duplicatejob.h jobs/network/kDrive_API/duplicatejob.cpp

--- a/src/libsyncengine/CMakeLists.txt
+++ b/src/libsyncengine/CMakeLists.txt
@@ -60,6 +60,7 @@ set(syncengine_SRCS
     jobs/network/kDrive_API/getfileinfojobV3.h jobs/network/kDrive_API/getfileinfojobV3.cpp
     jobs/network/kDrive_API/deletejob.h jobs/network/kDrive_API/deletejob.cpp
     jobs/network/kDrive_API/createdirjob.h jobs/network/kDrive_API/createdirjob.cpp
+    jobs/network/kDrive_API/createdirjob.h jobs/network/kDrive_API/checkhashmatchjob.cpp
     jobs/network/kDrive_API/movejob.h jobs/network/kDrive_API/movejob.cpp
     jobs/network/kDrive_API/renamejob.h jobs/network/kDrive_API/renamejob.cpp
     jobs/network/kDrive_API/duplicatejob.h jobs/network/kDrive_API/duplicatejob.cpp

--- a/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.cpp
@@ -16,96 +16,52 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "createdirjob.h"
-#include "libcommonserver/utility/utility.h"
+#include "checkhashmatchjob.h"
 #include "libcommonserver/utility/jsonparserutility.h"
 
 #include <Poco/Net/HTTPRequest.h>
 
 namespace KDC {
 
-CreateDirJob::CreateDirJob(const std::shared_ptr<Vfs> vfs, const DriveDbId driveDbId, const SyncPath &filepath,
-                           const NodeId &parentId, const SyncName &name, const std::string &color /*= ""*/) :
+CheckHashMatchJob::CheckHashMatchJob(const DriveDbId driveDbId, const SyncPath &filepath, const NodeId &nodeId, int localsize,
+                                     int remotesize) :
     AbstractTokenNetworkJob(ApiType::Drive, 0, 0, driveDbId, 0),
     _filePath(filepath),
-    _parentDirId(parentId),
-    _name(name),
-    _color(color),
-    _vfs(vfs) {
-    _httpMethod = Poco::Net::HTTPRequest::HTTP_POST;
+    _nodeId(nodeId) {
+    if (localsize != remotesize) abort();
+
+    _httpMethod = Poco::Net::HTTPRequest::HTTP_GET;
 }
 
-CreateDirJob::CreateDirJob(const std::shared_ptr<Vfs> vfs, const DriveDbId driveDbId, const NodeId &parentId,
-                           const SyncName &name) :
-    CreateDirJob(vfs, driveDbId, "", parentId, name) {}
+CheckHashMatchJob::~CheckHashMatchJob() {}
 
-CreateDirJob::CreateDirJob(const std::shared_ptr<Vfs> vfs, const UserDbId userDbId, const DriveId driveId, const NodeId &parentId,
-                           const SyncName &name) :
-    AbstractTokenNetworkJob(ApiType::Drive, userDbId, 0, 0, driveId),
-    _parentDirId(parentId),
-    _name(name),
-    _vfs(vfs) {
-    _httpMethod = Poco::Net::HTTPRequest::HTTP_POST;
-}
-
-CreateDirJob::~CreateDirJob() {
-    if (_filePath.empty() || !_vfs) return;
-    if (const ExitInfo exitInfo = _vfs->setPinState(_filePath, PinState::AlwaysLocal); !exitInfo) {
-        LOGW_WARN(_logger,
-                  L"Error in CreateDirJob::vfsSetPinState for " << Utility::formatSyncPath(_filePath) << L" : " << exitInfo);
-    }
-
-    if (const ExitInfo exitInfo =
-                _vfs->forceStatus(_filePath, VfsStatus({.isHydrated = true, .isSyncing = false, .progress = 0}));
-        !exitInfo) {
-        LOGW_WARN(_logger,
-                  L"Error in CreateDirJob::vfsForceStatus for " << Utility::formatSyncPath(_filePath) << L" : " << exitInfo);
-    }
-}
-std::string CreateDirJob::getSpecificUrl() {
+std::string CheckHashMatchJob::getSpecificUrl() {
     std::string str = AbstractTokenNetworkJob::getSpecificUrl();
     str += "/files/";
-    str += _parentDirId;
-    str += "/directory";
+    str += _nodeId;
+    str += "/hash";
     return str;
 }
 
-ExitInfo CreateDirJob::setData() {
-    Poco::JSON::Object json;
-    json.set("name", _name);
-    if (!_color.empty()) {
-        json.set("color", _color);
-    }
-
-    std::stringstream ss;
-    json.stringify(ss);
-    _data = ss.str();
-    return ExitCode::Ok;
-}
-
-ExitInfo CreateDirJob::handleResponse(std::istream &is) {
+ExitInfo CheckHashMatchJob::handleResponse(std::istream &is) {
     if (const auto exitInfo = AbstractTokenNetworkJob::handleResponse(is); !exitInfo) {
         return exitInfo;
     }
 
     if (jsonRes()) {
         if (const auto dataObj = jsonRes()->getObject(dataKey); dataObj) {
-            if (!JsonParserUtility::extractValue(dataObj, idKey, _nodeId)) {
-                return {};
-            }
-            if (!JsonParserUtility::extractValue(dataObj, lastModifiedAtKey, _modtime)) {
-                return {};
-            }
-        }
-
-        if (!_filePath.empty() && _vfs) {
-            constexpr VfsStatus vfsStatus({.isHydrated = true, .isSyncing = false, .progress = 0});
-            if (const auto exitInfo = _vfs->forceStatus(_filePath, vfsStatus); !exitInfo) {
-                LOGW_WARN(_logger, L"Error in CreateDirJob::_vfsForceStatus for " << Utility::formatSyncPath(_filePath) << L" : "
-                                                                                  << exitInfo);
+            if (!JsonParserUtility::extractValue(dataObj, hashKey, _distantHash)) {
+                return {ExitCode::BackError, ExitCause::MissingReplyData};
             }
         }
     }
+
+    std::ifstream ifs;
+    IoError ioError = IoError::Unknown;
+    _localHash = "xxh3:" + IoHelper::getFileChecksum(_filePath, ifs, ioError);
+
+    if (_localHash != _distantHash) return ExitCode::Ok;
+    _shouldDownload = false;
 
     return ExitCode::Ok;
 }

--- a/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.cpp
@@ -75,11 +75,20 @@ ExitInfo CheckHashMatchJob::getFileSize(const SyncPath &path, int64_t &size) {
 }
 
 ExitInfo CheckHashMatchJob::runJob() noexcept {
-    if (!_localSize)
-        if (const ExitInfo exitInfo = getFileSize(_filePath, _localSize); !exitInfo) return exitInfo;
+    if (const ExitInfo exitInfo = getFileSize(_filePath, _localSize); !exitInfo) {
+        LOGW_DEBUG(_logger, L"Failed to get local file size for " << Utility::formatSyncPath(_filePath)
+                                                                  << L", skipping hash check: " << exitInfo);
+        return exitInfo;
+    }
 
-    if (_localSize != _remoteSize) return ExitCode::Ok;
+    if (_localSize != _remoteSize) {
+        LOGW_DEBUG(_logger, L"File size mismatch for " << Utility::formatSyncPath(_filePath) << L": local size = " << _localSize
+                                                       << L", remote size = " << _remoteSize << L", skipping hash check");
+        return ExitCode::Ok;
+    }
     if (const ExitInfo exitInfo = AbstractTokenNetworkJob::runJob(); !exitInfo) {
+        LOGW_DEBUG(_logger, L"Failed to get remote hash for " << Utility::formatSyncPath(_filePath) << L", skipping hash check: "
+                                                              << exitInfo);
         return exitInfo;
     }
 
@@ -96,7 +105,7 @@ ExitInfo CheckHashMatchJob::runJob() noexcept {
 
     if (checksumIoError == IoError::InvalidArgument) {
         LOGW_WARN(_logger, L"File is a symlink: " << Utility::formatSyncPath(_filePath));
-        return {ExitCode::SystemError, ExitCause::FileAccessError};
+        return ExitCode::Ok;
     }
 
     assert(checksumIoError == IoError::Success);

--- a/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.cpp
@@ -47,41 +47,38 @@ CheckHashMatchJob::CheckHashMatchJob(const DriveDbId driveDbId, const SyncPath &
 }
 
 ExitInfo CheckHashMatchJob::getFileSize(const SyncPath &path, int64_t &size) {
-    using enum KDC::ExitCode;
-    IoError fileSizeIoError = IoError::Unknown;
+    IoError ioError = IoError::Unknown;
     uint64_t tmpSize = 0;
-    if (!IoHelper::getFileSize(path, tmpSize, fileSizeIoError)) {
-        LOGW_WARN(_logger, L"Error in IoHelper::getFileSize for " << Utility::formatIoError(path, fileSizeIoError));
-        return SystemError;
+    if (!IoHelper::getFileSize(path, tmpSize, ioError)) {
+        LOGW_WARN(_logger, L"Error in IoHelper::getFileSize for " << Utility::formatIoError(path, ioError));
+        return ExitCode::SystemError;
     }
     size = static_cast<int64_t>(tmpSize);
 
-    if (fileSizeIoError == IoError::NoSuchFileOrDirectory) { // The synchronization will
-                                                             // be re-started.
+    if (ioError == IoError::NoSuchFileOrDirectory) { // The synchronization will be re-started.
         LOGW_WARN(_logger, L"File doesn't exist: " << Utility::formatSyncPath(path));
-        return {SystemError, ExitCause::NotFound};
+        return {ExitCode::SystemError, ExitCause::NotFound};
     }
 
-    if (fileSizeIoError == IoError::AccessDenied) { // An action from the user is requested.
+    if (ioError == IoError::AccessDenied) { // An action from the user is requested.
         LOGW_WARN(_logger, L"File search permission missing: " << Utility::formatSyncPath(path));
-        return {SystemError, ExitCause::FileAccessError};
+        return {ExitCode::SystemError, ExitCause::FileAccessError};
     }
 
-    assert(fileSizeIoError == IoError::Success);
-    if (fileSizeIoError != IoError::Success) {
+    assert(ioError == IoError::Success);
+    if (ioError != IoError::Success) {
         LOGW_WARN(_logger, L"Unable to read file size for " << Utility::formatSyncPath(path));
-        return SystemError;
+        return ExitCode::SystemError;
     }
 
-    return Ok;
+    return ExitCode::Ok;
 }
 
 ExitInfo CheckHashMatchJob::runJob() noexcept {
-    using enum KDC::ExitCode;
     if (!_localSize)
         if (const ExitInfo exitInfo = getFileSize(_filePath, _localSize); !exitInfo) return exitInfo;
 
-    if (_localSize != _remoteSize) return Ok;
+    if (_localSize != _remoteSize) return ExitCode::Ok;
     if (const ExitInfo exitInfo = AbstractTokenNetworkJob::runJob(); !exitInfo) {
         return exitInfo;
     }
@@ -91,28 +88,28 @@ ExitInfo CheckHashMatchJob::runJob() noexcept {
 
     if (checksumIoError == IoError::NoSuchFileOrDirectory) {
         LOGW_WARN(_logger, L"File doesn't exist while computing checksum: " << Utility::formatSyncPath(_filePath));
-        return DataError;
+        return ExitCode::DataError;
     }
 
     if (checksumIoError == IoError::AccessDenied) {
         LOGW_WARN(_logger, L"File read permission missing while computing checksum: " << Utility::formatSyncPath(_filePath));
-        return {SystemError, ExitCause::FileAccessError};
+        return {ExitCode::SystemError, ExitCause::FileAccessError};
     }
 
     if (checksumIoError == IoError::InvalidArgument) {
         LOGW_WARN(_logger, L"File is a symlink: " << Utility::formatSyncPath(_filePath));
-        return {SystemError, ExitCause::FileAccessError};
+        return {ExitCode::SystemError, ExitCause::FileAccessError};
     }
 
     assert(checksumIoError == IoError::Success);
     if (checksumIoError != IoError::Success) {
         LOGW_WARN(_logger, L"Unable to compute checksum for " << Utility::formatIoError(_filePath, checksumIoError));
-        return SystemError;
+        return ExitCode::SystemError;
     }
 
-    if (_localHash != _remoteHash) return Ok;
+    if (_localHash != _remoteHash) return ExitCode::Ok;
     _shouldDownload = false;
-    return Ok;
+    return ExitCode::Ok;
 }
 
 std::string CheckHashMatchJob::getSpecificUrl() {

--- a/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.cpp
@@ -1,0 +1,113 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "createdirjob.h"
+#include "libcommonserver/utility/utility.h"
+#include "libcommonserver/utility/jsonparserutility.h"
+
+#include <Poco/Net/HTTPRequest.h>
+
+namespace KDC {
+
+CreateDirJob::CreateDirJob(const std::shared_ptr<Vfs> vfs, const DriveDbId driveDbId, const SyncPath &filepath,
+                           const NodeId &parentId, const SyncName &name, const std::string &color /*= ""*/) :
+    AbstractTokenNetworkJob(ApiType::Drive, 0, 0, driveDbId, 0),
+    _filePath(filepath),
+    _parentDirId(parentId),
+    _name(name),
+    _color(color),
+    _vfs(vfs) {
+    _httpMethod = Poco::Net::HTTPRequest::HTTP_POST;
+}
+
+CreateDirJob::CreateDirJob(const std::shared_ptr<Vfs> vfs, const DriveDbId driveDbId, const NodeId &parentId,
+                           const SyncName &name) :
+    CreateDirJob(vfs, driveDbId, "", parentId, name) {}
+
+CreateDirJob::CreateDirJob(const std::shared_ptr<Vfs> vfs, const UserDbId userDbId, const DriveId driveId, const NodeId &parentId,
+                           const SyncName &name) :
+    AbstractTokenNetworkJob(ApiType::Drive, userDbId, 0, 0, driveId),
+    _parentDirId(parentId),
+    _name(name),
+    _vfs(vfs) {
+    _httpMethod = Poco::Net::HTTPRequest::HTTP_POST;
+}
+
+CreateDirJob::~CreateDirJob() {
+    if (_filePath.empty() || !_vfs) return;
+    if (const ExitInfo exitInfo = _vfs->setPinState(_filePath, PinState::AlwaysLocal); !exitInfo) {
+        LOGW_WARN(_logger,
+                  L"Error in CreateDirJob::vfsSetPinState for " << Utility::formatSyncPath(_filePath) << L" : " << exitInfo);
+    }
+
+    if (const ExitInfo exitInfo =
+                _vfs->forceStatus(_filePath, VfsStatus({.isHydrated = true, .isSyncing = false, .progress = 0}));
+        !exitInfo) {
+        LOGW_WARN(_logger,
+                  L"Error in CreateDirJob::vfsForceStatus for " << Utility::formatSyncPath(_filePath) << L" : " << exitInfo);
+    }
+}
+std::string CreateDirJob::getSpecificUrl() {
+    std::string str = AbstractTokenNetworkJob::getSpecificUrl();
+    str += "/files/";
+    str += _parentDirId;
+    str += "/directory";
+    return str;
+}
+
+ExitInfo CreateDirJob::setData() {
+    Poco::JSON::Object json;
+    json.set("name", _name);
+    if (!_color.empty()) {
+        json.set("color", _color);
+    }
+
+    std::stringstream ss;
+    json.stringify(ss);
+    _data = ss.str();
+    return ExitCode::Ok;
+}
+
+ExitInfo CreateDirJob::handleResponse(std::istream &is) {
+    if (const auto exitInfo = AbstractTokenNetworkJob::handleResponse(is); !exitInfo) {
+        return exitInfo;
+    }
+
+    if (jsonRes()) {
+        if (const auto dataObj = jsonRes()->getObject(dataKey); dataObj) {
+            if (!JsonParserUtility::extractValue(dataObj, idKey, _nodeId)) {
+                return {};
+            }
+            if (!JsonParserUtility::extractValue(dataObj, lastModifiedAtKey, _modtime)) {
+                return {};
+            }
+        }
+
+        if (!_filePath.empty() && _vfs) {
+            constexpr VfsStatus vfsStatus({.isHydrated = true, .isSyncing = false, .progress = 0});
+            if (const auto exitInfo = _vfs->forceStatus(_filePath, vfsStatus); !exitInfo) {
+                LOGW_WARN(_logger, L"Error in CreateDirJob::_vfsForceStatus for " << Utility::formatSyncPath(_filePath) << L" : "
+                                                                                  << exitInfo);
+            }
+        }
+    }
+
+    return ExitCode::Ok;
+}
+
+} // namespace KDC

--- a/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.cpp
@@ -23,17 +23,31 @@
 
 namespace KDC {
 
-CheckHashMatchJob::CheckHashMatchJob(const DriveDbId driveDbId, const SyncPath &filepath, const NodeId &nodeId, int localsize,
-                                     int remotesize) :
+CheckHashMatchJob::CheckHashMatchJob(const DriveDbId driveDbId, const SyncPath &filepath, const NodeId &nodeId, int64_t localsize,
+                                     int64_t remotesize) :
     AbstractTokenNetworkJob(ApiType::Drive, 0, 0, driveDbId, 0),
     _filePath(filepath),
-    _nodeId(nodeId) {
-    if (localsize != remotesize) abort();
-
+    _nodeId(nodeId),
+    _localSize(localsize),
+    _remoteSize(remotesize) {
     _httpMethod = Poco::Net::HTTPRequest::HTTP_GET;
 }
 
-CheckHashMatchJob::~CheckHashMatchJob() {}
+ExitInfo CheckHashMatchJob::runJob() noexcept {
+    if (_localSize != _remoteSize) return ExitCode::Ok;
+
+    if (const ExitInfo exitInfo = AbstractTokenNetworkJob::runJob(); !exitInfo) {
+        return exitInfo;
+    }
+
+    std::ifstream ifs;
+    IoError ioError = IoError::Unknown;
+    _localHash = "xxh3:" + IoHelper::getFileChecksum(_filePath, ifs, ioError);
+
+    if (_localHash != _remoteHash) return ExitCode::Ok;
+    _shouldDownload = false;
+    return ExitCode::Ok;
+}
 
 std::string CheckHashMatchJob::getSpecificUrl() {
     std::string str = AbstractTokenNetworkJob::getSpecificUrl();
@@ -50,18 +64,11 @@ ExitInfo CheckHashMatchJob::handleResponse(std::istream &is) {
 
     if (jsonRes()) {
         if (const auto dataObj = jsonRes()->getObject(dataKey); dataObj) {
-            if (!JsonParserUtility::extractValue(dataObj, hashKey, _distantHash)) {
+            if (!JsonParserUtility::extractValue(dataObj, hashKey, _remoteHash)) {
                 return {ExitCode::BackError, ExitCause::MissingReplyData};
             }
         }
     }
-
-    std::ifstream ifs;
-    IoError ioError = IoError::Unknown;
-    _localHash = "xxh3:" + IoHelper::getFileChecksum(_filePath, ifs, ioError);
-
-    if (_localHash != _distantHash) return ExitCode::Ok;
-    _shouldDownload = false;
 
     return ExitCode::Ok;
 }

--- a/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.cpp
@@ -89,6 +89,22 @@ ExitInfo CheckHashMatchJob::runJob() noexcept {
     IoError ioError = IoError::Unknown;
     _localHash = "xxh3:" + IoHelper::getFileChecksum(_filePath, ifs, ioError);
 
+    if (ioError == IoError::NoSuchFileOrDirectory) {
+        LOGW_WARN(_logger, L"File doesn't exist while computing checksum: " << Utility::formatSyncPath(_filePath));
+        return ExitCode::DataError;
+    }
+
+    if (ioError == IoError::AccessDenied) {
+        LOGW_WARN(_logger, L"File read permission missing while computing checksum: " << Utility::formatSyncPath(_filePath));
+        return {ExitCode::SystemError, ExitCause::FileAccessError};
+    }
+
+    assert(ioError == IoError::Success);
+    if (ioError != IoError::Success) {
+        LOGW_WARN(_logger, L"Unable to compute checksum for " << Utility::formatIoError(_filePath, ioError));
+        return ExitCode::SystemError;
+    }
+
     if (_localHash != _remoteHash) return ExitCode::Ok;
     _shouldDownload = false;
     return ExitCode::Ok;

--- a/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.cpp
@@ -122,13 +122,13 @@ ExitInfo CheckHashMatchJob::handleResponse(std::istream &is) {
         return exitInfo;
     }
 
-    if (jsonRes()) {
-        if (const auto dataObj = jsonRes()->getObject(dataKey); dataObj) {
-            if (!JsonParserUtility::extractValue(dataObj, hashKey, _remoteHash)) {
-                return {ExitCode::BackError, ExitCause::MissingReplyData};
-            }
-        }
-    }
+    if (!jsonRes()) return {ExitCode::BackError, ExitCause::MissingReplyData};
+
+    const auto dataObj = jsonRes()->getObject(dataKey);
+    if (!dataObj) return {ExitCode::BackError, ExitCause::MissingReplyData};
+
+    if (!JsonParserUtility::extractValue(dataObj, hashKey, _remoteHash))
+        return {ExitCode::BackError, ExitCause::MissingReplyData};
 
     return ExitCode::Ok;
 }

--- a/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.cpp
@@ -20,11 +20,21 @@
 #include "libcommonserver/utility/jsonparserutility.h"
 
 #include <Poco/Net/HTTPRequest.h>
+#include <log4cplus/loggingmacros.h>
 
 namespace KDC {
 
-CheckHashMatchJob::CheckHashMatchJob(const DriveDbId driveDbId, const SyncPath &filepath, const NodeId &nodeId, int64_t localsize,
-                                     int64_t remotesize) :
+CheckHashMatchJob::CheckHashMatchJob(const DriveDbId driveDbId, const SyncPath &filepath, const NodeId &nodeId, const int64_t remotesize) :
+    AbstractTokenNetworkJob(ApiType::Drive, 0, 0, driveDbId, 0),
+    _filePath(filepath),
+    _nodeId(nodeId),
+    _localSize(0),
+    _remoteSize(remotesize) {
+    _httpMethod = Poco::Net::HTTPRequest::HTTP_GET;
+}
+
+CheckHashMatchJob::CheckHashMatchJob(const DriveDbId driveDbId, const SyncPath &filepath, const NodeId &nodeId,
+                                     const int64_t localsize, const int64_t remotesize) :
     AbstractTokenNetworkJob(ApiType::Drive, 0, 0, driveDbId, 0),
     _filePath(filepath),
     _nodeId(nodeId),
@@ -33,7 +43,39 @@ CheckHashMatchJob::CheckHashMatchJob(const DriveDbId driveDbId, const SyncPath &
     _httpMethod = Poco::Net::HTTPRequest::HTTP_GET;
 }
 
+ExitInfo CheckHashMatchJob::getFileSize(const SyncPath &path, int64_t &size) {
+    IoError ioError = IoError::Unknown;
+    uint64_t tmpSize = 0;
+    if (!IoHelper::getFileSize(path, tmpSize, ioError)) {
+        LOGW_WARN(_logger, L"Error in IoHelper::getFileSize for " << Utility::formatIoError(path, ioError));
+        return ExitCode::SystemError;
+    }
+    size = static_cast<int64_t>(tmpSize);
+
+    if (ioError == IoError::NoSuchFileOrDirectory) { // The synchronization will
+                                                     // be re-started.
+        LOGW_WARN(_logger, L"File doesn't exist: " << Utility::formatSyncPath(path));
+        return ExitCode::DataError;
+    }
+
+    if (ioError == IoError::AccessDenied) { // An action from the user is requested.
+        LOGW_WARN(_logger, L"File search permission missing: " << Utility::formatSyncPath(path));
+        return {ExitCode::SystemError, ExitCause::FileAccessError};
+    }
+
+    assert(ioError == IoError::Success);
+    if (ioError != IoError::Success) {
+        LOGW_WARN(_logger, L"Unable to read file size for " << Utility::formatSyncPath(path));
+        return ExitCode::SystemError;
+    }
+
+    return ExitCode::Ok;
+}
+
 ExitInfo CheckHashMatchJob::runJob() noexcept {
+    if (!_localSize)
+        if (const ExitInfo exitInfo = getFileSize(_filePath, _localSize); !exitInfo) return exitInfo;
+
     if (_localSize != _remoteSize) return ExitCode::Ok;
 
     if (const ExitInfo exitInfo = AbstractTokenNetworkJob::runJob(); !exitInfo) {

--- a/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.cpp
@@ -32,8 +32,8 @@ CheckHashMatchJob::CheckHashMatchJob(const DriveDbId driveDbId, const SyncPath &
     AbstractTokenNetworkJob(ApiType::Drive, 0, 0, driveDbId, 0),
     _filePath(filepath),
     _nodeId(nodeId),
-    _localSize(0),
     _remoteSize(remoteSize) {
+    _localSize = 0;
     _httpMethod = Poco::Net::HTTPRequest::HTTP_GET;
 }
 
@@ -77,11 +77,11 @@ ExitInfo CheckHashMatchJob::getFileSize(const SyncPath &path, int64_t &size) {
 }
 
 ExitInfo CheckHashMatchJob::runJob() noexcept {
+    using enum KDC::ExitCode;
     if (!_localSize)
         if (const ExitInfo exitInfo = getFileSize(_filePath, _localSize); !exitInfo) return exitInfo;
 
-    if (_localSize != _remoteSize) return ExitCode::Ok;
-
+    if (_localSize != _remoteSize) return Ok;
     if (const ExitInfo exitInfo = AbstractTokenNetworkJob::runJob(); !exitInfo) {
         return exitInfo;
     }
@@ -91,28 +91,28 @@ ExitInfo CheckHashMatchJob::runJob() noexcept {
 
     if (ioError == IoError::NoSuchFileOrDirectory) {
         LOGW_WARN(_logger, L"File doesn't exist while computing checksum: " << Utility::formatSyncPath(_filePath));
-        return ExitCode::DataError;
+        return DataError;
     }
 
     if (ioError == IoError::AccessDenied) {
         LOGW_WARN(_logger, L"File read permission missing while computing checksum: " << Utility::formatSyncPath(_filePath));
-        return {ExitCode::SystemError, ExitCause::FileAccessError};
+        return {SystemError, ExitCause::FileAccessError};
     }
 
     if (ioError == IoError::InvalidArgument) {
         LOGW_WARN(_logger, L"File is a symlink: " << Utility::formatSyncPath(_filePath));
-        return {ExitCode::SystemError, ExitCause::FileAccessError};
+        return {SystemError, ExitCause::FileAccessError};
     }
 
     assert(ioError == IoError::Success);
     if (ioError != IoError::Success) {
         LOGW_WARN(_logger, L"Unable to compute checksum for " << Utility::formatIoError(_filePath, ioError));
-        return ExitCode::SystemError;
+        return SystemError;
     }
 
-    if (_localHash != _remoteHash) return ExitCode::Ok;
+    if (_localHash != _remoteHash) return Ok;
     _shouldDownload = false;
-    return ExitCode::Ok;
+    return Ok;
 }
 
 std::string CheckHashMatchJob::getSpecificUrl() {

--- a/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.cpp
@@ -59,7 +59,7 @@ ExitInfo CheckHashMatchJob::getFileSize(const SyncPath &path, int64_t &size) {
     if (ioError == IoError::NoSuchFileOrDirectory) { // The synchronization will
                                                      // be re-started.
         LOGW_WARN(_logger, L"File doesn't exist: " << Utility::formatSyncPath(path));
-        return ExitCode::DataError;
+        return {ExitCode::SystemError, ExitCause::NotFound};
     }
 
     if (ioError == IoError::AccessDenied) { // An action from the user is requested.
@@ -96,6 +96,11 @@ ExitInfo CheckHashMatchJob::runJob() noexcept {
 
     if (ioError == IoError::AccessDenied) {
         LOGW_WARN(_logger, L"File read permission missing while computing checksum: " << Utility::formatSyncPath(_filePath));
+        return {ExitCode::SystemError, ExitCause::FileAccessError};
+    }
+
+    if (ioError == IoError::InvalidArgument) {
+        LOGW_WARN(_logger, L"File is a symlink: " << Utility::formatSyncPath(_filePath));
         return {ExitCode::SystemError, ExitCause::FileAccessError};
     }
 

--- a/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.cpp
@@ -17,8 +17,11 @@
  */
 
 #include "checkhashmatchjob.h"
+#include "libcommonserver/io/iohelper.h"
 #include "libcommonserver/utility/jsonparserutility.h"
+#include "libcommonserver/utility/utility.h"
 
+#include <fstream>
 #include <Poco/Net/HTTPRequest.h>
 #include <log4cplus/loggingmacros.h>
 

--- a/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.cpp
@@ -33,7 +33,6 @@ CheckHashMatchJob::CheckHashMatchJob(const DriveDbId driveDbId, const SyncPath &
     _filePath(filepath),
     _nodeId(nodeId),
     _remoteSize(remoteSize) {
-    _localSize = 0;
     _httpMethod = Poco::Net::HTTPRequest::HTTP_GET;
 }
 
@@ -49,27 +48,27 @@ CheckHashMatchJob::CheckHashMatchJob(const DriveDbId driveDbId, const SyncPath &
 
 ExitInfo CheckHashMatchJob::getFileSize(const SyncPath &path, int64_t &size) {
     using enum KDC::ExitCode;
-    IoError ioError = IoError::Unknown;
+    IoError fileSizeIoError = IoError::Unknown;
     uint64_t tmpSize = 0;
-    if (!IoHelper::getFileSize(path, tmpSize, ioError)) {
-        LOGW_WARN(_logger, L"Error in IoHelper::getFileSize for " << Utility::formatIoError(path, ioError));
+    if (!IoHelper::getFileSize(path, tmpSize, fileSizeIoError)) {
+        LOGW_WARN(_logger, L"Error in IoHelper::getFileSize for " << Utility::formatIoError(path, fileSizeIoError));
         return SystemError;
     }
     size = static_cast<int64_t>(tmpSize);
 
-    if (ioError == IoError::NoSuchFileOrDirectory) { // The synchronization will
-                                                     // be re-started.
+    if (fileSizeIoError == IoError::NoSuchFileOrDirectory) { // The synchronization will
+                                                             // be re-started.
         LOGW_WARN(_logger, L"File doesn't exist: " << Utility::formatSyncPath(path));
         return {SystemError, ExitCause::NotFound};
     }
 
-    if (ioError == IoError::AccessDenied) { // An action from the user is requested.
+    if (fileSizeIoError == IoError::AccessDenied) { // An action from the user is requested.
         LOGW_WARN(_logger, L"File search permission missing: " << Utility::formatSyncPath(path));
         return {SystemError, ExitCause::FileAccessError};
     }
 
-    assert(ioError == IoError::Success);
-    if (ioError != IoError::Success) {
+    assert(fileSizeIoError == IoError::Success);
+    if (fileSizeIoError != IoError::Success) {
         LOGW_WARN(_logger, L"Unable to read file size for " << Utility::formatSyncPath(path));
         return SystemError;
     }
@@ -88,26 +87,26 @@ ExitInfo CheckHashMatchJob::runJob() noexcept {
     }
 
     std::ifstream ifs;
-    const IoError ioError = IoHelper::getFileChecksum(_filePath, ifs, _localHash);
+    const IoError checksumIoError = IoHelper::getFileChecksum(_filePath, ifs, _localHash);
 
-    if (ioError == IoError::NoSuchFileOrDirectory) {
+    if (checksumIoError == IoError::NoSuchFileOrDirectory) {
         LOGW_WARN(_logger, L"File doesn't exist while computing checksum: " << Utility::formatSyncPath(_filePath));
         return DataError;
     }
 
-    if (ioError == IoError::AccessDenied) {
+    if (checksumIoError == IoError::AccessDenied) {
         LOGW_WARN(_logger, L"File read permission missing while computing checksum: " << Utility::formatSyncPath(_filePath));
         return {SystemError, ExitCause::FileAccessError};
     }
 
-    if (ioError == IoError::InvalidArgument) {
+    if (checksumIoError == IoError::InvalidArgument) {
         LOGW_WARN(_logger, L"File is a symlink: " << Utility::formatSyncPath(_filePath));
         return {SystemError, ExitCause::FileAccessError};
     }
 
-    assert(ioError == IoError::Success);
-    if (ioError != IoError::Success) {
-        LOGW_WARN(_logger, L"Unable to compute checksum for " << Utility::formatIoError(_filePath, ioError));
+    assert(checksumIoError == IoError::Success);
+    if (checksumIoError != IoError::Success) {
+        LOGW_WARN(_logger, L"Unable to compute checksum for " << Utility::formatIoError(_filePath, checksumIoError));
         return SystemError;
     }
 

--- a/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.cpp
@@ -83,9 +83,7 @@ ExitInfo CheckHashMatchJob::runJob() noexcept {
         return exitInfo;
     }
 
-    std::ifstream ifs;
-    const IoError checksumIoError = IoHelper::getFileChecksum(_filePath, ifs, _localHash);
-
+    const IoError checksumIoError = IoHelper::getFileChecksum(_filePath, _localHash);
     if (checksumIoError == IoError::NoSuchFileOrDirectory) {
         LOGW_WARN(_logger, L"File doesn't exist while computing checksum: " << Utility::formatSyncPath(_filePath));
         return ExitCode::DataError;

--- a/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.cpp
@@ -36,16 +36,6 @@ CheckHashMatchJob::CheckHashMatchJob(const DriveDbId driveDbId, const SyncPath &
     _httpMethod = Poco::Net::HTTPRequest::HTTP_GET;
 }
 
-CheckHashMatchJob::CheckHashMatchJob(const DriveDbId driveDbId, const SyncPath &filepath, const NodeId &nodeId,
-                                     const int64_t localSize, const int64_t remoteSize) :
-    AbstractTokenNetworkJob(ApiType::Drive, 0, 0, driveDbId, 0),
-    _filePath(filepath),
-    _nodeId(nodeId),
-    _localSize(localSize),
-    _remoteSize(remoteSize) {
-    _httpMethod = Poco::Net::HTTPRequest::HTTP_GET;
-}
-
 ExitInfo CheckHashMatchJob::getFileSize(const SyncPath &path, int64_t &size) {
     IoError ioError = IoError::Unknown;
     uint64_t tmpSize = 0;

--- a/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.cpp
@@ -27,22 +27,23 @@
 
 namespace KDC {
 
-CheckHashMatchJob::CheckHashMatchJob(const DriveDbId driveDbId, const SyncPath &filepath, const NodeId &nodeId, const int64_t remotesize) :
+CheckHashMatchJob::CheckHashMatchJob(const DriveDbId driveDbId, const SyncPath &filepath, const NodeId &nodeId,
+                                     const int64_t remoteSize) :
     AbstractTokenNetworkJob(ApiType::Drive, 0, 0, driveDbId, 0),
     _filePath(filepath),
     _nodeId(nodeId),
     _localSize(0),
-    _remoteSize(remotesize) {
+    _remoteSize(remoteSize) {
     _httpMethod = Poco::Net::HTTPRequest::HTTP_GET;
 }
 
 CheckHashMatchJob::CheckHashMatchJob(const DriveDbId driveDbId, const SyncPath &filepath, const NodeId &nodeId,
-                                     const int64_t localsize, const int64_t remotesize) :
+                                     const int64_t localSize, const int64_t remoteSize) :
     AbstractTokenNetworkJob(ApiType::Drive, 0, 0, driveDbId, 0),
     _filePath(filepath),
     _nodeId(nodeId),
-    _localSize(localsize),
-    _remoteSize(remotesize) {
+    _localSize(localSize),
+    _remoteSize(remoteSize) {
     _httpMethod = Poco::Net::HTTPRequest::HTTP_GET;
 }
 
@@ -86,8 +87,7 @@ ExitInfo CheckHashMatchJob::runJob() noexcept {
     }
 
     std::ifstream ifs;
-    IoError ioError = IoError::Unknown;
-    _localHash = "xxh3:" + IoHelper::getFileChecksum(_filePath, ifs, ioError);
+    const IoError ioError = IoHelper::getFileChecksum(_filePath, ifs, _localHash);
 
     if (ioError == IoError::NoSuchFileOrDirectory) {
         LOGW_WARN(_logger, L"File doesn't exist while computing checksum: " << Utility::formatSyncPath(_filePath));

--- a/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.cpp
@@ -48,32 +48,33 @@ CheckHashMatchJob::CheckHashMatchJob(const DriveDbId driveDbId, const SyncPath &
 }
 
 ExitInfo CheckHashMatchJob::getFileSize(const SyncPath &path, int64_t &size) {
+    using enum KDC::ExitCode;
     IoError ioError = IoError::Unknown;
     uint64_t tmpSize = 0;
     if (!IoHelper::getFileSize(path, tmpSize, ioError)) {
         LOGW_WARN(_logger, L"Error in IoHelper::getFileSize for " << Utility::formatIoError(path, ioError));
-        return ExitCode::SystemError;
+        return SystemError;
     }
     size = static_cast<int64_t>(tmpSize);
 
     if (ioError == IoError::NoSuchFileOrDirectory) { // The synchronization will
                                                      // be re-started.
         LOGW_WARN(_logger, L"File doesn't exist: " << Utility::formatSyncPath(path));
-        return {ExitCode::SystemError, ExitCause::NotFound};
+        return {SystemError, ExitCause::NotFound};
     }
 
     if (ioError == IoError::AccessDenied) { // An action from the user is requested.
         LOGW_WARN(_logger, L"File search permission missing: " << Utility::formatSyncPath(path));
-        return {ExitCode::SystemError, ExitCause::FileAccessError};
+        return {SystemError, ExitCause::FileAccessError};
     }
 
     assert(ioError == IoError::Success);
     if (ioError != IoError::Success) {
         LOGW_WARN(_logger, L"Unable to read file size for " << Utility::formatSyncPath(path));
-        return ExitCode::SystemError;
+        return SystemError;
     }
 
-    return ExitCode::Ok;
+    return Ok;
 }
 
 ExitInfo CheckHashMatchJob::runJob() noexcept {

--- a/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.h
+++ b/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.h
@@ -26,8 +26,6 @@ class CheckHashMatchJob : public AbstractTokenNetworkJob {
     public:
         CheckHashMatchJob(DriveDbId driveDbId, const SyncPath &filePath, const NodeId &nodeId,
                           const int64_t remoteSize);
-        CheckHashMatchJob(DriveDbId driveDbId, const SyncPath &filePath, const NodeId &nodeId, const int64_t localSize,
-                          const int64_t remoteSize);
 
         [[nodiscard]] const NodeId &nodeId() const { return _nodeId; }
         [[nodiscard]] bool shouldDownload() const { return _shouldDownload; }

--- a/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.h
+++ b/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.h
@@ -19,23 +19,15 @@
 #pragma once
 
 #include "jobs/network/abstracttokennetworkjob.h"
-#include "libcommonserver/vfs/vfs.h"
 
 namespace KDC {
 
-class CreateDirJob : public AbstractTokenNetworkJob {
+class CheckHashMatchJob : public AbstractTokenNetworkJob {
     public:
-        CreateDirJob(const std::shared_ptr<Vfs> vfs, DriveDbId driveDbId, const SyncPath &filepath, const NodeId &parentId,
-                     const SyncName &name, const std::string &color = "");
-        CreateDirJob(const std::shared_ptr<Vfs> vfs, DriveDbId driveDbId, const NodeId &parentId, const SyncName &name);
-        CreateDirJob(const std::shared_ptr<Vfs> vfs, UserDbId userDbId, DriveId driveId, const NodeId &parentId,
-                     const SyncName &name);
-        ~CreateDirJob() override;
+        CheckHashMatchJob(DriveDbId driveDbId, const SyncPath &filepath, const NodeId &nodeId, int localsize, int remotesize);
 
-        [[nodiscard]] inline const NodeId &parentDirId() const { return _parentDirId; }
-
-        [[nodiscard]] inline const NodeId &nodeId() const { return _nodeId; }
-        [[nodiscard]] inline SyncTime modtime() const { return _modtime; }
+        [[nodiscard]] const NodeId &nodeId() const { return _nodeId; }
+        [[nodiscard]] bool shouldDownload() const { return _shouldDownload; }
 
     protected:
         ExitInfo handleResponse(std::istream &is) override;
@@ -45,13 +37,13 @@ class CreateDirJob : public AbstractTokenNetworkJob {
         ExitInfo setData() override;
 
         SyncPath _filePath;
-        NodeId _parentDirId;
         SyncName _name;
-        std::string _color;
 
         NodeId _nodeId;
-        SyncTime _modtime = 0;
-        const std::shared_ptr<Vfs> _vfs;
+        std::string _distantHash;
+        std::string _localHash;
+
+        bool _shouldDownload = true;
 };
 
 } // namespace KDC

--- a/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.h
+++ b/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.h
@@ -24,10 +24,10 @@ namespace KDC {
 
 class CheckHashMatchJob : public AbstractTokenNetworkJob {
     public:
-        CheckHashMatchJob(DriveDbId driveDbId, const SyncPath &filepath, const NodeId &nodeId,
-                          const int64_t remotesize);
-        CheckHashMatchJob(DriveDbId driveDbId, const SyncPath &filepath, const NodeId &nodeId, const int64_t localsize,
-                          const int64_t remotesize);
+        CheckHashMatchJob(DriveDbId driveDbId, const SyncPath &filePath, const NodeId &nodeId,
+                          const int64_t remoteSize);
+        CheckHashMatchJob(DriveDbId driveDbId, const SyncPath &filePath, const NodeId &nodeId, const int64_t localSize,
+                          const int64_t remoteSize);
 
         [[nodiscard]] const NodeId &nodeId() const { return _nodeId; }
         [[nodiscard]] bool shouldDownload() const { return _shouldDownload; }

--- a/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.h
+++ b/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.h
@@ -24,7 +24,10 @@ namespace KDC {
 
 class CheckHashMatchJob : public AbstractTokenNetworkJob {
     public:
-        CheckHashMatchJob(DriveDbId driveDbId, const SyncPath &filepath, const NodeId &nodeId, int64_t localsize, int64_t remotesize);
+        CheckHashMatchJob(DriveDbId driveDbId, const SyncPath &filepath, const NodeId &nodeId,
+                          const int64_t remotesize);
+        CheckHashMatchJob(DriveDbId driveDbId, const SyncPath &filepath, const NodeId &nodeId, const int64_t localsize,
+                          const int64_t remotesize);
 
         [[nodiscard]] const NodeId &nodeId() const { return _nodeId; }
         [[nodiscard]] bool shouldDownload() const { return _shouldDownload; }
@@ -34,10 +37,10 @@ class CheckHashMatchJob : public AbstractTokenNetworkJob {
 
     private:
         std::string getSpecificUrl() override;
+        ExitInfo getFileSize(const SyncPath &path, int64_t &size);
         ExitInfo runJob() noexcept override;
 
         SyncPath _filePath;
-        SyncName _name;
 
         NodeId _nodeId;
         std::string _remoteHash;

--- a/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.h
+++ b/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.h
@@ -1,0 +1,57 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "jobs/network/abstracttokennetworkjob.h"
+#include "libcommonserver/vfs/vfs.h"
+
+namespace KDC {
+
+class CreateDirJob : public AbstractTokenNetworkJob {
+    public:
+        CreateDirJob(const std::shared_ptr<Vfs> vfs, DriveDbId driveDbId, const SyncPath &filepath, const NodeId &parentId,
+                     const SyncName &name, const std::string &color = "");
+        CreateDirJob(const std::shared_ptr<Vfs> vfs, DriveDbId driveDbId, const NodeId &parentId, const SyncName &name);
+        CreateDirJob(const std::shared_ptr<Vfs> vfs, UserDbId userDbId, DriveId driveId, const NodeId &parentId,
+                     const SyncName &name);
+        ~CreateDirJob() override;
+
+        [[nodiscard]] inline const NodeId &parentDirId() const { return _parentDirId; }
+
+        [[nodiscard]] inline const NodeId &nodeId() const { return _nodeId; }
+        [[nodiscard]] inline SyncTime modtime() const { return _modtime; }
+
+    protected:
+        ExitInfo handleResponse(std::istream &is) override;
+
+    private:
+        std::string getSpecificUrl() override;
+        ExitInfo setData() override;
+
+        SyncPath _filePath;
+        NodeId _parentDirId;
+        SyncName _name;
+        std::string _color;
+
+        NodeId _nodeId;
+        SyncTime _modtime = 0;
+        const std::shared_ptr<Vfs> _vfs;
+};
+
+} // namespace KDC

--- a/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.h
+++ b/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.h
@@ -24,7 +24,7 @@ namespace KDC {
 
 class CheckHashMatchJob : public AbstractTokenNetworkJob {
     public:
-        CheckHashMatchJob(DriveDbId driveDbId, const SyncPath &filepath, const NodeId &nodeId, int localsize, int remotesize);
+        CheckHashMatchJob(DriveDbId driveDbId, const SyncPath &filepath, const NodeId &nodeId, int64_t localsize, int64_t remotesize);
 
         [[nodiscard]] const NodeId &nodeId() const { return _nodeId; }
         [[nodiscard]] bool shouldDownload() const { return _shouldDownload; }
@@ -34,14 +34,17 @@ class CheckHashMatchJob : public AbstractTokenNetworkJob {
 
     private:
         std::string getSpecificUrl() override;
-        ExitInfo setData() override;
+        ExitInfo runJob() noexcept override;
 
         SyncPath _filePath;
         SyncName _name;
 
         NodeId _nodeId;
-        std::string _distantHash;
+        std::string _remoteHash;
         std::string _localHash;
+
+        int64_t _localSize = 0;
+        int64_t _remoteSize = 0;
 
         bool _shouldDownload = true;
 };

--- a/src/libsyncengine/jobs/network/networkjobsparams.h
+++ b/src/libsyncengine/jobs/network/networkjobsparams.h
@@ -110,6 +110,7 @@ static const std::string avatarKey = "avatar";
 static const std::string isStaffKey = "is_staff";
 static const std::string updatedAtKey = "updated_at";
 static const std::string versionsKey = "versions";
+static const std::string hashKey = "hash";
 
 static const std::string totalNbItemKey = "total";
 static const std::string pageKey = "page";

--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -826,32 +826,6 @@ ExitInfo ExecutorWorker::generateEditJob(SyncOpPtr syncOp, std::shared_ptr<SyncJ
         SyncPath relativeLocalFilePath = syncOp->nodePath(ReplicaSide::Local);
         SyncPath absoluteLocalFilePath = _syncPal->localPath() / relativeLocalFilePath;
 
-        // If both checksums are available and identical, the file content is already up-to-date locally.
-        // Skip the download and only update the local metadata (dates).
-        const std::string remoteChecksum =
-                _syncPal->snapshot(ReplicaSide::Remote)->contentChecksum(syncOp->affectedNode()->id().value_or(""));
-        const std::string localChecksum =
-                syncOp->correspondingNode()
-                        ? _syncPal->snapshot(ReplicaSide::Local)->contentChecksum(syncOp->correspondingNode()->id().value_or(""))
-                        : std::string{};
-        const int64_t remoteSize = _syncPal->snapshot(ReplicaSide::Remote)->size(syncOp->affectedNode()->id().value_or(""));
-        const int64_t localSize = _syncPal->snapshot(ReplicaSide::Local)->size(syncOp->correspondingNode()->id().value_or(""));
-        if (ParametersCache::isExtendedLogEnabled())
-            LOG_SYNCPAL_DEBUG(_logger, "Edit checksum comparison - remote: \"" << remoteChecksum << "\" local: \""
-                                                                               << localChecksum << "\"");
-        if (!remoteChecksum.empty() && remoteChecksum == localChecksum && localSize != remoteSize) {
-            LOGW_SYNCPAL_DEBUG(_logger, L"Checksums match, skipping download and updating metadata only: "
-                                                << Utility::formatSyncPath(absoluteLocalFilePath));
-            const SyncTime creationTime = syncOp->affectedNode()->createdAt().value_or(0);
-            const SyncTime modificationTime = syncOp->affectedNode()->modificationTime().value_or(0);
-            if (const IoError ioError = IoHelper::setFileDates(absoluteLocalFilePath, creationTime, modificationTime, false);
-                ioError != IoError::Success) {
-                LOGW_SYNCPAL_WARN(_logger,
-                                  L"Error in IoHelper::setFileDates for " << Utility::formatSyncPath(absoluteLocalFilePath));
-            }
-            return ExitCode::Ok;
-        }
-
         try {
             job = std::make_shared<DownloadJob>(
                     _syncPal->vfs(), _syncPal->cacheDirectory(),
@@ -870,24 +844,6 @@ ExitInfo ExecutorWorker::generateEditJob(SyncOpPtr syncOp, std::shared_ptr<SyncJ
     } else {
         SyncPath relativeLocalFilePath = syncOp->nodePath(ReplicaSide::Local);
         SyncPath absoluteLocalFilePath = _syncPal->localPath() / relativeLocalFilePath;
-
-        // If both checksums are available and identical, the remote already has the same content.
-        // Skip the upload entirely.
-        const std::string localChecksum =
-                _syncPal->snapshot(ReplicaSide::Local)->contentChecksum(syncOp->affectedNode()->id().value_or(""));
-        const std::string remoteChecksum =
-                syncOp->correspondingNode()
-                        ? _syncPal->snapshot(ReplicaSide::Remote)->contentChecksum(syncOp->correspondingNode()->id().value_or(""))
-                        : std::string{};
-        const int64_t remoteSize = _syncPal->snapshot(ReplicaSide::Remote)->size(syncOp->affectedNode()->id().value_or(""));
-        const int64_t localSize = _syncPal->snapshot(ReplicaSide::Local)->size(syncOp->correspondingNode()->id().value_or(""));
-        if (ParametersCache::isExtendedLogEnabled())
-            LOG_SYNCPAL_DEBUG(_logger, "Edit upload checksum comparison - local: \"" << localChecksum << "\" remote: \""
-                                                                                     << remoteChecksum << "\"");
-        if (!localChecksum.empty() && localChecksum == remoteChecksum && localSize == remoteSize) {
-            LOGW_SYNCPAL_DEBUG(_logger, L"Checksums match, skipping upload: " << Utility::formatSyncPath(absoluteLocalFilePath));
-            return ExitCode::Ok;
-        }
 
         uint64_t filesize;
         if (ExitInfo exitInfo = getFileSize(absoluteLocalFilePath, filesize); !exitInfo) {

--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -834,17 +834,20 @@ ExitInfo ExecutorWorker::generateEditJob(SyncOpPtr syncOp, std::shared_ptr<SyncJ
                 syncOp->correspondingNode()
                         ? _syncPal->snapshot(ReplicaSide::Local)->contentChecksum(syncOp->correspondingNode()->id().value_or(""))
                         : std::string{};
-        LOG_SYNCPAL_DEBUG(_logger, "Edit checksum comparison - remote: \"" << remoteChecksum << "\" local: \""
-                                                                           << localChecksum << "\"");
-        if (!remoteChecksum.empty() && remoteChecksum == localChecksum) {
+        const int64_t remoteSize = _syncPal->snapshot(ReplicaSide::Remote)->size(syncOp->affectedNode()->id().value_or(""));
+        const int64_t localSize = _syncPal->snapshot(ReplicaSide::Local)->size(syncOp->correspondingNode()->id().value_or(""));
+        if (ParametersCache::isExtendedLogEnabled())
+            LOG_SYNCPAL_DEBUG(_logger, "Edit checksum comparison - remote: \"" << remoteChecksum << "\" local: \""
+                                                                               << localChecksum << "\"");
+        if (!remoteChecksum.empty() && remoteChecksum == localChecksum && localSize != remoteSize) {
             LOGW_SYNCPAL_DEBUG(_logger, L"Checksums match, skipping download and updating metadata only: "
                                                 << Utility::formatSyncPath(absoluteLocalFilePath));
             const SyncTime creationTime = syncOp->affectedNode()->createdAt().value_or(0);
             const SyncTime modificationTime = syncOp->affectedNode()->modificationTime().value_or(0);
             if (const IoError ioError = IoHelper::setFileDates(absoluteLocalFilePath, creationTime, modificationTime, false);
                 ioError != IoError::Success) {
-                LOGW_SYNCPAL_WARN(_logger, L"Error in IoHelper::setFileDates for "
-                                                   << Utility::formatSyncPath(absoluteLocalFilePath));
+                LOGW_SYNCPAL_WARN(_logger,
+                                  L"Error in IoHelper::setFileDates for " << Utility::formatSyncPath(absoluteLocalFilePath));
             }
             return ExitCode::Ok;
         }
@@ -876,11 +879,13 @@ ExitInfo ExecutorWorker::generateEditJob(SyncOpPtr syncOp, std::shared_ptr<SyncJ
                 syncOp->correspondingNode()
                         ? _syncPal->snapshot(ReplicaSide::Remote)->contentChecksum(syncOp->correspondingNode()->id().value_or(""))
                         : std::string{};
-        LOG_SYNCPAL_DEBUG(_logger, "Edit upload checksum comparison - local: \"" << localChecksum << "\" remote: \""
-                                                                                 << remoteChecksum << "\"");
-        if (!localChecksum.empty() && localChecksum == remoteChecksum) {
-            LOGW_SYNCPAL_DEBUG(_logger, L"Checksums match, skipping upload: "
-                                                << Utility::formatSyncPath(absoluteLocalFilePath));
+        const int64_t remoteSize = _syncPal->snapshot(ReplicaSide::Remote)->size(syncOp->affectedNode()->id().value_or(""));
+        const int64_t localSize = _syncPal->snapshot(ReplicaSide::Local)->size(syncOp->correspondingNode()->id().value_or(""));
+        if (ParametersCache::isExtendedLogEnabled())
+            LOG_SYNCPAL_DEBUG(_logger, "Edit upload checksum comparison - local: \"" << localChecksum << "\" remote: \""
+                                                                                     << remoteChecksum << "\"");
+        if (!localChecksum.empty() && localChecksum == remoteChecksum && localSize == remoteSize) {
+            LOGW_SYNCPAL_DEBUG(_logger, L"Checksums match, skipping upload: " << Utility::formatSyncPath(absoluteLocalFilePath));
             return ExitCode::Ok;
         }
 

--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -826,6 +826,29 @@ ExitInfo ExecutorWorker::generateEditJob(SyncOpPtr syncOp, std::shared_ptr<SyncJ
         SyncPath relativeLocalFilePath = syncOp->nodePath(ReplicaSide::Local);
         SyncPath absoluteLocalFilePath = _syncPal->localPath() / relativeLocalFilePath;
 
+        // If both checksums are available and identical, the file content is already up-to-date locally.
+        // Skip the download and only update the local metadata (dates).
+        const std::string remoteChecksum =
+                _syncPal->snapshot(ReplicaSide::Remote)->contentChecksum(syncOp->affectedNode()->id().value_or(""));
+        const std::string localChecksum =
+                syncOp->correspondingNode()
+                        ? _syncPal->snapshot(ReplicaSide::Local)->contentChecksum(syncOp->correspondingNode()->id().value_or(""))
+                        : std::string{};
+        LOG_SYNCPAL_DEBUG(_logger, "Edit checksum comparison - remote: \"" << remoteChecksum << "\" local: \""
+                                                                           << localChecksum << "\"");
+        if (!remoteChecksum.empty() && remoteChecksum == localChecksum) {
+            LOGW_SYNCPAL_DEBUG(_logger, L"Checksums match, skipping download and updating metadata only: "
+                                                << Utility::formatSyncPath(absoluteLocalFilePath));
+            const SyncTime creationTime = syncOp->affectedNode()->createdAt().value_or(0);
+            const SyncTime modificationTime = syncOp->affectedNode()->modificationTime().value_or(0);
+            if (const IoError ioError = IoHelper::setFileDates(absoluteLocalFilePath, creationTime, modificationTime, false);
+                ioError != IoError::Success) {
+                LOGW_SYNCPAL_WARN(_logger, L"Error in IoHelper::setFileDates for "
+                                                   << Utility::formatSyncPath(absoluteLocalFilePath));
+            }
+            return ExitCode::Ok;
+        }
+
         try {
             job = std::make_shared<DownloadJob>(
                     _syncPal->vfs(), _syncPal->cacheDirectory(),
@@ -844,6 +867,22 @@ ExitInfo ExecutorWorker::generateEditJob(SyncOpPtr syncOp, std::shared_ptr<SyncJ
     } else {
         SyncPath relativeLocalFilePath = syncOp->nodePath(ReplicaSide::Local);
         SyncPath absoluteLocalFilePath = _syncPal->localPath() / relativeLocalFilePath;
+
+        // If both checksums are available and identical, the remote already has the same content.
+        // Skip the upload entirely.
+        const std::string localChecksum =
+                _syncPal->snapshot(ReplicaSide::Local)->contentChecksum(syncOp->affectedNode()->id().value_or(""));
+        const std::string remoteChecksum =
+                syncOp->correspondingNode()
+                        ? _syncPal->snapshot(ReplicaSide::Remote)->contentChecksum(syncOp->correspondingNode()->id().value_or(""))
+                        : std::string{};
+        LOG_SYNCPAL_DEBUG(_logger, "Edit upload checksum comparison - local: \"" << localChecksum << "\" remote: \""
+                                                                                 << remoteChecksum << "\"");
+        if (!localChecksum.empty() && localChecksum == remoteChecksum) {
+            LOGW_SYNCPAL_DEBUG(_logger, L"Checksums match, skipping upload: "
+                                                << Utility::formatSyncPath(absoluteLocalFilePath));
+            return ExitCode::Ok;
+        }
 
         uint64_t filesize;
         if (ExitInfo exitInfo = getFileSize(absoluteLocalFilePath, filesize); !exitInfo) {

--- a/test/libcommon/io/testgetfilechecksum.cpp
+++ b/test/libcommon/io/testgetfilechecksum.cpp
@@ -26,6 +26,8 @@ using namespace CppUnit;
 namespace KDC {
 
 void TestIo::testGetFileChecksum() {
+    constexpr std::string_view hash1 = "xxh3:5dcc477e35136516";
+    constexpr std::string_view hash2 = "xxh3:91f9d1732ca53515";
     // A regular file
     {
         const SyncPath path = _localTestDirPath / "test_pictures/picture-1.jpg";
@@ -34,7 +36,7 @@ void TestIo::testGetFileChecksum() {
         const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
         CPPUNIT_ASSERT(!checksum.empty());
-        CPPUNIT_ASSERT_EQUAL(std::string("5dcc477e35136516"), checksum);
+        CPPUNIT_ASSERT_EQUAL(std::string(hash1), checksum);
     }
 
     // A regular file whose name exists with a different capitalization
@@ -46,7 +48,7 @@ void TestIo::testGetFileChecksum() {
 #if defined(KD_MACOS) || defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
         CPPUNIT_ASSERT(!checksum.empty());
-        CPPUNIT_ASSERT_EQUAL(std::string("5dcc477e35136516"), checksum);
+        CPPUNIT_ASSERT_EQUAL(std::string(hash1), checksum);
 #else
         CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
         CPPUNIT_ASSERT(checksum.empty());
@@ -129,7 +131,7 @@ void TestIo::testGetFileChecksum() {
         const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
         CPPUNIT_ASSERT(!checksum.empty());
-        CPPUNIT_ASSERT_EQUAL(std::string("91f9d1732ca53515"), checksum);
+        CPPUNIT_ASSERT_EQUAL(std::string(hash2), checksum);
     }
 
     // A file with dots and colons in its name
@@ -148,7 +150,7 @@ void TestIo::testGetFileChecksum() {
         CPPUNIT_ASSERT(checksum.empty());
 #else
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
-        CPPUNIT_ASSERT_EQUAL(std::string("91f9d1732ca53515"), checksum);
+        CPPUNIT_ASSERT_EQUAL(std::string(hash2), checksum);
 #endif
     }
 
@@ -165,7 +167,7 @@ void TestIo::testGetFileChecksum() {
         const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
         CPPUNIT_ASSERT(!checksum.empty());
-        CPPUNIT_ASSERT_EQUAL(std::string("91f9d1732ca53515"), checksum);
+        CPPUNIT_ASSERT_EQUAL(std::string(hash2), checksum);
     }
 
     // A dangling symbolic link
@@ -238,7 +240,7 @@ void TestIo::testGetFileChecksum() {
 #if defined(KD_WINDOWS)
             CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
             CPPUNIT_ASSERT(!checksum.empty());
-            CPPUNIT_ASSERT_EQUAL(std::string("91f9d1732ca53515"), checksum);
+            CPPUNIT_ASSERT_EQUAL(std::string(hash2), checksum);
 #else
             CPPUNIT_ASSERT_EQUAL(IoError::AccessDenied, ioError);
             CPPUNIT_ASSERT(checksum.empty());
@@ -251,7 +253,7 @@ void TestIo::testGetFileChecksum() {
             const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
             CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
             CPPUNIT_ASSERT(!checksum.empty());
-            CPPUNIT_ASSERT_EQUAL(std::string("91f9d1732ca53515"), checksum);
+            CPPUNIT_ASSERT_EQUAL(std::string(hash2), checksum);
         }
     }
 
@@ -272,7 +274,7 @@ void TestIo::testGetFileChecksum() {
             const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
             CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
             CPPUNIT_ASSERT(!checksum.empty());
-            CPPUNIT_ASSERT_EQUAL(std::string("91f9d1732ca53515"), checksum);
+            CPPUNIT_ASSERT_EQUAL(std::string(hash2), checksum);
         }
         // Restore permission to allow subdir removal
         std::filesystem::permissions(subdir, std::filesystem::perms::owner_read, std::filesystem::perm_options::add);
@@ -282,7 +284,7 @@ void TestIo::testGetFileChecksum() {
             const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
             CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
             CPPUNIT_ASSERT(!checksum.empty());
-            CPPUNIT_ASSERT_EQUAL(std::string("91f9d1732ca53515"), checksum);
+            CPPUNIT_ASSERT_EQUAL(std::string(hash2), checksum);
         }
     }
 
@@ -307,7 +309,7 @@ void TestIo::testGetFileChecksum() {
 #if defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
         CPPUNIT_ASSERT(!checksum.empty());
-        CPPUNIT_ASSERT_EQUAL(std::string("91f9d1732ca53515"), checksum);
+        CPPUNIT_ASSERT_EQUAL(std::string(hash2), checksum);
 #else
         CPPUNIT_ASSERT_EQUAL(IoError::AccessDenied, ioError);
         CPPUNIT_ASSERT(checksum.empty());

--- a/test/libcommon/io/testgetfilechecksum.cpp
+++ b/test/libcommon/io/testgetfilechecksum.cpp
@@ -30,8 +30,8 @@ void TestIo::testGetFileChecksum() {
     {
         const SyncPath path = _localTestDirPath / "test_pictures/picture-1.jpg";
         std::ifstream ifs;
-        IoError ioError = IoError::Success;
-        const std::string checksum = IoHelper::getFileChecksum(path, ifs, ioError);
+        std::string checksum;
+        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
         CPPUNIT_ASSERT(!checksum.empty());
         CPPUNIT_ASSERT_EQUAL(std::string("5dcc477e35136516"), checksum);
@@ -41,8 +41,8 @@ void TestIo::testGetFileChecksum() {
     {
         const SyncPath path = _localTestDirPath / "test_pictures/Picture-1.jpg";
         std::ifstream ifs;
-        IoError ioError = IoError::Success;
-        const std::string checksum = IoHelper::getFileChecksum(path, ifs, ioError);
+        std::string checksum;
+        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
 #if defined(KD_MACOS) || defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
         CPPUNIT_ASSERT(!checksum.empty());
@@ -60,8 +60,8 @@ void TestIo::testGetFileChecksum() {
         const SyncPath path = temporaryDirectory.path() / "regular_file_symbolic_link";
         std::filesystem::create_symlink(targetPath, path);
         std::ifstream ifs;
-        IoError ioError = IoError::Success;
-        const std::string checksum = IoHelper::getFileChecksum(path, ifs, ioError);
+        std::string checksum;
+        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
         CPPUNIT_ASSERT_EQUAL(IoError::InvalidArgument, ioError);
         CPPUNIT_ASSERT(checksum.empty());
     }
@@ -70,8 +70,8 @@ void TestIo::testGetFileChecksum() {
     {
         const SyncPath path = _localTestDirPath / "non-existing.jpg"; // This file does not exist.
         std::ifstream ifs;
-        IoError ioError = IoError::Success;
-        const std::string checksum = IoHelper::getFileChecksum(path, ifs, ioError);
+        std::string checksum;
+        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
         CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
         CPPUNIT_ASSERT(checksum.empty());
     }
@@ -81,8 +81,8 @@ void TestIo::testGetFileChecksum() {
         const std::string veryLongfileName(1000, 'a'); // Exceeds the max allowed name length on every file system of interest.
         const SyncPath path = _localTestDirPath / veryLongfileName; // This file doesn't exist.
         std::ifstream ifs;
-        IoError ioError = IoError::Success;
-        const std::string checksum = IoHelper::getFileChecksum(path, ifs, ioError);
+        std::string checksum;
+        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
         CPPUNIT_ASSERT(checksum.empty());
 #if defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
@@ -99,8 +99,8 @@ void TestIo::testGetFileChecksum() {
             path /= pathSegment; // Eventually exceeds the max allowed path length on every file system of interest.
         }
         std::ifstream ifs;
-        IoError ioError = IoError::Success;
-        const std::string checksum = IoHelper::getFileChecksum(path, ifs, ioError);
+        std::string checksum;
+        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
         CPPUNIT_ASSERT(checksum.empty());
 #if defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
@@ -125,8 +125,8 @@ void TestIo::testGetFileChecksum() {
         IoHelper::setFileHidden(path, true);
 #endif
         std::ifstream ifs;
-        IoError ioError = IoError::Success;
-        const std::string checksum = IoHelper::getFileChecksum(path, ifs, ioError);
+        std::string checksum;
+        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
         CPPUNIT_ASSERT(!checksum.empty());
         CPPUNIT_ASSERT_EQUAL(std::string("91f9d1732ca53515"), checksum);
@@ -141,8 +141,8 @@ void TestIo::testGetFileChecksum() {
             ofs << "Some content.";
         }
         std::ifstream ifs;
-        IoError ioError = IoError::Success;
-        const std::string checksum = IoHelper::getFileChecksum(path, ifs, ioError);
+        std::string checksum;
+        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
 #if defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
         CPPUNIT_ASSERT(checksum.empty());
@@ -161,8 +161,8 @@ void TestIo::testGetFileChecksum() {
             ofs << "Some content.";
         }
         std::ifstream ifs;
-        IoError ioError = IoError::Success;
-        const std::string checksum = IoHelper::getFileChecksum(path, ifs, ioError);
+        std::string checksum;
+        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
         CPPUNIT_ASSERT(!checksum.empty());
         CPPUNIT_ASSERT_EQUAL(std::string("91f9d1732ca53515"), checksum);
@@ -175,8 +175,8 @@ void TestIo::testGetFileChecksum() {
         const SyncPath path = temporaryDirectory.path() / "dangling_symbolic_link";
         std::filesystem::create_symlink(targetPath, path);
         std::ifstream ifs;
-        IoError ioError = IoError::Success;
-        const std::string checksum = IoHelper::getFileChecksum(path, ifs, ioError);
+        std::string checksum;
+        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
         CPPUNIT_ASSERT_EQUAL(IoError::InvalidArgument, ioError);
         CPPUNIT_ASSERT(checksum.empty());
     }
@@ -192,8 +192,8 @@ void TestIo::testGetFileChecksum() {
         CPPUNIT_ASSERT(IoHelper::createAliasFromPath(targetPath, path, aliasError));
         CPPUNIT_ASSERT_EQUAL(Success, aliasError);
         std::ifstream ifs;
-        IoError ioError = IoError::Success;
-        const std::string checksum = IoHelper::getFileChecksum(path, ifs, ioError);
+        std::string checksum;
+        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
         CPPUNIT_ASSERT_EQUAL(InvalidArgument, ioError);
         CPPUNIT_ASSERT(checksum.empty());
     }
@@ -215,8 +215,8 @@ void TestIo::testGetFileChecksum() {
         CPPUNIT_ASSERT(IoHelper::deleteItem(targetPath, deleteError));
         CPPUNIT_ASSERT_EQUAL(Success, deleteError);
         std::ifstream ifs;
-        IoError ioError = IoError::Success;
-        const std::string checksum = IoHelper::getFileChecksum(path, ifs, ioError);
+        std::string checksum;
+        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
         CPPUNIT_ASSERT_EQUAL(InvalidArgument, ioError);
         CPPUNIT_ASSERT(checksum.empty());
     }
@@ -233,8 +233,8 @@ void TestIo::testGetFileChecksum() {
         std::filesystem::permissions(path, std::filesystem::perms::all, std::filesystem::perm_options::remove);
         {
             std::ifstream ifs;
-            IoError ioError = IoError::Success;
-            const std::string checksum = IoHelper::getFileChecksum(path, ifs, ioError);
+            std::string checksum;
+            const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
 #if defined(KD_WINDOWS)
             CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
             CPPUNIT_ASSERT(!checksum.empty());
@@ -247,8 +247,8 @@ void TestIo::testGetFileChecksum() {
         std::filesystem::permissions(path, std::filesystem::perms::all, std::filesystem::perm_options::add);
         {
             std::ifstream ifs;
-            IoError ioError = IoError::Success;
-            const std::string checksum = IoHelper::getFileChecksum(path, ifs, ioError);
+            std::string checksum;
+            const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
             CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
             CPPUNIT_ASSERT(!checksum.empty());
             CPPUNIT_ASSERT_EQUAL(std::string("91f9d1732ca53515"), checksum);
@@ -268,8 +268,8 @@ void TestIo::testGetFileChecksum() {
         std::filesystem::permissions(subdir, std::filesystem::perms::owner_read, std::filesystem::perm_options::remove);
         {
             std::ifstream ifs;
-            IoError ioError = IoError::Success;
-            const std::string checksum = IoHelper::getFileChecksum(path, ifs, ioError);
+            std::string checksum;
+            const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
             CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
             CPPUNIT_ASSERT(!checksum.empty());
             CPPUNIT_ASSERT_EQUAL(std::string("91f9d1732ca53515"), checksum);
@@ -278,8 +278,8 @@ void TestIo::testGetFileChecksum() {
         std::filesystem::permissions(subdir, std::filesystem::perms::owner_read, std::filesystem::perm_options::add);
         {
             std::ifstream ifs;
-            IoError ioError = IoError::Success;
-            const std::string checksum = IoHelper::getFileChecksum(path, ifs, ioError);
+            std::string checksum;
+            const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
             CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
             CPPUNIT_ASSERT(!checksum.empty());
             CPPUNIT_ASSERT_EQUAL(std::string("91f9d1732ca53515"), checksum);
@@ -300,8 +300,8 @@ void TestIo::testGetFileChecksum() {
         }
         std::filesystem::permissions(subdir, std::filesystem::perms::owner_exec, std::filesystem::perm_options::remove);
         std::ifstream ifs;
-        IoError ioError = IoError::Success;
-        const std::string checksum = IoHelper::getFileChecksum(path, ifs, ioError);
+        std::string checksum;
+        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
         // Restore permission to allow subdir removal
         std::filesystem::permissions(subdir, std::filesystem::perms::owner_exec, std::filesystem::perm_options::add);
 #if defined(KD_WINDOWS)

--- a/test/libcommon/io/testgetfilechecksum.cpp
+++ b/test/libcommon/io/testgetfilechecksum.cpp
@@ -30,8 +30,8 @@ void TestIo::testGetFileChecksum() {
     {
         const SyncPath path = _localTestDirPath / "test_pictures/picture-1.jpg";
         std::ifstream ifs;
-        std::string checksum;
-        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
+        IoError ioError = IoError::Success;
+        const std::string checksum = IoHelper::getFileChecksum(path, ifs, ioError);
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
         CPPUNIT_ASSERT(!checksum.empty());
         CPPUNIT_ASSERT_EQUAL(std::string("5dcc477e35136516"), checksum);
@@ -41,8 +41,8 @@ void TestIo::testGetFileChecksum() {
     {
         const SyncPath path = _localTestDirPath / "test_pictures/Picture-1.jpg";
         std::ifstream ifs;
-        std::string checksum;
-        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
+        IoError ioError = IoError::Success;
+        const std::string checksum = IoHelper::getFileChecksum(path, ifs, ioError);
 #if defined(KD_MACOS) || defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
         CPPUNIT_ASSERT(!checksum.empty());
@@ -60,8 +60,8 @@ void TestIo::testGetFileChecksum() {
         const SyncPath path = temporaryDirectory.path() / "regular_file_symbolic_link";
         std::filesystem::create_symlink(targetPath, path);
         std::ifstream ifs;
-        std::string checksum;
-        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
+        IoError ioError = IoError::Success;
+        const std::string checksum = IoHelper::getFileChecksum(path, ifs, ioError);
         CPPUNIT_ASSERT_EQUAL(IoError::InvalidArgument, ioError);
         CPPUNIT_ASSERT(checksum.empty());
     }
@@ -70,8 +70,8 @@ void TestIo::testGetFileChecksum() {
     {
         const SyncPath path = _localTestDirPath / "non-existing.jpg"; // This file does not exist.
         std::ifstream ifs;
-        std::string checksum;
-        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
+        IoError ioError = IoError::Success;
+        const std::string checksum = IoHelper::getFileChecksum(path, ifs, ioError);
         CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
         CPPUNIT_ASSERT(checksum.empty());
     }
@@ -81,8 +81,8 @@ void TestIo::testGetFileChecksum() {
         const std::string veryLongfileName(1000, 'a'); // Exceeds the max allowed name length on every file system of interest.
         const SyncPath path = _localTestDirPath / veryLongfileName; // This file doesn't exist.
         std::ifstream ifs;
-        std::string checksum;
-        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
+        IoError ioError = IoError::Success;
+        const std::string checksum = IoHelper::getFileChecksum(path, ifs, ioError);
         CPPUNIT_ASSERT(checksum.empty());
 #if defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
@@ -99,8 +99,8 @@ void TestIo::testGetFileChecksum() {
             path /= pathSegment; // Eventually exceeds the max allowed path length on every file system of interest.
         }
         std::ifstream ifs;
-        std::string checksum;
-        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
+        IoError ioError = IoError::Success;
+        const std::string checksum = IoHelper::getFileChecksum(path, ifs, ioError);
         CPPUNIT_ASSERT(checksum.empty());
 #if defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
@@ -125,8 +125,8 @@ void TestIo::testGetFileChecksum() {
         IoHelper::setFileHidden(path, true);
 #endif
         std::ifstream ifs;
-        std::string checksum;
-        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
+        IoError ioError = IoError::Success;
+        const std::string checksum = IoHelper::getFileChecksum(path, ifs, ioError);
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
         CPPUNIT_ASSERT(!checksum.empty());
         CPPUNIT_ASSERT_EQUAL(std::string("91f9d1732ca53515"), checksum);
@@ -141,8 +141,8 @@ void TestIo::testGetFileChecksum() {
             ofs << "Some content.";
         }
         std::ifstream ifs;
-        std::string checksum;
-        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
+        IoError ioError = IoError::Success;
+        const std::string checksum = IoHelper::getFileChecksum(path, ifs, ioError);
 #if defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
         CPPUNIT_ASSERT(checksum.empty());
@@ -152,7 +152,7 @@ void TestIo::testGetFileChecksum() {
 #endif
     }
 
-    // An existing file with emojis in its name
+    // An existing file with emojis
     {
         const LocalTemporaryDirectory temporaryDirectory;
         const SyncPath path = temporaryDirectory.path() / makeFileNameWithEmojis();
@@ -161,8 +161,8 @@ void TestIo::testGetFileChecksum() {
             ofs << "Some content.";
         }
         std::ifstream ifs;
-        std::string checksum;
-        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
+        IoError ioError = IoError::Success;
+        const std::string checksum = IoHelper::getFileChecksum(path, ifs, ioError);
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
         CPPUNIT_ASSERT(!checksum.empty());
         CPPUNIT_ASSERT_EQUAL(std::string("91f9d1732ca53515"), checksum);
@@ -175,8 +175,8 @@ void TestIo::testGetFileChecksum() {
         const SyncPath path = temporaryDirectory.path() / "dangling_symbolic_link";
         std::filesystem::create_symlink(targetPath, path);
         std::ifstream ifs;
-        std::string checksum;
-        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
+        IoError ioError = IoError::Success;
+        const std::string checksum = IoHelper::getFileChecksum(path, ifs, ioError);
         CPPUNIT_ASSERT_EQUAL(IoError::InvalidArgument, ioError);
         CPPUNIT_ASSERT(checksum.empty());
     }
@@ -192,13 +192,13 @@ void TestIo::testGetFileChecksum() {
         CPPUNIT_ASSERT(IoHelper::createAliasFromPath(targetPath, path, aliasError));
         CPPUNIT_ASSERT_EQUAL(Success, aliasError);
         std::ifstream ifs;
-        std::string checksum;
-        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
+        IoError ioError = IoError::Success;
+        const std::string checksum = IoHelper::getFileChecksum(path, ifs, ioError);
         CPPUNIT_ASSERT_EQUAL(InvalidArgument, ioError);
         CPPUNIT_ASSERT(checksum.empty());
     }
 
-    // A dangling macOS Finder alias (target deleted): not computed, returns empty checksum.
+    // A dangling macOS Finder alias
     {
         using enum IoError;
         const LocalTemporaryDirectory temporaryDirectory;
@@ -215,8 +215,8 @@ void TestIo::testGetFileChecksum() {
         CPPUNIT_ASSERT(IoHelper::deleteItem(targetPath, deleteError));
         CPPUNIT_ASSERT_EQUAL(Success, deleteError);
         std::ifstream ifs;
-        std::string checksum;
-        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
+        IoError ioError = IoError::Success;
+        const std::string checksum = IoHelper::getFileChecksum(path, ifs, ioError);
         CPPUNIT_ASSERT_EQUAL(InvalidArgument, ioError);
         CPPUNIT_ASSERT(checksum.empty());
     }
@@ -233,8 +233,8 @@ void TestIo::testGetFileChecksum() {
         std::filesystem::permissions(path, std::filesystem::perms::all, std::filesystem::perm_options::remove);
         {
             std::ifstream ifs;
-            std::string checksum;
-            const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
+            IoError ioError = IoError::Success;
+            const std::string checksum = IoHelper::getFileChecksum(path, ifs, ioError);
 #if defined(KD_WINDOWS)
             CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
             CPPUNIT_ASSERT(!checksum.empty());
@@ -247,8 +247,8 @@ void TestIo::testGetFileChecksum() {
         std::filesystem::permissions(path, std::filesystem::perms::all, std::filesystem::perm_options::add);
         {
             std::ifstream ifs;
-            std::string checksum;
-            const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
+            IoError ioError = IoError::Success;
+            const std::string checksum = IoHelper::getFileChecksum(path, ifs, ioError);
             CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
             CPPUNIT_ASSERT(!checksum.empty());
             CPPUNIT_ASSERT_EQUAL(std::string("91f9d1732ca53515"), checksum);
@@ -268,8 +268,8 @@ void TestIo::testGetFileChecksum() {
         std::filesystem::permissions(subdir, std::filesystem::perms::owner_read, std::filesystem::perm_options::remove);
         {
             std::ifstream ifs;
-            std::string checksum;
-            const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
+            IoError ioError = IoError::Success;
+            const std::string checksum = IoHelper::getFileChecksum(path, ifs, ioError);
             CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
             CPPUNIT_ASSERT(!checksum.empty());
             CPPUNIT_ASSERT_EQUAL(std::string("91f9d1732ca53515"), checksum);
@@ -278,8 +278,8 @@ void TestIo::testGetFileChecksum() {
         std::filesystem::permissions(subdir, std::filesystem::perms::owner_read, std::filesystem::perm_options::add);
         {
             std::ifstream ifs;
-            std::string checksum;
-            const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
+            IoError ioError = IoError::Success;
+            const std::string checksum = IoHelper::getFileChecksum(path, ifs, ioError);
             CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
             CPPUNIT_ASSERT(!checksum.empty());
             CPPUNIT_ASSERT_EQUAL(std::string("91f9d1732ca53515"), checksum);
@@ -300,8 +300,8 @@ void TestIo::testGetFileChecksum() {
         }
         std::filesystem::permissions(subdir, std::filesystem::perms::owner_exec, std::filesystem::perm_options::remove);
         std::ifstream ifs;
-        std::string checksum;
-        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
+        IoError ioError = IoError::Success;
+        const std::string checksum = IoHelper::getFileChecksum(path, ifs, ioError);
         // Restore permission to allow subdir removal
         std::filesystem::permissions(subdir, std::filesystem::perms::owner_exec, std::filesystem::perm_options::add);
 #if defined(KD_WINDOWS)

--- a/test/libcommon/io/testgetfilechecksum.cpp
+++ b/test/libcommon/io/testgetfilechecksum.cpp
@@ -31,9 +31,8 @@ void TestIo::testGetFileChecksum() {
     // A regular file
     {
         const SyncPath path = _localTestDirPath / "test_pictures/picture-1.jpg";
-        std::ifstream ifs;
         std::string checksum;
-        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
+        const IoError ioError = IoHelper::getFileChecksum(path, checksum);
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
         CPPUNIT_ASSERT(!checksum.empty());
         CPPUNIT_ASSERT_EQUAL(std::string(hash1), checksum);
@@ -42,9 +41,8 @@ void TestIo::testGetFileChecksum() {
     // A regular file whose name exists with a different capitalization
     {
         const SyncPath path = _localTestDirPath / "test_pictures/Picture-1.jpg";
-        std::ifstream ifs;
         std::string checksum;
-        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
+        const IoError ioError = IoHelper::getFileChecksum(path, checksum);
 #if defined(KD_MACOS) || defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
         CPPUNIT_ASSERT(!checksum.empty());
@@ -61,9 +59,8 @@ void TestIo::testGetFileChecksum() {
         const LocalTemporaryDirectory temporaryDirectory;
         const SyncPath path = temporaryDirectory.path() / "regular_file_symbolic_link";
         std::filesystem::create_symlink(targetPath, path);
-        std::ifstream ifs;
         std::string checksum;
-        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
+        const IoError ioError = IoHelper::getFileChecksum(path, checksum);
         CPPUNIT_ASSERT_EQUAL(IoError::InvalidArgument, ioError);
         CPPUNIT_ASSERT(checksum.empty());
     }
@@ -71,9 +68,8 @@ void TestIo::testGetFileChecksum() {
     // A non-existing file
     {
         const SyncPath path = _localTestDirPath / "non-existing.jpg"; // This file does not exist.
-        std::ifstream ifs;
         std::string checksum;
-        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
+        const IoError ioError = IoHelper::getFileChecksum(path, checksum);
         CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
         CPPUNIT_ASSERT(checksum.empty());
     }
@@ -82,9 +78,8 @@ void TestIo::testGetFileChecksum() {
     {
         const std::string veryLongfileName(1000, 'a'); // Exceeds the max allowed name length on every file system of interest.
         const SyncPath path = _localTestDirPath / veryLongfileName; // This file doesn't exist.
-        std::ifstream ifs;
         std::string checksum;
-        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
+        const IoError ioError = IoHelper::getFileChecksum(path, checksum);
         CPPUNIT_ASSERT(checksum.empty());
 #if defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
@@ -100,9 +95,8 @@ void TestIo::testGetFileChecksum() {
         for (auto i = 0; i < 1000; ++i) {
             path /= pathSegment; // Eventually exceeds the max allowed path length on every file system of interest.
         }
-        std::ifstream ifs;
         std::string checksum;
-        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
+        const IoError ioError = IoHelper::getFileChecksum(path, checksum);
         CPPUNIT_ASSERT(checksum.empty());
 #if defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
@@ -126,9 +120,8 @@ void TestIo::testGetFileChecksum() {
 #if defined(KD_MACOS) || defined(KD_WINDOWS)
         IoHelper::setFileHidden(path, true);
 #endif
-        std::ifstream ifs;
         std::string checksum;
-        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
+        const IoError ioError = IoHelper::getFileChecksum(path, checksum);
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
         CPPUNIT_ASSERT(!checksum.empty());
         CPPUNIT_ASSERT_EQUAL(std::string(hash2), checksum);
@@ -142,9 +135,8 @@ void TestIo::testGetFileChecksum() {
             std::ofstream ofs(path);
             ofs << "Some content.";
         }
-        std::ifstream ifs;
         std::string checksum;
-        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
+        const IoError ioError = IoHelper::getFileChecksum(path, checksum);
 #if defined(KD_WINDOWS)
         CPPUNIT_ASSERT_EQUAL(IoError::NoSuchFileOrDirectory, ioError);
         CPPUNIT_ASSERT(checksum.empty());
@@ -162,9 +154,8 @@ void TestIo::testGetFileChecksum() {
             std::ofstream ofs(path);
             ofs << "Some content.";
         }
-        std::ifstream ifs;
         std::string checksum;
-        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
+        const IoError ioError = IoHelper::getFileChecksum(path, checksum);
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
         CPPUNIT_ASSERT(!checksum.empty());
         CPPUNIT_ASSERT_EQUAL(std::string(hash2), checksum);
@@ -176,9 +167,8 @@ void TestIo::testGetFileChecksum() {
         const SyncPath targetPath = temporaryDirectory.path() / "non_existing_test_file.txt"; // This file does not exist.
         const SyncPath path = temporaryDirectory.path() / "dangling_symbolic_link";
         std::filesystem::create_symlink(targetPath, path);
-        std::ifstream ifs;
         std::string checksum;
-        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
+        const IoError ioError = IoHelper::getFileChecksum(path, checksum);
         CPPUNIT_ASSERT_EQUAL(IoError::InvalidArgument, ioError);
         CPPUNIT_ASSERT(checksum.empty());
     }
@@ -193,9 +183,8 @@ void TestIo::testGetFileChecksum() {
         IoError aliasError = Unknown;
         CPPUNIT_ASSERT(IoHelper::createAliasFromPath(targetPath, path, aliasError));
         CPPUNIT_ASSERT_EQUAL(Success, aliasError);
-        std::ifstream ifs;
         std::string checksum;
-        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
+        const IoError ioError = IoHelper::getFileChecksum(path, checksum);
         CPPUNIT_ASSERT_EQUAL(InvalidArgument, ioError);
         CPPUNIT_ASSERT(checksum.empty());
     }
@@ -216,9 +205,8 @@ void TestIo::testGetFileChecksum() {
         IoError deleteError = Unknown;
         CPPUNIT_ASSERT(IoHelper::deleteItem(targetPath, deleteError));
         CPPUNIT_ASSERT_EQUAL(Success, deleteError);
-        std::ifstream ifs;
         std::string checksum;
-        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
+        const IoError ioError = IoHelper::getFileChecksum(path, checksum);
         CPPUNIT_ASSERT_EQUAL(InvalidArgument, ioError);
         CPPUNIT_ASSERT(checksum.empty());
     }
@@ -234,9 +222,8 @@ void TestIo::testGetFileChecksum() {
         }
         std::filesystem::permissions(path, std::filesystem::perms::all, std::filesystem::perm_options::remove);
         {
-            std::ifstream ifs;
             std::string checksum;
-            const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
+            const IoError ioError = IoHelper::getFileChecksum(path, checksum);
 #if defined(KD_WINDOWS)
             CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
             CPPUNIT_ASSERT(!checksum.empty());
@@ -248,9 +235,8 @@ void TestIo::testGetFileChecksum() {
         }
         std::filesystem::permissions(path, std::filesystem::perms::all, std::filesystem::perm_options::add);
         {
-            std::ifstream ifs;
             std::string checksum;
-            const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
+            const IoError ioError = IoHelper::getFileChecksum(path, checksum);
             CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
             CPPUNIT_ASSERT(!checksum.empty());
             CPPUNIT_ASSERT_EQUAL(std::string(hash2), checksum);
@@ -269,9 +255,8 @@ void TestIo::testGetFileChecksum() {
         }
         std::filesystem::permissions(subdir, std::filesystem::perms::owner_read, std::filesystem::perm_options::remove);
         {
-            std::ifstream ifs;
             std::string checksum;
-            const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
+            const IoError ioError = IoHelper::getFileChecksum(path, checksum);
             CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
             CPPUNIT_ASSERT(!checksum.empty());
             CPPUNIT_ASSERT_EQUAL(std::string(hash2), checksum);
@@ -279,9 +264,8 @@ void TestIo::testGetFileChecksum() {
         // Restore permission to allow subdir removal
         std::filesystem::permissions(subdir, std::filesystem::perms::owner_read, std::filesystem::perm_options::add);
         {
-            std::ifstream ifs;
             std::string checksum;
-            const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
+            const IoError ioError = IoHelper::getFileChecksum(path, checksum);
             CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
             CPPUNIT_ASSERT(!checksum.empty());
             CPPUNIT_ASSERT_EQUAL(std::string(hash2), checksum);
@@ -301,9 +285,8 @@ void TestIo::testGetFileChecksum() {
             ofs << "Some content.";
         }
         std::filesystem::permissions(subdir, std::filesystem::perms::owner_exec, std::filesystem::perm_options::remove);
-        std::ifstream ifs;
         std::string checksum;
-        const IoError ioError = IoHelper::getFileChecksum(path, ifs, checksum);
+        const IoError ioError = IoHelper::getFileChecksum(path, checksum);
         // Restore permission to allow subdir removal
         std::filesystem::permissions(subdir, std::filesystem::perms::owner_exec, std::filesystem::perm_options::add);
 #if defined(KD_WINDOWS)

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -973,13 +973,13 @@ void TestNetworkJobs::testCheckHashMatch() {
 
     FileStat validFileStat;
     IoError ioError = IoError::Success;
-    IoHelper::getFileStat(validLocalFile, &validFileStat, ioError, IoHelper::PathCheckOption::Insensitive);
+    CPPUNIT_ASSERT(IoHelper::getFileStat(validLocalFile, &validFileStat, ioError, IoHelper::PathCheckOption::Insensitive));
     CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
     const int64_t validSize = validFileStat.size;
 
     // Create a tampered copy (wrong local content, same remote node)
     const SyncPath tamperedLocalFile = tmpDir.path() / "picture-1-tampered.jpg";
-    std::filesystem::copy_file(validLocalFile, tamperedLocalFile);
+    CPPUNIT_ASSERT(std::filesystem::copy_file(validLocalFile, tamperedLocalFile));
     {
         std::ofstream ofs(tamperedLocalFile, std::ios::binary | std::ios::app);
         ofs << "corrupted";

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -959,7 +959,7 @@ void TestNetworkJobs::testGetFileList() {
     }
 }
 
-void TestNetworkJobs::testGetFileHashMatch() {
+void TestNetworkJobs::testCheckHashMatch() {
     // Download picture-1.jpg once to use as a valid local reference file
     const LocalTemporaryDirectory tmpDir("testGetFileHashMatch");
     const SyncPath validLocalFile = tmpDir.path() / "picture-1.jpg";

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -1026,7 +1026,7 @@ void TestNetworkJobs::testCheckHashMatch() {
     };
 
     for (const auto &tc: testCases) {
-        CheckHashMatchJob job(_driveDbId, tc.localFile, tc.remoteNodeId, tc.localSize, tc.remoteSize);
+        CheckHashMatchJob job(_driveDbId, tc.localFile, tc.remoteNodeId, tc.remoteSize);
         job.runSynchronously();
         CPPUNIT_ASSERT_EQUAL_MESSAGE(tc.name + ": unexpected exit code", tc.expectedExitCode, job.exitInfo().code());
         CPPUNIT_ASSERT_EQUAL_MESSAGE(tc.name + ": unexpected shouldDownload", tc.expectedShouldDownload, job.shouldDownload());

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -38,6 +38,7 @@
 #include "jobs/network/infomaniak_API/getappversionjob.h"
 #include "jobs/network/directdownloadjob.h"
 #include "jobs/network/kDrive_API/createdirjob.h"
+#include "jobs/network/kDrive_API/checkhashmatchjob.h"
 #include "jobs/network/kDrive_API/itemsexistjob.h"
 #include "jobs/network/kDrive_API/searchjob.h"
 #include "jobs/network/kDrive_API/listing/csvfullfilelistwithcursorjob.h"
@@ -955,6 +956,79 @@ void TestNetworkJobs::testGetFileList() {
                 CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(1), dataArray->size());
             }
         }
+    }
+}
+
+void TestNetworkJobs::testGetFileHashMatch() {
+    // Download picture-1.jpg once to use as a valid local reference file
+    const LocalTemporaryDirectory tmpDir("testGetFileHashMatch");
+    const SyncPath validLocalFile = tmpDir.path() / "picture-1.jpg";
+    {
+        DownloadJob downloadJob(nullptr, _cacheDirectory,
+                                DownloadJob::FileDownloadInfo{_driveDbId, picture1RemoteId, validLocalFile, 0, 0, 0, false},
+                                DownloadJob::DateTimePolicy::ApplyDateTime);
+        CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, downloadJob.runSynchronously().code());
+    }
+    CPPUNIT_ASSERT(std::filesystem::exists(validLocalFile));
+
+    FileStat validFileStat;
+    IoError ioError = IoError::Success;
+    IoHelper::getFileStat(validLocalFile, &validFileStat, ioError, IoHelper::PathCheckOption::Insensitive);
+    CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+    const int64_t validSize = validFileStat.size;
+
+    // Create a tampered copy (wrong local content, same remote node)
+    const SyncPath tamperedLocalFile = tmpDir.path() / "picture-1-tampered.jpg";
+    std::filesystem::copy_file(validLocalFile, tamperedLocalFile);
+    {
+        std::ofstream ofs(tamperedLocalFile, std::ios::binary | std::ios::app);
+        ofs << "corrupted";
+    }
+
+    // Create a dummy file that has the same size as the valid file (to bypass size check but fail hash)
+    const SyncPath sameSizeDifferentContentFile = tmpDir.path() / "picture-1-same-size.jpg";
+    {
+        std::ofstream ofs(sameSizeDifferentContentFile, std::ios::binary);
+        ofs << std::string(static_cast<size_t>(validSize), 'X');
+    }
+
+    // Create an empty file (wrong size → should skip API call and trigger download)
+    const SyncPath emptyLocalFile = tmpDir.path() / "picture-1-empty.jpg";
+    std::ofstream(emptyLocalFile).close();
+
+    struct TestCase {
+            std::string name;
+            SyncPath localFile;
+            NodeId remoteNodeId;
+            int64_t localSize;
+            int64_t remoteSize;
+            bool expectedShouldDownload;
+            ExitCode expectedExitCode;
+    };
+
+    const std::vector<TestCase> testCases = {
+            // Both hash and size match → file is in sync
+            {"MatchingHashAndSize", validLocalFile, picture1RemoteId, validSize, validSize, false, ExitCode::Ok},
+
+            // Local file is corrupted but size is provided as matching → hash mismatch detected
+            {"LocalFileTampered_SizeForcedMatch", tamperedLocalFile, picture1RemoteId, validSize, validSize, true, ExitCode::Ok},
+
+            // Wrong remote node ID → API returns a different hash → mismatch
+            {"WrongRemoteNodeId", validLocalFile, testFileRemoteId, validSize, validSize, true, ExitCode::Ok},
+
+            // Sizes differ → job aborts immediately, no API call, shouldDownload stays true
+            {"SizeMismatch_EmptyLocal", emptyLocalFile, picture1RemoteId, 0, validSize, true, ExitCode::Ok},
+
+            // Same size, different content → passes size check, hash mismatch detected
+            {"SameSizeDifferentContent", sameSizeDifferentContentFile, picture1RemoteId, validSize, validSize, true,
+             ExitCode::Ok},
+    };
+
+    for (const auto &tc: testCases) {
+        CheckHashMatchJob job(_driveDbId, tc.localFile, tc.remoteNodeId, tc.localSize, tc.remoteSize);
+        job.runSynchronously();
+        CPPUNIT_ASSERT_EQUAL_MESSAGE(tc.name + ": unexpected exit code", tc.expectedExitCode, job.exitInfo().code());
+        CPPUNIT_ASSERT_EQUAL_MESSAGE(tc.name + ": unexpected shouldDownload", tc.expectedShouldDownload, job.shouldDownload());
     }
 }
 

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -967,7 +967,8 @@ void TestNetworkJobs::testCheckHashMatch() {
         DownloadJob downloadJob(nullptr, _cacheDirectory,
                                 DownloadJob::FileDownloadInfo{_driveDbId, picture1RemoteId, validLocalFile, 0, 0, 0, false},
                                 DownloadJob::DateTimePolicy::ApplyDateTime);
-        CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, downloadJob.runSynchronously().code());
+        const ExitInfo exitInfo = downloadJob.runSynchronously();
+        CPPUNIT_ASSERT_MESSAGE(toString(exitInfo), exitInfo);
     }
     CPPUNIT_ASSERT(std::filesystem::exists(validLocalFile));
 

--- a/test/libsyncengine/jobs/network/testnetworkjobs.h
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.h
@@ -43,6 +43,7 @@ class TestNetworkJobs : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST(testGetFileInfo);
         CPPUNIT_TEST(testGetFileList);
         CPPUNIT_TEST(testCheckHashMatch);
+        CPPUNIT_TEST(testGetFileListWithCursor);
         CPPUNIT_TEST(testFullFileListWithCursorCsv);
         CPPUNIT_TEST(testFullFileListWithCursorCsvZip);
         CPPUNIT_TEST(testFullFileListWithCursorCsvBlacklist);

--- a/test/libsyncengine/jobs/network/testnetworkjobs.h
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.h
@@ -42,7 +42,7 @@ class TestNetworkJobs : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST(testGetDriveList);
         CPPUNIT_TEST(testGetFileInfo);
         CPPUNIT_TEST(testGetFileList);
-        CPPUNIT_TEST(testGetFileHashMatch);
+        CPPUNIT_TEST(testCheckHashMatch);
         CPPUNIT_TEST(testFullFileListWithCursorCsv);
         CPPUNIT_TEST(testFullFileListWithCursorCsvZip);
         CPPUNIT_TEST(testFullFileListWithCursorCsvBlacklist);
@@ -87,7 +87,7 @@ class TestNetworkJobs : public CppUnit::TestFixture, public TestBase {
         void testGetDriveList();
         void testGetFileInfo();
         void testGetFileList();
-        void testGetFileHashMatch();
+        void testCheckHashMatch();
         void testGetFileListWithCursor();
         void testFullFileListWithCursorCsv();
         void testFullFileListWithCursorCsvZip();

--- a/test/libsyncengine/jobs/network/testnetworkjobs.h
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.h
@@ -42,7 +42,7 @@ class TestNetworkJobs : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST(testGetDriveList);
         CPPUNIT_TEST(testGetFileInfo);
         CPPUNIT_TEST(testGetFileList);
-        CPPUNIT_TEST(testGetFileListWithCursor);
+        CPPUNIT_TEST(testGetFileHashMatch);
         CPPUNIT_TEST(testFullFileListWithCursorCsv);
         CPPUNIT_TEST(testFullFileListWithCursorCsvZip);
         CPPUNIT_TEST(testFullFileListWithCursorCsvBlacklist);
@@ -87,6 +87,7 @@ class TestNetworkJobs : public CppUnit::TestFixture, public TestBase {
         void testGetDriveList();
         void testGetFileInfo();
         void testGetFileList();
+        void testGetFileHashMatch();
         void testGetFileListWithCursor();
         void testFullFileListWithCursorCsv();
         void testFullFileListWithCursorCsvZip();


### PR DESCRIPTION
This pull request introduces a new job for verifying file integrity between local and remote files in the kDrive API, along with comprehensive unit tests to ensure its correctness. The main focus is on adding the `CheckHashMatchJob` class, which compares file hashes and sizes to determine if a download is necessary.

**New file integrity checking job:**

* Added the `CheckHashMatchJob` class in `jobs/network/kDrive_API/checkhashmatchjob.h` and its implementation in `checkhashmatchjob.cpp`. This job compares the local and remote file hashes (using the xxh3 algorithm) and file sizes to decide if the file should be downloaded. It also handles the API request/response for retrieving the remote hash. [[1]](diffhunk://#diff-f0df3dba286f0b2426ee319f60fc0b9a8904980ef761db5ad0b715b6045dde2bR1-R52) [[2]](diffhunk://#diff-70ec71f86a41cad2be15ebadd9a5683169ff5e10b69c5e7e51e233a122346711R1-R76)
* Registered the new job source file in the build system by updating `src/libsyncengine/CMakeLists.txt`.
* Added the `hashKey` constant to `networkjobsparams.h` for parsing the remote hash from API responses.

**Testing enhancements:**

* Introduced a comprehensive unit test `testCheckHashMatch` in `testnetworkjobs.cpp` to cover various scenarios (matching files, tampered files, size mismatches, and hash mismatches).
* Registered the new test in the test suite (`testnetworkjobs.h` and `testnetworkjobs.cpp`). [[1]](diffhunk://#diff-7cb4981dbd48c6446082f1f1058fe4f92be59b6f6ef5d9dfe5dda249e0618330R45) [[2]](diffhunk://#diff-7cb4981dbd48c6446082f1f1058fe4f92be59b6f6ef5d9dfe5dda249e0618330R91) [[3]](diffhunk://#diff-a44011b4b2142730cdb600b754fc9df3f32479959030cd13cf167fda5bfc52ebR41)

These changes improve the reliability of file synchronization by ensuring that files are only downloaded when necessary, based on both size and hash comparisons.