### PR TITLE
feat(errors): add case conflict error handling

### DIFF
--- a/src/gui4/windows/kDrive client/checkTranslationKeys.ps1
+++ b/src/gui4/windows/kDrive client/checkTranslationKeys.ps1
@@ -20,7 +20,7 @@ if (-not $reswFiles) {
     exit 1
 }
 
-$literalPattern = 'Localizer\.Instance\.GetString\(\s*[''"](?<key>[^''"]+)[''"]'
+$literalPattern = 'Localizer\.Instance\.GetString\w*\(\s*[''"](?<key>[^''"]+)[''"]'
 $converterPattern = 'ConverterParameter\s*=\s*[''"][^''"]*key=(?<key>[^''";]+)'
 $dynamicPattern = 'Localizer\.Instance\.GetString\(\s*(?![''"])(?<arg>[^)]*)\)'
 

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/AdvancedSyncSetupContentDialog/DialogPages/SyncSetupPage.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/AdvancedSyncSetupContentDialog/DialogPages/SyncSetupPage.xaml
@@ -270,7 +270,7 @@
 
                 <TextBlock Grid.ColumnSpan="2"
                            Grid.Row="2"
-                           Text="{x:Bind kDrive:Localizer.Instance.GetString('liteSyncUnavailableDescription')}"
+                           Text="{x:Bind kDrive:Localizer.Instance.GetString('liteSyncUnavailableDescriptionWin')}"
                            TextWrapping="WrapWholeWords"
                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                            Style="{StaticResource CaptionTextBlockStyle}"

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/SyncSetupPage.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/DriveSetupContentDialog/DialogPages/SyncSetupPage.xaml
@@ -326,7 +326,7 @@
 
                     <TextBlock Grid.ColumnSpan="2"
                                Grid.Row="2"
