### PR TITLE
refactor(appserver): defer user info update logic

### DIFF
--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -392,18 +392,19 @@ void AppServer::init() {
         connect(OldCommServer::instance().get(), &OldCommServer::clientDisconnected, this,
                 &AppServer::onClientDisconnectedReceived);
     }
+    QTimer::singleShot(0, [=, this]() {
+        // Update users,accounts and drives info.
+        if (const auto exitInfo = updateAllUsersInfo(UpdateFollowUpAction::CleanUserDbEntry);
+            exitInfo.code() == ExitCode::InvalidToken) {
+            // The user will be asked to enter its credentials later.
+        } else if (!exitInfo) {
+            LOG_WARN(_logger, "Error in updateAllUsersInfo: " << exitInfo);
+            addError(Error(ERR_ID, exitInfo.code(), exitInfo.cause()));
+        }
 
-    // Update users,accounts and drives info.
-    if (const auto exitInfo = updateAllUsersInfo(UpdateFollowUpAction::CleanUserDbEntry);
-        exitInfo.code() == ExitCode::InvalidToken) {
-        // The user will be asked to enter its credentials later.
-    } else if (!exitInfo) {
-        LOG_WARN(_logger, "Error in updateAllUsersInfo: " << exitInfo);
-        addError(Error(ERR_ID, exitInfo.code(), exitInfo.cause()));
-    }
-
-    // Set sentry user
-    updateSentryUser();
+        // Set sentry user
+        updateSentryUser();
+    });
 
     // Read Updater activation flag
     AppStateValue noUpdateAppStateValue = 0;

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -392,6 +392,9 @@ void AppServer::init() {
         connect(OldCommServer::instance().get(), &OldCommServer::clientDisconnected, this,
                 &AppServer::onClientDisconnectedReceived);
     }
+
+    // Set sentry user
+    updateSentryUser();
     QTimer::singleShot(0, this, [this]() {
         // Update users,accounts and drives info.
         if (const auto exitInfo = updateAllUsersInfo(UpdateFollowUpAction::CleanUserDbEntry);
@@ -402,7 +405,7 @@ void AppServer::init() {
             addError(Error(ERR_ID, exitInfo.code(), exitInfo.cause()));
         }
 
-        // Set sentry user
+        // refresh sentry user
         updateSentryUser();
     });
 

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -392,7 +392,7 @@ void AppServer::init() {
         connect(OldCommServer::instance().get(), &OldCommServer::clientDisconnected, this,
                 &AppServer::onClientDisconnectedReceived);
     }
-    QTimer::singleShot(0, [=, this]() {
+    QTimer::singleShot(0, this, [this]() {
         // Update users,accounts and drives info.
         if (const auto exitInfo = updateAllUsersInfo(UpdateFollowUpAction::CleanUserDbEntry);
             exitInfo.code() == ExitCode::InvalidToken) {
@@ -481,7 +481,7 @@ void AppServer::init() {
 
     // Start syncs
     LOG_DEBUG(_logger, "Start syncs");
-    QTimer::singleShot(0, [=, this]() { startSyncsAndRetryOnError(); });
+    QTimer::singleShot(0, this, [this]() { startSyncsAndRetryOnError(); });
 
     // Init JobManager(s)
     if (!GuiJobManagerSingleton::instance()) {


### PR DESCRIPTION
Encapsulated the user info update (`updateAllUsersInfo`) and Sentry user update (`updateSentryUser`) in a `QTimer::singleShot` with a 0ms delay. This ensures the logic is executed after returning to the main event loop, improving client startup time.