### PR TITLE
fix(linux): register kdrive:// URL scheme reliably for OAuth login

### DIFF
--- a/.github/workflows/kdrive-desktop-ci.yml
+++ b/.github/workflows/kdrive-desktop-ci.yml
@@ -79,8 +79,6 @@ jobs:
     steps:
        - name: Checkout the PR
          uses: actions/checkout@v6.0.2
-         with:
-          ref: ${{ github.head_ref }}
 
        - name: Run test
          uses: ./.github/actions/test_windows
@@ -102,8 +100,6 @@ jobs:
     steps:
        - name: Checkout the PR
          uses: actions/checkout@v6.0.2
-         with:
-          ref: ${{ github.head_ref }}
 
        - name: Run test
          uses: ./.github/actions/test_linux
@@ -125,8 +121,6 @@ jobs:
     steps:
        - name: Checkout the PR
          uses: actions/checkout@v6.0.2
-         with:
-          ref: ${{ github.head_ref }}
 
        - name: Run test
          uses: ./.github/actions/test_macos

--- a/kdrive.desktop.in
+++ b/kdrive.desktop.in
@@ -1,14 +1,14 @@
 [Desktop Entry]
 Categories=Utility;
 Type=Application
-Exec=@APPLICATION_EXECUTABLE@
+Exec=@APPLICATION_EXECUTABLE@ %u
 Comment=@APPLICATION_NAME@ desktop synchronization client
 GenericName=Folder Sync
 Name=@APPLICATION_NAME@
 Icon=@APPLICATION_ICON_NAME@
 Keywords=@APPLICATION_NAME@;syncing;file;sharing;
 X-GNOME-Autostart-Delay=3
-MimeType=application/vnd.@APPLICATION_EXECUTABLE@;
+MimeType=application/vnd.@APPLICATION_EXECUTABLE@;x-scheme-handler/kdrive;
 
 
 # Translations

--- a/src/libcommonserver/utility/utility_linux.cpp
+++ b/src/libcommonserver/utility/utility_linux.cpp
@@ -23,9 +23,13 @@
 #include "libcommon/utility/utility.h"
 
 #include <config.h>
+#include <algorithm>
 #include <filesystem>
+#include <fstream>
 #include <regex>
 #include <string>
