### PR TITLE
feat: hash match to download job

### DIFF
--- a/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.cpp
@@ -105,7 +105,7 @@ ExitInfo CheckHashMatchJob::runJob() noexcept {
     }
 
     if (_localHash != _remoteHash) return ExitCode::Ok;
-    _shouldDownload = false;
+    _hashMatch = true;
     return ExitCode::Ok;
 }
 

--- a/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.cpp
@@ -65,6 +65,7 @@ ExitInfo CheckHashMatchJob::getFileSize(const SyncPath &path, int64_t &size) {
 }
 
 ExitInfo CheckHashMatchJob::runJob() noexcept {
+    _hashMatch = false;
     if (const ExitInfo exitInfo = getFileSize(_filePath, _localSize); !exitInfo) {
         LOGW_DEBUG(_logger, L"Failed to get local file size for " << Utility::formatSyncPath(_filePath)
                                                                   << L", skipping hash check: " << exitInfo);

--- a/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.h
+++ b/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.h
@@ -28,7 +28,7 @@ class CheckHashMatchJob : public AbstractTokenNetworkJob {
                           const int64_t remoteSize);
 
         [[nodiscard]] const NodeId &nodeId() const { return _nodeId; }
-        [[nodiscard]] bool shouldDownload() const { return _shouldDownload; }
+        [[nodiscard]] bool hashMatch() const { return _hashMatch; }
 
     protected:
         ExitInfo handleResponse(std::istream &is) override;
@@ -47,7 +47,7 @@ class CheckHashMatchJob : public AbstractTokenNetworkJob {
         int64_t _localSize = 0;
         int64_t _remoteSize = 0;
 
-        bool _shouldDownload = true;
+        bool _hashMatch = true;
 };
 
 } // namespace KDC

--- a/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.h
+++ b/src/libsyncengine/jobs/network/kDrive_API/checkhashmatchjob.h
@@ -47,7 +47,7 @@ class CheckHashMatchJob : public AbstractTokenNetworkJob {
         int64_t _localSize = 0;
         int64_t _remoteSize = 0;
 
-        bool _hashMatch = true;
+        bool _hashMatch = false;
 };
 
 } // namespace KDC

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
@@ -141,12 +141,14 @@ ExitInfo DownloadJob::canRun() {
     return ExitCode::Ok;
 }
 
