### PR TITLE
refactor(async): remove unnecessary async/await usage

### DIFF
--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/AdvancedSyncSetupContentDialog/DialogPages/RemoteLocationSelectionPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/AdvancedSyncSetupContentDialog/DialogPages/RemoteLocationSelectionPage.xaml.cs
@@ -43,7 +43,7 @@ namespace Infomaniak.kDrive.Pages.AdvancedSyncSetupContentDialog
         }
 
         // Navigation method
-        protected override async void OnNavigatedTo(NavigationEventArgs e)
+        protected override void OnNavigatedTo(NavigationEventArgs e)
         {
             if (e.Parameter is AdvancedSyncSetupContentDialogVM viewModel)
             {

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/AdvancedSyncSetupContentDialog/DialogPages/SyncSetupPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/AdvancedSyncSetupContentDialog/DialogPages/SyncSetupPage.xaml.cs
@@ -110,7 +110,7 @@ namespace Infomaniak.kDrive.Pages.AdvancedSyncSetupContentDialog
             AdvancedSyncSetupContentDialogVM.FinishSetup(CustomControls.AdvancedSyncSetupContentDialog.AdvancedSyncSetupResult.Confirmed);
         }
 
-        private async void AdvancedSyncSetupContentDialogVM_CurrentStepCancelled(object? sender, EventArgs e)
+        private void AdvancedSyncSetupContentDialogVM_CurrentStepCancelled(object? sender, EventArgs e)
         {
             if (AdvancedSyncSetupContentDialogVM is null)
             {

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/DriveSelectionPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/DriveSelectionPage.xaml.cs
@@ -43,7 +43,7 @@ namespace Infomaniak.kDrive.Pages.DriveSetupContentDialog
         }
 
         // Navigation method
-        protected override async void OnNavigatedTo(NavigationEventArgs e)
+        protected override void OnNavigatedTo(NavigationEventArgs e)
         {
             if (e.Parameter is DriveSetupContentDialogVM viewModel)
             {

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/SyncExclusionPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/SyncExclusionPage.xaml.cs
@@ -50,7 +50,7 @@ namespace Infomaniak.kDrive.Pages.DriveSetupContentDialog
         }
 
         // Navigation method
-        protected override async void OnNavigatedTo(NavigationEventArgs e)
+        protected override void OnNavigatedTo(NavigationEventArgs e)
         {
             if (e.Parameter is DriveSetupContentDialogVM viewModel)
             {

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/SyncSetupPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/SyncSetupPage.xaml.cs
@@ -47,7 +47,7 @@ namespace Infomaniak.kDrive.Pages.DriveSetupContentDialog
         }
 
         // Navigation method
-        protected override async void OnNavigatedTo(NavigationEventArgs e)
+        protected override void OnNavigatedTo(NavigationEventArgs e)
         {
             if (e.Parameter is DriveSetupContentDialogVM viewModel)
             {

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Dialogs/SystemErrorSyncDirAccessErrorDialog.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Dialogs/SystemErrorSyncDirAccessErrorDialog.xaml.cs
@@ -85,7 +85,7 @@ public partial class SystemErrorSyncDirAccessErrorDialog : Page
             FolderDeletedTextBlock.Inlines.Add(new Run { Text = parts[1] });
     }
 
-    private async void RecreateSync_Click(Hyperlink sender, HyperlinkClickEventArgs args)
+    private void RecreateSync_Click(Hyperlink sender, HyperlinkClickEventArgs args)
     {
         var frame = Utility.GetFrame(this);
         if (frame is null)

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/SyncPal/InvalidTokenError.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/SyncPal/InvalidTokenError.xaml.cs
@@ -38,7 +38,7 @@ namespace Infomaniak.kDrive.CustomControls.Errors.Templates.SyncPal
             Error = error;
         }
 
-        private async void ErrorCard_ActionClick(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+        private void ErrorCard_ActionClick(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
         {
             var frame = Utility.GetFrame(this);
             if (frame is null)

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/SyncPal/TmpDirAccessError.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/SyncPal/TmpDirAccessError.xaml.cs
@@ -38,7 +38,7 @@ namespace Infomaniak.kDrive.CustomControls.Errors.Templates.SyncPal
             this.InitializeComponent();
             Error = error;
         }
-        private async void ErrorCard_ActionClick(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+        private void ErrorCard_ActionClick(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
         {
             _analyticsService.TrackClick(Analytics.Keys.Category.Errors, Analytics.Keys.EventName.ManageTmpDirError);
             App.ExitApplicationAndShutdownServer();

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/ActivityPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/ActivityPage.xaml.cs
@@ -41,7 +41,7 @@ namespace Infomaniak.kDrive.Pages
             UpdateTitleTemplate();
         }
 
-        protected override async void OnNavigatedTo(NavigationEventArgs e)
+        protected override void OnNavigatedTo(NavigationEventArgs e)
         {
             if (ViewModel.SelectedSync is null)
             {

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Errors/ErrorPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Errors/ErrorPage.xaml.cs
@@ -56,7 +56,7 @@ namespace Infomaniak.kDrive.Pages.Errors
             }
         }
 
-        protected override async void OnNavigatedTo(NavigationEventArgs e)
+        protected override void OnNavigatedTo(NavigationEventArgs e)
         {
             _errorPageVM = new ErrorPageVM();
             _analyticsService.TrackPageView(Analytics.Keys.Category.ErrorPage);

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Errors/ResolveManyConflictPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Errors/ResolveManyConflictPage.xaml.cs
@@ -42,7 +42,7 @@ namespace Infomaniak.kDrive.Pages.Errors
             Logger.Log(Logger.Level.Debug, "ResolveManyConflictPage components initialized");
         }
 
-        protected override async void OnNavigatedTo(NavigationEventArgs e)
+        protected override void OnNavigatedTo(NavigationEventArgs e)
         {
             _errorPageVM = new ErrorPageVM();
             _errorPageVM.PropertyChanged += OnErrorPageVMPropertyChanged;

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/HomePage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/HomePage.xaml.cs
@@ -92,7 +92,7 @@ namespace Infomaniak.kDrive.Pages
             return true;
         }
 
-        protected override async void OnNavigatedTo(NavigationEventArgs e)
+        protected override void OnNavigatedTo(NavigationEventArgs e)
         {
             ViewModel.SelectedSyncChanged += OnSelectedSyncChanged;
             OnSelectedSyncChanged(null, new(null, ViewModel.SelectedSync));

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/UpdateDialogPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/UpdateDialogPage.xaml.cs
@@ -51,7 +51,7 @@ namespace Infomaniak.kDrive.Pages.Settings
             await LoadReleaseNotesAsync();
         }
 
-        protected override async void OnNavigatedTo(NavigationEventArgs e)
+        protected override void OnNavigatedTo(NavigationEventArgs e)
         {
             _analyticsService.TrackPageView(Analytics.Keys.Category.BatchConflictResolutionPage);
         }

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/SpecialErrorsPages/LogginErrorPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/SpecialErrorsPages/LogginErrorPage.xaml.cs
@@ -45,7 +45,7 @@ namespace Infomaniak.kDrive.Pages
             Loaded += OnLoaded;
         }
 
-        private async void OnLoaded(object sender, RoutedEventArgs e)
+        private void OnLoaded(object sender, RoutedEventArgs e)
         {
             if(_navigationParams?.TryReconnectOnLoad == true)
             {
@@ -53,7 +53,7 @@ namespace Infomaniak.kDrive.Pages
             }
         }
 
-        protected override async void OnNavigatedTo(NavigationEventArgs e)
+        protected override void OnNavigatedTo(NavigationEventArgs e)
         {
             base.OnNavigatedTo(e);
             _navigationParams = e.Parameter as NavigationParams?;

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/MockServerCommProtocol.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/MockServerCommProtocol.cs
@@ -285,7 +285,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             };
         }
 
-        private async Task<CommData> UpdaterVersionInfo(JsonObject parameters)
+        private Task<CommData> UpdaterVersionInfo(JsonObject parameters)
         {
             Logger.Log(Logger.Level.Debug, "Received UpdateVersionInfo request.");
             DistributionChannel channel = _mockData.Settings.DistributionChannel ?? throw new InvalidOperationException("Distribution channel is not set in mocked settings.");
@@ -304,15 +304,15 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 { "downloadUrl", "" }, // Not used
             };
 
-            return new CommData
+            return Task.FromResult(new CommData
             {
                 Type = CommMessageType.Request,
                 Id = (int)NextId,
                 RequestNum = RequestNum.UPDATER_VERSION_INFO,
                 Params = new JsonObject() { { JsonKeys.VersionInfo, versionInfo } }
-            };
+            });
         }
-        private async Task<CommData> UpdaterChangeChannel(JsonObject parameters)
+        private Task<CommData> UpdaterChangeChannel(JsonObject parameters)
         {
             Logger.Log(Logger.Level.Debug, "Received UpdaterChangeChannel request.");
             if (parameters.ContainsKey(JsonKeys.UpdateChannel) && parameters[JsonKeys.UpdateChannel] != null)
@@ -325,16 +325,16 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
 
             }
             EnqueueSignal(SignalNum.UPDATER_STATE_CHANGED, []);
-            return new CommData
+            return Task.FromResult(new CommData
             {
                 Type = CommMessageType.Request,
                 Id = (int)NextId,
                 RequestNum = RequestNum.UPDATER_CHANGE_CHANNEL,
                 Params = new JsonObject()
-            };
+            });
         }
 
-        private async Task<CommData> ParametersInfo(JsonObject parameters)
+        private Task<CommData> ParametersInfo(JsonObject parameters)
         {
             Logger.Log(Logger.Level.Debug, "Received ParametersInfo request.");
             var options = new JsonSerializerOptions
@@ -343,7 +343,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             };
             string parametersInfo = JsonSerializer.Serialize(_mockData.Settings, options);
 
-            return new CommData
+            return Task.FromResult(new CommData
             {
                 Type = CommMessageType.Request,
                 Id = (int)NextId,
@@ -352,23 +352,23 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 {
                     [JsonKeys.ParmsInfo] = JsonNode.Parse(parametersInfo)
                 }
-            };
+            });
         }
 
-        private async Task<CommData> ParametersUpdate(JsonObject parameters)
+        private Task<CommData> ParametersUpdate(JsonObject parameters)
         {
             Logger.Log(Logger.Level.Debug, "Received ParametersUpdate request.");
             if (!parameters.ContainsKey(JsonKeys.ParmsInfo) || parameters[JsonKeys.ParmsInfo] == null)
             {
                 Logger.Log(Logger.Level.Warning, "No parmsInfo specified in ParametersUpdate request, using existing settings.");
 
-                return new CommData
+                return Task.FromResult(new CommData
                 {
                     Type = CommMessageType.Request,
                     Id = (int)NextId,
                     RequestNum = RequestNum.PARAMETERS_UPDATE,
                     Params = new JsonObject()
-                };
+                });
             }
 
             var options = new JsonSerializerOptions
@@ -384,13 +384,13 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             }
             _mockData.Settings = updatedSettings;
 
