### PR TITLE
refactor(comm): Remove LegacyCommPort and improve comm handling

### DIFF
--- a/.github/actions/build_windows/action.yml
+++ b/.github/actions/build_windows/action.yml
@@ -137,7 +137,7 @@ runs:
           if ("${{ inputs.release_build }}" -eq "true") {
 
             if ("${{ inputs.build_new_client }}" -eq "true") {
-              & $script -thumbprint $thumbprint -ci -ext -msi -clean remake -upload -newGui $true
+              & $script -thumbprint $thumbprint -ci -ext -clean remake -upload -newGui $true # The new gui does not yet support msi generation, so we skip it for now
             }
             else {
               & $script -thumbprint $thumbprint -ci -ext -msi -clean remake -upload

--- a/.github/actions/build_windows/action.yml
+++ b/.github/actions/build_windows/action.yml
@@ -346,6 +346,7 @@ runs:
           $outDir = "${{ github.workspace }}/build-windows/sentry-client-artifacts"
           New-Item -ItemType Directory -Force -Path $outDir | Out-Null
 
+          Write-Host "PDB path: '$pdbFile'"
           .\sentry-cli debug-files bundle-sources $pdbFile
 
           Move-Item -Path $srcZip `

--- a/.github/actions/build_windows/action.yml
+++ b/.github/actions/build_windows/action.yml
@@ -334,7 +334,7 @@ runs:
         if: ${{ steps.build.outcome == 'success' && inputs.release_build == 'true' }}
         run: |
           if ("${{ inputs.build_new_client }}" -eq "true") {
-            $binDir = "${{ github.workspace }}/build-windows/build/bin/client"
+            $binDir = "${{ github.workspace }}/build-windows/install/bin/client"
             $pdbFile = "$binDir/kDrive.pdb"
             $srcZip  = "$binDir/kDrive.src.zip"
           } else {

--- a/.github/actions/build_windows/action.yml
+++ b/.github/actions/build_windows/action.yml
@@ -329,14 +329,30 @@ runs:
         shell: powershell
         if: ${{ steps.build.outcome == 'success' && inputs.release_build == 'true' }}
 
-      - name : Create sentry client artifacts
-        run: |
-          .\sentry-cli debug-files bundle-sources ${{ github.workspace }}/build-windows/build/bin/kDrive_client.pdb
-          mkdir ${{ github.workspace }}/build-windows/sentry-client-artifacts
-          Move-Item -Path ${{ github.workspace }}/build-windows/build/bin/kDrive_client.src.zip -Destination ${{ github.workspace }}/build-windows/sentry-client-artifacts/kDrive_client.src.zip
-          Move-Item -Path ${{ github.workspace }}/build-windows/build/bin/kDrive_client.pdb -Destination ${{ github.workspace }}/build-windows/sentry-client-artifacts/kDrive_client.pdb
+      - name: Create sentry client artifacts
         shell: powershell
         if: ${{ steps.build.outcome == 'success' && inputs.release_build == 'true' }}
+        run: |
+          if ("${{ inputs.build_new_client }}" -eq "true") {
+            $binDir = "${{ github.workspace }}/build-windows/build/bin/client"
+            $pdbFile = "$binDir/kDrive.pdb"
+            $srcZip  = "$binDir/kDrive.src.zip"
+          } else {
+            $binDir = "${{ github.workspace }}/build-windows/build/bin"
+            $pdbFile = "$binDir/kDrive_client.pdb"
+            $srcZip  = "$binDir/kDrive_client.src.zip"
+          }
+
+          $outDir = "${{ github.workspace }}/build-windows/sentry-client-artifacts"
+          New-Item -ItemType Directory -Force -Path $outDir | Out-Null
+
+          .\sentry-cli debug-files bundle-sources $pdbFile
+
+          Move-Item -Path $srcZip `
+                    -Destination "$outDir/kDrive_client.src.zip"
+
+          Move-Item -Path $pdbFile `
+                    -Destination "$outDir/kDrive_client.pdb"
 
       - name: Upload sentry server artifacts
         uses: actions/upload-artifact@v7.0.1

--- a/.github/actions/build_windows/action.yml
+++ b/.github/actions/build_windows/action.yml
@@ -329,31 +329,20 @@ runs:
         shell: powershell
         if: ${{ steps.build.outcome == 'success' && inputs.release_build == 'true' }}
 
-      - name: Create sentry client artifacts
+      - name : Create sentry client artifacts
+        run: |
+          mkdir ${{ github.workspace }}/build-windows/sentry-client-artifacts
+
+          if ("${{ inputs.build_new_client }}" -eq "true") {
+            Write-Host "New client build - source are embedded in the pdb, skipping source bundle creation."
+            Move-Item -Path ${{ github.workspace }}/build-windows/build/bin/client/kDrive.pdb -Destination ${{ github.workspace }}/build-windows/sentry-client-artifacts/kDrive_client.pdb
+          } else {
+            .\sentry-cli debug-files bundle-sources ${{ github.workspace }}/build-windows/build/bin/kDrive_client.pdb
+            Move-Item -Path ${{ github.workspace }}/build-windows/build/bin/kDrive_client.src.zip -Destination ${{ github.workspace }}/build-windows/sentry-client-artifacts/kDrive_client.src.zip
+            Move-Item -Path ${{ github.workspace }}/build-windows/build/bin/kDrive_client.pdb -Destination ${{ github.workspace }}/build-windows/sentry-client-artifacts/kDrive_client.pdb
+          }
         shell: powershell
         if: ${{ steps.build.outcome == 'success' && inputs.release_build == 'true' }}
-        run: |
-          if ("${{ inputs.build_new_client }}" -eq "true") {
-            $binDir = "${{ github.workspace }}/build-windows/install/bin/client"
-            $pdbFile = "$binDir/kDrive.pdb"
-            $srcZip  = "$binDir/kDrive.src.zip"
-          } else {
-            $binDir = "${{ github.workspace }}/build-windows/build/bin"
-            $pdbFile = "$binDir/kDrive_client.pdb"
-            $srcZip  = "$binDir/kDrive_client.src.zip"
-          }
-
-          $outDir = "${{ github.workspace }}/build-windows/sentry-client-artifacts"
-          New-Item -ItemType Directory -Force -Path $outDir | Out-Null
-
-          Write-Host "PDB path: '$pdbFile'"
-          .\sentry-cli debug-files bundle-sources $pdbFile
-
-          Move-Item -Path $srcZip `
-                    -Destination "$outDir/kDrive_client.src.zip"
-
-          Move-Item -Path $pdbFile `
-                    -Destination "$outDir/kDrive_client.pdb"
 
       - name: Upload sentry server artifacts
         uses: actions/upload-artifact@v7.0.1

--- a/.github/workflows/kdrive-desktop-release.yml
+++ b/.github/workflows/kdrive-desktop-release.yml
@@ -273,10 +273,16 @@ jobs:
 
       - name : Upload sentry artifacts - Windows
         run: |
-          .\sentry-cli.exe debug-files upload --project kdrive-server .\build-windows\kDrive.pdb
-          .\sentry-cli.exe debug-files upload --project kdrive-client .\build-windows\kDrive_client.pdb
+          .\sentry-cli.exe debug-files upload --project kdrive-server .\build-windows\kDrive.pdb 
           .\sentry-cli.exe debug-files upload --project kdrive-server --type sourcebundle .\build-windows\kDrive.src.zip
-          .\sentry-cli.exe debug-files upload --project kdrive-client --type sourcebundle .\build-windows\kDrive_client.src.zip
+          
+          if ("${{ inputs.build_windows }}" -eq "New client") {
+            .\sentry-cli.exe debug-files upload --project kdrive-win-client .\build-windows\kDrive_client.pdb
+          } else {
+            .\sentry-cli.exe debug-files upload --project kdrive-client .\build-windows\kDrive_client.pdb
+            .\sentry-cli.exe debug-files upload --project kdrive-client --type sourcebundle .\build-windows\kDrive_client.src.zip          
+          }
+
         shell: powershell
 
   upload-to-kDrive-and-sentry-Linux-amd:

--- a/infomaniak-build-tools/upload-release-to-kDrive.ps1
+++ b/infomaniak-build-tools/upload-release-to-kDrive.ps1
@@ -111,35 +111,56 @@ function Upload-FilesToKDrive {
     )
 
     Push-Location $directory
-    foreach ($file in $files) {
+    foreach ($fileEntry in $files) {
+        $file = $fileEntry
+        $isMandatory = $true
+
+        if ($fileEntry -is [array]) {
+            $file = [string]$fileEntry[0]
+            if ($fileEntry.Count -ge 2) {
+                $isMandatory = [bool]$fileEntry[1]
+            }
+        }
+
         try {
+            if (-not (Test-Path $file)) {
+                $message = if ($isMandatory) { "❌ File $file does not exist, aborting upload." } else { "⚠ Optional file $file does not exist, skipping upload." }
+                $color = if ($isMandatory) { 'Red' } else { 'Yellow' }
+                Write-Host $message -f $color
+                if ($isMandatory) {
+                    Pop-Location
+                    exit 1
+                }
+                continue
+            }
+
             $item = Get-Item $file
 
             # Check if it is a directory (zip it if needed)
             if ($item.PSIsContainer) {
               Write-Host "Zipping directory: $file" -f Yellow
 
-             # Define the ZIP file path: same parent location, same name + .zip
-             $parentDir = Split-Path $item.FullName -Parent
-             $zipFileName = "$($item.Name).zip"
-             $zipFilePath = Join-Path $parentDir $zipFileName
+              # Define the ZIP file path: same parent location, same name + .zip
+              $parentDir = Split-Path $item.FullName -Parent
+              $zipFileName = "$($item.Name).zip"
+              $zipFilePath = Join-Path $parentDir $zipFileName
 
-             # Remove existing zip if present
-             if (Test-Path $zipFilePath) {
-                    Remove-Item $zipFilePath -Force
-                 Write-Host "Existing zip removed: $zipFilePath" -f Cyan
-              }
+              # Remove existing zip if present
+              if (Test-Path $zipFilePath) {
+                     Remove-Item $zipFilePath -Force
+                  Write-Host "Existing zip removed: $zipFilePath" -f Cyan
+               }
 
-              # Load .NET Compression assembly
-               Add-Type -AssemblyName System.IO.Compression.FileSystem
+               # Load .NET Compression assembly
+                Add-Type -AssemblyName System.IO.Compression.FileSystem
             
-               # Create ZIP archive beside the folder
-               [System.IO.Compression.ZipFile]::CreateFromDirectory($item.FullName, $zipFilePath)
+                # Create ZIP archive beside the folder
+                [System.IO.Compression.ZipFile]::CreateFromDirectory($item.FullName, $zipFilePath)
             
-               # Replace $file with the zipped file for upload
-                $file = $zipFileName            
-               Write-Host "Directory zipped: $zipFilePath" -f Green
-            }    
+                # Replace $file with the zipped file for upload
+                 $file = $zipFileName            
+                Write-Host "Directory zipped: $zipFilePath" -f Green
+            }
 
             $size = (Get-Item $file).length
             if ($size -eq 0) {
@@ -158,9 +179,13 @@ function Upload-FilesToKDrive {
             Invoke-RestMethod -Method "POST" -Uri $uri -Header $headers -ContentType 'application/octet-stream' -InFile $file
             Write-Host "\t\t => ✅" -f Green
         } catch {
-            Write-Host "Failed to upload $file to kDrive -> $_" -f Red
-            Pop-Location
-            exit 1
+            if ($isMandatory) {
+                Write-Host "Failed to upload $file to kDrive -> $_" -f Red
+                Pop-Location
+                exit 1
+            }
+
+            Write-Host "Warning: failed to upload optional file $file to kDrive -> $_" -f Yellow
         }
         Sleep(5)
     }
@@ -170,13 +195,13 @@ function Upload-FilesToKDrive {
 if ($os -eq "win") {
     Write-Host " - Windows Files - " # Windows
     $win_files = @(
-        "$app.exe",
-        "$app.exe.sha256",
-        "$app.msi",
-        "kDrive.pdb",
-        "kDrive_client.pdb",
-        "kDrive.src.zip",
-        "kDrive_client.src.zip"
+        @("$app.exe", $true),
+        @("$app.exe.sha256", $true),
+        @("$app.msi", $false),
+        @("kDrive.pdb", $true),
+        @("kDrive_client.pdb", $true),
+        @("kDrive.src.zip", $true),
+        @("kDrive_client.src.zip", $false)
     )
     Upload-FilesToKDrive -directory build-windows -files $win_files -targetSubDir "windows"
     Write-Host " - Windows Files - \n"
@@ -185,14 +210,14 @@ if ($os -eq "win") {
 if ($os -eq "macos") {
     Write-Host " - macOS Files - " # macOS
     $macos_files = @(
-        "$app.pkg",
-        "$app.pkg.sha256",
-        "$app.zip", # Sparkle zip
-        "update-macos-$version.xml", # Sparkle update xml
-        "kDrive.dSYM",
-        "kDrive_client.dSYM",
-        "kDrive.src.zip",
-        "kDrive_client.src.zip"
+        @("$app.pkg", $true),
+        @("$app.pkg.sha256", $true),
+        @("$app.zip", $true), # Sparkle zip
+        @("update-macos-$version.xml", $true), # Sparkle update xml
+        @("kDrive.dSYM", $true),
+        @("kDrive_client.dSYM", $true),
+        @("kDrive.src.zip", $true),
+        @("kDrive_client.src.zip", $true)
     )
     Upload-FilesToKDrive -directory build-macos -files $macos_files -targetSubDir "macos"
     Write-Host " - macOS Files - \n"
@@ -201,12 +226,12 @@ if ($os -eq "macos") {
 if ($os -eq "linux-amd") {
     Write-Host " - Linux AMD64 Files - " # Linux AMD
     $linux_amd_files = @(
-        "$app-amd64.AppImage",
-        "$app-amd64.AppImage.sha256",
-        "kDrive.dbg",
-        "kDrive_client.dbg",
-        "kDrive.src.zip",
-        "kDrive_client.src.zip"
+        @("$app-amd64.AppImage", $true),
+        @("$app-amd64.AppImage.sha256", $true),
+        @("kDrive.dbg", $true),
+        @("kDrive_client.dbg", $true),
+        @("kDrive.src.zip", $true),
+        @("kDrive_client.src.zip", $true)
     )
     Upload-FilesToKDrive -directory build-linux-amd64 -files $linux_amd_files -targetSubDir "linux-amd"
     Write-Host " - Linux AMD64 Files - \n"
@@ -215,12 +240,12 @@ if ($os -eq "linux-amd") {
 if ($os -eq "linux-arm") {
     Write-Host " - Linux ARM64 Files - " # Linux ARM
     $linux_arm_files = @(
-        "$app-arm64.AppImage",
-        "$app-arm64.AppImage.sha256",
-        "kDrive.dbg",
-        "kDrive_client.dbg",
-        "kDrive.src.zip",
-        "kDrive_client.src.zip"
+        @("$app-arm64.AppImage", $true),
+        @("$app-arm64.AppImage.sha256", $true),
+        @("kDrive.dbg", $true),
+        @("kDrive_client.dbg", $true),
+        @("kDrive.src.zip", $true),
+        @("kDrive_client.src.zip", $true)
     )
     Upload-FilesToKDrive -directory build-linux-arm64 -files $linux_arm_files -targetSubDir "linux-arm"
     Write-Host " - Linux ARM64 Files - \n"

--- a/src/gui4/windows/kDrive client/kDrive client.Tests/FakeSocketServer.cs
+++ b/src/gui4/windows/kDrive client/kDrive client.Tests/FakeSocketServer.cs
@@ -22,16 +22,6 @@ internal sealed class FakeSocketServer : IAsyncDisposable
         _acceptTask = _listener.AcceptSocketAsync(_acceptCts.Token).AsTask();
     }
 
-    public async Task WriteCommFileAsync(string commFilePath)
-    {
-        var dir = Path.GetDirectoryName(commFilePath);
-        if (!string.IsNullOrEmpty(dir))
-        {
-            Directory.CreateDirectory(dir);
-        }
-
-        await File.WriteAllTextAsync(commFilePath, Port.ToString());
-    }
 
     public async Task<Socket> WaitForClientAsync(TimeSpan? timeout = null)
     {

--- a/src/gui4/windows/kDrive client/kDrive client.Tests/SocketServerCommProtocolTests.cs
+++ b/src/gui4/windows/kDrive client/kDrive client.Tests/SocketServerCommProtocolTests.cs
@@ -480,7 +480,7 @@ public class SocketServerCommProtocolTests
         var method = typeof(SocketServerCommProtocol).GetMethod("TryParseServerPortFromArguments", _staticPrivate)
                      ?? throw new InvalidOperationException("Failed to find TryParseServerPortFromArguments method.");
 
-        object?[] parameters = [arguments, 0, string.Empty];
+        object?[] parameters = new object?[] { arguments, 0, string.Empty };
         object? invokeResult = method.Invoke(null, parameters);
         bool success = invokeResult as bool? ??
                        throw new InvalidOperationException("TryParseServerPortFromArguments returned null.");

--- a/src/gui4/windows/kDrive client/kDrive client.Tests/SocketServerCommProtocolTests.cs
+++ b/src/gui4/windows/kDrive client/kDrive client.Tests/SocketServerCommProtocolTests.cs
@@ -12,6 +12,43 @@ namespace Infomaniak.kDrive.Tests;
 public class SocketServerCommProtocolTests
 {
     private static readonly BindingFlags _instancePrivate = BindingFlags.Instance | BindingFlags.NonPublic;
+    private static readonly BindingFlags _staticPrivate = BindingFlags.Static | BindingFlags.NonPublic;
+
+    [Fact]
+    public void TryParseServerPortFromArguments_ReturnsFalse_WhenArgumentIsMissing()
+    {
+        var arguments = new[] { "kDrive client.exe" };
+
+        bool success = TryParseServerPortFromArguments(arguments, out int port, out string errorMessage);
+
+        Assert.False(success);
+        Assert.Equal(0, port);
+        Assert.Equal("No commPort provided", errorMessage);
+    }
+
+    [Fact]
+    public void TryParseServerPortFromArguments_ReturnsFalse_WhenArgumentIsInvalid()
+    {
+        var arguments = new[] { "kDrive client.exe", "invalid-port" };
+
+        bool success = TryParseServerPortFromArguments(arguments, out int port, out string errorMessage);
+
+        Assert.False(success);
+        Assert.Equal(0, port);
+        Assert.Equal("Invalid commPort provided: invalid-port", errorMessage);
+    }
+
+    [Fact]
+    public void TryParseServerPortFromArguments_ReturnsTrue_WhenArgumentIsValid()
+    {
+        var arguments = new[] { "kDrive client.exe", "4242" };
+
+        bool success = TryParseServerPortFromArguments(arguments, out int port, out string errorMessage);
+
+        Assert.True(success);
+        Assert.Equal(4242, port);
+        Assert.Equal(string.Empty, errorMessage);
+    }
 
     [Fact]
     public async Task InitConnection_ReturnsFalse_WhenServerUnavailableAndCancelled()
@@ -436,5 +473,21 @@ public class SocketServerCommProtocolTests
         var completed = await Task.WhenAny(task, Task.Delay(timeout));
         Assert.True(completed == task, "Operation timed out.");
         return await task;
+    }
+
+    private static bool TryParseServerPortFromArguments(string[] arguments, out int port, out string errorMessage)
+    {
+        var method = typeof(SocketServerCommProtocol).GetMethod("TryParseServerPortFromArguments", _staticPrivate)
+                     ?? throw new InvalidOperationException("Failed to find TryParseServerPortFromArguments method.");
+
+        object?[] parameters = [arguments, 0, string.Empty];
+        object? invokeResult = method.Invoke(null, parameters);
+        bool success = invokeResult as bool? ??
+                       throw new InvalidOperationException("TryParseServerPortFromArguments returned null.");
+        port = parameters[1] as int? ??
+               throw new InvalidOperationException("Parsed port output is null.");
+        errorMessage = parameters[2] as string ??
+                       throw new InvalidOperationException("Parsed error message output is null.");
+        return success;
     }
 }

--- a/src/gui4/windows/kDrive client/kDrive client.Tests/SocketServerCommProtocolTests.cs
+++ b/src/gui4/windows/kDrive client/kDrive client.Tests/SocketServerCommProtocolTests.cs
@@ -4,14 +4,14 @@ using System.Net.Sockets;
 using System.Reflection;
 using System.Text;
 using System.Text.Json.Nodes;
-using static Infomaniak.kDrive.ServerCommunication.Interfaces.IServerCommProtocol;
+using static Infomaniak.kDrive.ServerCommunication.Interfaces.IServerCommClient;
 
 namespace Infomaniak.kDrive.Tests;
 
-public class MockSocketServer : SocketServerCommProtocol
+public class MockTcpServerCommClient : TcpServerCommClient
 {
     private int _port;
-    public MockSocketServer(int port)
+    public MockTcpServerCommClient(int port)
     {
         _port = port;
     }
@@ -22,7 +22,7 @@ public class MockSocketServer : SocketServerCommProtocol
     }
 }
 
-public class SocketServerCommProtocolTests
+public class TcpServerCommClientTests
 {
     private static readonly BindingFlags _instancePrivate = BindingFlags.Instance | BindingFlags.NonPublic;
     private static readonly BindingFlags _staticPrivate = BindingFlags.Static | BindingFlags.NonPublic;
@@ -66,7 +66,7 @@ public class SocketServerCommProtocolTests
     [Fact]
     public async Task InitConnection_ReturnsFalse_WhenServerUnavailableAndCancelled()
     {
-        var protocol = new MockSocketServer(65530);
+        var protocol = new MockTcpServerCommClient(65530);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(800));
         bool connected = await protocol.InitConnection(cts.Token);
@@ -80,7 +80,7 @@ public class SocketServerCommProtocolTests
     {
         await using var server = new FakeSocketServer();
 
-        var protocol = new MockSocketServer(server.Port);
+        var protocol = new MockTcpServerCommClient(server.Port);
         var connectionLost = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         protocol.ConnectionLost += (_, _) => connectionLost.TrySetResult();
 
@@ -99,7 +99,7 @@ public class SocketServerCommProtocolTests
     {
         await using var server = new FakeSocketServer();
 
-        var protocol = new MockSocketServer(server.Port);
+        var protocol = new MockTcpServerCommClient(server.Port);
         using var initCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         Assert.True(await protocol.InitConnection(initCts.Token));
         await server.WaitForClientAsync();
@@ -130,7 +130,7 @@ public class SocketServerCommProtocolTests
     public async Task SendRequestAsync_HandlesHighFrequencyConsecutiveMessages()
     {
         await using var server = new FakeSocketServer();
-        var protocol = new MockSocketServer(server.Port);
+        var protocol = new MockTcpServerCommClient(server.Port);
 
         using var initCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         Assert.True(await protocol.InitConnection(initCts.Token));
@@ -168,7 +168,7 @@ public class SocketServerCommProtocolTests
     {
         await using var server = new FakeSocketServer();
 
-        var protocol = new MockSocketServer(server.Port);
+        var protocol = new MockTcpServerCommClient(server.Port);
         using var initCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         Assert.True(await protocol.InitConnection(initCts.Token));
         await server.WaitForClientAsync();
@@ -214,7 +214,7 @@ public class SocketServerCommProtocolTests
     {
         await using var server = new FakeSocketServer();
 
-        var protocol = new MockSocketServer(server.Port);
+        var protocol = new MockTcpServerCommClient(server.Port);
         using var initCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         Assert.True(await protocol.InitConnection(initCts.Token));
         await server.WaitForClientAsync();
@@ -250,7 +250,7 @@ public class SocketServerCommProtocolTests
     {
         await using var server = new FakeSocketServer();
 
-        var protocol = new MockSocketServer(server.Port);
+        var protocol = new MockTcpServerCommClient(server.Port);
         using var initCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         Assert.True(await protocol.InitConnection(initCts.Token));
         await server.WaitForClientAsync();
@@ -285,7 +285,7 @@ public class SocketServerCommProtocolTests
     {
         await using var server = new FakeSocketServer();
 
-        var protocol = new MockSocketServer(server.Port);
+        var protocol = new MockTcpServerCommClient(server.Port);
         var lost = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         protocol.ConnectionLost += (_, _) => lost.TrySetResult();
 
@@ -304,7 +304,7 @@ public class SocketServerCommProtocolTests
     {
         await using var server = new FakeSocketServer();
 
-        var protocol = new MockSocketServer(server.Port);
+        var protocol = new MockTcpServerCommClient(server.Port);
         using var initCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         Assert.True(await protocol.InitConnection(initCts.Token));
         await server.WaitForClientAsync();
@@ -326,7 +326,7 @@ public class SocketServerCommProtocolTests
         for (int i = 0; i < 10; i++)
         {
             await using var server = new FakeSocketServer();
-            var protocol = new MockSocketServer(server.Port);
+            var protocol = new MockTcpServerCommClient(server.Port);
 
             var lost = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             protocol.ConnectionLost += (_, _) => lost.TrySetResult();
@@ -341,17 +341,17 @@ public class SocketServerCommProtocolTests
         }
     }
 
-    private static async Task ShutdownProtocolAsync(SocketServerCommProtocol protocol)
+    private static async Task ShutdownProtocolAsync(TcpServerCommClient protocol)
     {
-        var stopField = typeof(SocketServerCommProtocol).GetField("_stopRequested", _instancePrivate)
+        var stopField = typeof(TcpServerCommClient).GetField("_stopRequested", _instancePrivate)
                         ?? throw new InvalidOperationException("Failed to find _stopRequested field.");
         stopField.SetValue(protocol, true);
 
-        var socketField = typeof(SocketServerCommProtocol).GetField("_socket", _instancePrivate)
+        var socketField = typeof(TcpServerCommClient).GetField("_socket", _instancePrivate)
                           ?? throw new InvalidOperationException("Failed to find _socket field.");
         (socketField.GetValue(protocol) as Socket)?.Dispose();
 
-        var pollingTaskField = typeof(SocketServerCommProtocol).GetField("_pollingTask", _instancePrivate)
+        var pollingTaskField = typeof(TcpServerCommClient).GetField("_pollingTask", _instancePrivate)
                                ?? throw new InvalidOperationException("Failed to find _pollingTask field.");
 
         if (pollingTaskField.GetValue(protocol) is Task pollingTask)
@@ -376,7 +376,7 @@ public class SocketServerCommProtocolTests
 
     private static bool TryParseServerPortFromArguments(string[] arguments, out int port, out string errorMessage)
     {
-        var method = typeof(SocketServerCommProtocol).GetMethod("TryParseServerPortFromArguments", _staticPrivate)
+        var method = typeof(TcpServerCommClient).GetMethod("TryParseServerPortFromArguments", _staticPrivate)
                      ?? throw new InvalidOperationException("Failed to find TryParseServerPortFromArguments method.");
 
         object?[] parameters = new object?[] { arguments, 0, string.Empty };

--- a/src/gui4/windows/kDrive client/kDrive client.Tests/SocketServerCommProtocolTests.cs
+++ b/src/gui4/windows/kDrive client/kDrive client.Tests/SocketServerCommProtocolTests.cs
@@ -1,4 +1,3 @@
-using Infomaniak.kDrive.ServerCommunication.Interfaces;
 using Infomaniak.kDrive.ServerCommunication.Services;
 using Infomaniak.kDrive.Types;
 using System.Net.Sockets;
@@ -8,6 +7,20 @@ using System.Text.Json.Nodes;
 using static Infomaniak.kDrive.ServerCommunication.Interfaces.IServerCommProtocol;
 
 namespace Infomaniak.kDrive.Tests;
+
+public class MockSocketServer : SocketServerCommProtocol
+{
+    private int _port;
+    public MockSocketServer(int port)
+    {
+        _port = port;
+    }
+
+    protected override int? GetServerPort()
+    {
+        return _port;
+    }
+}
 
 public class SocketServerCommProtocolTests
 {
@@ -53,9 +66,7 @@ public class SocketServerCommProtocolTests
     [Fact]
     public async Task InitConnection_ReturnsFalse_WhenServerUnavailableAndCancelled()
     {
-        string commPath = CreateCommFilePath();
-        await File.WriteAllTextAsync(commPath, "65530");
-        var protocol = CreateProtocol(commPath);
+        var protocol = new MockSocketServer(65530);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(800));
         bool connected = await protocol.InitConnection(cts.Token);
@@ -65,31 +76,11 @@ public class SocketServerCommProtocolTests
     }
 
     [Fact]
-    public async Task InitConnection_EventuallyConnects_WhenServerStartsLater()
-    {
-        string commPath = CreateCommFilePath();
-        var protocol = CreateProtocol(commPath);
-        await using var server = new FakeSocketServer();
-
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        Task<bool> initTask = protocol.InitConnection(cts.Token);
-
-        await Task.Delay(250);
-        await server.WriteCommFileAsync(commPath);
-
-        Assert.True(await initTask);
-        await server.WaitForClientAsync();
-        await ShutdownProtocolAsync(protocol);
-    }
-
-    [Fact]
     public async Task ConnectionLost_Raised_WhenServerClosesConnection()
     {
-        string commPath = CreateCommFilePath();
         await using var server = new FakeSocketServer();
-        await server.WriteCommFileAsync(commPath);
 
-        var protocol = CreateProtocol(commPath);
+        var protocol = new MockSocketServer(server.Port);
         var connectionLost = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         protocol.ConnectionLost += (_, _) => connectionLost.TrySetResult();
 
@@ -106,11 +97,9 @@ public class SocketServerCommProtocolTests
     [Fact]
     public async Task SendRequestAsync_ReturnsResponse_ForSuccessfulRoundtrip()
     {
-        string commPath = CreateCommFilePath();
         await using var server = new FakeSocketServer();
-        await server.WriteCommFileAsync(commPath);
 
-        var protocol = CreateProtocol(commPath);
+        var protocol = new MockSocketServer(server.Port);
         using var initCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         Assert.True(await protocol.InitConnection(initCts.Token));
         await server.WaitForClientAsync();
@@ -140,11 +129,9 @@ public class SocketServerCommProtocolTests
     [Fact]
     public async Task SendRequestAsync_HandlesHighFrequencyConsecutiveMessages()
     {
-        string commPath = CreateCommFilePath();
         await using var server = new FakeSocketServer();
-        await server.WriteCommFileAsync(commPath);
+        var protocol = new MockSocketServer(server.Port);
 
-        var protocol = CreateProtocol(commPath);
         using var initCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         Assert.True(await protocol.InitConnection(initCts.Token));
         await server.WaitForClientAsync();
@@ -179,11 +166,9 @@ public class SocketServerCommProtocolTests
     [Fact]
     public async Task SignalHandling_ParsesMultipleMessagesInSinglePacket()
     {
-        string commPath = CreateCommFilePath();
         await using var server = new FakeSocketServer();
-        await server.WriteCommFileAsync(commPath);
 
-        var protocol = CreateProtocol(commPath);
+        var protocol = new MockSocketServer(server.Port);
         using var initCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         Assert.True(await protocol.InitConnection(initCts.Token));
         await server.WaitForClientAsync();
@@ -227,11 +212,9 @@ public class SocketServerCommProtocolTests
     [Fact]
     public async Task SignalHandling_ParsesFragmentedMessageAcrossArbitraryChunks_WithMultibyteCharacters()
     {
-        string commPath = CreateCommFilePath();
         await using var server = new FakeSocketServer();
-        await server.WriteCommFileAsync(commPath);
 
-        var protocol = CreateProtocol(commPath);
+        var protocol = new MockSocketServer(server.Port);
         using var initCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         Assert.True(await protocol.InitConnection(initCts.Token));
         await server.WaitForClientAsync();
@@ -265,11 +248,9 @@ public class SocketServerCommProtocolTests
     [Fact]
     public async Task SignalHandling_ParsesLargeMessagesBeyondReceiveBuffer()
     {
-        string commPath = CreateCommFilePath();
         await using var server = new FakeSocketServer();
-        await server.WriteCommFileAsync(commPath);
 
-        var protocol = CreateProtocol(commPath);
+        var protocol = new MockSocketServer(server.Port);
         using var initCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         Assert.True(await protocol.InitConnection(initCts.Token));
         await server.WaitForClientAsync();
@@ -302,11 +283,9 @@ public class SocketServerCommProtocolTests
     [Fact]
     public async Task ConnectionLost_Raised_WhenPayloadIsMalformed()
     {
-        string commPath = CreateCommFilePath();
         await using var server = new FakeSocketServer();
-        await server.WriteCommFileAsync(commPath);
 
-        var protocol = CreateProtocol(commPath);
+        var protocol = new MockSocketServer(server.Port);
         var lost = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         protocol.ConnectionLost += (_, _) => lost.TrySetResult();
 
@@ -323,11 +302,9 @@ public class SocketServerCommProtocolTests
     [Fact]
     public async Task SendRequestAsync_ReturnsDefault_WhenCancelledWhileWaitingForReply()
     {
-        string commPath = CreateCommFilePath();
         await using var server = new FakeSocketServer();
-        await server.WriteCommFileAsync(commPath);
 
-        var protocol = CreateProtocol(commPath);
+        var protocol = new MockSocketServer(server.Port);
         using var initCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         Assert.True(await protocol.InitConnection(initCts.Token));
         await server.WaitForClientAsync();
@@ -342,76 +319,14 @@ public class SocketServerCommProtocolTests
         await ShutdownProtocolAsync(protocol);
     }
 
-    [Fact]
-    public async Task MultipleInstances_CanCommunicateConcurrently()
-    {
-        var servers = new List<FakeSocketServer>();
-        var protocols = new List<SocketServerCommProtocol>();
-
-        try
-        {
-            for (int i = 0; i < 3; i++)
-            {
-                var server = new FakeSocketServer();
-                servers.Add(server);
-
-                string commPath = CreateCommFilePath();
-                await server.WriteCommFileAsync(commPath);
-                var protocol = CreateProtocol(commPath);
-                protocols.Add(protocol);
-
-                using var initCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-                Assert.True(await protocol.InitConnection(initCts.Token));
-                await server.WaitForClientAsync();
-            }
-
-            var tasks = protocols.Select((protocol, index) => Task.Run(async () =>
-            {
-                var requestTask = servers[index].ReceiveJsonAsync();
-                var responseTask = Task.Run(async () =>
-                {
-                    JsonObject request = await requestTask;
-                    var response = new JsonObject
-                    {
-                        ["type"] = (int)CommMessageType.Request,
-                        ["id"] = request["id"]!.GetValue<int>(),
-                        ["num"] = request["num"]!.GetValue<int>(),
-                        ["params"] = new JsonObject { ["instance"] = index }
-                    };
-                    await servers[index].SendJsonAsync(response);
-                });
-
-                var result = await protocol.SendRequestAsync(RequestNum.UTILITY_GET_APPSTATE, new JsonObject());
-                await responseTask;
-                return result.Params["instance"]?.GetValue<int>();
-            }));
-
-            int?[] values = await Task.WhenAll(tasks);
-            Assert.Equal([0, 1, 2], values);
-        }
-        finally
-        {
-            foreach (var protocol in protocols)
-            {
-                await ShutdownProtocolAsync(protocol);
-            }
-
-            foreach (var server in servers)
-            {
-                await server.DisposeAsync();
-            }
-        }
-    }
 
     [Fact]
     public async Task RapidConnectDisconnectCycles_RemainStable()
     {
         for (int i = 0; i < 10; i++)
         {
-            string commPath = CreateCommFilePath();
             await using var server = new FakeSocketServer();
-            await server.WriteCommFileAsync(commPath);
-            var protocol = CreateProtocol(commPath);
+            var protocol = new MockSocketServer(server.Port);
 
             var lost = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             protocol.ConnectionLost += (_, _) => lost.TrySetResult();
@@ -424,22 +339,6 @@ public class SocketServerCommProtocolTests
             await WaitAsync(lost.Task, TimeSpan.FromSeconds(5));
             await ShutdownProtocolAsync(protocol);
         }
-    }
-
-    private static SocketServerCommProtocol CreateProtocol(string commPath)
-    {
-        var protocol = new SocketServerCommProtocol();
-        var field = typeof(SocketServerCommProtocol).GetField("_commPortFilePath", _instancePrivate)
-                    ?? throw new InvalidOperationException("Failed to find _commPortFilePath field.");
-        field.SetValue(protocol, commPath);
-        return protocol;
-    }
-
-    private static string CreateCommFilePath()
-    {
-        string dir = Path.Combine(Path.GetTempPath(), "kdrive-socket-tests", Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(dir);
-        return Path.Combine(dir, ".comm");
     }
 
     private static async Task ShutdownProtocolAsync(SocketServerCommProtocol protocol)

--- a/src/gui4/windows/kDrive client/kDrive client.Tests/kDrive client.Tests.csproj
+++ b/src/gui4/windows/kDrive client/kDrive client.Tests/kDrive client.Tests.csproj
@@ -21,8 +21,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\kDrive client\ServerCommunication\Interfaces\IServerCommProtocol.cs" Link="ServerCommunication\Interfaces\IServerCommProtocol.cs" />
-    <Compile Include="..\kDrive client\ServerCommunication\Services\SocketServerCommProtocol.cs" Link="ServerCommunication\Services\SocketServerCommProtocol.cs" />
+    <Compile Include="..\kDrive client\ServerCommunication\Interfaces\IServerCommClient.cs" Link="ServerCommunication\Interfaces\IServerCommClient.cs" />
+    <Compile Include="..\kDrive client\ServerCommunication\Services\TcpServerCommClient.cs" Link="ServerCommunication\Services\TcpServerCommClient.cs" />
     <Compile Include="..\kDrive client\ServerCommunication\Services\CommSharedEnums.cs" Link="ServerCommunication\Services\CommSharedEnums.cs" />
     <Compile Include="..\kDrive client\ServerCommunication\JsonConverters\Base64StringJsonConverter.cs" Link="ServerCommunication\JsonConverters\Base64StringJsonConverter.cs" />
   </ItemGroup>

--- a/src/gui4/windows/kDrive client/kDrive client/App.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/App.xaml.cs
@@ -43,7 +43,6 @@ namespace Infomaniak.kDrive
         private Window? _currentWindow;
         private UpdateWindow? _updateWindow;
 
-        public int LegacyCommPort { get; private set; } = -1;
         public Window? CurrentWindow
         {
             get => _currentWindow;
@@ -117,16 +116,8 @@ namespace Infomaniak.kDrive
                     current.Kill();
                     return;
                 }
-                try
-                {
-                    LegacyCommPort = Int32.Parse(arguments[1]);
-                    Logger.Log(Logger.Level.Info, $"Parsed legacy communication port from arguments: {LegacyCommPort}");
-                }
-                catch (Exception ex)
-                {
-                    Logger.Log(Logger.Level.Error, $"Failed to parse legacy communication port from arguments {ex}");
-                }
             }
+
             // Register oAuth protocol handler
             RegisterOAuthProtocol();
 

--- a/src/gui4/windows/kDrive client/kDrive client/App.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/App.xaml.cs
@@ -74,7 +74,7 @@ namespace Infomaniak.kDrive
         {
             var services = new ServiceCollection();
             services.AddSingleton<AppModel>();
-            services.AddSingleton<IServerCommProtocol, SocketServerCommProtocol>();
+            services.AddSingleton<IServerCommClient, TcpServerCommClient>();
             services.AddSingleton<IServerCommService, ServerCommService>();
             services.AddSingleton<UserDefaults>();
             services.AddSingleton<TrayIconManager>();

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Interfaces/IServerCommClient.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Interfaces/IServerCommClient.cs
@@ -23,7 +23,7 @@ using System.Threading.Tasks;
 
 namespace Infomaniak.kDrive.ServerCommunication.Interfaces
 {
-    public interface IServerCommProtocol
+    public interface IServerCommClient
     {
         public class CommData
         {

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Interfaces/IServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Interfaces/IServerCommService.cs
@@ -22,7 +22,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using static Infomaniak.kDrive.ServerCommunication.Interfaces.IServerCommProtocol;
+using static Infomaniak.kDrive.ServerCommunication.Interfaces.IServerCommClient;
 
 namespace Infomaniak.kDrive.ServerCommunication.Interfaces
 {

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/MockTcpServerCommClientTestError.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/MockTcpServerCommClientTestError.cs
@@ -31,14 +31,14 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
 {
     /// <summary>
     /// Mock server protocol for testing error displays.
-    /// Extends MockServerCommProtocol with automatic generation of test errors
+    /// Extends MockTcpServerCommClient with automatic generation of test errors
     /// for all error templates. Errors are created with DbIds starting at 200.
     /// </summary>
-    public class MockServerCommProtocolTestError : SocketServerCommProtocol
+    public class MockTcpServerCommClientTestError : TcpServerCommClient
     {
         private DbId _nextErrorDbId = 200;
 
-        public MockServerCommProtocolTestError() : base()
+        public MockTcpServerCommClientTestError() : base()
         {
             Task.Run(async () =>
             {

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/MockTcpServerCommClientl.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/MockTcpServerCommClientl.cs
@@ -28,11 +28,11 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
-using static Infomaniak.kDrive.ServerCommunication.Interfaces.IServerCommProtocol;
+using static Infomaniak.kDrive.ServerCommunication.Interfaces.IServerCommClient;
 
 namespace Infomaniak.kDrive.ServerCommunication.Services
 {
-    public class MockServerCommProtocol : Interfaces.IServerCommProtocol
+    public class MockTcpServerCommClient : Interfaces.IServerCommClient
     {
         protected MockServerData _mockData = new();
 
@@ -45,14 +45,14 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
         public Task<bool> InitConnection(CancellationToken cancellationToken) { return Task.FromResult(true); }
         public event EventHandler<SignalEventArgs>? SignalReceived;
 
-#pragma warning disable CS0067 // ConnectionLost is not used in the mock implementation, but we need to declare it to satisfy the IServerCommProtocol interface. We can safely ignore the fact that it's never raised.
+#pragma warning disable CS0067 // ConnectionLost is not used in the mock implementation, but we need to declare it to satisfy the IServerCommClient interface. We can safely ignore the fact that it's never raised.
         public event EventHandler? ConnectionLost;
 #pragma warning restore CS0067 
 
         protected Queue<KeyValuePair<SignalNum, JsonObject>> PendingSignals { get; } = new Queue<KeyValuePair<SignalNum, JsonObject>>();
         private Task? _signalHandler;
         private Task? _customSignalsHandler;
-        public MockServerCommProtocol()
+        public MockTcpServerCommClient()
         {
             Initialize();
         }
@@ -74,7 +74,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 RequestNum.PARAMETERS_INFO => await ParametersInfo(parameters),
                 RequestNum.PARAMETERS_UPDATE => await ParametersUpdate(parameters),
                 RequestNum.ERROR_DELETE => await ErrorDelete(parameters),
-                _ => throw new NotImplementedException($"RequestNum {requestNum} not implemented in MockServerCommProtocol.")
+                _ => throw new NotImplementedException($"RequestNum {requestNum} not implemented in MockTcpServerCommClient.")
             };
         }
 

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -33,7 +33,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
-using static Infomaniak.kDrive.ServerCommunication.Interfaces.IServerCommProtocol;
+using static Infomaniak.kDrive.ServerCommunication.Interfaces.IServerCommClient;
 using static Infomaniak.kDrive.ServerCommunication.Interfaces.IServerCommService;
 
 namespace Infomaniak.kDrive.ServerCommunication.Services
@@ -43,9 +43,9 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
     // It uses a semaphore to limit the number of concurrent requests and queues additional requests until one of the ongoing requests is completed.
     internal class RequestQueue
     {
-        private readonly IServerCommProtocol _commClient;
+        private readonly IServerCommClient _commClient;
         private readonly SemaphoreSlim _semaphore;
-        public RequestQueue(IServerCommProtocol commClient, int maxConcurrentRequests)
+        public RequestQueue(IServerCommClient commClient, int maxConcurrentRequests)
         {
             _commClient = commClient;
             _semaphore = new SemaphoreSlim(maxConcurrentRequests, maxConcurrentRequests);
@@ -94,14 +94,14 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
 
     public class ServerCommService : IServerCommService
     {
-        private readonly IServerCommProtocol _commClient;
+        private readonly IServerCommClient _commClient;
         private readonly AppModel _viewModel;
         private const int _maxErrorLimit = 1000;
         private object _errorLock = new object();
         private Int64 _errorCount = 0;
         private bool _hasMoreError;
 
-        public ServerCommService(IServerCommProtocol commClient, AppModel viewModel)
+        public ServerCommService(IServerCommClient commClient, AppModel viewModel)
         {
             _commClient = commClient;
             _viewModel = viewModel;

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/SocketServerCommProtocol.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/SocketServerCommProtocol.cs
@@ -83,6 +83,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
 
         private int? GetServerPort()
         {
+#if DEBUG
             try
             {
                 int port = int.Parse(File.ReadAllText(_commPortFilePath).Trim());
@@ -97,6 +98,25 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 Logger.Log(Logger.Level.Error, $"Failed to read server port from .comm file: {ex.Message}");
                 return null;
             }
+
+#else
+            string[] arguments = Environment.GetCommandLineArgs();
+            if (arguments.Length < 2)
+            {
+                Logger.Log(Logger.Level.Fatal, "No commPort provided");
+                ConnectionLost?.Invoke(this, new EventArgs());
+                return null;
+            }
+
+            if (!int.TryParse(arguments[1], out int port))
+            {
+                Logger.Log(Logger.Level.Fatal, $"Invalid commPort provided: {arguments[1]}");
+                ConnectionLost?.Invoke(this, new EventArgs());
+                return null;
+            }
+
+            return port;
+#endif
         }
         public async Task<bool> InitConnection(CancellationToken cancellationToken)
         {
@@ -326,7 +346,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 }
 
                 UpdateJsonBalance(_inBuffer, ref _inBufferJsonBalanceSeen, ref _inBufferJsonBalance, ref jsonEndIndex);
-               
+
                 if (jsonEndIndex == -1)
                 {
                     Logger.Log(Logger.Level.Extended, "Incomplete JSON message, waiting for more data.");

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/SocketServerCommProtocol.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/SocketServerCommProtocol.cs
@@ -136,8 +136,14 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 {
                     if (port is null)
                     {
+#if DEBUG
+                        // In debug mode, the client can start before the server, so we wait and retry until the .comm file is available
                         await Task.Delay(500, cancellationToken).ConfigureAwait(false);
                         continue;
+#else
+                        Logger.Log(Logger.Level.Fatal, "Failed to get server port.");
+                        return false;
+#endif
                     }
 
                     Logger.Log(Logger.Level.Info, $"Attempting to connect to {_host}:{port}");

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/SocketServerCommProtocol.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/SocketServerCommProtocol.cs
@@ -52,6 +52,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
         private bool _stopRequested = false;
         private Task? _pollingTask;
         private const string _host = "127.0.0.1";
+        private readonly Func<string[]> _getCommandLineArgs;
         private int NextId
         {
             get
@@ -74,6 +75,11 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
 
         public event EventHandler<SignalEventArgs> SignalReceived = delegate { };
         public event EventHandler ConnectionLost = delegate { };
+
+        public SocketServerCommProtocol(Func<string[]>? getCommandLineArgs = null)
+        {
+            _getCommandLineArgs = getCommandLineArgs ?? Environment.GetCommandLineArgs;
+        }
 
         ~SocketServerCommProtocol()
         {
@@ -100,23 +106,35 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             }
 
 #else
-            string[] arguments = Environment.GetCommandLineArgs();
-            if (arguments.Length < 2)
+            if (!TryParseServerPortFromArguments(_getCommandLineArgs(), out int port, out string errorMessage))
             {
-                Logger.Log(Logger.Level.Fatal, "No commPort provided");
-                ConnectionLost?.Invoke(this, new EventArgs());
-                return null;
-            }
-
-            if (!int.TryParse(arguments[1], out int port))
-            {
-                Logger.Log(Logger.Level.Fatal, $"Invalid commPort provided: {arguments[1]}");
+                Logger.Log(Logger.Level.Fatal, errorMessage);
                 ConnectionLost?.Invoke(this, new EventArgs());
                 return null;
             }
 
             return port;
 #endif
+        }
+
+        private static bool TryParseServerPortFromArguments(string[] arguments, out int port, out string errorMessage)
+        {
+            port = 0;
+
+            if (arguments.Length < 2)
+            {
+                errorMessage = "No commPort provided";
+                return false;
+            }
+
+            if (!int.TryParse(arguments[1], out port))
+            {
+                errorMessage = $"Invalid commPort provided: {arguments[1]}";
+                return false;
+            }
+
+            errorMessage = string.Empty;
+            return true;
         }
         public async Task<bool> InitConnection(CancellationToken cancellationToken)
         {

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/SocketServerCommProtocol.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/SocketServerCommProtocol.cs
@@ -67,12 +67,6 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             }
         }
 
-        private string _commPortFilePath = Path.Combine(
-               Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-               "kDrive",
-               ".comm"
-           );
-
         public event EventHandler<SignalEventArgs> SignalReceived = delegate { };
         public event EventHandler ConnectionLost = delegate { };
 
@@ -92,7 +86,8 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
 #if DEBUG
             try
             {
-                int port = int.Parse(File.ReadAllText(_commPortFilePath).Trim());
+                string commPortFilePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "kDrive", ".comm");
+                int port = int.Parse(File.ReadAllText(commPortFilePath).Trim());
                 return port;
             }
             catch (FileNotFoundException)

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/SocketServerCommProtocol.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/SocketServerCommProtocol.cs
@@ -52,7 +52,6 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
         private bool _stopRequested = false;
         private Task? _pollingTask;
         private const string _host = "127.0.0.1";
-        private readonly Func<string[]> _getCommandLineArgs;
         private int NextId
         {
             get
@@ -70,10 +69,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
         public event EventHandler<SignalEventArgs> SignalReceived = delegate { };
         public event EventHandler ConnectionLost = delegate { };
 
-        public SocketServerCommProtocol(Func<string[]>? getCommandLineArgs = null)
-        {
-            _getCommandLineArgs = getCommandLineArgs ?? Environment.GetCommandLineArgs;
-        }
+        public SocketServerCommProtocol() {}
 
         ~SocketServerCommProtocol()
         {
@@ -81,7 +77,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             _stopRequested = true;
         }
 
-        private int? GetServerPort()
+        protected virtual int? GetServerPort()
         {
 #if DEBUG
             try
@@ -99,9 +95,8 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
                 Logger.Log(Logger.Level.Error, $"Failed to read server port from .comm file: {ex.Message}");
                 return null;
             }
-
 #else
-            if (!TryParseServerPortFromArguments(_getCommandLineArgs(), out int port, out string errorMessage))
+            if (!TryParseServerPortFromArguments(Environment.GetCommandLineArgs(), out int port, out string errorMessage))
             {
                 Logger.Log(Logger.Level.Fatal, errorMessage);
                 ConnectionLost?.Invoke(this, new EventArgs());

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/TcpServerCommClient.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/TcpServerCommClient.cs
@@ -28,12 +28,12 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
-using static Infomaniak.kDrive.ServerCommunication.Interfaces.IServerCommProtocol;
+using static Infomaniak.kDrive.ServerCommunication.Interfaces.IServerCommClient;
 
 
 namespace Infomaniak.kDrive.ServerCommunication.Services
 {
-    public class SocketServerCommProtocol : Interfaces.IServerCommProtocol
+    public class TcpServerCommClient : Interfaces.IServerCommClient
     {
         private Socket? _socket;
         private readonly SemaphoreSlim _sendLock = new(1, 1);
@@ -69,9 +69,9 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
         public event EventHandler<SignalEventArgs> SignalReceived = delegate { };
         public event EventHandler ConnectionLost = delegate { };
 
-        public SocketServerCommProtocol() {}
+        public TcpServerCommClient() {}
 
-        ~SocketServerCommProtocol()
+        ~TcpServerCommClient()
         {
             _socket?.Dispose();
             _stopRequested = true;

--- a/src/gui4/windows/kDrive client/kDrive client/kDrive client.csproj
+++ b/src/gui4/windows/kDrive client/kDrive client/kDrive client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <AssemblyVersion>3.8.5.2</AssemblyVersion>
+    <AssemblyVersion>3.8.6.1</AssemblyVersion>
     <OutputType>WinExe</OutputType>
     <FileVersion>$(AssemblyVersion)</FileVersion>
     <Version>$(AssemblyVersion)</Version>

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -3917,16 +3917,22 @@ bool AppServer::startClient() {
         }
 #else
         pathToExecutable = QCoreApplication::applicationDirPath() + QString("/%1").arg(APPLICATION_CLIENT_EXECUTABLE);
+        useClientV4 = KDRIVE_VERSION_MAJOR >= 4;
 #endif
 
         QStringList arguments;
         if (useClientV4 && useCommManager(true)) {
+#if defined(KD_WINDOWS) || defined(KD_LINUX)
             const auto port = _commManager->tryGetGUICommPort();
             if (port <= 0) {
                 LOG_FATAL(_logger, "Failed to start kDrive client (comm manager port isn't available)");
                 return false;
             }
             arguments << QString::number(port);
+
+#else
+            // On macOS the client communicates with the server through XPC and doesn't need the port number as argument.
+#endif
         } else if (!useClientV4 && useOldCommServer()) {
             arguments << QString::number(OldCommServer::instance()->commPort());
         } else {

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -3921,7 +3921,7 @@ bool AppServer::startClient() {
 
         QStringList arguments;
         if (useClientV4 && useCommManager(true)) {
-            const auto port = _commManager->tryGetCommPort();
+            const auto port = _commManager->tryGetGUICommPort();
             if (port <= 0) {
                 LOG_FATAL(_logger, "Failed to start kDrive client (comm manager port isn't available)");
                 return false;

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -3897,19 +3897,20 @@ bool AppServer::startClient() {
     startClient = true;
 #endif
     startClient |= QProcessEnvironment::systemEnvironment().value("KDRIVE_DEBUG_RUN_CLIENT") == "1";
-
+    bool useClientV4 = false;
     if (startClient) {
         // Start the client
         QString pathToExecutable;
 
 #if defined(KD_WINDOWS)
         pathToExecutable = QCoreApplication::applicationDirPath() + QString("/%1.exe").arg(APPLICATION_CLIENTV4_EXECUTABLE);
-
+        useClientV4 = true;
         IoError ioError = IoError::Success;
         bool exists = false;
         if (!IoHelper::checkIfPathExists(QStr2Path(pathToExecutable), exists, ioError, IoHelper::PathCheckOption::Insensitive) ||
             !exists || ioError != IoError::Success) {
             pathToExecutable.clear();
+            useClientV4 = false;
         }
         if (pathToExecutable.isEmpty()) {
             pathToExecutable = QCoreApplication::applicationDirPath() + QString("/%1.exe").arg(APPLICATION_CLIENT_EXECUTABLE);
@@ -3919,12 +3920,22 @@ bool AppServer::startClient() {
 #endif
 
         QStringList arguments;
-        if (useOldCommServer()) {
+        if (useClientV4 && useCommManager(true)) {
+            const auto port = _commManager->tryGetCommPort();
+            if (port <= 0) {
+                LOG_FATAL(_logger, "Failed to start kDrive client (comm manager port isn't available)");
+                return false;
+            }
+            arguments << QString::number(port);
+        } else if (!useClientV4 && useOldCommServer()) {
             arguments << QString::number(OldCommServer::instance()->commPort());
-
-            LOGW_INFO(_logger, L"Starting kDrive client - path=" << Path2WStr(QStr2Path(pathToExecutable)) << L" args="
-                                                                 << arguments[0].toStdWString());
+        } else {
+            LOG_FATAL(_logger, "Failed to start kDrive client (no communication method available)");
+            return false;
         }
+
+        LOGW_INFO(_logger, L"Starting kDrive client - path=" << Path2WStr(QStr2Path(pathToExecutable)) << L" args="
+                                                             << arguments[0].toStdWString());
 
         _clientProcess = new QProcess(this);
         _clientProcess->setProgram(pathToExecutable);

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -3941,7 +3941,7 @@ bool AppServer::startClient() {
         }
 
         LOGW_INFO(_logger, L"Starting kDrive client - path=" << Path2WStr(QStr2Path(pathToExecutable)) << L" args="
-                                                             << arguments[0].toStdWString());
+                                                             << (arguments.size() >= 1 ? arguments[0].toStdWString() : L""));
 
         _clientProcess = new QProcess(this);
         _clientProcess->setProgram(pathToExecutable);

--- a/src/server/appserver.h
+++ b/src/server/appserver.h
@@ -225,7 +225,7 @@ class AppServer : public SharedTools::QtSingleApplication {
 
         static bool useOldCommServer() {
 #if defined(KD_WINDOWS) || defined(KD_MACOS)
-            return false; // (KDRIVE_VERSION_MAJOR < 4);
+            return KDRIVE_VERSION_MAJOR < 4;
 #else
             return true;
 #endif

--- a/src/server/appserver.h
+++ b/src/server/appserver.h
@@ -225,7 +225,7 @@ class AppServer : public SharedTools::QtSingleApplication {
 
         static bool useOldCommServer() {
 #if defined(KD_WINDOWS) || defined(KD_MACOS)
-            return true; // (KDRIVE_VERSION_MAJOR < 4);
+            return false; // (KDRIVE_VERSION_MAJOR < 4);
 #else
             return true;
 #endif

--- a/src/server/comm/commmanager.cpp
+++ b/src/server/comm/commmanager.cpp
@@ -22,6 +22,9 @@
 #include "extjobmanager.h"
 #include "extensionjob.h"
 #endif
+#if defined(KD_WINDOWS) || defined(KD_LINUX)
+#include "socketcommserver.h"
+#endif
 #include "guijobmanager.h"
 #include "guijobs/abstractguijob.h"
 #include "guijobs/guijobfactory.h"

--- a/src/server/comm/commmanager.cpp
+++ b/src/server/comm/commmanager.cpp
@@ -298,7 +298,7 @@ bool CommManager::hasActiveGuiConnection() {
     return _guiCommServer && _guiCommServer->hasActiveConnexion();
 }
 
-int32_t CommManager::tryGetCommPort() const {
+int32_t CommManager::tryGetGUICommPort() const {
     const std::scoped_lock lock(_mutex);
     if (!_guiCommServer) {
         LOG_WARN(Log::instance()->getLogger(), "GUI Comm Server not initialized");

--- a/src/server/comm/commmanager.cpp
+++ b/src/server/comm/commmanager.cpp
@@ -298,6 +298,7 @@ bool CommManager::hasActiveGuiConnection() {
     return _guiCommServer && _guiCommServer->hasActiveConnexion();
 }
 
+#if defined(KD_WINDOWS) || defined(KD_LINUX)
 int32_t CommManager::tryGetGUICommPort() const {
     const std::scoped_lock lock(_mutex);
     if (!_guiCommServer) {
@@ -311,6 +312,7 @@ int32_t CommManager::tryGetGUICommPort() const {
     }
     return socketServer->getPort();
 }
+#endif
 
 void CommManager::onNewGuiConnection() {
     const std::scoped_lock lock(_mutex);

--- a/src/server/comm/commmanager.cpp
+++ b/src/server/comm/commmanager.cpp
@@ -298,6 +298,20 @@ bool CommManager::hasActiveGuiConnection() {
     return _guiCommServer && _guiCommServer->hasActiveConnexion();
 }
 
+int32_t CommManager::tryGetCommPort() const {
+    const std::scoped_lock lock(_mutex);
+    if (!_guiCommServer) {
+        LOG_WARN(Log::instance()->getLogger(), "GUI Comm Server not initialized");
+        return -1;
+    }
+    const std::shared_ptr<SocketCommServer> socketServer = std::dynamic_pointer_cast<SocketCommServer>(_guiCommServer);
+    if (!socketServer) {
+        LOG_WARN(Log::instance()->getLogger(), "GUI Comm Server is not a SocketCommServer");
+        return -1;
+    }
+    return socketServer->getPort();
+}
+
 void CommManager::onNewGuiConnection() {
     const std::scoped_lock lock(_mutex);
     if (!_guiCommServer) return;

--- a/src/server/comm/commmanager.h
+++ b/src/server/comm/commmanager.h
@@ -58,6 +58,9 @@ class CommManager : public std::enable_shared_from_this<CommManager> {
         void sendGuiSignal(const std::shared_ptr<AbstractGuiJob> signal);
         bool hasActiveGuiConnection();
 
+        // Get the communication port used by the GUI for plateform relying on a socket based communication (e.g. Windows & Linux)
+        int32_t tryGetCommPort() const;
+
     private:
         // AppServer maps
         AppServer &_appServer;
@@ -69,7 +72,7 @@ class CommManager : public std::enable_shared_from_this<CommManager> {
         std::shared_ptr<AbstractCommServer> _guiCommServer;
 
         std::unique_ptr<GuiJobFactory> _guiJobFactory;
-        std::recursive_mutex _mutex;
+        mutable std::recursive_mutex _mutex;
 
 #if defined(KD_MACOS) || defined(KD_WINDOWS)
         // Execute a command received from an extension, which does not require an answer

--- a/src/server/comm/commmanager.h
+++ b/src/server/comm/commmanager.h
@@ -58,8 +58,10 @@ class CommManager : public std::enable_shared_from_this<CommManager> {
         void sendGuiSignal(const std::shared_ptr<AbstractGuiJob> signal);
         bool hasActiveGuiConnection();
 
-        // Get the communication port used by the GUI for plateform relying on a socket based communication (e.g. Windows & Linux)
+#if defined(KD_WINDOWS) || defined(KD_LINUX)
+        // Get the communication port used by the GUI when it relies on socket-based communication (e.g. Windows & Linux)
         int32_t tryGetGUICommPort() const;
+#endif
 
     private:
         // AppServer maps

--- a/src/server/comm/commmanager.h
+++ b/src/server/comm/commmanager.h
@@ -59,7 +59,7 @@ class CommManager : public std::enable_shared_from_this<CommManager> {
         bool hasActiveGuiConnection();
 
         // Get the communication port used by the GUI for plateform relying on a socket based communication (e.g. Windows & Linux)
-        int32_t tryGetCommPort() const;
+        int32_t tryGetGUICommPort() const;
 
     private:
         // AppServer maps

--- a/src/server/comm/socketcommserver.cpp
+++ b/src/server/comm/socketcommserver.cpp
@@ -280,7 +280,11 @@ void SocketCommServer::execute() {
     } while (!bindSuccess); // Loop until bind is successful
 
     LOG_DEBUG(Log::instance()->getLogger(), name() << " listening on port " << getPort());
+#ifdef NDEBUG
+    // In release mode, the port is provided to the GUI process via launch arguments, no need to save it in a file.
+#else
     saveCommPort(getPort());
+#endif // NDEBUG
     while (!_stopAsked) {
         try {
             _serverSocket.listen();
@@ -336,7 +340,7 @@ void SocketCommServer::execute() {
 }
 void SocketCommServer::joinAndClearPostponedLostConnectionCbks() {
     // Join and remove all postponed lost-connection callback threads
-    for (const auto& thread: _postponedLostConnectionCbks) {
+    for (const auto &thread: _postponedLostConnectionCbks) {
         if (thread->joinable()) {
             thread->join();
         }


### PR DESCRIPTION
Removed LegacyCommPort and its related logic from App.xaml.cs. Introduced conditional port handling in SocketServerCommProtocol based on DEBUG/RELEASE modes. Enhanced client startup logic in appserver.cpp with CommManager port validation. Updated CommManager with tryGetCommPort method and made mutex mutable. Adjusted SocketCommServer to skip port file saving in RELEASE. Improved code style consistency in several methods.