### PR TITLE
refactor(onboarding): use generic Control type

### DIFF
--- a/src/gui4/windows/kDrive client/kDrive client/AppConstants.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/AppConstants.cs
@@ -85,7 +85,6 @@ namespace Infomaniak.kDrive
     }
     internal interface IkSuiteConstants
     {
-        public Uri HomeUri { get; }
         public Uri TarrifsUri { get; }
         public Uri HelpUri { get; }
     }
@@ -176,7 +175,6 @@ namespace Infomaniak.kDrive
 
     internal sealed class ProductionKSuite : IkSuiteConstants
     {
-        public Uri HomeUri { get; } = new Uri("https://www.infomaniak.com/fr/ksuite");
         public Uri TarrifsUri { get; } = new Uri("https://www.infomaniak.com/gtl/myksuite#prices");
         public Uri HelpUri { get; } = new Uri("https://www.infomaniak.com/gtl/support");
     }

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Onboarding/WelcomePage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Onboarding/WelcomePage.xaml.cs
@@ -58,7 +58,7 @@ namespace Infomaniak.kDrive.Pages.Onboarding
             {
                 control.IsEnabled = false;
 
-                await Windows.System.Launcher.LaunchUriAsync(App.Constants.kSuite.HomeUri);
+                await Localizer.Instance.TryLaunchUriAsync("kSuiteOfferUrl");
                 Logger.Log(Logger.Level.Debug, "Create account URL opened");
 
                 await Task.Delay(2000);

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Onboarding/WelcomePage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Onboarding/WelcomePage.xaml.cs
@@ -54,26 +54,26 @@ namespace Infomaniak.kDrive.Pages.Onboarding
         {
             Logger.Log(Logger.Level.Info, "Create account button clicked, opening sign up URL");
             _analyticsService.TrackClick(Analytics.Keys.Category.OnboardingWelcomePage, Analytics.Keys.EventName.OpenSignUpWeb);
-            if (sender is Button btn)
+            if (sender is Control control)
             {
-                btn.IsEnabled = false;
+                control.IsEnabled = false;
 
                 await Windows.System.Launcher.LaunchUriAsync(App.Constants.kSuite.HomeUri);
                 Logger.Log(Logger.Level.Debug, "Create account URL opened");
 
                 await Task.Delay(2000);
-                btn.IsEnabled = true;
+                control.IsEnabled = true;
             }
         }
         private void SigninButton_Click(object sender, RoutedEventArgs e)
         {
             Logger.Log(Logger.Level.Info, "Sign in button clicked, starting authentication process");
             _analyticsService.TrackClick(Analytics.Keys.Category.OnboardingWelcomePage, Analytics.Keys.EventName.OpenSignInWeb);
-            if (sender is Button btn)
+            if (sender is Control control)
             {
-                btn.IsEnabled = false;
+                control.IsEnabled = false;
                 Frame.Navigate(typeof(OAuthLoadingPage), _onBoardingViewModel);
-                btn.IsEnabled = true;
+                control.IsEnabled = true;
             }
         }
     }

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/da-DK/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/da-DK/Resources.resw
@@ -6,7 +6,7 @@
   Locale: da, Danish
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Tue, 19 May 2026 14:16:33 +0200 
+  Exported at: Wed, 27 May 2026 14:49:19 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -915,6 +915,9 @@ Synkronisering genoptages automatisk, når forbindelsen er genoprettet.</value>
   <data name="itemUnavailableBrowserFallback" xml:space="preserve"> 
     <value>Dette element er ikke tilgængeligt på denne enhed.
 Det åbnes i din browser.</value> 
+  </data> 
+  <data name="kSuiteOfferUrl" xml:space="preserve"> 
+    <value>https://www.infomaniak.com/en/ksuite</value> 
   </data> 
   <data name="labelAccessRightsModified" xml:space="preserve"> 
     <value>Adgangsrettigheder ændret</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/de-DE/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/de-DE/Resources.resw
@@ -6,7 +6,7 @@
   Locale: de, German
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Tue, 19 May 2026 14:16:33 +0200 
+  Exported at: Wed, 27 May 2026 14:49:19 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -915,6 +915,9 @@ Die Synchronisierung wird automatisch fortgesetzt, sobald die Verbindung wiederh
   <data name="itemUnavailableBrowserFallback" xml:space="preserve"> 
     <value>Dieses Element ist auf diesem Gerät nicht verfügbar.
 Es wird in Ihrem Browser geöffnet.</value> 
+  </data> 
+  <data name="kSuiteOfferUrl" xml:space="preserve"> 
+    <value>https://www.infomaniak.com/de/ksuite</value> 
   </data> 
   <data name="labelAccessRightsModified" xml:space="preserve"> 
     <value>Zugriffsrechte geändert</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/el-GR/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/el-GR/Resources.resw