-            return new CommData
+            return Task.FromResult(new CommData
             {
                 Type = CommMessageType.Request,
                 Id = (int)NextId,
                 RequestNum = RequestNum.PARAMETERS_UPDATE,
                 Params = new JsonObject()
-            };
+            });
         }
 
         private Task<CommData> ErrorDelete(JsonObject parameters)

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -1408,7 +1408,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                     await HandleUpdaterStateChangedAsync(sender, args);
                     break;
                 case SignalNum.SYNC_PROGRESSINFO:
-                    HandleSyncProgressInfo(sender, args);
+                    await HandleSyncProgressInfo(sender, args);
                     break;
                 case SignalNum.SYNC_COMPLETEDITEM:
                     await HandleSyncCompletedItem(sender, args);
@@ -1420,10 +1420,10 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                     await HandleErrorRemovedAsync(sender, args);
                     break;
                 case SignalNum.UTILITY_LOG_UPLOAD_STATUS_UPDATED:
-                    HandleLogUploadProgressAsync(sender, args);
+                    await HandleLogUploadProgressAsync(sender, args);
                     break;
                 case SignalNum.UTILITY_SHOW_NOTIFICATION:
-                    HandleUtilityShowNotification(sender, args);
+                    await HandleUtilityShowNotification(sender, args);
                     break;
                 case SignalNum.UTILITY_SHOW_SYNTHESIS:
                     await HandleUtilityShowSynthesis(sender, args);
