### PR TITLE
feat: Add file path handling to PostFileModificationDateJob and change modification time in locale

### DIFF
--- a/src/libsyncengine/jobs/network/kDrive_API/postfilemodificationdatejob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/postfilemodificationdatejob.cpp
@@ -18,14 +18,21 @@
 
 #include "postfilemodificationdatejob.h"
 
+#include "jobs/network/networkjobsparams.h"
+#include "libcommonserver/io/iohelper.h"
+#include "libcommonserver/utility/jsonparserutility.h"
+#include "libcommonserver/utility/utility.h"
+
 #include <Poco/Net/HTTPRequest.h>
 
 namespace KDC {
 
-PostFileModificationDateJob::PostFileModificationDateJob(const DriveDbId driveDbId, const NodeId &nodeId, uint64_t lastModifiedAt) :
+PostFileModificationDateJob::PostFileModificationDateJob(const DriveDbId driveDbId, const NodeId &nodeId, SyncTime lastModifiedAt,
+                                                         const SyncPath &filePath) :
     AbstractTokenNetworkJob(ApiType::Drive, 0, 0, driveDbId, 0),
     _nodeId(nodeId),
-    _lastModifiedAt(lastModifiedAt) {
+    _lastModifiedAt(lastModifiedAt),
+    _filePath(filePath) {
     _httpMethod = Poco::Net::HTTPRequest::HTTP_POST;
     _apiVersion = 3;
 }
@@ -44,6 +51,33 @@ ExitInfo PostFileModificationDateJob::setData() {
     std::stringstream ss;
     json.stringify(ss);
     _data = ss.str();
+    return ExitCode::Ok;
+}
+
+ExitInfo PostFileModificationDateJob::runJob() noexcept {
+    if (const ExitInfo exitInfo = AbstractTokenNetworkJob::runJob(); !exitInfo) return exitInfo;
+
+    if (_filePath.empty()) return ExitCode::Ok;
+
+    if (const IoError ioError = IoHelper::setFileDates(_filePath, 0, _lastModifiedAtOut, false); ioError != IoError::Success) {
+        LOGW_WARN(_logger, L"Error in IoHelper::setFileDates: " << Utility::formatIoError(_filePath, ioError));
+    }
+    return ExitCode::Ok;
+}
+
+ExitInfo PostFileModificationDateJob::handleResponse(std::istream &is) {
+    if (const auto exitInfo = AbstractTokenNetworkJob::handleResponse(is); !exitInfo) {
+        return exitInfo;
+    }
+
+    if (!jsonRes()) return {ExitCode::BackError, ExitCause::MissingReplyData};
+
+    const auto dataObj = jsonRes()->getObject(dataKey);
+    if (!dataObj) return {ExitCode::BackError, ExitCause::MissingReplyData};
+
+    if (!JsonParserUtility::extractValue(dataObj, lastModifiedAtKey, _lastModifiedAtOut))
+        return {ExitCode::BackError, ExitCause::MissingReplyData};
+
     return ExitCode::Ok;
 }
 

--- a/src/libsyncengine/jobs/network/kDrive_API/postfilemodificationdatejob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/postfilemodificationdatejob.cpp
@@ -19,23 +19,20 @@
 #include "postfilemodificationdatejob.h"
 
 #include "jobs/network/networkjobsparams.h"
-#include "libcommonserver/io/iohelper.h"
 #include "libcommonserver/utility/jsonparserutility.h"
-#include "libcommonserver/utility/utility.h"
 
 #include <Poco/Net/HTTPRequest.h>
 
 namespace KDC {
 
-PostFileModificationDateJob::PostFileModificationDateJob(const DriveDbId driveDbId, const NodeId &nodeId, SyncTime lastModifiedAt,
-                                                         const SyncPath &filePath) :
+PostFileModificationDateJob::PostFileModificationDateJob(const DriveDbId driveDbId, const NodeId &nodeId, SyncTime lastModifiedAt) :
     AbstractTokenNetworkJob(ApiType::Drive, 0, 0, driveDbId, 0),
     _nodeId(nodeId),
-    _lastModifiedAt(lastModifiedAt),
-    _filePath(filePath) {
+    _lastModifiedAt(lastModifiedAt){
     _httpMethod = Poco::Net::HTTPRequest::HTTP_POST;
     _apiVersion = 3;
 }
+
 std::string PostFileModificationDateJob::getSpecificUrl() {
     std::string str = AbstractTokenNetworkJob::getSpecificUrl();
     str += "/files/";
@@ -51,17 +48,6 @@ ExitInfo PostFileModificationDateJob::setData() {
     std::stringstream ss;
     json.stringify(ss);
     _data = ss.str();
-    return ExitCode::Ok;
-}
-
-ExitInfo PostFileModificationDateJob::runJob() noexcept {
-    if (const ExitInfo exitInfo = AbstractTokenNetworkJob::runJob(); !exitInfo) return exitInfo;
-
-    if (_filePath.empty()) return ExitCode::Ok;
-
-    if (const IoError ioError = IoHelper::setFileDates(_filePath, 0, _lastModifiedAtOut, false); ioError != IoError::Success) {
-        LOGW_WARN(_logger, L"Error in IoHelper::setFileDates: " << Utility::formatIoError(_filePath, ioError));
-    }
     return ExitCode::Ok;
 }
 

--- a/src/libsyncengine/jobs/network/kDrive_API/postfilemodificationdatejob.h
+++ b/src/libsyncengine/jobs/network/kDrive_API/postfilemodificationdatejob.h
@@ -24,14 +24,21 @@ namespace KDC {
 
 class PostFileModificationDateJob : public AbstractTokenNetworkJob {
     public:
-        PostFileModificationDateJob(DriveDbId driveDbId, const NodeId &nodeId, uint64_t lastModifiedAt);
+        PostFileModificationDateJob(DriveDbId driveDbId, const NodeId &nodeId, SyncTime lastModifiedAt,
+                                    const SyncPath &filePath);
+
+        [[nodiscard]] SyncTime lastModifiedAt() const { return _lastModifiedAtOut; }
 
     private:
         std::string getSpecificUrl() override;
-        inline ExitInfo setData() override;
+        ExitInfo setData() override;
+        ExitInfo handleResponse(std::istream &is) override;
+        ExitInfo runJob() noexcept override;
 
         NodeId _nodeId;
-        uint64_t _lastModifiedAt;
+        SyncTime _lastModifiedAt = 0;
+        SyncTime _lastModifiedAtOut = 0;
+        SyncPath _filePath;
 };
 
 } // namespace KDC

--- a/src/libsyncengine/jobs/network/kDrive_API/postfilemodificationdatejob.h
+++ b/src/libsyncengine/jobs/network/kDrive_API/postfilemodificationdatejob.h
@@ -24,8 +24,7 @@ namespace KDC {
 
 class PostFileModificationDateJob : public AbstractTokenNetworkJob {
     public:
-        PostFileModificationDateJob(DriveDbId driveDbId, const NodeId &nodeId, SyncTime lastModifiedAt,
-                                    const SyncPath &filePath);
+        PostFileModificationDateJob(DriveDbId driveDbId, const NodeId &nodeId, SyncTime lastModifiedAt);
 
         [[nodiscard]] SyncTime lastModifiedAt() const { return _lastModifiedAtOut; }
 
@@ -33,12 +32,10 @@ class PostFileModificationDateJob : public AbstractTokenNetworkJob {
         std::string getSpecificUrl() override;
         ExitInfo setData() override;
         ExitInfo handleResponse(std::istream &is) override;
-        ExitInfo runJob() noexcept override;
 
         NodeId _nodeId;
         SyncTime _lastModifiedAt = 0;
         SyncTime _lastModifiedAtOut = 0;
-        SyncPath _filePath;
 };
 
 } // namespace KDC

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -1918,7 +1918,7 @@ void TestNetworkJobs::testPostFileModificationDate() {
         const NodeId nodeId = uploadJob.nodeId();
         CPPUNIT_ASSERT(!nodeId.empty());
         const std::string targetId = testCase.targetNodeIdOverride.empty() ? nodeId : testCase.targetNodeIdOverride;
-        PostFileModificationDateJob testJob(_driveDbId, targetId, testCase.timestampToPost, localFilePath);
+        PostFileModificationDateJob testJob(_driveDbId, targetId, testCase.timestampToPost);
         exitInfo = testJob.runSynchronously();
         CPPUNIT_ASSERT_MESSAGE(toString(exitInfo), exitInfo.operator bool() == testCase.expectSuccess);
 
@@ -1930,6 +1930,10 @@ void TestNetworkJobs::testPostFileModificationDate() {
         SyncTime verifyLastModifiedAt = 0;
         CPPUNIT_ASSERT(JsonParserUtility::extractValue(verifyDataObj, lastModifiedAtKey, verifyLastModifiedAt, false));
         CPPUNIT_ASSERT_EQUAL(testCase.expectedServerValue, verifyLastModifiedAt);
+        if (testCase.expectSuccess) {
+            CPPUNIT_ASSERT_EQUAL_MESSAGE(testCase.fileName + ": lastModifiedAt() should match server value",
+                                         verifyLastModifiedAt, testJob.lastModifiedAt());
+        }
     }
 
     // A timestamp more than 24h in the future is capped by the server to its current time.
@@ -1943,7 +1947,7 @@ void TestNetworkJobs::testPostFileModificationDate() {
         CPPUNIT_ASSERT_MESSAGE(toString(uploadExitInfo), uploadExitInfo);
         const NodeId nodeId = uploadJob.nodeId();
         CPPUNIT_ASSERT(!nodeId.empty());
-        PostFileModificationDateJob testJob(_driveDbId, nodeId, invalidFutureModificationDate, localFilePath);
+        PostFileModificationDateJob testJob(_driveDbId, nodeId, invalidFutureModificationDate);
         CPPUNIT_ASSERT(testJob.runSynchronously());
 
         GetFileInfoJob verifyJob(_driveDbId, nodeId);
@@ -1953,6 +1957,7 @@ void TestNetworkJobs::testPostFileModificationDate() {
         SyncTime verifyLastModifiedAt = 0;
         CPPUNIT_ASSERT(JsonParserUtility::extractValue(verifyDataObj, lastModifiedAtKey, verifyLastModifiedAt, false));
         CPPUNIT_ASSERT_LESS(invalidFutureModificationDate, verifyLastModifiedAt);
+        CPPUNIT_ASSERT_EQUAL(testJob.lastModifiedAt(), verifyLastModifiedAt);
     }
 }
 

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -1903,8 +1903,7 @@ void TestNetworkJobs::testPostFileModificationDate() {
             // fileName                   timestampToPost         targetOverride    expectSuccess  expectedServerValue
             {"test_valid.txt",            pastModificationDateSec,           "",     true,        pastModificationDateSec},
             {"test_valid_future.txt",     valideFutureModificationDate,      "",     true,        valideFutureModificationDate},
-            {"test_nonExistent.txt",      pastModificationDateSec,           "0",     false,       nowTimeStampSec},
-            {"test_future.txt",           invalideFutureModificationDate,    "",      false,       nowTimeStampSec},
+            {"test_nonExistent.txt",      pastModificationDateSec,           "0",    false,       nowTimeStampSec},
             {"test_zero.txt",             0,                                 "",     true,        static_cast<SyncTime>(0)},
             // clang-format on
     };
@@ -1919,7 +1918,7 @@ void TestNetworkJobs::testPostFileModificationDate() {
         const NodeId nodeId = uploadJob.nodeId();
         CPPUNIT_ASSERT(!nodeId.empty());
         const std::string targetId = testCase.targetNodeIdOverride.empty() ? nodeId : testCase.targetNodeIdOverride;
-        PostFileModificationDateJob testJob(_driveDbId, targetId, testCase.timestampToPost);
+        PostFileModificationDateJob testJob(_driveDbId, targetId, testCase.timestampToPost, localFilePath);
         exitInfo = testJob.runSynchronously();
         CPPUNIT_ASSERT_MESSAGE(toString(exitInfo), exitInfo.operator bool() == testCase.expectSuccess);
 
@@ -1931,6 +1930,29 @@ void TestNetworkJobs::testPostFileModificationDate() {
         SyncTime verifyLastModifiedAt = 0;
         CPPUNIT_ASSERT(JsonParserUtility::extractValue(verifyDataObj, lastModifiedAtKey, verifyLastModifiedAt, false));
         CPPUNIT_ASSERT_EQUAL(testCase.expectedServerValue, verifyLastModifiedAt);
+    }
+
+    // A timestamp more than 24h in the future is capped by the server to its current time.
+    // We only know the capped value is strictly less than what we sent.
+    {
+        const SyncPath localFilePath = localTmpDir.path() / "test_future.txt";
+        testhelpers::generateOrEditTestFile(localFilePath);
+        UploadJob uploadJob(nullptr, _driveDbId, localFilePath, localFilePath.filename().native(), remoteTmpDir.id(),
+                            nowTimeStampSec, nowTimeStampSec);
+        const ExitInfo uploadExitInfo = uploadJob.runSynchronously();
+        CPPUNIT_ASSERT_MESSAGE(toString(uploadExitInfo), uploadExitInfo);
+        const NodeId nodeId = uploadJob.nodeId();
+        CPPUNIT_ASSERT(!nodeId.empty());
+        PostFileModificationDateJob testJob(_driveDbId, nodeId, invalideFutureModificationDate, localFilePath);
+        CPPUNIT_ASSERT(testJob.runSynchronously());
+
+        GetFileInfoJob verifyJob(_driveDbId, nodeId);
+        CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, verifyJob.runSynchronously().code());
+        Poco::JSON::Object::Ptr verifyDataObj = verifyJob.jsonRes()->getObject(dataKey);
+        CPPUNIT_ASSERT(verifyDataObj);
+        SyncTime verifyLastModifiedAt = 0;
+        CPPUNIT_ASSERT(JsonParserUtility::extractValue(verifyDataObj, lastModifiedAtKey, verifyLastModifiedAt, false));
+        CPPUNIT_ASSERT_LESS(invalideFutureModificationDate, verifyLastModifiedAt);
     }
 }
 

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -1952,12 +1952,8 @@ void TestNetworkJobs::testPostFileModificationDate() {
 
         GetFileInfoJob verifyJob(_driveDbId, nodeId);
         CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, verifyJob.runSynchronously().code());
-        Poco::JSON::Object::Ptr verifyDataObj = verifyJob.jsonRes()->getObject(dataKey);
-        CPPUNIT_ASSERT(verifyDataObj);
-        SyncTime verifyLastModifiedAt = 0;
-        CPPUNIT_ASSERT(JsonParserUtility::extractValue(verifyDataObj, lastModifiedAtKey, verifyLastModifiedAt, false));
-        CPPUNIT_ASSERT_LESS(invalidFutureModificationDate, verifyLastModifiedAt);
-        CPPUNIT_ASSERT_EQUAL(testJob.lastModifiedAt(), verifyLastModifiedAt);
+        CPPUNIT_ASSERT_LESS(verifyJob.modificationTime(), invalidFutureModificationDate);
+        CPPUNIT_ASSERT_EQUAL(testJob.lastModifiedAt(), verifyJob.modificationTime());
     }
 }
 

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -1887,7 +1887,7 @@ void TestNetworkJobs::testPostFileModificationDate() {
     const auto nowTimeStamp = system_clock::now().time_since_epoch();
     const SyncTime pastModificationDateSec = duration_cast<seconds>(nowTimeStamp - hours(1)).count();
     const SyncTime valideFutureModificationDate = duration_cast<seconds>(nowTimeStamp + hours(1)).count();
-    const SyncTime invalideFutureModificationDate = duration_cast<seconds>(nowTimeStamp + hours(25)).count();
+    const SyncTime invalidFutureModificationDate = duration_cast<seconds>(nowTimeStamp + hours(25)).count();
     const SyncTime nowTimeStampSec = duration_cast<seconds>(nowTimeStamp).count();
 
     struct TestCase {
@@ -1943,7 +1943,7 @@ void TestNetworkJobs::testPostFileModificationDate() {
         CPPUNIT_ASSERT_MESSAGE(toString(uploadExitInfo), uploadExitInfo);
         const NodeId nodeId = uploadJob.nodeId();
         CPPUNIT_ASSERT(!nodeId.empty());
-        PostFileModificationDateJob testJob(_driveDbId, nodeId, invalideFutureModificationDate, localFilePath);
+        PostFileModificationDateJob testJob(_driveDbId, nodeId, invalidFutureModificationDate, localFilePath);
         CPPUNIT_ASSERT(testJob.runSynchronously());
 
         GetFileInfoJob verifyJob(_driveDbId, nodeId);
@@ -1952,7 +1952,7 @@ void TestNetworkJobs::testPostFileModificationDate() {
         CPPUNIT_ASSERT(verifyDataObj);
         SyncTime verifyLastModifiedAt = 0;
         CPPUNIT_ASSERT(JsonParserUtility::extractValue(verifyDataObj, lastModifiedAtKey, verifyLastModifiedAt, false));
-        CPPUNIT_ASSERT_LESS(invalideFutureModificationDate, verifyLastModifiedAt);
+        CPPUNIT_ASSERT_LESS(invalidFutureModificationDate, verifyLastModifiedAt);
     }
 }
 

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -1924,15 +1924,10 @@ void TestNetworkJobs::testPostFileModificationDate() {
 
         // Verify the modification date on the server.
         GetFileInfoJob verifyJob(_driveDbId, nodeId);
-        CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, verifyJob.runSynchronously().code());
-        Poco::JSON::Object::Ptr verifyDataObj = verifyJob.jsonRes()->getObject(dataKey);
-        CPPUNIT_ASSERT(verifyDataObj);
-        SyncTime verifyLastModifiedAt = 0;
-        CPPUNIT_ASSERT(JsonParserUtility::extractValue(verifyDataObj, lastModifiedAtKey, verifyLastModifiedAt, false));
-        CPPUNIT_ASSERT_EQUAL(testCase.expectedServerValue, verifyLastModifiedAt);
+        CPPUNIT_ASSERT(verifyJob.runSynchronously());
         if (testCase.expectSuccess) {
             CPPUNIT_ASSERT_EQUAL_MESSAGE(testCase.fileName + ": lastModifiedAt() should match server value",
-                                         verifyLastModifiedAt, testJob.lastModifiedAt());
+                                         verifyJob.modificationTime(), testJob.lastModifiedAt());
         }
     }
 
@@ -1951,8 +1946,8 @@ void TestNetworkJobs::testPostFileModificationDate() {
         CPPUNIT_ASSERT(testJob.runSynchronously());
 
         GetFileInfoJob verifyJob(_driveDbId, nodeId);
-        CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, verifyJob.runSynchronously().code());
-        CPPUNIT_ASSERT_LESS(verifyJob.modificationTime(), invalidFutureModificationDate);
+        CPPUNIT_ASSERT(verifyJob.runSynchronously());
+        CPPUNIT_ASSERT_LESS(invalidFutureModificationDate, verifyJob.modificationTime());
         CPPUNIT_ASSERT_EQUAL(testJob.lastModifiedAt(), verifyJob.modificationTime());
     }
 }


### PR DESCRIPTION
This pull request enhances the `PostFileModificationDateJob` class by improving how file modification dates are handled and tested. The changes introduce more robust handling of file paths and server responses, as well as improved test coverage for edge cases involving future timestamps.

**Enhancements to file modification date handling:**

* The `PostFileModificationDateJob` constructor now takes an additional `filePath` parameter, allowing the job to update local file dates after a successful server response. (`src/libsyncengine/jobs/network/kDrive_API/postfilemodificationdatejob.cpp`, `src/libsyncengine/jobs/network/kDrive_API/postfilemodificationdatejob.h`, `test/libsyncengine/jobs/network/testnetworkjobs.cpp`) [[1]](diffhunk://#diff-36ffd882c8708ac2ed431d2a944b43ae38cf019a183d350497410d99627d6582R21-R35) [[2]](diffhunk://#diff-2c252d2f5464ee88faad59f47c5fc3e3ade9c4f445c178d66e70c9c11c8baa68L27-R41) [[3]](diffhunk://#diff-a44011b4b2142730cdb600b754fc9df3f32479959030cd13cf167fda5bfc52ebL1922-R1921)
* Added a `runJob()` override to update the local file's modification date using `IoHelper::setFileDates`, and a `handleResponse()` override to extract the updated timestamp from the server response. (`src/libsyncengine/jobs/network/kDrive_API/postfilemodificationdatejob.cpp`, `src/libsyncengine/jobs/network/kDrive_API/postfilemodificationdatejob.h`) [[1]](diffhunk://#diff-36ffd882c8708ac2ed431d2a944b43ae38cf019a183d350497410d99627d6582R57-R83) [[2]](diffhunk://#diff-2c252d2f5464ee88faad59f47c5fc3e3ade9c4f445c178d66e70c9c11c8baa68L27-R41)

**Improvements to testing:**

* The test for posting file modification dates now passes the file path to the job and adds a new test case to verify server-side capping of modification dates set far in the future. (`test/libsyncengine/jobs/network/testnetworkjobs.cpp`) [[1]](diffhunk://#diff-a44011b4b2142730cdb600b754fc9df3f32479959030cd13cf167fda5bfc52ebR1934-R1956) [[2]](diffhunk://#diff-a44011b4b2142730cdb600b754fc9df3f32479959030cd13cf167fda5bfc52ebL1922-R1921)
* Removed a redundant test case for future dates, replaced with a more thorough check for server capping behavior. (`test/libsyncengine/jobs/network/testnetworkjobs.cpp`)

These changes make file modification date handling more accurate and ensure that edge cases are properly tested.