### PR TITLE
fix: allow retry on HTTP 502

### DIFF
--- a/src/libcommonserver/utility/utility.cpp
+++ b/src/libcommonserver/utility/utility.cpp
@@ -514,18 +514,21 @@ SyncPath Utility::sharedFolderPath() {
     return path;
 }
 
-bool Utility::isError500(const Poco::Net::HTTPResponse::HTTPStatus httpErrorCode) {
+bool Utility::isError500(const Poco::Net::HTTPResponse::HTTPStatus httpErrorCode, bool &shouldRetry) {
+    shouldRetry = false;
     switch (httpErrorCode) {
-        case Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR:
-        case Poco::Net::HTTPResponse::HTTP_NOT_IMPLEMENTED:
         case Poco::Net::HTTPResponse::HTTP_BAD_GATEWAY:
-        case Poco::Net::HTTPResponse::HTTP_SERVICE_UNAVAILABLE:
         case Poco::Net::HTTPResponse::HTTP_GATEWAY_TIMEOUT:
-        case Poco::Net::HTTPResponse::HTTP_VERSION_NOT_SUPPORTED:
-        case Poco::Net::HTTPResponse::HTTP_VARIANT_ALSO_NEGOTIATES:
+            shouldRetry = true;
+            return true;
         case Poco::Net::HTTPResponse::HTTP_INSUFFICIENT_STORAGE:
         case Poco::Net::HTTPResponse::HTTP_LOOP_DETECTED:
         case Poco::Net::HTTPResponse::HTTP_NOT_EXTENDED:
+        case Poco::Net::HTTPResponse::HTTP_VARIANT_ALSO_NEGOTIATES:
+        case Poco::Net::HTTPResponse::HTTP_NOT_IMPLEMENTED:
+        case Poco::Net::HTTPResponse::HTTP_SERVICE_UNAVAILABLE:
+        case Poco::Net::HTTPResponse::HTTP_VERSION_NOT_SUPPORTED:
+        case Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR:
         case Poco::Net::HTTPResponse::HTTP_NETWORK_AUTHENTICATION_REQUIRED:
             return true;
         default:

--- a/src/libcommonserver/utility/utility.cpp
+++ b/src/libcommonserver/utility/utility.cpp
@@ -514,28 +514,6 @@ SyncPath Utility::sharedFolderPath() {
     return path;
 }
 
-bool Utility::isError500(const Poco::Net::HTTPResponse::HTTPStatus httpErrorCode, bool &shouldRetry) {
-    shouldRetry = false;
-    switch (httpErrorCode) {
-        case Poco::Net::HTTPResponse::HTTP_BAD_GATEWAY:
-        case Poco::Net::HTTPResponse::HTTP_GATEWAY_TIMEOUT:
-            shouldRetry = true;
-            return true;
-        case Poco::Net::HTTPResponse::HTTP_INSUFFICIENT_STORAGE:
-        case Poco::Net::HTTPResponse::HTTP_LOOP_DETECTED:
-        case Poco::Net::HTTPResponse::HTTP_NOT_EXTENDED:
-        case Poco::Net::HTTPResponse::HTTP_VARIANT_ALSO_NEGOTIATES:
-        case Poco::Net::HTTPResponse::HTTP_NOT_IMPLEMENTED:
-        case Poco::Net::HTTPResponse::HTTP_SERVICE_UNAVAILABLE:
-        case Poco::Net::HTTPResponse::HTTP_VERSION_NOT_SUPPORTED:
-        case Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR:
-        case Poco::Net::HTTPResponse::HTTP_NETWORK_AUTHENTICATION_REQUIRED:
-            return true;
-        default:
-            return false;
-    }
-}
-
 static constexpr uint64_t maxNbCreationTmpFolderRetries = 3;
 ExitInfo Utility::tryCreateTmpDir([[maybe_unused]] const std::shared_ptr<CacheDirectory> cacheDirectory,
                                   const SyncName &name /*= Str("testDir")*/) {

--- a/src/libcommonserver/utility/utility.h
+++ b/src/libcommonserver/utility/utility.h
@@ -197,7 +197,7 @@ struct COMMONSERVER_EXPORT Utility {
         // Possibly refactor to share code with UnixTimevalToFileTime in c_time.c
         static void unixTimeToFiletime(time_t t, FILETIME *filetime);
 #endif
-        static bool isError500(const Poco::Net::HTTPResponse::HTTPStatus httpErrorCode);
+        static bool isError500(const Poco::Net::HTTPResponse::HTTPStatus httpErrorCode, bool &shouldRetry);
 
         /**
          * @brief Check if a directory can be created in the temp directory.

--- a/src/libcommonserver/utility/utility.h
+++ b/src/libcommonserver/utility/utility.h
@@ -197,7 +197,6 @@ struct COMMONSERVER_EXPORT Utility {
         // Possibly refactor to share code with UnixTimevalToFileTime in c_time.c
         static void unixTimeToFiletime(time_t t, FILETIME *filetime);
 #endif
-        static bool isError500(const Poco::Net::HTTPResponse::HTTPStatus httpErrorCode, bool &shouldRetry);
 
         /**
          * @brief Check if a directory can be created in the temp directory.

--- a/src/libsyncengine/jobs/network/abstractnetworkjob.cpp
+++ b/src/libsyncengine/jobs/network/abstractnetworkjob.cpp
@@ -556,8 +556,10 @@ ExitInfo AbstractNetworkJob::receiveResponse(const Poco::URI &uri) {
 
             if (exitInfo.code() == ExitCode::Ok) return exitInfo;
 
-            if (exitInfo.cause() == ExitCause::Unknown && Utility::isError500(httpResponse().getStatus())) {
-                disableRetry();
+            bool shouldRetryOnError500 = true;
+            if (exitInfo.cause() == ExitCause::Unknown &&
+                Utility::isError500(httpResponse().getStatus(), shouldRetryOnError500)) {
+                if (!shouldRetryOnError500) disableRetry();
                 exitInfo.setCause(ExitCause::Http5xx);
             } else if (exitInfo.code() != ExitCode::DataError && exitInfo.code() != ExitCode::InvalidToken &&
                        (exitInfo.code() != ExitCode::BackError || exitInfo.cause() != ExitCause::NotFound)) {

--- a/src/libsyncengine/jobs/network/abstractnetworkjob.cpp
+++ b/src/libsyncengine/jobs/network/abstractnetworkjob.cpp
@@ -42,6 +42,9 @@
 #include <thread>
 #include <Poco/JSON/Parser.h>
 #include <Poco/Net/HTTPRequest.h>
+#include "kDrive_API/upload/upload_session/uploadsessionchunkjob.h"
+#include "kDrive_API/upload/uploadjob.h"
+#include "kDrive_API/downloadjob.h"
 
 #define BUF_SIZE 1024
 
@@ -556,9 +559,9 @@ ExitInfo AbstractNetworkJob::receiveResponse(const Poco::URI &uri) {
 
             if (exitInfo.code() == ExitCode::Ok) return exitInfo;
 
-            bool shouldRetryOnError500 = true;
-            if (exitInfo.cause() == ExitCause::Unknown &&
-                Utility::isError500(httpResponse().getStatus(), shouldRetryOnError500)) {
+
+            if (bool shouldRetryOnError500 = false;
+                exitInfo.cause() == ExitCause::Unknown && isError500(httpResponse().getStatus(), shouldRetryOnError500)) {
                 if (!shouldRetryOnError500) disableRetry();
                 exitInfo.setCause(ExitCause::Http5xx);
             } else if (exitInfo.code() != ExitCode::DataError && exitInfo.code() != ExitCode::InvalidToken &&
@@ -570,6 +573,31 @@ ExitInfo AbstractNetworkJob::receiveResponse(const Poco::URI &uri) {
     }
 
     return ExitCode::Ok;
+}
+
+bool AbstractNetworkJob::isError500(const Poco::Net::HTTPResponse::HTTPStatus httpErrorCode, bool &shouldRetry) {
+    shouldRetry = false;
+    switch (httpErrorCode) {
+        case Poco::Net::HTTPResponse::HTTP_BAD_GATEWAY:
+        case Poco::Net::HTTPResponse::HTTP_GATEWAY_TIMEOUT:
+            // Retry if the job is an uploadSession chunck job an upload job or a downalod job
+            // GATEWAY error can be due to poor network connexion. Some upload chunk can fail intermidently, we want to retry
+            // befor cancelling the complete upload session
+            shouldRetry = dynamic_cast<UploadSessionChunkJob *>(this) != nullptr;
+            return true;
+        case Poco::Net::HTTPResponse::HTTP_INSUFFICIENT_STORAGE:
+        case Poco::Net::HTTPResponse::HTTP_LOOP_DETECTED:
+        case Poco::Net::HTTPResponse::HTTP_NOT_EXTENDED:
+        case Poco::Net::HTTPResponse::HTTP_VARIANT_ALSO_NEGOTIATES:
+        case Poco::Net::HTTPResponse::HTTP_NOT_IMPLEMENTED:
+        case Poco::Net::HTTPResponse::HTTP_SERVICE_UNAVAILABLE:
+        case Poco::Net::HTTPResponse::HTTP_VERSION_NOT_SUPPORTED:
+        case Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR:
+        case Poco::Net::HTTPResponse::HTTP_NETWORK_AUTHENTICATION_REQUIRED:
+            return true;
+        default:
+            return false;
+    }
 }
 
 ExitInfo AbstractNetworkJob::handleError(std::istream &inputStream, const Poco::URI &uri) {

--- a/src/libsyncengine/jobs/network/abstractnetworkjob.cpp
+++ b/src/libsyncengine/jobs/network/abstractnetworkjob.cpp
@@ -579,12 +579,12 @@ bool AbstractNetworkJob::isError500(const Poco::Net::HTTPResponse::HTTPStatus ht
     shouldRetry = false;
     switch (httpErrorCode) {
         case Poco::Net::HTTPResponse::HTTP_BAD_GATEWAY:
-        case Poco::Net::HTTPResponse::HTTP_GATEWAY_TIMEOUT:
             // Retry if the job is an uploadSession chunck job an upload job or a downalod job
             // GATEWAY error can be due to poor network connexion. Some upload chunk can fail intermidently, we want to retry
             // befor cancelling the complete upload session
             shouldRetry = dynamic_cast<UploadSessionChunkJob *>(this) != nullptr;
             return true;
+        case Poco::Net::HTTPResponse::HTTP_GATEWAY_TIMEOUT:
         case Poco::Net::HTTPResponse::HTTP_INSUFFICIENT_STORAGE:
         case Poco::Net::HTTPResponse::HTTP_LOOP_DETECTED:
         case Poco::Net::HTTPResponse::HTTP_NOT_EXTENDED:

--- a/src/libsyncengine/jobs/network/abstractnetworkjob.cpp
+++ b/src/libsyncengine/jobs/network/abstractnetworkjob.cpp
@@ -44,7 +44,6 @@
 #include <Poco/Net/HTTPRequest.h>
 #include "kDrive_API/upload/upload_session/uploadsessionchunkjob.h"
 #include "kDrive_API/upload/uploadjob.h"
-#include "kDrive_API/downloadjob.h"
 
 #define BUF_SIZE 1024
 
@@ -579,9 +578,9 @@ bool AbstractNetworkJob::isError500(const Poco::Net::HTTPResponse::HTTPStatus ht
     shouldRetry = false;
     switch (httpErrorCode) {
         case Poco::Net::HTTPResponse::HTTP_BAD_GATEWAY:
-            // Retry if the job is an uploadSession chunck job an upload job or a downalod job
-            // GATEWAY error can be due to poor network connexion. Some upload chunk can fail intermidently, we want to retry
-            // befor cancelling the complete upload session
+            // Retry only if the job is an uploadSessionChunckJob, as 502 error can be due to a GATEWAY error which can be caused
+            // by poor network connexion dropping during the upload of a big file. In this case, retrying can help to complete the
+            // upload.
             shouldRetry = dynamic_cast<UploadSessionChunkJob *>(this) != nullptr;
             return true;
         case Poco::Net::HTTPResponse::HTTP_GATEWAY_TIMEOUT:

--- a/src/libsyncengine/jobs/network/abstractnetworkjob.h
+++ b/src/libsyncengine/jobs/network/abstractnetworkjob.h
@@ -109,6 +109,7 @@ class AbstractNetworkJob : public SyncJob {
         };
 
         ExitInfo receiveResponse(const Poco::URI &uri);
+        bool isError500(const Poco::Net::HTTPResponse::HTTPStatus httpErrorCode, bool &shouldRetry);
         ExitInfo handleError(std::istream &inputStream, const Poco::URI &uri);
 
         virtual void setQueryParameters(Poco::URI &) { /* Empty by default */ }

--- a/src/libsyncengine/jobs/network/kDrive_API/upload/upload_session/abstractuploadsession.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/upload/upload_session/abstractuploadsession.cpp
@@ -128,7 +128,8 @@ void AbstractUploadSession::uploadChunkCallback(const UniqueId jobId) {
     const auto jobInfo = _ongoingChunkJobs.extract(jobId);
     if (!jobInfo.empty() && jobInfo.mapped()) {
         if (jobInfo.mapped()->hasHttpError() || !jobInfo.mapped()->exitInfo()) {
-            LOGW_WARN(_logger, L"Failed to upload chunk " << jobId << L" of file " << Path2WStr(_filePath.filename()));
+            LOGW_WARN(_logger, L"Failed to upload chunk " << jobInfo.mapped()->chunkNb() << L" of file "
+                                                          << Path2WStr(_filePath.filename()));
             _jobExecutionError = true;
             _chunkJobExitInfo = jobInfo.mapped()->exitInfo();
         }

--- a/src/libsyncengine/jobs/network/kDrive_API/upload/upload_session/uploadsessionchunkjob.h
+++ b/src/libsyncengine/jobs/network/kDrive_API/upload/upload_session/uploadsessionchunkjob.h
@@ -35,6 +35,7 @@ class UploadSessionChunkJob : public AbstractUploadSessionJob {
         const std::string &chunkHash() const { return _chunkHash; }
         UniqueId sessionJobId() const { return _sessionJobId; }
         uint64_t chunkSize() const { return _chunkSize; }
+        uint64_t chunkNb() const { return _chunkNb; }
 
     private:
         std::string getSpecificUrl() override;


### PR DESCRIPTION
### Fix: Improve handling of transient HTTP 502 errors with retry logic

HTTP 502 errors can occur due to network instability between a local proxy/VPN and our backend services.

Users with slow or unstable connections may intermittently encounter transient 502 errors. This PR improves resilience by preserving the retry mechanism specifically for these cases, reducing the likelihood of unnecessary failures caused by temporary network issues.

However, if a job exceeds the maximum allowed number of retries, a 5xx exit code will still be returned. In this case, the existing pause and exponential backoff mechanisms remain unchanged.
