### PR TITLE
fix(sentry): add Sentry consent handling

### DIFF
--- a/src/libcommon/log/sentry/handler.cpp
+++ b/src/libcommon/log/sentry/handler.cpp
@@ -265,6 +265,7 @@ void Handler::init(AppType appType, int breadCrumbsSize) {
     sentry_options_set_release(options, KDRIVE_VERSION_STRING);
     sentry_options_set_debug(options, false);
     sentry_options_set_max_breadcrumbs(options, static_cast<size_t>(breadCrumbsSize));
+    sentry_options_set_require_user_consent(options, true);
 
     // !!! Not Supported in Crashpad on macOS & Limitations in Crashpad on Windows for Fast-fail Crashes !!!
     // See https://docs.sentry.io/platforms/native/configuration/filtering/
@@ -375,7 +376,7 @@ void Handler::handleEventsRateLimit(SentryEvent &event, bool &toUpload) {
     }
 
     auto &storedEvent = it->second;
-    storedEvent.captureCount = (std::min)(storedEvent.captureCount + 1, UINT_MAX - 1);
+    storedEvent.captureCount = (std::min) (storedEvent.captureCount + 1, UINT_MAX - 1);
     event.captureCount = storedEvent.captureCount;
 
     if (lastEventCaptureIsOutdated(storedEvent)) { // Reset the capture count if the last capture was more than 10 minutes ago
@@ -509,6 +510,14 @@ void Handler::setDistributionChannel(const DistributionChannel channel) {
 
 void Handler::setAppUUID(std::string appUUID) {
     setTag("appUUID", appUUID);
+}
+
+void Handler::setIsSentryActivated(bool isSentryActivated) {
+    _isSentryActivated = isSentryActivated;
+    if (isSentryActivated)
+        sentry_user_consent_give();
+    else
+        sentry_user_consent_revoke();
 }
 
 Handler::~Handler() {

--- a/src/libcommon/log/sentry/handler.h
+++ b/src/libcommon/log/sentry/handler.h
@@ -105,7 +105,7 @@ class Handler {
 
         void setDistributionChannel(DistributionChannel channel);
         void setAppUUID(std::string appUUID);
-        void setIsSentryActivated(bool isSentryActivated) { _isSentryActivated = isSentryActivated; }
+        void setIsSentryActivated(bool isSentryActivated);
 
         // Returns the file path where non-crash events of type `appType` are written locally.
         static SyncPath getEventFilePath(const AppType appType) { return getEventFilePath(appType, false); }

--- a/src/server/comm/guijobs/syncstartjob.cpp
+++ b/src/server/comm/guijobs/syncstartjob.cpp
@@ -54,11 +54,12 @@ ExitInfo SyncStartJob::serializeOutputParms() {
 ExitInfo SyncStartJob::process() {
     std::shared_ptr<SyncPal> syncPal;
     if (ExitInfo exitInfo = getSyncPal(_syncDbId, syncPal); !exitInfo) {
-        LOG_INFO(_logger, "Error in getSyncPal for syncDbId=" << _syncDbId << " : " << exitInfo <<
-                 " This means that the sync pal is not running, which is expected at this step. The sync will be started later "
-                 "in the process.");
+        LOG_INFO(_logger, "Error in getSyncPal for syncDbId=" << _syncDbId << " : " << exitInfo
+                                                              << " This means that the sync pal is not running, which is "
+                                                                 "expected at this step. The sync will be started later "
+                                                                 "in the process.");
     }
-    
+
     UserActionScopedLock lock;
     if (syncPal != nullptr && !lock.tryLock(syncPal, std::chrono::milliseconds(userActionLockShortTimeoutMs))) {
         LOG_WARN(_logger, "Could not acquire user action lock for syncDbId="


### PR DESCRIPTION
Added `sentry_options_set_require_user_consent` in `Handler::init` to enforce user consent for Sentry. Introduced `Handler::setIsSentryActivated` to manage Sentry activation based on user consent. Moved its definition from `handler.h` to `handler.cpp`.