### PR TITLE
fix(crash): Call log4cplus::threadCleanup after termination of PipeCommServer::listen to avoid a crash in CustomRollingFileAppender::append

### DIFF
--- a/src/libsyncengine/update_detection/file_system_observer/snapshot/livesnapshot.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/snapshot/livesnapshot.cpp
@@ -314,7 +314,7 @@ SnapshotRevision LiveSnapshot::revision() const {
 void LiveSnapshot::removeChildrenRecursively(const std::shared_ptr<SnapshotItem> parent) {
     auto it = parent->children().begin();
     while (it != parent->children().end()) {
-        const auto &child = *it;
+        const auto child = *it;
         const NodeId childId = child->id();
 
         removeChildrenRecursively(child);

--- a/src/libsyncengine/update_detection/file_system_observer/snapshot/snapshot.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/snapshot/snapshot.cpp
@@ -121,27 +121,27 @@ bool Snapshot::path(const NodeId &itemId, SyncPath &path, bool &ignore) const no
         return false;
     }
 
+    const std::scoped_lock lock(_mutex);
+
     bool ok = true;
     std::deque<std::pair<NodeId, SyncName>> ancestors;
-    {
-        bool parentIsRoot = false;
-        NodeId id = itemId;
-        const std::scoped_lock lock(_mutex);
-        while (!parentIsRoot) {
-            if (const auto item = findItem(id); item) {
-                if (!item->path().empty()) {
-                    path = item->path();
-                    break;
-                }
-                ancestors.push_back({item->id(), item->name()});
-                id = item->parentId();
-                parentIsRoot = id == _rootFolderId;
-                continue;
+    bool parentIsRoot = false;
+    NodeId id = itemId;
+    while (!parentIsRoot) {
+        if (const auto item = findItem(id); item) {
+            if (!item->path().empty()) {
+                path = item->path();
+                break;
             }
-            ok = false;
-            break;
+            (void) ancestors.emplace_back(item->id(), item->name());
+            id = item->parentId();
+            parentIsRoot = id == _rootFolderId;
+            continue;
         }
+        ok = false;
+        break;
     }
+
 
     // Construct path
     SyncPath tmpParentPath(path);

--- a/src/server/comm/pipecommserver.cpp
+++ b/src/server/comm/pipecommserver.cpp
@@ -138,7 +138,9 @@ bool PipeCommServer::listen() {
 
     _stopAsked = false;
     _isRunning = true;
-    _thread = (std::make_unique<StdLoggingThread>(executeFunc, this));
+
+    const std::function<void()> runFunction = std::bind(executeFunc, this);
+    _thread = (std::make_unique<StdLoggingThread>(runFunction));
 
     return true;
 }
@@ -161,7 +163,6 @@ std::list<std::shared_ptr<AbstractCommChannel>> PipeCommServer::connections() {
 
 void PipeCommServer::executeFunc(PipeCommServer *server) {
     server->execute();
-    log4cplus::threadCleanup();
 }
 
 void PipeCommServer::execute() {

--- a/src/server/comm/pipecommserver.cpp
+++ b/src/server/comm/pipecommserver.cpp
@@ -138,7 +138,7 @@ bool PipeCommServer::listen() {
 
     _stopAsked = false;
     _isRunning = true;
-    _thread = (std::make_unique<std::thread>(executeFunc, this));
+    _thread = (std::make_unique<StdLoggingThread>(executeFunc, this));
 
     return true;
 }

--- a/src/server/comm/pipecommserver.cpp
+++ b/src/server/comm/pipecommserver.cpp
@@ -139,7 +139,7 @@ bool PipeCommServer::listen() {
     _stopAsked = false;
     _isRunning = true;
 
-    const std::function<void()> runFunction = std::bind(executeFunc, this);
+    const std::function<void()> runFunction = std::bind_front(executeFunc, this);
     _thread = (std::make_unique<StdLoggingThread>(runFunction));
 
     return true;
@@ -161,7 +161,7 @@ std::list<std::shared_ptr<AbstractCommChannel>> PipeCommServer::connections() {
     return channelList;
 }
 
-void PipeCommServer::executeFunc(PipeCommServer *server) {
+void PipeCommServer::executeFunc(PipeCommServer *const server) {
     server->execute();
 }
 

--- a/src/server/comm/pipecommserver.h
+++ b/src/server/comm/pipecommserver.h
@@ -101,7 +101,7 @@ class PipeCommServer : public AbstractCommServer {
         void stop();
         void waitForExit();
 
-        static void executeFunc(PipeCommServer *server);
+        static void executeFunc(PipeCommServer *const server);
 
 #if defined(KD_WINDOWS)
         std::recursive_mutex _channelsMutex;


### PR DESCRIPTION
These changes are two-fold.

The main fix is a the fix for crash happening in `CustomRollingFileAppender::append` because the thread of `PipeCommServer::listen` did not call `log4cplus::threadCleanup` after its termination. 
The issue has already been identified in a previous PR :https://github.com/Infomaniak/desktop-kDrive/pull/1650 for different threads using the sever logger.

The second fix prevents a potential heap memory corruption from happening because of concurrent accesses to `Snapshots`.