### PR TITLE
feat: New log service for macOS

### DIFF
--- a/src/gui4/macOS/AGENTS.md
+++ b/src/gui4/macOS/AGENTS.md
@@ -135,6 +135,7 @@ NSLocalizedString("key", bundle: .kDriveResources, comment: "")
 ## Key Files
 - XPC query entry point: `kDriveCore/ServerBridge/XPC/XPCQueryFetcher.swift`
 - XPC connection: `kDriveCore/ServerBridge/XPC/XPCConnectionManager.swift`
+- Logging facade/service: `kDriveCore/Utils/IKLogger.swift`, `kDriveCore/Logging/LogService.swift`
 - Cache protocol: `kDriveCore/ServerBridge/Cache/CoherentCache.swift`
 - Cache (server impl): `kDriveCore/ServerBridge/Cache/ServerCoherentCache.swift`
 - Color tokens: `kDriveCoreUI/Tokens/ColorToken.swift`

--- a/src/gui4/macOS/AGENTS.md
+++ b/src/gui4/macOS/AGENTS.md
@@ -14,7 +14,7 @@ open src/gui4/macOS/kDrive.xcodeproj
 cd src/gui4/macOS && xcodebuild -scheme kDrive -destination "platform=macOS,arch=arm64" build-for-testing
 
 # Run tests (all)
-xcodebuild test -project src/gui4/macOS/kDrive.xcodeproj -scheme kDriveTests
+xcodebuild test -project src/gui4/macOS/kDrive.xcodeproj -scheme kDrive -destination "platform=macOS"
 
 # Run SwiftLint
 cd src/gui4/macOS && swiftlint lint
@@ -175,6 +175,7 @@ rg -n "NSLocalizedString" src/gui4/macOS/kDrive/
 - XPC data is base64-encoded for binary payloads — use `@Base64Coded*` property wrappers (in `XPC/DTOs/PropertyWrappers/`) for `URL`, `String`, `Data`, `NSColor`.
 - AppKit views (`NSView`) needing SwiftUI content: wrap with `NSHostingView<ContentView>`.
 - SwiftLint's `unused_import` analyzer rule is active — remove unused imports before committing.
+- The project has a `kDrive` scheme that runs `kDriveTests`; there is no separate `kDriveTests` scheme.
 
 ## Pre-PR Checks
 ```bash
@@ -182,5 +183,5 @@ rg -n "NSLocalizedString" src/gui4/macOS/kDrive/
 cd src/gui4/macOS && swiftlint lint
 
 # Build + test
-xcodebuild test -project src/gui4/macOS/kDrive.xcodeproj -scheme kDriveTests -destination 'platform=macOS'
+xcodebuild test -project src/gui4/macOS/kDrive.xcodeproj -scheme kDrive -destination 'platform=macOS'
 ```

