### PR TITLE
fix(extended-tests): Fixes extended tests build error on Windows CI runner

### DIFF
--- a/.github/actions/build_windows/action.yml
+++ b/.github/actions/build_windows/action.yml
@@ -132,9 +132,11 @@ runs:
         run: |
           if("${{ inputs.release_build }}" -eq "true") {
             Get-ChildItem "Cert:\LocalMachine\My\${{ inputs.ksp_client_cert_thumbprint }}" | Remove-Item
+            Remove-Item -path certificate -include ksp_client_certificate.pfx
             Write-Host "KSP client certificate removed successfully."
             } else {
             Get-ChildItem "Cert:\LocalMachine\My\${{ inputs.debug_cert_thumbprint }}" | Remove-Item
+            Remove-Item -path certificate -include debug_certificate.pfx
             Write-Host "Debug certificate removed successfully."
             }
         shell: powershell

--- a/.github/workflows/build-and-run-extended-tests.yml
+++ b/.github/workflows/build-and-run-extended-tests.yml
@@ -63,7 +63,7 @@ jobs:
             Set-Content -Path certificate/tempCert.txt -Value $env:WINDOWS_DEBUG_CERT_FILE_B64
             certutil -decode certificate/tempCert.txt certificate/debug_certificate.pfx
             Remove-Item -path certificate -include tempCert.txt
-            Import-PfxCertificate -FilePath certificate/debug_certificate.pfx -CertStoreLocation Cert:\CurrentUser\My -Password (ConvertTo-SecureString -String "${{ secrets.WINDOWS_DEBUG_CERT_PASSWORD }}" -Force -AsPlainText)
+            Import-PfxCertificate -FilePath certificate/debug_certificate.pfx -CertStoreLocation Cert:\LocalMachine\My -Password (ConvertTo-SecureString -String "${{ secrets.WINDOWS_DEBUG_CERT_PASSWORD }}" -Force -AsPlainText)
             Write-Host "Debug certificate imported successfully."
 
         shell: powershell

--- a/.github/workflows/build-and-run-extended-tests.yml
+++ b/.github/workflows/build-and-run-extended-tests.yml
@@ -97,6 +97,17 @@ jobs:
         run : "cov01.exe -0" # coverage off
         if: always()
 
+
+      - name: Remove Windows certificate
+        env:
+          WINDOWS_DEBUG_CERT_THUMBPRINT: ${{ secrets.WINDOWS_DEBUG_CERT_THUMBPRINT }}
+        run: |
+            Get-ChildItem "Cert:\LocalMachine\My\$env:WINDOWS_DEBUG_CERT_THUMBPRINT" | Remove-Item
+            Remove-Item -path certificate -include debug_certificate.pfx
+            Write-Host "Debug certificate removed successfully."
+
+        shell: powershell
+
       - name: Upload tests logs artifacts
         uses: actions/upload-artifact@v7.0.1
         with:


### PR DESCRIPTION
This PR fixes an incorrect storage location argument for the certificate-related setup commands of the extended tests build on the Windows CI runner.

**Successful Windows build:** https://github.com/Infomaniak/desktop-kDrive/actions/runs/26748469584