@@ -1622,19 +1622,19 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             }
             await Utility.RunOnUIThread(() => { deletedSync.Drive.Syncs.Remove(deletedSync); });
         }
-        public void HandleSyncProgressInfo(object? sender, SignalEventArgs args)
+        public Task HandleSyncProgressInfo(object? sender, SignalEventArgs args)
         {
             var signalData = args.SignalData;
 
             if (signalData == null || !signalData.ContainsKey(JsonKeys.SyncDbId))
             {
                 Logger.Log(Logger.Level.Error, $"{JsonKeys.SyncDbId} not found in parameters.");
-                return;
+                return Task.CompletedTask;
             }
             if (signalData == null || !signalData.ContainsKey(JsonKeys.SyncStatus))
             {
                 Logger.Log(Logger.Level.Error, $"{JsonKeys.SyncStatus} not found in parameters.");
-                return;
+                return Task.CompletedTask;
             }
 
             DbId? syncDbID = signalData[JsonKeys.SyncDbId]?.AsValue().GetValue<DbId>();
@@ -1643,21 +1643,22 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             if (syncDbID is null)
             {
                 Logger.Log(Logger.Level.Error, "syncDbID is null.");
-                return;
+                return Task.CompletedTask;
             }
             if (syncStatus is null)
             {
                 Logger.Log(Logger.Level.Error, "syncStatus is null.");
-                return;
+                return Task.CompletedTask;
             }
 
             Sync? updatedSync = _viewModel.AllSyncs.FirstOrDefault(s => s.DbId == syncDbID);
             if (updatedSync == null)
             {
                 Logger.Log(Logger.Level.Error, $"Sync with dbID {syncDbID} not found in the model.");
-                return;
+                return Task.CompletedTask;
             }
             updatedSync.SyncStatus = syncStatus ?? SyncStatus.Undefined;
+            return Task.CompletedTask;
         }
 
         public async Task HandleSyncCompletedItem(object? sender, SignalEventArgs args)
