### PR TITLE
feat: new set modification date job

### DIFF
--- a/src/libsyncengine/CMakeLists.txt
+++ b/src/libsyncengine/CMakeLists.txt
@@ -81,6 +81,7 @@ set(syncengine_SRCS
     jobs/network/kDrive_API/getdriveslistjob.h jobs/network/kDrive_API/getdriveslistjob.cpp
     jobs/network/kDrive_API/getthumbnailjob.h jobs/network/kDrive_API/getthumbnailjob.cpp
     jobs/network/kDrive_API/postfilelinkjob.h jobs/network/kDrive_API/postfilelinkjob.cpp
+    jobs/network/kDrive_API/postfilemodificationdatejob.h "jobs/network/kDrive_API/postfilemodificationdatejob.cpp"
     jobs/network/kDrive_API/getfilelinkjob.h jobs/network/kDrive_API/getfilelinkjob.cpp
     jobs/network/kDrive_API/getsizejob.h jobs/network/kDrive_API/getsizejob.cpp
     jobs/network/kDrive_API/searchjob.h jobs/network/kDrive_API/searchjob.cpp

--- a/src/libsyncengine/CMakeLists.txt
+++ b/src/libsyncengine/CMakeLists.txt
@@ -81,7 +81,7 @@ set(syncengine_SRCS
     jobs/network/kDrive_API/getdriveslistjob.h jobs/network/kDrive_API/getdriveslistjob.cpp
     jobs/network/kDrive_API/getthumbnailjob.h jobs/network/kDrive_API/getthumbnailjob.cpp
     jobs/network/kDrive_API/postfilelinkjob.h jobs/network/kDrive_API/postfilelinkjob.cpp
-    jobs/network/kDrive_API/postfilemodificationdatejob.h "jobs/network/kDrive_API/postfilemodificationdatejob.cpp"
+    jobs/network/kDrive_API/postfilemodificationdatejob.h jobs/network/kDrive_API/postfilemodificationdatejob.cpp
     jobs/network/kDrive_API/getfilelinkjob.h jobs/network/kDrive_API/getfilelinkjob.cpp
     jobs/network/kDrive_API/getsizejob.h jobs/network/kDrive_API/getsizejob.cpp
     jobs/network/kDrive_API/searchjob.h jobs/network/kDrive_API/searchjob.cpp

--- a/src/libsyncengine/jobs/network/kDrive_API/postfilemodificationdatejob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/postfilemodificationdatejob.cpp
@@ -1,0 +1,50 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "postfilemodificationdatejob.h"
+
+#include <Poco/Net/HTTPRequest.h>
+
+namespace KDC {
+
+PostFileModificationDateJob::PostFileModificationDateJob(const DriveDbId driveDbId, const NodeId &nodeId, uint64_t lastModifiedAt) :
+    AbstractTokenNetworkJob(ApiType::Drive, 0, 0, driveDbId, 0),
+    _nodeId(nodeId),
+    _lastModifiedAt(lastModifiedAt) {
+    _httpMethod = Poco::Net::HTTPRequest::HTTP_POST;
+    _apiVersion = 3;
+}
+std::string PostFileModificationDateJob::getSpecificUrl() {
+    std::string str = AbstractTokenNetworkJob::getSpecificUrl();
+    str += "/files/";
+    str += _nodeId;
+    str += "/last-modified";
+    return str;
+}
+
+ExitInfo PostFileModificationDateJob::setData() {
+    Poco::JSON::Object json;
+    json.set("last_modified_at", _lastModifiedAt);
+
+    std::stringstream ss;
+    json.stringify(ss);
+    _data = ss.str();
+    return ExitCode::Ok;
+}
+
+} // namespace KDC

--- a/src/libsyncengine/jobs/network/kDrive_API/postfilemodificationdatejob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/postfilemodificationdatejob.cpp
@@ -39,7 +39,7 @@ std::string PostFileModificationDateJob::getSpecificUrl() {
 
 ExitInfo PostFileModificationDateJob::setData() {
     Poco::JSON::Object json;
-    json.set("last_modified_at", _lastModifiedAt);
+    (void) json.set("last_modified_at", _lastModifiedAt);
 
     std::stringstream ss;
     json.stringify(ss);

--- a/src/libsyncengine/jobs/network/kDrive_API/postfilemodificationdatejob.h
+++ b/src/libsyncengine/jobs/network/kDrive_API/postfilemodificationdatejob.h
@@ -1,0 +1,38 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "jobs/network/abstracttokennetworkjob.h"
+
+namespace KDC {
+
+class PostFileModificationDateJob : public AbstractTokenNetworkJob {
+    public:
+        PostFileModificationDateJob(DriveDbId driveDbId, const NodeId &nodeId, uint64_t lastModifiedAt);
+
+    private:
+        virtual std::string getSpecificUrl() override;
+        virtual void setQueryParameters(Poco::URI &uri) override;
+        inline virtual ExitInfo setData() override { return ExitCode::Ok; }
+
+        NodeId _nodeId;
+        uint64_t _lastModifiedAt;
+};
+
+} // namespace KDC

--- a/src/libsyncengine/jobs/network/kDrive_API/postfilemodificationdatejob.h
+++ b/src/libsyncengine/jobs/network/kDrive_API/postfilemodificationdatejob.h
@@ -28,7 +28,7 @@ class PostFileModificationDateJob : public AbstractTokenNetworkJob {
 
     private:
         virtual std::string getSpecificUrl() override;
-        inline virtual ExitInfo setData() override;
+        virtual ExitInfo setData() override;
 
         NodeId _nodeId;
         uint64_t _lastModifiedAt;

--- a/src/libsyncengine/jobs/network/kDrive_API/postfilemodificationdatejob.h
+++ b/src/libsyncengine/jobs/network/kDrive_API/postfilemodificationdatejob.h
@@ -27,8 +27,8 @@ class PostFileModificationDateJob : public AbstractTokenNetworkJob {
         PostFileModificationDateJob(DriveDbId driveDbId, const NodeId &nodeId, uint64_t lastModifiedAt);
 
     private:
-        virtual std::string getSpecificUrl() override;
-        inline virtual ExitInfo setData() override;
+        std::string getSpecificUrl() override;
+        inline ExitInfo setData() override;
 
         NodeId _nodeId;
         uint64_t _lastModifiedAt;

--- a/src/libsyncengine/jobs/network/kDrive_API/postfilemodificationdatejob.h
+++ b/src/libsyncengine/jobs/network/kDrive_API/postfilemodificationdatejob.h
@@ -28,8 +28,7 @@ class PostFileModificationDateJob : public AbstractTokenNetworkJob {
 
     private:
         virtual std::string getSpecificUrl() override;
-        virtual void setQueryParameters(Poco::URI &uri) override;
-        inline virtual ExitInfo setData() override { return ExitCode::Ok; }
+        inline virtual ExitInfo setData() override;
 
         NodeId _nodeId;
         uint64_t _lastModifiedAt;

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "testnetworkjobs.h"
+#include "jobs/network/kDrive_API/postfilemodificationdatejob.h"
 #include "jobs/network/kDrive_API/copytodirectoryjob.h"
 #include "jobs/network/kDrive_API/deletejob.h"
 #include "jobs/network/kDrive_API/downloadjob.h"
@@ -1802,6 +1803,70 @@ void TestNetworkJobs::testGetAllFilesInDirectory() {
     exitInfo = listFilesInDirectoryJob.runSynchronously();
     CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok), exitInfo);
     CPPUNIT_ASSERT_EQUAL(size_t{3}, listFilesInDirectoryJob.v3RemoteNodeInfoList().size());
+}
+
+void TestNetworkJobs::testPostFileModificationDate() {
+    const RemoteTemporaryDirectory remoteTmpDir(_driveDbId, _remoteDirId, "testPostFileModificationDate");
+    const LocalTemporaryDirectory localTmpDir("testPostFileModificationDate");
+    const uint64_t newModificationDate = static_cast<uint64_t>(testhelpers::defaultTime) + 3600;
+    const auto futureTimestamp = static_cast<uint64_t>(
+            std::chrono::duration_cast<std::chrono::seconds>(
+                    (std::chrono::system_clock::now() + std::chrono::hours(24) + std::chrono::minutes(1)).time_since_epoch())
+                    .count());
+
+    struct TestCase {
+        std::string fileName;
+        uint64_t timestampToPost;
+        std::string targetNodeIdOverride; // non-empty overrides the uploaded node's ID
+        bool primeWithNewModificationDate; // set newModificationDate on the node before the actual test job
+        bool expectSuccess;
+        SyncTime expectedServerValue;
+    };
+
+    const std::vector<TestCase> testCases = {
+            // clang-format off
+            // fileName                              timestampToPost    targetOverride  prime   expectSuccess  expectedServerValue
+            {"test_valid.txt",                       newModificationDate, "",            false,  true,          static_cast<SyncTime>(newModificationDate)},
+            {"test_nonExistent.txt",                 newModificationDate, "0",           true,   false,         static_cast<SyncTime>(newModificationDate)},
+            {"test_future.txt",                      futureTimestamp,    "",             true,   false,         static_cast<SyncTime>(newModificationDate)},
+            {"test_zero.txt",                        0,                  "",             false,  true,          0},
+            // clang-format on
+    };
+
+    for (const auto &testCase: testCases) {
+        const SyncPath localFilePath = localTmpDir.path() / testCase.fileName;
+        testhelpers::generateOrEditTestFile(localFilePath);
+        const auto nowSec =
+                std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+        UploadJob uploadJob(nullptr, _driveDbId, localFilePath, localFilePath.filename().native(), remoteTmpDir.id(), nowSec,
+                            nowSec);
+        CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, uploadJob.runSynchronously().code());
+        const NodeId nodeId = uploadJob.nodeId();
+        CPPUNIT_ASSERT(!nodeId.empty());
+
+        if (testCase.primeWithNewModificationDate) {
+            PostFileModificationDateJob primeJob(_driveDbId, nodeId, newModificationDate);
+            CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, primeJob.runSynchronously().code());
+        }
+
+        const std::string targetId = testCase.targetNodeIdOverride.empty() ? nodeId : testCase.targetNodeIdOverride;
+        PostFileModificationDateJob testJob(_driveDbId, targetId, testCase.timestampToPost);
+        const auto exitInfo = testJob.runSynchronously();
+        if (testCase.expectSuccess) {
+            CPPUNIT_ASSERT_MESSAGE(toString(exitInfo), exitInfo);
+        } else {
+            CPPUNIT_ASSERT_MESSAGE(toString(exitInfo), !exitInfo);
+        }
+
+        // Verify the modification date on the server.
+        GetFileInfoJob verifyJob(_driveDbId, nodeId);
+        CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, verifyJob.runSynchronously().code());
+        Poco::JSON::Object::Ptr verifyDataObj = verifyJob.jsonRes()->getObject(dataKey);
+        CPPUNIT_ASSERT(verifyDataObj);
+        SyncTime verifyLastModifiedAt = 0;
+        CPPUNIT_ASSERT(JsonParserUtility::extractValue(verifyDataObj, lastModifiedAtKey, verifyLastModifiedAt, false));
+        CPPUNIT_ASSERT_EQUAL(testCase.expectedServerValue, verifyLastModifiedAt);
+    }
 }
 
 } // namespace KDC

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -1808,54 +1808,45 @@ void TestNetworkJobs::testGetAllFilesInDirectory() {
 void TestNetworkJobs::testPostFileModificationDate() {
     const RemoteTemporaryDirectory remoteTmpDir(_driveDbId, _remoteDirId, "testPostFileModificationDate");
     const LocalTemporaryDirectory localTmpDir("testPostFileModificationDate");
-    const auto nowSecForTest = static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::seconds>(
-            std::chrono::system_clock::now().time_since_epoch()).count());
-    const uint64_t newModificationDate = nowSecForTest - 3600; // keep it in the past to avoid backend "future timestamp" rejection
-    const uint64_t futureTimestamp = nowSecForTest + 24ULL * 3600ULL + 60ULL;
+    using namespace std::chrono;
+    const auto nowTimeStamp = system_clock::now().time_since_epoch();
+    const SyncTime pastModificationDateSec = duration_cast<seconds>(nowTimeStamp - hours(1)).count();
+    const SyncTime valideFutureModificationDate = duration_cast<seconds>(nowTimeStamp + hours(1)).count();
+    const SyncTime invalideFutureModificationDate = duration_cast<seconds>(nowTimeStamp + hours(25)).count();
+    const SyncTime nowTimeStampSec = duration_cast<seconds>(nowTimeStamp).count();
 
     struct TestCase {
-        std::string fileName;
-        uint64_t timestampToPost;
-        std::string targetNodeIdOverride; // non-empty overrides the uploaded node's ID
-        bool primeWithNewModificationDate; // set newModificationDate on the node before the actual test job
-        bool expectSuccess;
-        SyncTime expectedServerValue;
+            std::string fileName;
+            SyncTime timestampToPost;
+            std::string targetNodeIdOverride; // non-empty overrides the uploaded node's ID
+            bool expectSuccess;
+            SyncTime expectedServerValue;
     };
 
     const std::vector<TestCase> testCases = {
             // clang-format off
-            // fileName                              timestampToPost    targetOverride  prime   expectSuccess  expectedServerValue
-            {"test_valid.txt",                       newModificationDate, "",            false,  true,          static_cast<SyncTime>(newModificationDate)},
-            {"test_nonExistent.txt",                 newModificationDate, "0",           true,   false,         static_cast<SyncTime>(newModificationDate)},
-            {"test_future.txt",                      futureTimestamp,    "",             true,   false,         static_cast<SyncTime>(newModificationDate)},
-            {"test_zero.txt",                        0,                  "",             false,  true,          0},
+            // fileName                   timestampToPost         targetOverride    expectSuccess  expectedServerValue
+            {"test_valid.txt",            pastModificationDateSec,           "",     true,        pastModificationDateSec},
+            {"test_valid_future.txt",     valideFutureModificationDate,      "",     true,        valideFutureModificationDate},
+            {"test_nonExistent.txt",      pastModificationDateSec,           "0",     false,       nowTimeStampSec},
+            {"test_future.txt",           invalideFutureModificationDate,    "",      false,       nowTimeStampSec},
+            {"test_zero.txt",             0,                                 "",     true,        static_cast<SyncTime>(0)},
             // clang-format on
     };
 
     for (const auto &testCase: testCases) {
         const SyncPath localFilePath = localTmpDir.path() / testCase.fileName;
         testhelpers::generateOrEditTestFile(localFilePath);
-        const auto nowSec =
-                std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-        UploadJob uploadJob(nullptr, _driveDbId, localFilePath, localFilePath.filename().native(), remoteTmpDir.id(), nowSec,
-                            nowSec);
-        CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, uploadJob.runSynchronously().code());
+        UploadJob uploadJob(nullptr, _driveDbId, localFilePath, localFilePath.filename().native(), remoteTmpDir.id(),
+                            nowTimeStampSec, nowTimeStampSec);
+        ExitInfo exitInfo = uploadJob.runSynchronously();
+        CPPUNIT_ASSERT_MESSAGE(toString(exitInfo), exitInfo);
         const NodeId nodeId = uploadJob.nodeId();
         CPPUNIT_ASSERT(!nodeId.empty());
-
-        if (testCase.primeWithNewModificationDate) {
-            PostFileModificationDateJob primeJob(_driveDbId, nodeId, newModificationDate);
-            CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, primeJob.runSynchronously().code());
-        }
-
         const std::string targetId = testCase.targetNodeIdOverride.empty() ? nodeId : testCase.targetNodeIdOverride;
         PostFileModificationDateJob testJob(_driveDbId, targetId, testCase.timestampToPost);
-        const auto exitInfo = testJob.runSynchronously();
-        if (testCase.expectSuccess) {
-            CPPUNIT_ASSERT_MESSAGE(toString(exitInfo), exitInfo);
-        } else {
-            CPPUNIT_ASSERT_MESSAGE(toString(exitInfo), !exitInfo);
-        }
+        exitInfo = testJob.runSynchronously();
+        CPPUNIT_ASSERT_MESSAGE(toString(exitInfo), exitInfo == testCase.expectSuccess);
 
         // Verify the modification date on the server.
         GetFileInfoJob verifyJob(_driveDbId, nodeId);

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -1808,11 +1808,10 @@ void TestNetworkJobs::testGetAllFilesInDirectory() {
 void TestNetworkJobs::testPostFileModificationDate() {
     const RemoteTemporaryDirectory remoteTmpDir(_driveDbId, _remoteDirId, "testPostFileModificationDate");
     const LocalTemporaryDirectory localTmpDir("testPostFileModificationDate");
-    const uint64_t newModificationDate = static_cast<uint64_t>(testhelpers::defaultTime) + 3600;
-    const auto futureTimestamp = static_cast<uint64_t>(
-            std::chrono::duration_cast<std::chrono::seconds>(
-                    (std::chrono::system_clock::now() + std::chrono::hours(24) + std::chrono::minutes(1)).time_since_epoch())
-                    .count());
+    const auto nowSecForTest = static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::seconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count());
+    const uint64_t newModificationDate = nowSecForTest - 3600; // keep it in the past to avoid backend "future timestamp" rejection
+    const uint64_t futureTimestamp = nowSecForTest + 24ULL * 3600ULL + 60ULL;
 
     struct TestCase {
         std::string fileName;

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -1846,7 +1846,7 @@ void TestNetworkJobs::testPostFileModificationDate() {
         const std::string targetId = testCase.targetNodeIdOverride.empty() ? nodeId : testCase.targetNodeIdOverride;
         PostFileModificationDateJob testJob(_driveDbId, targetId, testCase.timestampToPost);
         exitInfo = testJob.runSynchronously();
-        CPPUNIT_ASSERT_MESSAGE(toString(exitInfo), exitInfo == testCase.expectSuccess);
+        CPPUNIT_ASSERT_MESSAGE(toString(exitInfo), exitInfo.operator bool() == testCase.expectSuccess);
 
         // Verify the modification date on the server.
         GetFileInfoJob verifyJob(_driveDbId, nodeId);

--- a/test/libsyncengine/jobs/network/testnetworkjobs.h
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.h
@@ -71,6 +71,7 @@ class TestNetworkJobs : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST(testGetInfoDriveOn401Error);
         CPPUNIT_TEST(testExists);
         CPPUNIT_TEST(testGetAllFilesInDirectory);
+        CPPUNIT_TEST(testPostFileModificationDate);
         CPPUNIT_TEST_SUITE_END();
 
     public:
@@ -116,6 +117,7 @@ class TestNetworkJobs : public CppUnit::TestFixture, public TestBase {
         void testGetInfoDriveOn401Error();
         void testExists();
         void testGetAllFilesInDirectory();
+        void testPostFileModificationDate();
 
     private:
         bool createTestFiles();


### PR DESCRIPTION
This pull request adds support for updating a file's modification date via the kDrive API and introduces comprehensive tests to validate this new functionality. The main changes include implementing the new network job class, registering it in the build system, and adding unit tests.

**New Feature: Update File Modification Date**

* Added new class `PostFileModificationDateJob` to handle POST requests for updating a file's modification date on the server. This includes both the implementation (`postfilemodificationdatejob.cpp`) and header (`postfilemodificationdatejob.h`). [[1]](diffhunk://#diff-36ffd882c8708ac2ed431d2a944b43ae38cf019a183d350497410d99627d6582R1-R50) [[2]](diffhunk://#diff-2c252d2f5464ee88faad59f47c5fc3e3ade9c4f445c178d66e70c9c11c8baa68R1-R37)
* Registered the new job in the CMake build system by adding its source files to `src/libsyncengine/CMakeLists.txt`.

**Testing Improvements**

* Added `testPostFileModificationDate` unit test to verify various scenarios for updating a file's modification date, including valid updates, attempts on non-existent files, future timestamps, and zero timestamps.
* Included the new job class in test includes and registered the new test in the test suite. [[1]](diffhunk://#diff-a44011b4b2142730cdb600b754fc9df3f32479959030cd13cf167fda5bfc52ebR20) [[2]](diffhunk://#diff-7cb4981dbd48c6446082f1f1058fe4f92be59b6f6ef5d9dfe5dda249e0618330R74) [[3]](diffhunk://#diff-7cb4981dbd48c6446082f1f1058fe4f92be59b6f6ef5d9dfe5dda249e0618330R120)