-                               Text="{x:Bind kDrive:Localizer.Instance.GetString('liteSyncUnavailableDescription')}"
+                               Text="{x:Bind kDrive:Localizer.Instance.GetString('liteSyncUnavailableDescriptionWin')}"
                                TextWrapping="WrapWholeWords"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                Style="{StaticResource CaptionTextBlockStyle}"

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/DefaultError.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/DefaultError.xaml.cs
@@ -77,9 +77,8 @@ namespace Infomaniak.kDrive.CustomControls.Errors
                 {
                     try
                     {
-                        var value = prop.GetValue(Error);
                         if (prop.Name == nameof(Error.NodeTypeTranslationKey)) continue;
-
+                        var value = prop.GetValue(Error);
                         AddIfNotEmpty($"{prop.Name}", value);
                     }
                     catch (Exception ex)

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/DefaultError.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/DefaultError.xaml.cs
@@ -78,6 +78,8 @@ namespace Infomaniak.kDrive.CustomControls.Errors
                     try
                     {
                         var value = prop.GetValue(Error);
+                        if (prop.Name == nameof(Error.NodeTypeTranslationKey)) continue;
+
                         AddIfNotEmpty($"{prop.Name}", value);
                     }
                     catch (Exception ex)

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/ErrorCard.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/ErrorCard.xaml
@@ -40,6 +40,7 @@
           RowSpacing="{StaticResource Infomaniak.Style.Spacing.XS}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
@@ -59,16 +60,13 @@
                                         Visibility="{x:Bind HasItemPath, Converter={StaticResource BooleanToVisibilityConverter}}" />
         </StackPanel>
         <!-- Description & CustomContent-->
-        <StackPanel Grid.Row="1"
-                    Grid.Column="0">
-            <TextBlock Text="{x:Bind Description, Mode=OneWay}"
-                       TextWrapping="Wrap"
-                       Style="{StaticResource BodyTextBlockStyle}"
-                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                       Visibility="{x:Bind HasDescription}"/>
-
-            <ContentPresenter Content="{x:Bind CustomContent, Mode=OneWay}" />
-        </StackPanel>
+        <TextBlock Grid.Row="1"
+                   Grid.Column="0"
+                   Text="{x:Bind Description, Mode=OneWay}"
+                   TextWrapping="Wrap"
+                   Style="{StaticResource BodyTextBlockStyle}"
+                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                   Visibility="{x:Bind HasDescription}"/>
 
         <!-- Action button -->
         <Button Grid.Row="0"
@@ -81,5 +79,10 @@
                 Content="{x:Bind ActionText}"
                 Click="ActionButton_Click"
                 Visibility="{x:Bind ActionText, Converter={StaticResource IsNullToBoolOrVisibilityConverter}, ConverterParameter='Inverted=True'}" />
+
+        <ContentPresenter Grid.Row="2"
+                          Grid.ColumnSpan="2"
+                          Content="{x:Bind CustomContent, Mode=OneWay}" />
+
     </Grid>
 </UserControl>

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/CaseError.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/CaseError.xaml
@@ -1,0 +1,34 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ -->
+<UserControl x:Class="Infomaniak.kDrive.CustomControls.Errors.Templates.Node.CaseError"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="using:Infomaniak.kDrive.CustomControls.Errors"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:converters="using:Infomaniak.kDrive.Converters"
+             xmlns:kDrive="using:Infomaniak.kDrive"
+             mc:Ignorable="d">
+    <local:ErrorCard x:Name="ErrorCard"
+                     Title="{x:Bind kDrive:Localizer.Instance.GetString('errCaseTitle')}"
+                     Description="{x:Bind kDrive:Localizer.Instance.GetStringCombine1s('errCaseDescription', Error.NodeTypeTranslationKey)}"
+                     ActionText="{x:Bind kDrive:Localizer.Instance.GetStringCombine1s('buttonRenameItem', Error.NodeTypeTranslationKey)}"
+                     ActionClick="ErrorCard_ActionClick"
+                     Error="{x:Bind Error}" />
+</UserControl>

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/CaseError.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/CaseError.xaml.cs
@@ -1,0 +1,50 @@
+﻿/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+using Infomaniak.kDrive.Analytics;
+using Infomaniak.kDrive.Types;
+using Infomaniak.kDrive.ViewModels;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.UI.Xaml.Controls;
+using System;
+
+namespace Infomaniak.kDrive.CustomControls.Errors.Templates.Node
+{
+    [ErrorMetadata(
+        Levels = new[] { ErrorLevel.Node },
+        NodeTypes = new[] { NodeType.File, NodeType.Directory },
+        InconsistencyTypes = new[] { InconsistencyType.None }
+    )]
+    public sealed partial class CaseError : UserControl
+    {
+        private readonly IAnalyticsService _analyticsService = App.ServiceProvider.GetRequiredService<IAnalyticsService>();
+        private Error Error { get; init; }
+        public CaseError(Error error)
+        {
+            this.InitializeComponent();
+            Error = error;
+        }
+
+        private async void ErrorCard_ActionClick(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+        {
+            _analyticsService.TrackClick(Analytics.Keys.Category.Errors, Analytics.Keys.EventName.ManageCaseConflictError);
+
+            if (!await Error.OpenItemInWebViewAsync())
+                Utility.ShowUnexpectedErrorTeachingTip();
+        }
+    }
+}

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/CaseError.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/CaseError.xaml.cs
@@ -27,7 +27,7 @@ namespace Infomaniak.kDrive.CustomControls.Errors.Templates.Node
     [ErrorMetadata(
         Levels = new[] { ErrorLevel.Node },
         NodeTypes = new[] { NodeType.File, NodeType.Directory },
-        InconsistencyTypes = new[] { InconsistencyType.None }
+        InconsistencyTypes = new[] { InconsistencyType.Case }
     )]
     public sealed partial class CaseError : UserControl
     {

--- a/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/ForbiddenCharError.xaml
+++ b/src/gui4/windows/kDrive client/kDrive client/CustomControls/Errors/Templates/Node/ForbiddenCharError.xaml
@@ -27,7 +27,7 @@
              mc:Ignorable="d">
     <local:ErrorCard x:Name="ErrorCard"
                      Title="{x:Bind kDrive:Localizer.Instance.GetString('errForbiddenCharTitle')}"
-                     Description="{x:Bind kDrive:Localizer.Instance.GetStringCombine1s('errForbiddenCharDescription_win', Error.NodeTypeTranslationKey)}"
+                     Description="{x:Bind kDrive:Localizer.Instance.GetStringCombine1s('errForbiddenCharDescription', Error.NodeTypeTranslationKey)}"
                      ActionText="{x:Bind kDrive:Localizer.Instance.GetStringCombine1s('buttonRenameItem', Error.NodeTypeTranslationKey)}"
                      ActionClick="ErrorCard_ActionClick"
                      Error="{x:Bind Error}" />

--- a/src/gui4/windows/kDrive client/kDrive client/Logger/Analytics/AnalyticsKeys.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Logger/Analytics/AnalyticsKeys.cs
@@ -132,6 +132,7 @@
         FileAccessErrorOpenFolder,
         ManageNotEnoughDiskSpace,
         ManageUnsupportedChar,
+        ManageCaseConflictError,
         ManageEndsWithSpace,
         ManageFileNameReserved,
         ManageFileNameTooLong,

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/da-DK/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/da-DK/Resources.resw
@@ -6,7 +6,7 @@
   Locale: da, Danish
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Wed, 27 May 2026 14:49:19 +0200 
+  Exported at: Fri, 29 May 2026 15:21:01 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -604,6 +604,13 @@ Log venligst ind igen med den korrekte e-mailadresse %@</value>
   <data name="enterPasswordPlaceholder" xml:space="preserve"> 
     <value>Indtast din adgangskode</value> 
   </data> 
+  <data name="errCaseDescription" xml:space="preserve"> 
+    <value>En anden %@, hvis navn kun adskiller sig ved store/små bogstaver, findes allerede i denne mappe. Denne type navn understøttes ikke af kDrive Windows-applikationen. Omdøb en af %@-mapperne fra kDrive online, så du kan synkronisere den på din pc.
+</value> 
+  </data> 
+  <data name="errCaseTitle" xml:space="preserve"> 
+    <value>Modstridende navne, skelner mellem store og små bogstaver</value> 
+  </data> 
   <data name="errCreateCancelDescription" xml:space="preserve"> 
     <value>Du har ikke de nødvendige tilladelser til at tilføje en %@ til denne placering.
 Anmod om adgang fra ejeren eller administratoren.</value> 
@@ -696,7 +703,7 @@ Kontakt din administrator for at øge filstørrelsesgrænsen.</value>
     <value>Adgang forbudt</value> 
     <comment>Title shown when a forbidden or unauthorized action is attempted.</comment> 
   </data> 
-  <data name="errForbiddenCharDescription_win" xml:space="preserve"> 
+  <data name="errForbiddenCharDescription" xml:space="preserve"> 
     <value>Navnet på dette %@ indeholder et eller flere tegn, der ikke understøttes af kDrive Windows-programmet. Omdøb %@ fra kDrive online.</value> 
   </data> 
   <data name="errForbiddenCharOnlySpacesDescription" xml:space="preserve"> 
@@ -1067,7 +1074,7 @@ Nyttigt, hvis du ved, at det vigtige arbejde er online på kDrive.</value>
     <value>Ingen konflikter matcher din søgning</value> 
   </data> 
   <data name="labelNoErrorsToFix" xml:space="preserve"> 
-    <value>Ingen fejl at rette.</value> 
+    <value>Ingen fejl at rette</value> 
   </data> 
   <data name="labelNotifications" xml:space="preserve"> 
     <value>Notifikation</value> 
@@ -1196,7 +1203,7 @@ For at fremskynde overførslen anbefaler vi at sende kun den seneste kDrive-sess
   <data name="linkCopiedToClipboardTitle" xml:space="preserve"> 
     <value>Link kopieret til udklipsholder</value> 
   </data> 
-  <data name="liteSyncUnavailableDescription" xml:space="preserve"> 
+  <data name="liteSyncUnavailableDescriptionWin" xml:space="preserve"> 
     <value>Inkompatibelt drev eller mappe direkte i roden af drevet (f.eks. vælg en mappe som D:/Mit drev i stedet for D:/)</value> 
   </data> 
   <data name="localLocation" xml:space="preserve"> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/da-DK/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/da-DK/Resources.resw
@@ -6,7 +6,7 @@
   Locale: da, Danish
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Fri, 29 May 2026 15:49:15 +0200 
+  Exported at: Fri, 29 May 2026 15:56:50 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/da-DK/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/da-DK/Resources.resw
@@ -6,7 +6,7 @@
   Locale: da, Danish
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Fri, 29 May 2026 15:21:01 +0200 
+  Exported at: Fri, 29 May 2026 15:49:15 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/de-DE/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/de-DE/Resources.resw
@@ -6,7 +6,7 @@
   Locale: de, German
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Fri, 29 May 2026 15:21:01 +0200 
+  Exported at: Fri, 29 May 2026 15:49:15 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -605,11 +605,11 @@ Bitte melden Sie sich erneut mit der korrekten E-Mail-Adresse %@ an</value>
     <value>Geben Sie Ihr Passwort ein</value> 
   </data> 
   <data name="errCaseDescription" xml:space="preserve"> 
-    <value>Ein weiteres %@, dessen Name sich nur in der Groß-/Kleinschreibung unterscheidet, existiert bereits in diesem Ordner. Dieser Namenstyp wird von der kDrive Windows-Anwendung nicht unterstützt. Benennen Sie eines der %@ aus kDrive online um, damit Sie es auf Ihrem PC synchronisieren können.
+    <value>Ein weiteres %@, dessen Name sich nur in der Gross-/Kleinschreibung unterscheidet, existiert bereits in diesem Ordner. Dieser Namenstyp wird von der kDrive Windows-Anwendung nicht unterstützt. Benennen Sie eines der %@ aus kDrive online um, damit Sie es auf Ihrem PC synchronisieren können.
 </value> 
   </data> 
   <data name="errCaseTitle" xml:space="preserve"> 
-    <value>Namenskonflikte in Groß- und Kleinschreibung</value> 
+    <value>Namenskonflikte in Gross- und Kleinschreibung</value> 
   </data> 
   <data name="errCreateCancelDescription" xml:space="preserve"> 
     <value>Sie haben nicht die erforderlichen Berechtigungen, um %@ zu diesem Speicherort hinzuzufügen.

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/de-DE/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/de-DE/Resources.resw
@@ -6,7 +6,7 @@
   Locale: de, German
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Fri, 29 May 2026 15:49:15 +0200 
+  Exported at: Fri, 29 May 2026 15:56:50 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/de-DE/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/de-DE/Resources.resw
@@ -6,7 +6,7 @@
   Locale: de, German
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Wed, 27 May 2026 14:49:19 +0200 
+  Exported at: Fri, 29 May 2026 15:21:01 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -604,6 +604,13 @@ Bitte melden Sie sich erneut mit der korrekten E-Mail-Adresse %@ an</value>
   <data name="enterPasswordPlaceholder" xml:space="preserve"> 
     <value>Geben Sie Ihr Passwort ein</value> 
   </data> 
+  <data name="errCaseDescription" xml:space="preserve"> 
+    <value>Ein weiteres %@, dessen Name sich nur in der Groß-/Kleinschreibung unterscheidet, existiert bereits in diesem Ordner. Dieser Namenstyp wird von der kDrive Windows-Anwendung nicht unterstützt. Benennen Sie eines der %@ aus kDrive online um, damit Sie es auf Ihrem PC synchronisieren können.
+</value> 
+  </data> 
+  <data name="errCaseTitle" xml:space="preserve"> 
+    <value>Namenskonflikte in Groß- und Kleinschreibung</value> 
+  </data> 
   <data name="errCreateCancelDescription" xml:space="preserve"> 
     <value>Sie haben nicht die erforderlichen Berechtigungen, um %@ zu diesem Speicherort hinzuzufügen.
 Fordern Sie den Zugriff beim Eigentümer oder Administrator an.</value> 
@@ -696,7 +703,7 @@ Wenden Sie sich an Ihren Administrator, um das Dateigrössenlimit zu erhöhen.</
     <value>Zugriff verboten</value> 
     <comment>Title shown when a forbidden or unauthorized action is attempted.</comment> 
   </data> 
-  <data name="errForbiddenCharDescription_win" xml:space="preserve"> 
+  <data name="errForbiddenCharDescription" xml:space="preserve"> 
     <value>Der Name dieses %@ enthält ein oder mehrere Zeichen, die von der kDrive Windows-Anwendung nicht unterstützt werden. Benennen Sie %@ über kDrive online um.</value> 
   </data> 
   <data name="errForbiddenCharOnlySpacesDescription" xml:space="preserve"> 
@@ -1067,7 +1074,7 @@ Nützlich, wenn Sie wissen, dass die wichtige Arbeit online auf kDrive ist.</val
     <value>Keine Konflikte entsprechen Ihrer Suche</value> 
   </data> 
   <data name="labelNoErrorsToFix" xml:space="preserve"> 
-    <value>Keine Fehler zu beheben.</value> 
+    <value>Keine Fehler zu beheben</value> 
   </data> 
   <data name="labelNotifications" xml:space="preserve"> 
     <value>Benachrichtigung</value> 
@@ -1196,7 +1203,7 @@ Um den Upload zu beschleunigen, empfehlen wir, nur die letzte kDrive-Sitzung zu 
   <data name="linkCopiedToClipboardTitle" xml:space="preserve"> 
     <value>Link in die Zwischenablage kopiert</value> 
   </data> 
-  <data name="liteSyncUnavailableDescription" xml:space="preserve"> 
+  <data name="liteSyncUnavailableDescriptionWin" xml:space="preserve"> 
     <value>Inkompatibles Laufwerk oder Ordner direkt im Stammverzeichnis des Laufwerks (z. B. wählen Sie einen Ordner wie D:/Mon drive statt D:/)</value> 
   </data> 
   <data name="localLocation" xml:space="preserve"> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/el-GR/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/el-GR/Resources.resw
@@ -6,7 +6,7 @@
   Locale: el, Greek
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Wed, 27 May 2026 14:49:19 +0200 
+  Exported at: Fri, 29 May 2026 15:21:01 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -604,6 +604,13 @@
   <data name="enterPasswordPlaceholder" xml:space="preserve"> 
     <value>Εισαγάγετε τον κωδικό πρόσβασής σας</value> 
   </data> 
+  <data name="errCaseDescription" xml:space="preserve"> 
+    <value>Ένα άλλο %@ του οποίου το όνομα διαφέρει μόνο στα κεφαλαία/μικρά γράμματα υπάρχει ήδη σε αυτόν το φάκελο. Αυτός ο τύπος ονόματος δεν υποστηρίζεται από την εφαρμογή kDrive Windows. Μετονομάστε έναν από τους φακέλους %@ από το kDrive online, ώστε να μπορείτε να τον συγχρονίσετε στον υπολογιστή σας.
+</value> 
+  </data> 
+  <data name="errCaseTitle" xml:space="preserve"> 
+    <value>Συγκρουόμενα ονόματα, ευαίσθητα στην πεζότητα</value> 
+  </data> 
   <data name="errCreateCancelDescription" xml:space="preserve"> 
     <value>Δεν έχετε τα απαραίτητα δικαιώματα για να προσθέσετε ένα %@ σε αυτή την τοποθεσία.
 Ζητήστε πρόσβαση από τον κάτοχο ή τον διαχειριστή.</value> 
@@ -696,7 +703,7 @@
     <value>Απαγορευμένη πρόσβαση</value> 
     <comment>Title shown when a forbidden or unauthorized action is attempted.</comment> 
   </data> 
-  <data name="errForbiddenCharDescription_win" xml:space="preserve"> 
+  <data name="errForbiddenCharDescription" xml:space="preserve"> 
     <value>Το όνομα αυτού του %@ περιέχει έναν ή περισσότερους χαρακτήρες που δεν υποστηρίζονται από την εφαρμογή kDrive Windows. Μετονομάστε το %@ από το kDrive online.</value> 
   </data> 
   <data name="errForbiddenCharOnlySpacesDescription" xml:space="preserve"> 
@@ -1067,7 +1074,7 @@
     <value>Καμία σύγκρουση δεν αντιστοιχεί στην αναζήτησή σας</value> 
   </data> 
   <data name="labelNoErrorsToFix" xml:space="preserve"> 
-    <value>Δεν υπάρχουν σφάλματα για διόρθωση.</value> 
+    <value>Δεν υπάρχουν σφάλματα για διόρθωση</value> 
   </data> 
   <data name="labelNotifications" xml:space="preserve"> 
     <value>Ειδοποίηση</value> 
@@ -1196,7 +1203,7 @@
   <data name="linkCopiedToClipboardTitle" xml:space="preserve"> 
     <value>Ο σύνδεσμος αντιγράφηκε στο πρόχειρο</value> 
   </data> 
-  <data name="liteSyncUnavailableDescription" xml:space="preserve"> 
+  <data name="liteSyncUnavailableDescriptionWin" xml:space="preserve"> 
     <value>Μη συμβατή μονάδα δίσκου ή φάκελος απευθείας στη ρίζα της μονάδας (π.χ. επιλέξτε έναν φάκελο όπως D:/Η μονάδα μου αντί για D:/)</value> 
   </data> 
   <data name="localLocation" xml:space="preserve"> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/el-GR/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/el-GR/Resources.resw
@@ -6,7 +6,7 @@
   Locale: el, Greek
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Fri, 29 May 2026 15:49:15 +0200 
+  Exported at: Fri, 29 May 2026 15:56:50 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/el-GR/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/el-GR/Resources.resw
@@ -6,7 +6,7 @@
   Locale: el, Greek
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Fri, 29 May 2026 15:21:01 +0200 
+  Exported at: Fri, 29 May 2026 15:49:15 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/en-US/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/en-US/Resources.resw
@@ -6,7 +6,7 @@
   Locale: en, English
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Fri, 29 May 2026 15:49:15 +0200 
+  Exported at: Fri, 29 May 2026 15:56:50 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -182,7 +182,7 @@ You can open them at any time, even without an internet connection.</value>
     <value>Advanced settings</value> 
   </data> 
   <data name="buttonApplyToXFiles" xml:space="preserve"> 
-    <value>Apply to %d files</value> 
+    <value>Apply to %@ files</value> 
   </data> 
   <data name="buttonAskForAccess" xml:space="preserve"> 
     <value>Request access</value> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/en-US/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/en-US/Resources.resw
@@ -6,7 +6,7 @@
   Locale: en, English
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Wed, 27 May 2026 14:49:19 +0200 
+  Exported at: Fri, 29 May 2026 15:21:01 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -182,7 +182,7 @@ You can open them at any time, even without an internet connection.</value>
     <value>Advanced settings</value> 
   </data> 
   <data name="buttonApplyToXFiles" xml:space="preserve"> 
-    <value>Apply to %@ files</value> 
+    <value>Apply to %d files</value> 
   </data> 
   <data name="buttonAskForAccess" xml:space="preserve"> 
     <value>Request access</value> 
@@ -604,6 +604,13 @@ Please sign in again with the correct email address %@</value>
   <data name="enterPasswordPlaceholder" xml:space="preserve"> 
     <value>Enter your password</value> 
   </data> 
+  <data name="errCaseDescription" xml:space="preserve"> 
+    <value>Another %@ with a name differing only in upper/lower case already exists in this folder. This type of name is not supported by the kDrive Windows application. Rename one of the %@ folders in kDrive online to synchronize it on your PC.
+</value> 
+  </data> 
+  <data name="errCaseTitle" xml:space="preserve"> 
+    <value>Case-sensitive name conflict</value> 
+  </data> 
   <data name="errCreateCancelDescription" xml:space="preserve"> 
     <value>You do not have the required permissions to add a %@ to this location.
 Request access from the owner or administrator.</value> 
@@ -696,7 +703,7 @@ Contact your administrator to increase the file size limit.</value>
     <value>Access forbidden</value> 
     <comment>Title shown when a forbidden or unauthorized action is attempted.</comment> 
   </data> 
-  <data name="errForbiddenCharDescription_win" xml:space="preserve"> 
+  <data name="errForbiddenCharDescription" xml:space="preserve"> 
     <value>The name of this %@ contains one or more characters not supported by the kDrive Windows application. Rename the %@ from kDrive online.</value> 
   </data> 
   <data name="errForbiddenCharOnlySpacesDescription" xml:space="preserve"> 
@@ -1067,7 +1074,7 @@ Useful if you know the important work is online on kDrive.</value>
     <value>No conflicts match your search</value> 
   </data> 
   <data name="labelNoErrorsToFix" xml:space="preserve"> 
-    <value>No errors to fix.</value> 
+    <value>No errors to fix</value> 
   </data> 
   <data name="labelNotifications" xml:space="preserve"> 
     <value>Notification</value> 
@@ -1196,7 +1203,7 @@ To speed up the upload, we recommend sending only the last kDrive session.</valu
   <data name="linkCopiedToClipboardTitle" xml:space="preserve"> 
     <value>Link copied to clipboard</value> 
   </data> 
-  <data name="liteSyncUnavailableDescription" xml:space="preserve"> 
+  <data name="liteSyncUnavailableDescriptionWin" xml:space="preserve"> 
     <value>Incompatible drive or folder directly at the root of the drive (e.g., choose a folder like D:/My drive instead of D:/)</value> 
   </data> 
   <data name="localLocation" xml:space="preserve"> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/en-US/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/en-US/Resources.resw
@@ -6,7 +6,7 @@
   Locale: en, English
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Fri, 29 May 2026 15:21:01 +0200 
+  Exported at: Fri, 29 May 2026 15:49:15 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/es-ES/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/es-ES/Resources.resw
@@ -6,7 +6,7 @@
   Locale: es, Spanish
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Wed, 27 May 2026 14:49:19 +0200 
+  Exported at: Fri, 29 May 2026 15:21:01 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -604,6 +604,13 @@ Inicie sesión nuevamente con la dirección de correo electrónico correcta %@</
   <data name="enterPasswordPlaceholder" xml:space="preserve"> 
     <value>Introduzca su contraseña</value> 
   </data> 
+  <data name="errCaseDescription" xml:space="preserve"> 
+    <value>En esta carpeta ya existe otro %@ cuyo nombre sólo difiere en mayúsculas/minúsculas. Este tipo de nombre no es compatible con la aplicación kDrive Windows. Cambie el nombre de una de las carpetas %@ desde kDrive online para poder sincronizarla en su PC.
+</value> 
+  </data> 
+  <data name="errCaseTitle" xml:space="preserve"> 
+    <value>Nombres contradictorios, distingue mayúsculas de minúsculas</value> 
+  </data> 
   <data name="errCreateCancelDescription" xml:space="preserve"> 
     <value>No tiene los permisos necesarios para agregar un %@ en esta ubicación.
 Solicite acceso al propietario o al administrador.</value> 
@@ -696,7 +703,7 @@ Contacte con su administrador para aumentar el límite de tamaño de archivo.</v
     <value>Acceso prohibido</value> 
     <comment>Title shown when a forbidden or unauthorized action is attempted.</comment> 
   </data> 
-  <data name="errForbiddenCharDescription_win" xml:space="preserve"> 
+  <data name="errForbiddenCharDescription" xml:space="preserve"> 
     <value>El nombre de este %@ contiene uno o más caracteres no admitidos por la aplicación kDrive Windows. Cambie el nombre del %@ desde kDrive en línea.</value> 
   </data> 
   <data name="errForbiddenCharOnlySpacesDescription" xml:space="preserve"> 
@@ -1067,7 +1074,7 @@ Tenga cuidado, esto puede sobrescribir el trabajo de sus colaboradores.</value>
     <value>Ningún conflicto coincide con su búsqueda</value> 
   </data> 
   <data name="labelNoErrorsToFix" xml:space="preserve"> 
-    <value>No hay errores que corregir.</value> 
+    <value>No hay errores que corregir</value> 
   </data> 
   <data name="labelNotifications" xml:space="preserve"> 
     <value>Notificación</value> 
@@ -1196,7 +1203,7 @@ Para acelerar el envío, recomendamos enviar solo la última sesión de kDrive.<
   <data name="linkCopiedToClipboardTitle" xml:space="preserve"> 
     <value>Enlace copiado al portapapeles</value> 
   </data> 
-  <data name="liteSyncUnavailableDescription" xml:space="preserve"> 
+  <data name="liteSyncUnavailableDescriptionWin" xml:space="preserve"> 
     <value>Disco incompatible o carpeta directamente en la raíz del disco (ej: elige una carpeta como D:/Mon drive en lugar de D:/)</value> 
   </data> 
   <data name="localLocation" xml:space="preserve"> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/es-ES/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/es-ES/Resources.resw
@@ -6,7 +6,7 @@
   Locale: es, Spanish
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Fri, 29 May 2026 15:21:01 +0200 
+  Exported at: Fri, 29 May 2026 15:49:15 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/es-ES/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/es-ES/Resources.resw
@@ -6,7 +6,7 @@
   Locale: es, Spanish
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Fri, 29 May 2026 15:49:15 +0200 
+  Exported at: Fri, 29 May 2026 15:56:50 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/fi-FI/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/fi-FI/Resources.resw
@@ -6,7 +6,7 @@
   Locale: fi, Finnish
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Fri, 29 May 2026 15:49:15 +0200 
+  Exported at: Fri, 29 May 2026 15:56:50 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/fi-FI/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/fi-FI/Resources.resw
@@ -6,7 +6,7 @@
   Locale: fi, Finnish
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Wed, 27 May 2026 14:49:19 +0200 
+  Exported at: Fri, 29 May 2026 15:21:01 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -604,6 +604,13 @@ Kirjaudu uudelleen sisään oikealla sähköpostiosoitteella %@</value>
   <data name="enterPasswordPlaceholder" xml:space="preserve"> 
     <value>Syötä salasanasi</value> 
   </data> 
+  <data name="errCaseDescription" xml:space="preserve"> 
+    <value>Tässä kansiossa on jo toinen %@, jonka nimi eroaa vain isojen ja pienten kirjainten osalta. Tämäntyyppistä nimeä ei tueta kDrive Windows -sovelluksessa. Nimeä yksi %@-kansioista uudelleen kDrive online -ohjelmassa, jotta voit synkronoida sen tietokoneellasi.
+</value> 
+  </data> 
+  <data name="errCaseTitle" xml:space="preserve"> 
+    <value>Ristiriitaiset nimet, isojen ja pienten kirjainten huomioiminen</value> 
+  </data> 
   <data name="errCreateCancelDescription" xml:space="preserve"> 
     <value>Sinulla ei ole tarvittavia käyttöoikeuksia lisätäksesi %@ tähän sijaintiin.
 Pyydä käyttöoikeutta omistajalta tai järjestelmänvalvojalta.</value> 
@@ -696,7 +703,7 @@ Ota yhteyttä järjestelmänvalvojaasi tiedostokokorajan kasvattamiseksi.</value
     <value>Pääsy kielletty</value> 
     <comment>Title shown when a forbidden or unauthorized action is attempted.</comment> 
   </data> 
-  <data name="errForbiddenCharDescription_win" xml:space="preserve"> 
+  <data name="errForbiddenCharDescription" xml:space="preserve"> 
     <value>Tämän %@ nimi sisältää yhden tai useamman merkin, joita kDriven Windows-sovellus ei tue. Nimeä %@ uudelleen kDrive-verkkopalvelusta.</value> 
   </data> 
   <data name="errForbiddenCharOnlySpacesDescription" xml:space="preserve"> 
@@ -1067,7 +1074,7 @@ Hyödyllinen, jos tiedät tärkeän työn olevan verkossa kDrivessa.</value>
     <value>Ei hakuasi vastaavia ristiriitoja</value> 
   </data> 
   <data name="labelNoErrorsToFix" xml:space="preserve"> 
-    <value>Ei korjattavia virheitä.</value> 
+    <value>Ei korjattavia virheitä</value> 
   </data> 
   <data name="labelNotifications" xml:space="preserve"> 
     <value>Ilmoitus</value> 
@@ -1196,7 +1203,7 @@ Lähetyksen nopeuttamiseksi suosittelemme lähettämään vain viimeisen kDrive-
   <data name="linkCopiedToClipboardTitle" xml:space="preserve"> 
     <value>Linkki kopioitu leikepöydälle</value> 
   </data> 
-  <data name="liteSyncUnavailableDescription" xml:space="preserve"> 
+  <data name="liteSyncUnavailableDescriptionWin" xml:space="preserve"> 
     <value>Yhteensopimaton asema tai kansio suoraan aseman juuressa (esim.: valitse kansio kuten D:/Oma asema D:/:n sijaan)</value> 
   </data> 
   <data name="localLocation" xml:space="preserve"> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/fi-FI/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/fi-FI/Resources.resw
@@ -6,7 +6,7 @@
   Locale: fi, Finnish
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Fri, 29 May 2026 15:21:01 +0200 
+  Exported at: Fri, 29 May 2026 15:49:15 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/fr-FR/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/fr-FR/Resources.resw
@@ -6,7 +6,7 @@
   Locale: fr, French
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Fri, 29 May 2026 15:49:15 +0200 
+  Exported at: Fri, 29 May 2026 15:56:50 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/fr-FR/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/fr-FR/Resources.resw
@@ -6,7 +6,7 @@
   Locale: fr, French
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Wed, 27 May 2026 14:49:19 +0200 
+  Exported at: Fri, 29 May 2026 15:21:01 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -604,6 +604,13 @@ Veuillez vous connecter à nouveau avec l’adresse électronique correcte %@</v
   <data name="enterPasswordPlaceholder" xml:space="preserve"> 
     <value>Entrez votre mot de passe</value> 
   </data> 
+  <data name="errCaseDescription" xml:space="preserve"> 
+    <value>Un autre %@ dont le nom diffère uniquement par les majuscules/minuscules existe déjà dans ce dossier. Ce type de nom n’est pas pris en charge par l’application kDrive Windows. Renommez l’un des %@ depuis kDrive en ligne pour pouvoir le synchroniser sur votre PC.
+</value> 
+  </data> 
+  <data name="errCaseTitle" xml:space="preserve"> 
+    <value>Conflit de noms à la casse près</value> 
+  </data> 
   <data name="errCreateCancelDescription" xml:space="preserve"> 
     <value>Vous n’avez pas les droits nécessaires pour ajouter un %@ à cet emplacement.
 Demandez l’accès au propriétaire ou à l’administrateur.</value> 
@@ -696,7 +703,7 @@ Contactez votre administrateur pour augmenter la limite de taille des fichiers.<
     <value>Accès interdit</value> 
     <comment>Title shown when a forbidden or unauthorized action is attempted.</comment> 
   </data> 
-  <data name="errForbiddenCharDescription_win" xml:space="preserve"> 
+  <data name="errForbiddenCharDescription" xml:space="preserve"> 
     <value>Le nom de ce %@ contient un ou plusieurs caractères non pris en charge par l’application kDrive Windows. Renommez le %@ depuis kDrive en ligne.</value> 
   </data> 
   <data name="errForbiddenCharOnlySpacesDescription" xml:space="preserve"> 
@@ -1067,7 +1074,7 @@ Utile si vous savez que le travail important est en ligne sur kDrive.</value>
     <value>Aucun conflit ne correspond à votre recherche</value> 
   </data> 
   <data name="labelNoErrorsToFix" xml:space="preserve"> 
-    <value>Aucune erreur à corriger.</value> 
+    <value>Aucune erreur à corriger</value> 
   </data> 
   <data name="labelNotifications" xml:space="preserve"> 
     <value>Notification</value> 
@@ -1196,7 +1203,7 @@ Pour accélérer l’envoi, nous vous recommandons de n’envoyer que la derniè
   <data name="linkCopiedToClipboardTitle" xml:space="preserve"> 
     <value>Lien copié dans le presse-papiers</value> 
   </data> 
-  <data name="liteSyncUnavailableDescription" xml:space="preserve"> 
+  <data name="liteSyncUnavailableDescriptionWin" xml:space="preserve"> 
     <value>Disque incompatible ou dossier directement à la racine du disque (ex : choisissez un dossier comme D:/Mon drive au lieu de D:/)</value> 
   </data> 
   <data name="localLocation" xml:space="preserve"> 
@@ -1649,7 +1656,7 @@ Si le problème persiste, veuillez contacter le service d’assistance.</value>
     <value>kDrive %@ disponible</value> 
   </data> 
   <data name="updateDialogDescription" xml:space="preserve"> 
-    <value>L’installation prend moins d'une minute.
+    <value>L’installation prend moins d’une minute.
 Votre synchronisation reprendra automatiquement à la fin.</value> 
   </data> 
   <data name="updateDialogIgnoreVersion" xml:space="preserve"> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/fr-FR/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/fr-FR/Resources.resw
@@ -6,7 +6,7 @@
   Locale: fr, French
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Fri, 29 May 2026 15:21:01 +0200 
+  Exported at: Fri, 29 May 2026 15:49:15 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/it-IT/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/it-IT/Resources.resw
@@ -6,7 +6,7 @@
   Locale: it, Italian
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Wed, 27 May 2026 14:49:19 +0200 
+  Exported at: Fri, 29 May 2026 15:21:01 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -604,6 +604,13 @@ Accedi di nuovo con l’indirizzo email corretto %@</value>
   <data name="enterPasswordPlaceholder" xml:space="preserve"> 
     <value>Inserisci la tua password</value> 
   </data> 
+  <data name="errCaseDescription" xml:space="preserve"> 
+    <value>In questa cartella esiste già un altro %@ il cui nome differisce solo per le lettere maiuscole/minuscole. Questo tipo di nome non è supportato dall'applicazione kDrive per Windows. Rinominare una delle cartelle %@ da kDrive online per poterla sincronizzare sul PC.
+</value> 
+  </data> 
+  <data name="errCaseTitle" xml:space="preserve"> 
+    <value>Nomi contrastanti, sensibili alle maiuscole e alle minuscole</value> 
+  </data> 
   <data name="errCreateCancelDescription" xml:space="preserve"> 
     <value>Non hai le autorizzazioni necessarie per aggiungere un %@ in questa posizione.
 Richiedi l’accesso al proprietario o all’amministratore.</value> 
@@ -696,7 +703,7 @@ Contatta il tuo amministratore per aumentare il limite di dimensione del file.</
     <value>Accesso vietato</value> 
     <comment>Title shown when a forbidden or unauthorized action is attempted.</comment> 
   </data> 
-  <data name="errForbiddenCharDescription_win" xml:space="preserve"> 
+  <data name="errForbiddenCharDescription" xml:space="preserve"> 
     <value>Il nome di questo %@ contiene uno o più caratteri non supportati dall’applicazione kDrive per Windows. Rinomina il %@ da kDrive online.</value> 
   </data> 
   <data name="errForbiddenCharOnlySpacesDescription" xml:space="preserve"> 
@@ -1067,7 +1074,7 @@ Attenzione, questa operazione potrebbe sovrascrivere il lavoro dei tuoi collabor
     <value>Nessun conflitto corrisponde alla tua ricerca</value> 
   </data> 
   <data name="labelNoErrorsToFix" xml:space="preserve"> 
-    <value>Nessun errore da correggere.</value> 
+    <value>Nessun errore da correggere</value> 
   </data> 
   <data name="labelNotifications" xml:space="preserve"> 
     <value>Notifica</value> 
@@ -1196,7 +1203,7 @@ Per velocizzare il caricamento, ti consigliamo di inviare solo l’ultima sessio
   <data name="linkCopiedToClipboardTitle" xml:space="preserve"> 
     <value>Link copiato negli appunti</value> 
   </data> 
-  <data name="liteSyncUnavailableDescription" xml:space="preserve"> 
+  <data name="liteSyncUnavailableDescriptionWin" xml:space="preserve"> 
     <value>Disco incompatibile o cartella direttamente nella radice del disco (es: scegli una cartella come D:/Mon drive invece di D:/)</value> 
   </data> 
   <data name="localLocation" xml:space="preserve"> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/it-IT/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/it-IT/Resources.resw
@@ -6,7 +6,7 @@
   Locale: it, Italian
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Fri, 29 May 2026 15:49:15 +0200 
+  Exported at: Fri, 29 May 2026 15:56:50 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/it-IT/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/it-IT/Resources.resw
@@ -6,7 +6,7 @@
   Locale: it, Italian
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Fri, 29 May 2026 15:21:01 +0200 
+  Exported at: Fri, 29 May 2026 15:49:15 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/nb-NO/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/nb-NO/Resources.resw
@@ -6,7 +6,7 @@
   Locale: nb, Norwegian Bokmål
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Fri, 29 May 2026 15:21:01 +0200 
+  Exported at: Fri, 29 May 2026 15:49:15 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/nb-NO/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/nb-NO/Resources.resw
@@ -6,7 +6,7 @@
   Locale: nb, Norwegian Bokmål
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Fri, 29 May 2026 15:49:15 +0200 
+  Exported at: Fri, 29 May 2026 15:56:50 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/nb-NO/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/nb-NO/Resources.resw
@@ -6,7 +6,7 @@
   Locale: nb, Norwegian Bokmål
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Wed, 27 May 2026 14:49:19 +0200 
+  Exported at: Fri, 29 May 2026 15:21:01 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -604,6 +604,13 @@ Logg inn igjen med riktig e-postadresse %@</value>
   <data name="enterPasswordPlaceholder" xml:space="preserve"> 
     <value>Skriv inn passordet ditt</value> 
   </data> 
+  <data name="errCaseDescription" xml:space="preserve"> 
+    <value>Det finnes allerede en annen %@ i denne mappen med et navn som bare skiller seg fra navnet med store og små bokstaver. Denne typen navn støttes ikke av kDrive Windows-applikasjonen. Gi nytt navn til en av %@-mappene fra kDrive online, slik at du kan synkronisere den på PC-en din.
+</value> 
+  </data> 
+  <data name="errCaseTitle" xml:space="preserve"> 
+    <value>Motstridende navn, små og store bokstaver</value> 
+  </data> 
   <data name="errCreateCancelDescription" xml:space="preserve"> 
     <value>Du har ikke de nødvendige tillatelsene til å legge til en %@ på dette stedet.
 Be om tilgang fra eieren eller administratoren.</value> 
@@ -696,7 +703,7 @@ Kontakt administratoren din for å øke filstørrelsesgrensen.</value>
     <value>Tilgang forbudt</value> 
     <comment>Title shown when a forbidden or unauthorized action is attempted.</comment> 
   </data> 
-  <data name="errForbiddenCharDescription_win" xml:space="preserve"> 
+  <data name="errForbiddenCharDescription" xml:space="preserve"> 
     <value>Navnet på dette %@ inneholder ett eller flere tegn som ikke støttes av kDrive Windows-programmet. Gi nytt navn til %@ fra kDrive på nett.</value> 
   </data> 
   <data name="errForbiddenCharOnlySpacesDescription" xml:space="preserve"> 
@@ -1067,7 +1074,7 @@ Nyttig hvis du vet at det viktige arbeidet er på nett på kDrive.</value>
     <value>Ingen konflikter samsvarer med søket ditt</value> 
   </data> 
   <data name="labelNoErrorsToFix" xml:space="preserve"> 
-    <value>Ingen feil å rette.</value> 
+    <value>Ingen feil å rette</value> 
   </data> 
   <data name="labelNotifications" xml:space="preserve"> 
     <value>Varsling</value> 
@@ -1196,7 +1203,7 @@ For å fremskynde opplastingen anbefaler vi å sende bare den siste kDrive-sesjo
   <data name="linkCopiedToClipboardTitle" xml:space="preserve"> 
     <value>Lenke kopiert til utklippstavle</value> 
   </data> 
-  <data name="liteSyncUnavailableDescription" xml:space="preserve"> 
+  <data name="liteSyncUnavailableDescriptionWin" xml:space="preserve"> 
     <value>Inkompatibel stasjon eller mappe direkte i roten av stasjonen (f.eks. velg en mappe som D:/Min stasjon i stedet for D:/)</value> 
   </data> 
   <data name="localLocation" xml:space="preserve"> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/nl-NL/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/nl-NL/Resources.resw
@@ -6,7 +6,7 @@
   Locale: nl, Dutch; Flemish
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Wed, 27 May 2026 14:49:19 +0200 
+  Exported at: Fri, 29 May 2026 15:21:01 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -604,6 +604,13 @@ Log opnieuw in met het juiste e-mailadres %@</value>
   <data name="enterPasswordPlaceholder" xml:space="preserve"> 
     <value>Voer uw wachtwoord in</value> 
   </data> 
+  <data name="errCaseDescription" xml:space="preserve"> 
+    <value>Er bestaat al een andere %@ waarvan de naam alleen verschilt in hoofdletters/kleine letters in deze map. Dit type naam wordt niet ondersteund door de kDrive Windows applicatie. Hernoem een van de %@ mappen van kDrive online zodat u deze op uw pc kunt synchroniseren.
+</value> 
+  </data> 
+  <data name="errCaseTitle" xml:space="preserve"> 
+    <value>Conflicterende namen, hoofdlettergevoelig</value> 
+  </data> 
   <data name="errCreateCancelDescription" xml:space="preserve"> 
     <value>U heeft niet de vereiste rechten om een %@ toe te voegen aan deze locatie.
 Vraag toegang aan bij de eigenaar of beheerder.</value> 
@@ -696,7 +703,7 @@ Neem contact op met uw beheerder om de bestandsgroottelimiet te verhogen.</value
     <value>Toegang geweigerd</value> 
     <comment>Title shown when a forbidden or unauthorized action is attempted.</comment> 
   </data> 
-  <data name="errForbiddenCharDescription_win" xml:space="preserve"> 
+  <data name="errForbiddenCharDescription" xml:space="preserve"> 
     <value>De naam van dit %@ bevat een of meer tekens die niet worden ondersteund door de kDrive Windows-applicatie. Hernoem de %@ vanuit kDrive online.</value> 
   </data> 
   <data name="errForbiddenCharOnlySpacesDescription" xml:space="preserve"> 
@@ -1067,7 +1074,7 @@ Handig als u weet dat het belangrijke werk online staat op kDrive.</value>
     <value>Geen conflicten gevonden voor uw zoekopdracht</value> 
   </data> 
   <data name="labelNoErrorsToFix" xml:space="preserve"> 
-    <value>Geen fouten te corrigeren.</value> 
+    <value>Geen fouten te corrigeren</value> 
   </data> 
   <data name="labelNotifications" xml:space="preserve"> 
     <value>Melding</value> 
@@ -1196,7 +1203,7 @@ Om het uploaden te versnellen, raden we aan alleen de laatste kDrive-sessie te v
   <data name="linkCopiedToClipboardTitle" xml:space="preserve"> 
     <value>Link gekopieerd naar klembord</value> 
   </data> 
-  <data name="liteSyncUnavailableDescription" xml:space="preserve"> 
+  <data name="liteSyncUnavailableDescriptionWin" xml:space="preserve"> 
     <value>Incompatibele schijf of map direct in de root van de schijf (bijv.: kies een map zoals D:/Mijn drive in plaats van D:/)</value> 
   </data> 
   <data name="localLocation" xml:space="preserve"> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/nl-NL/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/nl-NL/Resources.resw
@@ -6,7 +6,7 @@
   Locale: nl, Dutch; Flemish
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Fri, 29 May 2026 15:21:01 +0200 
+  Exported at: Fri, 29 May 2026 15:49:15 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/nl-NL/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/nl-NL/Resources.resw
@@ -6,7 +6,7 @@
   Locale: nl, Dutch; Flemish
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Fri, 29 May 2026 15:49:15 +0200 
+  Exported at: Fri, 29 May 2026 15:56:50 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/pl-PL/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/pl-PL/Resources.resw
@@ -6,7 +6,7 @@
   Locale: pl, Polish
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Fri, 29 May 2026 15:21:01 +0200 
+  Exported at: Fri, 29 May 2026 15:49:15 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/pl-PL/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/pl-PL/Resources.resw
@@ -6,7 +6,7 @@
   Locale: pl, Polish
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Fri, 29 May 2026 15:49:15 +0200 
+  Exported at: Fri, 29 May 2026 15:56:50 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/pl-PL/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/pl-PL/Resources.resw
@@ -6,7 +6,7 @@
   Locale: pl, Polish
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Wed, 27 May 2026 14:49:19 +0200 
+  Exported at: Fri, 29 May 2026 15:21:01 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -604,6 +604,13 @@ Zaloguj się ponownie przy użyciu właściwego adresu e-mail %@</value>
   <data name="enterPasswordPlaceholder" xml:space="preserve"> 
     <value>Wprowadź hasło</value> 
   </data> 
+  <data name="errCaseDescription" xml:space="preserve"> 
+    <value>W tym folderze istnieje już inny %@, którego nazwa różni się tylko wielkimi/małymi literami. Ten typ nazwy nie jest obsługiwany przez aplikację kDrive Windows. Zmień nazwę jednego z folderów %@ z aplikacji kDrive online, aby móc go zsynchronizować na komputerze.
+</value> 
+  </data> 
+  <data name="errCaseTitle" xml:space="preserve"> 
+    <value>Sprzeczne nazwy, wielkość liter ma znaczenie</value> 
+  </data> 
   <data name="errCreateCancelDescription" xml:space="preserve"> 
     <value>Nie masz wymaganych uprawnień, aby dodać %@ do tej lokalizacji.
 Poproś właściciela lub administratora o dostęp.</value> 
@@ -696,7 +703,7 @@ Skontaktuj się z administratorem, aby zwiększyć limit rozmiaru pliku.</value>
     <value>Dostęp zabroniony</value> 
     <comment>Title shown when a forbidden or unauthorized action is attempted.</comment> 
   </data> 
-  <data name="errForbiddenCharDescription_win" xml:space="preserve"> 
+  <data name="errForbiddenCharDescription" xml:space="preserve"> 
     <value>Nazwa tego %@ zawiera jeden lub więcej znaków nieobsługiwanych przez aplikację kDrive dla systemu Windows. Zmień nazwę %@ w kDrive online.</value> 
   </data> 
   <data name="errForbiddenCharOnlySpacesDescription" xml:space="preserve"> 
@@ -1067,7 +1074,7 @@ Przydatne, gdy wiesz, że ważna praca jest online w kDrive.</value>
     <value>Brak konfliktów pasujących do wyszukiwania</value> 
   </data> 
   <data name="labelNoErrorsToFix" xml:space="preserve"> 
-    <value>Brak błędów do naprawienia.</value> 
+    <value>Brak błędów do naprawienia</value> 
   </data> 
   <data name="labelNotifications" xml:space="preserve"> 
     <value>Powiadomienie</value> 
@@ -1196,7 +1203,7 @@ Aby przyspieszyć przesyłanie, zalecamy wysłanie tylko ostatniej sesji kDrive.
   <data name="linkCopiedToClipboardTitle" xml:space="preserve"> 
     <value>Łącze skopiowane do schowka</value> 
   </data> 
-  <data name="liteSyncUnavailableDescription" xml:space="preserve"> 
+  <data name="liteSyncUnavailableDescriptionWin" xml:space="preserve"> 
     <value>Niezgodny dysk lub folder bezpośrednio w katalogu głównym dysku (np. wybierz folder taki jak D:/Mój dysk zamiast D:/)</value> 
   </data> 
   <data name="localLocation" xml:space="preserve"> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/pt-PT/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/pt-PT/Resources.resw
@@ -6,7 +6,7 @@
   Locale: pt, Portuguese
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Wed, 27 May 2026 14:49:19 +0200 
+  Exported at: Fri, 29 May 2026 15:21:01 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -604,6 +604,13 @@ Inicie sessão novamente com o endereço de e-mail correto %@</value>
   <data name="enterPasswordPlaceholder" xml:space="preserve"> 
     <value>Introduza a sua palavra-passe</value> 
   </data> 
+  <data name="errCaseDescription" xml:space="preserve"> 
+    <value>Outro %@ cujo nome difere apenas em maiúsculas/minúsculas já existe nesta pasta. Este tipo de nome não é suportado pela aplicação kDrive para Windows. Renomeie uma das pastas %@ do kDrive online para que possa sincronizá-la no seu PC.
+</value> 
+  </data> 
+  <data name="errCaseTitle" xml:space="preserve"> 
+    <value>Nomes contraditórios, sensíveis a maiúsculas e minúsculas</value> 
+  </data> 
   <data name="errCreateCancelDescription" xml:space="preserve"> 
     <value>Não tem as permissões necessárias para adicionar um %@ a esta localização.
 Peça acesso ao proprietário ou administrador.</value> 
@@ -696,7 +703,7 @@ Contacte o seu administrador para aumentar o limite de tamanho dos ficheiros.</v
     <value>Acesso proibido</value> 
     <comment>Title shown when a forbidden or unauthorized action is attempted.</comment> 
   </data> 
-  <data name="errForbiddenCharDescription_win" xml:space="preserve"> 
+  <data name="errForbiddenCharDescription" xml:space="preserve"> 
     <value>O nome deste %@ contém um ou mais caracteres não suportados pela aplicação kDrive do Windows. Renomeie o %@ a partir do kDrive online.</value> 
   </data> 
   <data name="errForbiddenCharOnlySpacesDescription" xml:space="preserve"> 
@@ -1067,7 +1074,7 @@ Atenção, isto pode substituir o trabalho dos seus colaboradores.</value>
     <value>Nenhum conflito corresponde à sua pesquisa</value> 
   </data> 
   <data name="labelNoErrorsToFix" xml:space="preserve"> 
-    <value>Sem erros a corrigir.</value> 
+    <value>Sem erros a corrigir</value> 
   </data> 
   <data name="labelNotifications" xml:space="preserve"> 
     <value>Notificação</value> 
@@ -1196,7 +1203,7 @@ Para acelerar o envio, recomendamos enviar apenas a última sessão do kDrive.</
   <data name="linkCopiedToClipboardTitle" xml:space="preserve"> 
     <value>Link copiado para a área de transferência</value> 
   </data> 
-  <data name="liteSyncUnavailableDescription" xml:space="preserve"> 
+  <data name="liteSyncUnavailableDescriptionWin" xml:space="preserve"> 
     <value>Disco incompatível ou pasta diretamente na raiz do disco (ex: escolha uma pasta como D:/O meu drive em vez de D:/)</value> 
   </data> 
   <data name="localLocation" xml:space="preserve"> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/pt-PT/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/pt-PT/Resources.resw
@@ -6,7 +6,7 @@
   Locale: pt, Portuguese
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Fri, 29 May 2026 15:21:01 +0200 
+  Exported at: Fri, 29 May 2026 15:49:15 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/pt-PT/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/pt-PT/Resources.resw
@@ -6,7 +6,7 @@
   Locale: pt, Portuguese
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Fri, 29 May 2026 15:49:15 +0200 
+  Exported at: Fri, 29 May 2026 15:56:50 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/sv-SE/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/sv-SE/Resources.resw
@@ -6,7 +6,7 @@
   Locale: sv, Swedish
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Fri, 29 May 2026 15:49:15 +0200 
+  Exported at: Fri, 29 May 2026 15:56:50 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/sv-SE/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/sv-SE/Resources.resw
@@ -6,7 +6,7 @@
   Locale: sv, Swedish
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Wed, 27 May 2026 14:49:19 +0200 
+  Exported at: Fri, 29 May 2026 15:21:01 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -604,6 +604,13 @@ Logga in igen med rätt e-postadress %@</value>
   <data name="enterPasswordPlaceholder" xml:space="preserve"> 
     <value>Ange ditt lösenord</value> 
   </data> 
+  <data name="errCaseDescription" xml:space="preserve"> 
+    <value>En annan %@ vars namn endast skiljer sig åt i versaler/ gemener finns redan i den här mappen. Denna typ av namn stöds inte av Windows-programmet kDrive. Byt namn på en av %@-mapparna från kDrive online så att du kan synkronisera den på din dator.
+</value> 
+  </data> 
+  <data name="errCaseTitle" xml:space="preserve"> 
+    <value>Motstridiga namn, skiftlägeskänsliga</value> 
+  </data> 
   <data name="errCreateCancelDescription" xml:space="preserve"> 
     <value>Du har inte nödvändiga behörigheter för att lägga till en %@ på den här platsen.
 Begär åtkomst från ägaren eller administratören.</value> 
@@ -696,7 +703,7 @@ Kontakta din administratör för att öka filstorleksgränsen.</value>
     <value>Åtkomst förbjuden</value> 
     <comment>Title shown when a forbidden or unauthorized action is attempted.</comment> 
   </data> 
-  <data name="errForbiddenCharDescription_win" xml:space="preserve"> 
+  <data name="errForbiddenCharDescription" xml:space="preserve"> 
     <value>Namnet på denna %@ innehåller ett eller flera tecken som inte stöds av kDrive Windows-programmet. Byt namn på %@ från kDrive online.</value> 
   </data> 
   <data name="errForbiddenCharOnlySpacesDescription" xml:space="preserve"> 
@@ -1067,7 +1074,7 @@ Användbart om du vet att det viktiga arbetet finns online på kDrive.</value>
     <value>Inga konflikter matchar din sökning</value> 
   </data> 
   <data name="labelNoErrorsToFix" xml:space="preserve"> 
-    <value>Inga fel att åtgärda.</value> 
+    <value>Inga fel att åtgärda</value> 
   </data> 
   <data name="labelNotifications" xml:space="preserve"> 
     <value>Avisering</value> 
@@ -1196,7 +1203,7 @@ För att påskynda uppladdningen rekommenderar vi att du bara skickar den senast
   <data name="linkCopiedToClipboardTitle" xml:space="preserve"> 
     <value>Länk kopierad till urklipp</value> 
   </data> 
-  <data name="liteSyncUnavailableDescription" xml:space="preserve"> 
+  <data name="liteSyncUnavailableDescriptionWin" xml:space="preserve"> 
     <value>Inkompatibel enhet eller mapp direkt i roten av enheten (t.ex. välj en mapp som D:/Min enhet istället för D:/)</value> 
   </data> 
   <data name="localLocation" xml:space="preserve"> 

--- a/src/gui4/windows/kDrive client/kDrive client/Strings/sv-SE/Resources.resw
+++ b/src/gui4/windows/kDrive client/kDrive client/Strings/sv-SE/Resources.resw
@@ -6,7 +6,7 @@
   Locale: sv, Swedish
   Tagged: windows
   Exported by: Herve Eruam
-  Exported at: Fri, 29 May 2026 15:21:01 +0200 
+  Exported at: Fri, 29 May 2026 15:49:15 +0200 
   --> 
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />

--- a/src/gui4/windows/kDrive client/kDrive client/kDrive client.csproj
+++ b/src/gui4/windows/kDrive client/kDrive client/kDrive client.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyVersion>3.8.4.1</AssemblyVersion>
     <OutputType>WinExe</OutputType>
@@ -140,6 +140,9 @@
       <SubType>Designer</SubType>
     </Page>
     <Page Update="CustomControls\Errors\Templates\Node\ConflictError.xaml">
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Update="CustomControls\Errors\Templates\Node\CaseError.xaml">
       <SubType>Designer</SubType>
     </Page>
     <Page Update="CustomControls\Errors\Templates\Node\LocalAccessError.xaml">


### PR DESCRIPTION
feat(errors): add case conflict error handling

Added a new `CaseError` page and logic to handle case-sensitive name conflicts. Updated `DefaultError.xaml.cs` to skip `NodeTypeTranslationKey` property. Modified `ErrorCard.xaml` layout for better structure. Introduced `ManageCaseConflictError` key in `AnalyticsKeys.cs`. Updated `Resources.resw` with translations for case conflict errors. Adjusted `kDrive client.csproj` to include the new page. Implemented metadata and actions for case conflict error handling.