-ExitInfo DownloadJob::checkHashMatch(bool &shouldDownload) {
-    shouldDownload = true;
+ExitInfo DownloadJob::checkHashMatch() {
+    _shouldDownload = true;
     CheckHashMatchJob hashJob(_fileDownloadInfo.driveDbId, _fileDownloadInfo.localpath, _fileDownloadInfo.remoteFileId,
                               _fileDownloadInfo.expectedSize);
-    if (const ExitInfo exitInfo = hashJob.runSynchronously(); !exitInfo) {
-        LOG_WARN(_logger, "CheckHashMatchJob failed: " << exitInfo);
+    const ExitInfo exitInfo = hashJob.runSynchronously();
+    if (!exitInfo) {
+        LOGW_WARN(_logger, L"CheckHashMatchJob failed: " << exitInfo);
+        LOGW_DEBUG(_logger, L"Proceeding DownloadJob normally.");
         return ExitCode::Ok; // Non-fatal: fall through to download
     }
     if (hashJob.shouldDownload()) {
@@ -155,52 +157,18 @@ ExitInfo DownloadJob::checkHashMatch(bool &shouldDownload) {
     }
 
     LOGW_DEBUG(_logger, L"Hash match, skipping download: " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
-    if (_dateTimePolicy == DateTimePolicy::ApplyDateTime) {
-        if (const IoError ioError = IoHelper::setFileDates(_fileDownloadInfo.localpath, _fileDownloadInfo.creationTime,
-                                                           _fileDownloadInfo.modificationTime, false);
-            ioError == IoError::Unknown) {
-            LOGW_WARN(_logger, L"Error in IoHelper::setFileDates: " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
-        } else if (ioError == IoError::NoSuchFileOrDirectory || ioError == IoError::AccessDenied) {
-            return {ExitCode::DataError, ExitCause::InvalidSnapshot};
-        }
-    }
+    if (const ExitInfo exitInfo = applyFileDatesIfRequired(false); !exitInfo) return exitInfo;
 
-    FileStat filestat;
-    IoError ioError = IoError::Success;
-    if (!IoHelper::getFileStat(_fileDownloadInfo.localpath, &filestat, ioError, IoHelper::PathCheckOption::Insensitive) ||
-        ioError != IoError::Success) {
-        LOGW_WARN(_logger, L"Error in IoHelper::getFileStat: " << Utility::formatIoError(_fileDownloadInfo.localpath, ioError));
-        return ExitCode::SystemError;
-    }
-    _localNodeId = std::to_string(filestat.inode);
-    _creationTimeOut = filestat.creationTime;
-    _modificationTimeOut = filestat.modificationTime;
-    _sizeOut = filestat.size;
-#if defined(KD_MACOS) || defined(KD_WINDOWS)
-    if (_fileDownloadInfo.creationTime != _creationTimeOut || _fileDownloadInfo.modificationTime != _modificationTimeOut) {
-        LOGW_INFO(_logger, L"Impossible to set creation and/or modification time(s) on local file."
-                                   << L" Desired values: " << _fileDownloadInfo.creationTime << L"/"
-                                   << _fileDownloadInfo.modificationTime << L" Set values: " << _creationTimeOut << L"/"
-                                   << _modificationTimeOut << L" for " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
-    }
-#else
-    if (_fileDownloadInfo.modificationTime != _modificationTimeOut) {
-        LOGW_INFO(_logger, L"Impossible to set modification time on local file."
-                                   << L" Desired value: " << _fileDownloadInfo.modificationTime << L" Set value: "
-                                   << _modificationTimeOut << L" for " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
-    }
-#endif
-    shouldDownload = false;
-    return ExitCode::Ok;
+    _shouldDownload = false;
+    return readBackAndStoreLocalFileStats();
 }
 
 ExitInfo DownloadJob::runJob() noexcept {
     if (!_fileDownloadInfo.isCreate) {
-        bool shouldDownload = true;
-        if (const ExitInfo exitInfo = checkHashMatch(shouldDownload); !exitInfo) {
+        if (const ExitInfo exitInfo = checkHashMatch(); !exitInfo) {
             return exitInfo;
         }
-        if (!shouldDownload) return ExitCode::Ok;
+        if (!_shouldDownload) return ExitCode::Ok;
     }
 
     if (!_fileDownloadInfo.isCreate && _vfs) {
@@ -333,23 +301,28 @@ ExitInfo DownloadJob::handleResponse(std::istream &is) {
             }
         }
     }
-    if (_dateTimePolicy == DateTimePolicy::ApplyDateTime) {
-        if (const IoError ioError = IoHelper::setFileDates(_fileDownloadInfo.localpath, _fileDownloadInfo.creationTime,
-                                                           _fileDownloadInfo.modificationTime, isLink);
-            ioError == IoError::Unknown) {
-            LOGW_WARN(_logger, L"Error in IoHelper::setFileDates: " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
-            // Do nothing (remote file will be updated during the next sync)
-            sentry::Handler::captureMessage(sentry::Level::Warning, "DownloadJob::handleResponse", "Unable to set file dates");
-        } else if (ioError == IoError::NoSuchFileOrDirectory) {
-            LOGW_WARN(_logger, L"Item does not exist anymore: " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
-            return {ExitCode::SystemError, ExitCause::NotFound};
-        } else if (ioError == IoError::AccessDenied) {
-            LOGW_WARN(_logger, L"Item misses search permission: " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
-            return {ExitCode::SystemError, ExitCause::FileAccessError};
-        }
-    }
+    if (const ExitInfo exitInfo = applyFileDatesIfRequired(isLink); !exitInfo) return exitInfo;
+    return readBackAndStoreLocalFileStats();
+}
 
-    // Retrieve inode
+ExitInfo DownloadJob::applyFileDatesIfRequired(const bool isLink) {
+    if (_dateTimePolicy != DateTimePolicy::ApplyDateTime) return ExitCode::Ok;
+
+    if (const IoError ioError = IoHelper::setFileDates(_fileDownloadInfo.localpath, _fileDownloadInfo.creationTime,
+                                                       _fileDownloadInfo.modificationTime, isLink);
+        ioError == IoError::Unknown) {
+        LOGW_WARN(_logger, L"Error in IoHelper::setFileDates: " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
+        // Do nothing (remote file will be updated during the next sync)
+        sentry::Handler::captureMessage(sentry::Level::Warning, "DownloadJob::handleResponse", "Unable to set file dates");
+    } else if (ioError == IoError::NoSuchFileOrDirectory || ioError == IoError::AccessDenied) {
+        LOGW_INFO(_logger, L"Item does not exist anymore or access is denied. Restarting sync: "
+                                   << Utility::formatSyncPath(_fileDownloadInfo.localpath));
+        return {ExitCode::DataError, ExitCause::InvalidSnapshot};
+    }
+    return ExitCode::Ok;
+}
+
+ExitInfo DownloadJob::readBackAndStoreLocalFileStats() {
     FileStat filestat;
     IoError ioError = IoError::Success;
     if (!IoHelper::getFileStat(_fileDownloadInfo.localpath, &filestat, ioError, IoHelper::PathCheckOption::Insensitive)) {

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
@@ -154,7 +154,9 @@ ExitInfo DownloadJob::checkHashMatch() {
     return ExitCode::Ok;
 }
 
-ExitInfo DownloadJob::getHydrationStatus() {
+ExitInfo DownloadJob::getHydrationStatus(bool &shouldReturn) {
+    shouldReturn = false;
+
     // Get hydration status
     VfsStatus vfsStatus;
     if (_vfs) (void) _vfs->status(_fileDownloadInfo.localpath, vfsStatus);
@@ -163,23 +165,24 @@ ExitInfo DownloadJob::getHydrationStatus() {
     if (_isHydrated) {
         if (const ExitInfo exitInfo = checkHashMatch(); !exitInfo) {
             LOGW_DEBUG(_logger, L"Error in checkHashMatch: " << exitInfo);
+            shouldReturn = false;
             return exitInfo;
         }
         if (!_shouldDownload) {
             LOGW_DEBUG(_logger, L"Changing last modified date without downloading")
+            shouldReturn = true;
             if (const ExitInfo exitInfo = applyFileDatesIfRequired(FileType::Regular); !exitInfo) return exitInfo;
             return setOutputParameters();
         }
     }
+    return ExitCode::Ok;
 }
 
 ExitInfo DownloadJob::runJob() noexcept {
     if (_fileDownloadInfo.isCreate) return AbstractTokenNetworkJob::runJob();
 
-    if (const ExitInfo exitInfo = getHydrationStatus(); !exitInfo) {
-        LOGW_WARN(_logger, L"Error in getHydrationStatus: " << exitInfo);
-        return exitInfo;
-    }
+    bool shouldReturn = false;
+    if (const ExitInfo exitInfo = getHydrationStatus(shouldReturn); shouldReturn) return exitInfo;
 
     if (_vfs) {
         // Update size on file system

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
@@ -150,16 +150,8 @@ ExitInfo DownloadJob::checkHashMatch() {
         LOGW_DEBUG(_logger, L"CheckHashMatchJob failed: " << exitInfo << L"Proceeding DownloadJob normally.");
         return ExitCode::Ok; // Non-fatal: fall through to download
     }
-    if (hashJob.shouldDownload()) {
-        LOGW_DEBUG(_logger, L"Hash mismatch, downloading file: " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
-        return ExitCode::Ok;
-    }
-
-    LOGW_DEBUG(_logger, L"Hash match, skipping download: " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
-    if (const ExitInfo ApplyExitInfo = applyFileDatesIfRequired(false); !ApplyExitInfo) return ApplyExitInfo;
-
-    _shouldDownload = false;
-    return readBackAndStoreLocalFileStats();
+    _shouldDownload = hashJob.shouldDownload();
+    return ExitCode::Ok;
 }
 
 ExitInfo DownloadJob::runJob() noexcept {

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
@@ -157,6 +157,7 @@ ExitInfo DownloadJob::checkHashMatch() {
 ExitInfo DownloadJob::runJob() noexcept {
     if (!_fileDownloadInfo.isCreate && !_vfs) {
         if (const ExitInfo exitInfo = checkHashMatch(); !exitInfo) {
+            LOGW_DEBUG(_logger, L"Error in checkHashMatch: " << exitInfo);
             return exitInfo;
         }
         if (!_shouldDownload) return ExitCode::Ok;

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
@@ -157,7 +157,7 @@ ExitInfo DownloadJob::checkHashMatch() {
     }
 
     LOGW_DEBUG(_logger, L"Hash match, skipping download: " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
-    if (const ExitInfo exitInfo = applyFileDatesIfRequired(false); !exitInfo) return exitInfo;
+    if (const ExitInfo ApplyExitInfo = applyFileDatesIfRequired(false); !ApplyExitInfo) return ApplyExitInfo;
 
     _shouldDownload = false;
     return readBackAndStoreLocalFileStats();
@@ -306,15 +306,16 @@ ExitInfo DownloadJob::handleResponse(std::istream &is) {
 }
 
 ExitInfo DownloadJob::applyFileDatesIfRequired(const bool isLink) {
+    using enum KDC::IoError;
     if (_dateTimePolicy != DateTimePolicy::ApplyDateTime) return ExitCode::Ok;
 
     if (const IoError ioError = IoHelper::setFileDates(_fileDownloadInfo.localpath, _fileDownloadInfo.creationTime,
                                                        _fileDownloadInfo.modificationTime, isLink);
-        ioError == IoError::Unknown) {
+        ioError == Unknown) {
         LOGW_WARN(_logger, L"Error in IoHelper::setFileDates: " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
         // Do nothing (remote file will be updated during the next sync)
         sentry::Handler::captureMessage(sentry::Level::Warning, "DownloadJob::handleResponse", "Unable to set file dates");
-    } else if (ioError == IoError::NoSuchFileOrDirectory || ioError == IoError::AccessDenied) {
+    } else if (ioError == NoSuchFileOrDirectory || ioError == AccessDenied) {
         LOGW_INFO(_logger, L"Item does not exist anymore or access is denied. Restarting sync: "
                                    << Utility::formatSyncPath(_fileDownloadInfo.localpath));
         return {ExitCode::DataError, ExitCause::InvalidSnapshot};

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
@@ -144,7 +144,7 @@ ExitInfo DownloadJob::canRun() {
 
 void DownloadJob::computeHydrationStatus() {
     VfsStatus vfsStatus;
-    ExitInfo exitInfo;
+    ExitInfo exitInfo = ExitCode::Ok;
     if (_vfs) exitInfo = _vfs->status(_fileDownloadInfo.localpath, vfsStatus);
     _isHydrated = !_vfs || (exitInfo && vfsStatus.isHydrated);
 }
@@ -156,7 +156,7 @@ ExitInfo DownloadJob::resolveDownloadNeed() {
                               _fileDownloadInfo.expectedSize);
     if (const ExitInfo exitInfo = hashJob.runSynchronously(); !exitInfo) {
         LOGW_DEBUG(_logger, L"CheckHashMatchJob failed: " << exitInfo << L" Proceeding DownloadJob normally.");
-        return exitInfo; // Non-fatal for the caller: fall through to download
+        return exitInfo;
     }
     _shouldDownload = !hashJob.hashMatch();
 
@@ -171,7 +171,7 @@ ExitInfo DownloadJob::resolveDownloadNeed() {
             return exitInfo;
         }
     }
-    return ExitCode::Ok; // Download is needed: caller must continue
+    return ExitCode::Ok;
 }
 
 ExitInfo DownloadJob::runJob() noexcept {

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
@@ -294,7 +294,7 @@ ExitInfo DownloadJob::handleResponse(std::istream &is) {
         }
     }
     if (const ExitInfo exitInfo = applyFileDatesIfRequired(fileType); !exitInfo) return exitInfo;
-    return readBackAndStoreLocalFileStats();
+    return setOutputParamaters();
 }
 
 ExitInfo DownloadJob::applyFileDatesIfRequired(const FileType fileType) {
@@ -314,7 +314,7 @@ ExitInfo DownloadJob::applyFileDatesIfRequired(const FileType fileType) {
     return ExitCode::Ok;
 }
 
-ExitInfo DownloadJob::readBackAndStoreLocalFileStats() {
+ExitInfo DownloadJob::setOutputParamaters() {
     FileStat filestat;
     IoError ioError = IoError::Success;
     if (!IoHelper::getFileStat(_fileDownloadInfo.localpath, &filestat, ioError, IoHelper::PathCheckOption::Insensitive)) {

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
@@ -150,7 +150,7 @@ ExitInfo DownloadJob::checkHashMatch() {
         LOGW_DEBUG(_logger, L"CheckHashMatchJob failed: " << exitInfo << L"Proceeding DownloadJob normally.");
         return ExitCode::Ok; // Non-fatal: fall through to download
     }
-    _shouldDownload = hashJob.shouldDownload();
+    _shouldDownload = !hashJob.hashMatch();
     return ExitCode::Ok;
 }
 

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
@@ -155,11 +155,12 @@ ExitInfo DownloadJob::checkHashMatch() {
 }
 
 ExitInfo DownloadJob::runJob() noexcept {
-    if (!_fileDownloadInfo.isCreate && _vfs) {
+    if (!_fileDownloadInfo.isCreate) {
         // Get hydration status
         VfsStatus vfsStatus;
-        (void) _vfs->status(_fileDownloadInfo.localpath, vfsStatus);
-        _isHydrated = vfsStatus.isHydrated;
+        if (_vfs) (void) _vfs->status(_fileDownloadInfo.localpath, vfsStatus);
+        _isHydrated = !_vfs || vfsStatus.isHydrated;
+
         if (_isHydrated) {
             if (const ExitInfo exitInfo = checkHashMatch(); !exitInfo) {
                 LOGW_DEBUG(_logger, L"Error in checkHashMatch: " << exitInfo);
@@ -171,43 +172,39 @@ ExitInfo DownloadJob::runJob() noexcept {
                 return setOutputParameters();
             }
         }
-    }
 
-    if (!_fileDownloadInfo.isCreate && _vfs) {
-        // Get hydration status
-        VfsStatus vfsStatus;
-        (void) _vfs->status(_fileDownloadInfo.localpath, vfsStatus);
-        _isHydrated = vfsStatus.isHydrated;
+        if (_vfs) {
+            // Update size on file system
+            FileStat filestat;
+            IoError ioError = IoError::Success;
+            if (!IoHelper::getFileStat(_fileDownloadInfo.localpath, &filestat, ioError, IoHelper::PathCheckOption::Insensitive)) {
+                LOGW_WARN(_logger,
+                          L"Error in IoHelper::getFileStat: " << Utility::formatIoError(_fileDownloadInfo.localpath, ioError));
+                return ExitCode::SystemError;
+            }
+            if (ioError == IoError::NoSuchFileOrDirectory) {
+                LOGW_WARN(_logger, L"Item does not exist anymore: " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
+                return {ExitCode::SystemError, ExitCause::NotFound};
+            } else if (ioError == IoError::AccessDenied) {
+                LOGW_WARN(_logger, L"Item misses search permission: " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
+                return {ExitCode::SystemError, ExitCause::FileAccessError};
+            }
 
-        // Update size on file system
-        FileStat filestat;
-        IoError ioError = IoError::Success;
-        if (!IoHelper::getFileStat(_fileDownloadInfo.localpath, &filestat, ioError, IoHelper::PathCheckOption::Insensitive)) {
-            LOGW_WARN(_logger,
-                      L"Error in IoHelper::getFileStat: " << Utility::formatIoError(_fileDownloadInfo.localpath, ioError));
-            return ExitCode::SystemError;
-        }
-        if (ioError == IoError::NoSuchFileOrDirectory) {
-            LOGW_WARN(_logger, L"Item does not exist anymore: " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
-            return {ExitCode::SystemError, ExitCause::NotFound};
-        } else if (ioError == IoError::AccessDenied) {
-            LOGW_WARN(_logger, L"Item misses search permission: " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
-            return {ExitCode::SystemError, ExitCause::FileAccessError};
-        }
+            if (const ExitInfo exitInfo =
+                        _vfs->updateMetadata(_fileDownloadInfo.localpath, filestat.creationTime, filestat.modificationTime,
+                                             _fileDownloadInfo.expectedSize, std::to_string(filestat.inode));
+                !exitInfo) {
+                LOGW_WARN(_logger,
+                          L"Update metadata failed " << exitInfo << L" " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
+                return exitInfo;
+            }
 
-        if (const ExitInfo exitInfo =
-                    _vfs->updateMetadata(_fileDownloadInfo.localpath, filestat.creationTime, filestat.modificationTime,
-                                         _fileDownloadInfo.expectedSize, std::to_string(filestat.inode));
-            !exitInfo) {
-            LOGW_WARN(_logger,
-                      L"Update metadata failed " << exitInfo << L" " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
-            return exitInfo;
-        }
-
-        if (const ExitInfo exitInfo = _vfs->forceStatus(_fileDownloadInfo.localpath, VfsStatus({.isSyncing = true})); !exitInfo) {
-            LOGW_WARN(_logger,
-                      L"Error in vfsForceStatus: " << Utility::formatSyncPath(_fileDownloadInfo.localpath) << L": " << exitInfo);
-            return exitInfo;
+            if (const ExitInfo exitInfo = _vfs->forceStatus(_fileDownloadInfo.localpath, VfsStatus({.isSyncing = true}));
+                !exitInfo) {
+                LOGW_WARN(_logger, L"Error in vfsForceStatus: " << Utility::formatSyncPath(_fileDownloadInfo.localpath) << L": "
+                                                                << exitInfo);
+                return exitInfo;
+            }
         }
     }
 

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
@@ -73,6 +73,7 @@ DownloadJob::~DownloadJob() {
     if (!_vfs) return;
 
     // If the download job intent is to create a new local file, then there is no downloaded file after cancellation.
+    if (_responseHandlingCanceled && _fileDownloadInfo.isCreate) return;
     if (!_shouldDownload) return;
 
     if (_responseHandlingCanceled) {

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
@@ -73,7 +73,7 @@ DownloadJob::~DownloadJob() {
     if (!_vfs) return;
 
     // If the download job intent is to create a new local file, then there is no downloaded file after cancellation.
-    if (_responseHandlingCanceled && _fileDownloadInfo.isCreate) return;
+    if (!_shouldDownload) return;
 
     if (_responseHandlingCanceled) {
         if (const ExitInfo exitInfo = _vfs->setPinState(_fileDownloadInfo.localpath, PinState::OnlineOnly); !exitInfo) {
@@ -155,15 +155,21 @@ ExitInfo DownloadJob::checkHashMatch() {
 }
 
 ExitInfo DownloadJob::runJob() noexcept {
-    if (!_fileDownloadInfo.isCreate && !_vfs) {
-        if (const ExitInfo exitInfo = checkHashMatch(); !exitInfo) {
-            LOGW_DEBUG(_logger, L"Error in checkHashMatch: " << exitInfo);
-            return exitInfo;
-        }
-        if (!_shouldDownload) {
-            LOGW_DEBUG(_logger, L"hanging last modified date without downloading")
-            if (const ExitInfo exitInfo = applyFileDatesIfRequired(FileType::Regular); !exitInfo) return exitInfo;
-            return setOutputParameters();
+    if (!_fileDownloadInfo.isCreate && _vfs) {
+        // Get hydration status
+        VfsStatus vfsStatus;
+        (void) _vfs->status(_fileDownloadInfo.localpath, vfsStatus);
+        _isHydrated = vfsStatus.isHydrated;
+        if (_isHydrated) {
+            if (const ExitInfo exitInfo = checkHashMatch(); !exitInfo) {
+                LOGW_DEBUG(_logger, L"Error in checkHashMatch: " << exitInfo);
+                return exitInfo;
+            }
+            if (!_shouldDownload) {
+                LOGW_DEBUG(_logger, L"C hanging last modified date without downloading")
+                if (const ExitInfo exitInfo = applyFileDatesIfRequired(FileType::Regular); !exitInfo) return exitInfo;
+                return setOutputParameters();
+            }
         }
     }
 

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
@@ -163,7 +163,7 @@ ExitInfo DownloadJob::runJob() noexcept {
         if (!_shouldDownload) {
             LOGW_DEBUG(_logger, L"hanging last modified date without downloading")
             if (const ExitInfo exitInfo = applyFileDatesIfRequired(FileType::Regular); !exitInfo) return exitInfo;
-            return setOutputParamaters();
+            return setOutputParameters();
         }
     }
 
@@ -298,7 +298,7 @@ ExitInfo DownloadJob::handleResponse(std::istream &is) {
         }
     }
     if (const ExitInfo exitInfo = applyFileDatesIfRequired(fileType); !exitInfo) return exitInfo;
-    return setOutputParamaters();
+    return setOutputParameters();
 }
 
 ExitInfo DownloadJob::applyFileDatesIfRequired(const FileType fileType) {
@@ -318,7 +318,7 @@ ExitInfo DownloadJob::applyFileDatesIfRequired(const FileType fileType) {
     return ExitCode::Ok;
 }
 
-ExitInfo DownloadJob::setOutputParamaters() {
+ExitInfo DownloadJob::setOutputParameters() {
     FileStat filestat;
     IoError ioError = IoError::Success;
     if (!IoHelper::getFileStat(_fileDownloadInfo.localpath, &filestat, ioError, IoHelper::PathCheckOption::Insensitive)) {

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
@@ -160,11 +160,17 @@ ExitInfo DownloadJob::resolveDownloadNeed() {
     _shouldDownload = !hashJob.hashMatch();
 
     if (!_shouldDownload) {
-        LOGW_DEBUG(_logger, L"Changing last modified date without downloading")
-        if (const ExitInfo exitInfo = applyFileDatesIfRequired(FileType::Regular); !exitInfo) return exitInfo;
-        return setOutputParameters(); // Returns Ok on success: signals runJob to stop here
+        LOGW_DEBUG(_logger, L"Changing last modified date without downloading : hash match");
+        if (const ExitInfo exitInfo = applyFileDatesIfRequired(FileType::Regular); !exitInfo) {
+            LOGW_DEBUG(_logger, L"applyFileDatesIfRequired failed: " << exitInfo << L" Proceeding DownloadJob normally.");
+            return exitInfo;
+        }
+        if (const ExitInfo exitInfo = setOutputParameters(); !exitInfo) {
+            LOGW_DEBUG(_logger, L"setOutputParameters failed: " << exitInfo << L" Proceeding DownloadJob normally.");
+            return exitInfo;
+        }
     }
-    return {ExitCode::OperationCanceled, ExitCause::Unknown}; // Download is needed: caller must continue
+    return ExitCode::Ok; // Download is needed: caller must continue
 }
 
 ExitInfo DownloadJob::runJob() noexcept {
@@ -173,7 +179,7 @@ ExitInfo DownloadJob::runJob() noexcept {
     computeHydrationStatus();
     if (_isHydrated) {
         const ExitInfo exitInfo = resolveDownloadNeed();
-        if (exitInfo) return exitInfo;
+        if (!_shouldDownload && exitInfo) return ExitCode::Ok;
         LOGW_DEBUG(_logger, L"resolveDownloadNeed: proceeding with download - " << exitInfo);
     }
 

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
@@ -145,7 +145,7 @@ ExitInfo DownloadJob::canRun() {
 void DownloadJob::computeHydrationStatus() {
     VfsStatus vfsStatus;
     ExitInfo exitInfo;
-    if (_vfs ) exitInfo = _vfs->status(_fileDownloadInfo.localpath, vfsStatus);
+    if (_vfs) exitInfo = _vfs->status(_fileDownloadInfo.localpath, vfsStatus);
     _isHydrated = !_vfs || (exitInfo && vfsStatus.isHydrated);
 }
 
@@ -321,10 +321,12 @@ ExitInfo DownloadJob::applyFileDatesIfRequired(const FileType fileType) {
         LOGW_WARN(_logger, L"Error in IoHelper::setFileDates: " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
         // Do nothing (remote file will be updated during the next sync)
         sentry::Handler::captureMessage(sentry::Level::Warning, "DownloadJob::handleResponse", "Unable to set file dates");
-    } else if (ioError == IoError::NoSuchFileOrDirectory || ioError == IoError::AccessDenied) {
-        LOGW_INFO(_logger, L"Item does not exist anymore or access is denied. Restarting sync: "
-                                   << Utility::formatSyncPath(_fileDownloadInfo.localpath));
-        return {ExitCode::DataError, ExitCause::InvalidSnapshot};
+    } else if (ioError == IoError::NoSuchFileOrDirectory) {
+        LOGW_WARN(_logger, L"Item does not exist anymore: " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
+        return {ExitCode::SystemError, ExitCause::NotFound};
+    } else if (ioError == IoError::AccessDenied) {
+        LOGW_WARN(_logger, L"Item misses search permission: " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
+        return {ExitCode::SystemError, ExitCause::FileAccessError};
     }
     return ExitCode::Ok;
 }

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
@@ -141,7 +141,68 @@ ExitInfo DownloadJob::canRun() {
     return ExitCode::Ok;
 }
 
+ExitInfo DownloadJob::checkHashMatch(bool &shouldDownload) {
+    shouldDownload = true;
+    CheckHashMatchJob hashJob(_fileDownloadInfo.driveDbId, _fileDownloadInfo.localpath, _fileDownloadInfo.remoteFileId,
+                              _fileDownloadInfo.expectedSize);
+    if (const ExitInfo exitInfo = hashJob.runSynchronously(); !exitInfo) {
+        LOG_WARN(_logger, "CheckHashMatchJob failed: " << exitInfo);
+        return ExitCode::Ok; // Non-fatal: fall through to download
+    }
+    if (hashJob.shouldDownload()) {
+        LOGW_DEBUG(_logger, L"Hash mismatch, downloading file: " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
+        return ExitCode::Ok;
+    }
+
+    LOGW_DEBUG(_logger, L"Hash match, skipping download: " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
+    if (_dateTimePolicy == DateTimePolicy::ApplyDateTime) {
+        if (const IoError ioError = IoHelper::setFileDates(_fileDownloadInfo.localpath, _fileDownloadInfo.creationTime,
+                                                           _fileDownloadInfo.modificationTime, false);
+            ioError == IoError::Unknown) {
+            LOGW_WARN(_logger, L"Error in IoHelper::setFileDates: " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
+        } else if (ioError == IoError::NoSuchFileOrDirectory || ioError == IoError::AccessDenied) {
+            return {ExitCode::DataError, ExitCause::InvalidSnapshot};
+        }
+    }
+
+    FileStat filestat;
+    IoError ioError = IoError::Success;
+    if (!IoHelper::getFileStat(_fileDownloadInfo.localpath, &filestat, ioError, IoHelper::PathCheckOption::Insensitive) ||
+        ioError != IoError::Success) {
+        LOGW_WARN(_logger, L"Error in IoHelper::getFileStat: " << Utility::formatIoError(_fileDownloadInfo.localpath, ioError));
+        return ExitCode::SystemError;
+    }
+    _localNodeId = std::to_string(filestat.inode);
+    _creationTimeOut = filestat.creationTime;
+    _modificationTimeOut = filestat.modificationTime;
+    _sizeOut = filestat.size;
+#if defined(KD_MACOS) || defined(KD_WINDOWS)
+    if (_fileDownloadInfo.creationTime != _creationTimeOut || _fileDownloadInfo.modificationTime != _modificationTimeOut) {
+        LOGW_INFO(_logger, L"Impossible to set creation and/or modification time(s) on local file."
+                                   << L" Desired values: " << _fileDownloadInfo.creationTime << L"/"
+                                   << _fileDownloadInfo.modificationTime << L" Set values: " << _creationTimeOut << L"/"
+                                   << _modificationTimeOut << L" for " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
+    }
+#else
+    if (_fileDownloadInfo.modificationTime != _modificationTimeOut) {
+        LOGW_INFO(_logger, L"Impossible to set modification time on local file."
+                                   << L" Desired value: " << _fileDownloadInfo.modificationTime << L" Set value: "
+                                   << _modificationTimeOut << L" for " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
+    }
+#endif
+    shouldDownload = false;
+    return ExitCode::Ok;
+}
+
 ExitInfo DownloadJob::runJob() noexcept {
+    if (!_fileDownloadInfo.isCreate) {
+        bool shouldDownload = true;
+        if (const ExitInfo exitInfo = checkHashMatch(shouldDownload); !exitInfo) {
+            return exitInfo;
+        }
+        if (!shouldDownload) return ExitCode::Ok;
+    }
+
     if (!_fileDownloadInfo.isCreate && _vfs) {
         // Get hydration status
         VfsStatus vfsStatus;

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
@@ -144,8 +144,9 @@ ExitInfo DownloadJob::canRun() {
 
 void DownloadJob::computeHydrationStatus() {
     VfsStatus vfsStatus;
-    if (_vfs) (void) _vfs->status(_fileDownloadInfo.localpath, vfsStatus);
-    _isHydrated = !_vfs || vfsStatus.isHydrated;
+    ExitInfo exitInfo;
+    if (_vfs ) exitInfo = _vfs->status(_fileDownloadInfo.localpath, vfsStatus);
+    _isHydrated = !_vfs || (exitInfo && vfsStatus.isHydrated);
 }
 
 ExitInfo DownloadJob::resolveDownloadNeed() {

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
@@ -215,18 +215,18 @@ ExitInfo DownloadJob::handleResponse(std::istream &is) {
         mimeType = contentTypeElts[0];
     }
 
-    bool isLink = false;
+    FileType fileType = FileType::Regular;
     std::string linkData;
     if (mimeType == mimeTypeSymlink || mimeType == mimeTypeSymlinkFolder || mimeType == mimeTypeHardlink ||
         (mimeType == mimeTypeFinderAlias && CommonUtility::isMac()) ||
         (mimeType == mimeTypeJunction && CommonUtility::isWindows())) {
         // Read link data
         getStringFromStream(is, linkData);
-        isLink = true;
+        fileType = FileType::IsLink;
     }
 
     // Process download
-    if (isLink) {
+    if (fileType == FileType::IsLink) {
         // Create link
         LOG_DEBUG(_logger, "Create link: mimeType=" << mimeType);
         if (const ExitInfo exitInfo = createLink(mimeType, linkData); !exitInfo) {
@@ -293,15 +293,15 @@ ExitInfo DownloadJob::handleResponse(std::istream &is) {
             }
         }
     }
-    if (const ExitInfo exitInfo = applyFileDatesIfRequired(isLink); !exitInfo) return exitInfo;
+    if (const ExitInfo exitInfo = applyFileDatesIfRequired(fileType); !exitInfo) return exitInfo;
     return readBackAndStoreLocalFileStats();
 }
 
-ExitInfo DownloadJob::applyFileDatesIfRequired(const bool isLink) {
+ExitInfo DownloadJob::applyFileDatesIfRequired(const FileType fileType) {
     if (_dateTimePolicy != DateTimePolicy::ApplyDateTime) return ExitCode::Ok;
 
     if (const IoError ioError = IoHelper::setFileDates(_fileDownloadInfo.localpath, _fileDownloadInfo.creationTime,
-                                                       _fileDownloadInfo.modificationTime, isLink);
+                                                       _fileDownloadInfo.modificationTime, fileType == FileType::IsLink);
         ioError == IoError::Unknown) {
         LOGW_WARN(_logger, L"Error in IoHelper::setFileDates: " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
         // Do nothing (remote file will be updated during the next sync)

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
@@ -311,7 +311,7 @@ ExitInfo DownloadJob::applyFileDatesIfRequired(const bool isLink) {
 
     if (const IoError ioError = IoHelper::setFileDates(_fileDownloadInfo.localpath, _fileDownloadInfo.creationTime,
                                                        _fileDownloadInfo.modificationTime, isLink);
-        ioError == Unknown) {
+        ioError == IoError::Unknown) {
         LOGW_WARN(_logger, L"Error in IoHelper::setFileDates: " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
         // Do nothing (remote file will be updated during the next sync)
         sentry::Handler::captureMessage(sentry::Level::Warning, "DownloadJob::handleResponse", "Unable to set file dates");

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
@@ -142,48 +142,41 @@ ExitInfo DownloadJob::canRun() {
     return ExitCode::Ok;
 }
 
-ExitInfo DownloadJob::checkHashMatch() {
+void DownloadJob::computeHydrationStatus() {
+    VfsStatus vfsStatus;
+    if (_vfs) (void) _vfs->status(_fileDownloadInfo.localpath, vfsStatus);
+    _isHydrated = !_vfs || vfsStatus.isHydrated;
+}
+
+ExitInfo DownloadJob::resolveDownloadNeed() {
     _shouldDownload = true;
+
     CheckHashMatchJob hashJob(_fileDownloadInfo.driveDbId, _fileDownloadInfo.localpath, _fileDownloadInfo.remoteFileId,
                               _fileDownloadInfo.expectedSize);
     const ExitInfo exitInfo = hashJob.runSynchronously();
     if (!exitInfo) {
-        LOGW_DEBUG(_logger, L"CheckHashMatchJob failed: " << exitInfo << L"Proceeding DownloadJob normally.");
-        return ExitCode::Ok; // Non-fatal: fall through to download
+        LOGW_DEBUG(_logger, L"CheckHashMatchJob failed: " << exitInfo << L" Proceeding DownloadJob normally.");
+        return exitInfo; // Non-fatal for the caller: fall through to download
     }
     _shouldDownload = !hashJob.hashMatch();
-    return ExitCode::Ok;
-}
 
-ExitInfo DownloadJob::getHydrationStatus(bool &shouldReturn) {
-    shouldReturn = false;
-
-    // Get hydration status
-    VfsStatus vfsStatus;
-    if (_vfs) (void) _vfs->status(_fileDownloadInfo.localpath, vfsStatus);
-    _isHydrated = !_vfs || vfsStatus.isHydrated;
-
-    if (_isHydrated) {
-        if (const ExitInfo exitInfo = checkHashMatch(); !exitInfo) {
-            LOGW_DEBUG(_logger, L"Error in checkHashMatch: " << exitInfo);
-            shouldReturn = false;
-            return exitInfo;
-        }
-        if (!_shouldDownload) {
-            LOGW_DEBUG(_logger, L"Changing last modified date without downloading")
-            shouldReturn = true;
-            if (const ExitInfo exitInfo = applyFileDatesIfRequired(FileType::Regular); !exitInfo) return exitInfo;
-            return setOutputParameters();
-        }
+    if (!_shouldDownload) {
+        LOGW_DEBUG(_logger, L"Changing last modified date without downloading")
+        if (const ExitInfo exitInfo = applyFileDatesIfRequired(FileType::Regular); !exitInfo) return exitInfo;
+        return setOutputParameters(); // Returns Ok on success: signals runJob to stop here
     }
-    return ExitCode::Ok;
+    return {ExitCode::OperationCanceled, ExitCause::Unknown}; // Download is needed: caller must continue
 }
 
 ExitInfo DownloadJob::runJob() noexcept {
     if (_fileDownloadInfo.isCreate) return AbstractTokenNetworkJob::runJob();
 
-    bool shouldReturn = false;
-    if (const ExitInfo exitInfo = getHydrationStatus(shouldReturn); shouldReturn) return exitInfo;
+    computeHydrationStatus();
+    if (_isHydrated) {
+        const ExitInfo exitInfo = resolveDownloadNeed();
+        if (exitInfo) return exitInfo;
+        LOGW_DEBUG(_logger, L"resolveDownloadNeed: proceeding with download - " << exitInfo);
+    }
 
     if (_vfs) {
         // Update size on file system

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
@@ -153,8 +153,7 @@ ExitInfo DownloadJob::resolveDownloadNeed() {
 
     CheckHashMatchJob hashJob(_fileDownloadInfo.driveDbId, _fileDownloadInfo.localpath, _fileDownloadInfo.remoteFileId,
                               _fileDownloadInfo.expectedSize);
-    const ExitInfo exitInfo = hashJob.runSynchronously();
-    if (!exitInfo) {
+    if (const ExitInfo exitInfo = hashJob.runSynchronously(); !exitInfo) {
         LOGW_DEBUG(_logger, L"CheckHashMatchJob failed: " << exitInfo << L" Proceeding DownloadJob normally.");
         return exitInfo; // Non-fatal for the caller: fall through to download
     }

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
@@ -154,60 +154,65 @@ ExitInfo DownloadJob::checkHashMatch() {
     return ExitCode::Ok;
 }
 
-ExitInfo DownloadJob::runJob() noexcept {
-    if (!_fileDownloadInfo.isCreate) {
-        // Get hydration status
-        VfsStatus vfsStatus;
-        if (_vfs) (void) _vfs->status(_fileDownloadInfo.localpath, vfsStatus);
-        _isHydrated = !_vfs || vfsStatus.isHydrated;
+ExitInfo DownloadJob::getHydrationStatus() {
+    // Get hydration status
+    VfsStatus vfsStatus;
+    if (_vfs) (void) _vfs->status(_fileDownloadInfo.localpath, vfsStatus);
+    _isHydrated = !_vfs || vfsStatus.isHydrated;
 
-        if (_isHydrated) {
-            if (const ExitInfo exitInfo = checkHashMatch(); !exitInfo) {
-                LOGW_DEBUG(_logger, L"Error in checkHashMatch: " << exitInfo);
-                return exitInfo;
-            }
-            if (!_shouldDownload) {
-                LOGW_DEBUG(_logger, L"C hanging last modified date without downloading")
-                if (const ExitInfo exitInfo = applyFileDatesIfRequired(FileType::Regular); !exitInfo) return exitInfo;
-                return setOutputParameters();
-            }
+    if (_isHydrated) {
+        if (const ExitInfo exitInfo = checkHashMatch(); !exitInfo) {
+            LOGW_DEBUG(_logger, L"Error in checkHashMatch: " << exitInfo);
+            return exitInfo;
         }
-
-        if (_vfs) {
-            // Update size on file system
-            FileStat filestat;
-            IoError ioError = IoError::Success;
-            if (!IoHelper::getFileStat(_fileDownloadInfo.localpath, &filestat, ioError, IoHelper::PathCheckOption::Insensitive)) {
-                LOGW_WARN(_logger,
-                          L"Error in IoHelper::getFileStat: " << Utility::formatIoError(_fileDownloadInfo.localpath, ioError));
-                return ExitCode::SystemError;
-            }
-            if (ioError == IoError::NoSuchFileOrDirectory) {
-                LOGW_WARN(_logger, L"Item does not exist anymore: " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
-                return {ExitCode::SystemError, ExitCause::NotFound};
-            } else if (ioError == IoError::AccessDenied) {
-                LOGW_WARN(_logger, L"Item misses search permission: " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
-                return {ExitCode::SystemError, ExitCause::FileAccessError};
-            }
-
-            if (const ExitInfo exitInfo =
-                        _vfs->updateMetadata(_fileDownloadInfo.localpath, filestat.creationTime, filestat.modificationTime,
-                                             _fileDownloadInfo.expectedSize, std::to_string(filestat.inode));
-                !exitInfo) {
-                LOGW_WARN(_logger,
-                          L"Update metadata failed " << exitInfo << L" " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
-                return exitInfo;
-            }
-
-            if (const ExitInfo exitInfo = _vfs->forceStatus(_fileDownloadInfo.localpath, VfsStatus({.isSyncing = true}));
-                !exitInfo) {
-                LOGW_WARN(_logger, L"Error in vfsForceStatus: " << Utility::formatSyncPath(_fileDownloadInfo.localpath) << L": "
-                                                                << exitInfo);
-                return exitInfo;
-            }
+        if (!_shouldDownload) {
+            LOGW_DEBUG(_logger, L"Changing last modified date without downloading")
+            if (const ExitInfo exitInfo = applyFileDatesIfRequired(FileType::Regular); !exitInfo) return exitInfo;
+            return setOutputParameters();
         }
     }
+}
 
+ExitInfo DownloadJob::runJob() noexcept {
+    if (_fileDownloadInfo.isCreate) return AbstractTokenNetworkJob::runJob();
+
+    if (const ExitInfo exitInfo = getHydrationStatus(); !exitInfo) {
+        LOGW_WARN(_logger, L"Error in getHydrationStatus: " << exitInfo);
+        return exitInfo;
+    }
+
+    if (_vfs) {
+        // Update size on file system
+        FileStat filestat;
+        IoError ioError = IoError::Success;
+        if (!IoHelper::getFileStat(_fileDownloadInfo.localpath, &filestat, ioError, IoHelper::PathCheckOption::Insensitive)) {
+            LOGW_WARN(_logger,
+                      L"Error in IoHelper::getFileStat: " << Utility::formatIoError(_fileDownloadInfo.localpath, ioError));
+            return ExitCode::SystemError;
+        }
+        if (ioError == IoError::NoSuchFileOrDirectory) {
+            LOGW_WARN(_logger, L"Item does not exist anymore: " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
+            return {ExitCode::SystemError, ExitCause::NotFound};
+        } else if (ioError == IoError::AccessDenied) {
+            LOGW_WARN(_logger, L"Item misses search permission: " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
+            return {ExitCode::SystemError, ExitCause::FileAccessError};
+        }
+
+        if (const ExitInfo exitInfo =
+                    _vfs->updateMetadata(_fileDownloadInfo.localpath, filestat.creationTime, filestat.modificationTime,
+                                         _fileDownloadInfo.expectedSize, std::to_string(filestat.inode));
+            !exitInfo) {
+            LOGW_WARN(_logger,
+                      L"Update metadata failed " << exitInfo << L" " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
+            return exitInfo;
+        }
+
+        if (const ExitInfo exitInfo = _vfs->forceStatus(_fileDownloadInfo.localpath, VfsStatus({.isSyncing = true})); !exitInfo) {
+            LOGW_WARN(_logger,
+                      L"Error in vfsForceStatus: " << Utility::formatSyncPath(_fileDownloadInfo.localpath) << L": " << exitInfo);
+            return exitInfo;
+        }
+    }
     return AbstractTokenNetworkJob::runJob();
 }
 

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
@@ -155,7 +155,7 @@ ExitInfo DownloadJob::checkHashMatch() {
 }
 
 ExitInfo DownloadJob::runJob() noexcept {
-    if (!_fileDownloadInfo.isCreate) {
+    if (!_fileDownloadInfo.isCreate && !_vfs) {
         if (const ExitInfo exitInfo = checkHashMatch(); !exitInfo) {
             return exitInfo;
         }

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
@@ -160,7 +160,11 @@ ExitInfo DownloadJob::runJob() noexcept {
             LOGW_DEBUG(_logger, L"Error in checkHashMatch: " << exitInfo);
             return exitInfo;
         }
-        if (!_shouldDownload) return ExitCode::Ok;
+        if (!_shouldDownload) {
+            LOGW_DEBUG(_logger, L"hanging last modified date without downloading")
+            if (const ExitInfo exitInfo = applyFileDatesIfRequired(FileType::Regular); !exitInfo) return exitInfo;
+            return setOutputParamaters();
+        }
     }
 
     if (!_fileDownloadInfo.isCreate && _vfs) {

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
@@ -306,7 +306,6 @@ ExitInfo DownloadJob::handleResponse(std::istream &is) {
 }
 
 ExitInfo DownloadJob::applyFileDatesIfRequired(const bool isLink) {
-    using enum KDC::IoError;
     if (_dateTimePolicy != DateTimePolicy::ApplyDateTime) return ExitCode::Ok;
 
     if (const IoError ioError = IoHelper::setFileDates(_fileDownloadInfo.localpath, _fileDownloadInfo.creationTime,
@@ -315,7 +314,7 @@ ExitInfo DownloadJob::applyFileDatesIfRequired(const bool isLink) {
         LOGW_WARN(_logger, L"Error in IoHelper::setFileDates: " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
         // Do nothing (remote file will be updated during the next sync)
         sentry::Handler::captureMessage(sentry::Level::Warning, "DownloadJob::handleResponse", "Unable to set file dates");
-    } else if (ioError == NoSuchFileOrDirectory || ioError == AccessDenied) {
+    } else if (ioError == IoError::NoSuchFileOrDirectory || ioError == IoError::AccessDenied) {
         LOGW_INFO(_logger, L"Item does not exist anymore or access is denied. Restarting sync: "
                                    << Utility::formatSyncPath(_fileDownloadInfo.localpath));
         return {ExitCode::DataError, ExitCause::InvalidSnapshot};

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
@@ -147,8 +147,7 @@ ExitInfo DownloadJob::checkHashMatch() {
                               _fileDownloadInfo.expectedSize);
     const ExitInfo exitInfo = hashJob.runSynchronously();
     if (!exitInfo) {
-        LOGW_WARN(_logger, L"CheckHashMatchJob failed: " << exitInfo);
-        LOGW_DEBUG(_logger, L"Proceeding DownloadJob normally.");
+        LOGW_DEBUG(_logger, L"CheckHashMatchJob failed: " << exitInfo << L"Proceeding DownloadJob normally.");
         return ExitCode::Ok; // Non-fatal: fall through to download
     }
     if (hashJob.shouldDownload()) {

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.h
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.h
@@ -69,6 +69,7 @@ class DownloadJob : public AbstractTokenNetworkJob {
         ExitInfo runJob() noexcept override;
         ExitInfo handleResponse(std::istream &is) override;
         ExitInfo checkHashMatch();
+        ExitInfo getHydrationStatus();
 
         ExitInfo createLink(const std::string &mimeType, const std::string &data);
         bool removeTmpFile();

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.h
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.h
@@ -68,8 +68,8 @@ class DownloadJob : public AbstractTokenNetworkJob {
         ExitInfo canRun() override;
         ExitInfo runJob() noexcept override;
         ExitInfo handleResponse(std::istream &is) override;
-        ExitInfo checkHashMatch();
-        ExitInfo getHydrationStatus(bool &shouldReturn);
+        void computeHydrationStatus();
+        ExitInfo resolveDownloadNeed();
 
         ExitInfo createLink(const std::string &mimeType, const std::string &data);
         bool removeTmpFile();

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.h
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.h
@@ -19,7 +19,7 @@
 #pragma once
 
 #include "jobs/network/abstracttokennetworkjob.h"
-#include "jobs/network/kDrive_api/checkhashmatchjob.h"
+#include "jobs/network/kDrive_API/checkhashmatchjob.h"
 
 #include "libcommonserver/vfs/vfs.h"
 #include "libcommonserver/io/cachedirectory.h"

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.h
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.h
@@ -41,6 +41,10 @@ class DownloadJob : public AbstractTokenNetworkJob {
             IgnoreDateTime,
             ApplyDateTime
         };
+        enum class FileType {
+            Regular,
+            IsLink
+        };
 
         DownloadJob(const std::shared_ptr<Vfs> vfs, std::shared_ptr<CacheDirectory> cacheDirectory,
                     const FileDownloadInfo &fileDownloadInfo, DateTimePolicy dateTimePolicy);
@@ -89,7 +93,7 @@ class DownloadJob : public AbstractTokenNetworkJob {
         ExitInfo createTmpFile(const std::string &data, bool &writeError);
         static bool hasEnoughPlace(const SyncPath &tmpDirPath, const SyncPath &destDirPath, int64_t neededPlace,
                                    log4cplus::Logger logger);
-        ExitInfo applyFileDatesIfRequired(bool isLink);
+        ExitInfo applyFileDatesIfRequired(FileType fileType);
         ExitInfo readBackAndStoreLocalFileStats();
 
         const std::shared_ptr<Vfs> _vfs;

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.h
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "jobs/network/abstracttokennetworkjob.h"
+#include "jobs/network/kDrive_api/checkhashmatchjob.h"
 
 #include "libcommonserver/vfs/vfs.h"
 #include "libcommonserver/io/cachedirectory.h"
@@ -62,6 +63,7 @@ class DownloadJob : public AbstractTokenNetworkJob {
         ExitInfo canRun() override;
         ExitInfo runJob() noexcept override;
         ExitInfo handleResponse(std::istream &is) override;
+        ExitInfo checkHashMatch(bool &shouldDownload);
 
         ExitInfo createLink(const std::string &mimeType, const std::string &data);
         bool removeTmpFile();

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.h
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.h
@@ -46,24 +46,25 @@ class DownloadJob : public AbstractTokenNetworkJob {
                     const FileDownloadInfo &fileDownloadInfo, DateTimePolicy dateTimePolicy);
         ~DownloadJob() override;
 
-        inline const NodeId &remoteNodeId() const { return _fileDownloadInfo.remoteFileId; }
-        inline const SyncPath &localPath() const { return _fileDownloadInfo.localpath; }
+        const NodeId &remoteNodeId() const { return _fileDownloadInfo.remoteFileId; }
+        const SyncPath &localPath() const { return _fileDownloadInfo.localpath; }
 
-        inline const NodeId &localNodeId() const { return _localNodeId; }
-        inline SyncTime creationTime() const { return _creationTimeOut; }
-        inline SyncTime modificationTime() const { return _modificationTimeOut; }
-        [[nodiscard]] inline int64_t size() const { return _sizeOut; }
+        const NodeId &localNodeId() const { return _localNodeId; }
+        SyncTime creationTime() const { return _creationTimeOut; }
+        SyncTime modificationTime() const { return _modificationTimeOut; }
+        [[nodiscard]] int64_t size() const { return _sizeOut; }
 
         [[nodiscard]] int64_t expectedSize() const { return _fileDownloadInfo.expectedSize; }
+        [[nodiscard]] bool shouldDownload() const { return _shouldDownload; }
 
     private:
         std::string getSpecificUrl() override;
-        inline ExitInfo setData() override { return ExitCode::Ok; }
+        ExitInfo setData() override { return ExitCode::Ok; }
 
         ExitInfo canRun() override;
         ExitInfo runJob() noexcept override;
         ExitInfo handleResponse(std::istream &is) override;
-        ExitInfo checkHashMatch(bool &shouldDownload);
+        ExitInfo checkHashMatch();
 
         ExitInfo createLink(const std::string &mimeType, const std::string &data);
         bool removeTmpFile();
@@ -88,10 +89,13 @@ class DownloadJob : public AbstractTokenNetworkJob {
         ExitInfo createTmpFile(const std::string &data, bool &writeError);
         static bool hasEnoughPlace(const SyncPath &tmpDirPath, const SyncPath &destDirPath, int64_t neededPlace,
                                    log4cplus::Logger logger);
+        ExitInfo applyFileDatesIfRequired(bool isLink);
+        ExitInfo readBackAndStoreLocalFileStats();
 
         const std::shared_ptr<Vfs> _vfs;
         std::shared_ptr<CacheDirectory> _cacheDirectory;
         FileDownloadInfo _fileDownloadInfo;
+        bool _shouldDownload = true;
 
         SyncPath _tmpPath;
         DateTimePolicy _dateTimePolicy;

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.h
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.h
@@ -94,7 +94,7 @@ class DownloadJob : public AbstractTokenNetworkJob {
         static bool hasEnoughPlace(const SyncPath &tmpDirPath, const SyncPath &destDirPath, int64_t neededPlace,
                                    log4cplus::Logger logger);
         ExitInfo applyFileDatesIfRequired(FileType fileType);
-        ExitInfo setOutputParamaters();
+        ExitInfo setOutputParameters();
 
         const std::shared_ptr<Vfs> _vfs;
         std::shared_ptr<CacheDirectory> _cacheDirectory;

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.h
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.h
@@ -94,7 +94,7 @@ class DownloadJob : public AbstractTokenNetworkJob {
         static bool hasEnoughPlace(const SyncPath &tmpDirPath, const SyncPath &destDirPath, int64_t neededPlace,
                                    log4cplus::Logger logger);
         ExitInfo applyFileDatesIfRequired(FileType fileType);
-        ExitInfo readBackAndStoreLocalFileStats();
+        ExitInfo setOutputParamaters();
 
         const std::shared_ptr<Vfs> _vfs;
         std::shared_ptr<CacheDirectory> _cacheDirectory;

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.h
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.h
@@ -69,7 +69,7 @@ class DownloadJob : public AbstractTokenNetworkJob {
         ExitInfo runJob() noexcept override;
         ExitInfo handleResponse(std::istream &is) override;
         ExitInfo checkHashMatch();
-        ExitInfo getHydrationStatus();
+        ExitInfo getHydrationStatus(bool &shouldReturn);
 
         ExitInfo createLink(const std::string &mimeType, const std::string &data);
         bool removeTmpFile();

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -1952,4 +1952,74 @@ void TestNetworkJobs::testPostFileModificationDate() {
     }
 }
 
+void TestNetworkJobs::testDownloadChecksumMismatch() {
+    LOGW_DEBUG(Log::instance()->getLogger(), L"$$$$$ testDownloadChecksumMismatch");
+
+    const RemoteTemporaryDirectory remoteTmpDir(_driveDbId, _remoteDirId, "testDownloadChecksumMismatch");
+    const LocalTemporaryDirectory localTmpDir("testDownloadChecksumMismatch");
+
+    // Both versions have the same size so the size check passes and hash comparison is reached.
+    constexpr size_t fileSize = 64;
+    const std::string contentV1(fileSize, 'A');
+    const std::string contentV2(fileSize, 'B');
+
+    const SyncPath localFileV1 = localTmpDir.path() / "file_v1.txt";
+    {
+        std::ofstream ofs(localFileV1, std::ios::binary);
+        ofs << contentV1;
+    }
+    UploadJob uploadV1(nullptr, _driveDbId, localFileV1, localFileV1.filename().native(), remoteTmpDir.id(),
+                       testhelpers::defaultTime, testhelpers::defaultTime);
+    CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, uploadV1.runSynchronously().code());
+    const NodeId remoteFileId = uploadV1.nodeId();
+    CPPUNIT_ASSERT(!remoteFileId.empty());
+
+    const SyncPath localDestFile = localTmpDir.path() / "file_local.txt";
+    {
+        DownloadJob downloadV1(nullptr, _cacheDirectory,
+                               DownloadJob::FileDownloadInfo{_driveDbId, remoteFileId, localDestFile,
+                                                             static_cast<int64_t>(fileSize),
+                                                             testhelpers::defaultTime, testhelpers::defaultTime, true},
+                               DownloadJob::DateTimePolicy::IgnoreDateTime);
+        CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, downloadV1.runSynchronously().code());
+    }
+    CPPUNIT_ASSERT(std::filesystem::exists(localDestFile));
+
+    const SyncPath localFileV2 = localTmpDir.path() / "file_v2.txt";
+    {
+        std::ofstream ofs(localFileV2, std::ios::binary);
+        ofs << contentV2;
+    }
+    UploadJob uploadV2(nullptr, _driveDbId, localFileV2, remoteFileId, testhelpers::defaultTime);
+    CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, uploadV2.runSynchronously().code());
+
+    // Local file holds v1, remote holds v2: CheckHashMatchJob must detect the mismatch.
+    {
+        DownloadJob downloadJob(nullptr, _cacheDirectory,
+                                DownloadJob::FileDownloadInfo{_driveDbId, remoteFileId, localDestFile,
+                                                              static_cast<int64_t>(fileSize),
+                                                              testhelpers::defaultTime, testhelpers::defaultTime, false},
+                                DownloadJob::DateTimePolicy::IgnoreDateTime);
+        CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, downloadJob.runSynchronously().code());
+        CPPUNIT_ASSERT_EQUAL_MESSAGE("Checksum mismatch should trigger a download", true, downloadJob.shouldDownload());
+
+        // Verify the file content has been updated to v2.
+        {
+            std::ifstream ifs(localDestFile, std::ios::binary);
+            const std::string actualContent((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+            CPPUNIT_ASSERT_EQUAL_MESSAGE("File content should have been updated to v2", contentV2, actualContent);
+        }
+
+        // Verify the modification date is unchanged (IgnoreDateTime policy was used).
+        {
+            FileStat fileStat;
+            IoError ioError = IoError::Success;
+            IoHelper::getFileStat(localDestFile, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive);
+            CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+            CPPUNIT_ASSERT_EQUAL_MESSAGE("Modification time should be unchanged (IgnoreDateTime policy)",
+                                         downloadJob.modificationTime(), fileStat.modificationTime);
+        }
+    }
+}
+
 } // namespace KDC

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -1024,7 +1024,7 @@ void TestNetworkJobs::testCheckHashMatch() {
         CheckHashMatchJob job(_driveDbId, tc.localFile, tc.remoteNodeId, tc.remoteSize);
         job.runSynchronously();
         CPPUNIT_ASSERT_EQUAL_MESSAGE(tc.name + ": unexpected exit code", tc.expectedExitCode, job.exitInfo().code());
-        CPPUNIT_ASSERT_EQUAL_MESSAGE(tc.name + ": unexpected shouldDownload", tc.expectedShouldDownload, job.shouldDownload());
+        CPPUNIT_ASSERT_EQUAL_MESSAGE(tc.name + ": unexpected shouldDownload", tc.expectedShouldDownload, !job.hashMatch());
     }
 }
 

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -2014,7 +2014,7 @@ void TestNetworkJobs::testDownloadChecksumMismatch() {
         {
             FileStat fileStat;
             IoError ioError = IoError::Success;
-            IoHelper::getFileStat(localDestFile, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive);
+            CPPUNIT_ASSERT(IoHelper::getFileStat(localDestFile, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
             CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
             CPPUNIT_ASSERT_EQUAL_MESSAGE("Modification time should be unchanged (IgnoreDateTime policy)",
                                          downloadJob.modificationTime(), fileStat.modificationTime);

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -2001,7 +2001,7 @@ void TestNetworkJobs::testDownloadChecksumMismatch() {
                                                               testhelpers::defaultTime, testhelpers::defaultTime, false},
                                 DownloadJob::DateTimePolicy::IgnoreDateTime);
         CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, downloadJob.runSynchronously().code());
-        CPPUNIT_ASSERT_EQUAL_MESSAGE("Checksum mismatch should trigger a download", true, downloadJob.shouldDownload());
+        CPPUNIT_ASSERT_MESSAGE("Checksum mismatch should trigger a download", downloadJob.shouldDownload());
 
         // Verify the file content has been updated to v2.
         {

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -1952,73 +1952,106 @@ void TestNetworkJobs::testPostFileModificationDate() {
     }
 }
 
-void TestNetworkJobs::testDownloadChecksumMismatch() {
-    LOGW_DEBUG(Log::instance()->getLogger(), L"$$$$$ testDownloadChecksumMismatch");
+void TestNetworkJobs::testDownloadChecksumHandling() {
+    LOGW_DEBUG(Log::instance()->getLogger(), L"$$$$$ testDownloadChecksumHandling");
 
-    const RemoteTemporaryDirectory remoteTmpDir(_driveDbId, _remoteDirId, "testDownloadChecksumMismatch");
-    const LocalTemporaryDirectory localTmpDir("testDownloadChecksumMismatch");
+    const RemoteTemporaryDirectory remoteTmpDir(_driveDbId, _remoteDirId, "testDownloadChecksumHandling");
+    const LocalTemporaryDirectory localTmpDir("testDownloadChecksumHandling");
 
-    // Both versions have the same size so the size check passes and hash comparison is reached.
+    // Both content versions have the same size so the size check passes and hash comparison is reached.
     constexpr size_t fileSize = 64;
     const std::string contentV1(fileSize, 'A');
     const std::string contentV2(fileSize, 'B');
+    const SyncTime initialModTime = testhelpers::defaultTime;
+    const SyncTime updatedModTime = initialModTime + 3600; // 1 hour later
 
+    // Upload v1.
     const SyncPath localFileV1 = localTmpDir.path() / "file_v1.txt";
     {
         std::ofstream ofs(localFileV1, std::ios::binary);
         ofs << contentV1;
     }
     UploadJob uploadV1(nullptr, _driveDbId, localFileV1, localFileV1.filename().native(), remoteTmpDir.id(),
-                       testhelpers::defaultTime, testhelpers::defaultTime);
+                       initialModTime, initialModTime);
     CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, uploadV1.runSynchronously().code());
     const NodeId remoteFileId = uploadV1.nodeId();
     CPPUNIT_ASSERT(!remoteFileId.empty());
 
+    // Download v1 (CREATE) to establish the local copy.
     const SyncPath localDestFile = localTmpDir.path() / "file_local.txt";
     {
-        DownloadJob downloadV1(nullptr, _cacheDirectory,
-                               DownloadJob::FileDownloadInfo{_driveDbId, remoteFileId, localDestFile,
-                                                             static_cast<int64_t>(fileSize),
-                                                             testhelpers::defaultTime, testhelpers::defaultTime, true},
-                               DownloadJob::DateTimePolicy::IgnoreDateTime);
-        CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, downloadV1.runSynchronously().code());
+        DownloadJob downloadCreate(nullptr, _cacheDirectory,
+                                   DownloadJob::FileDownloadInfo{_driveDbId, remoteFileId, localDestFile,
+                                                                 static_cast<int64_t>(fileSize), initialModTime, initialModTime,
+                                                                 true},
+                                   DownloadJob::DateTimePolicy::ApplyDateTime);
+        CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, downloadCreate.runSynchronously().code());
     }
     CPPUNIT_ASSERT(std::filesystem::exists(localDestFile));
 
+    // Verify the initial modification time was applied.
+    {
+        FileStat fileStat;
+        IoError ioError = IoError::Success;
+        CPPUNIT_ASSERT(IoHelper::getFileStat(localDestFile, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
+        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+        CPPUNIT_ASSERT_EQUAL(initialModTime, fileStat.modificationTime);
+    }
+
+    // --- Case 1: same content, date mismatch ---
+    // CheckHashMatchJob detects a hash match → no re-download, but the date must be corrected.
+    {
+        DownloadJob downloadSameContent(nullptr, _cacheDirectory,
+                                        DownloadJob::FileDownloadInfo{_driveDbId, remoteFileId, localDestFile,
+                                                                      static_cast<int64_t>(fileSize), initialModTime,
+                                                                      updatedModTime, false},
+                                        DownloadJob::DateTimePolicy::ApplyDateTime);
+        CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, downloadSameContent.runSynchronously().code());
+        CPPUNIT_ASSERT_MESSAGE("Hash and size match — file should NOT be re-downloaded",
+                               !downloadSameContent.shouldDownload());
+    }
+
+    // Modification time must have been updated without touching the content.
+    {
+        FileStat fileStat;
+        IoError ioError = IoError::Success;
+        CPPUNIT_ASSERT(IoHelper::getFileStat(localDestFile, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
+        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+        CPPUNIT_ASSERT_EQUAL_MESSAGE("Modification time should have been updated without re-downloading", updatedModTime,
+                                     fileStat.modificationTime);
+    }
+    {
+        std::ifstream ifs(localDestFile, std::ios::binary);
+        const std::string actualContent((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+        CPPUNIT_ASSERT_EQUAL_MESSAGE("File content must be unchanged after date-only correction", contentV1, actualContent);
+    }
+
+    // --- Case 2: content mismatch (v2 uploaded), same size ---
+    // CheckHashMatchJob detects a hash mismatch → file must be re-downloaded.
     const SyncPath localFileV2 = localTmpDir.path() / "file_v2.txt";
     {
         std::ofstream ofs(localFileV2, std::ios::binary);
         ofs << contentV2;
     }
-    UploadJob uploadV2(nullptr, _driveDbId, localFileV2, remoteFileId, testhelpers::defaultTime);
+    UploadJob uploadV2(nullptr, _driveDbId, localFileV2, remoteFileId, updatedModTime);
     CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, uploadV2.runSynchronously().code());
 
-    // Local file holds v1, remote holds v2: CheckHashMatchJob must detect the mismatch.
+    // Local file still holds v1, remote now holds v2: mismatch must trigger a download.
     {
-        DownloadJob downloadJob(nullptr, _cacheDirectory,
-                                DownloadJob::FileDownloadInfo{_driveDbId, remoteFileId, localDestFile,
-                                                              static_cast<int64_t>(fileSize),
-                                                              testhelpers::defaultTime, testhelpers::defaultTime, false},
-                                DownloadJob::DateTimePolicy::IgnoreDateTime);
-        CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, downloadJob.runSynchronously().code());
-        CPPUNIT_ASSERT_MESSAGE("Checksum mismatch should trigger a download", downloadJob.shouldDownload());
+        DownloadJob downloadMismatch(nullptr, _cacheDirectory,
+                                     DownloadJob::FileDownloadInfo{_driveDbId, remoteFileId, localDestFile,
+                                                                   static_cast<int64_t>(fileSize), initialModTime,
+                                                                   updatedModTime, false},
+                                     DownloadJob::DateTimePolicy::IgnoreDateTime);
+        CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, downloadMismatch.runSynchronously().code());
+        CPPUNIT_ASSERT_MESSAGE("Checksum mismatch should trigger a download", downloadMismatch.shouldDownload());
+    }
 
-        // Verify the file content has been updated to v2.
-        {
-            std::ifstream ifs(localDestFile, std::ios::binary);
-            const std::string actualContent((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
-            CPPUNIT_ASSERT_EQUAL_MESSAGE("File content should have been updated to v2", contentV2, actualContent);
-        }
-
-        // Verify the modification date is unchanged (IgnoreDateTime policy was used).
-        {
-            FileStat fileStat;
-            IoError ioError = IoError::Success;
-            CPPUNIT_ASSERT(IoHelper::getFileStat(localDestFile, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive));
-            CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
-            CPPUNIT_ASSERT_EQUAL_MESSAGE("Modification time should be unchanged (IgnoreDateTime policy)",
-                                         downloadJob.modificationTime(), fileStat.modificationTime);
-        }
+    // File content must have been updated to v2.
+    {
+        std::ifstream ifs(localDestFile, std::ios::binary);
+        const std::string actualContent((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+        CPPUNIT_ASSERT_EQUAL_MESSAGE("File content should have been updated to v2", contentV2, actualContent);
     }
 }
 

--- a/test/libsyncengine/jobs/network/testnetworkjobs.h
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.h
@@ -38,7 +38,7 @@ class TestNetworkJobs : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST(testDelete);
         CPPUNIT_TEST(testDownload);
         CPPUNIT_TEST(testDownloadAborted);
-        CPPUNIT_TEST(testDownloadChecksumMismatch);
+        CPPUNIT_TEST(testDownloadChecksumHandling);
         CPPUNIT_TEST(testGetDriveList);
         CPPUNIT_TEST(testGetFileInfo);
         CPPUNIT_TEST(testGetFileList);
@@ -84,7 +84,7 @@ class TestNetworkJobs : public CppUnit::TestFixture, public TestBase {
         void testCopyToDir();
         void testDelete();
         void testDownload();
-        void testDownloadChecksumMismatch();
+        void testDownloadChecksumHandling();
         void testDownloadAborted();
         void testGetAvatar();
         void testGetDriveList();

--- a/test/libsyncengine/jobs/network/testnetworkjobs.h
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.h
@@ -38,7 +38,7 @@ class TestNetworkJobs : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST(testDelete);
         CPPUNIT_TEST(testDownload);
         CPPUNIT_TEST(testDownloadAborted);
-        CPPUNIT_TEST(testGetAvatar);
+        CPPUNIT_TEST(testDownloadChecksumMismatch);
         CPPUNIT_TEST(testGetDriveList);
         CPPUNIT_TEST(testGetFileInfo);
         CPPUNIT_TEST(testGetFileList);
@@ -84,6 +84,7 @@ class TestNetworkJobs : public CppUnit::TestFixture, public TestBase {
         void testCopyToDir();
         void testDelete();
         void testDownload();
+        void testDownloadChecksumMismatch();
         void testDownloadAborted();
         void testGetAvatar();
         void testGetDriveList();


### PR DESCRIPTION
This pull request improves the reliability of file downloads by ensuring that files are re-downloaded if their local content does not match the expected remote checksum. It introduces a hash check before downloading, refactors related logic for clarity, and adds a comprehensive test for checksum mismatch scenarios.

**File Download Validation and Logic Refactoring:**

* Added a `checkHashMatch` method to `DownloadJob` that runs a `CheckHashMatchJob` before downloading. If the local file's hash matches the remote, the download is skipped; otherwise, the file is re-downloaded. This helps avoid unnecessary downloads and ensures data integrity. [[1]](diffhunk://#diff-d26bcb2d5081f348dc5ea2853f0218bd32398377cb72dfddc21034104ccf1fb6R144-R173) [[2]](diffhunk://#diff-855887f466e24409a38f3c99d5ea8c13c2509b971209379a161ec84528b4ffc3L48-R67) [[3]](diffhunk://#diff-855887f466e24409a38f3c99d5ea8c13c2509b971209379a161ec84528b4ffc3R92-R98)
* Refactored the logic for applying file dates and reading file stats into separate methods (`applyFileDatesIfRequired` and `readBackAndStoreLocalFileStats`) for better modularity and readability. [[1]](diffhunk://#diff-d26bcb2d5081f348dc5ea2853f0218bd32398377cb72dfddc21034104ccf1fb6L275-R310) [[2]](diffhunk://#diff-d26bcb2d5081f348dc5ea2853f0218bd32398377cb72dfddc21034104ccf1fb6R322-R325) [[3]](diffhunk://#diff-855887f466e24409a38f3c99d5ea8c13c2509b971209379a161ec84528b4ffc3R92-R98)
* Updated the header to include `checkhashmatchjob.h` and made several method signatures non-inline for consistency and clarity. [[1]](diffhunk://#diff-855887f466e24409a38f3c99d5ea8c13c2509b971209379a161ec84528b4ffc3R22) [[2]](diffhunk://#diff-855887f466e24409a38f3c99d5ea8c13c2509b971209379a161ec84528b4ffc3L48-R67)

**Testing Improvements:**

* Added a new test, `testDownloadChecksumMismatch`, which verifies that a file is re-downloaded if the local and remote contents differ (even if the file size is the same), and that file modification times are handled correctly according to policy. [[1]](diffhunk://#diff-a44011b4b2142730cdb600b754fc9df3f32479959030cd13cf167fda5bfc52ebR1937-R2006) [[2]](diffhunk://#diff-7cb4981dbd48c6446082f1f1058fe4f92be59b6f6ef5d9dfe5dda249e0618330L41-R41) [[3]](diffhunk://#diff-7cb4981dbd48c6446082f1f1058fe4f92be59b6f6ef5d9dfe5dda249e0618330R87)