### PR TITLE
fix(mac): avoid logging localized error description

### DIFF
--- a/src/libcommonserver/utility/utility_mac.mm
+++ b/src/libcommonserver/utility/utility_mac.mm
@@ -277,7 +277,7 @@ bool Utility::runCommand(const std::string &launchPath, const std::vector<std::s
 
         NSError *error = nil;
         if (![task launchAndReturnError:&error]) {
-            LOG_ERROR(logger(), "Failed to launch " << launchPath << ": " << [error.localizedDescription UTF8String]);
+            LOG_ERROR(logger(), "Failed to launch " << launchPath);
             return false;
         }
 


### PR DESCRIPTION
Removes `error.localizedDescription` from the log in `utility_mac.mm` to avoid logging localized (non-English) error strings.