### PR TITLE
feat(navigation): add scroll position restoration

### DIFF
--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Errors/ErrorPage.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Errors/ErrorPage.xaml
@@ -121,7 +121,8 @@
         </Grid>
 
         <!-- Error view -->
-        <ScrollView Grid.Row="1"
+        <ScrollView x:Name="ErrorScrollView"
+                    Grid.Row="1"
                     Padding="0"
                     Margin="0"
                     Visibility="{x:Bind _errorPageVM.HasError, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}">

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Errors/ErrorPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Errors/ErrorPage.xaml.cs
@@ -18,6 +18,7 @@
 using Infomaniak.kDrive.Analytics;
 using Infomaniak.kDrive.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
 using System;
@@ -31,23 +32,47 @@ namespace Infomaniak.kDrive.Pages.Errors
         private readonly AppModel _viewModel = App.ServiceProvider.GetRequiredService<AppModel>();
         public AppModel ViewModel { get { return _viewModel; } }
         private ErrorPageVM? _errorPageVM;
+        private NavigationParameter _navigationParameter = NavigationParameter.Default;
+        static private double _lastVerticalOffset = 0;
+        public enum NavigationParameter
+        {
+            Default,
+            LastVerticalOffset
+        }
+
         public ErrorPage()
         {
             Logger.Log(Logger.Level.Info, "Navigated to ErrorPage - Initializing ErrorPage components");
             InitializeComponent();
             Logger.Log(Logger.Level.Debug, "ErrorPage components initialized");
+            Loaded += ErrorPage_Loaded;
+        }
+
+        private void ErrorPage_Loaded(object sender, RoutedEventArgs e)
+        {
+            if (_navigationParameter == NavigationParameter.LastVerticalOffset)
+            {
+                ErrorScrollView.ScrollTo(0, _lastVerticalOffset, new ScrollingScrollOptions(ScrollingAnimationMode.Disabled, ScrollingSnapPointsMode.Ignore));
+            }
         }
 
         protected override async void OnNavigatedTo(NavigationEventArgs e)
         {
             _errorPageVM = new ErrorPageVM();
             _analyticsService.TrackPageView(Analytics.Keys.Category.ErrorPage);
+            if (e.NavigationMode != NavigationMode.New)
+            {
+                _navigationParameter = NavigationParameter.LastVerticalOffset;
+            }
         }
 
         protected override void OnNavigatedFrom(NavigationEventArgs e)
         {
             if (_errorPageVM is not null)
                 _errorPageVM.Dispose();
+
+            _lastVerticalOffset = ErrorScrollView.VerticalOffset;
+
         }
 
         private void BreadcrumbActivity_Click(object sender, object e)

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/SettingsPage.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/SettingsPage.xaml
@@ -283,7 +283,8 @@
                             <DataTemplate x:DataType="viewmodel:User">
                                 <toolKit:SettingsExpander ItemsSource="{x:Bind AllDrives, Mode=OneWay}"
                                                           Expanded="UserSettingsExpander_Expanded"
-                                                          Loaded="UserSettingsExpander_Loaded">
+                                                          Loaded="UserSettingsExpander_Loaded"
+                                                          IsExpanded="True">
                                     <ProgressRing Height="6"
                                                   Width="Auto"
                                                   Visibility="{x:Bind DriveRefreshInProgress, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" />

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/SettingsPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/SettingsPage.xaml.cs
@@ -38,7 +38,7 @@ namespace Infomaniak.kDrive.Pages.Settings
         private readonly AppModel _viewModel = App.ServiceProvider.GetRequiredService<AppModel>();
         private const string _skipNextRefreshKey = "skipNextRefresh";
         private NavigationParameter? _navigationParameter;
-
+        static private double _lastVerticalOffset = 0;
 
         public AppModel ViewModel => _viewModel;
 
@@ -47,7 +47,8 @@ namespace Infomaniak.kDrive.Pages.Settings
             public enum SettingsTab
             {
                 Default,
-                Users
+                Users,
+                LastVerticalOffset
             }
 
             public SettingsTab Tab { get; set; }
@@ -72,6 +73,9 @@ namespace Infomaniak.kDrive.Pages.Settings
                 case NavigationParameter.SettingsTab.Users:
                     BringUserIntoView(_navigationParameter.Value.UserToShow);
                     break;
+                case NavigationParameter.SettingsTab.LastVerticalOffset:
+                    SettingsScrollView.ScrollTo(0, _lastVerticalOffset, new ScrollingScrollOptions(ScrollingAnimationMode.Disabled, ScrollingSnapPointsMode.Ignore));
+                    break;
                 default:
                     break;
             }
@@ -81,6 +85,16 @@ namespace Infomaniak.kDrive.Pages.Settings
         {
             _analyticsService.TrackPageView(Analytics.Keys.Category.SettingsPage);
             _navigationParameter = e.Parameter as NavigationParameter?;
+
+            if (e.NavigationMode != NavigationMode.New)
+            {
+                _navigationParameter = new NavigationParameter { Tab = NavigationParameter.SettingsTab.LastVerticalOffset };
+            }
+        }
+
+        protected override void OnNavigatedFrom(NavigationEventArgs e)
+        {
+            _lastVerticalOffset = SettingsScrollView.VerticalOffset;
         }
 
         private void BringUserIntoView(User? user)

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/SettingsPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/SettingsPage.xaml.cs
@@ -202,8 +202,6 @@ namespace Infomaniak.kDrive.Pages.Settings
                     Logger.Log(Logger.Level.Error, "Unable to find the SettingsExpander from sender.");
                     return;
                 }
-                senderExpander.Tag = _skipNextRefreshKey;
-                senderExpander.IsExpanded = true;
             }
             else
             {
@@ -213,13 +211,8 @@ namespace Infomaniak.kDrive.Pages.Settings
 
         private async void UserSettingsExpander_Expanded(object sender, EventArgs e)
         {
-            var control = sender as Control;
-            if (control?.Tag?.ToString() == _skipNextRefreshKey)
-            {
-                control.Tag = "";
+            if (!IsLoaded)
                 return;
-
-            }
 
             User? user = (sender as FrameworkElement)?.DataContext as User;
             if (user is null)


### PR DESCRIPTION
feat(navigation): add scroll position restoration

Added `ScrollView` in `ErrorPage` and `SettingsPage` to restore vertical scroll position on navigation. Introduced `NavigationParameter` enum for managing navigation states. Updated `OnNavigatedTo` and `OnNavigatedFrom` methods to handle scroll offset saving and restoration.