@@ -1794,28 +1795,29 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             await RefreshUpdaterVersionInfo((UpdateState?)args?.SignalData[JsonKeys.UpdateState]?.GetValue<int>(), CancellationToken.None);
         }
 
-        public void HandleLogUploadProgressAsync(object? sender, SignalEventArgs args)
+        public Task HandleLogUploadProgressAsync(object? sender, SignalEventArgs args)
         {
             var signalData = args.SignalData;
             if (signalData == null || !signalData.ContainsKey(JsonKeys.State) || !signalData.ContainsKey(JsonKeys.Percentage))
             {
                 Logger.Log(Logger.Level.Error, $"{JsonKeys.State} or {JsonKeys.Percentage} not found in parameters ${signalData}.");
-                return;
+                return Task.CompletedTask;
             }
             LogUploadState? state = signalData[JsonKeys.State]?.Deserialize<LogUploadState>();
             int? percentage = signalData[JsonKeys.Percentage]?.GetValue<int>();
             if (state is null)
             {
                 Logger.Log(Logger.Level.Error, "state is null.");
-                return;
+                return Task.CompletedTask;
             }
             if (percentage is null)
             {
                 Logger.Log(Logger.Level.Error, "percentage is null.");
-                return;
+                return Task.CompletedTask;
             }
             _viewModel.Settings.LogUploadManager.State = state ?? LogUploadState.Failed;
             _viewModel.Settings.LogUploadManager.PercentComplete = percentage ?? 0;
+            return Task.CompletedTask;
         }
 
         public async Task HandleUserRemovedAsync(object? sender, SignalEventArgs args)
@@ -1930,13 +1932,13 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             }
         }
 