--- a/src/gui4/macOS/AGENTS.md
+++ b/src/gui4/macOS/AGENTS.md
@@ -132,10 +132,24 @@ Strings live in `kDriveResources/Localizable/<lang>.lproj/`.
 NSLocalizedString("key", bundle: .kDriveResources, comment: "")
 ```
 
+### Logging file rotation
+The app writes to an active `<date>_kDrive_client.log` in `~/Library/Logs/kDrive` (real home, matching
+the C++ server's `CommonUtility::logDirectoryPath`). `<date>` is the session creation time
+(`yyyyMMdd_HHmm`, matching the server's `LOGFILE_TIME_FORMAT` and `<date>_kDrive.log` naming).
+`LogFileWriter` rolls it by size, mirroring the C++ `CustomRollingFileAppender`:
+- Rotates when the active file grows past `maxFileSize` (500 MiB, `CommonUtility::logMaxSize`).
+- On rotation the active file becomes `<date>_kDrive_client.log.0.gz` and existing backups shift up
+  (`.0` → `.1`, …). Backups beyond `maxBackupIndex` (4, i.e. `.0`…`.4`) are deleted.
+- Backups are gzip-compressed via `GzipCompressor`, which streams through the system `zlib`
+  (`import zlib`; the `kDriveCore` target links `libz.tbd`). Output is `gunzip`-compatible.
+- Keep the active file's `.log` extension — `LogUploadJob` keys on it to include the live log in
+  non-archived uploads.
+
 ## Key Files
 - XPC query entry point: `kDriveCore/ServerBridge/XPC/XPCQueryFetcher.swift`
 - XPC connection: `kDriveCore/ServerBridge/XPC/XPCConnectionManager.swift`
 - Logging facade/service: `kDriveCore/Utils/IKLogger.swift`, `kDriveCore/Logging/LogService.swift`
+- Log file rotation + gzip: `kDriveCore/Logging/LogFileWriter.swift`, `kDriveCore/Logging/GzipCompressor.swift`
 - Cache protocol: `kDriveCore/ServerBridge/Cache/CoherentCache.swift`
 - Cache (server impl): `kDriveCore/ServerBridge/Cache/ServerCoherentCache.swift`
 - Color tokens: `kDriveCoreUI/Tokens/ColorToken.swift`

--- a/src/gui4/macOS/kDrive.xcodeproj/project.pbxproj
+++ b/src/gui4/macOS/kDrive.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		37A1C4462E546A9600596DBB /* kDriveCoreUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 37A1C43F2E546A9600596DBB /* kDriveCoreUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		37A1C4602E546CB700596DBB /* kDriveCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 37A1C45A2E546CB600596DBB /* kDriveCore.framework */; };
 		37A1C4612E546CB700596DBB /* kDriveCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 37A1C45A2E546CB600596DBB /* kDriveCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		7A3127512FED6AE00053CDDE /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 7A31274F2FED6AC70053CDDE /* libz.tbd */; };
+		7A3127532FED6AFE0053CDDE /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 7A31274F2FED6AC70053CDDE /* libz.tbd */; };
 		7A43F1862F7590CA00A44D08 /* InfomaniakDI in Embed Frameworks */ = {isa = PBXBuildFile; productRef = F97805BD2E97E3AF00BC146C /* InfomaniakDI */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		7A9074A52F59D1350089E4F1 /* InfomaniakDI in Frameworks */ = {isa = PBXBuildFile; productRef = 7A9074A42F59D1350089E4F1 /* InfomaniakDI */; };
 		7A97962C2F0EB51100E36DDE /* Collections in Frameworks */ = {isa = PBXBuildFile; productRef = 7A97962B2F0EB51100E36DDE /* Collections */; };
@@ -65,13 +67,6 @@
 			remoteGlobalIDString = F967009D2E95352C00EDD4D7;
 			remoteInfo = kDriveResources;
 		};
-		F97269752E98EFAF002EA08D /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 37A1C41E2E546A5200596DBB /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = F97269622E98EC15002EA08D;
-			remoteInfo = kDriveLogin;
-		};
 		F9A927CB2ECF6BF400B09ABA /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 37A1C41E2E546A5200596DBB /* Project object */;
@@ -112,6 +107,8 @@
 		37A1C4262E546A5200596DBB /* kDrive.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = kDrive.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		37A1C43F2E546A9600596DBB /* kDriveCoreUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = kDriveCoreUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		37A1C45A2E546CB600596DBB /* kDriveCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = kDriveCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		7A31274F2FED6AC70053CDDE /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
+		7A3127522FED6AED0053CDDE /* libz.1.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.1.tbd; path = usr/lib/libz.1.tbd; sourceTree = SDKROOT; };
 		7A4DFBB12EA91F9D00B138B8 /* kDriveTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = kDriveTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		F967009E2E95352C00EDD4D7 /* kDriveResources.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = kDriveResources.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F9ACC5372E5DF50B0081E80B /* swiftgen.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = swiftgen.yml; sourceTree = "<group>"; };
@@ -128,9 +125,9 @@
 				Cache/CoherentCacheTests/CoherentCacheErrorTests.swift,
 				Cache/CoherentCacheTests/CoherentCacheSynchroTests.swift,
 				Cache/CoherentCacheTests/CoherentCacheUserTests.swift,
-				Cache/LogUploadStatusCacheTests.swift,
 				Cache/DTOs/SynchroTests.swift,
 				Cache/DTOs/UserUpdateTests.swift,
+				Cache/LogUploadStatusCacheTests.swift,
 				Cache/Observation/helpers/ObservableData.swift,
 				Cache/Observation/helpers/ObservedAccount.swift,
 				Cache/Observation/helpers/ObservedAvailableDrives.swift,
@@ -324,6 +321,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F97805C32E97E3F900BC146C /* InfomaniakDI in Frameworks */,
+				7A3127512FED6AE00053CDDE /* libz.tbd in Frameworks */,
 				7AFF54E22EC34B4100904C5C /* InfomaniakConcurrency in Frameworks */,
 				7A97962C2F0EB51100E36DDE /* Collections in Frameworks */,
 				F97590BC2ECC7A8A002CC428 /* Sentry in Frameworks */,
@@ -336,6 +334,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				7A9074A52F59D1350089E4F1 /* InfomaniakDI in Frameworks */,
+				7A3127532FED6AFE0053CDDE /* libz.tbd in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -378,6 +377,8 @@
 		F967014F2E953CF600EDD4D7 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				7A3127522FED6AED0053CDDE /* libz.1.tbd */,
+				7A31274F2FED6AC70053CDDE /* libz.tbd */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -425,7 +426,6 @@
 				37A1C4442E546A9600596DBB /* PBXTargetDependency */,
 				37A1C45F2E546CB700596DBB /* PBXTargetDependency */,
 				F96700A32E95352C00EDD4D7 /* PBXTargetDependency */,
-				F97269762E98EFAF002EA08D /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				37A1C4282E546A5200596DBB /* kDrive */,
@@ -730,10 +730,6 @@
 			isa = PBXTargetDependency;
 			target = F967009D2E95352C00EDD4D7 /* kDriveResources */;
 			targetProxy = F96701522E953CF600EDD4D7 /* PBXContainerItemProxy */;
-		};
-		F97269762E98EFAF002EA08D /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			targetProxy = F97269752E98EFAF002EA08D /* PBXContainerItemProxy */;
 		};
 		F9A927CC2ECF6BF400B09ABA /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/src/gui4/macOS/kDrive.xcodeproj/project.pbxproj
+++ b/src/gui4/macOS/kDrive.xcodeproj/project.pbxproj
@@ -142,6 +142,7 @@
 				Cache/Observation/helpers/ObservedUpdater.swift,
 				Cache/Observation/helpers/ObservedUser.swift,
 				Jobs/LoginJobTests.swift,
+				Logging/LogServiceTests.swift,
 				Parsing/Base64CodedTests.swift,
 				Parsing/CallbackMessageTests.swift,
 				Parsing/HexColorTests.swift,

--- a/src/gui4/macOS/kDrive.xcodeproj/project.pbxproj
+++ b/src/gui4/macOS/kDrive.xcodeproj/project.pbxproj
@@ -139,6 +139,7 @@
 				Cache/Observation/helpers/ObservedUpdater.swift,
 				Cache/Observation/helpers/ObservedUser.swift,
 				Jobs/LoginJobTests.swift,
+				Logging/GzipCompressorTests.swift,
 				Logging/LogServiceTests.swift,
 				Parsing/Base64CodedTests.swift,
 				Parsing/CallbackMessageTests.swift,

--- a/src/gui4/macOS/kDriveCore/Logging/GzipCompressor.swift
+++ b/src/gui4/macOS/kDriveCore/Logging/GzipCompressor.swift
@@ -68,10 +68,6 @@ enum GzipCompressor {
         return success && closeResult == Z_OK
     }
 
-    /// Decompresses the gzip file at `source` into `destination`, streaming in chunks.
-    ///
-    /// - Returns: `true` on success. On failure the caller is responsible for cleaning up any
-    ///   partially written `destination`.
     // periphery:ignore - Counterpart to compress, used to read gzip-archived log backups.
     static func decompress(source: URL, destination: URL) -> Bool {
         let handle = source.path.withCString { pathPtr in

--- a/src/gui4/macOS/kDriveCore/Logging/GzipCompressor.swift
+++ b/src/gui4/macOS/kDriveCore/Logging/GzipCompressor.swift
@@ -72,6 +72,7 @@ enum GzipCompressor {
     ///
     /// - Returns: `true` on success. On failure the caller is responsible for cleaning up any
     ///   partially written `destination`.
+    // periphery:ignore - Counterpart to compress, used to read gzip-archived log backups.
     static func decompress(source: URL, destination: URL) -> Bool {
         let handle = source.path.withCString { pathPtr in
             "rb".withCString { modePtr in

--- a/src/gui4/macOS/kDriveCore/Logging/GzipCompressor.swift
+++ b/src/gui4/macOS/kDriveCore/Logging/GzipCompressor.swift
@@ -1,0 +1,113 @@
+/*
+ Infomaniak kDrive - Desktop
+ Copyright (C) 2023-2026 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+import zlib
+
+/// Streaming gzip (`.gz`) compressor/decompressor backed by the system `zlib`.
+///
+/// Mirrors the C++ `CommonUtility::compressFile` (`gzopen` / `gzwrite` / `gzclose`) so the
+/// compressed log backups produced by the macOS app are byte-compatible with the rest of the
+/// kDrive tooling and decompressable with `gunzip`.
+enum GzipCompressor {
+    /// Read/write chunk size, matching the C++ implementation (1 MiB).
+    private static let chunkSize = 1024 * 1024
+
+    /// Compresses `source` into a gzip file at `destination`, streaming in chunks so files of any
+    /// size are never loaded into memory at once.
+    ///
+    /// - Returns: `true` on success. On failure the caller is responsible for cleaning up any
+    ///   partially written `destination`.
+    static func compress(source: URL, destination: URL) -> Bool {
+        guard let input = try? FileHandle(forReadingFrom: source) else { return false }
+        defer { try? input.close() }
+
+        let handle = destination.path.withCString { pathPtr in
+            "wb".withCString { modePtr in
+                gzopen(pathPtr, modePtr)
+            }
+        }
+        guard let handle else { return false }
+
+        var success = true
+        while true {
+            let chunk: Data
+            do {
+                chunk = try input.read(upToCount: chunkSize) ?? Data()
+            } catch {
+                success = false
+                break
+            }
+            if chunk.isEmpty { break }
+
+            let written = chunk.withUnsafeBytes { rawBuffer in
+                gzwrite(handle, rawBuffer.baseAddress, UInt32(rawBuffer.count))
+            }
+            if written <= 0 || Int(written) != chunk.count {
+                success = false
+                break
+            }
+        }
+
+        let closeResult = gzclose(handle)
+        return success && closeResult == Z_OK
+    }
+
+    /// Decompresses the gzip file at `source` into `destination`, streaming in chunks.
+    ///
+    /// - Returns: `true` on success. On failure the caller is responsible for cleaning up any
+    ///   partially written `destination`.
+    static func decompress(source: URL, destination: URL) -> Bool {
+        let handle = source.path.withCString { pathPtr in
+            "rb".withCString { modePtr in
+                gzopen(pathPtr, modePtr)
+            }
+        }
+        guard let handle else { return false }
+
+        _ = FileManager.default.createFile(atPath: destination.path, contents: nil)
+        guard let output = try? FileHandle(forWritingTo: destination) else {
+            _ = gzclose(handle)
+            return false
+        }
+        defer { try? output.close() }
+
+        var success = true
+        var buffer = [UInt8](repeating: 0, count: chunkSize)
+        while true {
+            let bytesRead = buffer.withUnsafeMutableBytes { rawBuffer in
+                gzread(handle, rawBuffer.baseAddress, UInt32(rawBuffer.count))
+            }
+            if bytesRead < 0 {
+                success = false
+                break
+            }
+            if bytesRead == 0 { break }
+
+            do {
+                try output.write(contentsOf: Data(buffer.prefix(Int(bytesRead))))
+            } catch {
+                success = false
+                break
+            }
+        }
+
+        let closeResult = gzclose(handle)
+        return success && closeResult == Z_OK
+    }
+}

--- a/src/gui4/macOS/kDriveCore/Logging/LogEvent.swift
+++ b/src/gui4/macOS/kDriveCore/Logging/LogEvent.swift
@@ -1,0 +1,29 @@
+/*
+ Infomaniak kDrive - Desktop
+ Copyright (C) 2023-2026 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+
+struct LogEvent: Sendable, Equatable {
+    let date: Date
+    let level: LogLevel
+    let category: String
+    let threadID: String
+    let file: String
+    let line: UInt
+    let message: String
+}

--- a/src/gui4/macOS/kDriveCore/Logging/LogFileWriter.swift
+++ b/src/gui4/macOS/kDriveCore/Logging/LogFileWriter.swift
@@ -59,7 +59,12 @@ final class LogFileWriter: LogFileWriting {
     }
 
     static func defaultLogDirectory() -> URL {
-        FileManager.default.temporaryDirectory.appendingPathComponent("\(appName)-logdir", isDirectory: true)
+        let libraryDirectory = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).first
+            ?? FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("Library", isDirectory: true)
+
+        return libraryDirectory
+            .appendingPathComponent("Logs", isDirectory: true)
+            .appendingPathComponent(appName, isDirectory: true)
     }
 
     private static func nextLogFileURL(in logDirectory: URL, date: Date, timeZone: TimeZone, fileManager: FileManager) -> URL {

--- a/src/gui4/macOS/kDriveCore/Logging/LogFileWriter.swift
+++ b/src/gui4/macOS/kDriveCore/Logging/LogFileWriter.swift
@@ -1,0 +1,82 @@
+/*
+ Infomaniak kDrive - Desktop
+ Copyright (C) 2023-2026 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+
+protocol LogFileWriting: AnyObject {
+    func append(_ line: String) throws
+}
+
+final class LogFileWriter: LogFileWriting {
+    private static let appName = "kDrive"
+    private static let clientLogName = "kDrive_client"
+
+    let fileURL: URL
+
+    private let fileHandle: FileHandle
+
+    init(
+        logDirectory: URL = LogFileWriter.defaultLogDirectory(),
+        date: Date = Date(),
+        timeZone: TimeZone = .current,
+        fileManager: FileManager = .default
+    ) throws {
+        try fileManager.createDirectory(at: logDirectory, withIntermediateDirectories: true)
+
+        fileURL = Self.nextLogFileURL(in: logDirectory, date: date, timeZone: timeZone, fileManager: fileManager)
+        if !fileManager.fileExists(atPath: fileURL.path) {
+            _ = fileManager.createFile(atPath: fileURL.path, contents: nil)
+        }
+
+        fileHandle = try FileHandle(forWritingTo: fileURL)
+        try fileHandle.seekToEnd()
+    }
+
+    deinit {
+        try? fileHandle.close()
+    }
+
+    func append(_ line: String) throws {
+        let data = Data("\(line)\n".utf8)
+
+        try fileHandle.seekToEnd()
+        try fileHandle.write(contentsOf: data)
+    }
+
+    static func defaultLogDirectory() -> URL {
+        FileManager.default.temporaryDirectory.appendingPathComponent("\(appName)-logdir", isDirectory: true)
+    }
+
+    private static func nextLogFileURL(in logDirectory: URL, date: Date, timeZone: TimeZone, fileManager: FileManager) -> URL {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = timeZone
+        formatter.dateFormat = "yyyyMMdd_HHmm"
+
+        let baseFileName = "\(formatter.string(from: date))_\(clientLogName).log"
+        var index = 0
+        var fileURL: URL
+
+        repeat {
+            fileURL = logDirectory.appendingPathComponent("\(baseFileName).\(index)")
+            index += 1
+        } while fileManager.fileExists(atPath: fileURL.path)
+
+        return fileURL
+    }
+}

--- a/src/gui4/macOS/kDriveCore/Logging/LogFileWriter.swift
+++ b/src/gui4/macOS/kDriveCore/Logging/LogFileWriter.swift
@@ -30,7 +30,6 @@ protocol LogFileWriting: AnyObject {
 /// previous backups are shifted up (`.0` → `.1`, `.1` → `.2`, …). Backups beyond `maxBackupIndex`
 /// are removed. This mirrors the C++ `CustomRollingFileAppender` (500 MiB, gzip-compressed backups).
 final class LogFileWriter: LogFileWriting {
-    private static let appName = "kDrive"
     private static let clientLogName = "kDrive_client"
     /// Creation-time prefix format, matching the server's `LOGFILE_TIME_FORMAT` (`%Y%m%d_%H%M`).
     private static let dateFormat = "yyyyMMdd_HHmm"
@@ -95,7 +94,7 @@ final class LogFileWriter: LogFileWriting {
         return FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent("Library", isDirectory: true)
             .appendingPathComponent("Logs", isDirectory: true)
-            .appendingPathComponent(appName, isDirectory: true)
+            .appendingPathComponent(Constants.appName, isDirectory: true)
     }
 
     private static func makeBaseFileName(date: Date, timeZone: TimeZone) -> String {

--- a/src/gui4/macOS/kDriveCore/Logging/LogFileWriter.swift
+++ b/src/gui4/macOS/kDriveCore/Logging/LogFileWriter.swift
@@ -59,10 +59,8 @@ final class LogFileWriter: LogFileWriting {
     }
 
     static func defaultLogDirectory() -> URL {
-        let libraryDirectory = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).first
-            ?? FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("Library", isDirectory: true)
-
-        return libraryDirectory
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library", isDirectory: true)
             .appendingPathComponent("Logs", isDirectory: true)
             .appendingPathComponent(appName, isDirectory: true)
     }

--- a/src/gui4/macOS/kDriveCore/Logging/LogFileWriter.swift
+++ b/src/gui4/macOS/kDriveCore/Logging/LogFileWriter.swift
@@ -22,23 +22,51 @@ protocol LogFileWriting: AnyObject {
     func append(_ line: String) throws
 }
 
+/// Size-based rolling log file writer for the macOS app.
+///
+/// Logs are written to an active `<date>_kDrive_client.log` file, where `<date>` is the session
+/// creation time (mirroring the server's `<date>_kDrive.log` naming). When it grows past
+/// `maxFileSize` it is rotated: the active file becomes `<date>_kDrive_client.log.0.gz` and the
+/// previous backups are shifted up (`.0` → `.1`, `.1` → `.2`, …). Backups beyond `maxBackupIndex`
+/// are removed. This mirrors the C++ `CustomRollingFileAppender` (500 MiB, gzip-compressed backups).
 final class LogFileWriter: LogFileWriting {
     private static let appName = "kDrive"
     private static let clientLogName = "kDrive_client"
+    /// Creation-time prefix format, matching the server's `LOGFILE_TIME_FORMAT` (`%Y%m%d_%H%M`).
+    private static let dateFormat = "yyyyMMdd_HHmm"
+
+    /// 500 MiB, matching the C++ `CommonUtility::logMaxSize`.
+    static let defaultMaxFileSize: UInt64 = 500 * 1024 * 1024
+    /// Highest backup index kept on disk. Backups range from `.0` to `.maxBackupIndex` (gzip-compressed).
+    static let defaultMaxBackupIndex = 4
 
     let fileURL: URL
 
-    private let fileHandle: FileHandle
+    private let logDirectory: URL
+    private let baseFileName: String
+    private let fileManager: FileManager
+    private let maxFileSize: UInt64
+    private let maxBackupIndex: Int
+
+    private var fileHandle: FileHandle
 
     init(
         logDirectory: URL = LogFileWriter.defaultLogDirectory(),
         date: Date = Date(),
         timeZone: TimeZone = .current,
-        fileManager: FileManager = .default
+        fileManager: FileManager = .default,
+        maxFileSize: UInt64 = LogFileWriter.defaultMaxFileSize,
+        maxBackupIndex: Int = LogFileWriter.defaultMaxBackupIndex
     ) throws {
+        self.logDirectory = logDirectory
+        self.fileManager = fileManager
+        self.maxFileSize = maxFileSize
+        self.maxBackupIndex = maxBackupIndex
+
         try fileManager.createDirectory(at: logDirectory, withIntermediateDirectories: true)
 
-        fileURL = Self.nextLogFileURL(in: logDirectory, date: date, timeZone: timeZone, fileManager: fileManager)
+        baseFileName = Self.makeBaseFileName(date: date, timeZone: timeZone)
+        fileURL = logDirectory.appendingPathComponent(baseFileName, isDirectory: false)
         if !fileManager.fileExists(atPath: fileURL.path) {
             _ = fileManager.createFile(atPath: fileURL.path, contents: nil)
         }
@@ -54,6 +82,11 @@ final class LogFileWriter: LogFileWriting {
     func append(_ line: String) throws {
         let data = Data("\(line)\n".utf8)
 
+        let currentSize = try fileHandle.seekToEnd()
+        if currentSize > maxFileSize {
+            try rotate()
+        }
+
         try fileHandle.seekToEnd()
         try fileHandle.write(contentsOf: data)
     }
@@ -65,21 +98,71 @@ final class LogFileWriter: LogFileWriting {
             .appendingPathComponent(appName, isDirectory: true)
     }
 
-    private static func nextLogFileURL(in logDirectory: URL, date: Date, timeZone: TimeZone, fileManager: FileManager) -> URL {
+    private static func makeBaseFileName(date: Date, timeZone: TimeZone) -> String {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.timeZone = timeZone
-        formatter.dateFormat = "yyyyMMdd_HHmm"
+        formatter.dateFormat = dateFormat
 
-        let baseFileName = "\(formatter.string(from: date))_\(clientLogName).log"
-        var index = 0
-        var fileURL: URL
+        return "\(formatter.string(from: date))_\(clientLogName).log"
+    }
 
-        repeat {
-            fileURL = logDirectory.appendingPathComponent("\(baseFileName).\(index)")
-            index += 1
-        } while fileManager.fileExists(atPath: fileURL.path)
+    // MARK: - Rotation
 
-        return fileURL
+    private func rotate() throws {
+        try fileHandle.close()
+
+        shiftBackups()
+
+        // Move the active file to `.0`, then compress it to `.0.gz`.
+        let rotatedURL = backupURL(index: 0, compressed: false)
+        let compressedURL = backupURL(index: 0, compressed: true)
+        removeIfExists(rotatedURL)
+        removeIfExists(compressedURL)
+        try fileManager.moveItem(at: fileURL, to: rotatedURL)
+
+        if GzipCompressor.compress(source: rotatedURL, destination: compressedURL) {
+            removeIfExists(rotatedURL)
+        } else {
+            // Compression failed: keep the uncompressed rotated file rather than losing logs.
+            removeIfExists(compressedURL)
+        }
+
+        // Start a fresh active log file.
+        _ = fileManager.createFile(atPath: fileURL.path, contents: nil)
+        fileHandle = try FileHandle(forWritingTo: fileURL)
+        try fileHandle.seekToEnd()
+    }
+
+    /// Deletes the oldest backup and shifts every other backup up by one index.
+    private func shiftBackups() {
+        // Delete the oldest backup, which would otherwise overflow past `maxBackupIndex`.
+        removeIfExists(backupURL(index: maxBackupIndex, compressed: true))
+        removeIfExists(backupURL(index: maxBackupIndex, compressed: false))
+
+        // Shift `.i` -> `.(i + 1)` from the second-oldest down to the newest.
+        for index in stride(from: maxBackupIndex - 1, through: 0, by: -1) {
+            moveBackup(from: index, to: index + 1, compressed: true)
+            moveBackup(from: index, to: index + 1, compressed: false)
+        }
+    }
+
+    private func moveBackup(from: Int, to: Int, compressed: Bool) {
+        let source = backupURL(index: from, compressed: compressed)
+        guard fileManager.fileExists(atPath: source.path) else { return }
+
+        let destination = backupURL(index: to, compressed: compressed)
+        removeIfExists(destination)
+        try? fileManager.moveItem(at: source, to: destination)
+    }
+
+    private func backupURL(index: Int, compressed: Bool) -> URL {
+        let suffix = compressed ? ".gz" : ""
+        return logDirectory.appendingPathComponent("\(baseFileName).\(index)\(suffix)", isDirectory: false)
+    }
+
+    private func removeIfExists(_ url: URL) {
+        guard fileManager.fileExists(atPath: url.path) else { return }
+        try? fileManager.removeItem(at: url)
     }
 }

--- a/src/gui4/macOS/kDriveCore/Logging/LogLevel.swift
+++ b/src/gui4/macOS/kDriveCore/Logging/LogLevel.swift
@@ -1,0 +1,61 @@
+/*
+ Infomaniak kDrive - Desktop
+ Copyright (C) 2023-2026 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Sentry
+
+public enum LogLevel: Int, Sendable, Comparable, CaseIterable {
+    case debug
+    case info
+    case warning
+    case error
+    case fatal
+
+    public static func < (lhs: LogLevel, rhs: LogLevel) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+
+    var logLetter: String {
+        switch self {
+        case .debug:
+            return "D"
+        case .info:
+            return "I"
+        case .warning:
+            return "W"
+        case .error:
+            return "C"
+        case .fatal:
+            return "F"
+        }
+    }
+
+    var sentryLevel: SentryLevel {
+        switch self {
+        case .debug:
+            return .debug
+        case .info:
+            return .info
+        case .warning:
+            return .warning
+        case .error:
+            return .error
+        case .fatal:
+            return .fatal
+        }
+    }
+}

--- a/src/gui4/macOS/kDriveCore/Logging/LogLineFormatter.swift
+++ b/src/gui4/macOS/kDriveCore/Logging/LogLineFormatter.swift
@@ -1,0 +1,36 @@
+/*
+ Infomaniak kDrive - Desktop
+ Copyright (C) 2023-2026 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+
+struct LogLineFormatter {
+    private let dateFormatter: DateFormatter
+
+    init(timeZone: TimeZone = .current) {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = timeZone
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss:SSS"
+        dateFormatter = formatter
+    }
+
+    func format(_ event: LogEvent) -> String {
+        let date = dateFormatter.string(from: event.date)
+        return "\(date) [\(event.level.logLetter)] (\(event.threadID)) \(event.file):\(event.line) - \(event.message)"
+    }
+}

--- a/src/gui4/macOS/kDriveCore/Logging/LogService.swift
+++ b/src/gui4/macOS/kDriveCore/Logging/LogService.swift
@@ -1,0 +1,112 @@
+/*
+ Infomaniak kDrive - Desktop
+ Copyright (C) 2023-2026 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Darwin
+import Foundation
+import OSLog
+
+public final class LogService: @unchecked Sendable {
+    public static let shared = LogService()
+
+    private let queue = DispatchQueue(label: "com.infomaniak.kdrive.log-service")
+    private let queueKey = DispatchSpecificKey<Void>()
+    private let formatter: LogLineFormatter
+    private let fileWriter: LogFileWriting?
+    private let sentryReporter: SentryLogReporting
+    private let dateProvider: () -> Date
+    private let threadIDProvider: () -> String
+
+    convenience init() {
+        self.init(fileWriter: try? LogFileWriter())
+    }
+
+    init(
+        formatter: LogLineFormatter = LogLineFormatter(),
+        fileWriter: LogFileWriting?,
+        sentryReporter: SentryLogReporting = SentryLogReporter(),
+        dateProvider: @escaping () -> Date = Date.init,
+        threadIDProvider: @escaping () -> String = LogService.currentThreadID
+    ) {
+        self.formatter = formatter
+        self.fileWriter = fileWriter
+        self.sentryReporter = sentryReporter
+        self.dateProvider = dateProvider
+        self.threadIDProvider = threadIDProvider
+
+        queue.setSpecific(key: queueKey, value: ())
+    }
+
+    public func log(
+        level: LogLevel,
+        category: String,
+        message: String,
+        file: StaticString = #fileID,
+        line: UInt = #line
+    ) {
+        let event = LogEvent(
+            date: dateProvider(),
+            level: level,
+            category: category,
+            threadID: threadIDProvider(),
+            file: Self.fileName(from: file),
+            line: line,
+            message: Self.normalizedMessage(message)
+        )
+
+        sentryReporter.addBreadcrumb(event)
+        if event.level >= .error {
+            sentryReporter.capture(event)
+        }
+
+        queue.async { [weak self] in
+            self?.write(event)
+        }
+    }
+
+    func flush() {
+        guard DispatchQueue.getSpecific(key: queueKey) == nil else { return }
+        queue.sync {}
+    }
+
+    private func write(_ event: LogEvent) {
+        guard let fileWriter else { return }
+
+        do {
+            try fileWriter.append(formatter.format(event))
+        } catch {
+            os_log(.error, "Failed to write kDrive log line: %@", error.localizedDescription)
+        }
+    }
+
+    private static func fileName(from file: StaticString) -> String {
+        let path = String(describing: file)
+        return path.split(separator: "/").last.map(String.init) ?? path
+    }
+
+    private static func normalizedMessage(_ message: String) -> String {
+        message
+            .replacingOccurrences(of: "\r", with: "\\r")
+            .replacingOccurrences(of: "\n", with: "\\n")
+    }
+
+    private static func currentThreadID() -> String {
+        var threadID: UInt64 = 0
+        pthread_threadid_np(nil, &threadID)
+        return String(threadID)
+    }
+}

--- a/src/gui4/macOS/kDriveCore/Logging/LogService.swift
+++ b/src/gui4/macOS/kDriveCore/Logging/LogService.swift
@@ -21,8 +21,6 @@ import Foundation
 import OSLog
 
 public final class LogService: @unchecked Sendable {
-    public static let shared = LogService()
-
     private let queue = DispatchQueue(label: "com.infomaniak.kdrive.log-service")
     private let queueKey = DispatchSpecificKey<Void>()
     private let formatter: LogLineFormatter

--- a/src/gui4/macOS/kDriveCore/Logging/LogService.swift
+++ b/src/gui4/macOS/kDriveCore/Logging/LogService.swift
@@ -76,6 +76,7 @@ public final class LogService: @unchecked Sendable {
         }
     }
 
+    // periphery:ignore - Public API to flush pending log writes, e.g. before exit.
     func flush() {
         guard DispatchQueue.getSpecific(key: queueKey) == nil else { return }
         queue.sync {}

--- a/src/gui4/macOS/kDriveCore/Logging/SentryLogReporter.swift
+++ b/src/gui4/macOS/kDriveCore/Logging/SentryLogReporter.swift
@@ -1,0 +1,54 @@
+/*
+ Infomaniak kDrive - Desktop
+ Copyright (C) 2023-2026 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Sentry
+
+protocol SentryLogReporting {
+    func addBreadcrumb(_ event: LogEvent)
+    func capture(_ event: LogEvent)
+}
+
+struct SentryLogReporter: SentryLogReporting {
+    func addBreadcrumb(_ event: LogEvent) {
+        let breadcrumb = Breadcrumb(level: event.level.sentryLevel, category: event.category)
+        breadcrumb.message = event.message
+        breadcrumb.timestamp = event.date
+        breadcrumb.type = "log"
+        breadcrumb.data = event.sentryData
+
+        SentrySDK.addBreadcrumb(breadcrumb)
+    }
+
+    func capture(_ event: LogEvent) {
+        SentrySDK.capture(message: event.message) { scope in
+            scope.setLevel(event.level.sentryLevel)
+            scope.setContext(value: event.sentryData, key: "log")
+        }
+    }
+}
+
+private extension LogEvent {
+    var sentryData: [String: Any] {
+        [
+            "category": category,
+            "file": file,
+            "line": line,
+            "thread_id": threadID
+        ]
+    }
+}

--- a/src/gui4/macOS/kDriveCore/Utils/IKLogger.swift
+++ b/src/gui4/macOS/kDriveCore/Utils/IKLogger.swift
@@ -38,7 +38,9 @@ public struct IKLogger: Sendable {
         Logger(subsystem: subsystem, category: category)
     }
 
-    public func log(_ message: String) {
+    public func log(_ message: String, file: StaticString = #fileID, line: UInt = #line) {
+        logService.log(level: .debug, category: category, message: message, file: file, line: line)
+
         if #available(macOS 11.0, *) {
             logger.log("\(message)")
         } else {
@@ -46,19 +48,51 @@ public struct IKLogger: Sendable {
         }
     }
 
-    public func info(_ message: String) {
+    public func debug(_ message: String, file: StaticString = #fileID, line: UInt = #line) {
+        log(message, file: file, line: line)
+    }
+
+    public func info(_ message: String, file: StaticString = #fileID, line: UInt = #line) {
+        logService.log(level: .info, category: category, message: message, file: file, line: line)
+
         if #available(macOS 11.0, *) {
-            logger.log("\(message)")
+            logger.info("\(message)")
         } else {
             os_log(.info, "%@", message)
         }
     }
 
-    public func error(_ message: String) {
+    public func warning(_ message: String, file: StaticString = #fileID, line: UInt = #line) {
+        logService.log(level: .warning, category: category, message: message, file: file, line: line)
+
+        if #available(macOS 11.0, *) {
+            logger.warning("\(message)")
+        } else {
+            os_log(.default, "%@", message)
+        }
+    }
+
+    public func error(_ message: String, file: StaticString = #fileID, line: UInt = #line) {
+        logService.log(level: .error, category: category, message: message, file: file, line: line)
+
         if #available(macOS 11.0, *) {
             logger.error("\(message)")
         } else {
             os_log(.error, "%@", message)
         }
+    }
+
+    public func fatal(_ message: String, file: StaticString = #fileID, line: UInt = #line) {
+        logService.log(level: .fatal, category: category, message: message, file: file, line: line)
+
+        if #available(macOS 11.0, *) {
+            logger.fault("\(message)")
+        } else {
+            os_log(.fault, "%@", message)
+        }
+    }
+
+    private var logService: LogService {
+        LogService.shared
     }
 }

--- a/src/gui4/macOS/kDriveCore/Utils/IKLogger.swift
+++ b/src/gui4/macOS/kDriveCore/Utils/IKLogger.swift
@@ -17,6 +17,7 @@
  */
 
 import Foundation
+import InfomaniakDI
 import OSLog
 
 public extension IKLogger {
@@ -32,6 +33,7 @@ public extension IKLogger {
 public struct IKLogger: Sendable {
     let subsystem: String
     let category: String
+    @InjectService var logService: LogService
 
     @available(macOS 11.0, *)
     private var logger: Logger {
@@ -90,9 +92,5 @@ public struct IKLogger: Sendable {
         } else {
             os_log(.fault, "%@", message)
         }
-    }
-
-    private var logService: LogService {
-        LogService.shared
     }
 }

--- a/src/gui4/macOS/kDriveCore/Utils/TargetAssembly.swift
+++ b/src/gui4/macOS/kDriveCore/Utils/TargetAssembly.swift
@@ -98,7 +98,7 @@ open class TargetAssembly {
                 StorageDataService()
             },
             Factory(type: LogService.self) { _, _ in
-                LogService.shared
+                LogService()
             }
         ]
     }

--- a/src/gui4/macOS/kDriveCore/Utils/TargetAssembly.swift
+++ b/src/gui4/macOS/kDriveCore/Utils/TargetAssembly.swift
@@ -18,7 +18,6 @@
 
 import Foundation
 import InfomaniakDI
-import OSLog
 
 public extension [Factory] {
     func registerFactoriesInDI() {
@@ -97,6 +96,9 @@ open class TargetAssembly {
             },
             Factory(type: StorageDataProviding.self) { _, _ in
                 StorageDataService()
+            },
+            Factory(type: LogService.self) { _, _ in
+                LogService.shared
             }
         ]
     }

--- a/src/gui4/macOS/kDriveCoreUI/UI/SwiftUI/Components/FileTree/FileTreeView.swift
+++ b/src/gui4/macOS/kDriveCoreUI/UI/SwiftUI/Components/FileTree/FileTreeView.swift
@@ -24,7 +24,6 @@ public struct FileTreeView: NSViewRepresentable {
     public let childrenFetcher: FileTreeChildrenFetcher
     public let onBlacklistChange: (Set<String>) -> Void
 
-    // periphery:ignore - Public API used by the main app target to build the file tree.
     public init(
         rootItems: [FileTreeItem],
         initialBlacklist: Set<String> = [],

--- a/src/gui4/macOS/kDriveCoreUI/UI/SwiftUI/Components/FileTree/FileTreeView.swift
+++ b/src/gui4/macOS/kDriveCoreUI/UI/SwiftUI/Components/FileTree/FileTreeView.swift
@@ -24,6 +24,7 @@ public struct FileTreeView: NSViewRepresentable {
     public let childrenFetcher: FileTreeChildrenFetcher
     public let onBlacklistChange: (Set<String>) -> Void
 
+    // periphery:ignore - Public API used by the main app target to build the file tree.
     public init(
         rootItems: [FileTreeItem],
         initialBlacklist: Set<String> = [],

--- a/src/gui4/macOS/kDriveTests/Logging/GzipCompressorTests.swift
+++ b/src/gui4/macOS/kDriveTests/Logging/GzipCompressorTests.swift
@@ -1,0 +1,84 @@
+/*
+ Infomaniak kDrive - Desktop
+ Copyright (C) 2023-2026 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+@testable import kDriveCore
+import Testing
+
+@Suite("GzipCompressor Tests")
+struct GzipCompressorTests {
+    @Test("Compresses then decompresses a file back to its original content")
+    func roundTripsFileThroughGzip() throws {
+        let fileManager = FileManager.default
+        let directory = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: directory) }
+
+        let originalURL = directory.appendingPathComponent("original.log", isDirectory: false)
+        let compressedURL = directory.appendingPathComponent("original.log.gz", isDirectory: false)
+        let decompressedURL = directory.appendingPathComponent("decompressed.log", isDirectory: false)
+
+        // Large enough (~1.5 MiB) to exercise multi-chunk streaming, with multibyte UTF-8 content.
+        let original = String(repeating: "kDrive log line with some entropy 0123456789 éàü\n", count: 30000)
+        try original.write(to: originalURL, atomically: true, encoding: .utf8)
+
+        #expect(GzipCompressor.compress(source: originalURL, destination: compressedURL))
+
+        // The output is a real gzip file (magic 0x1f 0x8b) and smaller than the source.
+        let compressedData = try Data(contentsOf: compressedURL)
+        let originalData = try Data(contentsOf: originalURL)
+        #expect(Array(compressedData.prefix(2)) == [0x1F, 0x8B])
+        #expect(compressedData.count < originalData.count)
+
+        #expect(GzipCompressor.decompress(source: compressedURL, destination: decompressedURL))
+
+        let decompressed = try String(contentsOf: decompressedURL, encoding: .utf8)
+        #expect(decompressed == original)
+    }
+
+    @Test("Round-trips an empty file")
+    func roundTripsEmptyFile() throws {
+        let fileManager = FileManager.default
+        let directory = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: directory) }
+
+        let originalURL = directory.appendingPathComponent("empty.log", isDirectory: false)
+        let compressedURL = directory.appendingPathComponent("empty.log.gz", isDirectory: false)
+        let decompressedURL = directory.appendingPathComponent("empty-decompressed.log", isDirectory: false)
+
+        #expect(fileManager.createFile(atPath: originalURL.path, contents: nil))
+
+        #expect(GzipCompressor.compress(source: originalURL, destination: compressedURL))
+        #expect(Array(try Data(contentsOf: compressedURL).prefix(2)) == [0x1F, 0x8B])
+
+        #expect(GzipCompressor.decompress(source: compressedURL, destination: decompressedURL))
+        #expect(try Data(contentsOf: decompressedURL).isEmpty)
+    }
+
+    @Test("Compressing a missing source fails")
+    func compressMissingSourceFails() {
+        let fileManager = FileManager.default
+        let directory = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+
+        let missingURL = directory.appendingPathComponent("does-not-exist.log", isDirectory: false)
+        let compressedURL = directory.appendingPathComponent("does-not-exist.log.gz", isDirectory: false)
+
+        #expect(!GzipCompressor.compress(source: missingURL, destination: compressedURL))
+    }
+}

--- a/src/gui4/macOS/kDriveTests/Logging/GzipCompressorTests.swift
+++ b/src/gui4/macOS/kDriveTests/Logging/GzipCompressorTests.swift
@@ -65,7 +65,7 @@ struct GzipCompressorTests {
         #expect(fileManager.createFile(atPath: originalURL.path, contents: nil))
 
         #expect(GzipCompressor.compress(source: originalURL, destination: compressedURL))
-        #expect(Array(try Data(contentsOf: compressedURL).prefix(2)) == [0x1F, 0x8B])
+        #expect(try Array(Data(contentsOf: compressedURL).prefix(2)) == [0x1F, 0x8B])
 
         #expect(GzipCompressor.decompress(source: compressedURL, destination: decompressedURL))
         #expect(try Data(contentsOf: decompressedURL).isEmpty)

--- a/src/gui4/macOS/kDriveTests/Logging/LogServiceTests.swift
+++ b/src/gui4/macOS/kDriveTests/Logging/LogServiceTests.swift
@@ -112,6 +112,15 @@ struct LogServiceTests {
         #expect(contents == "2026-06-09 12:00:46:529 [D] (227895) commclient.cpp:122 - Snd rqst 12 ERROR_INFOLIST_LEGACY(35)\n")
     }
 
+    @Test("Default log directory matches the macOS CommonUtility log path")
+    func defaultLogDirectoryMatchesCommonUtilityPath() throws {
+        let expectedDirectory = try #require(FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).first)
+            .appendingPathComponent("Logs", isDirectory: true)
+            .appendingPathComponent("kDrive", isDirectory: true)
+
+        #expect(LogFileWriter.defaultLogDirectory() == expectedDirectory)
+    }
+
     private static let utcTimeZone = TimeZone(secondsFromGMT: 0)!
 
     private static func date(

--- a/src/gui4/macOS/kDriveTests/Logging/LogServiceTests.swift
+++ b/src/gui4/macOS/kDriveTests/Logging/LogServiceTests.swift
@@ -1,0 +1,160 @@
+/*
+ Infomaniak kDrive - Desktop
+ Copyright (C) 2023-2026 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+@testable import kDriveCore
+import Testing
+
+@Suite("LogService Tests")
+struct LogServiceTests {
+    @Test("Formatter matches the legacy kDrive log line format")
+    func formatterMatchesLegacyFormat() throws {
+        let event = LogEvent(
+            date: try Self.date(year: 2026, month: 3, day: 24, hour: 14, minute: 8, second: 14, millisecond: 920),
+            level: .debug,
+            category: "general",
+            threadID: "2971261",
+            file: "matomoclient.cpp",
+            line: 57,
+            message: "MatomoClient initialized with URL: https://analytics.infomaniak.com and site ID: 29"
+        )
+
+        let formattedLine = LogLineFormatter(timeZone: Self.utcTimeZone).format(event)
+
+        #expect(
+            formattedLine == "2026-03-24 14:08:14:920 [D] (2971261) matomoclient.cpp:57 - MatomoClient initialized with URL: https://analytics.infomaniak.com and site ID: 29"
+        )
+    }
+
+    @Test("Error level uses the Qt critical log marker")
+    func errorLevelUsesCriticalMarker() throws {
+        #expect(LogLevel.error.logLetter == "C")
+    }
+
+    @Test("Service appends formatted lines and reports breadcrumbs for all levels")
+    func serviceAppendsLineAndReportsBreadcrumbs() throws {
+        let writer = InMemoryLogFileWriter()
+        let sentryReporter = SpySentryLogReporter()
+        let service = LogService(
+            formatter: LogLineFormatter(timeZone: Self.utcTimeZone),
+            fileWriter: writer,
+            sentryReporter: sentryReporter,
+            dateProvider: { try! Self.date(year: 2026, month: 6, day: 9, hour: 12, minute: 0, second: 46, millisecond: 529) },
+            threadIDProvider: { "227895" }
+        )
+
+        service.log(level: .info, category: "xpc", message: "first line\nsecond line", file: "Folder/File.swift", line: 42)
+        service.flush()
+
+        #expect(writer.lines == ["2026-06-09 12:00:46:529 [I] (227895) File.swift:42 - first line\\nsecond line"])
+        #expect(sentryReporter.breadcrumbs.map(\.level) == [.info])
+        #expect(sentryReporter.capturedEvents.isEmpty)
+    }
+
+    @Test("Service captures only error and fatal events")
+    func serviceCapturesOnlyErrorAndFatalEvents() throws {
+        let sentryReporter = SpySentryLogReporter()
+        let service = LogService(
+            formatter: LogLineFormatter(timeZone: Self.utcTimeZone),
+            fileWriter: InMemoryLogFileWriter(),
+            sentryReporter: sentryReporter,
+            dateProvider: { try! Self.date(year: 2026, month: 6, day: 9, hour: 12, minute: 0, second: 46, millisecond: 529) },
+            threadIDProvider: { "227895" }
+        )
+
+        service.log(level: .debug, category: "general", message: "debug", file: "File.swift", line: 1)
+        service.log(level: .warning, category: "general", message: "warning", file: "File.swift", line: 2)
+        service.log(level: .error, category: "general", message: "error", file: "File.swift", line: 3)
+        service.log(level: .fatal, category: "general", message: "fatal", file: "File.swift", line: 4)
+        service.flush()
+
+        #expect(sentryReporter.breadcrumbs.map(\.level) == [.debug, .warning, .error, .fatal])
+        #expect(sentryReporter.capturedEvents.map(\.level) == [.error, .fatal])
+    }
+
+    @Test("File writer uses legacy client session log names")
+    func fileWriterUsesLegacyClientSessionNames() throws {
+        let fileManager = FileManager.default
+        let logDirectory = fileManager.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? fileManager.removeItem(at: logDirectory) }
+
+        let date = try Self.date(year: 2026, month: 6, day: 9, hour: 12, minute: 0, second: 46, millisecond: 529)
+        let writer = try LogFileWriter(logDirectory: logDirectory, date: date, timeZone: Self.utcTimeZone, fileManager: fileManager)
+        let service = LogService(
+            formatter: LogLineFormatter(timeZone: Self.utcTimeZone),
+            fileWriter: writer,
+            sentryReporter: SpySentryLogReporter(),
+            dateProvider: { date },
+            threadIDProvider: { "227895" }
+        )
+
+        service.log(level: .debug, category: "xpc", message: "Snd rqst 12 ERROR_INFOLIST_LEGACY(35)", file: "commclient.cpp", line: 122)
+        service.flush()
+
+        let contents = try String(contentsOf: writer.fileURL, encoding: .utf8)
+        #expect(writer.fileURL.lastPathComponent == "20260609_1200_kDrive_client.log.0")
+        #expect(contents == "2026-06-09 12:00:46:529 [D] (227895) commclient.cpp:122 - Snd rqst 12 ERROR_INFOLIST_LEGACY(35)\n")
+    }
+
+    private static let utcTimeZone = TimeZone(secondsFromGMT: 0)!
+
+    private static func date(
+        year: Int,
+        month: Int,
+        day: Int,
+        hour: Int,
+        minute: Int,
+        second: Int,
+        millisecond: Int
+    ) throws -> Date {
+        var components = DateComponents()
+        components.calendar = Calendar(identifier: .gregorian)
+        components.timeZone = utcTimeZone
+        components.year = year
+        components.month = month
+        components.day = day
+        components.hour = hour
+        components.minute = minute
+        components.second = second
+        components.nanosecond = millisecond * 1_000_000
+
+        return try #require(components.date)
+    }
+}
+
+private final class InMemoryLogFileWriter: LogFileWriting {
+    private(set) var lines = [String]()
+
+    func append(_ line: String) throws {
+        lines.append(line)
+    }
+}
+
+private final class SpySentryLogReporter: SentryLogReporting {
+    private(set) var breadcrumbs = [LogEvent]()
+    private(set) var capturedEvents = [LogEvent]()
+
+    func addBreadcrumb(_ event: LogEvent) {
+        breadcrumbs.append(event)
+    }
+
+    func capture(_ event: LogEvent) {
+        capturedEvents.append(event)
+    }
+}

--- a/src/gui4/macOS/kDriveTests/Logging/LogServiceTests.swift
+++ b/src/gui4/macOS/kDriveTests/Logging/LogServiceTests.swift
@@ -24,8 +24,8 @@ import Testing
 struct LogServiceTests {
     @Test("Formatter matches the legacy kDrive log line format")
     func formatterMatchesLegacyFormat() throws {
-        let event = LogEvent(
-            date: try Self.date(year: 2026, month: 3, day: 24, hour: 14, minute: 8, second: 14, millisecond: 920),
+        let event = try LogEvent(
+            date: Self.date(year: 2026, month: 3, day: 24, hour: 14, minute: 8, second: 14, millisecond: 920),
             level: .debug,
             category: "general",
             threadID: "2971261",
@@ -42,12 +42,12 @@ struct LogServiceTests {
     }
 
     @Test("Error level uses the Qt critical log marker")
-    func errorLevelUsesCriticalMarker() throws {
+    func errorLevelUsesCriticalMarker() {
         #expect(LogLevel.error.logLetter == "C")
     }
 
     @Test("Service appends formatted lines and reports breadcrumbs for all levels")
-    func serviceAppendsLineAndReportsBreadcrumbs() throws {
+    func serviceAppendsLineAndReportsBreadcrumbs() {
         let writer = InMemoryLogFileWriter()
         let sentryReporter = SpySentryLogReporter()
         let service = LogService(
@@ -67,7 +67,7 @@ struct LogServiceTests {
     }
 
     @Test("Service captures only error and fatal events")
-    func serviceCapturesOnlyErrorAndFatalEvents() throws {
+    func serviceCapturesOnlyErrorAndFatalEvents() {
         let sentryReporter = SpySentryLogReporter()
         let service = LogService(
             formatter: LogLineFormatter(timeZone: Self.utcTimeZone),
@@ -95,7 +95,12 @@ struct LogServiceTests {
         defer { try? fileManager.removeItem(at: logDirectory) }
 
         let date = try Self.date(year: 2026, month: 6, day: 9, hour: 12, minute: 0, second: 46, millisecond: 529)
-        let writer = try LogFileWriter(logDirectory: logDirectory, date: date, timeZone: Self.utcTimeZone, fileManager: fileManager)
+        let writer = try LogFileWriter(
+            logDirectory: logDirectory,
+            date: date,
+            timeZone: Self.utcTimeZone,
+            fileManager: fileManager
+        )
         let service = LogService(
             formatter: LogLineFormatter(timeZone: Self.utcTimeZone),
             fileWriter: writer,
@@ -104,7 +109,13 @@ struct LogServiceTests {
             threadIDProvider: { "227895" }
         )
 
-        service.log(level: .debug, category: "xpc", message: "Snd rqst 12 ERROR_INFOLIST_LEGACY(35)", file: "commclient.cpp", line: 122)
+        service.log(
+            level: .debug,
+            category: "xpc",
+            message: "Snd rqst 12 ERROR_INFOLIST_LEGACY(35)",
+            file: "commclient.cpp",
+            line: 122
+        )
         service.flush()
 
         let contents = try String(contentsOf: writer.fileURL, encoding: .utf8)
@@ -174,12 +185,22 @@ struct LogServiceTests {
 
         // First session, then "kill" it by releasing the writer (closes the file handle).
         try autoreleasepool {
-            let writer = try LogFileWriter(logDirectory: logDirectory, date: firstDate, timeZone: Self.utcTimeZone, fileManager: fileManager)
+            let writer = try LogFileWriter(
+                logDirectory: logDirectory,
+                date: firstDate,
+                timeZone: Self.utcTimeZone,
+                fileManager: fileManager
+            )
             try writer.append("first session line")
         }
 
         // Restart: a new writer with a later launch time.
-        let secondWriter = try LogFileWriter(logDirectory: logDirectory, date: secondDate, timeZone: Self.utcTimeZone, fileManager: fileManager)
+        let secondWriter = try LogFileWriter(
+            logDirectory: logDirectory,
+            date: secondDate,
+            timeZone: Self.utcTimeZone,
+            fileManager: fileManager
+        )
         try secondWriter.append("second session line")
 
         let firstURL = logDirectory.appendingPathComponent("20260609_1200_kDrive_client.log", isDirectory: false)
@@ -201,11 +222,21 @@ struct LogServiceTests {
         let date = try Self.date(year: 2026, month: 6, day: 9, hour: 12, minute: 0, second: 0, millisecond: 0)
 
         try autoreleasepool {
-            let writer = try LogFileWriter(logDirectory: logDirectory, date: date, timeZone: Self.utcTimeZone, fileManager: fileManager)
+            let writer = try LogFileWriter(
+                logDirectory: logDirectory,
+                date: date,
+                timeZone: Self.utcTimeZone,
+                fileManager: fileManager
+            )
             try writer.append("before restart")
         }
 
-        let secondWriter = try LogFileWriter(logDirectory: logDirectory, date: date, timeZone: Self.utcTimeZone, fileManager: fileManager)
+        let secondWriter = try LogFileWriter(
+            logDirectory: logDirectory,
+            date: date,
+            timeZone: Self.utcTimeZone,
+            fileManager: fileManager
+        )
         try secondWriter.append("after restart")
 
         let url = logDirectory.appendingPathComponent("20260609_1200_kDrive_client.log", isDirectory: false)

--- a/src/gui4/macOS/kDriveTests/Logging/LogServiceTests.swift
+++ b/src/gui4/macOS/kDriveTests/Logging/LogServiceTests.swift
@@ -113,8 +113,9 @@ struct LogServiceTests {
     }
 
     @Test("Default log directory matches the macOS CommonUtility log path")
-    func defaultLogDirectoryMatchesCommonUtilityPath() throws {
-        let expectedDirectory = try #require(FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).first)
+    func defaultLogDirectoryMatchesCommonUtilityPath() {
+        let expectedDirectory = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library", isDirectory: true)
             .appendingPathComponent("Logs", isDirectory: true)
             .appendingPathComponent("kDrive", isDirectory: true)
 

--- a/src/gui4/macOS/kDriveTests/Logging/LogServiceTests.swift
+++ b/src/gui4/macOS/kDriveTests/Logging/LogServiceTests.swift
@@ -87,8 +87,8 @@ struct LogServiceTests {
         #expect(sentryReporter.capturedEvents.map(\.level) == [.error, .fatal])
     }
 
-    @Test("File writer uses legacy client session log names")
-    func fileWriterUsesLegacyClientSessionNames() throws {
+    @Test("File writer appends to a date-stamped rolling client log file")
+    func fileWriterAppendsToDateStampedRollingClientLog() throws {
         let fileManager = FileManager.default
         let logDirectory = fileManager.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -108,8 +108,109 @@ struct LogServiceTests {
         service.flush()
 
         let contents = try String(contentsOf: writer.fileURL, encoding: .utf8)
-        #expect(writer.fileURL.lastPathComponent == "20260609_1200_kDrive_client.log.0")
+        #expect(writer.fileURL.lastPathComponent == "20260609_1200_kDrive_client.log")
         #expect(contents == "2026-06-09 12:00:46:529 [D] (227895) commclient.cpp:122 - Snd rqst 12 ERROR_INFOLIST_LEGACY(35)\n")
+    }
+
+    @Test("File writer rotates oversized logs into compressed backups and trims old ones")
+    func fileWriterRotatesIntoCompressedBackups() throws {
+        let fileManager = FileManager.default
+        let logDirectory = fileManager.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? fileManager.removeItem(at: logDirectory) }
+
+        // Tiny size + a small backup count so a handful of lines trigger several rotations.
+        // Every single line is larger than `maxFileSize`, so each append after the first rotates.
+        let date = try Self.date(year: 2026, month: 6, day: 9, hour: 12, minute: 0, second: 46, millisecond: 529)
+        let maxBackupIndex = 2
+        let writer = try LogFileWriter(
+            logDirectory: logDirectory,
+            date: date,
+            timeZone: Self.utcTimeZone,
+            fileManager: fileManager,
+            maxFileSize: 10,
+            maxBackupIndex: maxBackupIndex
+        )
+
+        let lineCount = 12
+        for index in 0 ..< lineCount {
+            try writer.append("line \(index) - padding padding padding padding padding")
+        }
+
+        // Backup names share the active file's date-stamped base name.
+        let baseName = writer.fileURL.lastPathComponent
+        #expect(baseName == "20260609_1200_kDrive_client.log")
+        func backupURL(_ index: Int) -> URL {
+            logDirectory.appendingPathComponent("\(baseName).\(index).gz", isDirectory: false)
+        }
+
+        // The active file exists and only holds the most recent line.
+        let activeContents = try String(contentsOf: writer.fileURL, encoding: .utf8)
+        #expect(activeContents == "line \(lineCount - 1) - padding padding padding padding padding\n")
+
+        // Backups `.0.gz` … `.maxBackupIndex.gz` exist and are real gzip files (magic 0x1f 0x8b).
+        for index in 0 ... maxBackupIndex {
+            let url = backupURL(index)
+            #expect(fileManager.fileExists(atPath: url.path))
+
+            let header = try Data(contentsOf: url).prefix(2)
+            #expect(Array(header) == [0x1F, 0x8B])
+        }
+
+        // Nothing is kept beyond the maximum backup index (oldest removed).
+        #expect(!fileManager.fileExists(atPath: backupURL(maxBackupIndex + 1).path))
+        #expect(!fileManager.fileExists(atPath: logDirectory.appendingPathComponent("\(baseName).\(maxBackupIndex + 1)").path))
+    }
+
+    @Test("Restarting the app starts a new dated log file and leaves the previous session untouched")
+    func restartStartsNewDatedFileAndPreservesPrevious() throws {
+        let fileManager = FileManager.default
+        let logDirectory = fileManager.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? fileManager.removeItem(at: logDirectory) }
+
+        let firstDate = try Self.date(year: 2026, month: 6, day: 9, hour: 12, minute: 0, second: 0, millisecond: 0)
+        let secondDate = try Self.date(year: 2026, month: 6, day: 9, hour: 12, minute: 5, second: 0, millisecond: 0)
+
+        // First session, then "kill" it by releasing the writer (closes the file handle).
+        try autoreleasepool {
+            let writer = try LogFileWriter(logDirectory: logDirectory, date: firstDate, timeZone: Self.utcTimeZone, fileManager: fileManager)
+            try writer.append("first session line")
+        }
+
+        // Restart: a new writer with a later launch time.
+        let secondWriter = try LogFileWriter(logDirectory: logDirectory, date: secondDate, timeZone: Self.utcTimeZone, fileManager: fileManager)
+        try secondWriter.append("second session line")
+
+        let firstURL = logDirectory.appendingPathComponent("20260609_1200_kDrive_client.log", isDirectory: false)
+        let secondURL = logDirectory.appendingPathComponent("20260609_1205_kDrive_client.log", isDirectory: false)
+
+        #expect(secondWriter.fileURL == secondURL)
+        // The previous session's file still exists and is untouched (server compresses/trims it folder-wide).
+        #expect(try String(contentsOf: firstURL, encoding: .utf8) == "first session line\n")
+        #expect(try String(contentsOf: secondURL, encoding: .utf8) == "second session line\n")
+    }
+
+    @Test("Restarting within the same minute appends to the existing log file without truncating")
+    func restartWithinSameMinuteAppends() throws {
+        let fileManager = FileManager.default
+        let logDirectory = fileManager.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? fileManager.removeItem(at: logDirectory) }
+
+        let date = try Self.date(year: 2026, month: 6, day: 9, hour: 12, minute: 0, second: 0, millisecond: 0)
+
+        try autoreleasepool {
+            let writer = try LogFileWriter(logDirectory: logDirectory, date: date, timeZone: Self.utcTimeZone, fileManager: fileManager)
+            try writer.append("before restart")
+        }
+
+        let secondWriter = try LogFileWriter(logDirectory: logDirectory, date: date, timeZone: Self.utcTimeZone, fileManager: fileManager)
+        try secondWriter.append("after restart")
+
+        let url = logDirectory.appendingPathComponent("20260609_1200_kDrive_client.log", isDirectory: false)
+        #expect(secondWriter.fileURL == url)
+        #expect(try String(contentsOf: url, encoding: .utf8) == "before restart\nafter restart\n")
     }
 
     @Test("Default log directory matches the macOS CommonUtility log path")


### PR DESCRIPTION
- All logs are used as Sentry breadcrumbs
- All error logs are sent as Sentry errors
- Write to file capability following the expected format
- Unit test the whole thing
- Log rotation
- Correct folder path resolution
- Checked file name to use
- Use native macOS Zlib