### PR TITLE
feat(log): persist Linux logs in XDG_STATE_HOME

### DIFF
--- a/src/libcommon/utility/utility.cpp
+++ b/src/libcommon/utility/utility.cpp
@@ -1,20 +1,18 @@
-/*
- * Infomaniak kDrive - Desktop
- * Copyright (C) 2023-2026 Infomaniak Network SA
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Infomaniak kDrive - Desktop
+// Copyright (C) 2023-2026 Infomaniak Network SA
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "utility.h"
 #include "utility_base.h"
@@ -1531,7 +1529,7 @@ ExitInfo CommonUtility::deviceTempDirectoryPath(SyncPath &directoryPath) noexcep
     return stdErrorToExitInfo(ec);
 }
 
-#if defined(KD_WINDOWS) || defined(KD_LINUX)
+#if defined(KD_WINDOWS)
 ExitInfo CommonUtility::logDirectoryPath(SyncPath &directoryPath) noexcept {
     // Generate directory path
     if (const auto exitInfo = deviceTempDirectoryPath(directoryPath); !exitInfo) {

--- a/src/libcommon/utility/utility.cpp
+++ b/src/libcommon/utility/utility.cpp
@@ -1529,21 +1529,6 @@ ExitInfo CommonUtility::deviceTempDirectoryPath(SyncPath &directoryPath) noexcep
     return stdErrorToExitInfo(ec);
 }
 
-#if defined(KD_WINDOWS)
-ExitInfo CommonUtility::logDirectoryPath(SyncPath &directoryPath) noexcept {
-    // Generate directory path
-    if (const auto exitInfo = deviceTempDirectoryPath(directoryPath); !exitInfo) {
-        return exitInfo;
-    }
-
-    static const std::string LOGDIR_SUFFIX = "-logdir/";
-    const SyncName logDirName = SyncName(Str2SyncName(APPLICATION_NAME)) + SyncName(Str2SyncName(LOGDIR_SUFFIX));
-    directoryPath /= logDirName;
-
-    return ExitCode::Ok;
-}
-#endif
-
 ExitInfo CommonUtility::stdErrorToExitInfo(const int64_t error) noexcept {
     switch (error) {
         case 0:

--- a/src/libcommon/utility/utility_linux.cpp
+++ b/src/libcommon/utility/utility_linux.cpp
@@ -184,10 +184,12 @@ std::string CommonUtility::fileSystemName(const SyncPath &targetPath) {
 }
 
 ExitInfo CommonUtility::logDirectoryPath(SyncPath &directoryPath) noexcept {
-    // XDG Base Directory Specification: use $XDG_STATE_HOME, fallback to ~/.local/state
+    // XDG Base Directory Specification: use $XDG_STATE_HOME if it is absolute,
+    // otherwise fallback to ~/.local/state
     const auto xdgStateHome = envVarValue("XDG_STATE_HOME");
-    if (!xdgStateHome.empty()) {
-        directoryPath = SyncPath(xdgStateHome);
+    const auto xdgStateHomePath = SyncPath(xdgStateHome);
+    if (!xdgStateHome.empty() && xdgStateHomePath.is_absolute()) {
+        directoryPath = xdgStateHomePath;
     } else {
         auto homeDir = envVarValue("HOME");
         if (homeDir.empty()) homeDir = getHomeDirFromPasswd();

--- a/src/libcommon/utility/utility_linux.cpp
+++ b/src/libcommon/utility/utility_linux.cpp
@@ -1,18 +1,20 @@
-// Infomaniak kDrive - Desktop
-// Copyright (C) 2023-2026 Infomaniak Network SA
-//
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #include "utility.h"
 
@@ -30,7 +32,12 @@
 
 namespace KDC {
 
-static std::string getHomeDirFromPasswd() {
+static std::string homeDirectory() {
+    auto homeDir = CommonUtility::envVarValue("HOME");
+    if (!homeDir.empty()) return homeDir;
+
+    // The "HOME" environment variable might not be set. In this case, fallback on a more robust method by using getpwuid_r. The
+    // "passwd" struct retrieved contains information such as username, user id, encrypted password or  home directory.
     struct passwd pwd;
     struct passwd *result = nullptr;
     auto bufsize = sysconf(_SC_GETPW_R_SIZE_MAX);
@@ -43,8 +50,7 @@ static std::string getHomeDirFromPasswd() {
 }
 
 SyncPath CommonUtility::getGenericAppSupportDir() {
-    auto homeDir = CommonUtility::envVarValue("HOME");
-    if (homeDir.empty()) homeDir = getHomeDirFromPasswd();
+    auto homeDir = homeDirectory();
     if (homeDir.empty()) return {};
 
     SyncPath homePath(homeDir);
@@ -191,8 +197,7 @@ ExitInfo CommonUtility::logDirectoryPath(SyncPath &directoryPath) noexcept {
     if (!xdgStateHome.empty() && xdgStateHomePath.is_absolute()) {
         directoryPath = xdgStateHomePath;
     } else {
-        auto homeDir = envVarValue("HOME");
-        if (homeDir.empty()) homeDir = getHomeDirFromPasswd();
+        auto homeDir = homeDirectory();
         if (homeDir.empty()) return {ExitCode::SystemError, ExitCause::NotFound};
         directoryPath = SyncPath(homeDir) / ".local" / "state";
     }
@@ -202,13 +207,13 @@ ExitInfo CommonUtility::logDirectoryPath(SyncPath &directoryPath) noexcept {
 
     std::error_code ec;
     const bool directoryPathExists = std::filesystem::exists(directoryPath, ec);
-    if (ec.value() != 0) {
+    if (ec) {
         return stdErrorToExitInfo(ec);
     }
 
     if (directoryPathExists) {
         if (!std::filesystem::is_directory(directoryPath, ec)) {
-            if (ec.value() != 0) {
+            if (ec) {
                 return stdErrorToExitInfo(ec);
             }
             return stdErrorToExitInfo(std::make_error_code(std::errc::not_a_directory));

--- a/src/libcommon/utility/utility_linux.cpp
+++ b/src/libcommon/utility/utility_linux.cpp
@@ -32,9 +32,8 @@
 
 namespace KDC {
 
-static std::string homeDirectory() {
-    auto homeDir = CommonUtility::envVarValue("HOME");
-    if (!homeDir.empty()) return homeDir;
+static std::string homeDirectoryStr() {
+    if (auto homeDir = CommonUtility::envVarValue("HOME"); !homeDir.empty()) return homeDir;
 
     // The "HOME" environment variable might not be set. In this case, fallback on a more robust method by using getpwuid_r. The
     // "passwd" struct retrieved contains information such as username, user id, encrypted password or  home directory.
@@ -50,7 +49,7 @@ static std::string homeDirectory() {
 }
 
 SyncPath CommonUtility::getGenericAppSupportDir() {
-    auto homeDir = homeDirectory();
+    const auto homeDir = homeDirectoryStr();
     if (homeDir.empty()) return {};
 
     SyncPath homePath(homeDir);
@@ -197,7 +196,7 @@ ExitInfo CommonUtility::logDirectoryPath(SyncPath &directoryPath) noexcept {
     if (!xdgStateHome.empty() && xdgStateHomePath.is_absolute()) {
         directoryPath = xdgStateHomePath;
     } else {
-        auto homeDir = homeDirectory();
+        const auto homeDir = homeDirectoryStr();
         if (homeDir.empty()) return {ExitCode::SystemError, ExitCause::NotFound};
         directoryPath = SyncPath(homeDir) / ".local" / "state";
     }

--- a/src/libcommon/utility/utility_linux.cpp
+++ b/src/libcommon/utility/utility_linux.cpp
@@ -33,10 +33,10 @@ namespace KDC {
 static std::string getHomeDirFromPasswd() {
     struct passwd pwd;
     struct passwd *result = nullptr;
-    long bufsize = sysconf(_SC_GETPW_R_SIZE_MAX);
+    auto bufsize = sysconf(_SC_GETPW_R_SIZE_MAX);
     if (bufsize == -1) bufsize = 16384;
-    std::vector<char> buf(static_cast<size_t>(bufsize));
-    if (getpwuid_r(getuid(), &pwd, buf.data(), buf.size(), &result) == 0 && result != nullptr) {
+    if (std::vector<char> buf(static_cast<size_t>(bufsize));
+        getpwuid_r(getuid(), &pwd, buf.data(), buf.size(), &result) == 0 && result != nullptr) {
         return std::string(result->pw_dir);
     }
     return {};

--- a/src/libcommon/utility/utility_linux.cpp
+++ b/src/libcommon/utility/utility_linux.cpp
@@ -18,6 +18,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <vector>
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/vfs.h>
@@ -29,13 +30,24 @@
 
 namespace KDC {
 
-SyncPath CommonUtility::getGenericAppSupportDir() {
-    const char *homeDir;
-    if ((homeDir = getenv("HOME")) == NULL) {
-        homeDir = getpwuid(getuid())->pw_dir;
+static std::string getHomeDirFromPasswd() {
+    struct passwd pwd;
+    struct passwd *result = nullptr;
+    long bufsize = sysconf(_SC_GETPW_R_SIZE_MAX);
+    if (bufsize == -1) bufsize = 16384;
+    std::vector<char> buf(static_cast<size_t>(bufsize));
+    if (getpwuid_r(getuid(), &pwd, buf.data(), buf.size(), &result) == 0 && result != nullptr) {
+        return std::string(result->pw_dir);
     }
-    SyncPath homePath(homeDir);
+    return {};
+}
 
+SyncPath CommonUtility::getGenericAppSupportDir() {
+    auto homeDir = CommonUtility::envVarValue("HOME");
+    if (homeDir.empty()) homeDir = getHomeDirFromPasswd();
+    if (homeDir.empty()) return {};
+
+    SyncPath homePath(homeDir);
     std::string appSupportName(".config");
     SyncPath appSupportPath(homePath / appSupportName);
 
@@ -173,17 +185,13 @@ std::string CommonUtility::fileSystemName(const SyncPath &targetPath) {
 
 ExitInfo CommonUtility::logDirectoryPath(SyncPath &directoryPath) noexcept {
     // XDG Base Directory Specification: use $XDG_STATE_HOME, fallback to ~/.local/state
-    const char *xdgStateHome = getenv("XDG_STATE_HOME");
-    if (xdgStateHome && *xdgStateHome != '\0') {
+    const auto xdgStateHome = envVarValue("XDG_STATE_HOME");
+    if (!xdgStateHome.empty()) {
         directoryPath = SyncPath(xdgStateHome);
     } else {
-        const char *homeDir = getenv("HOME");
-        if (!homeDir || *homeDir == '\0') {
-            homeDir = getpwuid(getuid())->pw_dir;
-        }
-        if (!homeDir || *homeDir == '\0') {
-            return {ExitCode::SystemError, ExitCause::NotFound};
-        }
+        auto homeDir = envVarValue("HOME");
+        if (homeDir.empty()) homeDir = getHomeDirFromPasswd();
+        if (homeDir.empty()) return {ExitCode::SystemError, ExitCause::NotFound};
         directoryPath = SyncPath(homeDir) / ".local" / "state";
     }
 
@@ -193,11 +201,11 @@ ExitInfo CommonUtility::logDirectoryPath(SyncPath &directoryPath) noexcept {
     std::error_code ec;
     if (!std::filesystem::exists(directoryPath, ec)) {
         if (ec.value() != 0) {
-            return CommonUtility::stdErrorToExitInfo(ec);
+            return stdErrorToExitInfo(ec);
         }
 
         if (!std::filesystem::create_directories(directoryPath, ec)) {
-            return CommonUtility::stdErrorToExitInfo(ec);
+            return stdErrorToExitInfo(ec);
         }
     }
 

--- a/src/libcommon/utility/utility_linux.cpp
+++ b/src/libcommon/utility/utility_linux.cpp
@@ -1,20 +1,18 @@
-/*
- * Infomaniak kDrive - Desktop
- * Copyright (C) 2023-2026 Infomaniak Network SA
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Infomaniak kDrive - Desktop
+// Copyright (C) 2023-2026 Infomaniak Network SA
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "utility.h"
 
@@ -26,6 +24,8 @@
 #include <pwd.h>
 
 #include "utility/types.h"
+
+#include <config.h>
 
 namespace KDC {
 
@@ -169,6 +169,39 @@ std::string CommonUtility::fileSystemName(const SyncPath &targetPath) {
     }
 
     return "UNIDENTIFIED";
+}
+
+ExitInfo CommonUtility::logDirectoryPath(SyncPath &directoryPath) noexcept {
+    // XDG Base Directory Specification: use $XDG_STATE_HOME, fallback to ~/.local/state
+    const char *xdgStateHome = getenv("XDG_STATE_HOME");
+    if (xdgStateHome && *xdgStateHome != '\0') {
+        directoryPath = SyncPath(xdgStateHome);
+    } else {
+        const char *homeDir = getenv("HOME");
+        if (!homeDir || *homeDir == '\0') {
+            homeDir = getpwuid(getuid())->pw_dir;
+        }
+        if (!homeDir || *homeDir == '\0') {
+            return {ExitCode::SystemError, ExitCause::NotFound};
+        }
+        directoryPath = SyncPath(homeDir) / ".local" / "state";
+    }
+
+    directoryPath /= Str2SyncName(APPLICATION_NAME);
+    directoryPath /= "logs";
+
+    std::error_code ec;
+    if (!std::filesystem::exists(directoryPath, ec)) {
+        if (ec.value() != 0) {
+            return CommonUtility::stdErrorToExitInfo(ec);
+        }
+
+        if (!std::filesystem::create_directories(directoryPath, ec)) {
+            return CommonUtility::stdErrorToExitInfo(ec);
+        }
+    }
+
+    return ExitCode::Ok;
 }
 
 } // namespace KDC

--- a/src/libcommon/utility/utility_linux.cpp
+++ b/src/libcommon/utility/utility_linux.cpp
@@ -201,14 +201,20 @@ ExitInfo CommonUtility::logDirectoryPath(SyncPath &directoryPath) noexcept {
     directoryPath /= "logs";
 
     std::error_code ec;
-    if (!std::filesystem::exists(directoryPath, ec)) {
-        if (ec.value() != 0) {
-            return stdErrorToExitInfo(ec);
-        }
+    const bool directoryPathExists = std::filesystem::exists(directoryPath, ec);
+    if (ec.value() != 0) {
+        return stdErrorToExitInfo(ec);
+    }
 
-        if (!std::filesystem::create_directories(directoryPath, ec)) {
-            return stdErrorToExitInfo(ec);
+    if (directoryPathExists) {
+        if (!std::filesystem::is_directory(directoryPath, ec)) {
+            if (ec.value() != 0) {
+                return stdErrorToExitInfo(ec);
+            }
+            return stdErrorToExitInfo(std::make_error_code(std::errc::not_a_directory));
         }
+    } else if (!std::filesystem::create_directories(directoryPath, ec)) {
+        return stdErrorToExitInfo(ec);
     }
 
     return ExitCode::Ok;

--- a/src/libcommon/utility/utility_win.cpp
+++ b/src/libcommon/utility/utility_win.cpp
@@ -1,20 +1,18 @@
-/*
- * Infomaniak kDrive - Desktop
- * Copyright (C) 2023-2026 Infomaniak Network SA
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Infomaniak kDrive - Desktop
+// Copyright (C) 2023-2026 Infomaniak Network SA
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "utility.h"
 #include "utility_base.h"
@@ -35,6 +33,7 @@
 #include <QSettings>
 #include <QVariant>
 #include <QCoreApplication>
+#include <config.h>
 #include <sentry.h>
 
 static const char systemRunPathC[] = "HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\Run";
@@ -186,6 +185,19 @@ std::string CommonUtility::fileSystemName(const SyncPath &targetPath) {
 
 
     return "UNIDENTIFIED";
+}
+
+ExitInfo CommonUtility::logDirectoryPath(SyncPath &directoryPath) noexcept {
+    // Generate directory path
+    if (const auto exitInfo = deviceTempDirectoryPath(directoryPath); !exitInfo) {
+        return exitInfo;
+    }
+
+    static const std::string LOGDIR_SUFFIX = "-logdir/";
+    const SyncName logDirName = SyncName(Str2SyncName(APPLICATION_NAME)) + SyncName(Str2SyncName(LOGDIR_SUFFIX));
+    directoryPath /= logDirName;
+
+    return ExitCode::Ok;
 }
 
 } // namespace KDC


### PR DESCRIPTION
## Summary
- Modified "CommonUtility::logDirectoryPath()" on Linux to store logs in a persistent location
- Follows the XDG Base Directory Specification
- Uses "$XDG_STATE_HOME/{app}/logs/" with fallback to "~/.local/state/{app}/logs/"
- Replaces the previous temporary directory approach where logs were lost after reboot

## Rationale
Log files should persist across system restarts. The previous implementation placed them under /tmp/, causing data loss on reboot. The new path is widely supported across all modern Linux distributions.

## Changes
- "src/libcommon/utility/utility_linux.cpp": new logDirectoryPath() implementation
- "src/libcommon/utility/utility.cpp": removed Linux from the shared logDirectoryPath() block since Linux now has its own implementation in the platform-specific file