@@ -6,7 +6,7 @@
   Locale: el, Greek
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Tue, 19 May 2026 14:16:33 +0200 
+  Exported at: Wed, 27 May 2026 14:49:19 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -915,6 +915,9 @@
   <data name="itemUnavailableBrowserFallback" xml:space="preserve"> 
     <value>Αυτό το στοιχείο δεν είναι διαθέσιμο σε αυτή τη συσκευή.
 Θα ανοίξει στο πρόγραμμα περιήγησής σας.</value> 
+  </data> 
+  <data name="kSuiteOfferUrl" xml:space="preserve"> 
+    <value>https://www.infomaniak.com/en/ksuite</value> 
   </data> 
   <data name="labelAccessRightsModified" xml:space="preserve"> 
     <value>Τα δικαιώματα πρόσβασης τροποποιήθηκαν</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/en-US/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/en-US/Resources.resw
@@ -6,7 +6,7 @@
   Locale: en, English
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Tue, 19 May 2026 14:16:32 +0200 
+  Exported at: Wed, 27 May 2026 14:49:19 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -915,6 +915,9 @@ Sync will resume automatically once the connection is restored.</value>
   <data name="itemUnavailableBrowserFallback" xml:space="preserve"> 
     <value>This item is not available on this device.
 It will open in your browser.</value> 
+  </data> 
+  <data name="kSuiteOfferUrl" xml:space="preserve"> 
+    <value>https://www.infomaniak.com/en/ksuite</value> 
   </data> 
   <data name="labelAccessRightsModified" xml:space="preserve"> 
     <value>Access rights modified</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/es-ES/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/es-ES/Resources.resw
@@ -6,7 +6,7 @@
   Locale: es, Spanish
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Tue, 19 May 2026 14:16:33 +0200 
+  Exported at: Wed, 27 May 2026 14:49:19 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -915,6 +915,9 @@ La sincronización se reanudará automáticamente una vez que se restablezca la 
   <data name="itemUnavailableBrowserFallback" xml:space="preserve"> 
     <value>Este elemento no está disponible en este dispositivo.
 Se abrirá en su navegador.</value> 
+  </data> 
+  <data name="kSuiteOfferUrl" xml:space="preserve"> 
+    <value>https://www.infomaniak.com/es/ksuite</value> 
   </data> 
   <data name="labelAccessRightsModified" xml:space="preserve"> 
     <value>Derechos de acceso modificados</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/fi-FI/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/fi-FI/Resources.resw
@@ -6,7 +6,7 @@
   Locale: fi, Finnish
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Tue, 19 May 2026 14:16:33 +0200 
+  Exported at: Wed, 27 May 2026 14:49:19 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -915,6 +915,9 @@ Synkronointi jatkuu automaattisesti, kun yhteys on palautettu.</value>
   <data name="itemUnavailableBrowserFallback" xml:space="preserve"> 
     <value>Tämä kohde ei ole käytettävissä tällä laitteella.
 Se avautuu selaimessasi.</value> 
+  </data> 
+  <data name="kSuiteOfferUrl" xml:space="preserve"> 
+    <value>https://www.infomaniak.com/en/ksuite</value> 
   </data> 
   <data name="labelAccessRightsModified" xml:space="preserve"> 
     <value>Käyttöoikeuksia muutettu</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/fr-FR/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/fr-FR/Resources.resw
@@ -6,7 +6,7 @@
   Locale: fr, French
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Tue, 19 May 2026 14:16:33 +0200 
+  Exported at: Wed, 27 May 2026 14:49:19 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -915,6 +915,9 @@ La synchronisation reprendra automatiquement dès que la connexion sera rétabli
   <data name="itemUnavailableBrowserFallback" xml:space="preserve"> 
     <value>Cet élément n’est pas disponible sur cet appareil.
 Il s’ouvrira dans votre navigateur.</value> 
+  </data> 
+  <data name="kSuiteOfferUrl" xml:space="preserve"> 
+    <value>https://www.infomaniak.com/fr/ksuite</value> 
   </data> 
   <data name="labelAccessRightsModified" xml:space="preserve"> 
     <value>Droits d’accès modifiés</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/it-IT/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/it-IT/Resources.resw
@@ -6,7 +6,7 @@
   Locale: it, Italian
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Tue, 19 May 2026 14:16:33 +0200 
+  Exported at: Wed, 27 May 2026 14:49:19 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -915,6 +915,9 @@ La sincronizzazione riprenderà automaticamente una volta ripristinata la connes
   <data name="itemUnavailableBrowserFallback" xml:space="preserve"> 
     <value>Questo elemento non è disponibile su questo dispositivo.
 Si aprirà nel tuo browser.</value> 
