### PR TITLE
docs(agents): Add PR and commit rules to AGENTS.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -31,5 +31,3 @@ Before proposing code or review comments:
 
 ## Pull Request & Commit Rules (MANDATORY)
 See `AGENTS.md` for the canonical version.
-
-When the user asks to create a PR or prepare PR content:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -30,12 +30,6 @@ Before proposing code or review comments:
 - Do not duplicate SonarCloud findings verbatim unless they identify a concrete actionable problem in the changed code.
 
 ## Pull Request & Commit Rules (MANDATORY)
-When the user asks to create a PR or prepare PR content:
-1. Use English only for PR title and PR description.
-2. Create the PR as Draft by default.
-3. Use `develop` as the default target branch unless the user explicitly asks for a different base branch.
+See `AGENTS.md` for the canonical version.
 
-When proposing commit messages:
-1. Use English only.
-2. Use Conventional Commits format: `<type>(<scope>): <subject>`.
-3. Allowed types: `feat`, `fix`, `refactor`, `perf`, `test`, `docs`, `chore`, `ci`.
+When the user asks to create a PR or prepare PR content:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,14 @@ clang-format -i <file>
 - **Commits:** Conventional commits format (`feat(scope):`, `fix(scope):`, `refactor(scope):`), validated by `.githooks/commit-msg`.
 - **Branch naming:** No enforced convention currently.
 
+## Pull Requests & Commits
+- **Language:** All PR titles, PR descriptions, and commit messages must be written in **English**.
+- **PR Title Format:** PR titles must follow the same Conventional Commits format as commit messages.
+- **PR Target Branch:** Use `develop` as the default target branch unless the user explicitly asks for a different base branch.
+- **PR Status:** Create the PR as **Draft** by default.
+- **Branch creation (AI/automation):** If the user requests a PR but has not created a branch, create one with an appropriate name before opening the PR.
+- **Commit Format:** Follow the project's semantic-commit validation rules defined in [`.github/workflows/semantic-commit.yml`](https://github.com/Infomaniak/.github/blob/main/.github/workflows/semantic-commit.yml).
+
 ## Security & Secrets
 - Never commit API tokens, passwords, or credentials. Use env vars (`KDRIVE_TEST_CI_API_TOKEN`, etc.).
 - Keychain access is managed by `libcommonserver/keychainmanager/`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,8 @@ clang-format -i <file>
 - **PR Target Branch:** Use `develop` as the default target branch unless the user explicitly asks for a different base branch.
 - **PR Status:** Create the PR as **Draft** by default.
 - **Branch creation (AI/automation):** If the user requests a PR but has not created a branch, create one with an appropriate name before opening the PR.
+- **History rewriting (AI/automation):** Never amend, rebase, or force-push commits unless the user explicitly asks for it.
+- **Commit & push:** Only commit and push when the user explicitly asks for it.
 - **Commit Format:** Follow the project's semantic-commit validation rules defined in [`.github/workflows/semantic-commit.yml`](https://github.com/Infomaniak/.github/blob/main/.github/workflows/semantic-commit.yml).
 
 ## Security & Secrets
@@ -64,6 +66,8 @@ clang-format -i <file>
 - In versioned documentation such as `AGENTS.md`, use repo-relative paths, not hardcoded absolute filesystem paths.
 - For Linux builds/validation, use `infomaniak-build-tools/linux/build-release-via-podman.sh` rather than direct `cmake --build`.
 - For dependency builds, use `infomaniak-build-tools/conan/build_dependencies.sh <Debug|Release|RelWithDebInfo>` rather than direct `conan install` so the project-specific environment is set correctly.
+- Never rewrite commit history (amend, rebase, force-push) unless explicitly asked by the user.
+- Only commit and push when explicitly asked by the user.
 <!-- Add project-specific user corrections here -->
 
 ## JIT Index


### PR DESCRIPTION
This PR centralizes the Pull Request and commit rules into the root AGENTS.md, making it the single source of truth for all AI agents and contributors.

**Changes:**
- Added a new "Pull Requests & Commits" section to AGENTS.md with the following rules:
  - All PR titles, descriptions, and commit messages must be in **English**.
  - Default target branch: `develop`.
  - PRs must be created as **Draft** by default.
  - If the user requests a PR but has not created a branch, automatically create one with an appropriate name.
  - **Conventional Commits** format is mandatory (`<type>(<scope>): <subject>`).
- Removed the duplicate rules from `.github/copilot-instructions.md` and replaced them with a reference to `AGENTS.md` to avoid drift.