### PR TITLE
fix(macos): use absolute path for pluginkit command

### DIFF
--- a/src/libcommonserver/utility/utility_mac.mm
+++ b/src/libcommonserver/utility/utility_mac.mm
@@ -84,12 +84,12 @@ void Utility::restartFinderExtension() {
     // The commands below aims to simulate this manipulation.
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t) (0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
       LOG_DEBUG(logger(), "Running ignore Finder Extension command for " << [processName UTF8String]);
-      Utility::runCommand("pluginkit", {"-e", "ignore", "-i", [processName UTF8String]});
+      Utility::runCommand("/usr/bin/pluginkit", {"-e", "ignore", "-i", [processName UTF8String]});
     });
 
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t) (1.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
       LOG_DEBUG(logger(), "Running use Finder Extension command for " << [processName UTF8String]);
-      Utility::runCommand("pluginkit", {"-e", "use", "-i", [processName UTF8String]});
+      Utility::runCommand("/usr/bin/pluginkit", {"-e", "use", "-i", [processName UTF8String]});
     });
 }
 

--- a/src/server/comm/commmanager.cpp
+++ b/src/server/comm/commmanager.cpp
@@ -69,14 +69,14 @@ CommManager::CommManager(AppServer &appServer) :
 
 #if defined(KD_MACOS)
     // Tell the Finder to use the Extension (checking it from System Preferences -> Extensions)
-    Utility::runCommand("pluginkit", {"-v", "-e", "use", "-i", std::string(APPLICATION_REV_DOMAIN) + ".Extension"});
+    Utility::runCommand("/usr/bin/pluginkit", {"-v", "-e", "use", "-i", std::string(APPLICATION_REV_DOMAIN) + ".Extension"});
 
     // Add it again. This was needed for Mojave to trigger a load.
     // TODO: Still needed?
     SyncPath extPath(CommonUtility::getExtensionPath());
     if (std::filesystem::exists(extPath)) {
         // Bundled app (i.e. not test executable)
-        Utility::runCommand("pluginkit", {"-v", "-a", extPath.native()});
+        Utility::runCommand("/usr/bin/pluginkit", {"-v", "-a", extPath.native()});
     }
 #endif
 


### PR DESCRIPTION
Replace bare 'pluginkit' with '/usr/bin/pluginkit' to avoid PATH-based command resolution, improving security and reliability.