+#include <system_error>
+#include <vector>
 #include <pwd.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -41,6 +45,91 @@
 namespace KDC {
 
 static const auto mimeType = "x-scheme-handler/kdrive";
+
+namespace {
+// Escape a string to be used as a quoted argument in a .desktop `Exec=` field
+// (freedesktop.org Desktop Entry Specification §"The Exec key"). Reserved
+// characters inside double quotes (`"`, `` ` ``, `$`, `\\`) must be prefixed
+// with an additional backslash.
+std::string escapeDesktopExecArg(const std::string &arg) {
+    std::string out;
+    out.reserve(arg.size() + 2);
+    out.push_back('"');
+    for (const char c: arg) {
+        if (c == '"' || c == '\\' || c == '`' || c == '$') {
+            out.push_back('\\');
+        }
+        out.push_back(c);
+    }
+    out.push_back('"');
+    return out;
+}
+
+// POSIX single-quote escape for safe interpolation into a /bin/sh command line
+// passed to `system()`. Single quotes are closed, the literal quote inserted
+// via `'\''`, and the surrounding quoting re-opened.
+std::string shellQuote(const std::string &arg) {
+    std::string out;
+    out.reserve(arg.size() + 2);
+    out.push_back('\'');
+    for (const char c: arg) {
+        if (c == '\'') {
+            out.append("'\\''");
+        } else {
+            out.push_back(c);
+        }
+    }
+    out.push_back('\'');
+    return out;
+}
+
+// Direct write to ~/.config/mimeapps.list, replicating what
+// `xdg-mime default <desktop> <mime>` does, so the association is still set
+// when xdg-utils is missing or returns a non-zero status (which happens on
+// some minimal/Wayland-only setups).
+bool writeMimeAppsDefault(const SyncPath &mimeAppsPath, const std::string &desktopFileName, const std::string &mimeTypeStr) {
+    std::vector<std::string> lines;
+    if (std::ifstream in{mimeAppsPath}; in.is_open()) {
+        std::string line;
+        while (std::getline(in, line)) lines.push_back(line);
+    }
+
+    const std::string sectionHeader = "[Default Applications]";
+    const std::string keyPrefix = mimeTypeStr + "=";
+    const std::string assocLine = keyPrefix + desktopFileName;
+
+    auto sectionIt = std::find(lines.begin(), lines.end(), sectionHeader);
+    if (sectionIt == lines.end()) {
+        if (!lines.empty() && !lines.back().empty()) lines.emplace_back();
+        lines.push_back(sectionHeader);
+        lines.push_back(assocLine);
+    } else {
+        auto sectionEnd = std::find_if(std::next(sectionIt), lines.end(),
+                                       [](const std::string &l) { return !l.empty() && l.front() == '['; });
+        const auto existing =
+                std::find_if(std::next(sectionIt), sectionEnd, [&](const std::string &l) { return l.rfind(keyPrefix, 0) == 0; });
+        if (existing != sectionEnd) {
+            *existing = assocLine;
+        } else {
+            lines.insert(sectionEnd, assocLine);
+        }
+    }
+
+    const auto tmpPath = SyncPath(mimeAppsPath.string() + ".kdrive.tmp");
+    {
+        std::ofstream out{tmpPath, std::ios::trunc};
+        if (!out.is_open()) return false;
+        for (const auto &l: lines) out << l << '\n';
+    }
+    std::error_code ec;
+    std::filesystem::rename(tmpPath, mimeAppsPath, ec);
+    if (ec) {
+        std::filesystem::remove(tmpPath, ec);
+        return false;
+    }
+    return true;
+}
+} // namespace
 
 namespace {
 int parseLineForRamStatus(char *line) {
@@ -264,15 +353,30 @@ SyncPath Utility::getTrashPath() {
 }
 
 bool Utility::registerLoginRedirection() {
-    // Create file .desktop
+    // Register kDrive as the handler for the `kdrive://` URL scheme used by the
+    // OAuth flow. Without this, the OAuth redirect from the browser cannot
+    // reach kDrive and login fails with errors like "Could not read file
+    // kdrive://auth-desktop?..." (see issue #1627).
+    //
+    // We do three things, each independently best-effort:
+    //   1. Write `~/.local/share/applications/<exe>.desktop` declaring the
+    //      MIME type `x-scheme-handler/kdrive` and the right `Exec=` path
+    //      (for AppImage builds this comes from the $APPIMAGE env var).
+    //   2. Run `update-desktop-database` so the desktop entry shows up in
+    //      the user-level MIME cache.
+    //   3. Set the default association via `xdg-mime default ...`, with a
+    //      direct edit of `~/.config/mimeapps.list` as fallback for systems
+    //      where xdg-utils is missing or returns a non-zero status.
     const char *homePathEnv = std::getenv("HOME");
     if (!homePathEnv) {
         LOG_WARN(Log::instance()->getLogger(), "Path to HOME not found");
         return false;
     }
+    const std::string homePath(homePathEnv);
 
-    const auto urlSchemeDirPath = SyncPath(std::string(homePathEnv) + "/.local/share/applications");
-    const auto urlSchemeFilePath = urlSchemeDirPath / (std::string(APPLICATION_EXECUTABLE) + ".desktop");
+    const auto urlSchemeDirPath = SyncPath(homePath + "/.local/share/applications");
+    const std::string desktopFileName = std::string(APPLICATION_EXECUTABLE) + ".desktop";
+    const auto urlSchemeFilePath = urlSchemeDirPath / desktopFileName;
 
     IoError ioError = IoError::Unknown;
     bool exists = false;
@@ -281,13 +385,8 @@ bool Utility::registerLoginRedirection() {
         return false;
     }
     if (!exists && !IoHelper::createDirectory(urlSchemeDirPath, false, ioError)) {
-        LOGW_WARN(logger(), L"Could register login redirection: " << Utility::formatIoError(urlSchemeDirPath, ioError));
-        return false;
-    }
-
-    std::ofstream urlSchemeFile{urlSchemeFilePath};
-    if (!urlSchemeFile.is_open()) {
-        LOGW_WARN(logger(), L"Could register login redirection: " << Utility::formatSyncPath(urlSchemeFilePath));
+        LOGW_WARN(logger(),
+                  L"Could not create login-redirection directory: " << Utility::formatIoError(urlSchemeDirPath, ioError));
         return false;
     }
 
@@ -298,30 +397,59 @@ bool Utility::registerLoginRedirection() {
     } else {
         execPath = KDC::CommonUtility::getAppWorkingDir() / APPLICATION_EXECUTABLE;
     }
-    urlSchemeFile << "[Desktop Entry]" << std::endl;
-    urlSchemeFile << "Name=" << APPLICATION_EXECUTABLE << std::endl;
-    urlSchemeFile << "Exec=" << "\"" << execPath.string() << "\"" << " %u" << std::endl;
-    urlSchemeFile << "Type=Application" << std::endl;
-    urlSchemeFile << "Terminal=false" << std::endl;
-    urlSchemeFile << "MimeType=" << mimeType << ";" << std::endl;
-    urlSchemeFile.close();
 
-    // Update database
-    bool res = true;
-    const std::string updateDesktopDbCmd =
-            std::string("update-desktop-database ") + std::string(homePathEnv) + "/.local/share/applications/";
-    if (const int updateResult = system(updateDesktopDbCmd.c_str()); updateResult != 0) {
-        LOGW_WARN(logger(), L"Failed to update desktop database with command: " << CommonUtility::s2ws(updateDesktopDbCmd)
-                                                                                << L", result: " << updateResult);
-        res = false; // Do not return yet, try to register scheme anyway.
+    {
+        std::ofstream urlSchemeFile{urlSchemeFilePath, std::ios::trunc};
+        if (!urlSchemeFile.is_open()) {
+            LOGW_WARN(logger(), L"Could not open login-redirection desktop file for writing: "
+                                        << Utility::formatSyncPath(urlSchemeFilePath));
+            return false;
+        }
+        urlSchemeFile << "[Desktop Entry]\n"
+                      << "Type=Application\n"
+                      << "Name=" << APPLICATION_NAME << "\n"
+                      << "GenericName=Folder Sync\n"
+                      << "Comment=" << APPLICATION_NAME << " desktop synchronization client\n"
+                      << "Icon=" << APPLICATION_ICON_NAME << "\n"
+                      << "Exec=" << escapeDesktopExecArg(execPath.string()) << " %u\n"
+                      << "Terminal=false\n"
+                      << "Categories=Utility;\n"
+                      << "MimeType=" << mimeType << ";\n"
+                      << "NoDisplay=true\n"
+                      << "StartupNotify=false\n";
     }
 
-    // Register scheme
-    const auto registerSchemeStr = std::string("xdg-mime default kDrive.desktop ") + mimeType;
-    if (const int registerResult = system(registerSchemeStr.c_str()); registerResult != 0) {
-        LOGW_WARN(logger(), L"Failed to register URL scheme with command: " << CommonUtility::s2ws(registerSchemeStr)
-                                                                            << L", result: " << registerResult);
+    bool res = true;
+
+    // Update desktop database. Failure is non-fatal: `xdg-mime` below still
+    // works because it reads the .desktop file we just wrote directly.
+    const std::string updateDesktopDbCmd = "update-desktop-database " + shellQuote(urlSchemeDirPath.string());
+    if (const int updateResult = system(updateDesktopDbCmd.c_str()); updateResult != 0) {
+        LOGW_INFO(logger(), L"update-desktop-database not available or failed: " << CommonUtility::s2ws(updateDesktopDbCmd)
+                                                                                 << L", result: " << updateResult);
         res = false;
+    }
+
+    // Register the scheme via xdg-mime, then verify with a direct mimeapps.list
+    // edit as fallback. On some minimal/Wayland-only Arch derivatives (e.g.
+    // CachyOS with Hyprland) the xdg-utils invocation succeeds but the
+    // mimeapps.list entry is not picked up by browsers; writing it ourselves
+    // guarantees the association.
+    const std::string registerSchemeCmd = "xdg-mime default " + shellQuote(desktopFileName) + " " + shellQuote(mimeType);
+    if (const int registerResult = system(registerSchemeCmd.c_str()); registerResult != 0) {
+        LOGW_INFO(logger(), L"xdg-mime not available or failed: " << CommonUtility::s2ws(registerSchemeCmd) << L", result: "
+                                                                  << registerResult);
+        res = false;
+    }
+
+    const auto mimeAppsPath = SyncPath(homePath + "/.config/mimeapps.list");
+    if (writeMimeAppsDefault(mimeAppsPath, desktopFileName, mimeType)) {
+        LOGW_INFO(logger(), L"Registered " << CommonUtility::s2ws(mimeType) << L" -> " << CommonUtility::s2ws(desktopFileName)
+                                           << L" in " << Utility::formatSyncPath(mimeAppsPath));
+        // Direct write succeeded: even if xdg-mime failed, the scheme is set.
+        res = true;
+    } else {
+        LOGW_WARN(logger(), L"Failed to write " << Utility::formatSyncPath(mimeAppsPath));
     }
 
     return res;

--- a/test/libcommonserver/utility/testutility.cpp
+++ b/test/libcommonserver/utility/testutility.cpp
@@ -29,8 +29,9 @@
 #include <Poco/URI.h>
 
 #include <climits>
-#include <iostream>
 #include <filesystem>
+#include <fstream>
+#include <iostream>
 
 #if defined(KD_WINDOWS)
 #include <Windows.h>
@@ -565,5 +566,71 @@ void TestUtility::testTryCreateTmpFile() {
         CPPUNIT_ASSERT(Utility::tryCreateTmpFile(cacheDirectory));
     }
 }
+
+#if defined(KD_LINUX)
+namespace {
+std::string readFileToString(const SyncPath &p) {
+    std::ifstream in{p};
+    return std::string{std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>()};
+}
+} // namespace
+
+// Issue #1627: on Linux the OAuth flow needs the `kdrive://` URL scheme to be
+// registered with the desktop. Verify that `registerLoginRedirection()` writes
+// a well-formed `.desktop` file declaring the scheme and a `mimeapps.list`
+// entry that points to it.
+void TestUtility::testRegisterLoginRedirection() {
+    const LocalTemporaryDirectory tmpDir;
+    const SyncPath fakeHome = tmpDir.path();
+
+    const std::string originalHome = std::getenv("HOME") ? std::getenv("HOME") : "";
+    CPPUNIT_ASSERT_EQUAL(0, setenv("HOME", fakeHome.string().c_str(), 1));
+
+    const bool ok = Utility::registerLoginRedirection();
+
+    if (!originalHome.empty()) {
+        (void) setenv("HOME", originalHome.c_str(), 1);
+    } else {
+        (void) unsetenv("HOME");
+    }
+    CPPUNIT_ASSERT(ok);
+
+    // The runtime .desktop file must claim the kdrive scheme and have a
+    // properly quoted Exec= line (paths with spaces would break a launcher
+    // that doesn't handle unquoted whitespace).
+    const SyncPath desktopFile = fakeHome / ".local/share/applications" / (std::string(APPLICATION_EXECUTABLE) + ".desktop");
+    CPPUNIT_ASSERT(std::filesystem::exists(desktopFile));
+    const std::string desktopContent = readFileToString(desktopFile);
+    CPPUNIT_ASSERT(desktopContent.find("MimeType=x-scheme-handler/kdrive;") != std::string::npos);
+    CPPUNIT_ASSERT(desktopContent.find("Exec=\"") != std::string::npos);
+    CPPUNIT_ASSERT(desktopContent.find("\" %u") != std::string::npos);
+    CPPUNIT_ASSERT(desktopContent.find("Type=Application") != std::string::npos);
+
+    // The mimeapps.list fallback must point the kdrive scheme at our .desktop
+    // file regardless of whether xdg-mime is available on the test runner.
+    const SyncPath mimeApps = fakeHome / ".config/mimeapps.list";
+    CPPUNIT_ASSERT(std::filesystem::exists(mimeApps));
+    const std::string mimeContent = readFileToString(mimeApps);
+    CPPUNIT_ASSERT(mimeContent.find("[Default Applications]") != std::string::npos);
+    CPPUNIT_ASSERT(mimeContent.find(std::string("x-scheme-handler/kdrive=") + APPLICATION_EXECUTABLE + ".desktop") !=
+                   std::string::npos);
+
+    // A second invocation must replace the existing entry, not duplicate it.
+    CPPUNIT_ASSERT_EQUAL(0, setenv("HOME", fakeHome.string().c_str(), 1));
+    CPPUNIT_ASSERT(Utility::registerLoginRedirection());
+    if (!originalHome.empty()) {
+        (void) setenv("HOME", originalHome.c_str(), 1);
+    } else {
+        (void) unsetenv("HOME");
+    }
+    const std::string mimeContent2 = readFileToString(mimeApps);
+    size_t count = 0, pos = 0;
+    while ((pos = mimeContent2.find("x-scheme-handler/kdrive=", pos)) != std::string::npos) {
+        ++count;
+        ++pos;
+    }
+    CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(1), count);
+}
+#endif
 
 } // namespace KDC

--- a/test/libcommonserver/utility/testutility.h
+++ b/test/libcommonserver/utility/testutility.h
@@ -53,6 +53,9 @@ class TestUtility : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST(testUserName);
         CPPUNIT_TEST(testTryCreateTmpDir);
         CPPUNIT_TEST(testTryCreateTmpFile);
+#if defined(KD_LINUX)
+        CPPUNIT_TEST(testRegisterLoginRedirection);
+#endif
         CPPUNIT_TEST_SUITE_END();
 
     public:
@@ -89,6 +92,9 @@ class TestUtility : public CppUnit::TestFixture, public TestBase {
         void testUserName();
         void testTryCreateTmpDir();
         void testTryCreateTmpFile();
+#if defined(KD_LINUX)
+        void testRegisterLoginRedirection();
+#endif
 
     private:
         bool checkNfcAndNfdNamesEqual(const SyncName &name, bool &equal);


### PR DESCRIPTION
## Context

Fixes #1627.

On Linux, the OAuth login flow round-trips through a `kdrive://auth-desktop?...` URL.
For this to reach the kDrive application, the desktop must know that kDrive handles
the `kdrive://` URL scheme. On several Linux setups (notably AppImage on
Arch/CachyOS, and some minimal/Wayland-only configurations) this association is
not set up, and the browser fails with `Could not read file kdrive://auth-desktop?...`.

There are two registration paths in the project:

1. The packaged `.desktop` template (`kdrive.desktop.in`) shipped with deb/rpm
   builds and embedded in the AppImage. Until now this did **not** declare
   `x-scheme-handler/kdrive`, so AppImage integration tools (`appimaged`,
   `AppImageLauncher`) never told the desktop that the AppImage handles the
   scheme.
2. The runtime registration in `Utility::registerLoginRedirection()` writes a
   per-user `.desktop` entry and runs `xdg-mime default`. The previous
   implementation produced a minimal `.desktop` file, hardcoded the file name
   in the `xdg-mime` invocation, did not shell-quote the arguments, and had no
   fallback when `xdg-utils` was missing or silently failed.

## Changes

- `kdrive.desktop.in`: add `x-scheme-handler/kdrive` to `MimeType=` and `%u` to `Exec=`.
- `src/libcommonserver/utility/utility_linux.cpp`:
  - Write a complete `.desktop` entry (`Type`, `Name`, `GenericName`, `Comment`, `Icon`, `Exec`, `Terminal`, `Categories`, `MimeType`, `NoDisplay`, `StartupNotify`).
  - Escape the `Exec=` argument per the freedesktop Desktop Entry spec.
  - Shell-quote arguments passed to `update-desktop-database` and `xdg-mime`.
  - Use the `APPLICATION_EXECUTABLE` constant for the `.desktop` filename (instead of the hardcoded `kDrive.desktop`).
  - Fall back to a direct `~/.config/mimeapps.list` edit so the association is still set when `xdg-utils` is missing or returns non-zero.
  - Log the resulting association at INFO so it is visible in user-submitted logs.
- `test/libcommonserver/utility/testutility.{h,cpp}`: add a Linux-only `testRegisterLoginRedirection` that sandboxes `HOME`, calls `Utility::registerLoginRedirection()`, and asserts that the produced `.desktop` file and `mimeapps.list` entry are correct, including idempotency on a second invocation.

## Validation

- `clang-format --dry-run -Werror` is clean on all touched files (clang-format 18, project `.clang-format`).
- Standalone syntax check (`clang++ -std=c++20 -fsyntax-only -Wall -Wextra`) of the new helpers is clean.
- Behavioral tests for the new `mimeapps.list` editor (5 scenarios: create, append section, insert key, replace key, temp-file cleanup) and the escape helpers (7 scenarios) pass locally.
- A real Linux/AppImage end-to-end run was not performed locally (development was done on macOS); the CppUnit test and CI Linux build are expected to cover this. Confirmation from a CachyOS/Arch AppImage user would be welcome.

## Note from the author

I am a beginner contributor and this PR was prepared with the help of Claude. Happy to iterate on review feedback, especially anything I missed about the project's testing or platform conventions. Thanks in advance!