### PR TITLE
feat(updatetreeworker): reset blacklisted nodes from update tree

### DIFF
--- a/src/libsyncengine/syncpal/isyncworker.h
+++ b/src/libsyncengine/syncpal/isyncworker.h
@@ -79,7 +79,7 @@ class ISyncWorker {
         // Implement this method in your subclass with the code you want your thread to run
         virtual void execute() = 0;
 
-        inline SyncDbId syncDbId() const { return _syncPal ? _syncPal->syncDbId() : -1; }
+        virtual SyncDbId syncDbId() const { return _syncPal ? _syncPal->syncDbId() : -1; }
 
     private:
         const std::string _name;

--- a/src/libsyncengine/update_detection/update_detector/updatetree.cpp
+++ b/src/libsyncengine/update_detection/update_detector/updatetree.cpp
@@ -56,6 +56,7 @@ bool UpdateTree::deleteNode(std::shared_ptr<Node> node, bool deleteNodeLater, in
 
     if (depth > MAX_DEPTH) {
         assert(false);
+        LOG_WARN(Log::instance()->getLogger(), "Update tree depth is too big");
         sentry::Handler::captureMessage(sentry::Level::Warning, "UpdateTree::deleteNode", "Update tree depth is too big");
         return false;
     }

--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
@@ -53,34 +53,39 @@ UpdateTreeWorker::~UpdateTreeWorker() {
     _updateTree.reset();
 }
 
-void UpdateTreeWorker::resetNodes() {
+bool UpdateTreeWorker::resetNodes() {
     // Reset nodes working properties
+    NodeSet tmpBlacklist;
+    SyncNodeCache::instance()->syncNodes(
+            syncDbId(), _side == ReplicaSide::Remote ? SyncNodeType::TmpRemoteBlacklist : SyncNodeType::TmpLocalBlacklist,
+            tmpBlacklist);
+
     auto nodeIt = _updateTree->nodes().begin();
     while (nodeIt != _updateTree->nodes().end()) {
-        if (nodeIt->second->status() == NodeStatus::ToDelete) {
-            nodeIt = _updateTree->nodes().erase(nodeIt);
+        const auto node = nodeIt->second;
+        if (node->status() == NodeStatus::ToDelete) {
+            nodeIt++;
+            if (!_updateTree->deleteNode(node)) return false;
             continue;
         }
 
         // Make sure no blacklist node remains in the update tree
-        NodeSet tmpBlacklist;
-        SyncNodeCache::instance()->syncNodes(
-                syncDbId(), _side == ReplicaSide::Remote ? SyncNodeType::TmpRemoteBlacklist : SyncNodeType::TmpLocalBlacklist,
-                tmpBlacklist);
-        if (nodeIt->second->id().has_value() && tmpBlacklist.contains(nodeIt->second->id().value())) {
+        if (node->id().has_value() && tmpBlacklist.contains(node->id().value())) {
             // Remove blacklisted nodes from the update tree
-            nodeIt = _updateTree->nodes().erase(nodeIt);
+            nodeIt++;
+            if (!_updateTree->deleteNode(node)) return false;
             continue;
         }
 
-        nodeIt->second->clearChangeEvents();
-        nodeIt->second->clearConflictAlreadyConsidered();
-        nodeIt->second->setInconsistencyType(InconsistencyType::None);
-        nodeIt->second->setPreviousId(std::nullopt);
-        nodeIt->second->setStatus(NodeStatus::Unprocessed);
-        nodeIt->second->clearMoveOriginInfos();
+        node->clearChangeEvents();
+        node->clearConflictAlreadyConsidered();
+        node->setInconsistencyType(InconsistencyType::None);
+        node->setPreviousId(std::nullopt);
+        node->setStatus(NodeStatus::Unprocessed);
+        node->clearMoveOriginInfos();
         ++nodeIt;
     }
+    return true;
 }
 
 void UpdateTreeWorker::execute() {
@@ -92,7 +97,10 @@ void UpdateTreeWorker::execute() {
 
     _updateTree->startUpdate();
 
-    resetNodes();
+    if (!resetNodes()) {
+        LOG_SYNCPAL_WARN(_logger, "Failed to reset nodes. Rebuilding update tree from scratch!");
+        _updateTree->clear();
+    }
 
     _updateTree->previousIdSet().clear();
 

--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
@@ -63,15 +63,9 @@ bool UpdateTreeWorker::resetNodes() {
     auto nodeIt = _updateTree->nodes().begin();
     while (nodeIt != _updateTree->nodes().end()) {
         const auto node = nodeIt->second;
-        if (node->status() == NodeStatus::ToDelete) {
-            nodeIt++;
-            if (!_updateTree->deleteNode(node)) return false;
-            continue;
-        }
 
-        // Make sure no blacklist node remains in the update tree
-        if (node->id().has_value() && tmpBlacklist.contains(node->id().value())) {
-            // Remove blacklisted nodes from the update tree
+        // Make sure no node flagged with status "ToDelete" or blacklisted node remains in the update tree
+        if (node->status() == NodeStatus::ToDelete || (node->id().has_value() && tmpBlacklist.contains(node->id().value()))) {
             nodeIt++;
             if (!_updateTree->deleteNode(node)) return false;
             continue;

--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
@@ -22,6 +22,7 @@
 #include "libcommon/utility/logiffail.h"
 #include "libcommonserver/utility/utility.h"
 #include "requests/parameterscache.h"
+#include "requests/syncnodecache.h"
 #include "utility/timerutility.h"
 
 #include <iostream>
@@ -52,6 +53,36 @@ UpdateTreeWorker::~UpdateTreeWorker() {
     _updateTree.reset();
 }
 
+void UpdateTreeWorker::resetNodes() {
+    // Reset nodes working properties
+    auto nodeIt = _updateTree->nodes().begin();
+    while (nodeIt != _updateTree->nodes().end()) {
+        if (nodeIt->second->status() == NodeStatus::ToDelete) {
+            nodeIt = _updateTree->nodes().erase(nodeIt);
+            continue;
+        }
+
+        // Make sure no blacklist node remains in the update tree
+        NodeSet tmpBlacklist;
+        SyncNodeCache::instance()->syncNodes(
+                syncDbId(), _side == ReplicaSide::Remote ? SyncNodeType::TmpRemoteBlacklist : SyncNodeType::TmpLocalBlacklist,
+                tmpBlacklist);
+        if (nodeIt->second->id().has_value() && tmpBlacklist.contains(nodeIt->second->id().value())) {
+            // Remove blacklisted nodes from the update tree
+            nodeIt = _updateTree->nodes().erase(nodeIt);
+            continue;
+        }
+
+        nodeIt->second->clearChangeEvents();
+        nodeIt->second->clearConflictAlreadyConsidered();
+        nodeIt->second->setInconsistencyType(InconsistencyType::None);
+        nodeIt->second->setPreviousId(std::nullopt);
+        nodeIt->second->setStatus(NodeStatus::Unprocessed);
+        nodeIt->second->clearMoveOriginInfos();
+        ++nodeIt;
+    }
+}
+
 void UpdateTreeWorker::execute() {
     ExitCode exitCode(ExitCode::Unknown);
 
@@ -61,21 +92,7 @@ void UpdateTreeWorker::execute() {
 
     _updateTree->startUpdate();
 
-    // Reset nodes working properties
-    auto nodeIt = _updateTree->nodes().begin();
-    while (nodeIt != _updateTree->nodes().end()) {
-        if (nodeIt->second->status() == NodeStatus::ToDelete) {
-            nodeIt = _updateTree->nodes().erase(nodeIt);
-        } else {
-            nodeIt->second->clearChangeEvents();
-            nodeIt->second->clearConflictAlreadyConsidered();
-            nodeIt->second->setInconsistencyType(InconsistencyType::None);
-            nodeIt->second->setPreviousId(std::nullopt);
-            nodeIt->second->setStatus(NodeStatus::Unprocessed);
-            nodeIt->second->clearMoveOriginInfos();
-            ++nodeIt;
-        }
-    }
+    resetNodes();
 
     _updateTree->previousIdSet().clear();
 

--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.h
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.h
@@ -167,6 +167,8 @@ class UpdateTreeWorker : public ISyncWorker {
         bool checkNodeIntegrity(const std::shared_ptr<Node> node);
         bool checkOperationTypes(const std::shared_ptr<Node> node);
 
+        void resetNodes();
+
         friend class TestUpdateTreeWorker;
 };
 

--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.h
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.h
@@ -167,7 +167,7 @@ class UpdateTreeWorker : public ISyncWorker {
         bool checkNodeIntegrity(const std::shared_ptr<Node> node);
         bool checkOperationTypes(const std::shared_ptr<Node> node);
 
-        void resetNodes();
+        bool resetNodes();
 
         friend class TestUpdateTreeWorker;
 };

--- a/test/libsyncengine/update_detection/update_detector/testupdatetreeworker.cpp
+++ b/test/libsyncengine/update_detection/update_detector/testupdatetreeworker.cpp
@@ -19,6 +19,7 @@
 #include "testupdatetreeworker.h"
 #include "requests/parameterscache.h"
 #include "mocks/libcommonserver/db/mockdb.h"
+#include "requests/syncnodecache.h"
 
 #include "test_utility/testhelpers.h"
 
@@ -36,7 +37,7 @@ void TestUpdateTreeWorker::setUp() {
 
     // Create DB
     bool alreadyExists = false;
-    const SyncPath syncDbPath = MockDb::makeDbName(1, 1, 1, 1, alreadyExists);
+    const SyncPath syncDbPath = MockDb::makeDbName(1, 1, 1, testSyncDbId, alreadyExists);
     _syncDb = std::make_shared<SyncDb>(syncDbPath.string());
     _syncDb->init(KDRIVE_VERSION_STRING);
     _syncDb->setAutoDelete(true);
@@ -45,15 +46,17 @@ void TestUpdateTreeWorker::setUp() {
     _localUpdateTree = std::make_shared<UpdateTree>(ReplicaSide::Local, SyncDb::driveRootNode());
     _remoteUpdateTree = std::make_shared<UpdateTree>(ReplicaSide::Remote, SyncDb::driveRootNode());
 
-    _localUpdateTreeWorker = std::make_shared<UpdateTreeWorker>(_syncDb->cache(), _operationSet, _localUpdateTree,
-                                                                "Test Tree Updater", "LTRU", ReplicaSide::Local);
-    _remoteUpdateTreeWorker = std::make_shared<UpdateTreeWorker>(_syncDb->cache(), _operationSet, _remoteUpdateTree,
-                                                                 "Test Tree Updater", "RTRU", ReplicaSide::Remote);
+    _localUpdateTreeWorker = std::make_shared<MockUpdateTreeWorker>(_syncDb->cache(), _operationSet, _localUpdateTree,
+                                                                    "Test Tree Updater", "LTRU", ReplicaSide::Local);
+    _remoteUpdateTreeWorker = std::make_shared<MockUpdateTreeWorker>(_syncDb->cache(), _operationSet, _remoteUpdateTree,
+                                                                     "Test Tree Updater", "RTRU", ReplicaSide::Remote);
 
     setUpDbTree();
 
     _localUpdateTree->init();
     _remoteUpdateTree->init();
+
+    SyncNodeCache::instance()->initCache(testSyncDbId, _syncDb);
 }
 
 void TestUpdateTreeWorker::tearDown() {
@@ -1221,6 +1224,43 @@ void TestUpdateTreeWorker::testIntegrityCheck() {
         integrityExceptionCaught = true;
     }
     CPPUNIT_ASSERT(integrityExceptionCaught);
+}
+
+void TestUpdateTreeWorker::testResetNodes() {
+    auto updateTree = std::make_shared<UpdateTree>(ReplicaSide::Remote, SyncDb::driveRootNode());
+    // Normal unmodified node
+    const auto nodeA = std::make_shared<Node>(ReplicaSide::Remote, Str("A"), NodeType::Directory, updateTree->rootNode());
+    _remoteUpdateTree->insertNode(nodeA);
+    // Node created on previous sync
+    const auto nodeB = std::make_shared<Node>(ReplicaSide::Remote, Str("B"), NodeType::Directory, updateTree->rootNode());
+    nodeB->setChangeEvents(OperationType::Create);
+    nodeB->setStatus(NodeStatus::Processed);
+    _remoteUpdateTree->insertNode(nodeB);
+    // Node moved on previous sync
+    const auto nodeC = std::make_shared<Node>(ReplicaSide::Remote, Str("C2"), NodeType::Directory, updateTree->rootNode());
+    nodeC->setMoveOriginInfos({"C1", "1"});
+    nodeC->setChangeEvents(OperationType::Move);
+    _remoteUpdateTree->insertNode(nodeC);
+    // Node to be removed from the UpdateTree
+    const auto nodeD = std::make_shared<Node>(ReplicaSide::Remote, Str("D"), NodeType::Directory, updateTree->rootNode());
+    nodeD->setStatus(NodeStatus::ToDelete);
+    _remoteUpdateTree->insertNode(nodeD);
+    // Blacklisted node
+    const auto nodeE = std::make_shared<Node>(ReplicaSide::Remote, Str("E"), NodeType::Directory, updateTree->rootNode());
+    (void) SyncNodeCache::instance()->update(testSyncDbId, SyncNodeType::TmpRemoteBlacklist, {nodeE->id().value()});
+    _remoteUpdateTree->insertNode(nodeE);
+
+    _remoteUpdateTreeWorker->resetNodes();
+
+    CPPUNIT_ASSERT(_remoteUpdateTree->exists(nodeA->id().value()));
+    CPPUNIT_ASSERT(_remoteUpdateTree->exists(nodeB->id().value()));
+    CPPUNIT_ASSERT_EQUAL(OperationType::None, nodeB->changeEvents());
+    CPPUNIT_ASSERT_EQUAL(NodeStatus::Unprocessed, nodeB->status());
+    CPPUNIT_ASSERT(_remoteUpdateTree->exists(nodeC->id().value()));
+    CPPUNIT_ASSERT_EQUAL(OperationType::None, nodeC->changeEvents());
+    CPPUNIT_ASSERT(!nodeC->moveOriginInfos().isValid());
+    CPPUNIT_ASSERT(!_remoteUpdateTree->exists(nodeD->id().value()));
+    CPPUNIT_ASSERT(!_remoteUpdateTree->exists(nodeE->id().value()));
 }
 
 } // namespace KDC

--- a/test/libsyncengine/update_detection/update_detector/testupdatetreeworker.cpp
+++ b/test/libsyncengine/update_detection/update_detector/testupdatetreeworker.cpp
@@ -56,7 +56,7 @@ void TestUpdateTreeWorker::setUp() {
     _localUpdateTree->init();
     _remoteUpdateTree->init();
 
-    SyncNodeCache::instance()->initCache(testSyncDbId, _syncDb);
+    (void) SyncNodeCache::instance()->initCache(testSyncDbId, _syncDb);
 }
 
 void TestUpdateTreeWorker::tearDown() {
@@ -65,6 +65,7 @@ void TestUpdateTreeWorker::tearDown() {
     // As the two singletons are instantiated in different translation units, the order of their destruction is unknown.
     ParmsDb::reset();
     ParametersCache::reset();
+    (void) SyncNodeCache::instance()->clear(testSyncDbId);
     TestBase::stop();
 }
 
@@ -1227,26 +1228,25 @@ void TestUpdateTreeWorker::testIntegrityCheck() {
 }
 
 void TestUpdateTreeWorker::testResetNodes() {
-    auto updateTree = std::make_shared<UpdateTree>(ReplicaSide::Remote, SyncDb::driveRootNode());
     // Normal unmodified node
-    const auto nodeA = std::make_shared<Node>(ReplicaSide::Remote, Str("A"), NodeType::Directory, updateTree->rootNode());
+    const auto nodeA = std::make_shared<Node>(ReplicaSide::Remote, Str("A"), NodeType::Directory, _remoteUpdateTree->rootNode());
     _remoteUpdateTree->insertNode(nodeA);
     // Node created on previous sync
-    const auto nodeB = std::make_shared<Node>(ReplicaSide::Remote, Str("B"), NodeType::Directory, updateTree->rootNode());
+    const auto nodeB = std::make_shared<Node>(ReplicaSide::Remote, Str("B"), NodeType::Directory, _remoteUpdateTree->rootNode());
     nodeB->setChangeEvents(OperationType::Create);
     nodeB->setStatus(NodeStatus::Processed);
     _remoteUpdateTree->insertNode(nodeB);
     // Node moved on previous sync
-    const auto nodeC = std::make_shared<Node>(ReplicaSide::Remote, Str("C2"), NodeType::Directory, updateTree->rootNode());
+    const auto nodeC = std::make_shared<Node>(ReplicaSide::Remote, Str("C2"), NodeType::Directory, _remoteUpdateTree->rootNode());
     nodeC->setMoveOriginInfos({"C1", "1"});
     nodeC->setChangeEvents(OperationType::Move);
     _remoteUpdateTree->insertNode(nodeC);
     // Node to be removed from the UpdateTree
-    const auto nodeD = std::make_shared<Node>(ReplicaSide::Remote, Str("D"), NodeType::Directory, updateTree->rootNode());
+    const auto nodeD = std::make_shared<Node>(ReplicaSide::Remote, Str("D"), NodeType::Directory, _remoteUpdateTree->rootNode());
     nodeD->setStatus(NodeStatus::ToDelete);
     _remoteUpdateTree->insertNode(nodeD);
     // Blacklisted node
-    const auto nodeE = std::make_shared<Node>(ReplicaSide::Remote, Str("E"), NodeType::Directory, updateTree->rootNode());
+    const auto nodeE = std::make_shared<Node>(ReplicaSide::Remote, Str("E"), NodeType::Directory, _remoteUpdateTree->rootNode());
     (void) SyncNodeCache::instance()->update(testSyncDbId, SyncNodeType::TmpRemoteBlacklist, {nodeE->id().value()});
     _remoteUpdateTree->insertNode(nodeE);
 

--- a/test/libsyncengine/update_detection/update_detector/testupdatetreeworker.h
+++ b/test/libsyncengine/update_detection/update_detector/testupdatetreeworker.h
@@ -27,6 +27,19 @@ using namespace CppUnit;
 
 namespace KDC {
 
+constexpr SyncDbId testSyncDbId = 1;
+
+class MockUpdateTreeWorker : public UpdateTreeWorker {
+    public:
+        MockUpdateTreeWorker(SyncDbReadOnlyCache &syncDbReadOnlyCache, std::shared_ptr<FSOperationSet> operationSet,
+                             std::shared_ptr<UpdateTree> updateTree, const std::string &name, const std::string &shortName,
+                             ReplicaSide side) :
+            UpdateTreeWorker(syncDbReadOnlyCache, operationSet, updateTree, name, shortName, side) {}
+
+    protected:
+        SyncDbId syncDbId() const override { return testSyncDbId; }
+};
+
 class TestUpdateTreeWorker : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST_SUITE(TestUpdateTreeWorker);
         CPPUNIT_TEST(testUtilsFunctions);
@@ -61,6 +74,7 @@ class TestUpdateTreeWorker : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST(testDeleteRecreateBranch);
         CPPUNIT_TEST(testGetNodeFromDeletedPath);
         CPPUNIT_TEST(testIntegrityCheck);
+        CPPUNIT_TEST(testResetNodes);
         CPPUNIT_TEST_SUITE_END();
 
     public:
@@ -116,10 +130,11 @@ class TestUpdateTreeWorker : public CppUnit::TestFixture, public TestBase {
 
         void testGetNodeFromDeletedPath();
         void testIntegrityCheck();
+        void testResetNodes();
 
     private:
-        std::shared_ptr<UpdateTreeWorker> _localUpdateTreeWorker;
-        std::shared_ptr<UpdateTreeWorker> _remoteUpdateTreeWorker;
+        std::shared_ptr<MockUpdateTreeWorker> _localUpdateTreeWorker;
+        std::shared_ptr<MockUpdateTreeWorker> _remoteUpdateTreeWorker;
         std::shared_ptr<SyncDb> _syncDb;
         std::shared_ptr<FSOperationSet> _operationSet;
         std::shared_ptr<UpdateTree> _localUpdateTree;


### PR DESCRIPTION
## Summary

Extracts the node-reset logic from `UpdateTreeWorker::execute()` into a dedicated `resetNodes()` method and extends it to also remove nodes that are present in the temporary blacklist (TmpRemoteBlacklist / TmpLocalBlacklist).

### Changes

- `ISyncWorker::syncDbId()` is now `virtual` so tests can mock it via `MockUpdateTreeWorker`.
- New private method `UpdateTreeWorker::resetNodes()` centralises node cleanup before each sync cycle.
- Nodes whose ids appear in the sync-node blacklist are erased from the update tree.

### Tests

- Added `MockUpdateTreeWorker` test double returning a fixed `syncDbId`.
- Added `testResetNodes()` covering:
  - Unmodified nodes are preserved
  - Processed nodes get their events and status reset
  - Moved nodes get their origin info cleared
  - Nodes marked `ToDelete` are removed
  - Blacklisted nodes are removed