-        public void HandleUtilityShowNotification(object? sender, SignalEventArgs args)
+        public Task HandleUtilityShowNotification(object? sender, SignalEventArgs args)
         {
             var signalData = args.SignalData;
             if (signalData == null || !signalData.ContainsKey(JsonKeys.Title) || !signalData.ContainsKey(JsonKeys.Message))
             {
                 Logger.Log(Logger.Level.Error, $"{JsonKeys.Title} or {JsonKeys.Message} not found in parameters.");
-                return;
+                return Task.CompletedTask;
             }
             string? title = signalData[JsonKeys.Title]?.GetValue<string>();
             string? message = signalData[JsonKeys.Message]?.GetValue<string>();
@@ -1950,21 +1952,22 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             catch (FormatException ex)
             {
                 Logger.Log(Logger.Level.Error, $"Failed to decode title or message from base64. Title: {title}, Message: {message}. Exception: {ex}");
-                return;
+                return Task.CompletedTask;
             }
             catch (Exception ex)
             {
                 Logger.Log(Logger.Level.Error, $"Unexpected error while decoding title or message from base64. Title: {title}, Message: {message}. Exception: {ex}");
-                return;
+                return Task.CompletedTask;
             }
 
             if (title is null || message is null)
             {
                 Logger.Log(Logger.Level.Error, "title or message is null.");
-                return;
+                return Task.CompletedTask;
             }
 
             App.ServiceProvider.GetRequiredService<NotificationManager>().ShowNotification(title, message);
+            return Task.CompletedTask;
         }
 
         public async Task HandleUpdaterShowDialog(object? sender, SignalEventArgs args)

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -1408,7 +1408,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                     await HandleUpdaterStateChangedAsync(sender, args);
                     break;
                 case SignalNum.SYNC_PROGRESSINFO:
-                    await HandleSyncProgressInfo(sender, args);
+                    HandleSyncProgressInfo(sender, args);
                     break;
                 case SignalNum.SYNC_COMPLETEDITEM:
                     await HandleSyncCompletedItem(sender, args);
@@ -1420,10 +1420,10 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                     await HandleErrorRemovedAsync(sender, args);
                     break;
                 case SignalNum.UTILITY_LOG_UPLOAD_STATUS_UPDATED:
-                    await HandleLogUploadProgressAsync(sender, args);
+                    HandleLogUploadProgressAsync(sender, args);
                     break;
                 case SignalNum.UTILITY_SHOW_NOTIFICATION:
-                    await HandleUtilityShowNotification(sender, args);
+                    HandleUtilityShowNotification(sender, args);
                     break;
                 case SignalNum.UTILITY_SHOW_SYNTHESIS:
                     await HandleUtilityShowSynthesis(sender, args);
@@ -1622,7 +1622,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             }
             await Utility.RunOnUIThread(() => { deletedSync.Drive.Syncs.Remove(deletedSync); });
         }
-        public async Task HandleSyncProgressInfo(object? sender, SignalEventArgs args)
+        public void HandleSyncProgressInfo(object? sender, SignalEventArgs args)
         {
             var signalData = args.SignalData;
 
@@ -1794,7 +1794,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             await RefreshUpdaterVersionInfo((UpdateState?)args?.SignalData[JsonKeys.UpdateState]?.GetValue<int>(), CancellationToken.None);
         }
 
-        public async Task HandleLogUploadProgressAsync(object? sender, SignalEventArgs args)
+        public void HandleLogUploadProgressAsync(object? sender, SignalEventArgs args)
         {
             var signalData = args.SignalData;
             if (signalData == null || !signalData.ContainsKey(JsonKeys.State) || !signalData.ContainsKey(JsonKeys.Percentage))
@@ -1930,7 +1930,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             }
         }
 
-        public async Task HandleUtilityShowNotification(object? sender, SignalEventArgs args)
+        public void HandleUtilityShowNotification(object? sender, SignalEventArgs args)
         {
             var signalData = args.SignalData;
             if (signalData == null || !signalData.ContainsKey(JsonKeys.Title) || !signalData.ContainsKey(JsonKeys.Message))

--- a/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/Sync.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ViewModels/App/Sync.cs
@@ -287,7 +287,7 @@ namespace Infomaniak.kDrive.ViewModels
 
         public async Task RefreshErrorState()
         {
-            await Utility.RunOnUIThread(async () =>
+            await Utility.RunOnUIThread(() =>
             {
 
                 SyncErrorState = SyncErrorStates.Undefined;


### PR DESCRIPTION
Simplified event handlers and methods by removing `async` and `await` where not required. Updated `OnNavigatedTo` methods and other handlers to synchronous versions. Replaced `Task.FromResult` in `MockServerCommProtocol.cs` and adjusted logging to reflect these changes. Improved code readability and reduced overhead.