### PR TITLE
fix(comm): correct return value for UTILITY_ERROR_REMOVED toString

### DIFF
--- a/src/libcommon/comm.h
+++ b/src/libcommon/comm.h
@@ -384,7 +384,7 @@ inline std::string toString(SignalNum e) {
         case SignalNum::UTILITY_ERROR_ADDED:
             return "UTILITY_ERROR_ADDED";
         case SignalNum::UTILITY_ERROR_REMOVED:
-            return "UTILITY_ERROR_ADDED";
+            return "UTILITY_ERROR_REMOVED";
         case SignalNum::UTILITY_ERRORS_CLEARED:
             return "UTILITY_ERRORS_CLEARED";
         case SignalNum::UTILITY_SHOW_SETTINGS:


### PR DESCRIPTION
fix(comm): correct return value for UTILITY_ERROR_REMOVED

Corrected the return value in the `toString(SignalNum e)` function
for the case `SignalNum::UTILITY_ERROR_REMOVED`. Previously, it
returned `"UTILITY_ERROR_ADDED"` instead of the correct value
`"UTILITY_ERROR_REMOVED"`.