### PR TITLE
fix(appserver): capture variable by copy in lambda

### DIFF
--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -2433,7 +2433,7 @@ void AppServer::startSyncsAndRetryOnError(const std::unordered_set<SyncDbId> &to
             LOG_DEBUG(_logger, "Retry to start syncs in " << START_SYNCPALS_RETRY_INTERVAL << " ms");
             startedSyncDbIds.insert(toIgnoreSyncDbIds.begin(), toIgnoreSyncDbIds.end());
             QTimer::singleShot(START_SYNCPALS_RETRY_INTERVAL, this,
-                               [&startedSyncDbIds, this]() { startSyncsAndRetryOnError(startedSyncDbIds); });
+                               [startedSyncDbIds, this]() { startSyncsAndRetryOnError(startedSyncDbIds); });
         }
     }
 }


### PR DESCRIPTION
Updated the lambda in `QTimer::singleShot` to capture `startedSyncDbIds` by copy instead of by reference. This change prevents potential issues/crash caused by destruction of the original variable before the lambda execution, improving code safety and predictability.