+  </data> 
+  <data name="kSuiteOfferUrl" xml:space="preserve"> 
+    <value>https://www.infomaniak.com/it/ksuite</value> 
   </data> 
   <data name="labelAccessRightsModified" xml:space="preserve"> 
     <value>Diritti di accesso modificati</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/nb-NO/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/nb-NO/Resources.resw
@@ -6,7 +6,7 @@
   Locale: nb, Norwegian Bokmål
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Tue, 19 May 2026 14:16:33 +0200 
+  Exported at: Wed, 27 May 2026 14:49:19 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -915,6 +915,9 @@ Synkroniseringen gjenopptas automatisk når tilkoblingen er gjenopprettet.</valu
   <data name="itemUnavailableBrowserFallback" xml:space="preserve"> 
     <value>Dette elementet er ikke tilgjengelig på denne enheten.
 Det vil åpnes i nettleseren din.</value> 
+  </data> 
+  <data name="kSuiteOfferUrl" xml:space="preserve"> 
+    <value>https://www.infomaniak.com/en/ksuite</value> 
   </data> 
   <data name="labelAccessRightsModified" xml:space="preserve"> 
     <value>Tilgangsrettigheter endret</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/nl-NL/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/nl-NL/Resources.resw
@@ -6,7 +6,7 @@
   Locale: nl, Dutch; Flemish
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Tue, 19 May 2026 14:16:33 +0200 
+  Exported at: Wed, 27 May 2026 14:49:19 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -915,6 +915,9 @@ De synchronisatie wordt automatisch hervat zodra de verbinding is hersteld.</val
   <data name="itemUnavailableBrowserFallback" xml:space="preserve"> 
     <value>Dit item is niet beschikbaar op dit apparaat.
 Het wordt geopend in uw browser.</value> 
+  </data> 
+  <data name="kSuiteOfferUrl" xml:space="preserve"> 
+    <value>https://www.infomaniak.com/en/ksuite</value> 
   </data> 
   <data name="labelAccessRightsModified" xml:space="preserve"> 
     <value>Toegangsrechten gewijzigd</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/pl-PL/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/pl-PL/Resources.resw
@@ -6,7 +6,7 @@
   Locale: pl, Polish
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Tue, 19 May 2026 14:16:33 +0200 
+  Exported at: Wed, 27 May 2026 14:49:19 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -915,6 +915,9 @@ Synchronizacja zostanie wznowiona automatycznie po przywróceniu połączenia.</
   <data name="itemUnavailableBrowserFallback" xml:space="preserve"> 
     <value>Ten element nie jest dostępny na tym urządzeniu.
 Otworzy się w Twojej przeglądarce.</value> 
+  </data> 
+  <data name="kSuiteOfferUrl" xml:space="preserve"> 
+    <value>https://www.infomaniak.com/en/ksuite</value> 
   </data> 
   <data name="labelAccessRightsModified" xml:space="preserve"> 
     <value>Prawa dostępu zmienione</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/pt-PT/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/pt-PT/Resources.resw
@@ -6,7 +6,7 @@
   Locale: pt, Portuguese
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Tue, 19 May 2026 14:16:33 +0200 
+  Exported at: Wed, 27 May 2026 14:49:19 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -915,6 +915,9 @@ A sincronização será retomada automaticamente quando a ligação for restabel
   <data name="itemUnavailableBrowserFallback" xml:space="preserve"> 
     <value>Este item não está disponível neste dispositivo.
 Será aberto no seu navegador.</value> 
+  </data> 
+  <data name="kSuiteOfferUrl" xml:space="preserve"> 
+    <value>https://www.infomaniak.com/en/ksuite</value> 
   </data> 
   <data name="labelAccessRightsModified" xml:space="preserve"> 
     <value>Direitos de acesso modificados</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/sv-SE/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/sv-SE/Resources.resw
@@ -6,7 +6,7 @@
   Locale: sv, Swedish
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Tue, 19 May 2026 14:16:33 +0200 
+  Exported at: Wed, 27 May 2026 14:49:19 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -915,6 +915,9 @@ Synkroniseringen återuptas automatiskt när anslutningen har återställts.</va
   <data name="itemUnavailableBrowserFallback" xml:space="preserve"> 
     <value>Det här objektet är inte tillgängligt på den här enheten.
 Det öppnas i din webbläsare.</value> 
+  </data> 
+  <data name="kSuiteOfferUrl" xml:space="preserve"> 
+    <value>https://www.infomaniak.com/en/ksuite</value> 
   </data> 
   <data name="labelAccessRightsModified" xml:space="preserve"> 
     <value>Åtkomsträttigheter ändrade</value> 


### PR DESCRIPTION
refactor(onboarding): use generic Control type

Updated event handlers in `SignupButton_Click` and `SigninButton_Click`
to use the `Control` type instead of `Button`. This change improves
flexibility by allowing any control derived from `Control` to be used,
while maintaining the same functionality.