### PR TITLE
fix: Improve sync robustness and backend error handling

### DIFF
--- a/src/libsyncengine/jobs/network/abstractnetworkjob.cpp
+++ b/src/libsyncengine/jobs/network/abstractnetworkjob.cpp
@@ -488,14 +488,6 @@ ExitInfo AbstractNetworkJob::receiveResponse(const Poco::URI &uri) {
                                   << httpResponse().getReason());
     logReplyInfo();
 
-    if (Utility::isError500(httpResponse().getStatus())) {
-        std::string replyBody;
-        getStringFromStream(stream[0].get(), replyBody);
-        LOG_WARN(_logger, "Reply " << jobId() << ": " << replyBody);
-        disableRetry();
-        return {ExitCode::BackError, ExitCause::Http5xx};
-    }
-
     switch (httpResponse().getStatus()) {
         case Poco::Net::HTTPResponse::HTTP_OK: {
             try {

--- a/src/libsyncengine/jobs/network/abstractnetworkjob.cpp
+++ b/src/libsyncengine/jobs/network/abstractnetworkjob.cpp
@@ -543,27 +543,26 @@ ExitInfo AbstractNetworkJob::receiveResponse(const Poco::URI &uri) {
             [[fallthrough]];
         }
         default: {
-            if (!isAborted()) {
-                ExitInfo exitInfo;
-                try {
-                    exitInfo = handleError(stream[0].get(), uri);
-                } catch (const std::exception &e) {
-                    LOG_WARN(_logger, "handleError failed: " << errorText(e));
-                    return {};
-                }
+            if (isAborted()) return ExitCode::Ok;
 
-                if (!exitInfo) {
-                    if (exitInfo.cause() == ExitCause::Unknown && Utility::isError500(httpResponse().getStatus())) {
-                        disableRetry();
-                        exitInfo.setCause(ExitCause::Http5xx);
-                    } else if (exitInfo.code() != ExitCode::DataError && exitInfo.code() != ExitCode::InvalidToken &&
-                               (exitInfo.code() != ExitCode::BackError || exitInfo.cause() != ExitCause::NotFound)) {
-                        LOG_WARN(_logger, "Error handling failed");
-                    }
-                    return exitInfo;
-                }
+            ExitInfo exitInfo;
+            try {
+                exitInfo = handleError(stream[0].get(), uri);
+            } catch (const std::exception &e) {
+                LOG_WARN(_logger, "handleError failed: " << errorText(e));
+                return ExitCode::NetworkError;
             }
-            break;
+
+            if (exitInfo.code() == ExitCode::Ok) return exitInfo;
+
+            if (exitInfo.cause() == ExitCause::Unknown && Utility::isError500(httpResponse().getStatus())) {
+                disableRetry();
+                exitInfo.setCause(ExitCause::Http5xx);
+            } else if (exitInfo.code() != ExitCode::DataError && exitInfo.code() != ExitCode::InvalidToken &&
+                       (exitInfo.code() != ExitCode::BackError || exitInfo.cause() != ExitCause::NotFound)) {
+                LOG_WARN(_logger, "Error handling failed");
+            }
+            return exitInfo;
         }
     }
 

--- a/src/libsyncengine/jobs/network/abstractnetworkjob.cpp
+++ b/src/libsyncengine/jobs/network/abstractnetworkjob.cpp
@@ -184,6 +184,7 @@ ExitInfo AbstractNetworkJob::runJob() noexcept {
 
     Poco::URI uri;
     ExitInfo outputExitInfo = ExitCode::Ok;
+    _trials = _defaultTrials;
     for (int trials = 1; trials <= std::min(_trials, MAX_TRIALS); trials++) {
         outputExitInfo = ExitCode::Ok;
 

--- a/src/libsyncengine/jobs/network/abstractnetworkjob.cpp
+++ b/src/libsyncengine/jobs/network/abstractnetworkjob.cpp
@@ -553,8 +553,11 @@ ExitInfo AbstractNetworkJob::receiveResponse(const Poco::URI &uri) {
                 }
 
                 if (!exitInfo) {
-                    if (exitInfo.code() != ExitCode::DataError && exitInfo.code() != ExitCode::InvalidToken &&
-                        (exitInfo.code() != ExitCode::BackError || exitInfo.cause() != ExitCause::NotFound)) {
+                    if (exitInfo.cause() == ExitCause::Unknown && Utility::isError500(httpResponse().getStatus())) {
+                        disableRetry();
+                        exitInfo.setCause(ExitCause::Http5xx);
+                    } else if (exitInfo.code() != ExitCode::DataError && exitInfo.code() != ExitCode::InvalidToken &&
+                               (exitInfo.code() != ExitCode::BackError || exitInfo.cause() != ExitCause::NotFound)) {
                         LOG_WARN(_logger, "Error handling failed");
                     }
                     return exitInfo;

--- a/src/libsyncengine/jobs/network/abstractnetworkjob.h
+++ b/src/libsyncengine/jobs/network/abstractnetworkjob.h
@@ -81,7 +81,8 @@ class AbstractNetworkJob : public SyncJob {
         uint8_t _apiVersion{2};
         std::string _data;
         int _customTimeout = 0;
-        int32_t _trials = 2; // By default, try again once if exception is thrown
+        static const int32_t _defaultTrials = 2;
+        int32_t _trials = _defaultTrials; // By default, try again once if exception is thrown
         BackError _backError;
 
     private:

--- a/src/libsyncengine/jobs/network/abstracttokennetworkjob.cpp
+++ b/src/libsyncengine/jobs/network/abstracttokennetworkjob.cpp
@@ -276,6 +276,13 @@ ExitInfo AbstractTokenNetworkJob::handleError(const std::string &replyBody, cons
             exitInfo.setCause(exitCause);
             break;
     }
+
+    if (exitInfo.cause() == ExitCause::Unknown && Utility::isError500(httpResponse().getStatus())) {
+        LOG_WARN(_logger, "Reply " << jobId() << ": " << replyBody);
+        disableRetry();
+        exitInfo.setCause(ExitCause::Http5xx);
+    }
+
     return exitInfo;
 }
 

--- a/src/libsyncengine/jobs/network/abstracttokennetworkjob.cpp
+++ b/src/libsyncengine/jobs/network/abstracttokennetworkjob.cpp
@@ -276,13 +276,6 @@ ExitInfo AbstractTokenNetworkJob::handleError(const std::string &replyBody, cons
             exitInfo.setCause(exitCause);
             break;
     }
-
-    if (exitInfo.cause() == ExitCause::Unknown && Utility::isError500(httpResponse().getStatus())) {
-        LOG_WARN(_logger, "Reply " << jobId() << ": " << replyBody);
-        disableRetry();
-        exitInfo.setCause(ExitCause::Http5xx);
-    }
-
     return exitInfo;
 }
 

--- a/src/libsyncengine/syncpal/syncpalworker.cpp
+++ b/src/libsyncengine/syncpal/syncpalworker.cpp
@@ -18,6 +18,7 @@
 
 #include "syncpalworker.h"
 #include "update_detection/file_system_observer/filesystemobserverworker.h"
+#include "update_detection/file_system_observer/remotefilesystemobserverworker.h"
 #include "update_detection/file_system_observer/computefsoperationworker.h"
 #include "update_detection/update_detector/updatetreeworker.h"
 #include "reconciliation/platform_inconsistency_checker/platforminconsistencycheckerworker.h"
@@ -84,11 +85,10 @@ bool SyncPalWorker::shouldBePaused(const std::shared_ptr<ISyncWorker> w1, const 
             (w1 && w1->exitCode() == ExitCode::NetworkError) || (w2 && w2->exitCode() == ExitCode::NetworkError);
     const auto httpBlockingError =
             (w1 && w1->exitCode() == ExitCode::BackError &&
-             (w1->exitCause() == ExitCause::Http5xx || w1->exitCause() == ExitCause::HttpErr ||
-              w1->exitCause() == ExitCause::FullListParsingError || w1->exitCause() == ExitCause::MissingReplyData)) ||
+             (w1->exitCause() == ExitCause::Http5xx || w1->exitCause() == ExitCause::HttpErr || w1->exitCause() == ExitCause::MissingReplyData)) ||
             (w2 && w2->exitCode() == ExitCode::BackError &&
-             (w2->exitCause() == ExitCause::Http5xx || w2->exitCause() == ExitCause::HttpErr ||
-              w2->exitCause() == ExitCause::FullListParsingError || w2->exitCause() == ExitCause::MissingReplyData));
+             (w2->exitCause() == ExitCause::Http5xx || w2->exitCause() == ExitCause::HttpErr || w2->exitCause() == ExitCause::MissingReplyData));
+
     const auto syncDirNotAccessible =
             (w1 && w1->exitCode() == ExitCode::SystemError &&
              (w1->exitCause() == ExitCause::SyncDirAccessError || w1->exitCause() == ExitCause::SyncDirDiskMissing)) ||
@@ -97,8 +97,13 @@ bool SyncPalWorker::shouldBePaused(const std::shared_ptr<ISyncWorker> w1, const 
     const auto invalidOperation =
             (w1 && w1->exitCode() == ExitCode::InvalidOperation) || (w2 && w2->exitCode() == ExitCode::InvalidOperation);
 
+    std::shared_ptr<RemoteFileSystemObserverWorker> r1 = std::dynamic_pointer_cast<RemoteFileSystemObserverWorker>(w1);
+    std::shared_ptr<RemoteFileSystemObserverWorker> r2 = std::dynamic_pointer_cast<RemoteFileSystemObserverWorker>(w2);
+    const auto rfsoError = (r1 != nullptr && r1->exitCode() != ExitCode::Ok) || (r2 != nullptr && r2->exitCode() != ExitCode::Ok);
+
     if (handleRateLimited(w1, w2)) return true;
-    if (httpBlockingError) {
+
+    if (httpBlockingError || rfsoError) {
         handleBackError();
         return true;
     }

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -3141,7 +3141,7 @@ void AppServer::resolveErrors(std::vector<Error> errorList) const {
 }
 
 ExitInfo AppServer::startSyncs() {
-    std::unordered_set<SyncDbId> emptyList;
+    const std::unordered_set<SyncDbId> emptyList;
     std::unordered_set<SyncDbId> startedSyncDbIds;
     return startSyncs(emptyList, startedSyncDbIds);
 }
@@ -3304,7 +3304,7 @@ ExitInfo AppServer::startSyncs(User &user, std::unordered_set<SyncDbId> toIgnore
                     mainExitInfo.merge(exitInfo, {ExitCode::SystemError});
                 }
 
-                startedSyncDbIds.insert(sync.dbId());
+                (void) startedSyncDbIds.insert(sync.dbId());
             }
         }
     }

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -2423,7 +2423,7 @@ void AppServer::onRequestReceived(int id, RequestNum num, const QByteArray &para
     OldCommServer::instance()->sendReply(id, results);
 }
 
-void AppServer::startSyncsAndRetryOnError(const std::unordered_set<SyncDbId>& toIgnoreSyncDbIds) {
+void AppServer::startSyncsAndRetryOnError(const std::unordered_set<SyncDbId> &toIgnoreSyncDbIds) {
     LOG_DEBUG(_logger, "Start syncs");
     std::unordered_set<SyncDbId> startedSyncDbIds;
     if (const auto exitInfo = startSyncs(toIgnoreSyncDbIds, startedSyncDbIds); !exitInfo) {
@@ -3145,7 +3145,8 @@ ExitInfo AppServer::startSyncs() {
     std::unordered_set<SyncDbId> startedSyncDbIds;
     return startSyncs(emptyList, startedSyncDbIds);
 }
-ExitInfo AppServer::startSyncs(const std::unordered_set<SyncDbId> &toIgnoreSyncDbIds, std::unordered_set<SyncDbId> &startedSyncDbIds) {
+ExitInfo AppServer::startSyncs(const std::unordered_set<SyncDbId> &toIgnoreSyncDbIds,
+                               std::unordered_set<SyncDbId> &startedSyncDbIds) {
     // Load user list
     std::vector<User> userList;
     if (!ParmsDb::instance()->selectAllUsers(userList)) {
@@ -3197,7 +3198,7 @@ ExitInfo AppServer::startSyncs(User &user) {
     std::unordered_set<SyncDbId> emptyList;
     return startSyncs(user, emptyList, emptyList);
 }
-ExitInfo AppServer::startSyncs(User &user, std::unordered_set<SyncDbId> toIgnoreSyncDbIds,
+ExitInfo AppServer::startSyncs(User &user, const std::unordered_set<SyncDbId> toIgnoreSyncDbIds,
                                std::unordered_set<SyncDbId> &startedSyncDbIds) {
     logExtendedLogActivationMessage(ParametersCache::isExtendedLogEnabled());
 
@@ -3233,7 +3234,6 @@ ExitInfo AppServer::startSyncs(User &user, std::unordered_set<SyncDbId> toIgnore
                     continue;
                 }
 
-                auto syncPalMapIt = syncPalMap.find(sync.dbId());
                 QSet<QString> blackList;
                 bool syncUpdated = false;
 

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -2423,14 +2423,17 @@ void AppServer::onRequestReceived(int id, RequestNum num, const QByteArray &para
     OldCommServer::instance()->sendReply(id, results);
 }
 
-void AppServer::startSyncsAndRetryOnError() {
+void AppServer::startSyncsAndRetryOnError(const std::unordered_set<SyncDbId>& toIgnoreSyncDbIds) {
     LOG_DEBUG(_logger, "Start syncs");
-    if (const auto exitInfo = startSyncs(); !exitInfo) {
+    std::unordered_set<SyncDbId> startedSyncDbIds;
+    if (const auto exitInfo = startSyncs(toIgnoreSyncDbIds, startedSyncDbIds); !exitInfo) {
         LOG_WARN(_logger, "Error in startSyncsAndRetryOnError: " << exitInfo);
         if (exitInfo.code() == ExitCode::SystemError &&
             (exitInfo.cause() == ExitCause::SyncDirAccessError || exitInfo.cause() == ExitCause::SyncDirDiskMissing)) {
             LOG_DEBUG(_logger, "Retry to start syncs in " << START_SYNCPALS_RETRY_INTERVAL << " ms");
-            QTimer::singleShot(START_SYNCPALS_RETRY_INTERVAL, this, [=, this]() { startSyncsAndRetryOnError(); });
+            startedSyncDbIds.insert(toIgnoreSyncDbIds.begin(), toIgnoreSyncDbIds.end());
+            QTimer::singleShot(START_SYNCPALS_RETRY_INTERVAL, this,
+                               [&startedSyncDbIds, this]() { startSyncsAndRetryOnError(startedSyncDbIds); });
         }
     }
 }
@@ -3137,7 +3140,7 @@ void AppServer::resolveErrors(std::vector<Error> errorList) const {
     }
 }
 
-ExitInfo AppServer::startSyncs() {
+ExitInfo AppServer::startSyncs(std::unordered_set<SyncDbId> toIgnoreSyncDbIds, std::unordered_set<SyncDbId> &startedSyncDbIds) {
     // Load user list
     std::vector<User> userList;
     if (!ParmsDb::instance()->selectAllUsers(userList)) {
@@ -3147,10 +3150,12 @@ ExitInfo AppServer::startSyncs() {
 
     ExitInfo mainExitInfo = ExitCode::Ok;
     for (User &user: userList) {
-        if (const auto exitInfo = startSyncs(user); !exitInfo) {
+        std::unordered_set<SyncDbId> userStartedSyncDbIds;
+        if (const auto exitInfo = startSyncs(user, toIgnoreSyncDbIds, userStartedSyncDbIds); !exitInfo) {
             LOG_WARN(_logger, "Error in startSyncs for userDbId=" << user.dbId() << " " << exitInfo);
             mainExitInfo.merge(exitInfo, {ExitCode::SystemError});
         }
+        startedSyncDbIds.insert(userStartedSyncDbIds.begin(), userStartedSyncDbIds.end());
     }
 #if defined(KD_MACOS)
     Utility::restartFinderExtension();
@@ -3183,8 +3188,12 @@ ExitInfo AppServer::tryCreateAndStartVfs(const Sync &sync, bool &startPostponed)
 
     return ExitCode::Ok;
 }
-
 ExitInfo AppServer::startSyncs(User &user) {
+    std::unordered_set<SyncDbId> emptyList;
+    return startSyncs(user, emptyList, emptyList);
+}
+ExitInfo AppServer::startSyncs(User &user, std::unordered_set<SyncDbId> toIgnoreSyncDbIds,
+                               std::unordered_set<SyncDbId> &startedSyncDbIds) {
     logExtendedLogActivationMessage(ParametersCache::isExtendedLogEnabled());
 
     ExitInfo mainExitInfo = ExitCode::Ok;
@@ -3214,11 +3223,12 @@ ExitInfo AppServer::startSyncs(User &user) {
             }
 
             for (Sync &sync: syncList) {
+                if (toIgnoreSyncDbIds.contains(sync.dbId())) {
+                    LOG_INFO(_logger, "Skipping sync with dbId=" << sync.dbId() << " as it is in the ignore list");
+                    continue;
+                }
+
                 auto syncPalMapIt = syncPalMap.find(sync.dbId());
-
-                // If the syncPal already exists, no need to recreate it.
-                if (syncPalMapIt != syncPalMap.end()) continue;
-
                 QSet<QString> blackList;
                 bool syncUpdated = false;
 
@@ -3288,6 +3298,8 @@ ExitInfo AppServer::startSyncs(User &user) {
                     addError(Error(sync.dbId(), ERR_ID, exitInfo));
                     mainExitInfo.merge(exitInfo, {ExitCode::SystemError});
                 }
+
+                startedSyncDbIds.insert(sync.dbId());
             }
         }
     }

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -3140,7 +3140,12 @@ void AppServer::resolveErrors(std::vector<Error> errorList) const {
     }
 }
 
-ExitInfo AppServer::startSyncs(std::unordered_set<SyncDbId> toIgnoreSyncDbIds, std::unordered_set<SyncDbId> &startedSyncDbIds) {
+ExitInfo AppServer::startSyncs() {
+    std::unordered_set<SyncDbId> emptyList;
+    std::unordered_set<SyncDbId> startedSyncDbIds;
+    return startSyncs(emptyList, startedSyncDbIds);
+}
+ExitInfo AppServer::startSyncs(const std::unordered_set<SyncDbId> &toIgnoreSyncDbIds, std::unordered_set<SyncDbId> &startedSyncDbIds) {
     // Load user list
     std::vector<User> userList;
     if (!ParmsDb::instance()->selectAllUsers(userList)) {

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -3214,6 +3214,11 @@ ExitInfo AppServer::startSyncs(User &user) {
             }
 
             for (Sync &sync: syncList) {
+                auto syncPalMapIt = syncPalMap.find(sync.dbId());
+
+                // If the syncPal already exists, no need to recreate it.
+                if (syncPalMapIt != syncPalMap.end()) continue;
+
                 QSet<QString> blackList;
                 bool syncUpdated = false;
 

--- a/src/server/appserver.h
+++ b/src/server/appserver.h
@@ -186,6 +186,8 @@ class AppServer : public SharedTools::QtSingleApplication {
 
         [[nodiscard]] ExitInfo stopVfs(SyncDbId syncDbId, bool unregister);
         [[nodiscard]] ExitInfo startSyncs(User &user);
+        [[nodiscard]] ExitInfo startSyncs(User &user, std::unordered_set<SyncDbId> toIgnoreSyncDbIds,
+                                          std::unordered_set<SyncDbId> &startedSyncDbIds);
         void stopSyncTask(SyncDbId syncDbId, const SyncPal::DbBehaviorAfterStop behavior = SyncPal::DbBehaviorAfterStop::Keep);
         [[nodiscard]] ExitInfo setSupportsVirtualFilesAsync(SyncDbId syncDbId, bool value);
         [[nodiscard]] ExitInfo setSupportsVirtualFiles(SyncDbId syncDbId, bool value);
@@ -323,8 +325,10 @@ class AppServer : public SharedTools::QtSingleApplication {
         [[nodiscard]] ExitInfo createAndStartVfs(const Sync &sync) noexcept;
         [[nodiscard]] ExitInfo setSupportsVirtualFiles(SyncDbId syncDbId, bool value, bool asyncResponse);
 
-        void startSyncsAndRetryOnError();
+        void startSyncsAndRetryOnError(const std::unordered_set<SyncDbId> &toIgnoreSyncDbIds = {});
         [[nodiscard]] ExitInfo startSyncs();
+        [[nodiscard]] ExitInfo startSyncs(std::unordered_set<SyncDbId> toIgnoreSyncDbIds,
+                                          std::unordered_set<SyncDbId> &startedSyncDbIds);
         [[nodiscard]] ExitInfo processMigratedSyncOnceConnected(UserDbId userDbId, DriveId driveId, Sync &sync,
                                                                 QSet<QString> &blackList, bool &syncUpdated);
 

--- a/src/server/appserver.h
+++ b/src/server/appserver.h
@@ -327,7 +327,7 @@ class AppServer : public SharedTools::QtSingleApplication {
 
         void startSyncsAndRetryOnError(const std::unordered_set<SyncDbId> &toIgnoreSyncDbIds = {});
         [[nodiscard]] ExitInfo startSyncs();
-        [[nodiscard]] ExitInfo startSyncs(std::unordered_set<SyncDbId> toIgnoreSyncDbIds,
+        [[nodiscard]] ExitInfo startSyncs(const std::unordered_set<SyncDbId> &toIgnoreSyncDbIds,
                                           std::unordered_set<SyncDbId> &startedSyncDbIds);
         [[nodiscard]] ExitInfo processMigratedSyncOnceConnected(UserDbId userDbId, DriveId driveId, Sync &sync,
                                                                 QSet<QString> &blackList, bool &syncUpdated);

--- a/test/server/appserver/testappserver.cpp
+++ b/test/server/appserver/testappserver.cpp
@@ -156,10 +156,13 @@ void TestAppServer::testStartAndStopSync() {
     CPPUNIT_ASSERT(_appPtr->vfsMap.empty());
 
     // Start syncs for all users
-    exitInfo = _appPtr->startSyncs();
+    std::unordered_set<SyncDbId> toIgnoreSyncDbIds;
+    std::unordered_set<SyncDbId> startedSyncDbIds;
+    exitInfo = _appPtr->startSyncs(toIgnoreSyncDbIds, startedSyncDbIds);
     CPPUNIT_ASSERT(exitInfo);
     CPPUNIT_ASSERT(_appPtr->syncPalMap[syncDbId]->isRunning());
     CPPUNIT_ASSERT(syncIsActive(syncDbId));
+    CPPUNIT_ASSERT(startedSyncDbIds.contains(syncDbId));
 
     // Stop syncs & clear maps for all users
     _appPtr->stopAllSyncsTask({syncDbId});
@@ -169,6 +172,14 @@ void TestAppServer::testStartAndStopSync() {
     auto ioError = IoError::Unknown;
     CPPUNIT_ASSERT(IoHelper::checkIfPathExists(syncDbPath, exists, ioError, IoHelper::PathCheckOption::Insensitive));
     CPPUNIT_ASSERT(exists);
+
+    // Start syncs for all users with an ignored syncDbId
+    toIgnoreSyncDbIds = {syncDbId};
+    startedSyncDbIds.clear();
+    exitInfo = _appPtr->startSyncs(toIgnoreSyncDbIds, startedSyncDbIds);
+    CPPUNIT_ASSERT(exitInfo);
+    CPPUNIT_ASSERT(!_appPtr->syncPalMap.contains(syncDbId));
+    CPPUNIT_ASSERT(!startedSyncDbIds.contains(syncDbId));
 
     // Update sync local folder with a dummy value
     Sync sync;

--- a/test/server/test.cpp
+++ b/test/server/test.cpp
@@ -38,9 +38,8 @@
 #include "comm/testguijobpriority.h"
 
 namespace KDC {
-CPPUNIT_TEST_SUITE_REGISTRATION(TestAppServer);
 
-/* #if defined (KD_MACOS)
+#if defined (KD_MACOS)
 CPPUNIT_TEST_SUITE_REGISTRATION(TestVfsMac);
 CPPUNIT_TEST_SUITE_REGISTRATION(TestLiteSyncCommClient);
 #endif
@@ -57,7 +56,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION(TestPipeComm);
 #endif
 CPPUNIT_TEST_SUITE_REGISTRATION(TestGuiCommChannel);
 CPPUNIT_TEST_SUITE_REGISTRATION(TestAbstractGuiJob);
-CPPUNIT_TEST_SUITE_REGISTRATION(TestGuiJobPriority);*/
+CPPUNIT_TEST_SUITE_REGISTRATION(TestGuiJobPriority);
 } // namespace KDC
 
 int main(int, char **) {

--- a/test/server/test.cpp
+++ b/test/server/test.cpp
@@ -38,7 +38,9 @@
 #include "comm/testguijobpriority.h"
 
 namespace KDC {
-#if defined(KD_MACOS)
+CPPUNIT_TEST_SUITE_REGISTRATION(TestAppServer);
+
+/* #if defined (KD_MACOS)
 CPPUNIT_TEST_SUITE_REGISTRATION(TestVfsMac);
 CPPUNIT_TEST_SUITE_REGISTRATION(TestLiteSyncCommClient);
 #endif
@@ -55,7 +57,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION(TestPipeComm);
 #endif
 CPPUNIT_TEST_SUITE_REGISTRATION(TestGuiCommChannel);
 CPPUNIT_TEST_SUITE_REGISTRATION(TestAbstractGuiJob);
-CPPUNIT_TEST_SUITE_REGISTRATION(TestGuiJobPriority);
+CPPUNIT_TEST_SUITE_REGISTRATION(TestGuiJobPriority);*/
 } // namespace KDC
 
 int main(int, char **) {


### PR DESCRIPTION
This change introduces several stability and reliability improvements across sync startup behavior and backend error handling:

* Fixed startup retry logic so that only failed syncs are retried, preventing unnecessary restarts of healthy syncs and avoiding incorrect error state resets.
* Improved backend resilience by treating any RFSO error as a blocking condition, triggering an immediate stop and applying the backoff mechanism.
* Fixed an issue where Drive maintenance responses were incorrectly interpreted as HTTP 5xx errors, preventing proper UI display.
